### PR TITLE
Update Speaker Notes for compound-types.md

### DIFF
--- a/src/basic-syntax/compound-types.md
+++ b/src/basic-syntax/compound-types.md
@@ -55,6 +55,8 @@ Tuples:
 * The empty tuple `()` is also known as the "unit type". It is both a type, and
   the only valid value of that type - that is to say both the type and its value
   are expressed as `()`. It is used to indicate, for example, that a function or
-  expression has no return value, as we'll see in a future slide.
+  expression has no return value, as we'll see in a future slide. 
+    * You can think of it as `void` that can be familiar to you from other 
+      programming languages.
 
 </details>


### PR DESCRIPTION
It could be a "gotcha" moment for readers when they associate `()` with `void` from, say, C++.