### PR TITLE
remove "No memory leaks" from guarantees

### DIFF
--- a/src/why-rust/compile-time.md
+++ b/src/why-rust/compile-time.md
@@ -3,7 +3,6 @@
 Static memory management at compile time:
 
 * No uninitialized variables.
-* No memory leaks.
 * No double-frees.
 * No use-after-free.
 * No `NULL` pointers.


### PR DESCRIPTION
Rust doesn't guarantee this, as evidenced by the safe `Box::leak` function.