### PR TITLE
Fix a typo in `result.md`

### DIFF
--- a/src/error-handling/result.md
+++ b/src/error-handling/result.md
@@ -1,6 +1,6 @@
 # Structured Error Handling with `Result`
 
-We have already see the `Result` enum. This is used pervasively when errors are
+We have already seen the `Result` enum. This is used pervasively when errors are
 expected as part of normal operation:
 
 ```rust


### PR DESCRIPTION
"have already see" -> "have already seen"