### PR TITLE
Update moves-function-calls.md

### DIFF
--- a/src/ownership/moves-function-calls.md
+++ b/src/ownership/moves-function-calls.md
@@ -18,6 +18,7 @@ fn main() {
 <details>
 
 * With the first call to `say_hello`, `main` gives up ownership of `name`. Afterwards, `name` cannot be used anymore within `main`.
+* The heap memory allocated for `name` will be freed at the end of the `say_hello` function.
 * `main` can retain ownership if it passes `name` as a reference (`&name`) and if `say_hello` accepts a reference as a parameter.
 * Alternatively, `main` can pass a clone of `name` in the first call (`name.clone()`).
 * Rust makes it harder than C++ to inadvertently create copies by making move semantics the default, and by forcing programmers to make clones explicit.


### PR DESCRIPTION
Additional note helps to understand what move really means. The `name` ownership went fully into the `say_hello`.