### PR TITLE
Adds speaker notes for 6.4.1. String vs str

### DIFF
--- a/src/basic-syntax/string-slices.md
+++ b/src/basic-syntax/string-slices.md
@@ -18,3 +18,15 @@ Rust terminology:
 
 * `&str` an immutable reference to a string slice.
 * `String` a mutable string buffer.
+
+<details>
+
+* `&str` introduces a string slice, which is an immutable reference to UTF-8 encoded string data stored in a block of memory. String literals (`”Hello”`), are stored in the program’s binary.
+
+* Rust’s `String` type is a wrapper around a vector of bytes. As with a `Vec<T>`, it is mutable and owned.
+
+* `String::from` creates a string from a string literal; `String::new` creates a new empty string, to which string data can be added using the `to_string` method.
+
+* The `push_str` method appends a string slice to the string.
+    
+</details>


### PR DESCRIPTION
Adds speaker notes including:
-Brief explanation of &str, String type
-String::from and String::new
-push_str method