### PR TITLE
Propose to use the generic term perimeter instead of circumference for shapes

### DIFF
--- a/src/exercises/day-2/points-polygons.rs
+++ b/src/exercises/day-2/points-polygons.rs
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shape_circumferences() {
+    fn test_shape_perimeters() {
         let mut poly = Polygon::new();
         poly.add_point(Point::new(12, 13));
         poly.add_point(Point::new(17, 11));
@@ -213,12 +213,12 @@ mod tests {
             Shape::from(poly),
             Shape::from(Circle::new(Point::new(10, 20), 5)),
         ];
-        let circumferences = shapes
+        let perimeters = shapes
             .iter()
-            .map(Shape::circumference)
+            .map(Shape::perimeter)
             .map(round_two_digits)
             .collect::<Vec<_>>();
-        assert_eq!(circumferences, vec![15.48, 31.42]);
+        assert_eq!(perimeters, vec![15.48, 31.42]);
     }
 }
 // ANCHOR_END: unit-tests

--- a/src/exercises/day-2/points-polygons.rs
+++ b/src/exercises/day-2/points-polygons.rs
@@ -142,7 +142,7 @@ impl From<Circle> for Shape {
 }
 
 impl Shape {
-    pub fn circumference(&self) -> f64 {
+    pub fn perimeter(&self) -> f64 {
         match self {
             Shape::Polygon(poly) => poly.length(),
             Shape::Circle(circle) => circle.circumference(),


### PR DESCRIPTION
Closes #280 