### PR TITLE
Simplify error handling pages

### DIFF
--- a/src/error-handling/converting-error-types.md
+++ b/src/error-handling/converting-error-types.md
@@ -20,9 +20,8 @@ type returned by the function:
 
 ```rust,editable
 use std::error::Error;
-use std::{fs, io};
+use std::{fs, fmt, io};
 use std::io::Read;
-use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug)]
 enum ReadUsernameError {
@@ -32,11 +31,11 @@ enum ReadUsernameError {
 
 impl Error for ReadUsernameError {}
 
-impl Display for ReadUsernameError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+impl fmt::Display for ReadUsernameError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::IoError(e) => write!(f, "IO error: {}", e),
-            Self::EmptyUsername(filename) => write!(f, "Found no username in {}", filename),
+            Self::IoError(err) => write!(f, "IO error: {err}"),
+            Self::EmptyUsername(path) => write!(f, "No username in {path}"),
         }
     }
 }
@@ -48,7 +47,7 @@ impl From<io::Error> for ReadUsernameError {
 }
 
 fn read_username(path: &str) -> Result<String, ReadUsernameError> {
-    let mut username = String::with_capacity(100);
+    let mut username = String::new();
     fs::File::open(path)?.read_to_string(&mut username)?;
     if username.is_empty() {
         return Err(ReadUsernameError::EmptyUsername(String::from(path)));

--- a/src/error-handling/deriving-error-enums.md
+++ b/src/error-handling/deriving-error-enums.md
@@ -17,7 +17,7 @@ enum ReadUsernameError {
 }
 
 fn read_username(path: &str) -> Result<String, ReadUsernameError> {
-    let mut username = String::with_capacity(100);
+    let mut username = String::new();
     fs::File::open(path)?.read_to_string(&mut username)?;
     if username.is_empty() {
         return Err(ReadUsernameError::EmptyUsername(String::from(path)));

--- a/src/error-handling/dynamic-errors.md
+++ b/src/error-handling/dynamic-errors.md
@@ -4,7 +4,7 @@ Sometimes we want to allow any type of error to be returned without writing our 
 all the different possibilities. `std::error::Error` makes this easy.
 
 ```rust,editable,compile_fail
-use std::fs::{self, File};
+use std::fs;
 use std::io::Read;
 use thiserror::Error;
 use std::error::Error;
@@ -14,8 +14,8 @@ use std::error::Error;
 struct EmptyUsernameError(String);
 
 fn read_username(path: &str) -> Result<String, Box<dyn Error>> {
-    let mut username = String::with_capacity(100);
-    File::open(path)?.read_to_string(&mut username)?;
+    let mut username = String::new();
+    fs::File::open(path)?.read_to_string(&mut username)?;
     if username.is_empty() {
         return Err(EmptyUsernameError(String::from(path)).into());
     }

--- a/src/error-handling/error-contexts.md
+++ b/src/error-handling/error-contexts.md
@@ -10,11 +10,9 @@ use std::io::Read;
 use anyhow::{Context, Result, bail};
 
 fn read_username(path: &str) -> Result<String> {
-    let mut username = String::with_capacity(100);
-    fs::File::open(path)
-        .context(format!("Failed to open {path}"))?
-        .read_to_string(&mut username)
-        .context("Failed to read")?;
+    let mut username = String::new();
+    fs::File::open(path).context(format!("Failed to open {path}"))?
+        .read_to_string(&mut username).context("Failed to read")?;
     if username.is_empty() {
         bail!("Found no username in {path}");
     }

--- a/src/error-handling/result.md
+++ b/src/error-handling/result.md
@@ -3,12 +3,12 @@
 We have already seen the `Result` enum. This is used pervasively when errors are
 expected as part of normal operation:
 
-```rust
-use std::fs::File;
+```rust,editable
+use std::fs;
 use std::io::Read;
 
 fn main() {
-    let file = File::open("diary.txt");
+    let file = fs::File::open("diary.txt");
     match file {
         Ok(mut file) => {
             let mut contents = String::new();

--- a/src/error-handling/try-operator.md
+++ b/src/error-handling/try-operator.md
@@ -19,22 +19,22 @@ some_expression?
 We can use this to simplify our error handing code:
 
 ```rust,editable
-use std::fs;
-use std::io::{self, Read};
+use std::{fs, io};
+use std::io::Read;
 
 fn read_username(path: &str) -> Result<String, io::Error> {
     let username_file_result = fs::File::open(path);
 
     let mut username_file = match username_file_result {
         Ok(file) => file,
-        Err(e) => return Err(e),
+        Err(err) => return Err(err),
     };
 
     let mut username = String::new();
 
     match username_file.read_to_string(&mut username) {
         Ok(_) => Ok(username),
-        Err(e) => Err(e),
+        Err(err) => Err(err),
     }
 }
 


### PR DESCRIPTION
This makes the `use` statements more consistent and shortens some variable names. When teaching the class last week, I noticed that the pages were too large to fit on the screen, so I hope this helps a tiny bit with this.