### PR TITLE
Add a solution for day 1's bonus question with generics.

### DIFF
--- a/src/exercises/day-1/solutions-morning.md
+++ b/src/exercises/day-1/solutions-morning.md
@@ -9,8 +9,39 @@
 ```
 ### Bonus question
 
-It honestly doesn't work so well. It might seem that we could use a slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make our function handle any size of matrix. However, this quickly breaks down: the return type cannot be `&[&[i32]]` since it needs to own the data you return.
+It requires more advanced concepts. It might seem that we could use a slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make our function handle any size of matrix. However, this quickly breaks down: the return type cannot be `&[&[i32]]` since it needs to own the data you return.
 
-You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work very well either: it's hard to convert from `Vec<Vec<i32>>` to `&[&[i32]]` so now you cannot easily use `pretty_print` either.
+You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to `&[&[i32]]` so now you cannot easily use `pretty_print` either.
+
+Once we get to traits and generics, we'll be able to use the [`std::convert::AsRef`][1] trait to abstract over anything that can be referenced as a slice.
+
+```rust
+use std::convert::AsRef;
+use std::fmt::Debug;
+
+fn pretty_print<T, Line, Matrix>(matrix: Matrix)
+where
+    T: Debug,
+    // A line references a slice of items
+    Line: AsRef<[T]>,
+    // A matrix references a slice of lines
+    Matrix: AsRef<[Line]>
+{
+    for row in matrix.as_ref() {
+        println!("{:?}", row.as_ref());
+    }
+}
+
+fn main() {
+    // &[&[i32]]
+    pretty_print(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);
+    // [[&str; 2]; 2]
+    pretty_print([["a", "b"], ["c", "d"]]);
+    // Vec<Vec<i32>>
+    pretty_print(vec![vec![1, 2], vec![3, 4]]);
+}
+```
 
 In addition, the type itself would not enforce that the child slices are of the same length, so such variable could contain an invalid matrix.
+
+[1]: https://doc.rust-lang.org/std/convert/trait.AsRef.html


### PR DESCRIPTION
The current solution mentions that it doesn't work so well. It's not quite true as one can use more advanced concepts such as the [AsRef](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to generalize over an owned vs. borrowed slice.

It's probably too early to introduce all of these concepts in the class, but I think the solution should mention that it's possible to do. In the end, showing this advanced solution or not is a matter of balancing between giving the following impressions to the students:

1. "Rust is complicated", by showing advanced syntax with generics and trait bounds before they are explained in the course,
2. "Rust is not powerful enough", by (incorrectly) stating that it's not possible to generalize between `&[&[i32]]` and `Vec<Vec<i32>>`.

IMO, generics are a cornerstone of the Rust language, so we shouldn't leave a false impression about 2. And given that we are in the "bonus" section, it's fine to mention some advanced concepts that will be covered later in the course.