### PR TITLE
Update mutex.md

### DIFF
--- a/src/concurrency/shared_state/mutex.md
+++ b/src/concurrency/shared_state/mutex.md
@@ -26,3 +26,13 @@ implementation.
 [1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
 [2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E
 [3]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+
+<details>
+    
+* `Mutex` in Rust looks like a collection with just one element - the protected data.
+    * It is not possible to forget to acquire the mutex before accessing the protected data.
+* A read-write lock counterpart - `RwLock`.
+* *Q from the audience:* Why does the `lock()` return a `Result`? 
+    * *A:* If the thread that held the `Mutex` panicked, the `Mutex` becomes "poisoned". `lock()` on poisoned mutexes fails, but it is still possible to extract the data from the `Mutex` via special methods to recover.  
+    
+</details>

--- a/src/concurrency/shared_state/mutex.md
+++ b/src/concurrency/shared_state/mutex.md
@@ -32,7 +32,9 @@ implementation.
 * `Mutex` in Rust looks like a collection with just one element - the protected data.
     * It is not possible to forget to acquire the mutex before accessing the protected data.
 * A read-write lock counterpart - `RwLock`.
-* *Q from the audience:* Why does the `lock()` return a `Result`? 
-    * *A:* If the thread that held the `Mutex` panicked, the `Mutex` becomes "poisoned". `lock()` on poisoned mutexes fails, but it is still possible to extract the data from the `Mutex` via special methods to recover.  
+* Why does `lock()` return a `Result`? 
+    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "poisoned" to signal that the data it protected might be in an inconsistent state. Calling `lock()` on a poisoned mutex fails with a [`PoisonError`]. You can call `into_inner()` on the error to recover the data regardless.
+
+[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html  
     
 </details>


### PR DESCRIPTION
Adding speaker notes why Rust `Mutex` has its design and mentioning briefly `RwLock`.

Someone from the audience can notice `unwrap()` in the code, it might be worth to have the answer in speaker notes.