### PR TITLE
Misc doc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /book/
 /target/
+Cargo.lock

--- a/src/other-resources.md
+++ b/src/other-resources.md
@@ -3,7 +3,7 @@
 The Rust community has created a wealth of high-quality and free resources
 online.
 
-## Offical Documentation
+## Official Documentation
 
 The Rust project hosts many resources. These cover Rust in general:
 

--- a/src/std/vec.md
+++ b/src/std/vec.md
@@ -1,6 +1,6 @@
 # `Vec`
 
-[`Vec`][1] is the standard resizeable heap-allocated buffer:
+[`Vec`][1] is the standard resizable heap-allocated buffer:
 
 ```rust,editable
 fn main() {


### PR DESCRIPTION
List of changes:
- fix typos found via `codespell -S target -L crate`
- ignore Cargo.lock
- hide dollar signs used before commands without output for easier copy and paste in Github