### PR TITLE
Show speaker notes as closed by default

### DIFF
--- a/speaker-notes.js
+++ b/speaker-notes.js
@@ -61,7 +61,7 @@
   // Get the state of the speaker note window: "inline-open", "inline-closed",
   // or "popup".
   function getState() {
-    return window.localStorage["speakerNotes"] || "inline-open";
+    return window.localStorage["speakerNotes"] || "inline-closed";
   }
 
   // Set the state of the speaker note window. Call applyState as needed


### PR DESCRIPTION
This makes it clearer that the notes are extra content.