### PR TITLE
Hide speaker note popup link on mobile

### DIFF
--- a/speaker-notes.css
+++ b/speaker-notes.css
@@ -22,3 +22,9 @@
 .content details summary a {
   margin-left: 0.5em;
 }
+
+@media only screen and (max-width: 1080px) {
+  .content details summary a {
+    display: none;
+  }
+}


### PR DESCRIPTION
This uses the same media query as the rest of the mdbook theme: devices with a width less than 1080px (mobiles) will not see the link to open speaker notes in a new window.