### PR TITLE
Simplify `Vec` slide

### DIFF
--- a/src/std/vec.md
+++ b/src/std/vec.md
@@ -12,9 +12,6 @@ fn main() {
     v2.extend(v1.iter());
     v2.push(9999);
     println!("v2: len = {}, capacity = {}", v2.len(), v2.capacity());
-    
-    let mut numbers = vec![1, 2, 3];
-    numbers.push(42);
 }
 ```
 


### PR DESCRIPTION
The code is probably meant to illustrate the `vec!` macro, but it feels out of place when teaching: there is already enough material here to get through.