### PR TITLE
`welcome.md`: indicate we skip the subtle details of unsafe Rust

### DIFF
--- a/src/welcome.md
+++ b/src/welcome.md
@@ -30,9 +30,9 @@ Some non-goals of this course are:
   Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by
   Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead.
 * Learn the details of how to write unsafe Rust. We will talk about unsafe Rust
-  on Day 3, but we go into the subtle details. Please see [Chapter 19.1 in the
-  Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) and the
-  [Rustonomicon](https://doc.rust-lang.org/nomicon/) instead.
+  on Day 3, but we do not cover the subtle details. Please see [Chapter 19.1 in
+  the Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) and
+  the [Rustonomicon](https://doc.rust-lang.org/nomicon/) instead.
 
 ## Assumptions
 


### PR DESCRIPTION
This sentence was missing a negation: it was supposed to say this course does not cover unsafe Rust in depth, but actually said "we go into the subtle details". This PR adds the missing negation.