### PR TITLE
Publish translations to `/xx` subdirectories

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  LANGUAGES: da
 
 jobs:
   publish:
@@ -35,8 +36,17 @@ jobs:
       - name: Install mdbook
         uses: ./.github/workflows/install-mdbook
 
-      - name: Build book
-        run: mdbook build
+      - name: Build course in English
+        run: mdbook build -d book
+
+      - name: Build all translations
+        run: |
+          for po_lang in ${{ env.LANGUAGES }}; do
+              MDBOOK_BOOK__LANGUAGE=$po_lang \
+              MDBOOK_PREPROCESSOR__GETTEXT__PO_FILE=po/$po_lang.po \
+              MDBOOK_OUTPUT__HTML__SITE_URL=/comprehensive-rust/$po_lang/ \
+              mdbook build -d book/$po_lang
+          done
 
       - name: Setup Pages
         uses: actions/configure-pages@v2
@@ -44,7 +54,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'book'
+          path: book
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This publishes translations (currently only the Danish translation) to subdirectories named after the ISO 639-1 language code: “da/” for Danish, “ko/” for Korean, etc.

The list of translation is an explicit list to make it easy for us to enable/disable translations without being tied to the files in po/. This allows us to experiment with a translation without publishing it immediately.

I propose that we eventually move the English pages to an “en/” directory for symmetry with the other locales. However, for now, the pages remain at the room of our site (which works fine since we don’t have a subdirectory named “en/” in the course).