### PR TITLE
Update methods.md

### DIFF
--- a/src/generics/methods.md
+++ b/src/generics/methods.md
@@ -19,3 +19,13 @@ fn main() {
     println!("p.x = {}", p.x());
 }
 ```
+
+<details>
+
+* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that redundant?
+    * This is because it is a generic implementation section for generic type. They are independently generic.
+    * It means these methods are defined for any `T`.
+    * It is possible to write `impl Point<u32> { .. }`. 
+      * `Point` is still generic and you can use `Point<f64>`, but methods in this block will only be available for `Point<u32>`.
+
+</details>


### PR DESCRIPTION
Adding a Q/A about `impl<T> Point<T>`, why is it specified twice.

This was confusing me a lot at early stages of learning Rust.