### PR TITLE
Adds speaker notes to Compound Types section

### DIFF
--- a/src/basic-syntax/compound-types.md
+++ b/src/basic-syntax/compound-types.md
@@ -35,19 +35,7 @@ Arrays:
 
 *We can use literals to assign values to arrays.
 
-*Demonstrate out of bounds errors by setting n to different values 
-
-```
-a[n+15] = 11 // index out of bounds error since len is 10
-```
-
-*Efficient way to check n is in bounds:
-
-```
-assert!(n+20 < a.len()); // panics
-```
-
-*In the main function, the print statement asks for the debug implementation with the `?` format parameter: `{a}` gives default output, `{a:?}` gives debug output.
+*In the main function, the print statement asks for the debug implementation with the `?` format parameter: `{a}` gives the default output, `{a:?}` gives the debug output.
 
 *Adding `#`, eg `{a:#?}`, invokes a "pretty printing" format, which can be easier to read.
 

--- a/src/basic-syntax/compound-types.md
+++ b/src/basic-syntax/compound-types.md
@@ -31,7 +31,7 @@ Key points:
     
 Arrays:
     
-*Arrays have elements of the same type, T, and length, N, which is fixed. 
+*Arrays have elements of the same type, `T`, and length, `N`, which is a compile-time constant. 
 
 *We can use literals to assign values to arrays.
 

--- a/src/basic-syntax/compound-types.md
+++ b/src/basic-syntax/compound-types.md
@@ -36,14 +36,20 @@ Arrays:
 *We can use literals to assign values to arrays.
 
 *Demonstrate out of bounds errors by setting n to different values 
-    e.g. a[n+15] = 11 // index out of bounds error since len is 10
+
+```
+a[n+15] = 11 // index out of bounds error since len is 10
+```
 
 *Efficient way to check n is in bounds:
-    assert!(n+20 < a.len()); // panics
+
+```
+assert!(n+20 < a.len()); // panics
+```
 
 *In the main function, the print statement contains the debug implementation {a :?}.
 
-*Adding #, eg {a:#?}, invokes a "pretty printing" format, which can be easier to read.
+*Adding `#`, eg `{a:#?}`, invokes a "pretty printing" format, which can be easier to read.
 
 Tuples:
 

--- a/src/basic-syntax/compound-types.md
+++ b/src/basic-syntax/compound-types.md
@@ -47,7 +47,7 @@ a[n+15] = 11 // index out of bounds error since len is 10
 assert!(n+20 < a.len()); // panics
 ```
 
-*In the main function, the print statement contains the debug implementation {a :?}.
+*In the main function, the print statement asks for the debug implementation with the `?` format parameter: `{a}` gives default output, `{a:?}` gives debug output.
 
 *Adding `#`, eg `{a:#?}`, invokes a "pretty printing" format, which can be easier to read.
 

--- a/src/basic-syntax/compound-types.md
+++ b/src/basic-syntax/compound-types.md
@@ -24,3 +24,33 @@ fn main() {
     println!("2nd index: {}", t.1);
 }
 ```
+
+<details>
+    
+Key points:
+    
+Arrays:
+    
+*Arrays have elements of the same type, T, and length, N, which is fixed. 
+
+*We can use literals to assign values to arrays.
+
+*Demonstrate out of bounds errors by setting n to different values 
+    e.g. a[n+15] = 11 // index out of bounds error since len is 10
+
+*Efficient way to check n is in bounds:
+    assert!(n+20 < a.len()); // panics
+
+*In the main function, the print statement contains the debug implementation {a :?}.
+
+*Adding #, eg {a:#?}, invokes a "pretty printing" format, which can be easier to read.
+
+Tuples:
+
+*Like arrays, tuples have a fixed length.
+
+*Tuples group together values of different types into a compound type. 
+
+*Fields that can be accessed by the period and the index of the value, e.g. t.0, t.1.
+
+</details>


### PR DESCRIPTION
Speaker notes for 6. Basic Syntax, 6.2 Compound Types section. Briefly explains arrays and tuples properties.
Adds option for instructor to check for out of bounds errors using assert!().