### PR TITLE
Update if-let-expressions.md

### DIFF
--- a/src/control-flow/if-let-expressions.md
+++ b/src/control-flow/if-let-expressions.md
@@ -19,6 +19,7 @@ Rust.
 <details>
 
 * `if let` can be more concise than `match`, e.g., when only one case is interesting. In contrast, `match` requires all branches to be covered.
+    * For the similar use case consider demonstrating a newly stabilized [`let else`](https://github.com/rust-lang/rust/pull/93628) feature.
 * A common usage is handling `Some` values when working with `Option`.
 * Unlike `match`, `if let` does not support guard clauses for pattern matching.
 


### PR DESCRIPTION
Mention `let else` in the speaker notes.

Alternatively, `let else` may deserve it's own section. It is very nice. https://github.com/rust-lang/rust/pull/93628. Please let me know if you'd prefer me to add this section.