### PR TITLE
Typo in "Fearless Concurrency" intro

### DIFF
--- a/src/concurrency.md
+++ b/src/concurrency.md
@@ -4,5 +4,5 @@ Rust has full support for concurrency using OS threads with mutexes and
 channels.
 
 The Rust type system plays an important role in making many concurrency bugs
-compile time bugs. This is often referred to a _fearless concurrency_ since you
+compile time bugs. This is often referred to as _fearless concurrency_ since you
 can rely on the compiler to ensure correctness at runtime.


### PR DESCRIPTION
"referred to a _fearless concurrency_" -> "referred to a**s** _fearless concurrency_"