### PR TITLE
Comparison: copyedit 'destructors' to 'destructor'

### DIFF
--- a/src/memory-management/comparison.md
+++ b/src/memory-management/comparison.md
@@ -25,7 +25,7 @@ Here is a rough comparison of the memory management techniques.
   * Memory leaks.
 * Automatic like Java:
   * Garbage collection pauses.
-  * Destructors delayed.
+  * Destructor delays.
 * Scope-based like C++:
   * Complex, opt-in by programmer.
   * Potential for use-after-free.

--- a/src/memory-management/comparison.md
+++ b/src/memory-management/comparison.md
@@ -25,7 +25,7 @@ Here is a rough comparison of the memory management techniques.
   * Memory leaks.
 * Automatic like Java:
   * Garbage collection pauses.
-  * Destructors delays.
+  * Destructors delayed.
 * Scope-based like C++:
   * Complex, opt-in by programmer.
   * Potential for use-after-free.


### PR DESCRIPTION
This is the correct grammatical form for the bullet point, it expands into "Destructors [of objects are] delayed."