### PR TITLE
Update destructuring-enums.md

### DIFF
--- a/src/pattern-matching/destructuring-enums.md
+++ b/src/pattern-matching/destructuring-enums.md
@@ -29,3 +29,11 @@ fn main() {
 Here we have used the arms to _destructure_ the `Result` value. In the first
 arm, `half` is bound to the value inside the `Ok` variant. In the second arm,
 `msg` is bound to the error message.
+
+<details>
+
+Consider demonstrating what happens if you add the third enum variant. Rust
+will try to be helpful and the code won't compile, because you haven't handled
+the new case in your match statements.
+
+</details>


### PR DESCRIPTION
Adding a speaker note that suggests to demonstrate to students what happens if you add a third variant to the enum.