### PR TITLE
Fix C array syntax in memory-management/manual.md

### DIFF
--- a/src/memory-management/manual.md
+++ b/src/memory-management/manual.md
@@ -8,7 +8,7 @@ You must call `free` on every pointer you allocate with `malloc`:
 
 ```c
 void foo(size_t n) {
-    int[] int_array = (int*)malloc(n * sizeof(int));
+    int* int_array = (int*)malloc(n * sizeof(int));
     //
     // ... lots of code
     //


### PR DESCRIPTION
Heap-allocated arrays in C use `int*` instead of `int[]`.