### PR TITLE
Added some more detail on rustup.

### DIFF
--- a/src/cargo.md
+++ b/src/cargo.md
@@ -34,7 +34,7 @@ $ sudo apt install cargo rust-src
 This will allow [rust-analyzer][1] to jump to the definitions. We suggest using
 [VS Code][2] to edit the code (but any LSP compatible editor works).
 
-Some folks also like to use the [Jetbrains][4] family of IDEs, which do their own analysis but have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take note that as of writing debugging only works on the CLion version of the Jetbrains IDEA suite.
+Some folks also like to use the [Jetbrains][4] family of IDEs, which do their own analysis but have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take note that as of January 2023 debugging only works on the CLion version of the Jetbrains IDEA suite.
 
 [1]: https://rust-analyzer.github.io/
 [2]: https://code.visualstudio.com/

--- a/src/cargo.md
+++ b/src/cargo.md
@@ -11,15 +11,7 @@ and how it fits into this training.
 
 You can follow the instructions to install cargo and rust compiler, among other standard ecosystem tools with the [rustup][3] tool, which is maintained by the Rust Foundation.
 
-On Unix-like systems you can curl down the install script and pipe it into your shell like so:
-
-```shell
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-On windows there is a `rustup-init.exe` available on the website.
-
-Rustup also installs itself as an additional command line utility that you can use to install toolchains, setup cross compilation, etc.
+Along with cargo and rustc, Rustup will install itself as a command line utility that you can use to install/switch toolchains, setup cross compilation, etc.
 
 ### Package Managers
 

--- a/src/cargo.md
+++ b/src/cargo.md
@@ -5,6 +5,26 @@ used in the Rust ecosystem to build and run Rust applications. Here we want to
 give a brief overview of what Cargo is and how it fits into the wider ecosystem
 and how it fits into this training.
 
+## Installation
+
+### Rustup (Recommended)
+
+You can follow the instructions to install cargo and rust compiler, among other standard ecosystem tools with the [rustup][3] tool, which is maintained by the Rust Foundation.
+
+On Unix-like systems you can curl down the install script and pipe it into your shell like so:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+On windows there is a `rustup-init.exe` available on the website.
+
+Rustup also installs itself as an additional command line utility that you can use to install toolchains, setup cross compilation, etc.
+
+### Package Managers
+
+#### Debian
+
 On Debian/Ubuntu, you can install Cargo and the Rust source with
 
 ```shell
@@ -14,9 +34,6 @@ $ sudo apt install cargo rust-src
 This will allow [rust-analyzer][1] to jump to the definitions. We suggest using
 [VS Code][2] to edit the code (but any LSP compatible editor works).
 
-As a sidenote: if you have the access/capability to do so, it's recommended to
-install Rust's tooling via [rustup](https://rustup.rs/) since it's better integrated with the
-rest of the ecosystem.
-
 [1]: https://rust-analyzer.github.io/
 [2]: https://code.visualstudio.com/
+[3]: https://rustup.rs/

--- a/src/cargo.md
+++ b/src/cargo.md
@@ -34,6 +34,10 @@ $ sudo apt install cargo rust-src
 This will allow [rust-analyzer][1] to jump to the definitions. We suggest using
 [VS Code][2] to edit the code (but any LSP compatible editor works).
 
+Some folks also like to use the [Jetbrains][4] family of IDEs, which do their own analysis but have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take note that as of writing debugging only works on the CLion version of the Jetbrains IDEA suite.
+
 [1]: https://rust-analyzer.github.io/
 [2]: https://code.visualstudio.com/
 [3]: https://rustup.rs/
+[4]: https://www.jetbrains.com/clion/
+[5]: https://www.jetbrains.com/rust/


### PR DESCRIPTION
Rusutp is the reccomended way to install rust and maintained by the core team.

I added some organization and suggested that that be the method of installation.