### PR TITLE
Filter out “fuzzy” translations

### DIFF
--- a/i18n-helpers/src/bin/mdbook-gettext.rs
+++ b/i18n-helpers/src/bin/mdbook-gettext.rs
@@ -52,6 +52,7 @@ fn translate(text: &str, catalog: &Catalog) -> String {
 
         let translated = catalog
             .find_message(paragraph)
+            .filter(|msg| !msg.flags.contains("fuzzy"))
             .and_then(|msg| msg.get_msgstr().ok())
             .filter(|msgstr| !msgstr.is_empty())
             .map(|msgstr| msgstr.as_str())


### PR DESCRIPTION
When the source text is updated, existing translations become outdated. The `msgmerge` program will attempt to find a similar source text among the existing translations and will reuse the translation. The translation is marked “fuzzy” to signal to the translator that it needs to be proofread.