### PR TITLE
Update scoped-threads.md

### DIFF
--- a/src/concurrency/scoped-threads.md
+++ b/src/concurrency/scoped-threads.md
@@ -31,3 +31,10 @@ fn main() {
 ```
 
 [1]: https://doc.rust-lang.org/std/thread/fn.scope.html
+
+<details>
+    
+* The reason for that is that when the `thread::scope` function completes, all the threads are guaranteed to be joined, so they can return borrowed data.
+* Normal Rust borrowing rules apply: you can either borrow mutably by one thread, or immutably by any number of threads.
+    
+</details>


### PR DESCRIPTION
Adding speaker notes explaining why scoped threads work and what borrowing rules apply.