### PR TITLE
Make library mutable in book-library exercise

### DIFF
--- a/src/exercises/day-1/book-library.rs
+++ b/src/exercises/day-1/book-library.rs
@@ -100,7 +100,7 @@ impl Library {
 // implement the missing methods. You will need to update the
 // method signatures, including the "self" parameter!
 fn main() {
-    let library = Library::new();
+    let mut library = Library::new();
 
     //println!("Our library is empty: {}", library.is_empty());
     //


### PR DESCRIPTION
Otherwise the library cannot have changes (books) added to it when testing via main.

Compile error:
```
error[E0596]: cannot borrow `library` as mutable, as it is not declared as mutable
```

I could definitely be missing something, but I also tried compiling with the given solution (with main uncommented) and received the same error.