### PR TITLE
Update receiver.md

### DIFF
--- a/src/methods/receiver.md
+++ b/src/methods/receiver.md
@@ -11,9 +11,19 @@ are other possible receivers for a method:
   method becomes the owner of the object. The object will be dropped (deallocated)
   when the method returns, unless its ownership is explicitly
   transmitted.
+* `mut self`: same as above, but while the method owns the object, it can
+  mutate it too. Complete ownership does not automatically mean mutability.
 * No receiver: this becomes a static method on the struct. Typically used to
   create constructors which are called `new` by convention.
 
 Beyond variants on `self`, there are also
 [special wrapper types](https://doc.rust-lang.org/reference/special-types-and-traits.html)
 allowed to be receiver types, such as `Box<Self>`.
+
+<details>
+  
+Consider emphasizing on "shared and immutable" and "unique and mutable". These constraints always come
+together in Rust due to borrow checker rules, and `self` is no exception. It won't be possible to
+reference a struct from multiple locations and call a mutating (`&mut self`) method on it.
+  
+</details>


### PR DESCRIPTION
The key takeaway is mutability of receivers and the rules that come with it. It might be a repetition of borrow checker rules, but it is important to know they apply to `self` as to any other variable or argument.