### PR TITLE
Add speaker notes for Android interoperability slide

### DIFF
--- a/src/android/interoperability/with-c/rust.md
+++ b/src/android/interoperability/with-c/rust.md
@@ -40,3 +40,10 @@ Build, push, and run the binary on your device:
 ```shell
 {{#include ../../build_all.sh:analyze_numbers}}
 ```
+
+<details>
+
+`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol will just be the name of
+the function. You can also use `#[export_name = "some_name"]` to specify whatever name you want.
+
+</details>

--- a/src/android/logging/src/main.rs
+++ b/src/android/logging/src/main.rs
@@ -15,7 +15,7 @@
 // ANCHOR: main
 //! Rust logging demo.
 
-use log::{debug, error};
+use log::{debug, error, info};
 
 /// Logs a greeting.
 fn main() {
@@ -25,5 +25,6 @@ fn main() {
             .with_min_level(log::Level::Trace),
     );
     debug!("Starting program.");
+    info!("Things are going fine.");
     error!("Something went wrong!");
 }


### PR DESCRIPTION
Also fixed the logging example to be consistent with the output given.