### PR TITLE
Create an empty Vec rather than pre-allocating

### DIFF
--- a/src/traits/read-write.md
+++ b/src/traits/read-write.md
@@ -31,7 +31,7 @@ fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let mut buffer = Vec::with_capacity(1024);
+    let mut buffer = Vec::new();
     log(&mut buffer, "Hello")?;
     log(&mut buffer, "World")?;
     println!("Logged: {:?}", buffer);


### PR DESCRIPTION
It might give the impression that you can only write to a Vec that has capacity, when in fact Vec's Write impl will grow the storage as needed. While pre-allocating is probably a good efficiency win in many circumstances, I think it's probably worth minimizing the number of concepts in play in this example.