### PR TITLE
Fix `Cargo.toml` syntax

### DIFF
--- a/src/error-handling/panic-unwind.md
+++ b/src/error-handling/panic-unwind.md
@@ -18,4 +18,4 @@ assert!(result.is_err());
 
 * This can be useful in servers which should keep running even if a single
   request crashes.
-* This does not work if `panic = abort` is set in your `Cargo.toml`.
+* This does not work if `panic = 'abort'` is set in your `Cargo.toml`.


### PR DESCRIPTION
This is very minor fix that uses the correct `Cargo.toml` syntax by quoting a field value.

This matches what is used in [the Rust Book](https://doc.rust-lang.org/book/ch09-01-unrecoverable-errors-with-panic.html).