### PR TITLE
Add speaker for Drop trait and lifetime of references.

### DIFF
--- a/src/traits/drop.md
+++ b/src/traits/drop.md
@@ -28,3 +28,34 @@ fn main() {
     println!("Exiting main");
 }
 ```
+
+<details>
+
+* References in structs must have a lifetime annotation and the compiler will use it to verify assigments.
+```rust,editable
+struct Droppable<'a> {
+    name: &'a String,
+}
+
+impl Drop for Droppable<'_> {
+    fn drop(&mut self) {
+        println!("Dropping {}", self.name);
+    }
+}
+
+fn main() {
+    let a_str = String::from("a");
+    let a = Droppable { name: &a_str};
+    {
+        let c_str = String::from("c");
+        let mut c = Droppable { name: &c_str};
+        let d_str = String::from("d");
+        let mut d = Droppable { name: &d_str};
+        d.name = &c_str;  // Allowed, c_str lives longer than d.
+        //c.name = d.name;  // Fails! d_str gets deconstructed before c.
+    }
+    println!("Exiting main");
+}
+```
+
+</details>


### PR DESCRIPTION
Add a little example that demonstrates that the compiler checks lifetimes of references. It's not specific to the Drop trait but the question might come up in the context.