### PR TITLE
remove `$` to make copy paste easier

### DIFF
--- a/src/cargo.md
+++ b/src/cargo.md
@@ -8,7 +8,7 @@ and how it fits into this training.
 On Debian/Ubuntu, you can install Cargo and the Rust source with
 
 ```shell
-$ sudo apt install cargo rust-src
+sudo apt install cargo rust-src
 ```
 
 This will allow [rust-analyzer][1] to jump to the definitions. We suggest using


### PR DESCRIPTION
removing the `$` sign user can directly copy and paste the command into terminal