### PR TITLE
Mention that strings are UTF-8 encoded

### DIFF
--- a/src/hello-world.md
+++ b/src/hello-world.md
@@ -15,4 +15,4 @@ What you see:
 * Blocks are delimited by curly braces like in C and C++.
 * The `main` function is the entry point of the program.
 * Rust has hygienic macros, `println!` is an example of this.
-* Rust strings can contain Unicode characters, such as emoji.
+* Rust strings are UTF-8 encoded and can contain any Unicode character.


### PR DESCRIPTION
Technically, it's the Rust source file that is UTF-8 encoded, but in practical terms, this means that the string literals are UTF-8 encoded. It's only if you start using non-ASCII identifiers that you end up with UTF-8 encoded text outside of a string literal.

Fixes #35.