### PR TITLE
Add trailing backslash for multiline command

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -110,7 +110,7 @@ we'll tell `mdbook` to watch the `po/` directory for changes:
 
 ```shell
 $ MDBOOK_BOOK__LANGUAGE=xx \
-  MDBOOK_PREPROCESSOR__GETTEXT__PO_FILE=po/xx.po
-  MDBOOK_BUILD__EXTRA_WATCH_DIRS='["po"]'
+  MDBOOK_PREPROCESSOR__GETTEXT__PO_FILE=po/xx.po \
+  MDBOOK_BUILD__EXTRA_WATCH_DIRS='["po"]' \
   mdbook serve -d book/xx
 ```


### PR DESCRIPTION
There were some backslashed missing in the command to serve the translated book. Thus the shell would execute the lines one after the other, instead of as one command.

This lead to the environment variables not actually being set, and thus the non-translated version was served anyway.