### PR TITLE
Show expanded speaker notes on print page

### DIFF
--- a/speaker-notes.js
+++ b/speaker-notes.js
@@ -115,6 +115,18 @@
     summary.append(popOut);
   }
 
+  // Create headers on the print page.
+  function setupPrintPage() {
+    for (const notes of document.querySelectorAll("details")) {
+      notes.open = true;
+      let summary = document.createElement("summary");
+      notes.insertBefore(summary, notes.firstChild);
+      let h4 = document.createElement("h4");
+      h4.append("Speaker Notes");
+      summary.append(h4);
+    }
+  }
+
   // Create controls for a speaker note window.
   function setupSpeakerNotes() {
     // Show the notes inline again when the window is closed.
@@ -215,6 +227,11 @@
       markDefunct();
       break;
     default:
+      if (window.location.pathname == "/print.html") {
+        setupPrintPage();
+        return;
+      }
+
       // We are on a regular page. We force the state to "inline-open" if this
       // looks like a direct link to the speaker notes.
       if (window.location.hash == "#speaker-notes") {


### PR DESCRIPTION
The `/print.html` page is concatenates all pages in the book and can be reached from the printer icon in the top-right corner.

On this page, we will have many speaker notes. Since the page is for people who want all information in one place, I think it makes sense to render all these notes in their expanded form.

I wrote the logic for this as a separate little function since it has to be different: we don’t want to add an `id` attribute to the generated headers (since there will be more than one of them) and we don’t want to generate links to open the notes into a separate window.