### PR TITLE
Fix JetBrains capitalization

### DIFF
--- a/po/da.po
+++ b/po/da.po
@@ -1161,10 +1161,10 @@ msgstr ""
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [Jetbrains][4] family of IDEs, which do "
+"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
 "their own analysis but have their own tradeoffs. If you prefer them, you can "
 "install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the Jetbrains IDEA suite."
+"debugging only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
 
 #: src/cargo.md:31

--- a/po/da.po
+++ b/po/da.po
@@ -1161,10 +1161,10 @@ msgstr ""
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
+"Some folks also like to use the [Jetbrains][4] family of IDEs, which do "
 "their own analysis but have their own tradeoffs. If you prefer them, you can "
 "install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"debugging only works on the CLion version of the Jetbrains IDEA suite."
 msgstr ""
 
 #: src/cargo.md:31

--- a/src/cargo.md
+++ b/src/cargo.md
@@ -26,7 +26,7 @@ $ sudo apt install cargo rust-src
 This will allow [rust-analyzer][1] to jump to the definitions. We suggest using
 [VS Code][2] to edit the code (but any LSP compatible editor works).
 
-Some folks also like to use the [Jetbrains][4] family of IDEs, which do their own analysis but have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take note that as of January 2023 debugging only works on the CLion version of the Jetbrains IDEA suite.
+Some folks also like to use the [JetBrains][4] family of IDEs, which do their own analysis but have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take note that as of January 2023 debugging only works on the CLion version of the JetBrains IDEA suite.
 
 [1]: https://rust-analyzer.github.io/
 [2]: https://code.visualstudio.com/


### PR DESCRIPTION
Minor capitalization fix: `Jetbrains` -> `JetBrains`