### PR TITLE
Cache the artifacts built by the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,18 +30,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: Install mdbook
         run: cargo install mdbook
+
       - name: Install mdbook-svgbob
         run: cargo install mdbook-svgbob
+
       - name: Build book
         run: mdbook build
+
       - name: Setup Pages
         uses: actions/configure-pages@v2
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'book'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
This should speed up the publication: right now we spend around 4 minutes to build `mdbook` and `mdbook-svgbob`.

With this change, we will only pay that cost once a week (caches created by GitHub Actions [last 7 days][1]).

[1]: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy