### PR TITLE
Update trait-bounds.md

### DIFF
--- a/src/generics/trait-bounds.md
+++ b/src/generics/trait-bounds.md
@@ -15,3 +15,22 @@ fn main() {
     let pair = duplicate(foo);
 }
 ```
+
+<details>
+
+Consider showing a `where` clause syntax. Students can encounter it too when reading code.
+    
+```rust,ignore
+fn duplicate<T>(a: T) -> (T, T)
+where
+    T: Clone,
+{
+    (a.clone(), a.clone())
+}
+```
+
+* It declutters the function signature if you have many parameters.
+* It has additional features making it more powerful.
+    * If someone asks, the extra feature is that the type on the left of ":" can be arbitrary, like `Option<T>`.
+    
+</details>


### PR DESCRIPTION
Mentioning `where` clause syntax in speaker notes.

This PR suggests to add it into the speaker notes, but maybe it should just be added to the code.