### PR TITLE
Extract common build steps to composite actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/workflows/setup-rust-cache
 
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/workflows/setup-rust-cache
 
       - name: Test Rust code
         run: cargo test
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/workflows/setup-rust-cache
 
       - name: Install Gettext
         run: sudo apt install gettext
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/workflows/setup-rust-cache
 
       - name: Install Gettext
         run: sudo apt install gettext

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install mdbook
-        run: cargo install mdbook --version 0.4.25
-
-      - name: Install mdbook-svgbob
-        run: cargo install mdbook-svgbob --version 0.2.1
+        uses: ./.github/workflows/install-mdbook
 
       - name: Test code snippets
         run: mdbook test
@@ -57,13 +54,7 @@ jobs:
         run: sudo apt install gettext
 
       - name: Install mdbook
-        run: cargo install mdbook --version 0.4.25
-
-      - name: Install mdbook-svgbob
-        run: cargo install mdbook-svgbob --version 0.2.1
-
-      - name: Install i18n-helpers
-        run: cargo install --path i18n-helpers --locked
+        uses: ./.github/workflows/install-mdbook
 
       - name: Generate po/messages.pot
         run: mdbook build -d po
@@ -107,13 +98,7 @@ jobs:
         run: sudo apt install gettext
 
       - name: Install mdbook
-        run: cargo install mdbook --version 0.4.25
-
-      - name: Install mdbook-svgbob
-        run: cargo install mdbook-svgbob --version 0.2.1
-
-      - name: Install i18n-helpers
-        run: cargo install --path i18n-helpers --locked
+        uses: ./.github/workflows/install-mdbook
 
       - name: Test ${{ matrix.language }} translation
         run: msgfmt --statistics -o /dev/null po/${{ matrix.language }}.po

--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -1,0 +1,18 @@
+name: Install mdbook and dependencies
+
+description: Install the mdbook with the dependencies we need.
+
+runs:
+  using: composite
+  steps:
+    - name: Install mdbook
+      run: cargo install mdbook --version 0.4.25
+      shell: bash
+
+    - name: Install mdbook-svgbob
+      run: cargo install mdbook-svgbob --version 0.2.1
+      shell: bash
+
+    - name: Install i18n-helpers
+      run: cargo install --path i18n-helpers --locked
+      shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install mdbook
-        run: cargo install mdbook --version 0.4.25
-
-      - name: Install mdbook-svgbob
-        run: cargo install mdbook-svgbob --version 0.2.1
+        uses: ./.github/workflows/install-mdbook
 
       - name: Build book
         run: mdbook build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/workflows/setup-rust-cache
 
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook

--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -1,0 +1,13 @@
+name: Setup Rust cache
+
+description: Configure the rust-cache workflow.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          . -> target
+          i18n-helpers -> target


### PR DESCRIPTION
This allows us to repeat ourselves less across the different jobs.

I also tested using a “reusable workflow” to factor out the common steps. However, this starts a separate job without a shared file system, which in turn requires us to upload/download artifacts when we want to use them in several jobs. The artifacts are downloaded one-by-one and this adds delays and extra steps to all jobs.