### PR TITLE
Take out unnecessary watch dir

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -111,6 +111,5 @@ we'll tell `mdbook` to watch the `po/` directory for changes:
 ```shell
 $ MDBOOK_BOOK__LANGUAGE=xx \
   MDBOOK_PREPROCESSOR__GETTEXT__PO_FILE=po/xx.po \
-  MDBOOK_BUILD__EXTRA_WATCH_DIRS='["po"]' \
   mdbook serve -d book/xx
 ```


### PR DESCRIPTION
The directory is already mentioned in our `book.toml`.