### PR TITLE
`anyhow`: Remove `ReadUsernameError::IoError`

### DIFF
--- a/src/error-handling/error-contexts.md
+++ b/src/error-handling/error-contexts.md
@@ -11,8 +11,6 @@ use anyhow::{Context, Result};
 
 #[derive(Error, Debug)]
 enum ReadUsernameError {
-    #[error("Could not read: {0}")]
-    IoError(#[from] io::Error),
     #[error("Found no username in {0}")]
     EmptyUsername(String),
 }

--- a/src/error-handling/error-contexts.md
+++ b/src/error-handling/error-contexts.md
@@ -1,7 +1,8 @@
 # Adding Context to Errors
 
 The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add
-contextual information to your errors:
+contextual information to your errors and allows you to have fewer
+custom error types:
 
 ```rust,editable,compile_fail
 use std::{fs, io};


### PR DESCRIPTION
As far as I understand, the example with the `anyhow` example does not use its special `IoError` anymore, unlike the previous example with just `thiserror`.

I think this should be made clear. I considered just adding a `// Now unused` comment, but I think ti's clearer to just remove the unused code.

Fixes #116.