### PR TITLE
Remove dangling links in cargo/rust-ecosystem.md.

### DIFF
--- a/src/cargo/rust-ecosystem.md
+++ b/src/cargo/rust-ecosystem.md
@@ -3,12 +3,12 @@
 The Rust ecosystem consists of a number of tools, of which the main ones are:
 
 * `rustc`: the Rust compiler which turns `.rs` files into binaries and other
-  intermediate formats[^rustc].
+  intermediate formats.
 
 * `cargo`: the Rust dependency manager and build tool. Cargo knows how to
   download dependencies hosted on <https://crates.io> and it will pass them to
   `rustc` when building your project. Cargo also comes with a built-in test
-  runner which is used to execute unit tests[^cargo].
+  runner which is used to execute unit tests.
 
 * `rustup`: the Rust toolchain installer and updater. This tool is used to
   install and update `rustc` and `cargo` when new versions of Rust is released.


### PR DESCRIPTION
I'm not sure whether they should point to any relevant content, but these footnotes are currently undefined.