### PR TITLE
Error handling: clarify printing of Result

### DIFF
--- a/src/error-handling/converting-error-types.md
+++ b/src/error-handling/converting-error-types.md
@@ -46,6 +46,6 @@ fn read_username(path: &str) -> Result<String, ReadUsernameError> {
 fn main() {
     //fs::write("config.dat", "").unwrap();
     let username = read_username("config.dat");
-    println!("username: {username:?}");
+    println!("username or error: {username:?}");
 }
 ```

--- a/src/error-handling/try-operator.md
+++ b/src/error-handling/try-operator.md
@@ -41,6 +41,6 @@ fn read_username(path: &str) -> Result<String, io::Error> {
 fn main() {
     //fs::write("config.dat", "alice").unwrap();
     let username = read_username("config.dat");
-    println!("username: {username:?}");
+    println!("username or error: {username:?}");
 }
 ```


### PR DESCRIPTION
Two examples may print either `Ok(username)` or `Err(error)`.
This commit clarifies this fact.

This is not so much a fix as a way to not confuse users who may not run the code.