### PR TITLE
Update channels.md

### DIFF
--- a/src/concurrency/channels.md
+++ b/src/concurrency/channels.md
@@ -21,3 +21,9 @@ fn main() {
     println!("Received: {:?}", rx.recv());
 }
 ```
+
+<details>
+
+* `send()` and `recv()` return `Result`. If they return `Err`, it means the counterpart `Sender` or `Receiver` is dropped.
+
+</details>


### PR DESCRIPTION
Adding speaker notes explaining why `send` and `recv` can fail.