### PR TITLE
Install specific mdbook version in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install mdbook
-        run: cargo install mdbook
+        run: cargo install mdbook --version 0.4.25
 
       - name: Install mdbook-svgbob
-        run: cargo install mdbook-svgbob
+        run: cargo install mdbook-svgbob --version 0.2.1
 
       - name: Test code snippets
         run: mdbook test


### PR DESCRIPTION
Like in #30, we should install a known-good version of `mdbook` and `mdbook-svgbob` when testing PRs.