### PR TITLE
Update for-expressions.md

### DIFF
--- a/src/control-flow/for-expressions.md
+++ b/src/control-flow/for-expressions.md
@@ -10,7 +10,19 @@ fn main() {
     for x in v {
         println!("x: {x}");
     }
+    
+    for i in (0..10).step_by(2) {
+        println!("i: {i}");
+    }
 }
 ```
 
 You can use `break` and `continue` here as usual.
+
+<details>
+    
+* Index iteration is not a special syntax in Rust for just that case.
+* `(0..10)` is a range that implements an `Iterator` trait. 
+* `step_by` is a method that returns another `Iterator` that skips every other element. 
+    
+</details>


### PR DESCRIPTION
If we are introducing `for` loops, I think it is beneficial to show a very basic `for i=0; i < 10; i+=2` too.