### PR TITLE
Makes ownership of `self` more accurate

### DIFF
--- a/src/methods/receiver.md
+++ b/src/methods/receiver.md
@@ -8,7 +8,8 @@ are other possible receivers for a method:
 * `&mut self`: borrows the object from the caller using a unique and mutable
   reference. The object can be used again afterwards.
 * `self`: takes ownership of the object and moves it away from the caller. The
-  method becomes the owner of the object and will drop (deallocate) it at the
-  end of the scope.
+  method becomes the owner of the object. The object will be drop (deallocated)
+  when the method returns, unless it’s ownership is explicitly
+  transmitted.
 * No receiver: this becomes a static method on the struct. Typically used to
   create constructors which are called `new` by convention.


### PR DESCRIPTION
It’s entirely possible that a method gives ownership of self to another object, or return `self`.  For example
```
    fn id(self) -> Self {
        return self;
    }
```
or more realistically 
```
    fn or(self, other) -> Self {
      if (self.isValid()) { return self;}
      return other;
    }
```