### PR TITLE
Uses into_inter consistently in day 1

### DIFF
--- a/src/exercises/day-1/iterators-and-ownership.md
+++ b/src/exercises/day-1/iterators-and-ownership.md
@@ -22,7 +22,7 @@ You use this trait like this:
 ```rust,editable
 fn main() {
     let v: Vec<i8> = vec![10, 20, 30];
-    let mut iter = v.iter();
+    let mut iter = v.into_iter();
 
     println!("v[0]: {:?}", iter.next());
     println!("v[1]: {:?}", iter.next());
@@ -36,7 +36,7 @@ What is the type returned by the iterator? Test your answer here:
 ```rust,editable,compile_fail
 fn main() {
     let v: Vec<i8> = vec![10, 20, 30];
-    let mut iter = v.iter();
+    let mut iter = v.into_iter();
 
     let v0: Option<..> = iter.next();
     println!("v0: {v0:?}");


### PR DESCRIPTION
This page started by using `iter` and then used `into_iter`. No explanation was given. Worse, since the second part is about IntoIterator, intuition would indicate that the word "into" in `IntoIterator` and in `into_iter` refers to the same concept, and this is why `into` was not necessary in the first part of the page.

Since the authors seems not to want to introduce the difference between `into_iter` and `iter` here, I believe it’s more sensical to use `into_iter` everywhere