### PR TITLE
Limit playground references to tests

### DIFF
--- a/src/exercises/day-1/book-library.md
+++ b/src/exercises/day-1/book-library.md
@@ -14,8 +14,8 @@ fn main() {
 }
 ```
 
-Use this to create a library application. Copy the code below to
-<https://play.rust-lang.org/> and update the types to make it compile:
+Use this to create a library application. Update the types to make the code
+below compile:
 
 ```rust,should_panic
 // TODO: remove this when you're done with your implementation.

--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -46,8 +46,7 @@ a function `transpose` which will transpose a matrix (turn rows into columns):
 
 Hard-code both functions to operate on 3 × 3 matrices.
 
-Copy the code below to <https://play.rust-lang.org/> and implement the
-functions:
+Implement the functions:
 
 ```rust,should_panic
 // TODO: remove this when you're done with your implementation.

--- a/src/exercises/day-2/health-statistics.md
+++ b/src/exercises/day-2/health-statistics.md
@@ -2,8 +2,7 @@
 
 {{#include ../../../third_party/rust-on-exercism/health-statistics.md}}
 
-Copy the code below to <https://play.rust-lang.org/> and fill in the missing
-methods:
+Fill in the missing methods in the code below:
 
 ```rust,should_panic
 // TODO: remove this when you're done with your implementation.

--- a/src/exercises/day-2/luhn.md
+++ b/src/exercises/day-2/luhn.md
@@ -16,8 +16,7 @@ following to validate the credit card number:
 
 * The credit card number is valid if the sum is ends with `0`.
 
-Copy the following code to <https://play.rust-lang.org/> and implement the
-function:
+Implement the function:
 
 
 ```rust

--- a/src/exercises/day-2/points-polygons.md
+++ b/src/exercises/day-2/points-polygons.md
@@ -1,8 +1,7 @@
 # Polygon Struct
 
-We will create a `Polygon` struct which contain some points. Copy the code below
-to <https://play.rust-lang.org/> and fill in the missing methods to make the
-tests pass:
+We will create a `Polygon` struct which contain some points. Fill in the
+missing methods to make the tests pass:
 
 ```rust
 // TODO: remove this when you're done with your implementation.

--- a/src/exercises/day-2/strings-iterators.md
+++ b/src/exercises/day-2/strings-iterators.md
@@ -5,8 +5,8 @@ server is configured with a number of _path prefixes_ which are matched against
 _request paths_. The path prefixes can contain a wildcard character which
 matches a full segment. See the unit tests below.
 
-Copy the following code to <https://play.rust-lang.org/> and make the tests
-pass. Try avoiding allocating a `Vec` for your intermediate results:
+Edit the following code and make the tests pass. Try avoiding allocating a
+`Vec` for your intermediate results:
 
 
 ```rust

--- a/src/exercises/day-3/safe-ffi-wrapper.md
+++ b/src/exercises/day-3/safe-ffi-wrapper.md
@@ -19,8 +19,7 @@ C. The [Nomicon] also has a very useful chapter about FFI.
 [`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html
 [Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html
 
-Copy the code below to <https://play.rust-lang.org/> and fill in the missing
-functions and methods:
+Fill in the missing functions and methods:
 
 ```rust,should_panic
 // TODO: remove this when you're done with your implementation.

--- a/src/exercises/day-3/simple-gui.md
+++ b/src/exercises/day-3/simple-gui.md
@@ -12,8 +12,8 @@ We will have a number of widgets in our library:
 
 The widgets will implement a `Widget` trait, see below.
 
-Copy the code below to <https://play.rust-lang.org/>, fill in the missing
-`draw_into` methods so that you implement the `Widget` trait:
+Fill in the missing `draw_into` methods in the code below so that you
+implement the `Widget` trait:
 
 ```rust,should_panic
 // TODO: remove this when you're done with your implementation.

--- a/src/testing/test-modules.md
+++ b/src/testing/test-modules.md
@@ -1,7 +1,8 @@
 # Test Modules
 
-Unit tests are often put in a nested module (run tests on the
-[Playground](https://play.rust-lang.org/)):
+Unit tests are often put in a nested module. If you run the code below, tests
+are not executed, so you’ll need to run tests on the
+[Playground](https://play.rust-lang.org/).
 
 ```rust,editable
 fn helper(a: &str, b: &str) -> String {


### PR DESCRIPTION
The system used by https://google.github.io/comprehensive-rust/exercises/day-1/book-library.html allows to execute code directly in the book. So playground references became useless. If I got it wrong, it would be nice to at least explain why it’s not sufficient to edit and run in this book.

The only exception I saw is in the test setting. Playground allows to run tests. In this case, I believe adding a sentence warning that tests are ignored by this book running system means that we really must use the playground and ignore the "run" button provided by the book