### PR TITLE
Update lifetimes-data-structures.md

### DIFF
--- a/src/ownership/lifetimes-data-structures.md
+++ b/src/ownership/lifetimes-data-structures.md
@@ -26,5 +26,5 @@ fn main() {
 * If `text` is consumed before the end of the lifetime of `fox` (or `dog`), the borrow checker throws an error.
 * Types with borrowed data force users to hold on to the original data. This can be useful for creating lightweight views, but it generally makes them somewhat harder to use.
 * When possible, make data structures own their data directly.
-
+* Some structs with multiple references inside can have more than one lifetime annontation. This can be necessary if there is a need to describe lifetime relationships between the references themselves, in addition to the lifetime of the struct itself. Those are very advanced use cases.
 </details>

--- a/src/ownership/lifetimes-data-structures.md
+++ b/src/ownership/lifetimes-data-structures.md
@@ -26,5 +26,5 @@ fn main() {
 * If `text` is consumed before the end of the lifetime of `fox` (or `dog`), the borrow checker throws an error.
 * Types with borrowed data force users to hold on to the original data. This can be useful for creating lightweight views, but it generally makes them somewhat harder to use.
 * When possible, make data structures own their data directly.
-* Some structs with multiple references inside can have more than one lifetime annontation. This can be necessary if there is a need to describe lifetime relationships between the references themselves, in addition to the lifetime of the struct itself. Those are very advanced use cases.
+* Some structs with multiple references inside can have more than one lifetime annotation. This can be necessary if there is a need to describe lifetime relationships between the references themselves, in addition to the lifetime of the struct itself. Those are very advanced use cases.
 </details>


### PR DESCRIPTION
The example is quite simple, but in it's simplicity it may raise the question why do we even need lifetimes in the structs? Isn't it obvious that the referenced value should always outlive the struct? This sentence tries to explain that more complex cases exist.