### PR TITLE
Update Speaker Notes for compile-time.md

### DIFF
--- a/src/why-rust/compile-time.md
+++ b/src/why-rust/compile-time.md
@@ -22,6 +22,8 @@ are:
   a value (meaning the destructor is never run).
 * You can also accidentally create a [reference cycle] with `Rc` or
   `Arc`.
+* In fact infinitely populating a collection some will consider a memory
+  leak and Rust does not protect from those.
 
 For the purpose of this course, "No memory leaks" should be understood
 as "Pretty much no *accidental* memory leaks".

--- a/src/why-rust/compile-time.md
+++ b/src/why-rust/compile-time.md
@@ -22,7 +22,7 @@ are:
   a value (meaning the destructor is never run).
 * You can also accidentally create a [reference cycle] with `Rc` or
   `Arc`.
-* In fact infinitely populating a collection some will consider a memory
+* In fact, some will consider infinitely populating a collection a memory
   leak and Rust does not protect from those.
 
 For the purpose of this course, "No memory leaks" should be understood


### PR DESCRIPTION
The definition of memory leaks is indeed blurry, so it is important not have right expectations about this particular kind of error.