### PR TITLE
Move GA code directly into main template

### DIFF
--- a/ga4.js
+++ b/ga4.js
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Setup cookie consent banner.
-var consent = document.createElement('script');
-consent.setAttribute('data-autoload-cookie-consent-bar', 'true');
-consent.setAttribute('src', 'https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js');
-document.head.appendChild(consent);
-
-// Load and configure Google Analytics.
-var ga4 = document.createElement('script');
-ga4.setAttribute('src', 'https://www.googletagmanager.com/gtag/js?id=G-ZN78TEJMRW');
-document.head.appendChild(ga4);
-
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', 'G-ZN78TEJMRW');
-
 // Look through all Playgrounds on the page to determine if the code snippet
 // matches one of the. If the code is different from all Playgrounds, we
 // conclude that the user modified the Playground before submitting it.

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -11,6 +11,16 @@
         <base href="{{ base_url }}">
         {{/if}}
 
+        <script async src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js"
+                data-autoload-cookie-consent-bar="true"></script>
+
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZN78TEJMRW"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-ZN78TEJMRW');
+        </script>
 
         <!-- Custom HTML head -->
         {{> head}}


### PR DESCRIPTION
This replaces a bit of code with the equivalent HTML code.

We also load the script async, which means that the browser won’t block rendering while waiting for the scripts.