### PR TITLE
Dark Mode SVG Text Fix

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -14,6 +14,7 @@ class = "bob"
 [output.html]
 curly-quotes = true
 additional-js = ["ga4.js"]
+additional-css = ["svgbob.css"]
 git-repository-url = "https://github.com/google/comprehensive-rust"
 edit-url-template = "https://github.com/google/comprehensive-rust/edit/main/{path}"
 

--- a/svgbob.css
+++ b/svgbob.css
@@ -1,0 +1,4 @@
+/* Ensure text is legible in all themes. */
+svg text {
+  fill: var(--fg);
+}


### PR DESCRIPTION
Currently, SVG text in many of the diagrams appears as black on dark blue in dark mode. The SVG `text` elements currently receive the default color, black:

Light mode:
![image](https://user-images.githubusercontent.com/10041771/209367220-dafdd8d5-b092-4fa0-9f1e-c9e27c88b5f8.png)

Dark mode:
![image](https://user-images.githubusercontent.com/10041771/209367277-0abe4d8b-7bf2-4c62-9cae-e6b273624281.png)

This PR suggests a one-liner CSS fix to apply the foreground css variable (`var(--fg)`) to the svg text element to make svg text legible and accessible. This is bundled into the output using the `additional-css` property in mdbook's config `book.toml`. 

This is probably something that could be fixed upstream in `mdbook`/`mdbook-svgbob`  sometime, but this patch would fix it for current usability.
