### PR TITLE
Automatically build and test all translations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,13 +78,31 @@ jobs:
       - name: Compare no translation to no-op translation
         run: diff -r expanded no-op
 
+  find-translations:
+    runs-on: ubuntu-latest
+    outputs:
+      languages: ${{ steps.find-translations.outputs.languages }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Find translations
+        id: find-translations
+        shell: python
+        run: |
+          import os, json, pathlib
+          languages = [p.stem for p in pathlib.Path("po").iterdir() if p.suffix == ".po"]
+          github_output = open(os.environ["GITHUB_OUTPUT"], "a")
+          github_output.write("languages=")
+          json.dump(sorted(languages), github_output)
+
   translations:
     runs-on: ubuntu-latest
+    needs:
+      - find-translations
     strategy:
       matrix:
-        language:
-          - da
-          - ko
+        language: ${{ fromJSON(needs.find-translations.outputs.languages) }}
     env:
       MDBOOK_BOOK__LANGUAGE: ${{ matrix.language }}
       MDBOOK_PREPROCESSOR__GETTEXT__PO_FILE: po/${{ matrix.language }}.po


### PR DESCRIPTION
This changes the build workflow to first list all available `.po` files, and then use this information to start parallel jobs which test each translation.