### PR TITLE
Clarify from/into

### DIFF
--- a/src/exercises/day-1/implicit-conversions.md
+++ b/src/exercises/day-1/implicit-conversions.md
@@ -23,8 +23,9 @@ Implementing these traits is how a type expresses that it can be converted into
 another type.
 
 The standard library has an implementation of `From<i8> for i16`, which means
-that we can convert an `i8` to an `i16` by calling the `into()` method on the
-`i8`.
+that we can convert a variable `x` of type `i8` to an `i16` by calling 
+`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`
+implementation automatically create an implementation of `Into<i16> for i8`.
 
 1. Execute the above program and look at the compiler error.
 


### PR DESCRIPTION
I found the phrasing confusing. Mentionning that a class implements From and then using `into()` seems confusing. It looks like that you meant that it implements `Into`.
So I believe that a little more details may help show why this exercise is valid.

I would have considered clarifying that `into` does not need to specify that we use the implementation for `i16` thanks to type analysis, but I assume this would add too much text, and this can either be ignored by the reader for the time being, or guessed