### PR TITLE
Better Test Case for Day 2 Polygon Exercise

### DIFF
--- a/src/exercises/day-2/points-polygons.rs
+++ b/src/exercises/day-2/points-polygons.rs
@@ -84,8 +84,8 @@ impl Polygon {
     }
 
     pub fn length(&self) -> f64 {
-        if self.points.is_empty() {
-            return 0.0;
+        if self.points.len() < 3 {
+            return f64::NAN;
         }
 
         let mut result = 0.0;
@@ -207,6 +207,7 @@ mod tests {
     fn test_shape_circumferences() {
         let mut poly = Polygon::new();
         poly.add_point(Point::new(12, 13));
+        poly.add_point(Point::new(17, 11));
         poly.add_point(Point::new(16, 16));
         let shapes = vec![
             Shape::from(poly),
@@ -217,7 +218,7 @@ mod tests {
             .map(Shape::circumference)
             .map(round_two_digits)
             .collect::<Vec<_>>();
-        assert_eq!(circumferences, vec![10.0, 31.42]);
+        assert_eq!(circumferences, vec![15.48, 31.42]);
     }
 }
 // ANCHOR_END: unit-tests

--- a/src/exercises/day-2/points-polygons.rs
+++ b/src/exercises/day-2/points-polygons.rs
@@ -84,8 +84,8 @@ impl Polygon {
     }
 
     pub fn length(&self) -> f64 {
-        if self.points.len() < 3 {
-            return f64::NAN;
+        if self.points.is_empty() {
+            return 0.0;
         }
 
         let mut result = 0.0;


### PR DESCRIPTION
`test_shape_circumferences()` is testing the circumference of a `Polygon` with only **2** points in total. However, according to the the general definition:

"A polygon is a closed figure where the sides are all line segments. Each side must intersect **exactly two others sides** but only at their endpoints. The sides must be noncollinear and have a common endpoint."

In short, a valid polygon is supposed to have at least **3** points.


### Proposal

To avoid ambiguity (i.e., users might implement `circumference()` with an early-return condition like `points.len() < 3` and end up with test failure), let's add one more point to the test case.

![NewTestCase.png](https://i.imgur.com/vFQlllt.png)
