### PR TITLE
"question" typo

### DIFF
--- a/src/structure.md
+++ b/src/structure.md
@@ -16,7 +16,7 @@ days:
 
 The course is interactive and your questions will drive our exploration of Rust!
 
-* Please ask quesitons when you get then, don't save them to the end.
+* Please ask questions when you get then, don't save them to the end.
 * Discussions are very much encouraged!
 * We will likely talk about things ahead of the slides.
   * The slides are just a support and we are free to skip them as we like.


### PR DESCRIPTION
You actually may want to consider removing this section, or indicating when/where people that are not Googlers may follow this course. 
Plus, this is displayed as a book. You may either want to allow users to get it as Google Slide/pdf, or rename "slide" to "book" here