### PR TITLE
Set the site-url to fix 404 page on GitHub Pages

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -25,6 +25,7 @@ class = "bob"
 curly-quotes = true
 additional-js = ["ga4.js", "speaker-notes.js"]
 additional-css = ["svgbob.css", "speaker-notes.css"]
+site-url = "/comprehensive-rust/"
 git-repository-url = "https://github.com/google/comprehensive-rust"
 edit-url-template = "https://github.com/google/comprehensive-rust/edit/main/{path}"
 


### PR DESCRIPTION
This fixes the 404 page on GitHub Pages: the default is `/`, but we’re hosting the site from a subdirectory because of how the repository is setup.

Fixes #178.