### PR TITLE
Add speaker notes to exercise pages

### DIFF
--- a/src/exercises/day-1/afternoon.md
+++ b/src/exercises/day-1/afternoon.md
@@ -5,3 +5,11 @@ We will look at two things:
 * A small book library,
 
 * Iterators and ownership (hard).
+
+<details>
+
+After looking at the exercises, you can look at the [solutions] provided.
+
+[solutions]: solutions-afternoon.md
+
+</details>

--- a/src/exercises/day-1/morning.md
+++ b/src/exercises/day-1/morning.md
@@ -19,6 +19,10 @@ A few things to consider while solving the exercises:
 The code snippets are not editable on purpose: the inline code snippets lose
 their state if you navigate away from the page.
 
+After looking at the exercises, you can look at the [solutions] provided.
+
+[solutions]: solutions-morning.md
+
 [Using Cargo]: ../../cargo.md
 
 </details>

--- a/src/exercises/day-2/afternoon.md
+++ b/src/exercises/day-2/afternoon.md
@@ -1,3 +1,11 @@
 # Day 2: Afternoon Exercises
 
 The exercises for this afternoon will focus on strings and iterators.
+
+<details>
+
+After looking at the exercises, you can look at the [solutions] provided.
+
+[solutions]: solutions-afternoon.md
+
+</details>

--- a/src/exercises/day-2/morning.md
+++ b/src/exercises/day-2/morning.md
@@ -5,3 +5,11 @@ We will look at implementing methods in two contexts:
 * Simple struct which tracks health statistics.
 
 * Multiple structs and enums for a drawing library.
+
+<details>
+
+After looking at the exercises, you can look at the [solutions] provided.
+
+[solutions]: solutions-morning.md
+
+</details>

--- a/src/exercises/day-3/afternoon.md
+++ b/src/exercises/day-3/afternoon.md
@@ -1,3 +1,11 @@
 # Day 3: Afternoon Exercises
 
 Let us build a safe wrapper for reading directory content!
+
+<details>
+
+After looking at the exercise, you can look at the [solution] provided.
+
+[solutions]: solutions-afternoon.md
+
+</details>

--- a/src/exercises/day-3/morning.md
+++ b/src/exercises/day-3/morning.md
@@ -1,3 +1,11 @@
 # Day 3: Morning Exercises
 
 We will design a classical GUI library traits and trait objects.
+
+<details>
+
+After looking at the exercises, you can look at the [solutions] provided.
+
+[solutions]: solutions-morning.md
+
+</details>

--- a/src/exercises/day-4/afternoon.md
+++ b/src/exercises/day-4/afternoon.md
@@ -6,3 +6,10 @@ group up and do this together. Some suggestions:
 * Call your AIDL service with a client written in Rust.
 
 * Move a function from your project to Rust and call it.
+
+<details>
+
+No solution is provided here since this is open-ended: it relies on someone in
+the class having a piece of code which you can turn in to Rust on the fly.
+
+</details>

--- a/src/exercises/day-4/morning.md
+++ b/src/exercises/day-4/morning.md
@@ -6,3 +6,11 @@ Let us practice our new concurrency skills with
 
 * Multi-threaded link checker: a larger project where you'll use Cargo to
   download dependencies and then check links in parallel.
+
+<details>
+
+After looking at the exercises, you can look at the [solutions] provided.
+
+[solutions]: solutions-morning.md
+
+</details>


### PR DESCRIPTION
The notes link to the corresponding solutions.

I used a reference-style link to cut down on the number of new strings to translate. This is something we should slowly start taking into account when adding new content: each new paragraph puts load on the translators, so if there is a possibility to deduplicate them via Markdown "tricks", we should consider doing so.