### PR TITLE
Inline variables printed with `println!` and friends

### DIFF
--- a/src/concurrency/channels/bounded.md
+++ b/src/concurrency/channels/bounded.md
@@ -21,7 +21,7 @@ fn main() {
     thread::sleep(Duration::from_millis(100));
 
     for msg in rx.iter() {
-        println!("Main: got {}", msg);
+        println!("Main: got {msg}");
     }
 }
 ```

--- a/src/exercises/day-3/simple-gui.rs
+++ b/src/exercises/day-3/simple-gui.rs
@@ -24,7 +24,7 @@ pub trait Widget {
     fn draw(&self) {
         let mut buffer = String::new();
         self.draw_into(&mut buffer);
-        println!("{}", &buffer);
+        println!("{buffer}");
     }
 }
 

--- a/src/exercises/day-4/dining-philosophers.rs
+++ b/src/exercises/day-4/dining-philosophers.rs
@@ -90,6 +90,6 @@ fn main() {
 
     drop(tx);
     for thought in rx {
-        println!("{}", thought);
+        println!("{thought}");
     }
 }

--- a/src/generics/trait-objects.md
+++ b/src/generics/trait-objects.md
@@ -6,7 +6,7 @@ We've seen how a function can take arguments which implement a trait:
 use std::fmt::Display;
 
 fn print<T: Display>(x: T) {
-    println!("Your value: {}", x);
+    println!("Your value: {x}");
 }
 
 fn main() {

--- a/src/pattern-matching/destructuring-enums.md
+++ b/src/pattern-matching/destructuring-enums.md
@@ -13,7 +13,7 @@ fn divide_in_two(n: i32) -> Result {
     if n % 2 == 0 {
         Result::Ok(n / 2)
     } else {
-        Result::Err(format!("cannot divide {} into two equal parts", n))
+        Result::Err(format!("cannot divide {n} into two equal parts"))
     }
 }
 

--- a/src/unsafe/mutable-static-variables.md
+++ b/src/unsafe/mutable-static-variables.md
@@ -6,7 +6,7 @@ It is safe to read an immutable static variable:
 static HELLO_WORLD: &str = "Hello, world!";
 
 fn main() {
-    println!("HELLO_WORLD: {}", HELLO_WORLD);
+    println!("HELLO_WORLD: {HELLO_WORLD}");
 }
 ```
 
@@ -23,7 +23,7 @@ fn add_to_counter(inc: u32) {
 fn main() {
     add_to_counter(42);
 
-    unsafe { println!("COUNTER: {}", COUNTER); }  // Potential data race!
+    unsafe { println!("COUNTER: {COUNTER}"); }  // Potential data race!
 }
 ```
 


### PR DESCRIPTION
The course follows the style of inlining variable names where possible in `println!` statements.