### PR TITLE
Add Brazilian Portuguese translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,0 +1,20567 @@
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Comprehensive Rust 🦀\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-02-01 11:03+0100\n"
+"Last-Translator: Martin Geisler <mgeisler@google.com>\n"
+"Language-Team: Brazilian Portuguese "
+"<ldpbr-translation@lists.sourceforge.net>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: src/SUMMARY.md:3
+#, fuzzy
+msgid "Welcome to Comprehensive Rust 🦀"
+msgstr "Bem-vindo ao Comprehensive Rust 🦀"
+
+#: src/SUMMARY.md:4
+#, fuzzy
+msgid "Running the Course"
+msgstr "Executando o Curso"
+
+#: src/SUMMARY.md:5
+#, fuzzy
+msgid "Course Structure"
+msgstr "Estrutura do curso"
+
+#: src/SUMMARY.md:6
+#, fuzzy
+msgid "Keyboard Shortcuts"
+msgstr "Atalhos do teclado"
+
+#: src/SUMMARY.md:7
+#, fuzzy
+msgid "Using Cargo"
+msgstr "Usando Cargo"
+
+#: src/SUMMARY.md:8
+#, fuzzy
+msgid "Rust Ecosystem"
+msgstr "Ecossistema de rust"
+
+#: src/SUMMARY.md:9
+#, fuzzy
+msgid "Code Samples"
+msgstr "Amostras de código"
+
+#: src/SUMMARY.md:10
+#, fuzzy
+msgid "Running Cargo Locally"
+msgstr "Executando Cargo Localmente"
+
+#: src/SUMMARY.md:13
+#, fuzzy
+msgid "Day 1: Morning"
+msgstr "Dia 1: Manhã"
+
+#: src/SUMMARY.md:17 src/SUMMARY.md:73 src/SUMMARY.md:126 src/SUMMARY.md:180
+#, fuzzy
+msgid "Welcome"
+msgstr "Bem-vindo"
+
+#: src/SUMMARY.md:18
+#, fuzzy
+msgid "What is Rust?"
+msgstr "O que é Rust?"
+
+#: src/SUMMARY.md:19
+#, fuzzy
+msgid "Hello World!"
+msgstr "Olá Mundo!"
+
+#: src/SUMMARY.md:20
+#, fuzzy
+msgid "Small Example"
+msgstr "Pequeno Exemplo"
+
+#: src/SUMMARY.md:21
+#, fuzzy
+msgid "Why Rust?"
+msgstr "Por que Rust?"
+
+#: src/SUMMARY.md:22
+#, fuzzy
+msgid "Compile Time Guarantees"
+msgstr "Garantias em tempo de compilação"
+
+#: src/SUMMARY.md:23
+#, fuzzy
+msgid "Runtime Guarantees"
+msgstr "Garantias de tempo de execução"
+
+#: src/SUMMARY.md:24
+#, fuzzy
+msgid "Modern Features"
+msgstr "Recursos modernos"
+
+#: src/SUMMARY.md:25
+#, fuzzy
+msgid "Basic Syntax"
+msgstr "Sintaxe Básica"
+
+#: src/SUMMARY.md:26
+#, fuzzy
+msgid "Scalar Types"
+msgstr "Tipos escalares"
+
+#: src/SUMMARY.md:27
+#, fuzzy
+msgid "Compound Types"
+msgstr "Tipos de compostos"
+
+#: src/SUMMARY.md:28
+#, fuzzy
+msgid "References"
+msgstr "Referências"
+
+#: src/SUMMARY.md:29
+#, fuzzy
+msgid "Dangling References"
+msgstr "Referências pendentes"
+
+#: src/SUMMARY.md:30
+#, fuzzy
+msgid "Slices"
+msgstr "Slices"
+
+#: src/SUMMARY.md:31
+#, fuzzy
+msgid "String vs str"
+msgstr "String vs str"
+
+#: src/SUMMARY.md:32
+#, fuzzy
+msgid "Functions"
+msgstr "Funções"
+
+#: src/SUMMARY.md:33 src/SUMMARY.md:80
+#, fuzzy
+msgid "Methods"
+msgstr "Métodos"
+
+#: src/SUMMARY.md:34
+#, fuzzy
+msgid "Overloading"
+msgstr "Sobrecargo"
+
+#: src/SUMMARY.md:35 src/SUMMARY.md:64 src/SUMMARY.md:88 src/SUMMARY.md:117
+#: src/SUMMARY.md:145 src/SUMMARY.md:172 src/SUMMARY.md:195 src/SUMMARY.md:222
+#, fuzzy
+msgid "Exercises"
+msgstr "Exercícios"
+
+#: src/SUMMARY.md:36
+#, fuzzy
+msgid "Implicit Conversions"
+msgstr "Conversões implícitas"
+
+#: src/SUMMARY.md:37
+#, fuzzy
+msgid "Arrays and for Loops"
+msgstr "Arrays e for Loops"
+
+#: src/SUMMARY.md:39
+#, fuzzy
+msgid "Day 1: Afternoon"
+msgstr "Dia 1: Tarde"
+
+#: src/SUMMARY.md:41
+#, fuzzy
+msgid "Variables"
+msgstr "Variáveis"
+
+#: src/SUMMARY.md:42
+#, fuzzy
+msgid "Type Inference"
+msgstr "Inferência de tipo"
+
+#: src/SUMMARY.md:43
+#, fuzzy
+msgid "static & const"
+msgstr "static & const"
+
+#: src/SUMMARY.md:44
+#, fuzzy
+msgid "Scopes and Shadowing"
+msgstr "Escopos e Sombra"
+
+#: src/SUMMARY.md:45
+#, fuzzy
+msgid "Memory Management"
+msgstr "Gerenciamento de memória"
+
+****TODO check vocab****
+#: src/SUMMARY.md:46
+#, fuzzy
+msgid "Stack vs Heap"
+msgstr "Pilha vs Heap"
+
+#: src/SUMMARY.md:47
+#, fuzzy
+msgid "Stack Memory"
+msgstr "Memória de Pilha"
+
+#: src/SUMMARY.md:48
+#, fuzzy
+msgid "Manual Memory Management"
+msgstr "Gerenciamento Manual de Memória"
+
+#: src/SUMMARY.md:49
+#, fuzzy
+msgid "Scope-Based Memory Management"
+msgstr "Gerenciamento de memória baseado em escopo"
+
+#: src/SUMMARY.md:50
+#, fuzzy
+msgid "Garbage Collection"
+msgstr "Garbage Collection (Coleta de lixo)"
+
+#: src/SUMMARY.md:51
+#, fuzzy
+msgid "Rust Memory Management"
+msgstr "Gerenciamento de Memória Rust"
+
+#: src/SUMMARY.md:52
+#, fuzzy
+msgid "Comparison"
+msgstr "Comparação"
+
+#: src/SUMMARY.md:53
+#, fuzzy
+msgid "Ownership"
+msgstr "Ownership"
+
+#: src/SUMMARY.md:54
+#, fuzzy
+msgid "Move Semantics"
+msgstr "Mover semântica"
+
+#: src/SUMMARY.md:55
+#, fuzzy
+msgid "Moved Strings in Rust"
+msgstr "Strings movidas em Rust"
+
+#: src/SUMMARY.md:56
+#, fuzzy
+msgid "Double Frees in Modern C++"
+msgstr "Liberações duplas em C++ moderno"
+
+#: src/SUMMARY.md:57
+#, fuzzy
+msgid "Moves in Function Calls"
+msgstr "Movimentos em Chamadas de Função"
+
+#: src/SUMMARY.md:58
+#, fuzzy
+msgid "Copying and Cloning"
+msgstr "Copiar e clonar"
+
+#: src/SUMMARY.md:59
+#, fuzzy
+msgid "Borrowing"
+msgstr "Empréstimo"
+
+#: src/SUMMARY.md:60
+#, fuzzy
+msgid "Shared and Unique Borrows"
+msgstr "Empréstimos Compartilhados e Únicos"
+
+****TODO check vocab. vidas?****
+#: src/SUMMARY.md:61
+#, fuzzy
+msgid "Lifetimes"
+msgstr "Tempos de vida (Lifetimes)"
+
+****TODO check vocab****
+#: src/SUMMARY.md:62
+#, fuzzy
+msgid "Lifetimes in Function Calls"
+msgstr "Tempos de vida (Lifetimes) em chamadas de função"
+
+****TODO check vocab****
+#: src/SUMMARY.md:63
+#, fuzzy
+msgid "Lifetimes in Data Structures"
+msgstr "Tempos de vida em estruturas de dados"
+
+#: src/SUMMARY.md:65
+#, fuzzy
+msgid "Designing a Library"
+msgstr "Projetando uma biblioteca"
+
+#: src/SUMMARY.md:66
+#, fuzzy
+msgid "Iterators and Ownership"
+msgstr "Iteradores e Ownership"
+
+#: src/SUMMARY.md:69
+#, fuzzy
+msgid "Day 2: Morning"
+msgstr "Dia 2: Manhã"
+
+#: src/SUMMARY.md:74
+#, fuzzy
+msgid "Structs"
+msgstr "Structs"
+
+#: src/SUMMARY.md:75
+#, fuzzy
+msgid "Tuple Structs"
+msgstr "Structs Tuplas"
+
+#: src/SUMMARY.md:76
+#, fuzzy
+msgid "Field Shorthand Syntax"
+msgstr "Sintaxe abreviada de campos"
+
+#: src/SUMMARY.md:77
+#, fuzzy
+msgid "Enums"
+msgstr "Enums"
+
+#: src/SUMMARY.md:78
+#, fuzzy
+msgid "Variant Payloads"
+msgstr "Cargos úteis variantes"
+
+#: src/SUMMARY.md:79
+#, fuzzy
+msgid "Enum Sizes"
+msgstr "Tamanhos de Enum"
+
+#: src/SUMMARY.md:81
+#, fuzzy
+msgid "Method Receiver"
+msgstr "Receptor do método"
+
+#: src/SUMMARY.md:82 src/SUMMARY.md:190
+#, fuzzy
+msgid "Example"
+msgstr "Exemplo"
+
+#: src/SUMMARY.md:83
+#, fuzzy
+msgid "Pattern Matching"
+msgstr "Correspondência de padrões"
+
+#: src/SUMMARY.md:84
+#, fuzzy
+msgid "Destructuring Enums"
+msgstr "Desestruturando Enums"
+
+#: src/SUMMARY.md:85
+#, fuzzy
+msgid "Destructuring Structs"
+msgstr "Structs Destruidoras"
+
+#: src/SUMMARY.md:86
+#, fuzzy
+msgid "Destructuring Arrays"
+msgstr "Desestruturando Arrays"
+
+#: src/SUMMARY.md:87
+#, fuzzy
+msgid "Match Guards"
+msgstr "Guardas de Match"
+
+#: src/SUMMARY.md:89
+#, fuzzy
+msgid "Health Statistics"
+msgstr "Estatísticas de saúde"
+
+#: src/SUMMARY.md:90
+#, fuzzy
+msgid "Points and Polygons"
+msgstr "Points e polígonos"
+
+#: src/SUMMARY.md:92
+#, fuzzy
+msgid "Day 2: Afternoon"
+msgstr "Dia 2: Tarde"
+
+#: src/SUMMARY.md:94
+#, fuzzy
+msgid "Control Flow"
+msgstr "Controle de fluxo"
+
+#: src/SUMMARY.md:95
+#, fuzzy
+msgid "Blocks"
+msgstr "Blocos"
+
+#: src/SUMMARY.md:96
+#, fuzzy
+msgid "if expressions"
+msgstr "if expressões"
+
+#: src/SUMMARY.md:97
+#, fuzzy
+msgid "if let expressions"
+msgstr "if let expressões"
+
+#: src/SUMMARY.md:98
+#, fuzzy
+msgid "while expressions"
+msgstr "enquanto expressões"
+
+#: src/SUMMARY.md:99
+#, fuzzy
+msgid "while let expressions"
+msgstr "while let expressões"
+
+#: src/SUMMARY.md:100
+#, fuzzy
+msgid "for expressions"
+msgstr "for expressões"
+
+#: src/SUMMARY.md:101
+#, fuzzy
+msgid "loop expressions"
+msgstr "expressões de loop"
+
+#: src/SUMMARY.md:102
+#, fuzzy
+msgid "match expressions"
+msgstr "expressões de match"
+
+#: src/SUMMARY.md:103
+#, fuzzy
+msgid "break & continue"
+msgstr "break e continue"
+
+#: src/SUMMARY.md:104
+#, fuzzy
+msgid "Standard Library"
+msgstr "Biblioteca padrão"
+
+#: src/SUMMARY.md:105
+#, fuzzy
+msgid "Option and Result"
+msgstr "Option e Result"
+
+#: src/SUMMARY.md:106
+#, fuzzy
+msgid "String"
+msgstr "String"
+
+#: src/SUMMARY.md:107
+#, fuzzy
+msgid "Vec"
+msgstr "Vec"
+
+#: src/SUMMARY.md:108
+#, fuzzy
+msgid "HashMap"
+msgstr "HashMap"
+
+#: src/SUMMARY.md:109
+#, fuzzy
+msgid "Box"
+msgstr "Box"
+
+#: src/SUMMARY.md:110
+#, fuzzy
+msgid "Recursive Data Types"
+msgstr "Tipos de dados recursivos"
+
+#: src/SUMMARY.md:111
+#, fuzzy
+msgid "Niche Optimization"
+msgstr "Otimização de Nicho"
+
+#: src/SUMMARY.md:112
+#, fuzzy
+msgid "Rc"
+msgstr "Rc"
+
+#: src/SUMMARY.md:113
+#, fuzzy
+msgid "Modules"
+msgstr "Módulos"
+
+#: src/SUMMARY.md:114
+#, fuzzy
+msgid "Visibility"
+msgstr "Visibilage"
+
+#: src/SUMMARY.md:115
+#, fuzzy
+msgid "Paths"
+msgstr "Caminhos"
+
+#: src/SUMMARY.md:116
+#, fuzzy
+msgid "Filesystem Hierarchy"
+msgstr "Hierarquia do sistema de arquivos"
+
+#: src/SUMMARY.md:118
+#, fuzzy
+msgid "Luhn Algorithm"
+msgstr "Algoritmo de LuhnName"
+
+#: src/SUMMARY.md:119
+#, fuzzy
+msgid "Strings and Iterators"
+msgstr "Strings e iteradores"
+
+#: src/SUMMARY.md:122
+#, fuzzy
+msgid "Day 3: Morning"
+msgstr "Dia 3: Manhã"
+
+#: src/SUMMARY.md:127
+#, fuzzy
+msgid "Traits"
+msgstr "Traits"
+
+#: src/SUMMARY.md:128
+#, fuzzy
+msgid "Deriving Traits"
+msgstr "Traits derivados"
+
+#: src/SUMMARY.md:129
+#, fuzzy
+msgid "Default Methods"
+msgstr "Métodos padrão"
+
+#: src/SUMMARY.md:130
+#, fuzzy
+msgid "Important Traits"
+msgstr "Traits importantes"
+
+#: src/SUMMARY.md:131
+#, fuzzy
+msgid "Iterator"
+msgstr "Iterator"
+
+#: src/SUMMARY.md:132
+#, fuzzy
+msgid "FromIterator"
+msgstr "FromIterator"
+
+#: src/SUMMARY.md:133
+#, fuzzy
+msgid "From and Into"
+msgstr "From e Into"
+
+#: src/SUMMARY.md:134
+#, fuzzy
+msgid "Read and Write"
+msgstr "Read e Write"
+
+#: src/SUMMARY.md:135
+#, fuzzy
+msgid "Add, Mul, ..."
+msgstr "Add, Mul, ..."
+
+#: src/SUMMARY.md:136
+#, fuzzy
+msgid "Drop"
+msgstr "Drop"
+
+#: src/SUMMARY.md:137
+#, fuzzy
+msgid "Generics"
+msgstr "Genéricos"
+
+#: src/SUMMARY.md:138
+#, fuzzy
+msgid "Generic Data Types"
+msgstr "Tipos de dados genéricos"
+
+#: src/SUMMARY.md:139
+#, fuzzy
+msgid "Generic Methods"
+msgstr "Métodos Genéricos"
+
+#: src/SUMMARY.md:140
+#, fuzzy
+msgid "Trait Bounds"
+msgstr "Limites de trait"
+
+#: src/SUMMARY.md:141
+#, fuzzy
+msgid "impl Trait"
+msgstr "impl Trait"
+
+#: src/SUMMARY.md:142
+#, fuzzy
+msgid "Closures"
+msgstr "fechamentos"
+
+#: src/SUMMARY.md:143
+#, fuzzy
+msgid "Monomorphization"
+msgstr "Monomorfização"
+
+#: src/SUMMARY.md:144
+#, fuzzy
+msgid "Trait Objects"
+msgstr "Objetos de Trait"
+
+#: src/SUMMARY.md:146
+#, fuzzy
+msgid "A Simple GUI Library"
+msgstr "Uma biblioteca GUI simples"
+
+#: src/SUMMARY.md:148
+#, fuzzy
+msgid "Day 3: Afternoon"
+msgstr "Dia 3: Tarde"
+
+#: src/SUMMARY.md:150
+#, fuzzy
+msgid "Error Handling"
+msgstr "Manipulação de erros"
+
+#: src/SUMMARY.md:151
+#, fuzzy
+msgid "Panics"
+msgstr "Pânico"
+
+#: src/SUMMARY.md:152
+#, fuzzy
+msgid "Catching Stack Unwinding"
+msgstr "Capturando pilha desenrolando"
+
+#: src/SUMMARY.md:153
+#, fuzzy
+msgid "Structured Error Handling"
+msgstr "Tratamento de Erros Estruturado"
+
+#: src/SUMMARY.md:154
+#, fuzzy
+msgid "Propagating Errors with ?"
+msgstr "Propagando erros com ?"
+
+#: src/SUMMARY.md:155
+#, fuzzy
+msgid "Converting Error Types"
+msgstr "Convertendo Tipos de Erro"
+
+#: src/SUMMARY.md:156
+#, fuzzy
+msgid "Deriving Error Enums"
+msgstr "Derivando Enums de erro"
+
+#: src/SUMMARY.md:157
+#, fuzzy
+msgid "Dynamic Error Types"
+msgstr "Tipos de erros dinâmicos"
+
+#: src/SUMMARY.md:158
+#, fuzzy
+msgid "Adding Context to Errors"
+msgstr "Adicionando Contexto aos Erros"
+
+#: src/SUMMARY.md:159
+#, fuzzy
+msgid "Testing"
+msgstr "Testes"
+
+#: src/SUMMARY.md:160
+#, fuzzy
+msgid "Unit Tests"
+msgstr "Testes de unage"
+
+#: src/SUMMARY.md:161
+#, fuzzy
+msgid "Test Modules"
+msgstr "Módulos de teste"
+
+#: src/SUMMARY.md:162
+#, fuzzy
+msgid "Documentation Tests"
+msgstr "Testes de Documentação"
+
+#: src/SUMMARY.md:163
+#, fuzzy
+msgid "Integration Tests"
+msgstr "Testes de Integração"
+
+#: src/SUMMARY.md:164
+#, fuzzy
+msgid "Unsafe Rust"
+msgstr "Unsafe Rust"
+
+#: src/SUMMARY.md:165
+#, fuzzy
+msgid "Dereferencing Raw Pointers"
+msgstr "Desreferenciando ponteiros brutos"
+
+#: src/SUMMARY.md:166
+#, fuzzy
+msgid "Mutable Static Variables"
+msgstr "Variáveis estáticas mutáveis"
+
+#: src/SUMMARY.md:167
+#, fuzzy
+msgid "Unions"
+msgstr "Sindicatos"
+
+#: src/SUMMARY.md:168
+#, fuzzy
+msgid "Calling Unsafe Functions"
+msgstr "Chamando Funções Inseguras"
+
+#: src/SUMMARY.md:169
+#, fuzzy
+msgid "Writing Unsafe Functions"
+msgstr "Escrevendo Funções Inseguras"
+
+#: src/SUMMARY.md:170
+#, fuzzy
+msgid "Extern Functions"
+msgstr "Funções Externas"
+
+#: src/SUMMARY.md:171
+#, fuzzy
+msgid "Implementing Unsafe Traits"
+msgstr "Implementando Traits Inseguros"
+
+#: src/SUMMARY.md:173
+#, fuzzy
+msgid "Safe FFI Wrapper"
+msgstr "Invólucro FFI seguro"
+
+#: src/SUMMARY.md:176
+#, fuzzy
+msgid "Day 4: Morning"
+msgstr "Dia 4: Manhã"
+
+#: src/SUMMARY.md:181
+#, fuzzy
+msgid "Concurrency"
+msgstr "Simultaneage"
+
+#: src/SUMMARY.md:182
+#, fuzzy
+msgid "Threads"
+msgstr "Tópicos"
+
+#: src/SUMMARY.md:183
+#, fuzzy
+msgid "Scoped Threads"
+msgstr "Tópicos com Escopo"
+
+#: src/SUMMARY.md:184
+#, fuzzy
+msgid "Channels"
+msgstr "Channels"
+
+#: src/SUMMARY.md:185
+#, fuzzy
+msgid "Unbounded Channels"
+msgstr "Channels Ilimitados"
+
+#: src/SUMMARY.md:186
+#, fuzzy
+msgid "Bounded Channels"
+msgstr "Channels Delimitados"
+
+#: src/SUMMARY.md:187
+#, fuzzy
+msgid "Shared State"
+msgstr "Estado Compartilhado"
+
+#: src/SUMMARY.md:188
+#, fuzzy
+msgid "Arc"
+msgstr "Arc"
+
+#: src/SUMMARY.md:189
+#, fuzzy
+msgid "Mutex"
+msgstr "Mutex"
+
+#: src/SUMMARY.md:191
+#, fuzzy
+msgid "Send and Sync"
+msgstr "Send e Sync"
+
+#: src/SUMMARY.md:191
+#, fuzzy
+msgid "Send"
+msgstr "Send"
+
+#: src/SUMMARY.md:191
+#, fuzzy
+msgid "Sync"
+msgstr "Sync"
+
+#: src/SUMMARY.md:194
+#, fuzzy
+msgid "Examples"
+msgstr "Exemplos"
+
+#: src/SUMMARY.md:196
+#, fuzzy
+msgid "Dining Philosophers"
+msgstr "Jantar com filósofos"
+
+#: src/SUMMARY.md:197
+#, fuzzy
+msgid "Multi-threaded Link Checker"
+msgstr "Verificador de links multiencadeados"
+
+#: src/SUMMARY.md:199
+#, fuzzy
+msgid "Day 4: Afternoon"
+msgstr "Dia 4: Tarde"
+
+#: src/SUMMARY.md:203
+#, fuzzy
+msgid "Android"
+msgstr "Android"
+
+#: src/SUMMARY.md:204
+#, fuzzy
+msgid "Setup"
+msgstr "Configurar"
+
+#: src/SUMMARY.md:205
+#, fuzzy
+msgid "Build Rules"
+msgstr "Regras de construção"
+
+#: src/SUMMARY.md:206
+#, fuzzy
+msgid "Binary"
+msgstr "Binário"
+
+#: src/SUMMARY.md:207
+#, fuzzy
+msgid "Library"
+msgstr "Biblioteca"
+
+#: src/SUMMARY.md:208
+#, fuzzy
+msgid "AIDL"
+msgstr "AIDL"
+
+#: src/SUMMARY.md:209
+#, fuzzy
+msgid "Interface"
+msgstr "Interface"
+
+#: src/SUMMARY.md:210
+#, fuzzy
+msgid "Implementation"
+msgstr "Implementação"
+
+#: src/SUMMARY.md:211
+#, fuzzy
+msgid "Server"
+msgstr "Servidor"
+
+#: src/SUMMARY.md:212
+#, fuzzy
+msgid "Deploy"
+msgstr "Implantar"
+
+#: src/SUMMARY.md:213
+#, fuzzy
+msgid "Client"
+msgstr "Cliente"
+
+#: src/SUMMARY.md:214
+#, fuzzy
+msgid "Changing API"
+msgstr "Alterando API"
+
+#: src/SUMMARY.md:215
+#, fuzzy
+msgid "Logging"
+msgstr "Exploração madeireira"
+
+#: src/SUMMARY.md:216
+#, fuzzy
+msgid "Interoperability"
+msgstr "Interoperabilage"
+
+#: src/SUMMARY.md:217
+#, fuzzy
+msgid "With C"
+msgstr "Com C"
+
+#: src/SUMMARY.md:218
+#, fuzzy
+msgid "Calling C with Bindgen"
+msgstr "Chamando C com Bindgen"
+
+#: src/SUMMARY.md:219
+#, fuzzy
+msgid "Calling Rust from C"
+msgstr "Chamando Rust de C"
+
+#: src/SUMMARY.md:220
+#, fuzzy
+msgid "With C++"
+msgstr "Com C++"
+
+#: src/SUMMARY.md:221
+#, fuzzy
+msgid "With Java"
+msgstr "Com Java"
+
+#: src/SUMMARY.md:224
+#, fuzzy
+msgid "Final Words"
+msgstr "Palavras Finais"
+
+#: src/SUMMARY.md:226
+#, fuzzy
+msgid "Thanks!"
+msgstr "Obrigado!"
+
+#: src/SUMMARY.md:227
+#, fuzzy
+msgid "Other Resources"
+msgstr "Outros recursos"
+
+#: src/SUMMARY.md:228
+#, fuzzy
+msgid "Credits"
+msgstr "Créditos"
+
+#: src/SUMMARY.md:232
+#, fuzzy
+msgid "Solutions"
+msgstr "Soluções"
+
+#: src/SUMMARY.md:237
+#, fuzzy
+msgid "Day 1 Morning"
+msgstr "Dia 1 Manhã"
+
+#: src/SUMMARY.md:238
+#, fuzzy
+msgid "Day 1 Afternoon"
+msgstr "Dia 1 Tarde"
+
+#: src/SUMMARY.md:239
+#, fuzzy
+msgid "Day 2 Morning"
+msgstr "Dia 2 Manhã"
+
+#: src/SUMMARY.md:240
+#, fuzzy
+msgid "Day 2 Afternoon"
+msgstr "Dia 2 Tarde"
+
+#: src/SUMMARY.md:241
+#, fuzzy
+msgid "Day 3 Morning"
+msgstr "Dia 3 Manhã"
+
+#: src/SUMMARY.md:242
+#, fuzzy
+msgid "Day 3 Afternoon"
+msgstr "Dia 3 Tarde"
+
+#: src/SUMMARY.md:243
+#, fuzzy
+msgid "Day 4 Morning"
+msgstr "Dia 4 Manhã"
+
+#: src/welcome.md:1
+#, fuzzy
+msgid "# Welcome to Comprehensive Rust 🦀"
+msgstr "# Bem-vindo ao Comprehensive Rust 🦀"
+
+#: src/welcome.md:3
+#, fuzzy
+msgid ""
+"This is a four day Rust course developed by the Android team. The course "
+"covers\n"
+"the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics\n"
+"and error handling. It also includes Android-specific content on the last "
+"day."
+msgstr ""
+"Este é um curso de Rust de quatro dias desenvolvido pela equipe do Android. O "
+"curso abrange\n"
+"o espectro completo de Rust, desde a sintaxe básica até tópicos avançados "
+"como genéricos\n"
+"e tratamento de erros. Também inclui conteúdo específico para Android no "
+"último dia."
+
+#: src/welcome.md:7
+#, fuzzy
+msgid ""
+"The goal of the course is to teach you Rust. We assume you don't know "
+"anything\n"
+"about Rust and hope to:"
+msgstr ""
+"O objetivo do curso é ensinar Rust a você. Nós assumimos que você não sabe "
+"nada\n"
+"sobre Rust e esperamos:"
+
+#: src/welcome.md:10
+#, fuzzy
+msgid ""
+"* Give you a comprehensive understanding of the Rust syntax and language.\n"
+"* Enable you to modify existing programs and write new programs in Rust.\n"
+"* Show you common Rust idioms."
+msgstr ""
+"* Dar a você uma compreensão abrangente da sintaxe e linguagem de Rust.\n"
+"* Permite modificar programas existentes e escrever novos programas em "
+"Rust.\n"
+"* Mostrar expressões idiomáticas comuns de Rust."
+
+#: src/welcome.md:14
+#, fuzzy
+msgid "On Day 4, we will cover Android-specific things such as:"
+msgstr "No Dia 4, abordaremos assuntos específicos do Android, como:"
+
+#: src/welcome.md:16
+#, fuzzy
+msgid ""
+"* Building Android components in Rust.\n"
+"* AIDL servers and clients.\n"
+"* Interoperability with C, C++, and Java."
+msgstr ""
+"* Construindo componentes Android em Rust.\n"
+"* Servidores e clientes AIDL.\n"
+"* Interoperabilage com C, C++ e Java."
+
+#: src/welcome.md:20
+#, fuzzy
+msgid ""
+"It is important to note that this course does not cover Android "
+"**application** \n"
+"development in Rust, and that the Android-specific parts are specifically "
+"about\n"
+"writing code for Android itself, the operating system. "
+msgstr ""
+"É importante observar que este curso não cobre o **aplicativo** do Android\n"
+"desenvolvimento em Rust, e que as partes específicas do Android são "
+"especificamente sobre\n"
+"escrever código para o sistema operacional do Android."
+
+#: src/welcome.md:24
+#, fuzzy
+msgid "## Non-Goals"
+msgstr "## Fora do escopo"
+
+#: src/welcome.md:26
+#, fuzzy
+msgid ""
+"Rust is a large language and we won't be able to cover all of it in a few "
+"days.\n"
+"Some non-goals of this course are:"
+msgstr ""
+"Rust é uma linguagem extensa e não conseguiremos cobrir tudo em poucos "
+"dias.\n"
+"Alguns alguns assuntos que não são objetivos deste curso são:"
+
+#: src/welcome.md:29
+#, fuzzy
+msgid ""
+"* Learn how to use async Rust --- we'll only mention async Rust when\n"
+"  covering traditional concurrency primitives. Please see [Asynchronous\n"
+"  Programming in Rust](https://rust-lang.github.io/async-book/) instead for\n"
+"  details on this topic.\n"
+"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
+"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
+"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+msgstr ""
+"* Aprenda a usar o async Rust --- só mencionaremos o async Rust quando\n"
+"  cobrindo primitivas de simultaneage tradicionais. Consulte [Assíncrono\n"
+"  Programação em Rust](https://rust-lang.github.io/async-book/) em vez de\n"
+"  detalhes sobre este tema.\n"
+"* Aprenda a desenvolver macros, consulte [Capítulo 19.5 no Rust\n"
+"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) e [Rust by\n"
+"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) em vez "
+"disso."
+
+#: src/welcome.md:37
+#, fuzzy
+msgid "## Assumptions"
+msgstr "## Suposições"
+
+#: src/welcome.md:39
+#, fuzzy
+msgid ""
+"The course assumes that you already know how to program. Rust is a "
+"statically\n"
+"typed language and we will sometimes make comparisons with C and C++ to "
+"better\n"
+"explain or contrast the Rust approach."
+msgstr ""
+"O curso pressupõe que você já saiba programar. Rust é uma linguagem de tipagem estática\n"
+"e às vezes comparamos com C e C++ para melhor\n"
+"explicar ou contrastar a abordagem Rust."
+
+#: src/welcome.md:43
+#, fuzzy
+msgid ""
+"If you know how to program in a dynamically typed language such as Python "
+"or\n"
+"JavaScript, then you will be able to follow along just fine too."
+msgstr ""
+"Se você sabe programar em uma linguagem de tipagem dinâmica, como Python ou\n"
+"JavaScript, então você será capaz de acompanhar muito bem também."
+
+#: src/welcome.md:46 src/cargo/rust-ecosystem.md:19
+#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
+#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
+#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
+#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
+#: src/why-rust/modern.md:19 src/basic-syntax/compound-types.md:28
+#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
+#: src/basic-syntax/functions.md:33 src/basic-syntax/functions-interlude.md:25
+#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
+#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
+#: src/basic-syntax/static-and-const.md:46
+#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
+#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
+#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
+#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
+#: src/ownership/lifetimes-function-calls.md:27
+#: src/ownership/lifetimes-data-structures.md:23
+#: src/exercises/day-1/afternoon.md:9 src/structs/tuple-structs.md:35
+#: src/structs/field-shorthand.md:25 src/enums/variant-payloads.md:33
+#: src/methods.md:28 src/pattern-matching/destructuring-enums.md:33
+#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
+#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
+#: src/control-flow/if-expressions.md:29
+#: src/control-flow/if-let-expressions.md:19
+#: src/control-flow/while-let-expressions.md:25 src/std/option-result.md:16
+#: src/std/string.md:28 src/std/box.md:32 src/std/rc.md:26
+#: src/exercises/day-2/afternoon.md:5 src/traits.md:39
+#: src/traits/iterator.md:30 src/traits/from-iterator.md:12
+#: src/traits/operators.md:24 src/traits/drop.md:32 src/generics/methods.md:23
+#: src/generics/trait-bounds.md:20 src/generics/impl-trait.md:22
+#: src/generics/closures.md:23 src/exercises/day-3/morning.md:5
+#: src/error-handling/result.md:25 src/error-handling/try-operator.md:48
+#: src/error-handling/converting-error-types.md:66
+#: src/error-handling/deriving-error-enums.md:37
+#: src/error-handling/dynamic-errors.md:34
+#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
+#: src/unsafe/raw-pointers.md:24 src/unsafe/mutable-static-variables.md:30
+#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
+#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
+#: src/exercises/day-3/afternoon.md:5 src/concurrency/threads.md:28
+#: src/concurrency/channels.md:25 src/concurrency/shared_state/arc.md:27
+#: src/concurrency/shared_state/example.md:21 src/concurrency/send-sync.md:18
+#: src/concurrency/send-sync/sync.md:12 src/exercises/day-4/morning.md:10
+#: src/android/interoperability/with-c/rust.md:81
+#: src/exercises/day-4/afternoon.md:10
+#, fuzzy
+msgid "<details>"
+msgstr "<details>"
+
+#: src/welcome.md:48
+#, fuzzy
+msgid ""
+"This is an example of a _speaker note_. We will use these to add additional\n"
+"information to the slides. This could be key points which the instructor "
+"should\n"
+"cover as well as answers to typical questions which come up in class."
+msgstr ""
+"Este é um exemplo de _nota do orador_. Nós os usaremos para adicionar\n"
+"informações aos slides. Estes podem ser Points-chave que o instrutor deve\n"
+"capa, bem como respostas a perguntas típicas que surgem em sala de aula."
+
+#: src/welcome.md:52 src/cargo/rust-ecosystem.md:67
+#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
+#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
+#: src/hello-world.md:36 src/hello-world/small-example.md:44 src/why-rust.md:24
+#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
+#: src/why-rust/modern.md:66 src/basic-syntax/compound-types.md:62
+#: src/basic-syntax/references.md:28 src/basic-syntax/slices.md:36
+#: src/basic-syntax/functions.md:54 src/exercises/day-1/morning.md:28
+#: src/exercises/day-1/for-loops.md:95 src/basic-syntax/variables.md:20
+#: src/basic-syntax/type-inference.md:48
+#: src/basic-syntax/static-and-const.md:52
+#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:32
+#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
+#: src/ownership/moves-function-calls.md:26 src/ownership/borrowing.md:51
+#: src/ownership/shared-unique-borrows.md:29
+#: src/ownership/lifetimes-function-calls.md:60
+#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:103
+#: src/structs.md:40 src/enums/variant-payloads.md:39 src/enums/sizes.md:49
+#: src/methods/example.md:53 src/pattern-matching/destructuring-enums.md:39
+#: src/exercises/day-2/morning.md:15 src/exercises/day-2/points-polygons.md:125
+#: src/control-flow/if-let-expressions.md:26 src/std.md:31
+#: src/std/option-result.md:25 src/std/string.md:34 src/std/vec.md:38
+#: src/std/box.md:37 src/std/rc.md:32 src/exercises/day-2/afternoon.md:11
+#: src/traits.md:54 src/traits/from-iterator.md:23 src/traits/operators.md:38
+#: src/traits/drop.md:42 src/generics/methods.md:31 src/generics/closures.md:38
+#: src/exercises/day-3/morning.md:11 src/error-handling/try-operator.md:55
+#: src/error-handling/converting-error-types.md:78
+#: src/error-handling/deriving-error-enums.md:45
+#: src/error-handling/dynamic-errors.md:41
+#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
+#: src/unsafe/raw-pointers.md:42 src/unsafe/mutable-static-variables.md:35
+#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
+#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
+#: src/exercises/day-3/afternoon.md:11 src/concurrency/threads.md:45
+#: src/concurrency/channels.md:32 src/concurrency/shared_state/arc.md:38
+#: src/concurrency/shared_state/example.md:60
+#: src/concurrency/send-sync/sync.md:18 src/exercises/day-4/morning.md:16
+#: src/android/interoperability/with-c/rust.md:86
+#: src/exercises/day-4/afternoon.md:15
+#, fuzzy
+msgid "</details>"
+msgstr "</details>"
+
+#: src/running-the-course.md:1
+#, fuzzy
+msgid "# Running the Course"
+msgstr "# Executando o Curso"
+
+#: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
+#, fuzzy
+msgid "> This page is for the course instructor."
+msgstr "> Esta página é para o instrutor do curso."
+
+#: src/running-the-course.md:5
+#, fuzzy
+msgid ""
+"Here is a bit of background information about how we've been running the "
+"course\n"
+"internally at Google."
+msgstr ""
+"Aqui estão algumas informações básicas sobre como estamos conduzindo o "
+"curso\n"
+"internamente no Google."
+
+#: src/running-the-course.md:8
+#, fuzzy
+msgid "To run the course, you need to:"
+msgstr "Para executar o curso, você precisa:"
+
+#: src/running-the-course.md:10
+#, fuzzy
+msgid ""
+"1. Make yourself familiar with the course material. We've included speaker "
+"notes\n"
+"   on some of the pages to help highlight the key points (please help us by\n"
+"   contributing more speaker notes!). You should make sure to open the "
+"speaker\n"
+"   notes in a popup (click the link with a little arrow next to \"Speaker\n"
+"   Notes\"). This way you have a clean screen to present to the class."
+msgstr ""
+"1. Familiarize-se com o material do curso. Incluímos notas do orador\n"
+"   em algumas das páginas para ajudar a destacar os Points-chave (por favor, "
+"ajude-nos\n"
+"   contribuindo com mais notas do orador!). Você deve certificar-se de abrir "
+"as notas\n"
+"   do orador em um pop-up (clique no link com uma pequena seta ao lado de "
+"\"Speaker\n"
+"   Notes\"). Dessa forma, você tem uma tela limpa para apresentar à turma."
+
+#: src/running-the-course.md:16
+#, fuzzy
+msgid ""
+"2. Decide on the dates. Since the course is large, we recommend that you\n"
+"   schedule the four days over two weeks. Course participants have said "
+"that\n"
+"   they find it helpful to have a gap in the course since it helps them "
+"process\n"
+"   all the information we give them."
+msgstr ""
+"2. Decida as datas. Como o curso é grande, recomendamos que você\n"
+"   agende os quatro dias em duas semanas. Os participantes do curso disseram "
+"que\n"
+"   eles acham útil ter uma lacuna no curso, pois os ajuda a processar\n"
+"   todas as informações que lhes damos."
+
+#: src/running-the-course.md:21
+#, fuzzy
+msgid ""
+"3. Find a room large enough for your in-person participants. We recommend a\n"
+"   class size of 15-20 people. That's small enough that people are "
+"comfortable\n"
+"   asking questions --- it's also small enough that one instructor will "
+"have\n"
+"   time to answer the questions."
+msgstr ""
+"3. Encontre uma sala suficientemente grande para seus participantes "
+"presenciais. Recomendamos um\n"
+"   turmas de 15 a 20 Persons. Isso é suficientemente pequeno para que as "
+"Persons se sintam confortáveis\n"
+"   fazendo perguntas é para que um instrutor "
+"tenha\n"
+"   tempo para responder às perguntas."
+
+#: src/running-the-course.md:26
+#, fuzzy
+msgid ""
+"4. On the day of your course, show up to the room a little early to set "
+"things\n"
+"   up. We recommend presenting directly using `mdbook serve` running on "
+"your\n"
+"   laptop. This ensures optimal performance with no lag as you change "
+"pages.\n"
+"   Using your laptop will also allow you to fix typos as you or the course\n"
+"   participants spot them."
+msgstr ""
+"4. No dia do seu curso, chegue um pouco mais cedo na sala para acertar as "
+"coisas.\n"
+"   Recomendamos apresentar diretamente usando `mdbook serve` "
+"rodando em seu\n"
+"   computador portátil. Isso garante um desempenho ideal sem atrasos "
+"quando você muda de página.\n"
+"   Usar seu laptop também permitirá que você corrija erros de digitação "
+"enquanto você ou\n"
+"   os participantes os identificam."
+
+#: src/running-the-course.md:32
+#, fuzzy
+msgid ""
+"5. Let people solve the exercises by themselves or in small groups. Make "
+"sure to\n"
+"   ask people if they're stuck or if there is anything you can help with. "
+"When\n"
+"   you see that several people have the same problem, call it out to the "
+"class\n"
+"   and offer a solution, e.g., by showing people where to find the relevant\n"
+"   information in the standard library."
+msgstr ""
+"5. Deixe as Persons resolverem os exercícios sozinhas ou em pequenos grupos. "
+"Tenha certeza de\n"
+"   pergunte às Persons se elas estão empacadas ou se há algo em que você "
+"possa ajudar. Quando\n"
+"   você vê que várias Persons têm o mesmo problema, chame a turma\n"
+"   e oferecer uma solução, por exemplo, mostrando às Persons onde encontrar "
+"as informações relevantes\n"
+"   informações na biblioteca padrão."
+
+#: src/running-the-course.md:38
+#, fuzzy
+msgid ""
+"6. If you don't skip the Android specific parts on Day 4, you will need an "
+"[AOSP\n"
+"   checkout][1]. Make a checkout of the [course repository][2] on the same\n"
+"   machine and move the `src/android/` directory into the root of your AOSP\n"
+"   checkout. This will ensure that the Android build system sees the\n"
+"   `Android.bp` files in `src/android/`."
+msgstr ""
+"6. Se você não pular as partes específicas do Android no Dia 4, precisará de "
+"um [AOSP\n"
+"   checkout [1]. Faça um checkout do [repositório do curso][2] no mesmo\n"
+"   máquina e mova o diretório `src/android/` para a raiz do seu AOSP\n"
+"   checkout. Isso garantirá que o sistema de compilação do Android veja o\n"
+"   Arquivos `Android.bp` em `src/android/`."
+
+#: src/running-the-course.md:44
+#, fuzzy
+msgid ""
+"   Ensure that `adb sync` works with your emulator or real device and "
+"pre-build\n"
+"   all Android examples using `src/android/build_all.sh`. Read the script to "
+"see\n"
+"   the commands it runs and make sure they work when you run them by hand."
+msgstr ""
+"   Certifique-se de que `adb sync` funcione com seu emulador ou dispositivo "
+"real e pré-construa\n"
+"   todos os exemplos do Android usando `src/android/build_all.sh`. Leia o "
+"roteiro para ver\n"
+"   os comandos executados e verifique se eles funcionam quando você os "
+"executa manualmente."
+
+#: src/running-the-course.md:48
+#, fuzzy
+msgid ""
+"That is all, good luck running the course! We hope it will be as much fun "
+"for\n"
+"you as it has been for us!"
+msgstr ""
+"Isso é tudo, boa sorte no curso! Esperamos que seja tão divertido para\n"
+"você como tem sido para nós!"
+
+#: src/running-the-course.md:51
+#, fuzzy
+msgid ""
+"Please [provide feedback][3] afterwards so that we can keep improving the\n"
+"course. We would love to hear what worked well for you and what can be made\n"
+"better. Your students are also very welcome to [send us feedback][4]!"
+msgstr ""
+"Por favor, [forneça feedback][3] depois para que possamos continuar "
+"melhorando o\n"
+"curso. Adoraríamos saber o que funcionou bem para você e o que pode ser "
+"melhorado.\n"
+" Seus alunos também são muito bem-vindos para [nos enviar "
+"feedback][4]!"
+
+#: src/running-the-course.md:55
+#, fuzzy
+msgid ""
+"[1]: https://source.android.com/docs/setup/download/downloading\n"
+"[2]: https://github.com/google/comprehensive-rust\n"
+"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
+"[4]: https://github.com/google/comprehensive-rust/discussions/100"
+msgstr ""
+"[1]: https://source.android.com/docs/setup/download/downloading\n"
+"[2]: https://github.com/google/comprehensive-rust\n"
+"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
+"[4]: https://github.com/google/comprehensive-rust/discussions/100"
+
+#: src/running-the-course/course-structure.md:1
+#, fuzzy
+msgid "# Course Structure"
+msgstr "# Estrutura do curso"
+
+#: src/running-the-course/course-structure.md:5
+#, fuzzy
+msgid "The course is fast paced and covers a lot of ground:"
+msgstr "O curso é rápido e cobre muito terreno:"
+
+#: src/running-the-course/course-structure.md:7
+#, fuzzy
+msgid ""
+"* Day 1: Basic Rust, ownership and the borrow checker.\n"
+"* Day 2: Compound data types,  pattern matching, the standard library.\n"
+"* Day 3: Traits and generics, error handling, testing, unsafe Rust.\n"
+"* Day 4: Concurrency in Rust and interoperability with other languages"
+msgstr ""
+"* Dia 1: Rust básico, ownership e verificador de empréstimo.\n"
+"* Dia 2: Tipos de dados compostos, correspondência de padrões, a biblioteca "
+"padrão.\n"
+"* Dia 3: Características e genéricos, tratamento de erros, testes, Rust "
+"inseguro.\n"
+"* Dia 4: Simultaneage em Rust e interoperabilage com outras linguagens"
+
+#: src/running-the-course/course-structure.md:12
+#, fuzzy
+msgid ""
+"> **Exercise for Day 4:** Do you interface with some C/C++ code in your "
+"project\n"
+"> which we could attempt to move to Rust? The fewer dependencies the "
+"better.\n"
+"> Parsing code would be ideal."
+msgstr ""
+"> **Exercício para o dia 4:** Você faz interface com algum código C/C++ em "
+"seu projeto\n"
+"> que poderíamos tentar mover para Rust? Quanto menos dependências, melhor.\n"
+"> Analisar o código seria o ideal."
+
+#: src/running-the-course/course-structure.md:16
+#, fuzzy
+msgid "## Format"
+msgstr "## Formato"
+
+#: src/running-the-course/course-structure.md:18
+#, fuzzy
+msgid ""
+"The course is meant to be very interactive and we recommend letting the\n"
+"questions drive the exploration of Rust!"
+msgstr ""
+"O curso pretende ser muito interativo e recomendamos deixar o\n"
+"perguntas conduzem a exploração de Rust!"
+
+#: src/running-the-course/keyboard-shortcuts.md:1
+#, fuzzy
+msgid "# Keyboard Shortcuts"
+msgstr "# Atalhos do teclado"
+
+#: src/running-the-course/keyboard-shortcuts.md:3
+#, fuzzy
+msgid "There are several useful keyboard shortcuts in mdBook:"
+msgstr "Existem vários atalhos de teclado úteis no mdBook:"
+
+#: src/running-the-course/keyboard-shortcuts.md:5
+#, fuzzy
+msgid ""
+"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
+"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
+"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
+"* <kbd>s</kbd>: Activate the search bar."
+msgstr ""
+"* <kbd>Seta para a esquerda</kbd>: Navega para a página anterior.\n"
+"* <kbd>Seta para a direita</kbd>: Navega para a próxima página.\n"
+"* <kbd>Ctrl + Enter</kbd>: Executa o exemplo de código que tem o foco.\n"
+"* <kbd>s</kbd>: ativa a barra de pesquisa."
+
+#: src/cargo.md:1
+#, fuzzy
+msgid "# Using Cargo"
+msgstr "# Usando cargo"
+
+#: src/cargo.md:3
+#, fuzzy
+msgid ""
+"When you start reading about Rust, you will soon meet "
+"[Cargo](https://doc.rust-lang.org/cargo/), the standard tool\n"
+"used in the Rust ecosystem to build and run Rust applications. Here we want "
+"to\n"
+"give a brief overview of what Cargo is and how it fits into the wider "
+"ecosystem\n"
+"and how it fits into this training."
+msgstr ""
+"Quando você começar a ler sobre Rust, logo conhecerá "
+"[Cargo](https://doc.rust-lang.org/cargo/), a ferramenta padrão\n"
+"usado no ecossistema Rust para criar e executar aplicativos Rust. Aqui nós "
+"queremos\n"
+"dê uma breve visão geral do que é Cargo e como ele se encaixa no ecossistema "
+"mais amplo\n"
+"e como ele se encaixa neste treinamento."
+
+#: src/cargo.md:8
+#, fuzzy
+msgid "## Installation"
+msgstr "## Instalação"
+
+#: src/cargo.md:10
+#, fuzzy
+msgid "### Rustup (Recommended)"
+msgstr "### Rustup (Recomendado)"
+
+#: src/cargo.md:12
+#, fuzzy
+msgid ""
+"You can follow the instructions to install cargo and rust compiler, among "
+"other standard ecosystem tools with the [rustup][3] tool, which is "
+"maintained by the Rust Foundation."
+msgstr ""
+"Você pode seguir as instruções para instalar o compilador de cargo e "
+"Rust, entre outras ferramentas padrão do ecossistema com a ferramenta "
+"[rustup][3], que é mantida pela Rust Foundation."
+
+#: src/cargo.md:14
+#, fuzzy
+msgid ""
+"Along with cargo and rustc, Rustup will install itself as a command line "
+"utility that you can use to install/switch toolchains, setup cross "
+"compilation, etc."
+msgstr ""
+"Juntamente com cargo e rustc, o Rustup se instalará como um utilitário de "
+"linha de comando que você pode usar para instalar/alternar "
+"ferramentas, configurar compilação cruzada, etc."
+
+#: src/cargo.md:16
+#, fuzzy
+msgid "### Package Managers"
+msgstr "### Gerenciadores de pacotes"
+
+#: src/cargo.md:18
+#, fuzzy
+msgid "#### Debian"
+msgstr "#### Debian"
+
+#: src/cargo.md:20
+#, fuzzy
+msgid "On Debian/Ubuntu, you can install Cargo and the Rust source with"
+msgstr "No Debian/Ubuntu, você pode instalar o Cargo e o fonte Rust com"
+
+#: src/cargo.md:22
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ sudo apt install cargo rust-src\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ sudo apt install cargo rust-src\n"
+"```"
+
+#: src/cargo.md:26
+#, fuzzy
+msgid ""
+"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
+"using\n"
+"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+msgstr ""
+"Isso permitirá que o [analisador de rust] [1] pule para as definições. "
+"Sugerimos usar\n"
+"[VS Code][2] para editar o código (mas qualquer editor compatível com LSP "
+"funciona)."
+
+#: src/cargo.md:29
+#, fuzzy
+msgid ""
+"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
+"their own analysis but have their own tradeoffs. If you prefer them, you can "
+"install the [Rust Plugin][5]. Please take note that as of January 2023 "
+"debugging only works on the CLion version of the JetBrains IDEA suite."
+msgstr ""
+"Algumas Persons também gostam de usar a família de IDEs [JetBrains][4], que "
+"fazem suas próprias análises, mas têm suas próprias compensações. Se você "
+"preferir, pode instalar o [Plugin Rust] [5]. Observe que, a partir de "
+"Janeiro de 2023, a depuração funciona apenas na versão CLion do pacote "
+"JetBrains IDEA."
+
+#: src/cargo.md:31
+#, fuzzy
+msgid ""
+"[1]: https://rust-analyzer.github.io/\n"
+"[2]: https://code.visualstudio.com/\n"
+"[3]: https://rustup.rs/\n"
+"[4]: https://www.jetbrains.com/clion/\n"
+"[5]: https://www.jetbrains.com/rust/"
+msgstr ""
+"[1]: https://rust-analyzer.github.io/\n"
+"[2]: https://code.visualstudio.com/\n"
+"[3]: https://rustup.rs/\n"
+"[4]: https://www.jetbrains.com/clion/\n"
+"[5]: https://www.jetbrains.com/rust/"
+
+#: src/cargo/rust-ecosystem.md:1
+#, fuzzy
+msgid "# The Rust Ecosystem"
+msgstr "# O ecossistema da rust"
+
+#: src/cargo/rust-ecosystem.md:3
+#, fuzzy
+msgid ""
+"The Rust ecosystem consists of a number of tools, of which the main ones are:"
+msgstr ""
+"O ecossistema Rust consiste em várias ferramentas, das quais as principais "
+"são:"
+
+#: src/cargo/rust-ecosystem.md:5
+#, fuzzy
+msgid ""
+"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
+"other\n"
+"  intermediate formats[^rustc]."
+msgstr ""
+"* `rustc`: o compilador Rust que transforma arquivos `.rs` em binários e "
+"outros\n"
+"  formatos intermediários[^rustc]."
+
+#: src/cargo/rust-ecosystem.md:8
+#, fuzzy
+msgid ""
+"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
+"  download dependencies hosted on <https://crates.io> and it will pass them "
+"to\n"
+"  `rustc` when building your project. Cargo also comes with a built-in test\n"
+"  runner which is used to execute unit tests[^cargo]."
+msgstr ""
+"* `cargo`: o gerenciador de dependências Rust e a ferramenta de construção. "
+"cargo sabe como\n"
+"  baixe as dependências hospedadas em <https://crates.io> e as passará para\n"
+"  `rustc` ao construir seu projeto. Cargo também vem com um teste embutido\n"
+"  runner que é usado para executar testes de unage[^cargo]."
+
+#: src/cargo/rust-ecosystem.md:13
+#, fuzzy
+msgid ""
+"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
+"  install and update `rustc` and `cargo` when new versions of Rust is "
+"released.\n"
+"  In addition, `rustup` can also download documentation for the standard\n"
+"  library. You can have multiple versions of Rust installed at once and "
+"`rustup`\n"
+"  will let you switch between them as needed."
+msgstr ""
+"* `rustup`: o instalador e atualizador da cadeia de ferramentas Rust. Esta "
+"ferramenta é utilizada para\n"
+"  instale e atualize `rustc` e `cargo` quando novas versões do Rust forem "
+"lançadas.\n"
+"  Além disso, `rustup` também pode baixar documentação para o padrão\n"
+"  biblioteca. Você pode ter várias versões do Rust instaladas ao mesmo tempo "
+"e `rustup`\n"
+"  permitirá que você alterne entre eles conforme necessário."
+
+#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
+#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
+#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:30
+#: src/error-handling/try-operator.md:50
+#: src/error-handling/converting-error-types.md:68
+#: src/concurrency/threads.md:30
+#, fuzzy
+msgid "Key points:"
+msgstr "Points chave:"
+
+#: src/cargo/rust-ecosystem.md:23
+#, fuzzy
+msgid ""
+"* Rust has a rapid release schedule with a new release coming out\n"
+"  every six weeks. New releases maintain backwards compatibility with\n"
+"  old releases --- plus they enable new functionality."
+msgstr ""
+"* Rust tem um cronograma de lançamento rápido com um novo lançamento saindo\n"
+"  a cada seis semanas. Novos lançamentos mantêm compatibilage com versões "
+"anteriores\n"
+"  lançamentos antigos --- além disso, eles permitem novas funcionalages."
+
+#: src/cargo/rust-ecosystem.md:27
+#, fuzzy
+msgid ""
+"* There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "* Existem três canais de lançamento: \"stable\", \"beta\" e \"nightly\"."
+
+#: src/cargo/rust-ecosystem.md:29
+#, fuzzy
+msgid ""
+"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
+"  \"stable\" every six weeks."
+msgstr ""
+"* Novos recursos estão sendo testados em \"nightly\", \"beta\" é o que se "
+"torna\n"
+"  \"estável\" a cada seis semanas."
+
+#: src/cargo/rust-ecosystem.md:32
+#, fuzzy
+msgid ""
+"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
+"  editions were Rust 2015 and Rust 2018."
+msgstr ""
+"* Rust também tem [edições]: a edição atual é Rust 2021. Anterior\n"
+"  edições foram Rust 2015 e Rust 2018."
+
+#: src/cargo/rust-ecosystem.md:35
+#, fuzzy
+msgid ""
+"  * The editions are allowed to make backwards incompatible changes to\n"
+"    the language."
+msgstr ""
+"  * As edições podem fazer alterações incompatíveis com versões anteriores\n"
+"    o idioma."
+
+#: src/cargo/rust-ecosystem.md:38
+#, fuzzy
+msgid ""
+"  * To prevent breaking code, editions are opt-in: you select the\n"
+"    edition for your crate via the `Cargo.toml` file."
+msgstr ""
+"  * Para evitar quebra de código, as edições são opcionais: você seleciona "
+"o\n"
+"    edição para sua caixa através do arquivo `Cargo.toml`."
+
+#: src/cargo/rust-ecosystem.md:41
+#, fuzzy
+msgid ""
+"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
+"    written for different editions."
+msgstr ""
+"  * Para evitar a divisão do ecossistema, os compiladores Rust podem "
+"misturar código\n"
+"    escrito para diferentes edições."
+
+#: src/cargo/rust-ecosystem.md:44
+#, fuzzy
+msgid ""
+"  * Mention that it is quite rare to ever use the compiler directly not "
+"through `cargo` (most users never do)."
+msgstr ""
+"  * Mencione que é muito raro usar o compilador diretamente, não através do "
+"`cargo` (a maioria dos usuários nunca o faz)."
+
+#: src/cargo/rust-ecosystem.md:46
+#, fuzzy
+msgid ""
+"  * It might be worth alluding that Cargo itself is an extremely powerful "
+"and comprehensive tool.  It is capable of many advanced features including "
+"but not limited to: \n"
+"      * Project/package structure\n"
+"      * [workspaces]\n"
+"      * Dev Dependencies and Runtime Dependency management/caching\n"
+"      * [build scripting]\n"
+"      * [global installation]\n"
+"      * It is also extensible with sub command plugins as well (such as "
+"[cargo clippy]).\n"
+"  * Read more from the [official Cargo Book]"
+msgstr ""
+"  * Pode valer a pena aludir que o próprio Cargo é uma ferramenta "
+"extremamente poderosa e abrangente. Ele é capaz de muitos recursos "
+"avançados, incluindo, entre outros:\n"
+"      * Estrutura do projeto/pacote\n"
+"      * [espaços de trabalho]\n"
+"      * Dependências de desenvolvimento e gerenciamento/cache de dependência "
+"de tempo de execução\n"
+"      * [criar script]\n"
+"      * [instalação global]\n"
+"      * Também é extensível com plugins de subcomando (como [cargo "
+"clippy]).\n"
+"  * Leia mais no [livro de cargo oficial]"
+
+#: src/cargo/rust-ecosystem.md:55
+#, fuzzy
+msgid "[editions]: https://doc.rust-lang.org/edition-guide/"
+msgstr "[edições]: https://doc.rust-lang.org/edition-guide/"
+
+#: src/cargo/rust-ecosystem.md:57
+#, fuzzy
+msgid "[workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
+msgstr ""
+"[espaços de trabalho]: "
+"https://doc.rust-lang.org/cargo/reference/workspaces.html"
+
+#: src/cargo/rust-ecosystem.md:59
+#, fuzzy
+msgid ""
+"[build scripting]: "
+"https://doc.rust-lang.org/cargo/reference/build-scripts.html"
+msgstr ""
+"[script de construção]: "
+"https://doc.rust-lang.org/cargo/reference/build-scripts.html"
+
+#: src/cargo/rust-ecosystem.md:61
+#, fuzzy
+msgid ""
+"[global installation]: "
+"https://doc.rust-lang.org/cargo/commands/cargo-install.html"
+msgstr ""
+"[instalação global]: "
+"https://doc.rust-lang.org/cargo/commands/cargo-install.html"
+
+#: src/cargo/rust-ecosystem.md:63
+#, fuzzy
+msgid "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
+msgstr "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
+
+#: src/cargo/rust-ecosystem.md:65
+#, fuzzy
+msgid "[official Cargo Book]: https://doc.rust-lang.org/cargo/"
+msgstr "[Livro de cargo oficial]: https://doc.rust-lang.org/cargo/"
+
+#: src/cargo/code-samples.md:1
+#, fuzzy
+msgid "# Code Samples in This Training"
+msgstr "# Amostras de código neste treinamento"
+
+#: src/cargo/code-samples.md:3
+#, fuzzy
+msgid ""
+"For this training, we will mostly explore the Rust language through "
+"examples\n"
+"which can be executed through your browser. This makes the setup much easier "
+"and\n"
+"ensures a consistent experience for everyone."
+msgstr ""
+"Para este treinamento, exploraremos principalmente a linguagem Rust por meio "
+"de exemplos\n"
+"que pode ser executado através do seu navegador. Isso torna a configuração "
+"muito mais fácil e\n"
+"garante uma experiência consistente para todos."
+
+#: src/cargo/code-samples.md:7
+#, fuzzy
+msgid ""
+"Installing Cargo is still encouraged: it will make it easier for you to do "
+"the\n"
+"exercises. On the last day, we will do a larger exercise which shows you how "
+"to\n"
+"work with dependencies and for that you need Cargo."
+msgstr ""
+"A instalação do Cargo ainda é incentivada: será mais fácil para você fazer "
+"o\n"
+"exercícios. No último dia, faremos um exercício maior que mostra como\n"
+"Trabalho com dependências e para isso você precisa do Cargo."
+
+#: src/cargo/code-samples.md:11
+#, fuzzy
+msgid "The code blocks in this course are fully interactive:"
+msgstr "Os blocos de código neste curso são totalmente interativos:"
+
+#: src/cargo/code-samples.md:13
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    println!(\"Edite-me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/code-samples.md:19
+#, fuzzy
+msgid ""
+"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
+"the\n"
+"text box."
+msgstr ""
+"Você pode usar <kbd>Ctrl + Enter</kbd> para executar o código quando o foco "
+"estiver no\n"
+"caixa de texto."
+
+#: src/cargo/code-samples.md:24
+#, fuzzy
+msgid ""
+"Most code samples are editable like shown above. A few code samples\n"
+"are not editable for various reasons:"
+msgstr ""
+"A maioria dos exemplos de código são editáveis, como mostrado acima. Alguns "
+"exemplos de código\n"
+"não são editáveis por vários motivos:"
+
+#: src/cargo/code-samples.md:27
+#, fuzzy
+msgid ""
+"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
+"  code and open it in the real Playground to demonstrate unit tests."
+msgstr ""
+"* Os playgrounds incorporados não podem executar testes de unage. Copie e "
+"cole o\n"
+"  código e abri-lo no Playground real para demonstrar os testes de unage."
+
+#: src/cargo/code-samples.md:30
+#, fuzzy
+msgid ""
+"* The embedded playgrounds lose their state the moment you navigate\n"
+"  away from the page! This is the reason that the students should\n"
+"  solve the exercises using a local Rust installation or via the\n"
+"  Playground."
+msgstr ""
+"* Os playgrounds embutidos perdem seu estado no momento em que você navega\n"
+"  fora da página! Esta é a razão pela qual os alunos devem\n"
+"  resolva os exercícios usando uma instalação Rust local ou via\n"
+"  Parque infantil."
+
+#: src/cargo/running-locally.md:1
+#, fuzzy
+msgid "# Running Code Locally with Cargo"
+msgstr "# Executando código localmente com cargo"
+
+#: src/cargo/running-locally.md:3
+#, fuzzy
+msgid ""
+"If you want to experiment with the code on your own system, then you will "
+"need\n"
+"to first install Rust. Do this by following the [instructions in the Rust\n"
+"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
+"of\n"
+"writing, the latest stable Rust release has these version numbers:"
+msgstr ""
+"Se você quiser experimentar o código em seu próprio sistema, precisará\n"
+"para primeiro instalar o Rust. Faça isso seguindo as [instruções no Rust\n"
+"Livro][1]. Isso deve fornecer `rustc` e `cargo` funcionando. Na hora de\n"
+"escrevendo, a última versão estável do Rust tem estes números de versão:"
+
+#: src/cargo/running-locally.md:8
+#, fuzzy
+msgid ""
+"```shell\n"
+"% rustc --version\n"
+"rustc 1.61.0 (fe5b13d68 2022-05-18)\n"
+"% cargo --version\n"
+"cargo 1.61.0 (a028ae4 2022-04-29)\n"
+"```"
+msgstr ""
+"```shell\n"
+"% rustc --version\n"
+"rust 1.61.0 (fe5b13d68 2022-05-18)\n"
+"% cargo --version\n"
+"cargo 1.61.0 (a028ae4 2022-04-29)\n"
+"```"
+
+#: src/cargo/running-locally.md:15
+#, fuzzy
+msgid ""
+"With this is in place, then follow these steps to build a Rust binary from "
+"one\n"
+"of the examples in this training:"
+msgstr ""
+"Com isso instalado, siga estas etapas para criar um binário Rust a partir de "
+"um\n"
+"dos exemplos neste treinamento:"
+
+#: src/cargo/running-locally.md:18
+#, fuzzy
+msgid ""
+"1. Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr ""
+"1. Clique no botão \"Copiar para a área de transferência\" no exemplo que "
+"deseja copiar."
+
+#: src/cargo/running-locally.md:20
+#, fuzzy
+msgid ""
+"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
+"code:"
+msgstr ""
+"2. Use `cargo new exercise` para criar um novo diretório `exercise/` para o "
+"seu código:"
+
+#: src/cargo/running-locally.md:22
+#, fuzzy
+msgid ""
+"    ```shell\n"
+"    $ cargo new exercise\n"
+"         Created binary (application) `exercise` package\n"
+"    ```"
+msgstr ""
+"    ```shell\n"
+"    $ cargo new exercise\n"
+"         Criou o pacote binário (aplicativo) `exercise`\n"
+"    ```"
+
+#: src/cargo/running-locally.md:27
+#, fuzzy
+msgid ""
+"3. Navigate into `exercise/` and use `cargo run` to build and run your "
+"binary:"
+msgstr ""
+"3. Navegue até `exercise/` e use `cargo run` para compilar e executar seu "
+"binário:"
+
+#: src/cargo/running-locally.md:29
+#, fuzzy
+msgid ""
+"    ```shell\n"
+"    $ cd exercise\n"
+"    $ cargo run\n"
+"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"         Running `target/debug/exercise`\n"
+"    Hello, world!\n"
+"    ```"
+msgstr ""
+"    ```shell\n"
+"    exercise $cd\n"
+"    $ cargo run\n"
+"       exercise de compilação v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"        Destino(s) dev finalizado [não otimizado + debuginfo] em 0,75s\n"
+"         Executando `target/debug/exercise`\n"
+"    Olá Mundo!\n"
+"    ```"
+
+#: src/cargo/running-locally.md:38
+#, fuzzy
+msgid ""
+"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
+"   example, using the example on the previous page, make `src/main.rs` look "
+"like"
+msgstr ""
+"4. Substitua o código da placa da caldeira em `src/main.rs` pelo seu próprio "
+"código. Para\n"
+"   exemplo, usando o exemplo da página anterior, faça `src/main.rs` parecer"
+
+#: src/cargo/running-locally.md:41
+#, fuzzy
+msgid ""
+"    ```rust\n"
+"    fn main() {\n"
+"        println!(\"Edit me!\");\n"
+"    }\n"
+"    ```"
+msgstr ""
+"    ```rust\n"
+"    fn main() {\n"
+"        println!(\"Edite-me!\");\n"
+"    }\n"
+"    ```"
+
+#: src/cargo/running-locally.md:47
+#, fuzzy
+msgid "5. Use `cargo run` to build and run your updated binary:"
+msgstr "5. Use `cargo run` para compilar e executar seu binário atualizado:"
+
+#: src/cargo/running-locally.md:49
+#, fuzzy
+msgid ""
+"    ```shell\n"
+"    $ cargo run\n"
+"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"         Running `target/debug/exercise`\n"
+"    Edit me!\n"
+"    ```"
+msgstr ""
+"    ```shell\n"
+"    $ cargo run\n"
+"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"         Running `target/debug/exercise`\n"
+"    Edite-me!\n"
+"    ```"
+
+#: src/cargo/running-locally.md:57
+#, fuzzy
+msgid ""
+"6. Use `cargo check` to quickly check your project for errors, use `cargo "
+"build`\n"
+"   to compile it without running it. You will find the output in "
+"`target/debug/`\n"
+"   for a normal debug build. Use `cargo build --release` to produce an "
+"optimized\n"
+"   release build in `target/release/`."
+msgstr ""
+"6. Use `cargo check` para verificar rapidamente se há erros em seu projeto, "
+"use `cargo build`\n"
+"   para compilá-lo sem executá-lo. Você encontrará a saída em "
+"`target/debug/`\n"
+"   para uma compilação de depuração normal. Use `cargo build --release` para "
+"produzir um otimizado\n"
+"   libere build em `target/release/`."
+
+#: src/cargo/running-locally.md:62
+#, fuzzy
+msgid ""
+"7. You can add dependencies for your project by editing `Cargo.toml`. When "
+"you\n"
+"   run `cargo` commands, it will automatically download and compile missing\n"
+"   dependencies for you."
+msgstr ""
+"7. Você pode adicionar dependências para seu projeto editando `Cargo.toml`. "
+"Quando você\n"
+"   execute os comandos `cargo`, ele irá baixar e compilar automaticamente\n"
+"   dependências para você."
+
+#: src/cargo/running-locally.md:66
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
+msgstr "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
+
+#: src/cargo/running-locally.md:70
+#, fuzzy
+msgid ""
+"Try to encourage the class participants to install Cargo and use a\n"
+"local editor. It will make their life easier since they will have a\n"
+"normal development environment."
+msgstr ""
+"Tente encorajar os participantes da aula a instalar o Cargo e usar um\n"
+"redator local. Isso facilitará a vida deles, pois eles terão uma\n"
+"ambiente normal de desenvolvimento."
+
+#: src/welcome-day-1.md:1
+#, fuzzy
+msgid "# Welcome to Day 1"
+msgstr "# Bem-vindo ao Dia 1"
+
+#: src/welcome-day-1.md:3
+#, fuzzy
+msgid ""
+"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"today:"
+msgstr ""
+"Este é o primeiro dia do Comprehensive Rust. Nós cobriremos muito terreno\n"
+"hoje:"
+
+#: src/welcome-day-1.md:6
+#, fuzzy
+msgid ""
+"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
+"  references, functions, and methods."
+msgstr ""
+"* Sintaxe básica do Rust: variáveis, tipos escalares e compostos, enums, "
+"structs,\n"
+"  referências, funções e métodos."
+
+#: src/welcome-day-1.md:9
+#, fuzzy
+msgid ""
+"* Memory management: stack vs heap, manual memory management, scope-based "
+"memory\n"
+"  management, and garbage collection."
+msgstr ""
+"* Gerenciamento de memória: pilha versus heap, gerenciamento de memória "
+"manual, memória baseada em escopo\n"
+"  gerenciamento e garbage collection (coleta de lixo)."
+
+#: src/welcome-day-1.md:12
+#, fuzzy
+msgid ""
+"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"* Ownership: semântica de movimento, cópia e clonagem, empréstimo e tempos "
+"de vida."
+
+#: src/welcome-day-1.md:16
+#, fuzzy
+msgid "Please remind the students that:"
+msgstr "Lembre aos alunos que:"
+
+#: src/welcome-day-1.md:18
+#, fuzzy
+msgid ""
+"* They should ask questions when they get them, don't save them to the end.\n"
+"* The class is meant to be interactive and discussions are very much "
+"encouraged!\n"
+"  * As an instructor, you should try to keep the discussions relevant, "
+"i.e.,\n"
+"    keep the related to how Rust does things vs some other language. It can "
+"be\n"
+"    hard to find the right balance, but err on the side of allowing "
+"discussions\n"
+"    since they engage people much more than one-way communication.\n"
+"* The questions will likely mean that we about things ahead of the slides.\n"
+"  * This is perfectly okay! Repetition is an important part of leaning. "
+"Remember\n"
+"    that the slides are just a support and you are free to skip them as you\n"
+"    like."
+msgstr ""
+"* Devem fazer perguntas quando as obtiverem, não as guarde para o fim.\n"
+"* A aula é para ser interativa e as discussões são muito encorajadas!\n"
+"  * Como instrutor, você deve tentar manter as discussões relevantes, ou "
+"seja,\n"
+"    mantenha o relacionado a como Rust faz as coisas versus alguma outra "
+"linguagem. Pode ser\n"
+"    difícil encontrar o equilíbrio certo, mas erra ao permitir discussões\n"
+"    uma vez que envolvem as Persons muito mais do que uma comunicação "
+"unidirecional.\n"
+"* As perguntas provavelmente significarão que estamos falando sobre as "
+"coisas antes dos slides.\n"
+"  * Isso está perfeitamente bem! A repetição é uma parte importante do "
+"aprendizado. Lembrar\n"
+"    que os slides são apenas um suporte e você está livre para ignorá-los "
+"enquanto\n"
+"    Curti."
+
+#: src/welcome-day-1.md:29
+#, fuzzy
+msgid ""
+"The idea for the first day is to show _just enough_ of Rust to be able to "
+"speak\n"
+"about the famous borrow checker. The way Rust handles memory is a major "
+"feature\n"
+"and we should show students this right away."
+msgstr ""
+"A ideia para o primeiro dia é mostrar _apenas o suficiente_ de Rust para "
+"poder falar\n"
+"sobre o famoso verificador de empréstimos. A maneira como o Rust lida com a "
+"memória é uma característica importante\n"
+"e devemos mostrar isso aos alunos imediatamente."
+
+#: src/welcome-day-1.md:33
+#, fuzzy
+msgid ""
+"If you're teaching this in a classroom, this is a good place to go over the\n"
+"schedule. We suggest splitting the day into two parts (following the slides):"
+msgstr ""
+"Se você estiver ensinando isso em uma sala de aula, este é um bom lugar para "
+"repassar\n"
+"cronograma. Sugerimos dividir o dia em duas partes (seguindo os slides):"
+
+#: src/welcome-day-1.md:36
+#, fuzzy
+msgid "* Morning: 9:00 to 12:00,\n* Afternoon: 13:00 to 16:00."
+msgstr "* Manhã: 9h00 às 12h00,\n* Tarde: 13h às 16h."
+
+#: src/welcome-day-1.md:39
+#, fuzzy
+msgid ""
+"You can of course adjust this as necessary. Please make sure to include "
+"breaks,\n"
+"we recommend a break every hour!"
+msgstr ""
+"É claro que você pode ajustar isso conforme necessário. Certifique-se de "
+"incluir pausas,\n"
+"recomendamos uma pausa a cada hora!"
+
+#: src/welcome-day-1/what-is-rust.md:1
+#, fuzzy
+msgid "# What is Rust?"
+msgstr "# O que é rust?"
+
+#: src/welcome-day-1/what-is-rust.md:3
+#, fuzzy
+msgid "Rust is a new programming language which had its 1.0 release in 2015:"
+msgstr ""
+"Rust é uma nova linguagem de programação que teve seu lançamento 1.0 em 2015:"
+
+#: src/welcome-day-1/what-is-rust.md:5
+#, fuzzy
+msgid ""
+"* Rust is a statically compiled language in a similar role as C++\n"
+"  * `rustc` uses LLVM as its backend.\n"
+"* Rust supports many [platforms and\n"
+"  "
+"architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
+"  * x86, ARM, WebAssembly, ...\n"
+"  * Linux, Mac, Windows, ...\n"
+"* Rust is used for a wide range of devices:\n"
+"  * firmware and boot loaders,\n"
+"  * smart displays,\n"
+"  * mobile phones,\n"
+"  * desktops,\n"
+"  * servers."
+msgstr ""
+"* Rust é uma linguagem compilada estaticamente em um papel semelhante ao "
+"C++\n"
+"  * `rustc` usa LLVM como back-end.\n"
+"* Rust suporta muitas [plataformas e\n"
+"  "
+"arquiteturas](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
+"  * x86, ARM, WebAssembly, ...\n"
+"  * Linux, Mac, Windows, ...\n"
+"* Rust é usado para uma ampla gama de dispositivos:\n"
+"  * firmware e carregadores de boot,\n"
+"  * monitores inteligentes,\n"
+"  * celulares,\n"
+"  * desktops,\n"
+"  * servidores."
+
+#: src/welcome-day-1/what-is-rust.md:21
+#, fuzzy
+msgid "Rust fits in the same area as C++:"
+msgstr "Rust se encaixa na mesma área que C++:"
+
+#: src/welcome-day-1/what-is-rust.md:23
+#, fuzzy
+msgid ""
+"* High flexibility.\n"
+"* High level of control.\n"
+"* Can be scaled down to very constrained devices like mobile phones.\n"
+"* Has no runtime or garbage collection.\n"
+"* Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"* Alta flexibilage.\n"
+"* Alto nível de controle.\n"
+"* Pode ser reduzido para dispositivos muito restritos, como telefones "
+"celulares.\n"
+"* Não tem tempo de execução ou garbage collection.\n"
+"* Concentra-se na confiabilage e segurança sem sacrificar o desempenho."
+
+#: src/hello-world.md:1
+#, fuzzy
+msgid "# Hello World!"
+msgstr "# Olá Mundo!"
+
+#: src/hello-world.md:3
+#, fuzzy
+msgid ""
+"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"program:"
+msgstr ""
+"Vamos pular para o programa Rust mais simples possível, um clássico Hello "
+"World\n"
+"programa:"
+
+#: src/hello-world.md:6
+#, fuzzy
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Hello 🌍!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Olá 🌍!\");\n"
+"}\n"
+"```"
+
+#: src/hello-world.md:12
+#, fuzzy
+msgid "What you see:"
+msgstr "O que você vê:"
+
+#: src/hello-world.md:14
+#, fuzzy
+msgid ""
+"* Functions are introduced with `fn`.\n"
+"* Blocks are delimited by curly braces like in C and C++.\n"
+"* The `main` function is the entry point of the program.\n"
+"* Rust has hygienic macros, `println!` is an example of this.\n"
+"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr ""
+"* Funções são introduzidas com `fn`.\n"
+"* Os blocos são delimitados por chaves como em C e C++.\n"
+"* A função `main` é o Point de entrada do programa.\n"
+"* Rust tem macros higiênicas, `println!` é um exemplo disso.\n"
+"* As strings Rust são codificadas em UTF-8 e podem conter qualquer caractere "
+"Unicode."
+
+#: src/hello-world.md:22
+#, fuzzy
+msgid ""
+"This slide tries to make the students comfortable with Rust code. They will "
+"see\n"
+"a ton of it over the next four days so we start small with something "
+"familiar."
+msgstr ""
+"Este slide tenta deixar os alunos familiarizados com o código Rust. Eles vão "
+"ver\n"
+"uma tonelada nos próximos quatro dias, então começamos pequeno com algo "
+"familiar."
+
+#: src/hello-world.md:27
+#, fuzzy
+msgid ""
+"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
+"  imperative (not functional) and it doesn't try to reinvent things unless\n"
+"  absolutely necessary."
+msgstr ""
+"* Rust é muito parecido com outras linguagens na tradição do C/C++/Java. Isso "
+"é\n"
+"  imperativo (não funcional) e não tenta reinventar as coisas a menos que\n"
+"  absolutamente necessário."
+
+#: src/hello-world.md:31
+#, fuzzy
+msgid "* Rust is modern with full support for things like Unicode."
+msgstr "* Rust é moderno com suporte total para coisas como Unicode."
+
+#: src/hello-world.md:33
+#, fuzzy
+msgid ""
+"* Rust uses macros for situations where you want to have a variable number "
+"of\n"
+"  arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"* Rust usa macros para situações em que você deseja ter um número variável "
+"de\n"
+"  argumentos (sem função [overloading](sintaxe-básica/funções-interlude.md))."
+
+#: src/hello-world/small-example.md:1
+#, fuzzy
+msgid "# Small Example"
+msgstr "# Pequeno Exemplo"
+
+#: src/hello-world/small-example.md:3
+#, fuzzy
+msgid "Here is a small example program in Rust:"
+msgstr "Aqui está um pequeno programa de exemplo em Rust:"
+
+#: src/hello-world/small-example.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {              // Program entry point\n"
+"    let mut x: i32 = 6;  // Mutable variable binding\n"
+"    print!(\"{x}\");       // Macro for printing, like printf\n"
+"    while x != 1 {       // No parenthesis around expression\n"
+"        if x % 2 == 0 {  // Math like in other languages\n"
+"            x = x / 2;\n"
+"        } else {\n"
+"            x = 3 * x + 1;\n"
+"        }\n"
+"        print!(\" -> {x}\");\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() { // Point de entrada do programa\n"
+"    let mut x: i32 = 6; // Vinculação de variável mutável\n"
+"    print!(\"{x}\"); // Macro para impressão, como printf\n"
+"    while x != 1 { // Sem parênteses em torno da expressão\n"
+"        if x % 2 == 0 { // Matemática como em outras linguagens\n"
+"            x = x/2;\n"
+"        } else {\n"
+"            x = 3 * x + 1;\n"
+"        }\n"
+"        print!(\" -> {x}\");\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+
+#: src/hello-world/small-example.md:23
+#, fuzzy
+msgid ""
+"The code implements the Collatz conjecture: it is believed that the loop "
+"will\n"
+"always end, but this is not yet proved. Edit the code and play with "
+"different\n"
+"inputs."
+msgstr ""
+"O código implementa a conjectura de Collatz: acredita-se que o loop\n"
+"sempre termina, mas isso ainda não está provado. Edite o código e jogue com "
+"diferentes\n"
+"entradas."
+
+#: src/hello-world/small-example.md:29
+#, fuzzy
+msgid ""
+"* Explain that all variables are statically typed. Try removing `i32` to "
+"trigger\n"
+"  type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
+msgstr ""
+"* Explique que todas as variáveis são estaticamente tipadas. Tente remover "
+"`i32` para acionar\n"
+"  inferência de tipo. Em vez disso, tente com `i8` e acione um estouro de "
+"número inteiro em tempo de execução."
+
+#: src/hello-world/small-example.md:32
+#, fuzzy
+msgid "* Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "* Altere `let mut x` para `let x`, discuta o erro do compilador."
+
+#: src/hello-world/small-example.md:34
+#, fuzzy
+msgid ""
+"* Show how `print!` gives a compilation error if the arguments don't match "
+"the\n"
+"  format string."
+msgstr ""
+"* Mostra como `print!` dá um erro de compilação se os argumentos não "
+"combinam com o\n"
+"  sequência de formato."
+
+#: src/hello-world/small-example.md:37
+#, fuzzy
+msgid ""
+"* Show how you need to use `{}` as a placeholder if you want to print an\n"
+"  expression which is more complex than just a single variable."
+msgstr ""
+"* Mostre como você precisa usar `{}` como espaço reservado se quiser "
+"imprimir um\n"
+"  expressão que é mais complexa do que apenas uma única variável."
+
+#: src/hello-world/small-example.md:40
+#, fuzzy
+msgid ""
+"* Show the students the standard library, show them how to search for "
+"`std::fmt`\n"
+"  which has the rules of the formatting mini-language. It's important that "
+"the\n"
+"  students become familiar with searching in the standard library."
+msgstr ""
+"* Mostre aos alunos a biblioteca padrão, mostre como pesquisar `std::fmt`\n"
+"  que possui as regras da minilinguagem de formatação. É importante que o\n"
+"  os alunos se familiarizam com a pesquisa na biblioteca padrão."
+
+#: src/why-rust.md:1
+#, fuzzy
+msgid "# Why Rust?"
+msgstr "# Por que Rust?"
+
+#: src/why-rust.md:3
+#, fuzzy
+msgid "Some unique selling points of Rust:"
+msgstr "Alguns Points de venda exclusivos de Rust:"
+
+#: src/why-rust.md:5
+#, fuzzy
+msgid ""
+"* Compile time memory safety.\n"
+"* Lack of undefined runtime behavior.\n"
+"* Modern language features."
+msgstr ""
+"* Segurança de memória em tempo de compilação.\n"
+"* Falta de comportamento de tempo de execução indefinido.\n"
+"* Recursos de linguagem moderna."
+
+#: src/why-rust.md:11
+#, fuzzy
+msgid ""
+"Make sure to ask the class which languages they have experience with. "
+"Depending\n"
+"on the answer you can highlight different features of Rust:"
+msgstr ""
+"Certifique-se de perguntar à classe com quais idiomas eles têm experiência. "
+"dependendo\n"
+"na resposta você pode destacar diferentes características do Rust:"
+
+#: src/why-rust.md:14
+#, fuzzy
+msgid ""
+"* Experience with C or C++: Rust eliminates a whole class of _runtime "
+"errors_\n"
+"  via the borrow checker. You get performance like in C and C++, but you "
+"don't\n"
+"  have the memory unsafety issues. In addition, you get a modern language "
+"with\n"
+"  constructs like pattern matching and built-in dependency management."
+msgstr ""
+"* Experiência com C ou C++: Rust elimina toda uma classe de _erros de tempo "
+"de execução_\n"
+"  através do verificador de empréstimo. Você obtém desempenho como em C e "
+"C++, mas não\n"
+"  tem problemas de insegurança de memória. Além disso, você obtém uma "
+"linguagem moderna com\n"
+"  construções como correspondência de padrões e gerenciamento de dependência "
+"integrado."
+
+#: src/why-rust.md:19
+#, fuzzy
+msgid ""
+"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety\n"
+"  as in those languages, plus a similar high-level language feeling. In "
+"addition\n"
+"  you get fast and predictable performance like C and C++ (no garbage "
+"collector)\n"
+"  as well as access to low-level hardware (should you need it)"
+msgstr ""
+"* Experiência com Java, Go, Python, JavaScript...: Você obtém a mesma "
+"segurança de memória\n"
+"  como nesses idiomas, além de um sentimento de idioma de alto nível "
+"semelhante. Além disso\n"
+"  você obtém desempenho rápido e previsível como C e C++ (sem coletor de "
+"lixo)\n"
+"  bem como acesso a hardware de baixo nível (caso você precise)"
+
+#: src/why-rust/compile-time.md:1
+#, fuzzy
+msgid "# Compile Time Guarantees"
+msgstr "# Garantias de tempo de compilação"
+
+#: src/why-rust/compile-time.md:3
+#, fuzzy
+msgid "Static memory management at compile time:"
+msgstr "Gerenciamento de memória estática em tempo de compilação:"
+
+#: src/why-rust/compile-time.md:5
+#, fuzzy
+msgid ""
+"* No uninitialized variables.\n"
+"* No memory leaks (_mostly_, see notes).\n"
+"* No double-frees.\n"
+"* No use-after-free.\n"
+"* No `NULL` pointers.\n"
+"* No forgotten locked mutexes.\n"
+"* No data races between threads.\n"
+"* No iterator invalidation."
+msgstr ""
+"* Nenhuma variável não inicializada.\n"
+"* Sem vazamentos de memória (_principalmente_, veja as notas).\n"
+"* Sem liberações duplas.\n"
+"* Sem 'uso após livre'.\n"
+"* Sem ponteiros `NULL`.\n"
+"* Sem mutexes bloqueados esquecidos.\n"
+"* Sem corridas de dados entre threads.\n"
+"* Nenhuma invalidação do iterador."
+
+#: src/why-rust/compile-time.md:16
+#, fuzzy
+msgid ""
+"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
+"are:"
+msgstr ""
+"É possível produzir vazamentos de memória no Rust (seguro). Alguns exemplos\n"
+"está:"
+
+#: src/why-rust/compile-time.md:19
+#, fuzzy
+msgid ""
+"* You can for use [`Box::leak`] to leak a pointer. A use of this could\n"
+"  be to get runtime-initialized and runtime-sized static variables\n"
+"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
+"  a value (meaning the destructor is never run).\n"
+"* You can also accidentally create a [reference cycle] with `Rc` or\n"
+"  `Arc`.\n"
+"* In fact, some will consider infinitely populating a collection a memory\n"
+"  leak and Rust does not protect from those."
+msgstr ""
+"* Você pode usar [`Box::leak`] para vazar um ponteiro. Um uso disso poderia\n"
+"  be para obter variáveis estáticas inicializadas em tempo de execução e "
+"dimensionadas em tempo de execução\n"
+"* Você pode usar [`std::mem::forget`] para fazer o compilador \"esquecer\" "
+"sobre\n"
+"  um valor (o que significa que o destruidor nunca é executado).\n"
+"* Você também pode criar acidentalmente um [ciclo de referência] com `Rc` "
+"ou\n"
+"  `Arc`.\n"
+"* Na verdade, alguns considerarão preencher infinitamente uma coleção de uma "
+"memória\n"
+"  vazamento e Rust não protege deles."
+
+#: src/why-rust/compile-time.md:28
+#, fuzzy
+msgid ""
+"For the purpose of this course, \"No memory leaks\" should be understood\n"
+"as \"Pretty much no *accidental* memory leaks\"."
+msgstr ""
+"Para o propósito deste curso, \"Sem vazamentos de memória\" deve ser "
+"entendido\n"
+"como \"Praticamente sem vazamentos de memória *acidentais*\"."
+
+#: src/why-rust/compile-time.md:31
+#, fuzzy
+msgid ""
+"[`Box::leak`]: "
+"https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
+"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
+"[reference cycle]: "
+"https://doc.rust-lang.org/book/ch15-06-reference-cycles.html"
+msgstr ""
+"[`Box::leak`]: "
+"https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
+"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
+"[ciclo de referência]: "
+"https://doc.rust-lang.org/book/ch15-06-reference-cycles.html"
+
+#: src/why-rust/runtime.md:1
+#, fuzzy
+msgid "# Runtime Guarantees"
+msgstr "# Garantias de tempo de execução"
+
+#: src/why-rust/runtime.md:3
+#, fuzzy
+msgid "No undefined behavior at runtime:"
+msgstr "Nenhum comportamento indefinido em tempo de execução:"
+
+#: src/why-rust/runtime.md:5
+#, fuzzy
+msgid "* Array access is bounds checked.\n* Integer overflow is defined."
+msgstr ""
+"* O acesso ao array tem limites verificados.\n"
+"* Estouro inteiro é definido."
+
+#: src/why-rust/runtime.md:12
+#, fuzzy
+msgid ""
+"* Integer overflow is defined via a compile-time flag. The options are\n"
+"  either a panic (a controlled crash of the program) or wrap-around\n"
+"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
+"  and wrap-around in release mode (`cargo build --release`)."
+msgstr ""
+"* O estouro de inteiro é definido por meio de um sinalizador de tempo de "
+"compilação. As opções são\n"
+"  ou um pânico (uma falha controlada do programa) ou wrap-around\n"
+"  semântica. Por padrão, você obtém pânico no modo de depuração (`cargo "
+"build`)\n"
+"  e wrap-around no modo de liberação (`cargo build --release`)."
+
+#: src/why-rust/runtime.md:17
+#, fuzzy
+msgid ""
+"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
+"  not be disabled directly with the `unsafe` keyword. However,\n"
+"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
+"  which does not do bounds checking."
+msgstr ""
+"* A verificação de limites não pode ser desativada com um sinalizador de "
+"compilador. também pode\n"
+"  não pode ser desativado diretamente com a palavra-chave `unsafe`. No "
+"entanto,\n"
+"  `unsafe` permite que você chame funções como `slice::get_unchecked`\n"
+"  que não faz verificação de limites."
+
+#: src/why-rust/modern.md:1
+#, fuzzy
+msgid "# Modern Features"
+msgstr "# Recursos modernos"
+
+#: src/why-rust/modern.md:3
+#, fuzzy
+msgid "Rust is built with all the experience gained in the last 40 years."
+msgstr ""
+"A Rust é construída com toda a experiência adquirida nos últimos 40 anos."
+
+#: src/why-rust/modern.md:5
+#, fuzzy
+msgid "## Language Features"
+msgstr "## Características da linguagem"
+
+#: src/why-rust/modern.md:7
+#, fuzzy
+msgid ""
+"* Enums and pattern matching.\n"
+"* Generics.\n"
+"* No overhead FFI.\n"
+"* Zero-cost abstractions."
+msgstr ""
+"* Enums e correspondência de padrões.\n"
+"* Genéricos.\n"
+"* Sem sobrecargo FFI.\n"
+"* Abstrações de custo zero."
+
+#: src/why-rust/modern.md:12
+#, fuzzy
+msgid "## Tooling"
+msgstr "## Ferramentas"
+
+#: src/why-rust/modern.md:14
+#, fuzzy
+msgid ""
+"* Great compiler errors.\n"
+"* Built-in dependency manager.\n"
+"* Built-in support for testing.\n"
+"* Excellent Language Server Protocol support."
+msgstr ""
+"* Grandes erros do compilador.\n"
+"* Gerenciador de dependências integrado.\n"
+"* Suporte integrado para testes.\n"
+"* Excelente suporte ao protocolo de servidor de idiomas."
+
+#: src/why-rust/modern.md:23
+#, fuzzy
+msgid ""
+"* Zero-cost abstractions, similar to C++, means that you don't have to "
+"'pay'\n"
+"  for higher-level programming constructs with memory or CPU. For example,\n"
+"  writing a loop using `for` should result in roughly the same low level\n"
+"  instructions as using the `.iter().fold()` construct."
+msgstr ""
+"* Abstrações de custo zero, semelhantes ao C++, significa que você não "
+"precisa 'pagar'\n"
+"  para construções de programação de alto nível com memória ou CPU. Por "
+"exemplo,\n"
+"  escrever um loop usando `for` deve resultar aproximadamente no mesmo nível "
+"baixo\n"
+"  instruções como usar a construção `.iter().fold()`."
+
+#: src/why-rust/modern.md:28
+#, fuzzy
+msgid ""
+"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
+"also\n"
+"  known as 'sum types', which allow the type system to express things like\n"
+"  `Option<T>` and `Result<T, E>`."
+msgstr ""
+"* Pode valer a pena mencionar que Rust enums são 'Algebraic Data Types', "
+"também\n"
+"  conhecidos como 'tipos de soma', que permitem que o sistema de tipos "
+"expresse coisas como\n"
+"  `Option<T>` e `Result<T, E>`."
+
+#: src/why-rust/modern.md:32
+#, fuzzy
+msgid ""
+"* Remind people to read the errors --- many developers have gotten used to\n"
+"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
+"  talkative than other compilers. It will often provide you with "
+"_actionable_\n"
+"  feedback, ready to copy-paste into your code."
+msgstr ""
+"* Lembre as Persons de lerem os erros --- muitos desenvolvedores se "
+"acostumaram\n"
+"  ignore a longa saída do compilador. O compilador Rust é significativamente "
+"mais\n"
+"  falador do que outros compiladores. Muitas vezes, ele fornecerá a você "
+"_acionável_\n"
+"  feedback, pronto para copiar e colar em seu código."
+
+#: src/why-rust/modern.md:37
+#, fuzzy
+msgid ""
+"* The Rust standard library is small compared to languages like Java, "
+"Python,\n"
+"  and Go. Rust does not come with several things you might consider standard "
+"and\n"
+"  essential:"
+msgstr ""
+"* A biblioteca padrão do Rust é pequena comparada a linguagens como Java, "
+"Python,\n"
+"  e ir. Rust não vem com várias coisas que você pode considerar padrão e\n"
+"  essencial:"
+
+#: src/why-rust/modern.md:41
+#, fuzzy
+msgid ""
+"  * a random number generator, but see [rand].\n"
+"  * support for SSL or TLS, but see [rusttls].\n"
+"  * support for JSON, but see [serde_json]."
+msgstr ""
+"  * um gerador de números aleatórios, mas veja [rand].\n"
+"  * suporte para SSL ou TLS, mas consulte [rusttls].\n"
+"  * suporte para JSON, mas consulte [serde_json]."
+
+#: src/why-rust/modern.md:45
+#, fuzzy
+msgid ""
+"  The reasoning behind this is that functionality in the standard library "
+"cannot\n"
+"  go away, so it has to be very stable. For the examples above, the Rust\n"
+"  community is still working on finding the best solution --- and perhaps "
+"there\n"
+"  isn't a single \"best solution\" for some of these things."
+msgstr ""
+"  O raciocínio por trás disso é que a funcionalage na biblioteca padrão "
+"não pode\n"
+"  ir embora, então tem que ser muito estável. Para os exemplos acima, o "
+"Rust\n"
+"  comunage ainda está trabalhando para encontrar a melhor solução --- e "
+"talvez haja\n"
+"  não é uma única \"melhor solução\" para algumas dessas coisas."
+
+#: src/why-rust/modern.md:50
+#, fuzzy
+msgid ""
+"  Rust comes with a built-in package manager in the form of Cargo and this "
+"makes\n"
+"  it trivial to download and compile third-party crates. A consequence of "
+"this\n"
+"  is that the standard library can be smaller."
+msgstr ""
+"  Rust vem com um gerenciador de pacotes embutido na forma de Cargo e isso "
+"torna\n"
+"  é trivial baixar e compilar caixas de terceiros. Uma consequência disso\n"
+"  é que a biblioteca padrão pode ser menor."
+
+#: src/why-rust/modern.md:54
+#, fuzzy
+msgid ""
+"  Discovering good third-party crates can be a problem. Sites like\n"
+"  <https://lib.rs/> help with this by letting you compare health metrics "
+"for\n"
+"  crates to find a good and trusted one.\n"
+"  \n"
+"* [rust-analyzer] is a well supported LSP implementation used in major\n"
+"  IDEs and text editors."
+msgstr ""
+"  Descobrir boas caixas de terceiros pode ser um problema. sites como\n"
+"  <https://lib.rs/> ajuda com isso, permitindo que você compare métricas de "
+"saúde para\n"
+"  caixotes para encontrar um bom e confiável.\n"
+"  \n"
+"* [rust-analyzer] é uma implementação LSP bem suportada usada em grandes\n"
+"  IDEs e editores de texto."
+
+#: src/why-rust/modern.md:61
+#, fuzzy
+msgid ""
+"[rand]: https://docs.rs/rand/\n"
+"[rusttls]: https://docs.rs/rustls/\n"
+"[serde_json]: https://docs.rs/serde_json/\n"
+"[rust-analyzer]: https://rust-analyzer.github.io/"
+msgstr ""
+"[rand]: https://docs.rs/rand/\n"
+"[rusttls]: https://docs.rs/rustls/\n"
+"[serde_json]: https://docs.rs/serde_json/\n"
+"[analisador de rust]: https://rust-analyzer.github.io/"
+
+#: src/basic-syntax.md:1
+#, fuzzy
+msgid "# Basic Syntax"
+msgstr "# Sintaxe Básica"
+
+#: src/basic-syntax.md:3
+#, fuzzy
+msgid "Much of the Rust syntax will be familiar to you from C or C++:"
+msgstr "Grande parte da sintaxe do Rust será familiar para você em C ou C++:"
+
+#: src/basic-syntax.md:5
+#, fuzzy
+msgid ""
+"* Blocks and scopes are delimited by curly braces.\n"
+"* Line comments are started with `//`, block comments are delimited by `/* "
+"...\n"
+"  */`.\n"
+"* Keywords like `if` and `while` work the same.\n"
+"* Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+"* Blocos e escopos são delimitados por chaves.\n"
+"* Comentários de linha são iniciados com `//`, comentários de bloco são "
+"delimitados por `/* ...\n"
+"  */`.\n"
+"* Palavras-chave como `if` e `while` funcionam da mesma forma.\n"
+"* A atribuição de variável é feita com `=`, a comparação é feita com `==`."
+
+#: src/basic-syntax/scalar-types.md:1
+#, fuzzy
+msgid "# Scalar Types"
+msgstr "# Tipos escalares"
+
+#: src/basic-syntax/scalar-types.md:3
+#, fuzzy
+msgid ""
+"|                        | Types                                      | "
+"Literals                      |\n"
+"|------------------------|--------------------------------------------|-------------------------------|\n"
+"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
+"`-10`, `0`, `1_000`, `123i64` |\n"
+"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
+"`123`, `10u16`           |\n"
+"| Floating point numbers | `f32`, `f64`                               | "
+"`3.14`, `-10.0e20`, `2f32`    |\n"
+"| Strings                | `&str`                                     | "
+"`\"foo\"`, `r#\"\\\\\"#`            |\n"
+"| Unicode scalar values  | `char`                                     | "
+"`'a'`, `'α'`, `'∞'`           |\n"
+"| Byte strings           | `&[u8]`                                    | "
+"`b\"abc\"`, `br#\" \" \"#`         |\n"
+"| Booleans               | `bool`                                     | "
+"`true`, `false`               |"
+msgstr ""
+"| | Tipos | Literais |\n"
+"|------------------------|------------------------ "
+"--------------------|----------------------------- --|\n"
+"| Inteiros assinados | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, "
+"`0`, `1_000`, `123i64` |\n"
+"| Inteiros sem sinal | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
+"`123`, `10u16` |\n"
+"| Números de Point flutuante | `f32`, `f64` | `3.14`, `-10.0e20`, `2f32` |\n"
+"| Strings | `&str` | `\"foo\"`, `r#\"\\\\\"#` |\n"
+"| Valores escalares Unicode | `char` | `'a'`, `'α'`, `'∞'` |\n"
+"| Cadeias de bytes | `&[u8]` | `b\"abc\"`, `br#\" \" \"#` |\n"
+"| Booleanos | `bool` | `true`, `false` |"
+
+#: src/basic-syntax/scalar-types.md:13
+#, fuzzy
+msgid "The types have widths as follows:"
+msgstr "Os tipos têm larguras como segue:"
+
+#: src/basic-syntax/scalar-types.md:15
+#, fuzzy
+msgid ""
+"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
+"* `isize` and `usize` are the width of a pointer,\n"
+"* `char` is 32 bit wide,\n"
+"* `bool` is 8 bit wide."
+msgstr ""
+"* `iN`, `uN` e `fN` são _N_ bits de largura,\n"
+"* `isize` e `usize` são a largura de um ponteiro,\n"
+"* `char` tem 32 bits de largura,\n"
+"* `bool` tem 8 bits de largura."
+
+#: src/basic-syntax/compound-types.md:1
+#, fuzzy
+msgid "# Compound Types"
+msgstr "# Tipos de compostos"
+
+#: src/basic-syntax/compound-types.md:3
+#, fuzzy
+msgid ""
+"|        | Types                         | Literals                          "
+"|\n"
+"|--------|-------------------------------|-----------------------------------|\n"
+"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
+"|\n"
+"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
+"|"
+msgstr ""
+"| | Tipos | Literais |\n"
+"|--------|-------------------------------|-------- "
+"---------------------------|\n"
+"| Arrays | `[T; N]` | `[20, 30, 40]`, `[0; 3]` |\n"
+"| Tuplas | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
+"|"
+
+#: src/basic-syntax/compound-types.md:8
+#, fuzzy
+msgid "Array assignment and access:"
+msgstr "Atribuição e acesso ao array:"
+
+#: src/basic-syntax/compound-types.md:10
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut a: [i8; 10] = [42; 10];\n"
+"    a[5] = 0;\n"
+"    println!(\"a: {:?}\", a);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut a: [i8; 10] = [42; 10];\n"
+"    a[5] = 0;\n"
+"    println!(\"a: {:?}\", a);\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/compound-types.md:18
+#, fuzzy
+msgid "Tuple assignment and access:"
+msgstr "Atribuição e acesso de tupla:"
+
+#: src/basic-syntax/compound-types.md:20
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let t: (i8, bool) = (7, true);\n"
+"    println!(\"1st index: {}\", t.0);\n"
+"    println!(\"2nd index: {}\", t.1);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let t: (i8, bool) = (7, true);\n"
+"    println!(\"1st index: {}\", t.0);\n"
+"    println!(\"2nd index: {}\", t.1);\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/compound-types.md:32
+#, fuzzy
+msgid "Arrays:"
+msgstr "Arrays:"
+
+#: src/basic-syntax/compound-types.md:34
+#, fuzzy
+msgid ""
+"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant.\n"
+"  Note that the length of the array is *part of its type*, which means that "
+"`[u8; 3]` and\n"
+"  `[u8; 4]` are considered two different types."
+msgstr ""
+"* Arrays possuem elementos do mesmo tipo, `T`, e comprimento, `N`, que é uma "
+"constante de tempo de compilação.\n"
+"  Observe que o comprimento do array é *parte de seu tipo*, o que significa "
+"que `[u8; 3]` e\n"
+"  `[u8; 4]` são considerados dois tipos diferentes."
+
+#: src/basic-syntax/compound-types.md:38
+#, fuzzy
+msgid "* We can use literals to assign values to arrays."
+msgstr "* Podemos usar literais para atribuir valores a arrays."
+
+#: src/basic-syntax/compound-types.md:40
+#, fuzzy
+msgid ""
+"* In the main function, the print statement asks for the debug "
+"implementation with the `?` format\n"
+"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
+"We\n"
+"  could also have used `{a}` and `{a:?}` without specifying the value after "
+"the\n"
+"  format string."
+msgstr ""
+"* Na função principal, a instrução print solicita a implementação de "
+"depuração com o formato `?`\n"
+"  parâmetro: `{}` fornece a saída padrão, `{:?}` fornece a saída de "
+"depuração. Nós\n"
+"  também poderia ter usado `{a}` e `{a:?}` sem especificar o valor após o\n"
+"  sequência de formato."
+
+#: src/basic-syntax/compound-types.md:45
+#, fuzzy
+msgid ""
+"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
+"be easier to read."
+msgstr ""
+"* Adicionar `#`, por exemplo `{a:#?}`, chama um formato de \"impressão "
+"bonita\", que pode ser mais fácil de ler."
+
+#: src/basic-syntax/compound-types.md:47
+#, fuzzy
+msgid "Tuples:"
+msgstr "Tuplas:"
+
+#: src/basic-syntax/compound-types.md:49
+#, fuzzy
+msgid "* Like arrays, tuples have a fixed length."
+msgstr "* Assim como os arrays, as tuplas têm um comprimento fixo."
+
+#: src/basic-syntax/compound-types.md:51
+#, fuzzy
+msgid "* Tuples group together values of different types into a compound type."
+msgstr "* As tuplas agrupam valores de tipos diferentes em um tipo composto."
+
+#: src/basic-syntax/compound-types.md:53
+#, fuzzy
+msgid ""
+"* Fields of a tuple can be accessed by the period and the index of the "
+"value, e.g. `t.0`, `t.1`."
+msgstr ""
+"* Os campos de uma tupla podem ser acessados pelo Point e pelo índice do "
+"valor, por exemplo `t.0`, `t.1`."
+
+#: src/basic-syntax/compound-types.md:55
+#, fuzzy
+msgid ""
+"* The empty tuple `()` is also known as the \"unit type\". It is both a "
+"type, and\n"
+"  the only valid value of that type - that is to say both the type and its "
+"value\n"
+"  are expressed as `()`. It is used to indicate, for example, that a "
+"function or\n"
+"  expression has no return value, as we'll see in a future slide. \n"
+"    * You can think of it as `void` that can be familiar to you from other \n"
+"      programming languages."
+msgstr ""
+"* A tupla vazia `()` também é conhecida como \"tipo de unage\". É um tipo "
+"e\n"
+"  o único valor válido desse tipo - ou seja, o tipo e seu valor\n"
+"  são expressos como `()`. É usado para indicar, por exemplo, que uma função "
+"ou\n"
+"  A expressão não tem valor de retorno, como veremos em um slide futuro.\n"
+"    * Você pode pensar nisso como um 'vazio' que pode ser familiar para você "
+"de outras\n"
+"      linguagens de programação."
+
+#: src/basic-syntax/references.md:1
+#, fuzzy
+msgid "# References"
+msgstr "# Referências"
+
+#: src/basic-syntax/references.md:3
+#, fuzzy
+msgid "Like C++, Rust has references:"
+msgstr "Como C++, Rust tem referências:"
+
+#: src/basic-syntax/references.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x: i32 = 10;\n"
+"    let ref_x: &mut i32 = &mut x;\n"
+"    *ref_x = 20;\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut x: i32 = 10;\n"
+"    let ref_x: &mut i32 = &mut x;\n"
+"    *ref_x = 20;\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/references.md:14
+#, fuzzy
+msgid "Some notes:"
+msgstr "Algumas notas:"
+
+#: src/basic-syntax/references.md:16
+#, fuzzy
+msgid ""
+"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers.\n"
+"* Rust will auto-dereference in some cases, in particular when invoking\n"
+"  methods (try `ref_x.count_ones()`).\n"
+"* References that are declared as `mut` can be bound to different values "
+"over their lifetime."
+msgstr ""
+"* Devemos desreferenciar `ref_x` ao atribuir a ele, semelhante aos ponteiros "
+"C e C++.\n"
+"* Rust desreferenciará automaticamente em alguns casos, em particular ao "
+"invocar\n"
+"  métodos (tente `ref_x.count_ones()`).\n"
+"* As referências que são declaradas como `mut` podem ser vinculadas a "
+"diferentes valores ao longo de seu tempo de vida."
+
+#: src/basic-syntax/references.md:21
+#, fuzzy
+msgid "<details>\nKey points:"
+msgstr "<details>\nPoints chave:"
+
+#: src/basic-syntax/references.md:24
+#, fuzzy
+msgid ""
+"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
+"ref_x:\n"
+"  &mut i32`. The first one represents a mutable reference which can be bound "
+"to\n"
+"  different values, while the second represents a reference to a mutable "
+"value."
+msgstr ""
+"* Certifique-se de observar a diferença entre `let mut ref_x: &i32` e `let "
+"ref_x:\n"
+"  &mut i32`. O primeiro representa uma referência mutável que pode ser "
+"ligada a\n"
+"  valores diferentes, enquanto o segundo representa uma referência a um "
+"valor mutável."
+
+#: src/basic-syntax/references-dangling.md:1
+#, fuzzy
+msgid "# Dangling References"
+msgstr "# Referências pendentes"
+
+#: src/basic-syntax/references-dangling.md:3
+#, fuzzy
+msgid "Rust will statically forbid dangling references:"
+msgstr "Rust proibirá estaticamente as referências pendentes:"
+
+#: src/basic-syntax/references-dangling.md:5
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let ref_x: &i32;\n"
+"    {\n"
+"        let x: i32 = 10;\n"
+"        ref_x = &x;\n"
+"    }\n"
+"    println!(\"ref_x: {ref_x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let ref_x: &i32;\n"
+"    {\n"
+"        seja x: i32 = 10;\n"
+"        ref_x = &x;\n"
+"    }\n"
+"    println!(\"ref_x: {ref_x}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/references-dangling.md:16
+#, fuzzy
+msgid ""
+"* A reference is said to \"borrow\" the value it refers to.\n"
+"* Rust is tracking the lifetimes of all references to ensure they live long\n"
+"  enough.\n"
+"* We will talk more about borrowing when we get to ownership."
+msgstr ""
+"* Diz-se que uma referência \"pega emprestado\" o valor a que se refere.\n"
+"* Rust está rastreando os tempos de vida de todas as referências para garantir "
+"que elas durem muito\n"
+"  o suficiente.\n"
+"* Falaremos mais sobre empréstimos quando chegarmos à ownership."
+
+#: src/basic-syntax/slices.md:1
+#, fuzzy
+msgid "# Slices"
+msgstr "# Slices (do Inglês, slice)"
+
+#: src/basic-syntax/slices.md:3
+#, fuzzy
+msgid "A slice gives you a view into a larger collection:"
+msgstr "Uma slice oferece uma visão de uma coleção maior:"
+
+#: src/basic-syntax/slices.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];\n"
+"    println!(\"a: {a:?}\");"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];\n"
+"    println!(\"a: {a:?}\");"
+
+#: src/basic-syntax/slices.md:10
+#, fuzzy
+msgid ""
+"    let s: &[i32] = &a[2..4];\n"
+"    println!(\"s: {s:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    let: &[i32] = &a[2..4];\n"
+"    println!(\"s: {s:?}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/slices.md:15
+#, fuzzy
+msgid ""
+"* Slices borrow data from the sliced type.\n"
+"* Question: What happens if you modify `a[3]`?"
+msgstr ""
+"* As slices emprestam dados do tipo slicedo.\n"
+"* Pergunta: O que acontece se você modificar `a[3]`?"
+
+#: src/basic-syntax/slices.md:20
+#, fuzzy
+msgid ""
+"* We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr ""
+"* Criamos uma slice pegando emprestado `a` e especificando os índices "
+"inicial e final entre colchetes."
+
+#: src/basic-syntax/slices.md:22
+#, fuzzy
+msgid ""
+"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical.\n"
+"    \n"
+"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"* Se a slice começa no índice 0, a sintaxe de intervalo do Rust nos permite "
+"descartar o índice inicial, o que significa que `&a[0..a.len()]` e "
+"`&a[..a.len()]` são idênticos .\n"
+"    \n"
+"* O mesmo vale para o último índice, então `&a[2..a.len()]` e `&a[2..]` são "
+"idênticos."
+
+#: src/basic-syntax/slices.md:26
+#, fuzzy
+msgid ""
+"* To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+"* Para criar facilmente uma slice do array completo, podemos usar `&a[..]`."
+
+#: src/basic-syntax/slices.md:28
+#, fuzzy
+msgid ""
+"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes.\n"
+" \n"
+"* Slices always borrow from another object. In this example, `a` has to "
+"remain 'alive' (in scope) for at least as long as our slice. \n"
+"    \n"
+"* The question about modifying `a[3]` can spark an interesting discussion, "
+"but the answer is that for memory safety reasons\n"
+"  you cannot do it through `a` after you created a slice, but you can read "
+"the data from both `a` and `s` safely. \n"
+"  More details will be explained in the borrow checker section."
+msgstr ""
+"* `s` é uma referência a uma slice de `i32`s. Observe que o tipo de `s` "
+"(`&[i32]`) não menciona mais o tamanho do array. Isso nos permite realizar "
+"cálculos em slices de tamanhos diferentes.\n"
+" \n"
+"* As slices sempre pegam emprestado de outro objeto. Neste exemplo, `a` deve "
+"permanecer 'vivo' (no escopo) por pelo menos tanto tempo quanto nossa "
+"slice.\n"
+"    \n"
+"* A questão sobre a modificação de `a[3]` pode gerar uma discussão "
+"interessante, mas a resposta é por motivos de segurança de memória\n"
+"  você não pode fazer isso por meio de `a` depois de criar uma slice, mas "
+"pode ler os dados de `a` e `s` com segurança.\n"
+"  Mais detalhes serão explicados na seção do verificador de empréstimo."
+
+#: src/basic-syntax/string-slices.md:1
+#, fuzzy
+msgid "# `String` vs `str`"
+msgstr "# `String` vs `str`"
+
+#: src/basic-syntax/string-slices.md:3
+#, fuzzy
+msgid "We can now understand the two string types in Rust:"
+msgstr "Agora podemos entender os dois tipos de string em Rust:"
+
+#: src/basic-syntax/string-slices.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: &str = \"World\";\n"
+"    println!(\"s1: {s1}\");"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let s1: &str = \"Mundo\";\n"
+"    println!(\"s1: {s1}\");"
+
+#: src/basic-syntax/string-slices.md:10
+#, fuzzy
+msgid ""
+"    let mut s2: String = String::from(\"Hello \");\n"
+"    println!(\"s2: {s2}\");\n"
+"    s2.push_str(s1);\n"
+"    println!(\"s2: {s2}\");\n"
+"    \n"
+"    let s3: &str = &s2[6..];\n"
+"    println!(\"s3: {s3}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    let mut s2: String = String::from(\"Olá \");\n"
+"    println!(\"s2: {s2}\");\n"
+"    s2.push_str(s1);\n"
+"    println!(\"s2: {s2}\");\n"
+"    \n"
+"    let s3: &str = &s2[6..];\n"
+"    println!(\"s3: {s3}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/string-slices.md:20
+#, fuzzy
+msgid "Rust terminology:"
+msgstr "Terminologia da rust:"
+
+#: src/basic-syntax/string-slices.md:22
+#, fuzzy
+msgid ""
+"* `&str` an immutable reference to a string slice.\n"
+"* `String` a mutable string buffer."
+msgstr ""
+"* `&str` uma referência imutável para uma slice de string.\n"
+"* `String` um buffer de string mutável."
+
+#: src/basic-syntax/string-slices.md:27
+#, fuzzy
+msgid ""
+"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data \n"
+"  stored in a block of memory. String literals (`”Hello”`), are stored in "
+"the program’s binary."
+msgstr ""
+"* `&str` introduz uma slice de string, que é uma referência imutável para "
+"dados de string codificados em UTF-8\n"
+"  armazenados em um bloco de memória. String literais (`”Hello”`), são "
+"armazenados no binário do programa."
+
+#: src/basic-syntax/string-slices.md:30
+#, fuzzy
+msgid ""
+"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned.\n"
+"    \n"
+"* As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()` \n"
+"  creates a new empty string, to which string data can be added using the "
+"`push()` and `push_str()` methods."
+msgstr ""
+"* O tipo `String` do Rust é um wrapper em torno de um vetor de bytes. Tal "
+"como acontece com um `Vec<T>`, ele é possuído.\n"
+"    \n"
+"* Assim como muitos outros tipos `String::from()` cria uma string a partir "
+"de uma string literal; `String::new()`\n"
+"  cria uma nova string vazia, na qual os dados da string podem ser "
+"adicionados usando os métodos `push()` e `push_str()`."
+
+#: src/basic-syntax/string-slices.md:35
+#, fuzzy
+msgid ""
+"* The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It \n"
+"  accepts the same format specification as `println!()`.\n"
+"    \n"
+"* You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection.\n"
+"    \n"
+"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
+"one that always points \n"
+"  to a valid string in memory. Rust `String` is a rough equivalent of "
+"`std::string` from C++ \n"
+"  (main difference: it can only contain UTF-8 encoded bytes and will never "
+"use a small-string optimization).\n"
+"    \n"
+"</details>"
+msgstr ""
+"* A macro `format!()` é uma maneira conveniente de gerar uma string própria "
+"a partir de valores dinâmicos. Isto\n"
+"  aceita a mesma especificação de formato que `println!()`.\n"
+"    \n"
+"* Você pode emprestar slices `&str` de `String` via `&` e, opcionalmente, "
+"seleção de intervalo.\n"
+"    \n"
+"* Para programadores C++: pense em `&str` como `const char*` de C++, mas "
+"aquele que sempre aponta\n"
+"  para uma string válida na memória. Rust `String` é um equivalente "
+"aproximado de `std::string` de C++\n"
+"  (principal diferença: ele só pode conter bytes codificados em UTF-8 e "
+"nunca usará uma otimização de string pequena).\n"
+"    \n"
+"</details>"
+
+#: src/basic-syntax/functions.md:1
+#, fuzzy
+msgid "# Functions"
+msgstr "# Funções"
+
+#: src/basic-syntax/functions.md:3
+#, fuzzy
+msgid ""
+"A Rust version of the famous "
+"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
+msgstr ""
+"Uma versão Rust da famosa pergunta da entrevista "
+"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz):"
+
+#: src/basic-syntax/functions.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    fizzbuzz_to(20);   // Defined below, no forward declaration needed\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    fizzbuzz_to(20); // Definido abaixo, nenhuma declaração de "
+"encaminhamento é necessária\n"
+"}"
+
+#: src/basic-syntax/functions.md:10
+#, fuzzy
+msgid ""
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
+"    if rhs == 0 {\n"
+"        return false;  // Corner case, early return\n"
+"    }\n"
+"    lhs % rhs == 0     // The last expression in a block is the return "
+"value\n"
+"}"
+msgstr ""
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
+"    if rh == 0 {\n"
+"        return false; // Caixa de canto, retorno antecipado\n"
+"    }\n"
+"    lhs % rhs == 0 // A última expressão em um bloco é o valor de retorno\n"
+"}"
+
+#: src/basic-syntax/functions.md:17
+#, fuzzy
+msgid ""
+"fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit "
+"type `()`\n"
+"    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
+"        (true,  true)  => println!(\"fizzbuzz\"),\n"
+"        (true,  false) => println!(\"fizz\"),\n"
+"        (false, true)  => println!(\"buzz\"),\n"
+"        (false, false) => println!(\"{n}\"),\n"
+"    }\n"
+"}"
+msgstr ""
+"fn fizzbuzz(n: u32) -> () { // Nenhum valor de retorno significa retornar o "
+"type `()`\n"
+"    match (is_divisible_by(n, 3), é_divisível_por(n, 5)) {\n"
+"        (true, true) => println!(\"fizzbuzz\"),\n"
+"        (true, false) => println!(\"fizz\"),\n"
+"        (false, true) => println!(\"buzz\"),\n"
+"        (false, false) => println!(\"{n}\"),\n"
+"    }\n"
+"}"
+
+#: src/basic-syntax/functions.md:26
+#, fuzzy
+msgid ""
+"fn fizzbuzz_to(n: u32) {  // `-> ()` is normally omitted\n"
+"    for i in 1..=n {\n"
+"        fizzbuzz(i);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn fizzbuzz_to(n: u32) { // `-> ()` normalmente é omitido\n"
+"    for i in 1..=n {\n"
+"        fizzbuzz(i);\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/functions.md:35
+#, fuzzy
+msgid ""
+"* We refer in `main` to a function written below. Neither forward "
+"declarations nor headers are necessary. \n"
+"* Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type.\n"
+"* The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression.\n"
+"* Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted.\n"
+"* The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
+"which causes it to include the upper bound.\n"
+"* The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
+"expanded below to show what is happening."
+msgstr ""
+"* Nos referimos em `main` a uma função escrita abaixo. Nem declarações de "
+"encaminhamento nem cabeçalhos são necessários.\n"
+"* Os parâmetros de declaração são seguidos por um tipo (o inverso de algumas "
+"linguagens de programação) e, em seguida, um tipo de retorno.\n"
+"* A última expressão em um corpo de função (ou qualquer bloco) torna-se o "
+"valor de retorno. Simplesmente omita o `;` no final da expressão.\n"
+"* Algumas funções não têm valor de retorno e retornam o 'tipo de unage', "
+"`()`. O compilador inferirá isso se o tipo de retorno `-> ()` for omitido.\n"
+"* A expressão de intervalo no loop `for` em `fizzbuzz_to()` contém `=n`, o "
+"que faz com que inclua o limite superior.\n"
+"* A expressão `match` em `fizzbuzz()` está dando muito trabalho. É expandido "
+"abaixo para mostrar o que está acontecendo."
+
+#: src/basic-syntax/functions.md:42
+#, fuzzy
+msgid "  (Type annotations added for clarity, but they can be elided.)"
+msgstr ""
+"  (As anotações de tipo foram adicionadas para maior clareza, mas podem ser "
+"omitidas.)"
+
+#: src/basic-syntax/functions.md:44
+#, fuzzy
+msgid ""
+"  ```rust,ignore\n"
+"  let by_3: bool = is_divisible_by(n, 3);\n"
+"  let by_5: bool = is_divisible_by(n, 5);\n"
+"  let by_35: (bool, bool) = (by_3, by_5);\n"
+"  match by_35 {\n"
+"    // ...\n"
+"  ```"
+msgstr ""
+"  ```rust, ignore\n"
+"  let by_3: bool = is_divisible_by(n, 3);\n"
+"  let by_5: bool = is_divisible_by(n, 5);\n"
+"  let by_35: (bool, bool) = (by_3, by_5);\n"
+"  match by_35 {\n"
+"    // ...\n"
+"  ```"
+
+#: src/basic-syntax/functions.md:52
+#, fuzzy
+msgid "  "
+msgstr "  "
+
+#: src/basic-syntax/methods.md:1 src/methods.md:1
+#, fuzzy
+msgid "# Methods"
+msgstr "# Métodos"
+
+#: src/basic-syntax/methods.md:3
+#, fuzzy
+msgid ""
+"Rust has methods, they are simply functions that are associated with a "
+"particular type. The\n"
+"first argument of a method is an instance of the type it is associated with:"
+msgstr ""
+"Rust tem métodos, eles são simplesmente funções associadas a um tipo "
+"específico. o\n"
+"primeiro argumento de um método é uma instância do tipo ao qual está "
+"associado:"
+
+#: src/basic-syntax/methods.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"struct Rectangle {\n"
+"    width: u32,\n"
+"    height: u32,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"struct Retângulo {\n"
+"    width: u32,\n"
+"    height: u32,\n"
+"}"
+
+#: src/basic-syntax/methods.md:12
+#, fuzzy
+msgid ""
+"impl Rectangle {\n"
+"    fn area(&self) -> u32 {\n"
+"        self.width * self.height\n"
+"    }"
+msgstr ""
+"impl Rectangle {\n"
+"    fn area(&self) -> u32 {\n"
+"        self.width * self.height\n"
+"    }"
+
+#: src/basic-syntax/methods.md:17
+#, fuzzy
+msgid ""
+"    fn inc_width(&mut self, delta: u32) {\n"
+"        self.width += delta;\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn inc_width(&mut self, delta: u32) {\n"
+"        self.width += delta;\n"
+"    }\n"
+"}"
+
+#: src/basic-syntax/methods.md:22
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut rect = Rectangle { width: 10, height: 5 };\n"
+"    println!(\"old area: {}\", rect.area());\n"
+"    rect.inc_width(5);\n"
+"    println!(\"new area: {}\", rect.area());\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let mut rect = Rectangle { width: 10, height: 5 };\n"
+"    println!(\"área antiga: {}\", rect.area());\n"
+"    rect.inc_width(5);\n"
+"    println!(\"nova área: {}\", rect.area());\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/methods.md:30
+#, fuzzy
+msgid ""
+"* We will look much more at methods in today's exercise and in tomorrow's "
+"class."
+msgstr "* Veremos muito mais métodos no exercício de hoje e na aula de amanhã."
+
+#: src/basic-syntax/functions-interlude.md:1
+#, fuzzy
+msgid "# Function Overloading"
+msgstr "# Sobrecargo de funções"
+
+#: src/basic-syntax/functions-interlude.md:3
+#, fuzzy
+msgid "Overloading is not supported:"
+msgstr "A sobrecargo não é suportada:"
+
+#: src/basic-syntax/functions-interlude.md:5
+#, fuzzy
+msgid ""
+"* Each function has a single implementation:\n"
+"  * Always takes a fixed number of parameters.\n"
+"  * Always takes a single set of parameter types.\n"
+"* Default values are not supported:\n"
+"  * All call sites have the same number of arguments.\n"
+"  * Macros are sometimes used as an alternative."
+msgstr ""
+"* Cada função tem uma única implementação:\n"
+"  * Sempre leva um número fixo de parâmetros.\n"
+"  * Sempre usa um único conjunto de tipos de parâmetros.\n"
+"* Valores padrão não são suportados:\n"
+"  * Todos os sites de chamada têm o mesmo número de argumentos.\n"
+"  * Às vezes, as macros são usadas como alternativa."
+
+#: src/basic-syntax/functions-interlude.md:12
+#, fuzzy
+msgid "However, function parameters can be generic:"
+msgstr "No entanto, os parâmetros da função podem ser genéricos:"
+
+#: src/basic-syntax/functions-interlude.md:14
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn pick_one<T>(a: T, b: T) -> T {\n"
+"    if std::process::id() % 2 == 0 { a } else { b }\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn pick_one<T>(a: T, b: T) -> T {\n"
+"    if std::process::id() % 2 == 0 { a } else { b }\n"
+"}"
+
+#: src/basic-syntax/functions-interlude.md:19
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
+"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    println!(\"jogo de moeda: {}\", pick_one(\"cara\", \"coroa\"));\n"
+"    println!(\"prêmio em dinheiro: {}\", pick_one(500, 1000));\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/functions-interlude.md:27
+#, fuzzy
+msgid ""
+"* When using generics, the standard library's `Into<T>` can provide a kind "
+"of limited\n"
+"  polymorphism on argument types. We will see more details in a later "
+"section."
+msgstr ""
+"* Ao usar genéricos, o `Into<T>` da biblioteca padrão pode fornecer um tipo "
+"de limitação\n"
+"  polimorfismo em tipos de argumento. Veremos mais detalhes em uma seção "
+"posterior."
+
+#: src/basic-syntax/functions-interlude.md:30
+#, fuzzy
+msgid "</defails>"
+msgstr "</defails>"
+
+#: src/exercises/day-1/morning.md:1
+#, fuzzy
+msgid "# Day 1: Morning Exercises"
+msgstr "# Dia 1: Exercícios matinais"
+
+#: src/exercises/day-1/morning.md:3
+#, fuzzy
+msgid "In these exercises, we will explore two parts of Rust:"
+msgstr "Nestes exercícios, exploraremos duas partes do Rust:"
+
+#: src/exercises/day-1/morning.md:5
+#, fuzzy
+msgid "* Implicit conversions between types."
+msgstr "* Conversões implícitas entre tipos."
+
+#: src/exercises/day-1/morning.md:7
+#, fuzzy
+msgid "* Arrays and `for` loops."
+msgstr "* Arrays e loops `for`."
+
+#: src/exercises/day-1/morning.md:11
+#, fuzzy
+msgid "A few things to consider while solving the exercises:"
+msgstr "Algumas coisas a considerar ao resolver os exercícios:"
+
+#: src/exercises/day-1/morning.md:13
+#, fuzzy
+msgid ""
+"* Use a local Rust installation, if possible. This way you can get\n"
+"  auto-completion in your editor. See the page about [Using Cargo] for "
+"details\n"
+"  on installing Rust."
+msgstr ""
+"* Use uma instalação Rust local, se possível. Desta forma, você pode obter\n"
+"  preenchimento automático em seu editor. Veja a página sobre [Using Cargo] "
+"para detalhes\n"
+"  na instalação do Rust."
+
+#: src/exercises/day-1/morning.md:17
+#, fuzzy
+msgid "* Alternatively, use the Rust Playground."
+msgstr "* Como alternativa, use o Rust Playground."
+
+#: src/exercises/day-1/morning.md:19
+#, fuzzy
+msgid ""
+"The code snippets are not editable on purpose: the inline code snippets "
+"lose\n"
+"their state if you navigate away from the page."
+msgstr ""
+"Os trechos de código não são editáveis de propósito: os trechos de código "
+"embutidos perdem\n"
+"seu estado se você sair da página."
+
+#: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
+#: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
+#: src/exercises/day-3/morning.md:7 src/exercises/day-4/morning.md:12
+#, fuzzy
+msgid "After looking at the exercises, you can look at the [solutions] provided."
+msgstr "Depois de ver os exercícios, você pode ver as [soluções] fornecidas."
+
+#: src/exercises/day-1/morning.md:24 src/exercises/day-2/morning.md:13
+#: src/exercises/day-3/morning.md:9 src/exercises/day-4/morning.md:14
+#, fuzzy
+msgid "[solutions]: solutions-morning.md"
+msgstr "[soluções]:solutions-morning.md"
+
+#: src/exercises/day-1/morning.md:26
+#, fuzzy
+msgid "[Using Cargo]: ../../cargo.md"
+msgstr "[Usando Cargo]: ../../cargo.md"
+
+#: src/exercises/day-1/implicit-conversions.md:1
+#, fuzzy
+msgid "# Implicit Conversions"
+msgstr "# Conversões implícitas"
+
+#: src/exercises/day-1/implicit-conversions.md:3
+#, fuzzy
+msgid ""
+"Rust will not automatically apply _implicit conversions_ between types "
+"([unlike\n"
+"C++][3]). You can see this in a program like this:"
+msgstr ""
+"Rust não aplicará automaticamente _conversões implícitas_ entre os tipos "
+"([ao contrário\n"
+"C++][3]). Você pode ver isso em um programa como este:"
+
+#: src/exercises/day-1/implicit-conversions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn multiply(x: i16, y: i16) -> i16 {\n"
+"    x * y\n"
+"}"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"fn multiply(x: i16, y: i16) -> i16 {\n"
+"    x * y\n"
+"}"
+
+#: src/exercises/day-1/implicit-conversions.md:11
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let x: i8 = 15;\n"
+"    let y: i16 = 1000;"
+msgstr ""
+"fn main() {\n"
+"    let x: i8 = 15;\n"
+"    let y: i16 = 1000;"
+
+#: src/exercises/day-1/implicit-conversions.md:15
+#, fuzzy
+msgid ""
+"    println!(\"{x} * {y} = {}\", multiply(x, y));\n"
+"}\n"
+"```"
+msgstr ""
+"    println!(\"{x} * {y} = {}\", multiply(x, y));\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/implicit-conversions.md:19
+#, fuzzy
+msgid ""
+"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
+"traits to let us convert between them. The `From<T>` trait has a single "
+"`from()`\n"
+"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
+"Implementing these traits is how a type expresses that it can be converted "
+"into\n"
+"another type."
+msgstr ""
+"Todos os tipos Rust integer implementam [`From<T>`][1] e [`Into<T>`][2]\n"
+"características para nos deixar converter entre eles. A característica "
+"`From<T>` tem um único `from()`\n"
+"e da mesma forma, o trait `Into<T>` tem um único método `into()`.\n"
+"A implementação dessas características é como um tipo expressa que pode ser "
+"convertido em\n"
+"outro tipo."
+
+#: src/exercises/day-1/implicit-conversions.md:25
+#, fuzzy
+msgid ""
+"The standard library has an implementation of `From<i8> for i16`, which "
+"means\n"
+"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
+"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
+"implementation automatically create an implementation of `Into<i16> for i8`."
+msgstr ""
+"A biblioteca padrão tem uma implementação de `From<i8> for i16`, o que "
+"significa\n"
+"que podemos converter uma variável `x` do tipo `i8` para um `i16` chamando\n"
+"`i16::de(x)`. Ou, mais simples, com `x.into()`, porque `From<i8> for i16`\n"
+"implementação cria automaticamente uma implementação de `Into<i16> para i8`."
+
+#: src/exercises/day-1/implicit-conversions.md:30
+#, fuzzy
+msgid ""
+"The same applies for your own `From` implementations for your own types, so "
+"it is\n"
+"sufficient to only implement `From` to get a respective `Into` "
+"implementation automatically."
+msgstr ""
+"O mesmo se aplica para suas próprias implementações `From` para seus "
+"próprios tipos, então é\n"
+"suficiente para apenas implementar `From` para obter uma respectiva "
+"implementação `Into` automaticamente."
+
+#: src/exercises/day-1/implicit-conversions.md:33
+#, fuzzy
+msgid "1. Execute the above program and look at the compiler error."
+msgstr "1. Execute o programa acima e observe o erro do compilador."
+
+#: src/exercises/day-1/implicit-conversions.md:35
+#, fuzzy
+msgid "2. Update the code above to use `into()` to do the conversion."
+msgstr "2. Atualize o código acima para usar `into()` para fazer a conversão."
+
+#: src/exercises/day-1/implicit-conversions.md:37
+#, fuzzy
+msgid ""
+"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
+"   `i128`) to see which types you can convert to which other types. Try\n"
+"   converting small types to big types and the other way around. Check the\n"
+"   [standard library documentation][1] to see if `From<T>` is implemented "
+"for\n"
+"   the pairs you check."
+msgstr ""
+"3. Mude os tipos de `x` e `y` para outras coisas (como `f32`, `bool`,\n"
+"   `i128`) para ver quais tipos você pode converter para quais outros tipos. "
+"Experimentar\n"
+"   convertendo tipos pequenos em tipos grandes e vice-versa. Verifica a\n"
+"   [documentação da biblioteca padrão][1] para ver se `From<T>` está "
+"implementado para\n"
+"   os pares que você verifica."
+
+#: src/exercises/day-1/implicit-conversions.md:43
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
+"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
+"[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
+"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
+"[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
+
+#: src/exercises/day-1/for-loops.md:1
+#, fuzzy
+msgid "# Arrays and `for` Loops"
+msgstr "# Arrays e loops `for`"
+
+#: src/exercises/day-1/for-loops.md:3
+#, fuzzy
+msgid "We saw that an array can be declared like this:"
+msgstr "Vimos que um array pode ser declarado assim:"
+
+#: src/exercises/day-1/for-loops.md:5
+#, fuzzy
+msgid ""
+"```rust\n"
+"let array = [10, 20, 30];\n"
+"```"
+msgstr ""
+"```rust\n"
+"let array = [10, 20, 30];\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:9
+#, fuzzy
+msgid ""
+"You can print such an array by asking for its debug representation with "
+"`{:?}`:"
+msgstr ""
+"Você pode imprimir tal array solicitando sua representação de depuração com "
+"`{:?}`:"
+
+#: src/exercises/day-1/for-loops.md:11
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    println!(\"array: {array:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    println!(\"array: {array:?}\");\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:18
+#, fuzzy
+msgid ""
+"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"keyword:"
+msgstr ""
+"Rust permite iterar coisas como arrays e intervalos usando o `for`\n"
+"palavra-chave:"
+
+#: src/exercises/day-1/for-loops.md:21
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    print!(\"Iterating over array:\");\n"
+"    for n in array {\n"
+"        print!(\" {n}\");\n"
+"    }\n"
+"    println!();"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    print!(\"Iterando sobre o array:\");\n"
+"    for n in array {\n"
+"        print!(\"{n}\");\n"
+"    }\n"
+"    println!();"
+
+#: src/exercises/day-1/for-loops.md:30
+#, fuzzy
+msgid ""
+"    print!(\"Iterating over range:\");\n"
+"    for i in 0..3 {\n"
+"        print!(\" {}\", array[i]);\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+msgstr ""
+"    print!(\"Iterando sobre o intervalo:\");\n"
+"    for i em 0..3 {\n"
+"        imprima!(\" {}\", array[i]);\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:38
+#, fuzzy
+msgid ""
+"Use the above to write a function `pretty_print` which pretty-print a matrix "
+"and\n"
+"a function `transpose` which will transpose a matrix (turn rows into "
+"columns):"
+msgstr ""
+"Use o acima para escrever uma função `pretty_print` que imprime uma array "
+"e\n"
+"uma função `transpose` que irá transpose uma array (transformar linhas em "
+"colunas):"
+
+#: src/exercises/day-1/for-loops.md:41
+#, fuzzy
+msgid ""
+"```bob\n"
+"           ⎛⎡1 2 3⎤⎞      ⎡1 4 7⎤\n"
+"\"transpose\"⎜⎢4 5 6⎥⎟  \"==\"⎢2 5 8⎥\n"
+"           ⎝⎣7 8 9⎦⎠      ⎣3 6 9⎦\n"
+"```"
+msgstr ""
+"```bob\n"
+"           ⎛⎡1 2 3⎤⎞ ⎡1 4 7⎤\n"
+"\"transpose\"⎜⎢4 5 6⎥⎟ \"==\"⎢2 5 8⎥\n"
+"           ⎝⎣7 8 9⎦⎠ ⎣3 6 9⎦\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:47
+#, fuzzy
+msgid "Hard-code both functions to operate on 3 × 3 matrices."
+msgstr "Codifique ambas as funções para operar em Arrays 3 × 3."
+
+#: src/exercises/day-1/for-loops.md:49
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"functions:"
+msgstr ""
+"Copie o código abaixo para <https://play.rust-lang.org/> e implemente o\n"
+"funções:"
+
+#: src/exercises/day-1/for-loops.md:52 src/exercises/day-1/book-library.md:20
+#: src/exercises/day-2/health-statistics.md:13
+#, fuzzy
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]"
+msgstr ""
+"```rust,should_panic\n"
+"// TODO: remova isso quando terminar sua implementação.\n"
+"#![allow(unused_variables, dead_code)]"
+
+#: src/exercises/day-1/for-loops.md:56
+#, fuzzy
+msgid ""
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+"fn transpose(array: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    não implementado!()\n"
+"}"
+
+#: src/exercises/day-1/for-loops.md:60
+#, fuzzy
+msgid ""
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+"fn pretty_print(array: &[[i32; 3]; 3]) {\n"
+"    não implementado!()\n"
+"}"
+
+#: src/exercises/day-1/for-loops.md:64
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];"
+msgstr ""
+"fn main() {\n"
+"    let array = [\n"
+"        [101, 102, 103], // <-- o comentário faz com que o rustfmt adicione "
+"uma nova linha\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];"
+
+#: src/exercises/day-1/for-loops.md:71
+#: src/exercises/day-1/solutions-morning.md:70
+#, fuzzy
+msgid "    println!(\"matrix:\");\n    pretty_print(&matrix);"
+msgstr "    println!(\"array:\");\n    bonita_impressão(&array);"
+
+#: src/exercises/day-1/for-loops.md:74
+#, fuzzy
+msgid ""
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
+msgstr ""
+"    let transposed = transpose(array);\n"
+"    println!(\"transposto:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:80
+#, fuzzy
+msgid "## Bonus Question"
+msgstr "## Pergunta Bônus"
+
+#: src/exercises/day-1/for-loops.md:82
+#, fuzzy
+msgid ""
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"slice-of-slices. Why or why not?"
+msgstr ""
+"Você poderia usar slices `&[i32]` em vez de Arrays 3 × 3 codificadas para "
+"o seu\n"
+"argumentos e tipos de retorno? Algo como `&[&[i32]]` para um bidimensional\n"
+"slice-de-slices. Por que ou por que não?"
+
+#: src/exercises/day-1/for-loops.md:87
+#, fuzzy
+msgid ""
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
+"quality\n"
+"implementation."
+msgstr ""
+"Veja a [caixa `ndarray`](https://docs.rs/ndarray/) para uma qualage de "
+"produção\n"
+"implementação."
+
+#: src/exercises/day-1/for-loops.md:92
+#, fuzzy
+msgid ""
+"The solution and the answer to the bonus section are available in the \n"
+"[Solution](solutions-morning.md#arrays-and-for-loops) section."
+msgstr ""
+"A solução e a resposta para a seção de bônus estão disponíveis no\n"
+"Seção [Solution](solutions-morning.md#arrays-and-for-loops)."
+
+#: src/basic-syntax/variables.md:1
+#, fuzzy
+msgid "# Variables"
+msgstr "# Variáveis"
+
+#: src/basic-syntax/variables.md:3
+#, fuzzy
+msgid ""
+"Rust provides type safety via static typing. Variable bindings are immutable "
+"by\n"
+"default:"
+msgstr ""
+"Rust fornece segurança de tipo por meio de digitação estática. Vinculações "
+"de variáveis são imutáveis por\n"
+"predefinição:"
+
+#: src/basic-syntax/variables.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let x: i32 = 10;\n"
+"    println!(\"x: {x}\");\n"
+"    // x = 20;\n"
+"    // println!(\"x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let x: i32 = 10;\n"
+"    println!(\"x: {x}\");\n"
+"    // x = 20;\n"
+"    // println!(\"x: {x}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/variables.md:17
+#, fuzzy
+msgid ""
+"* Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the type progresses.\n"
+"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"function like syntax of `println!(\"x: {}\", x)`"
+msgstr ""
+"* Devido à inferência de tipos, o `i32` é opcional. Mostraremos gradualmente "
+"os tipos cada vez menos à medida que o tipo progride.\n"
+"* Observe que como `println!` é uma macro, `x` não é movido, mesmo usando a "
+"função como a sintaxe de `println!(\"x: {}\", x)`"
+
+#: src/basic-syntax/type-inference.md:1
+#, fuzzy
+msgid "# Type Inference"
+msgstr "# Inferência do tipo"
+
+#: src/basic-syntax/type-inference.md:3
+#, fuzzy
+msgid "Rust will look at how the variable is _used_ to determine the type:"
+msgstr "Rust verá como a variável é _usada_ para determinar o tipo:"
+
+#: src/basic-syntax/type-inference.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn takes_u32(x: u32) {\n"
+"    println!(\"u32: {x}\");\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn takes_u32(x:u32) {\n"
+"    println!(\"u32: {x}\");\n"
+"}"
+
+#: src/basic-syntax/type-inference.md:10
+#, fuzzy
+msgid ""
+"fn takes_i8(y: i8) {\n"
+"    println!(\"i8: {y}\");\n"
+"}"
+msgstr ""
+"fn takes_i8(y: i8) {\n"
+"    println!(\"i8: {y}\");\n"
+"}"
+
+#: src/basic-syntax/type-inference.md:14
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let x = 10;\n"
+"    let y = 20;"
+msgstr ""
+"fn main() {\n"
+"    let x = 10;\n"
+"    let y = 20;"
+
+#: src/basic-syntax/type-inference.md:18
+#, fuzzy
+msgid ""
+"    takes_u32(x);\n"
+"    takes_i8(y);\n"
+"    // takes_u32(y);\n"
+"}\n"
+"```"
+msgstr ""
+"    takes_u32(x);\n"
+"    takes_i8(y);\n"
+"    // takes_u32(y);\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/type-inference.md:26
+#, fuzzy
+msgid ""
+"This slide demonstrates how the Rust compiler infers types based on "
+"constraints given by variable declarations and usages.\n"
+"    \n"
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can\n"
+"hold any data. The machine code generated by such declaration is identical "
+"to the explicit declaration of a type.\n"
+"The compiler does the job for us and helps us to write a more concise code."
+msgstr ""
+"Este slide demonstra como o compilador Rust infere tipos com base em "
+"restrições dadas por declarações e usos de variáveis.\n"
+"    \n"
+"É muito importante enfatizar que variáveis declaradas assim não são de algum "
+"tipo dinâmico \"qualquer tipo\" que possa\n"
+"manter quaisquer dados. O código de máquina gerado por tal declaração é "
+"idêntico à declaração explícita de um tipo.\n"
+"O compilador faz o trabalho para nós e nos ajuda a escrever um código mais "
+"conciso."
+
+#: src/basic-syntax/type-inference.md:32
+#, fuzzy
+msgid ""
+"The following code tells the compiler to copy into a certain generic "
+"container without the code ever explicitly specifying the contained type, "
+"using `_` as a placeholder:"
+msgstr ""
+"O código a seguir informa ao compilador para copiar em um determinado "
+"contêiner genérico sem que o código especifique explicitamente o tipo "
+"contido, usando `_` como espaço reservado:"
+
+#: src/basic-syntax/type-inference.md:34
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut v = Vec::new();\n"
+"    v.push((10, false));\n"
+"    v.push((20, true));\n"
+"    println!(\"v: {v:?}\");"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut v = Vec::new();\n"
+"    v.push((10, false));\n"
+"    v.push((20, true));\n"
+"    println!(\"v: {v:?}\");"
+
+#: src/basic-syntax/type-inference.md:41
+#, fuzzy
+msgid ""
+"    let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
+"    println!(\"vv: {vv:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
+"    println!(\"vv: {vv:?}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/type-inference.md:46
+#, fuzzy
+msgid ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
+"relies on `FromIterator`, which "
+"[`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"implements."
+msgstr ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
+"depende de `FromIterator`, que [`HashSet`](https:/ "
+"/doc.rust-lang.org/std/iter/trait.FromIterator.html) implementa."
+
+#: src/basic-syntax/static-and-const.md:1
+#, fuzzy
+msgid "# Static and Constant Variables"
+msgstr "# Variáveis Estáticas e Constantes"
+
+#: src/basic-syntax/static-and-const.md:3
+#, fuzzy
+msgid "Global state is managed with static and constant variables."
+msgstr "O estado global é gerenciado com variáveis estáticas e constantes."
+
+#: src/basic-syntax/static-and-const.md:5
+#, fuzzy
+msgid "## `const`"
+msgstr "## `const`"
+
+#: src/basic-syntax/static-and-const.md:7
+#, fuzzy
+msgid "You can declare compile-time constants:"
+msgstr "Você pode declarar constantes de tempo de compilação:"
+
+#: src/basic-syntax/static-and-const.md:9
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"const DIGEST_SIZE: usize = 3;\n"
+"const ZERO: Option<u8> = Some(42);"
+msgstr ""
+"```rust, editable\n"
+"const DIGEST_SIZE: usize = 3;\n"
+"const ZERO: Option<u8> = Some(42);"
+
+#: src/basic-syntax/static-and-const.md:13
+#, fuzzy
+msgid ""
+"fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
+"    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
+"    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
+"        digest[idx % DIGEST_SIZE] = digest[idx % "
+"DIGEST_SIZE].wrapping_add(b);\n"
+"    }\n"
+"    digest\n"
+"}"
+msgstr ""
+"fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
+"    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
+"    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
+"        digest[idx % DIGEST_SIZE] = digest[idx % "
+"DIGEST_SIZE].wrapping_add(b);\n"
+"    }\n"
+"    digest\n"
+"}"
+
+#: src/basic-syntax/static-and-const.md:21
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let digest = compute_digest(\"Hello\");\n"
+"    println!(\"Digest: {digest:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let digest = compute_digest(\"Hello\");\n"
+"    println!(\"Digest: {digest:?}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/static-and-const.md:27
+#, fuzzy
+msgid "According the the [Rust RFC Book][1] these are inlined upon use."
+msgstr "De acordo com o [Rust RFC Book] [1], eles são embutidos após o uso."
+
+#: src/basic-syntax/static-and-const.md:29
+#, fuzzy
+msgid "## `static`"
+msgstr "##`static`"
+
+#: src/basic-syntax/static-and-const.md:31
+#, fuzzy
+msgid "You can also declare static variables:"
+msgstr "Você também pode declarar variáveis estáticas:"
+
+#: src/basic-syntax/static-and-const.md:33
+#, fuzzy
+msgid "```rust,editable\nstatic BANNER: &str = \"Welcome to RustOS 3.14\";"
+msgstr ""
+"```rust, editable\n"
+"BANNER static: &str = \"Bem-vindo ao RustOS 3.14\";"
+
+#: src/basic-syntax/static-and-const.md:36
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    println!(\"{BANNER}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    println!(\"{BANNER}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/static-and-const.md:41
+#, fuzzy
+msgid ""
+"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
+"an actual associated memory location.  This is useful for unsafe and "
+"embedded code, and the variable lives through the entirety of the program "
+"execution."
+msgstr ""
+"Conforme observado no [Rust RFC Book][1], eles não são embutidos após o uso "
+"e possuem um local de memória real associado. Isso é útil para código "
+"inseguro e incorporado, e a variável permanece durante toda a execução do "
+"programa."
+
+#: src/basic-syntax/static-and-const.md:44
+#, fuzzy
+msgid ""
+"We will look at mutating static data in the [chapter on Unsafe "
+"Rust](../unsafe.md)."
+msgstr ""
+"Veremos a mutação de dados statics no [capítulo sobre Unsafe "
+"Rust](../unsafe.md)."
+
+#: src/basic-syntax/static-and-const.md:48
+#, fuzzy
+msgid ""
+"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
+"* `static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++.\n"
+"* It isn't super common that one would need a runtime evaluated constant, "
+"but it is helpful and safer than using a static."
+msgstr ""
+"* Mencione que `const` se comporta semanticamente similar ao `constexpr` de "
+"C++.\n"
+"* `static`, por outro lado, é muito mais parecido com um `const` ou variável "
+"global mutável em C++.\n"
+"* Não é muito comum que alguém precise de uma constante avaliada em tempo de "
+"execução, mas é útil e mais seguro do que usar uma estática."
+
+#: src/basic-syntax/static-and-const.md:54
+#, fuzzy
+msgid "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
+msgstr "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
+
+#: src/basic-syntax/scopes-shadowing.md:1
+#, fuzzy
+msgid "# Scopes and Shadowing"
+msgstr "# Escopos e Sombreamento"
+
+#: src/basic-syntax/scopes-shadowing.md:3
+#, fuzzy
+msgid ""
+"You can shadow variables, both those from outer scopes and variables from "
+"the\n"
+"same scope:"
+msgstr ""
+"Você pode sombrear variáveis, tanto aquelas de escopos externos quanto "
+"variáveis do\n"
+"mesmo escopo:"
+
+#: src/basic-syntax/scopes-shadowing.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a = 10;\n"
+"    println!(\"before: {a}\");"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let a = 10;\n"
+"    println!(\"antes: {a}\");"
+
+#: src/basic-syntax/scopes-shadowing.md:11
+#, fuzzy
+msgid ""
+"    {\n"
+"        let a = \"hello\";\n"
+"        println!(\"inner scope: {a}\");"
+msgstr ""
+"    {\n"
+"        let um = \"olá\";\n"
+"        println!(\"escopo interno: {a}\");"
+
+#: src/basic-syntax/scopes-shadowing.md:15
+#, fuzzy
+msgid ""
+"        let a = true;\n"
+"        println!(\"shadowed in inner scope: {a}\");\n"
+"    }"
+msgstr ""
+"        let a = true;\n"
+"        println!(\"sombreado no escopo interno: {a}\");\n"
+"    }"
+
+#: src/basic-syntax/scopes-shadowing.md:19
+#, fuzzy
+msgid ""
+"    println!(\"after: {a}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    println!(\"após: {a}\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/scopes-shadowing.md:25
+#, fuzzy
+msgid ""
+"* Definition: Shadowing is different from mutation, because after shadowing "
+"both variable's memory locations exist at the same time. Both are available "
+"under the same name, depending where you use it in the code. \n"
+"* A shadowing variable can have a different type. \n"
+"* Shadowing looks obscure at first, but is convenient for holding on to "
+"values after `.unwrap()`.\n"
+"* The following code demonstrates why the compiler can't simply reuse memory "
+"locations when shadowing an immutable variable in a scope, even if the type "
+"does not change."
+msgstr ""
+"* Definição: O sombreamento é diferente da mutação, porque após o "
+"sombreamento, os locais de memória de ambas as variáveis existem ao mesmo "
+"tempo. Ambos estão disponíveis com o mesmo name, dependendo de onde você os "
+"usa no código.\n"
+"* Uma variável de sombreamento pode ter um tipo diferente.\n"
+"* O sombreamento parece obscuro a princípio, mas é conveniente para manter "
+"os valores após `.unwrap()`.\n"
+"* O código a seguir demonstra por que o compilador não pode simplesmente "
+"reutilizar locais de memória ao sombrear uma variável imutável em um escopo, "
+"mesmo que o tipo não seja alterado."
+
+#: src/basic-syntax/scopes-shadowing.md:30
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a = 1;\n"
+"    let b = &a;\n"
+"    let a = a + 1;\n"
+"    println!(\"{a} {b}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let a = 1;\n"
+"    let b = &a;\n"
+"    let a = a + 1;\n"
+"    println!(\"{a} {b}\");\n"
+"}\n"
+"```"
+
+#: src/memory-management.md:1
+#, fuzzy
+msgid "# Memory Management"
+msgstr "# Gerenciamento de memória"
+
+#: src/memory-management.md:3
+#, fuzzy
+msgid "Traditionally, languages have fallen into two broad categories:"
+msgstr "Tradicionalmente, as línguas caíram em duas grandes categorias:"
+
+#: src/memory-management.md:5
+#, fuzzy
+msgid ""
+"* Full control via manual memory management: C, C++, Pascal, ...\n"
+"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Haskell, ..."
+msgstr ""
+"* Controle total via gerenciamento de memória manual: C, C++, Pascal, ...\n"
+"* Segurança total através do gerenciamento automático de memória em tempo de "
+"execução: Java, Python, Go, Haskell, ..."
+
+#: src/memory-management.md:8
+#, fuzzy
+msgid "Rust offers a new mix:"
+msgstr "Rust oferece uma nova mistura:"
+
+#: src/memory-management.md:10
+#, fuzzy
+msgid ""
+"> Full control *and* safety via compile time enforcement of correct memory\n"
+"> management."
+msgstr ""
+"> Controle total *e* segurança por meio da aplicação do tempo de compilação "
+"da memória correta\n"
+"> gestão."
+
+#: src/memory-management.md:13
+#, fuzzy
+msgid "It does this with an explicit ownership concept."
+msgstr "Ele faz isso com um conceito de ownership explícito."
+
+#: src/memory-management.md:15
+#, fuzzy
+msgid "First, let's refresh how memory management works."
+msgstr "Primeiro, vamos atualizar como o gerenciamento de memória funciona."
+
+#: src/memory-management/stack-vs-heap.md:1
+#, fuzzy
+msgid "# The Stack vs The Heap"
+msgstr "# A Pilha vs A Heap"
+
+#: src/memory-management/stack-vs-heap.md:3
+#, fuzzy
+msgid ""
+"* Stack: Continuous area of memory for local variables.\n"
+"  * Values have fixed sizes known at compile time.\n"
+"  * Extremely fast: just move a stack pointer.\n"
+"  * Easy to manage: follows function calls.\n"
+"  * Great memory locality."
+msgstr ""
+"* Stack: Área contínua de memória para variáveis locais.\n"
+"  * Os valores têm tamanhos fixos conhecidos em tempo de compilação.\n"
+"  * Extremamente rápido: basta mover um ponteiro de pilha.\n"
+"  * Fácil de gerenciar: segue chamadas de função.\n"
+"  * Ótima localage de memória."
+
+#: src/memory-management/stack-vs-heap.md:9
+#, fuzzy
+msgid ""
+"* Heap: Storage of values outside of function calls.\n"
+"  * Values have dynamic sizes determined at runtime.\n"
+"  * Slightly slower than the stack: some book-keeping needed.\n"
+"  * No guarantee of memory locality."
+msgstr ""
+"* Heap: Armazenamento de valores fora das chamadas de função.\n"
+"  * Os valores têm tamanhos dinâmicos determinados em tempo de execução.\n"
+"  * Ligeiramente mais lento que a pilha: é necessária alguma contabilage.\n"
+"  * Sem garantia de localage de memória."
+
+#: src/memory-management/stack.md:1
+#, fuzzy
+msgid "# Stack Memory"
+msgstr "# Memória de Pilha"
+
+#: src/memory-management/stack.md:3
+#, fuzzy
+msgid ""
+"Creating a `String` puts fixed-sized data on the stack and dynamically "
+"sized\n"
+"data on the heap:"
+msgstr ""
+"A criação de uma `String` coloca dados de tamanho fixo na pilha e "
+"dimensionados dinamicamente\n"
+"dados na heap:"
+
+#: src/memory-management/stack.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1 = String::from(\"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let s1 = String::from(\"Olá\");\n"
+"}\n"
+"```"
+
+#: src/memory-management/stack.md:12
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.\n"
+":                           :     :                               :\n"
+":    s1                     :     :                               :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+----+  :\n"
+":   | ptr       |   o---+---+-----+-->| H  | e  | l  | l  | o  |  :\n"
+":   | len       |     5 |   :     :   +----+----+----+----+----+  :\n"
+":   | capacity  |     5 |   :     :                               :\n"
+":   +-----------+-------+   :     :                               :\n"
+":                           :     `- - - - - - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - - -. .- - - - - - - - - - - - - - - -.\n"
+": : : :\n"
+":s1 : : :\n"
+": +-----------+-------+ : : +----+----+----+----+----+ :\n"
+": | ptr | o---+---+-----+-->| H | e | eu | eu | o | :\n"
+": | len | 5 | : : +----+----+----+----+----+ :\n"
+": | capacage | 5 | : : :\n"
+": +-----------+-------+ : : :\n"
+": : `- - - - - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+
+#: src/memory-management/stack.md:28
+#, fuzzy
+msgid ""
+"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
+msgstr ""
+"* Mencione que um `String` é apoiado por um `Vec`, então ele tem capacage "
+"e comprimento e pode crescer se for mutável por meio de realocação no heap."
+
+#: src/memory-management/stack.md:30
+#, fuzzy
+msgid ""
+"* If students ask about it, you can mention that the underlying memory is "
+"heap allocated using the [System Allocator] and custom allocators can be "
+"implemented using the [Allocator API]"
+msgstr ""
+"* Se os alunos perguntarem sobre isso, você pode mencionar que a memória "
+"subjacente é heap alocada usando o [System Allocator] e alocadores "
+"personalizados podem ser implementados usando a [Allocator API]"
+
+#: src/memory-management/stack.md:34
+#, fuzzy
+msgid ""
+"[System Allocator]: https://doc.rust-lang.org/std/alloc/struct.System.html\n"
+"[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
+msgstr ""
+"[Alocador do sistema]: "
+"https://doc.rust-lang.org/std/alloc/struct.System.html\n"
+"[API do alocador]: https://doc.rust-lang.org/std/alloc/index.html"
+
+#: src/memory-management/manual.md:1
+#, fuzzy
+msgid "# Manual Memory Management"
+msgstr "# Gerenciamento de memória manual"
+
+#: src/memory-management/manual.md:3
+#, fuzzy
+msgid "You allocate and deallocate heap memory yourself."
+msgstr "Você mesmo aloca e desaloca memória heap."
+
+#: src/memory-management/manual.md:5
+#, fuzzy
+msgid ""
+"If not done with care, this can lead to crashes, bugs, security "
+"vulnerabilities, and memory leaks."
+msgstr ""
+"Se não for feito com cuidado, isso pode levar a travamentos, bugs, "
+"vulnerabilages de segurança e vazamentos de memória."
+
+#: src/memory-management/manual.md:7
+#, fuzzy
+msgid "## C Example"
+msgstr "## C Exemplo"
+
+#: src/memory-management/manual.md:9
+#, fuzzy
+msgid "You must call `free` on every pointer you allocate with `malloc`:"
+msgstr "Você deve chamar `free` em cada ponteiro que alocar com `malloc`:"
+
+#: src/memory-management/manual.md:11
+#, fuzzy
+msgid ""
+"```c\n"
+"void foo(size_t n) {\n"
+"    int* int_array = (int*)malloc(n * sizeof(int));\n"
+"    //\n"
+"    // ... lots of code\n"
+"    //\n"
+"    free(int_array);\n"
+"}\n"
+"```"
+msgstr ""
+"```c\n"
+"void foo(size_t n) {\n"
+"    int* int_array = (int*)malloc(n * sizeof(int));\n"
+"    //\n"
+"    // ... muito código\n"
+"    //\n"
+"    free(int_array);\n"
+"}\n"
+"```"
+
+#: src/memory-management/manual.md:21
+#, fuzzy
+msgid ""
+"Memory is leaked if the function returns early between `malloc` and `free`: "
+"the\n"
+"pointer is lost and we cannot deallocate the memory."
+msgstr ""
+"A memória vaza se a função retornar cedo entre `malloc` e `free`: o\n"
+"ponteiro é perdido e não podemos desalocar a memória."
+
+#: src/memory-management/scope-based.md:1
+#, fuzzy
+msgid "# Scope-Based Memory Management"
+msgstr "# Gerenciamento de memória baseado em escopo"
+
+#: src/memory-management/scope-based.md:3
+#, fuzzy
+msgid "Constructors and destructors let you hook into the lifetime of an object."
+msgstr ""
+"Construtores e destruidores permitem que você se conecte ao tempo de vida de "
+"um objeto."
+
+#: src/memory-management/scope-based.md:5
+#, fuzzy
+msgid ""
+"By wrapping a pointer in an object, you can free memory when the object is\n"
+"destroyed. The compiler guarantees that this happens, even if an exception "
+"is\n"
+"raised."
+msgstr ""
+"Ao envolver um ponteiro em um objeto, você pode liberar memória quando o "
+"objeto é\n"
+"destruído. O compilador garante que isso aconteça, mesmo que uma exceção "
+"seja\n"
+"criado."
+
+#: src/memory-management/scope-based.md:9
+#, fuzzy
+msgid ""
+"This is often called _resource acquisition is initialization_ (RAII) and "
+"gives\n"
+"you smart pointers."
+msgstr ""
+"Isso geralmente é chamado de _aquisição de recursos é inicialização_ (RAII) "
+"e fornece\n"
+"vocês ponteiros inteligentes."
+
+#: src/memory-management/scope-based.md:12
+#, fuzzy
+msgid "## C++ Example"
+msgstr "## Exemplo C++"
+
+#: src/memory-management/scope-based.md:14
+#, fuzzy
+msgid ""
+"```c++\n"
+"void say_hello(std::unique_ptr<Person> person) {\n"
+"  std::cout << \"Hello \" << person->name << std::endl;\n"
+"}\n"
+"```"
+msgstr ""
+"```c++\n"
+"void say_hello(std::unique_ptr<Person> person) {\n"
+"  std::cout << \"Hello \" << person->name << std::endl;\n"
+"}\n"
+"```"
+
+#: src/memory-management/scope-based.md:20
+#, fuzzy
+msgid ""
+"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
+"  memory allocated on the heap.\n"
+"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
+"* The destructor frees the `Person` object it points to."
+msgstr ""
+"* O objeto `std::unique_ptr` é alocado na pilha e aponta para\n"
+"  memória alocada no heap.\n"
+"* No final de `say_hello`, o destruidor `std::unique_ptr` será executado.\n"
+"* O destruidor libera o objeto `Person` para o qual ele aponta."
+
+#: src/memory-management/scope-based.md:25
+#, fuzzy
+msgid "Special move constructors are used when passing ownership to a function:"
+msgstr ""
+"Construtores de movimentos especiais são usados ao passar a ownership para "
+"uma função:"
+
+#: src/memory-management/scope-based.md:27
+#, fuzzy
+msgid ""
+"```c++\n"
+"std::unique_ptr<Person> person = find_person(\"Carla\");\n"
+"say_hello(std::move(person));\n"
+"```"
+msgstr ""
+"```c++\n"
+"std::unique_ptr<Person> person = find_person(\"Carla\");\n"
+"say_hello(std::move(person));\n"
+"```"
+
+#: src/memory-management/garbage-collection.md:1
+#, fuzzy
+msgid "# Automatic Memory Management"
+msgstr "# Gerenciamento Automático de Memória"
+
+#: src/memory-management/garbage-collection.md:3
+#, fuzzy
+msgid ""
+"An alternative to manual and scope-based memory management is automatic "
+"memory\n"
+"management:"
+msgstr ""
+"Uma alternativa ao gerenciamento de memória manual e baseado em escopo é a "
+"memória automática\n"
+"gestão:"
+
+#: src/memory-management/garbage-collection.md:6
+#, fuzzy
+msgid ""
+"* The programmer never allocates or deallocates memory explicitly.\n"
+"* A garbage collector finds unused memory and deallocates it for the "
+"programmer."
+msgstr ""
+"* O programador nunca aloca ou desaloca memória explicitamente.\n"
+"* Um garbage collector encontra memória não utilizada e a desaloca para o "
+"programador."
+
+#: src/memory-management/garbage-collection.md:9
+#, fuzzy
+msgid "## Java Example"
+msgstr "## Exemplo em Java"
+
+#: src/memory-management/garbage-collection.md:11
+#, fuzzy
+msgid "The `person` object is not deallocated after `sayHello` returns:"
+msgstr "O objeto `person` não é desalocado depois que `sayHello` retorna:"
+
+#: src/memory-management/garbage-collection.md:13
+#, fuzzy
+msgid ""
+"```java\n"
+"void sayHello(Person person) {\n"
+"  System.out.println(\"Hello \" + person.getName());\n"
+"}\n"
+"```"
+msgstr ""
+"```java\n"
+"void sayHello(Person person) {\n"
+"  System.out.println(\"Hello \" + person.getName());\n"
+"}\n"
+"```"
+
+#: src/memory-management/rust.md:1
+#, fuzzy
+msgid "# Memory Management in Rust"
+msgstr "# Gerenciamento de memória em Rust"
+
+#: src/memory-management/rust.md:3
+#, fuzzy
+msgid "Memory management in Rust is a mix:"
+msgstr "O gerenciamento de memória no Rust é uma mistura:"
+
+#: src/memory-management/rust.md:5
+#, fuzzy
+msgid ""
+"* Safe and correct like Java, but without a garbage collector.\n"
+"* Depending on which abstraction (or combination of abstractions) you "
+"choose, can be a single unique pointer, reference counted, or atomically "
+"reference counted.\n"
+"* Scope-based like C++, but the compiler enforces full adherence.\n"
+"* A Rust user can choose the right abstraction for the situation, some even "
+"have no cost at runtime like C."
+msgstr ""
+"* Seguro e correto como Java, mas sem coletor de lixo.\n"
+"* Dependendo de qual abstração (ou combinação de abstrações) você escolher, "
+"pode ser um único ponteiro único, referência contada ou referência "
+"atomicamente contada.\n"
+"* Baseado em escopo como C++, mas o compilador impõe adesão total.\n"
+"* Um usuário do Rust pode escolher a abstração certa para a situação, "
+"algumas até sem custo em tempo de execução como C."
+
+#: src/memory-management/rust.md:10
+#, fuzzy
+msgid "It achieves this by modeling _ownership_ explicitly."
+msgstr "Ele consegue isso modelando _ownership_ explicitamente."
+
+#: src/memory-management/rust.md:14
+#, fuzzy
+msgid ""
+"* If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
+"encapsulate ownership and memory allocation via various means, and prevent "
+"the potential errors in C."
+msgstr ""
+"* Se perguntado como neste Point, você pode mencionar que em Rust isso "
+"geralmente é tratado por tipos de wrapper RAII como [Box], [Vec], [Rc] ou "
+"[Arc]. Eles encapsulam a ownership e a alocação de memória por vários "
+"meios e evitam possíveis erros em C."
+
+#: src/memory-management/rust.md:16
+#, fuzzy
+msgid ""
+"* You may be asked about destructors here, the [Drop] trait is the Rust "
+"equivalent."
+msgstr ""
+"* Você pode ser questionado sobre destruidores aqui, o trait [Drop] é o "
+"equivalente ao Rust."
+
+#: src/memory-management/rust.md:20
+#, fuzzy
+msgid ""
+"[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
+msgstr ""
+"[Caixa]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
+
+#: src/memory-management/comparison.md:1
+#, fuzzy
+msgid "# Comparison"
+msgstr "# Comparação"
+
+#: src/memory-management/comparison.md:3
+#, fuzzy
+msgid "Here is a rough comparison of the memory management techniques."
+msgstr ""
+"Aqui está uma comparação aproximada das técnicas de gerenciamento de memória."
+
+#: src/memory-management/comparison.md:5
+#, fuzzy
+msgid "## Pros of Different Memory Management Techniques"
+msgstr "## Prós de diferentes técnicas de gerenciamento de memória"
+
+#: src/memory-management/comparison.md:7
+#, fuzzy
+msgid ""
+"* Manual like C:\n"
+"  * No runtime overhead.\n"
+"* Automatic like Java:\n"
+"  * Fully automatic.\n"
+"  * Safe and correct.\n"
+"* Scope-based like C++:\n"
+"  * Partially automatic.\n"
+"  * No runtime overhead.\n"
+"* Compiler-enforced scope-based like Rust:\n"
+"  * Enforced by compiler.\n"
+"  * No runtime overhead.\n"
+"  * Safe and correct."
+msgstr ""
+"* Manual como C:\n"
+"  * Nenhuma sobrecargo de tempo de execução.\n"
+"* Automático como Java:\n"
+"  * Totalmente automatizado.\n"
+"  * Seguro e correto.\n"
+"* Baseado em escopo como C++:\n"
+"  * Parcialmente automático.\n"
+"  * Nenhuma sobrecargo de tempo de execução.\n"
+"* Baseado em escopo aplicado pelo compilador como Rust:\n"
+"  * Aplicado pelo compilador.\n"
+"  * Nenhuma sobrecargo de tempo de execução.\n"
+"  * Seguro e correto."
+
+#: src/memory-management/comparison.md:20
+#, fuzzy
+msgid "## Cons of Different Memory Management Techniques"
+msgstr "## Contras de diferentes técnicas de gerenciamento de memória"
+
+#: src/memory-management/comparison.md:22
+#, fuzzy
+msgid ""
+"* Manual like C:\n"
+"  * Use-after-free.\n"
+"  * Double-frees.\n"
+"  * Memory leaks.\n"
+"* Automatic like Java:\n"
+"  * Garbage collection pauses.\n"
+"  * Destructor delays.\n"
+"* Scope-based like C++:\n"
+"  * Complex, opt-in by programmer.\n"
+"  * Potential for use-after-free.\n"
+"* Compiler-enforced and scope-based like Rust:\n"
+"  * Some upfront complexity.\n"
+"  * Can reject valid programs."
+msgstr ""
+"* Manual como C:\n"
+"  * Use-after-free.\n"
+"  * Liberações duplas.\n"
+"  * Perdas de memória.\n"
+"* Automático como Java:\n"
+"  * Pausa na garbage collection.\n"
+"  * Atrasos destruidores.\n"
+"* Baseado em escopo como C++:\n"
+"  * Complexo, opt-in pelo programador.\n"
+"  *Potencial para uso pós-livre.\n"
+"* Reforçado pelo compilador e baseado em escopo como Rust:\n"
+"  * Alguma complexage inicial.\n"
+"  * Pode rejeitar programas válidos."
+
+#: src/ownership.md:1
+#, fuzzy
+msgid "# Ownership"
+msgstr "# Ownership"
+
+#: src/ownership.md:3
+#, fuzzy
+msgid ""
+"All variable bindings have a _scope_ where they are valid and it is an error "
+"to\n"
+"use a variable outside its scope:"
+msgstr ""
+"Todas as associações de variáveis têm um _scope_ onde são válidas e é um "
+"erro\n"
+"use uma variável fora de seu escopo:"
+
+#: src/ownership.md:6
+#, fuzzy
+msgid "```rust,editable,compile_fail\nstruct Point(i32, i32);"
+msgstr "```rust,editable,compile_fail\nstruct Point(i32, i32);"
+
+#: src/ownership.md:9
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    {\n"
+"        let p = Point(3, 4);\n"
+"        println!(\"x: {}\", p.0);\n"
+"    }\n"
+"    println!(\"y: {}\", p.1);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    {\n"
+"        let p = Point(3, 4);\n"
+"        println!(\"x: {}\", p.0);\n"
+"    }\n"
+"    println!(\"y: {}\", p.1);\n"
+"}\n"
+"```"
+
+#: src/ownership.md:18
+#, fuzzy
+msgid ""
+"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
+"* A destructor can run here to free up resources.\n"
+"* We say that the variable _owns_ the value."
+msgstr ""
+"* No final do escopo, a variável é _dropada_ e os dados são liberados.\n"
+"* Um destruidor pode ser executado aqui para liberar recursos.\n"
+"* Dizemos que a variável _possui_ o valor."
+
+#: src/ownership/move-semantics.md:1
+#, fuzzy
+msgid "# Move Semantics"
+msgstr "# Mover semântica"
+
+#: src/ownership/move-semantics.md:3
+#, fuzzy
+msgid "An assignment will transfer ownership between variables:"
+msgstr "Uma atribuição transferirá a ownership entre variáveis:"
+
+#: src/ownership/move-semantics.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Hello!\");\n"
+"    let s2: String = s1;\n"
+"    println!(\"s2: {s2}\");\n"
+"    // println!(\"s1: {s1}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Olá!\");\n"
+"    let s2: String = s1;\n"
+"    println!(\"s2: {s2}\");\n"
+"    // println!(\"s1: {s1}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/move-semantics.md:14
+#, fuzzy
+msgid ""
+"* The assignment of `s1` to `s2` transfers ownership.\n"
+"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
+"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
+"* When `s2` goes out of scope, the string data is freed.\n"
+"* There is always _exactly_ one variable binding which owns a value."
+msgstr ""
+"* A atribuição de `s1` a `s2` transfere a ownership.\n"
+"* Os dados foram _movidos_ de `s1` e `s1` não estão mais acessíveis.\n"
+"* Quando `s1` sai do escopo, nada acontece: ele não tem ownership.\n"
+"* Quando `s2` sai do escopo, os dados da string são liberados.\n"
+"* Há sempre _exatamente_ uma associação de variável que possui um valor."
+
+#: src/ownership/move-semantics.md:22
+#, fuzzy
+msgid ""
+"* Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
+msgstr ""
+"* Mencione que isso é o oposto dos padrões em C++, que copia por valor, a "
+"menos que você use `std::move` (e o construtor de movimento esteja "
+"definido!)."
+
+#: src/ownership/move-semantics.md:24
+#, fuzzy
+msgid "* In Rust, you clones are explicit (by using `clone`)."
+msgstr "* No Rust, seus clones são explícitos (usando `clone`)."
+
+#: src/ownership/moved-strings-rust.md:1
+#, fuzzy
+msgid "# Moved Strings in Rust"
+msgstr "# Strings movidas em Rust"
+
+#: src/ownership/moved-strings-rust.md:3
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Rust\");\n"
+"    let s2: String = s1;\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Rust\");\n"
+"    let s2: String = s1;\n"
+"}\n"
+"```"
+
+#: src/ownership/moved-strings-rust.md:10
+#, fuzzy
+msgid ""
+"* The heap data from `s1` is reused for `s2`.\n"
+"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgstr ""
+"* Os dados heap de `s1` são reutilizados para `s2`.\n"
+"* Quando `s1` sai do escopo, nada acontece (foi movido de)."
+
+#: src/ownership/moved-strings-rust.md:13
+#, fuzzy
+msgid "Before move to `s2`:"
+msgstr "Antes de mover para `s2`:"
+
+#: src/ownership/moved-strings-rust.md:15
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1                     :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+-----+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :     :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :     :                           :\n"
+":   +-----------+-------+   :     :                           :\n"
+":                           :     `- - - - - - - - - - - - - -'\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - - -. .- - - - - - - - - - - - - -.\n"
+": : : :\n"
+":s1 : : :\n"
+": +-----------+-------+ : : +----+----+----+----+ :\n"
+": | ptr | o---+---+-----+-->| R | você | s | t | :\n"
+": | len | 4 | : : +----+----+----+----+ :\n"
+": | capacage | 4 | : : :\n"
+": +-----------+-------+ : : :\n"
+": : `- - - - - - - - - - - - -'\n"
+": :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+
+#: src/ownership/moved-strings-rust.md:30
+#, fuzzy
+msgid "After move to `s2`:"
+msgstr "Depois de mover para `s2`:"
+
+#: src/ownership/moved-strings-rust.md:32
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1 \"(inaccessible)\"    :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :  |  :                           :\n"
+":   +-----------+-------+   :  |  :                           :\n"
+":                           :  |  `- - - - - - - - - - - - - -'\n"
+":    s2                     :  |\n"
+":   +-----------+-------+   :  |\n"
+":   | ptr       |   o---+---+--'\n"
+":   | len       |     4 |   :\n"
+":   | capacity  |     4 |   :\n"
+":   +-----------+-------+   :\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - - -. .- - - - - - - - - - - - - -.\n"
+": : : :\n"
+": s1 \"(inacessível)\" : : :\n"
+": +-----------+-------+ : : +----+----+----+----+ :\n"
+": | ptr | o---+---+--+--+-->| R | você | s | t | :\n"
+": | len | 4 | : | : +----+----+----+----+:\n"
+": | capacage | 4 | : | : :\n"
+": +-----------+-------+ : | : :\n"
+": : | `- - - - - - - - - - - - - -'\n"
+": s2 : |\n"
+": +-----------+-------+ : |\n"
+": | ptr | o---+---+--'\n"
+": | len | 4 | :\n"
+": | capacage | 4 | :\n"
+": +-----------+-------+ :\n"
+": :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+
+#: src/ownership/double-free-modern-cpp.md:1
+#, fuzzy
+msgid "# Double Frees in Modern C++"
+msgstr "# Liberações duplas em C++ moderno"
+
+#: src/ownership/double-free-modern-cpp.md:3
+#, fuzzy
+msgid "Modern C++ solves this differently:"
+msgstr "O C++ moderno resolve isso de maneira diferente:"
+
+#: src/ownership/double-free-modern-cpp.md:5
+#, fuzzy
+msgid ""
+"```c++\n"
+"std::string s1 = \"Cpp\";\n"
+"std::string s2 = s1;  // Duplicate the data in s1.\n"
+"```"
+msgstr ""
+"```c++\n"
+"std::string s1 = \"Cpp\";\n"
+"std::string s2 = s1; // Duplica os dados em s1.\n"
+"```"
+
+#: src/ownership/double-free-modern-cpp.md:10
+#, fuzzy
+msgid ""
+"* The heap data from `s1` is duplicated and `s2` gets its own independent "
+"copy.\n"
+"* When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"* Os dados heap de `s1` são duplicados e `s2` obtém sua própria cópia "
+"independente.\n"
+"* Quando `s1` e `s2` saem do escopo, cada um libera sua própria memória."
+
+#: src/ownership/double-free-modern-cpp.md:13
+#, fuzzy
+msgid "Before copy-assignment:"
+msgstr "Antes da atribuição de cópias:"
+
+#: src/ownership/double-free-modern-cpp.md:16
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - -.\n"
+":                           :     :                       :\n"
+":    s1                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+--+--+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     `- - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - - -. .- - - - - - - - - - - -.\n"
+": : : :\n"
+":s1 : : :\n"
+": +-----------+-------+ : : +----+----+----+ :\n"
+": | ptr | o---+---+--+--+-->| C | p | p | :\n"
+": | len | 3 | : : +----+----+----+ :\n"
+": | capacage | 3 | : : :\n"
+": +-----------+-------+ : : :\n"
+": : `- - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+
+#: src/ownership/double-free-modern-cpp.md:30
+#, fuzzy
+msgid "After copy-assignment:"
+msgstr "Após atribuição de cópia:"
+
+#: src/ownership/double-free-modern-cpp.md:32
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - -.\n"
+":                           :     :                       :\n"
+":    s1                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+--+--+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     :                       :\n"
+":    s2                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+-----+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     `- - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - - -. .- - - - - - - - - - - -.\n"
+": : : :\n"
+":s1 : : :\n"
+": +-----------+-------+ : : +----+----+----+ :\n"
+": | ptr | o---+---+--+--+-->| C | p | p | :\n"
+": | len | 3 | : : +----+----+----+ :\n"
+": | capacage | 3 | : : :\n"
+": +-----------+-------+ : : :\n"
+": : : :\n"
+":s2 : : :\n"
+": +-----------+-------+ : : +----+----+----+ :\n"
+": | ptr | o---+---+-----+-->| C | p | p | :\n"
+": | len | 3 | : : +----+----+----+ :\n"
+": | capacage | 3 | : : :\n"
+": +-----------+-------+ : : :\n"
+": : `- - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+
+#: src/ownership/moves-function-calls.md:1
+#, fuzzy
+msgid "# Moves in Function Calls"
+msgstr "# Movimentos em Chamadas de Função"
+
+#: src/ownership/moves-function-calls.md:3
+#, fuzzy
+msgid ""
+"When you pass a value to a function, the value is assigned to the function\n"
+"parameter. This transfers ownership:"
+msgstr ""
+"Quando você passa um valor para uma função, o valor é atribuído à função\n"
+"parâmetro. Isso transfere a ownership:"
+
+#: src/ownership/moves-function-calls.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn say_hello(name: String) {\n"
+"    println!(\"Hello {name}\")\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn say_hello(name: String) {\n"
+"    println!(\"Hello {name}\")\n"
+"}"
+
+#: src/ownership/moves-function-calls.md:11
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let name = String::from(\"Alice\");\n"
+"    say_hello(name);\n"
+"    // say_hello(name);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let name = String::from(\"Alice\");\n"
+"    say_hello(name);\n"
+"    // say_hello(name);\n"
+"}\n"
+"```"
+
+#: src/ownership/moves-function-calls.md:20
+#, fuzzy
+msgid ""
+"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`.\n"
+"* The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function.\n"
+"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
+"and if `say_hello` accepts a reference as a parameter.\n"
+"* Alternatively, `main` can pass a clone of `name` in the first call "
+"(`name.clone()`).\n"
+"* Rust makes it harder than C++ to inadvertently create copies by making "
+"move semantics the default, and by forcing programmers to make clones "
+"explicit."
+msgstr ""
+"* Com a primeira chamada para `say_hello`, `main` desiste da ownership de "
+"`name`. Depois disso, `name` não pode mais ser usado dentro de `main`.\n"
+"* A memória heap alocada para `name` será liberada no final da função "
+"`say_hello`.\n"
+"* `main` pode manter a ownership se passar `name` como uma referência "
+"(`&name`) e se `say_hello` aceitar uma referência como um parâmetro.\n"
+"* Alternativamente, `main` pode passar um clone de `name` na primeira "
+"chamada (`name.clone()`).\n"
+"* Rust torna mais difícil do que C++ criar cópias inadvertidamente, tornando "
+"a semântica de movimento o padrão e forçando os programadores a tornar os "
+"clones explícitos."
+
+#: src/ownership/copy-clone.md:1
+#, fuzzy
+msgid "# Copying and Cloning"
+msgstr "# Copiar e clonar"
+
+#: src/ownership/copy-clone.md:3
+#, fuzzy
+msgid ""
+"While move semantics are the default, certain types are copied by default:"
+msgstr ""
+"Embora a semântica de movimento seja o padrão, certos tipos são copiados por "
+"padrão:"
+
+#: src/ownership/copy-clone.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let x = 42;\n"
+"    let y = x;\n"
+"    println!(\"x: {x}\");\n"
+"    println!(\"y: {y}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let x = 42;\n"
+"    let y = x;\n"
+"    println!(\"x: {x}\");\n"
+"    println!(\"y: {y}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/copy-clone.md:14
+#, fuzzy
+msgid "These types implement the `Copy` trait."
+msgstr "Esses tipos implementam o recurso `Copy`."
+
+#: src/ownership/copy-clone.md:16
+#, fuzzy
+msgid "You can opt-in your own types to use copy semantics:"
+msgstr "Você pode ativar seus próprios tipos para usar a semântica de cópia:"
+
+#: src/ownership/copy-clone.md:18
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Copy, Clone, Debug)]\n"
+"struct Point(i32, i32);"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Copy, Clone, Debug)]\n"
+"struct Point(i32, i32);"
+
+#: src/ownership/copy-clone.md:22
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = p1;\n"
+"    println!(\"p1: {p1:?}\");\n"
+"    println!(\"p2: {p2:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = p1;\n"
+"    println!(\"p1: {p1:?}\");\n"
+"    println!(\"p2: {p2:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/copy-clone.md:30
+#, fuzzy
+msgid ""
+"* After the assignment, both `p1` and `p2` own their own data.\n"
+"* We can also use `p1.clone()` to explicitly copy the data."
+msgstr ""
+"* Após a atribuição, tanto `p1` quanto `p2` possuem seus próprios dados.\n"
+"* Também podemos usar `p1.clone()` para copiar explicitamente os dados."
+
+#: src/ownership/copy-clone.md:35
+#, fuzzy
+msgid "Copying and cloning are not the same thing:"
+msgstr "Copiar e clonar não são a mesma coisa:"
+
+#: src/ownership/copy-clone.md:37
+#, fuzzy
+msgid ""
+"* Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects.\n"
+"* Copying does not allow for custom logic (unlike copy constructors in "
+"C++).\n"
+"* Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait.\n"
+"* Copying does not work on types that implement the `Drop` trait."
+msgstr ""
+"* A cópia refere-se a cópias bit a bit de regiões de memória e não funciona "
+"em objetos arbitrários.\n"
+"* A cópia não permite lógica personalizada (ao contrário dos construtores de "
+"cópia em C++).\n"
+"* A clonagem é uma operação mais geral e também permite um comportamento "
+"personalizado implementando a trait `Clone`.\n"
+"* A cópia não funciona em tipos que implementam a característica `Drop`."
+
+#: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
+#, fuzzy
+msgid "In the above example, try the following:"
+msgstr "No exemplo acima, tente o seguinte:"
+
+#: src/ownership/copy-clone.md:44
+#, fuzzy
+msgid ""
+"* Add a `String` field to `struct Point`. It will not compile because "
+"`String` is not a `Copy` type.\n"
+"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
+"the `println!` for  `p1`.\n"
+"* Show that it works if you clone `p1` instead."
+msgstr ""
+"* Adicione um campo `String` ao `struct Point`. Não irá compilar porque "
+"`String` não é um tipo `Copy`.\n"
+"* Remova `Copy` do atributo `derive`. O erro do compilador agora está no "
+"`println!` para `p1`.\n"
+"* Mostre que funciona se você clonar `p1` em vez disso."
+
+#: src/ownership/copy-clone.md:48
+#, fuzzy
+msgid ""
+"If students ask about `derive`, it is sufficient to say that this is a way "
+"to generate code in Rust\n"
+"at compile time. In this case the default implementations of `Copy` and "
+"`Clone` traits are generated.\n"
+"    \n"
+"</details>"
+msgstr ""
+"Se os alunos perguntarem sobre `derive`, basta dizer que esta é uma forma de "
+"gerar código em Rust\n"
+"em tempo de compilação. Nesse caso, as implementações padrão dos traits "
+"`Copy` e `Clone` são geradas.\n"
+"    \n"
+"</details>"
+
+#: src/ownership/borrowing.md:1
+#, fuzzy
+msgid "# Borrowing"
+msgstr "# Empréstimo"
+
+#: src/ownership/borrowing.md:3
+#, fuzzy
+msgid ""
+"Instead of transferring ownership when calling a function, you can let a\n"
+"function _borrow_ the value:"
+msgstr ""
+"Em vez de transferir a ownership ao chamar uma função, você pode permitir "
+"que um\n"
+"função _emprestar_ o valor:"
+
+#: src/ownership/borrowing.md:6 src/ownership/lifetimes-function-calls.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);"
+
+#: src/ownership/borrowing.md:10
+#, fuzzy
+msgid ""
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
+"}"
+msgstr ""
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
+"}"
+
+#: src/ownership/borrowing.md:14
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/borrowing.md:22
+#, fuzzy
+msgid ""
+"* The `add` function _borrows_ two points and returns a new point.\n"
+"* The caller retains ownership of the inputs."
+msgstr ""
+"* A função `add` _pega emprestado_ dois Points e retorna um novo Point.\n"
+"* O chamador mantém a ownership das entradas."
+
+#: src/ownership/borrowing.md:27
+#, fuzzy
+msgid ""
+"Notes on stack returns:\n"
+"* Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
+"addresses should change, while the stay the same when changing to the "
+"\"RELEASE\" setting:"
+msgstr ""
+"Notas sobre retornos de pilha:\n"
+"* Demonstre que o retorno de `add` é barato porque o compilador pode "
+"eliminar a operação de cópia. Altere o código acima para imprimir endereços "
+"de pilha e execute-o no [Playground]. No nível de otimização \"DEBUG\", os "
+"endereços devem mudar, enquanto os permanecem os mesmos ao mudar para a "
+"configuração \"RELEASE\":"
+
+#: src/ownership/borrowing.md:30
+#, fuzzy
+msgid ""
+"  ```rust,editable\n"
+"  #[derive(Debug)]\n"
+"  struct Point(i32, i32);"
+msgstr ""
+"  ```rust, editable\n"
+"  #[derive(Debug)]\n"
+"  struct Point(i32, i32);"
+
+#: src/ownership/borrowing.md:34
+#, fuzzy
+msgid ""
+"  fn add(p1: &Point, p2: &Point) -> Point {\n"
+"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"      println!(\"&p.0: {:p}\", &p.0);\n"
+"      p\n"
+"  }"
+msgstr ""
+"  fn add(p1: &Point, p2: &Point) -> Point {\n"
+"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"      println!(\"&p.0: {:p}\", &p.0);\n"
+"      p\n"
+"  }"
+
+#: src/ownership/borrowing.md:40
+#, fuzzy
+msgid ""
+"  fn main() {\n"
+"      let p1 = Point(3, 4);\n"
+"      let p2 = Point(10, 20);\n"
+"      let p3 = add(&p1, &p2);\n"
+"      println!(\"&p3.0: {:p}\", &p3.0);\n"
+"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"  }\n"
+"  ```\n"
+"* The Rust compiler can do return value optimization (RVO).\n"
+"* In C++, copy elision has to be defined in the language specification "
+"because constructors can have side effects. In Rust, this is not an issue at "
+"all. If RVO did not happen, Rust will always performs a simple and efficient "
+"`memcpy` copy."
+msgstr ""
+"  fn main() {\n"
+"      let p1 = Point(3, 4);\n"
+"      let p2 = Point(10, 20);\n"
+"      let p3 = add(&p1, &p2);\n"
+"      println!(\"&p3.0: {:p}\", &p3.0);\n"
+"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"  }\n"
+"  ```\n"
+"* O compilador Rust pode fazer otimização de valor de retorno (RVO).\n"
+"* Em C++, a elisão de cópia deve ser definida na especificação da linguagem "
+"porque os construtores podem ter efeitos colaterais. Em Rust, isso não é um "
+"problema. Se o RVO não aconteceu, o Rust sempre executará uma cópia `memcpy` "
+"simples e eficiente."
+
+#: src/ownership/borrowing.md:53
+#, fuzzy
+msgid "[Playground]: https://play.rust-lang.org/"
+msgstr "[Playground]: https://play.rust-lang.org/"
+
+#: src/ownership/shared-unique-borrows.md:1
+#, fuzzy
+msgid "# Shared and Unique Borrows"
+msgstr "# Empréstimos compartilhados e exclusivos"
+
+#: src/ownership/shared-unique-borrows.md:3
+#, fuzzy
+msgid "Rust puts constraints on the ways you can borrow values:"
+msgstr "O Rust coloca restrições nas formas como você pode emprestar valores:"
+
+#: src/ownership/shared-unique-borrows.md:5
+#, fuzzy
+msgid ""
+"* You can have one or more `&T` values at any given time, _or_\n"
+"* You can have exactly one `&mut T` value."
+msgstr ""
+"* Você pode ter um ou mais valores `&T` a qualquer momento, _ou_\n"
+"* Você pode ter exatamente um valor `&mut T`."
+
+#: src/ownership/shared-unique-borrows.md:8
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let mut a: i32 = 10;\n"
+"    let b: &i32 = &a;"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let mut a: i32 = 10;\n"
+"    let b: &i32 = &a;"
+
+#: src/ownership/shared-unique-borrows.md:13
+#, fuzzy
+msgid ""
+"    {\n"
+"        let c: &mut i32 = &mut a;\n"
+"        *c = 20;\n"
+"    }"
+msgstr ""
+"    {\n"
+"        let c: &mut i32 = &mut a;\n"
+"        *c = 20;\n"
+"    }"
+
+#: src/ownership/shared-unique-borrows.md:18 src/std/rc.md:13
+#, fuzzy
+msgid ""
+"    println!(\"a: {a}\");\n"
+"    println!(\"b: {b}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    println!(\"a: {a}\");\n"
+"    println!(\"b: {b}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/shared-unique-borrows.md:25
+#, fuzzy
+msgid ""
+"* The above code does not compile because `a` is borrowed as mutable "
+"(through `c`) and as immutable (through `b`) at the same time.\n"
+"* Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile.\n"
+"* After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
+msgstr ""
+"* O código acima não compila porque `a` é emprestado como mutável (através "
+"de `c`) e como imutável (através de `b`) ao mesmo tempo.\n"
+"* Mova a instrução `println!` para `b` antes do escopo que introduz `c` para "
+"fazer o código compilar.\n"
+"* Após essa alteração, o compilador percebe que `b` só é usado antes do novo "
+"empréstimo mutável de `a` a `c`. Este é um recurso do verificador de "
+"empréstimo chamado \"tempo de vida não lexical\"."
+
+#: src/ownership/lifetimes.md:1
+#, fuzzy
+msgid "# Lifetimes"
+msgstr "# Tempos de vida"
+
+#: src/ownership/lifetimes.md:3
+#, fuzzy
+msgid "A borrowed value has a _lifetime_:"
+msgstr "Um valor emprestado tem um _lifetime_:"
+
+#: src/ownership/lifetimes.md:5
+#, fuzzy
+msgid ""
+"* The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`.\n"
+"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
+"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
+"  lifetime `a`\".\n"
+"* Lifetimes are always inferred by the compiler: you cannot assign a "
+"lifetime\n"
+"  yourself.\n"
+"  * Lifetime annotations create constraints; the compiler verifies that "
+"there is\n"
+"    a valid solution."
+msgstr ""
+"* O tempo de vida pode ser excluído: `add(p1: &Point, p2: &Point) -> "
+"Point`.\n"
+"* Tempos de vida também podem ser explícitos: `&'a Point`, `&'document str`.\n"
+"* Leia `&'um Point` como \"um `Point` emprestado que é válido por pelo menos "
+"o\n"
+"  tempo de vida `a`\".\n"
+"* Os tempos de vida são sempre inferidos pelo compilador: você não pode "
+"atribuir um tempo de vida\n"
+"  você mesmo.\n"
+"  * As anotações vitalícias criam restrições; o compilador verifica se há\n"
+"    uma solução válida."
+
+#: src/ownership/lifetimes-function-calls.md:1
+#, fuzzy
+msgid "# Lifetimes in Function Calls"
+msgstr "# Tempos de vida em Chamadas de Função"
+
+#: src/ownership/lifetimes-function-calls.md:3
+#, fuzzy
+msgid ""
+"In addition to borrowing its arguments, a function can return a borrowed "
+"value:"
+msgstr ""
+"Além de emprestar seus argumentos, uma função pode retornar um valor "
+"emprestado:"
+
+#: src/ownership/lifetimes-function-calls.md:9
+#, fuzzy
+msgid ""
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}"
+msgstr ""
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}"
+
+#: src/ownership/lifetimes-function-calls.md:13
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p2: Point = Point(20, 20);\n"
+"    let p3: &Point = left_most(&p1, &p2);\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p2: Point = Point(20, 20);\n"
+"    let p3: &Point = left_most(&p1, &p2);\n"
+"    println!(\"Point mais à esquerda: {:?}\", p3);\n"
+"}\n"
+"```"
+
+#: src/ownership/lifetimes-function-calls.md:21
+#, fuzzy
+msgid ""
+"* `'a` is a generic parameter, it is inferred by the compiler.\n"
+"* Lifetimes start with `'` and `'a` is a typical default name.\n"
+"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
+"  lifetime `a`\".\n"
+"  * The _at least_ part is important when parameters are in different scopes."
+msgstr ""
+"* `'a` é um parâmetro genérico, é inferido pelo compilador.\n"
+"* Os tempos de vida começam com `'` e `'a` é um name padrão típico.\n"
+"* Leia `&'um Point` como \"um `Point` emprestado que é válido por pelo menos "
+"o\n"
+"  tempo de vida `a`\".\n"
+"  * A parte _pelo menos_ é importante quando os parâmetros estão em escopos "
+"diferentes."
+
+#: src/ownership/lifetimes-function-calls.md:31
+#, fuzzy
+msgid ""
+"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:\n"
+"  ```rust,ignore\n"
+"  #[derive(Debug)]\n"
+"  struct Point(i32, i32);"
+msgstr ""
+"* Mova a declaração de `p2` e `p3` para um novo escopo (`{ ... }`), "
+"resultando no seguinte código:\n"
+"  ```rust, ignore\n"
+"  #[derive(Debug)]\n"
+"  struct Point(i32, i32);"
+
+#: src/ownership/lifetimes-function-calls.md:36
+#, fuzzy
+msgid ""
+"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"      if p1.0 < p2.0 { p1 } else { p2 }\n"
+"  }"
+msgstr ""
+"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"      if p1.0 < p2.0 { p1 } else { p2 }\n"
+"  }"
+
+#: src/ownership/lifetimes-function-calls.md:40
+#, fuzzy
+msgid ""
+"  fn main() {\n"
+"      let p1: Point = Point(10, 10);\n"
+"      let p3: &Point;\n"
+"      {\n"
+"          let p2: Point = Point(20, 20);\n"
+"          p3 = left_most(&p1, &p2);\n"
+"      }\n"
+"      println!(\"left-most point: {:?}\", p3);\n"
+"  }\n"
+"  ```\n"
+"  Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+"  fn main() {\n"
+"      let p1: Point = Point(10, 10);\n"
+"      let p3: &Point;\n"
+"      {\n"
+"          let p2: Point = Point(20, 20);\n"
+"          p3 = left_most(&p1, &p2);\n"
+"      }\n"
+"      println!(\"left-most point: {:?}\", p3);\n"
+"  }\n"
+"  ```\n"
+"  Observe como isso não compila, pois `p3` sobrevive a `p2`."
+
+#: src/ownership/lifetimes-function-calls.md:52
+#, fuzzy
+msgid ""
+"* Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
+"* Another way to explain it:\n"
+"  * Two references to two values are borrowed by a function and the function "
+"returns\n"
+"    another reference.\n"
+"  * It must have come from one of those two inputs (or from a global "
+"variable).\n"
+"  * Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used\n"
+"    for longer than a variable from where the reference came from."
+msgstr ""
+"* Redefina o espaço de trabalho e altere a assinatura da função para `fn "
+"left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. Isso não será "
+"compilado porque a relação entre os tempos de vida `'a` e `'b` não é clara.\n"
+"* Outra forma de explicar:\n"
+"  * Duas referências a dois valores são emprestadas por uma função e a "
+"função retorna\n"
+"    outra referência.\n"
+"  * Deve ter vindo de uma dessas duas entradas (ou de uma variável global).\n"
+"  * Qual é? O compilador precisa saber, portanto, no local da chamada, a "
+"referência retornada não é usada\n"
+"    por mais tempo do que uma variável de onde veio a referência."
+
+#: src/ownership/lifetimes-data-structures.md:1
+#, fuzzy
+msgid "# Lifetimes in Data Structures"
+msgstr "# Tempos de vida em Structs de dados"
+
+#: src/ownership/lifetimes-data-structures.md:3
+#, fuzzy
+msgid ""
+"If a data type stores borrowed data, it must be annotated with a lifetime:"
+msgstr ""
+"Se um tipo de dados armazena dados emprestados, ele deve ser anotado com um "
+"tempo de vida:"
+
+#: src/ownership/lifetimes-data-structures.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);"
+
+#: src/ownership/lifetimes-data-structures.md:9
+#, fuzzy
+msgid ""
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}"
+msgstr ""
+"fn erase(texto: String) {\n"
+"    println!(\"Tchau {texto}!\");\n"
+"}"
+
+#: src/ownership/lifetimes-data-structures.md:13
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy "
+"dog.\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(text);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy "
+"dog.\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(texto);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/lifetimes-data-structures.md:25
+#, fuzzy
+msgid ""
+"* In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data.\n"
+"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error.\n"
+"* Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use.\n"
+"* When possible, make data structures own their data directly.\n"
+"* Some structs with multiple references inside can have more than one "
+"lifetime annotation. This can be necessary if there is a need to describe "
+"lifetime relationships between the references themselves, in addition to the "
+"lifetime of the struct itself. Those are very advanced use cases.\n"
+"</details>"
+msgstr ""
+"* No exemplo acima, a anotação em `Highlight` impõe que os dados subjacentes "
+"ao `&str` contido vivam pelo menos tanto quanto qualquer instância de "
+"`Highlight` que usa esses dados.\n"
+"* Se `text` for consumido antes do final do tempo de vida de `fox` (ou "
+"`dog`), o verificador de empréstimo lançará um erro.\n"
+"* Tipos com dados emprestados forçam os usuários a manter os dados "
+"originais. Isso pode ser útil para criar exibições leves, mas geralmente as "
+"torna um pouco mais difíceis de usar.\n"
+"* Quando possível, faça com que as Structs de dados possuam seus dados "
+"diretamente.\n"
+"* Algumas Structs com várias referências internas podem ter mais de uma "
+"anotação vitalícia. Isso pode ser necessário se houver necessage de "
+"descrever relacionamentos de tempo de vida entre as próprias referências, "
+"além do tempo de vida da própria estrutura. Esses são casos de uso muito "
+"avançados.\n"
+"</details>"
+
+#: src/exercises/day-1/afternoon.md:1
+#, fuzzy
+msgid "# Day 1: Afternoon Exercises"
+msgstr "# Dia 1: Exercícios da Tarde"
+
+#: src/exercises/day-1/afternoon.md:3
+#, fuzzy
+msgid "We will look at two things:"
+msgstr "Veremos duas coisas:"
+
+#: src/exercises/day-1/afternoon.md:5
+#, fuzzy
+msgid "* A small book library,"
+msgstr "* Uma pequena biblioteca de livros,"
+
+#: src/exercises/day-1/afternoon.md:7
+#, fuzzy
+msgid "* Iterators and ownership (hard)."
+msgstr "* Iteradores e ownership (difícil)."
+
+#: src/exercises/day-1/afternoon.md:13 src/exercises/day-2/afternoon.md:9
+#, fuzzy
+msgid "[solutions]: solutions-afternoon.md"
+msgstr "[soluções]: soluções-tarde.md"
+
+#: src/exercises/day-1/book-library.md:1
+#, fuzzy
+msgid "# Designing a Library"
+msgstr "# Projetando uma biblioteca"
+
+#: src/exercises/day-1/book-library.md:3
+#, fuzzy
+msgid ""
+"We will learn much more about structs and the `Vec<T>` type tomorrow. For "
+"now,\n"
+"you just need to know part of its API:"
+msgstr ""
+"Aprenderemos muito mais sobre structs e o tipo `Vec<T>` amanhã. Por agora,\n"
+"você só precisa conhecer parte de sua API:"
+
+#: src/exercises/day-1/book-library.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut vec = vec![10, 20];\n"
+"    vec.push(30);\n"
+"    println!(\"middle value: {}\", vec[vec.len() / 2]);\n"
+"    for item in vec.iter() {\n"
+"        println!(\"item: {item}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut vec = vec![10, 20];\n"
+"    vec.push(30);\n"
+"    println!(\"valor do meio: {}\", vec[vec.len() / 2]);\n"
+"    for item in vec.iter() {\n"
+"        println!(\"item: {item}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/book-library.md:17
+#, fuzzy
+msgid ""
+"Use this to create a library application. Copy the code below to\n"
+"<https://play.rust-lang.org/> and update the types to make it compile:"
+msgstr ""
+"Use isso para criar um aplicativo de biblioteca. Copie o código abaixo para\n"
+"<https://play.rust-lang.org/> e atualize os tipos para compilar:"
+
+#: src/exercises/day-1/book-library.md:24
+#, fuzzy
+msgid ""
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}"
+msgstr ""
+"library struct {\n"
+"    books: Vec<Book>,\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:28
+#: src/exercises/day-1/solutions-afternoon.md:27
+#, fuzzy
+msgid ""
+"struct Book {\n"
+"    title: String,\n"
+"    year: u16,\n"
+"}"
+msgstr ""
+"struct Book {\n"
+"    título: String,\n"
+"    ano: u16,\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:33
+#: src/exercises/day-1/solutions-afternoon.md:32
+#, fuzzy
+msgid ""
+"impl Book {\n"
+"    // This is a constructor, used below.\n"
+"    fn new(title: &str, year: u16) -> Book {\n"
+"        Book {\n"
+"            title: String::from(title),\n"
+"            year,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Livro {\n"
+"    // Este é um construtor, usado abaixo.\n"
+"    fn new(title: &str, ano: u16) -> Book {\n"
+"        Book {\n"
+"            title: String::from(title),\n"
+"            year,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:43
+#, fuzzy
+msgid ""
+"// This makes it possible to print Book values with {}.\n"
+"impl std::fmt::Display for Book {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        write!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}"
+msgstr ""
+"// Isso torna possível imprimir valores de livro com {}.\n"
+"impl std::fmt::Display for Book {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        escreva!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:50
+#, fuzzy
+msgid ""
+"impl Library {\n"
+"    fn new() -> Library {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"biblioteca impl {\n"
+"    fn new() -> Library {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-1/book-library.md:55
+#, fuzzy
+msgid ""
+"    //fn len(self) -> usize {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn len(self) -> usize {\n"
+"    // não implementado!()\n"
+"    ///}"
+
+#: src/exercises/day-1/book-library.md:59
+#, fuzzy
+msgid ""
+"    //fn is_empty(self) -> bool {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn is_empty(self) -> bool {\n"
+"    // não implementado!()\n"
+"    ///}"
+
+#: src/exercises/day-1/book-library.md:63
+#, fuzzy
+msgid ""
+"    //fn add_book(self, book: Book) {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn add_book(self, book: Book) {\n"
+"    // não implementado!()\n"
+"    ///}"
+
+#: src/exercises/day-1/book-library.md:67
+#, fuzzy
+msgid ""
+"    //fn print_books(self) {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn print_books(self) {\n"
+"    // não implementado!()\n"
+"    ///}"
+
+#: src/exercises/day-1/book-library.md:71
+#, fuzzy
+msgid ""
+"    //fn oldest_book(self) -> Option<&Book> {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"}"
+msgstr ""
+"    //fn oldest_book(self) -> Option<&Book> {\n"
+"    // não implementado!()\n"
+"    ///}\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:76
+#, fuzzy
+msgid ""
+"// This shows the desired behavior. Uncomment the code below and\n"
+"// implement the missing methods. You will need to update the\n"
+"// method signatures, including the \"self\" parameter! You may\n"
+"// also need to update the variable bindings within main.\n"
+"fn main() {\n"
+"    let library = Library::new();"
+msgstr ""
+"// Isso mostra o comportamento desejado. Descomente o código abaixo e\n"
+"// implementa os métodos ausentes. Você precisará atualizar o\n"
+"// assinaturas de método, incluindo o parâmetro \"self\"! Você pode\n"
+"// também precisa atualizar as ligações de variáveis dentro de main.\n"
+"fn main() {\n"
+"    let library = Library::new();"
+
+#: src/exercises/day-1/book-library.md:83
+#, fuzzy
+msgid ""
+"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
+"    //\n"
+"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    //\n"
+"    //library.print_books();\n"
+"    //\n"
+"    //match library.oldest_book() {\n"
+"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
+"    //    None => println!(\"My library is empty!\"),\n"
+"    //}\n"
+"    //\n"
+"    //println!(\"Our library has {} books\", library.len());\n"
+"}\n"
+"```"
+msgstr ""
+"    //println!(\"Nossa biblioteca está vazia: {}\", library.is_empty());\n"
+"    //\n"
+"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    //\n"
+"    //library.print_books();\n"
+"    //\n"
+"    //corresponde à library.oldest_book() {\n"
+"    // Some(book) => println!(\"Meu livro mais antigo é {book}\"),\n"
+"    // Nenhum => println!(\"Minha biblioteca está vazia!\"),\n"
+"    ///}\n"
+"    //\n"
+"    //println!(\"Nossa biblioteca tem {} livros\", library.len());\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/book-library.md:99
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"[Solution](solutions-afternoon.md#designing-a-library)"
+msgstr ""
+"<details>\n"
+"    \n"
+"[Solution](solutions-afternoon.md#designing-a-library)"
+
+#: src/exercises/day-1/iterators-and-ownership.md:1
+#, fuzzy
+msgid "# Iterators and Ownership"
+msgstr "# Iteradores e ownership"
+
+#: src/exercises/day-1/iterators-and-ownership.md:3
+#, fuzzy
+msgid ""
+"The ownership model of Rust affects many APIs. An example of this is the\n"
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"traits."
+msgstr ""
+"O modelo de ownership do Rust afeta muitas APIs. Um exemplo disso é o\n"
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) e\n"
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"características."
+
+#: src/exercises/day-1/iterators-and-ownership.md:8
+#, fuzzy
+msgid "## `Iterator`"
+msgstr "## `Iterador`"
+
+#: src/exercises/day-1/iterators-and-ownership.md:10
+#, fuzzy
+msgid ""
+"Traits are like interfaces: they describe behavior (methods) for a type. "
+"The\n"
+"`Iterator` trait simply says that you can call `next` until you get `None` "
+"back:"
+msgstr ""
+"Os traits são como interfaces: eles descrevem o comportamento (métodos) para "
+"um tipo. o\n"
+"O trait `Iterator` simplesmente diz que você pode chamar `next` até obter "
+"`None` de volta:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:13
+#, fuzzy
+msgid ""
+"```rust\n"
+"pub trait Iterator {\n"
+"    type Item;\n"
+"    fn next(&mut self) -> Option<Self::Item>;\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"pub trait Iterator {\n"
+"    type Item;\n"
+"    fn next(&mut self) -> Option<Self::Item>;\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/iterators-and-ownership.md:20
+#, fuzzy
+msgid "You use this trait like this:"
+msgstr "Você usa esse trait assim:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:22
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();"
+
+#: src/exercises/day-1/iterators-and-ownership.md:27
+#, fuzzy
+msgid ""
+"    println!(\"v[0]: {:?}\", iter.next());\n"
+"    println!(\"v[1]: {:?}\", iter.next());\n"
+"    println!(\"v[2]: {:?}\", iter.next());\n"
+"    println!(\"No more items: {:?}\", iter.next());\n"
+"}\n"
+"```"
+msgstr ""
+"    println!(\"v[0]: {:?}\", iter.next());\n"
+"    println!(\"v[1]: {:?}\", iter.next());\n"
+"    println!(\"v[2]: {:?}\", iter.next());\n"
+"    println!(\"Sem mais itens: {:?}\", iter.next());\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/iterators-and-ownership.md:34
+#, fuzzy
+msgid "What is the type returned by the iterator? Test your answer here:"
+msgstr "Qual é o tipo retornado pelo iterador? Teste sua resposta aqui:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:36
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();"
+
+#: src/exercises/day-1/iterators-and-ownership.md:41
+#: src/exercises/day-1/iterators-and-ownership.md:78
+#, fuzzy
+msgid ""
+"    let v0: Option<..> = iter.next();\n"
+"    println!(\"v0: {v0:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    let v0: Option<..> = iter.next();\n"
+"    println!(\"v0: {v0:?}\");\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/iterators-and-ownership.md:46
+#, fuzzy
+msgid "Why is this type used?"
+msgstr "Por que esse tipo?"
+
+#: src/exercises/day-1/iterators-and-ownership.md:48
+#, fuzzy
+msgid "## `IntoIterator`"
+msgstr "## `IntoIterator`"
+
+#: src/exercises/day-1/iterators-and-ownership.md:50
+#, fuzzy
+msgid ""
+"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"iterator. The related trait `IntoIterator` tells you how to create the "
+"iterator:"
+msgstr ""
+"O trait `Iterator` informa como _iterar_ depois de criar um\n"
+"iterador. A característica relacionada `IntoIterator` informa como criar o "
+"iterador:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:53
+#, fuzzy
+msgid ""
+"```rust\n"
+"pub trait IntoIterator {\n"
+"    type Item;\n"
+"    type IntoIter: Iterator<Item = Self::Item>;"
+msgstr ""
+"```rust\n"
+"pub trait IntoIterator {\n"
+"    type Item;\n"
+"    type IntoIter: Iterator<Item = Self::Item>;"
+
+#: src/exercises/day-1/iterators-and-ownership.md:58
+#, fuzzy
+msgid ""
+"    fn into_iter(self) -> Self::IntoIter;\n"
+"}\n"
+"```"
+msgstr ""
+"    fn into_iter(self) -> Self::IntoIter;\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/iterators-and-ownership.md:62
+#, fuzzy
+msgid ""
+"The syntax here means that every implementation of `IntoIterator` must\n"
+"declare two types:"
+msgstr ""
+"A sintaxe aqui significa que toda implementação de `IntoIterator` deve\n"
+"declarar dois tipos:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:65
+#, fuzzy
+msgid ""
+"* `Item`: the type we iterate over, such as `i8`,\n"
+"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr ""
+"* `Item`: o tipo sobre o qual iteramos, como `i8`,\n"
+"* `IntoIter`: o tipo `Iterator` retornado pelo método `into_iter`."
+
+#: src/exercises/day-1/iterators-and-ownership.md:68
+#, fuzzy
+msgid ""
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"`Item` type, which means that it returns `Option<Item>`"
+msgstr ""
+"Observe que `IntoIter` e `Item` estão vinculados: o iterador deve ter o "
+"mesmo\n"
+"Tipo `Item`, o que significa que ele retorna `Option<Item>`"
+
+#: src/exercises/day-1/iterators-and-ownership.md:71
+#, fuzzy
+msgid "Like before, what  is the type returned by the iterator?"
+msgstr "Como antes, qual é o tipo retornado pelo iterador?"
+
+#: src/exercises/day-1/iterators-and-ownership.md:73
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), "
+"String::from(\"bar\")];\n"
+"    let mut iter = v.into_iter();"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), "
+"String::from(\"bar\")];\n"
+"    let mut iter = v.into_iter();"
+
+#: src/exercises/day-1/iterators-and-ownership.md:83
+#, fuzzy
+msgid "## `for` Loops"
+msgstr "## `for` Loops"
+
+#: src/exercises/day-1/iterators-and-ownership.md:85
+#, fuzzy
+msgid ""
+"Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
+"loops.\n"
+"They call `into_iter()` on an expression and iterates over the resulting\n"
+"iterator:"
+msgstr ""
+"Agora que conhecemos `Iterator` e `IntoIterator`, podemos construir loops "
+"`for`.\n"
+"Eles chamam `into_iter()` em uma expressão e itera sobre o resultado\n"
+"iterador:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:89
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];"
+
+#: src/exercises/day-1/iterators-and-ownership.md:93
+#, fuzzy
+msgid ""
+"    for word in &v {\n"
+"        println!(\"word: {word}\");\n"
+"    }"
+msgstr ""
+"    for word in &v {\n"
+"        println!(\"word: {word}\");\n"
+"    }"
+
+#: src/exercises/day-1/iterators-and-ownership.md:97
+#, fuzzy
+msgid ""
+"    for word in v {\n"
+"        println!(\"word: {word}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    for word in v {\n"
+"        println!(\"word: {word}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/iterators-and-ownership.md:103
+#, fuzzy
+msgid "What is the type of `word` in each loop?"
+msgstr "Qual é o tipo de `palavra` em cada loop?"
+
+#: src/exercises/day-1/iterators-and-ownership.md:105
+#, fuzzy
+msgid ""
+"Experiment with the code above and then consult the documentation for "
+"[`impl\n"
+"IntoIterator for\n"
+"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
+"and [`impl IntoIterator for\n"
+"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
+"to check your answers."
+msgstr ""
+"Experimente o código acima e depois consulte a documentação para [`impl\n"
+"IntoIterator para\n"
+"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
+"e [`impl IntoIterator para\n"
+"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
+"para verificar suas respostas."
+
+#: src/welcome-day-2.md:1
+#, fuzzy
+msgid "# Welcome to Day 2"
+msgstr "# Bem-vindo ao Dia 2"
+
+#: src/welcome-day-2.md:3
+#, fuzzy
+msgid "Now that we have seen a fair amount of Rust, we will continue with:"
+msgstr "Agora que vimos uma boa quantage de Rust, continuaremos com:"
+
+#: src/welcome-day-2.md:5
+#, fuzzy
+msgid "* Structs, enums, methods."
+msgstr "* Structs, enums, métodos."
+
+#: src/welcome-day-2.md:7
+#, fuzzy
+msgid "* Pattern matching: destructuring enums, structs, and arrays."
+msgstr "* Correspondência de padrões: desestruturando enums, structs e arrays."
+
+#: src/welcome-day-2.md:9
+#, fuzzy
+msgid ""
+"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
+"and\n"
+"  `continue`."
+msgstr ""
+"* Construções de fluxo de controle: `if`, `if let`, `while`, `while let`, "
+"`break` e\n"
+"  `continue`."
+
+#: src/welcome-day-2.md:12
+#, fuzzy
+msgid ""
+"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc`\n"
+"  and `Arc`."
+msgstr ""
+"* A Biblioteca Padrão: `String`, `Option` e `Result`, `Vec`, `HashMap`, "
+"`Rc`\n"
+"  e 'Arc'."
+
+#: src/welcome-day-2.md:15
+#, fuzzy
+msgid "* Modules: visibility, paths, and filesystem hierarchy."
+msgstr "* Módulos: visibilage, caminhos e hierarquia do sistema de arquivos."
+
+#: src/structs.md:1
+#, fuzzy
+msgid "# Structs"
+msgstr "# Structs"
+
+#: src/structs.md:3
+#, fuzzy
+msgid "Like C and C++, Rust has support for custom structs:"
+msgstr "Como C e C++, Rust tem suporte para structs personalizados:"
+
+#: src/structs.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}"
+
+#: src/structs.md:11
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    peter.age = 28;\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    let jackie = Person {\n"
+"        name: String::from(\"Jackie\"),\n"
+"        ..peter\n"
+"    };\n"
+"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let mut peter = Person {\n"
+"        name: String::from(\"Pedro\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    peter.age = 28;\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    let jackie = Person {\n"
+"        name: String::from(\"Jackie\"),\n"
+"        ..Pedro\n"
+"    };\n"
+"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
+"}\n"
+"```"
+
+#: src/structs.md:29
+#, fuzzy
+msgid "<details>\nKey Points: "
+msgstr "<details>\nPoints chave:"
+
+#: src/structs.md:32
+#, fuzzy
+msgid ""
+"* Structs work like in C or C++.\n"
+"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
+"  * Unlike in C++, there is no inheritance between structs.\n"
+"* Methods are defined in an `impl` block, which we will see in following "
+"slides.\n"
+"* This may be a good time to let people know there are different types of "
+"structs. \n"
+"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself. \n"
+"  * The next slide will introduce Tuple structs."
+msgstr ""
+"* Structs funcionam como em C ou C++.\n"
+"  * Como em C++, e ao contrário de C, nenhum typedef é necessário para "
+"definir um tipo.\n"
+"  * Ao contrário do C++, não há herança entre structs.\n"
+"* Os métodos são definidos em um bloco `impl`, que veremos nos próximos "
+"slides.\n"
+"* Este pode ser um bom momento para que as Persons saibam que existem "
+"diferentes tipos de structs.\n"
+"  * Structs de tamanho zero `por exemplo, struct Foo;` podem ser usadas "
+"ao implementar uma característica em algum tipo, mas não possuem nenhum dado "
+"que você deseja armazenar no próprio valor.\n"
+"  * O próximo slide apresentará as Structs Tuple."
+
+#: src/structs/tuple-structs.md:1
+#, fuzzy
+msgid "# Tuple Structs"
+msgstr "# Structs Tuplas"
+
+#: src/structs/tuple-structs.md:3
+#, fuzzy
+msgid "If the field names are unimportant, you can use a tuple struct:"
+msgstr ""
+"Se os names dos campos não forem importantes, você pode usar uma estrutura "
+"de tupla:"
+
+#: src/structs/tuple-structs.md:5
+#, fuzzy
+msgid "```rust,editable\nstruct Point(i32, i32);"
+msgstr "```rust, editable\nstruct Point(i32, i32);"
+
+#: src/structs/tuple-structs.md:8
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let p = Point(17, 23);\n"
+"    println!(\"({}, {})\", p.0, p.1);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let p = Point(17, 23);\n"
+"    println!(\"({}, {})\", p.0, p.1);\n"
+"}\n"
+"```"
+
+#: src/structs/tuple-structs.md:14
+#, fuzzy
+msgid "This is often used for single-field wrappers (called newtypes):"
+msgstr ""
+"Isso geralmente é usado para wrappers de campo único (chamados newtypes):"
+
+#: src/structs/tuple-structs.md:16
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"struct PoundOfForce(f64);\n"
+"struct Newtons(f64);"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"struct PoundOfForce(f64);\n"
+"struct Newtons(f64);"
+
+#: src/structs/tuple-structs.md:20
+#, fuzzy
+msgid ""
+"fn compute_thruster_force() -> PoundOfForce {\n"
+"    todo!(\"Ask a rocket scientist at NASA\")\n"
+"}"
+msgstr ""
+"fn compute_thruster_force() -> PoundOfForce {\n"
+"    todo!(\"Pergunte a um cientista de foguetes da NASA\")\n"
+"}"
+
+#: src/structs/tuple-structs.md:24
+#, fuzzy
+msgid ""
+"fn set_thruster_force(force: Newtons) {\n"
+"    // ...\n"
+"}"
+msgstr ""
+"fn set_thruster_force(force: Newtons) {\n"
+"    // ...\n"
+"}"
+
+#: src/structs/tuple-structs.md:28
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let force = compute_thruster_force();\n"
+"    ift_thruster_force(force);\n"
+"}"
+msgstr ""
+"fn main() {\n"
+"    let force = compute_thruster_force();\n"
+"    ift_thruster_force(force);\n"
+"}"
+
+#: src/structs/tuple-structs.md:33 src/generics/trait-objects.md:86
+#, fuzzy
+msgid "```"
+msgstr "```"
+
+#: src/structs/tuple-structs.md:37
+#, fuzzy
+msgid ""
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:\n"
+"  * The number is measured in some units: `Newtons` in the example above.\n"
+"  * The value passed some validation when it was created, so you no longer "
+"have to validate it again at every use: 'PhoneNumber(String)` or "
+"`OddNumber(u32)`.\n"
+"    \n"
+"</details>"
+msgstr ""
+"Newtypes são uma ótima maneira de codificar informações adicionais sobre o "
+"valor em um tipo primitivo, por exemplo:\n"
+"  * O número é medido em algumas unages: `Newtons` no exemplo acima.\n"
+"  * O valor passou por alguma validação quando foi criado, então você não "
+"precisa mais validá-lo novamente a cada uso: 'PhoneNumber(String)` ou "
+"`OddNumber(u32)`.\n"
+"    \n"
+"</details>"
+
+#: src/structs/field-shorthand.md:1
+#, fuzzy
+msgid "# Field Shorthand Syntax"
+msgstr "# Sintaxe abreviada de campo"
+
+#: src/structs/field-shorthand.md:3
+#, fuzzy
+msgid ""
+"If you already have variables with the right names, then you can create the\n"
+"struct using a shorthand:"
+msgstr ""
+"Se você já tiver variáveis com os names corretos, poderá criar o\n"
+"struct usando uma abreviação:"
+
+#: src/structs/field-shorthand.md:6 src/methods.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}"
+
+#: src/structs/field-shorthand.md:13
+#, fuzzy
+msgid ""
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Person {\n"
+"        Person { name, age }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Person {\n"
+"        Person { name, age }\n"
+"    }\n"
+"}"
+
+#: src/structs/field-shorthand.md:19
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
+"    println!(\"{peter:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
+"    println!(\"{peter:?}\");\n"
+"}\n"
+"```"
+
+#: src/structs/field-shorthand.md:27
+#, fuzzy
+msgid ""
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
+msgstr ""
+"A função `new` pode ser escrita usando `Self` como um tipo, já que é "
+"intercambiável com o name do tipo struct"
+
+#: src/structs/field-shorthand.md:29
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```\n"
+"    \n"
+"</details>"
+msgstr ""
+"```rust, ignore\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```\n"
+"    \n"
+"</details>"
+
+#: src/enums.md:1
+#, fuzzy
+msgid "# Enums"
+msgstr "# Enums"
+
+#: src/enums.md:3
+#, fuzzy
+msgid ""
+"The `enum` keyword allows the creation of a type which has a few\n"
+"different variants:"
+msgstr ""
+"A palavra-chave `enum` permite a criação de um tipo que possui alguns\n"
+"diferentes variantes:"
+
+#: src/enums.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn generate_random_number() -> i32 {\n"
+"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn generate_random_number() -> i32 {\n"
+"    4 // Escolhido por jogada de dados justa. Garantido para ser aleatório.\n"
+"}"
+
+#: src/enums.md:11
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"enum CoinFlip {\n"
+"    Heads,\n"
+"    Tails,\n"
+"}"
+msgstr ""
+"#[derive(Debug)]\n"
+"enum CoinFlip {\n"
+"    Heads,\n"
+"    Tails,\n"
+"}"
+
+#: src/enums.md:17
+#, fuzzy
+msgid ""
+"fn flip_coin() -> CoinFlip {\n"
+"    let random_number = generate_random_number();\n"
+"    if random_number % 2 == 0 {\n"
+"        return CoinFlip::Heads;\n"
+"    } else {\n"
+"        return CoinFlip::Tails;\n"
+"    }\n"
+"}"
+msgstr ""
+"fn flip_coin() -> CoinFlip {\n"
+"    let random_number = generate_random_number();\n"
+"    if random_number % 2 == 0 {\n"
+"        return CoinFlip::Heads;\n"
+"    } else {\n"
+"        return CoinFlip::Tails;\n"
+"    }\n"
+"}"
+
+#: src/enums.md:26
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    println!(\"You got: {:?}\", flip_coin());\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    println!(\"You got: {:?}\", flip_coin());\n"
+"}\n"
+"```"
+
+#: src/enums.md:31
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points:"
+msgstr ""
+"<details>\n"
+"    \n"
+"Points chave:"
+
+#: src/enums.md:35
+#, fuzzy
+msgid ""
+"* Enumerations allow you to collect a set of values under one type\n"
+"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants.\n"
+"* This might be a good time to compare Structs and Enums:\n"
+"  * In both, you can have a simple version without fields (unit struct) or "
+"one with different types of fields (variant payloads). \n"
+"  * In both, associated functions are defined within an `impl` block.\n"
+"  * You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. \n"
+"</details>"
+msgstr ""
+"* As enumerações permitem que você colete um conjunto de valores em um tipo\n"
+"* Esta página oferece um tipo de Enum `CoinFlip` com duas variantes "
+"`Heads` e `Tail`. Você pode observar o namespace ao usar variantes.\n"
+"* Este pode ser um bom momento para comparar Structs e Enums:\n"
+"  * Em ambos, você pode ter uma versão simples sem campos (unit struct) ou "
+"uma com diferentes tipos de campos (variant payloads).\n"
+"  * Em ambos, as funções associadas são definidas dentro de um bloco "
+"`impl`.\n"
+"  * Você pode até mesmo implementar as diferentes variantes de uma "
+"Enum com Structs separadas, mas elas não seriam do mesmo tipo que "
+"seriam se todas fossem definidas em uma Enum.\n"
+"</details>"
+
+#: src/enums/variant-payloads.md:1
+#, fuzzy
+msgid "# Variant Payloads"
+msgstr "# cargos úteis variantes"
+
+#: src/enums/variant-payloads.md:3
+#, fuzzy
+msgid ""
+"You can define richer enums where the variants carry data. You can then use "
+"the\n"
+"`match` statement to extract the data from each variant:"
+msgstr ""
+"Você pode definir enums mais ricos onde as variantes carregam dados. Você "
+"pode então usar o\n"
+"instrução `match` para extrair os dados de cada variante:"
+
+#: src/enums/variant-payloads.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"enum WebEvent {\n"
+"    PageLoad,                 // Variant without payload\n"
+"    KeyPress(char),           // Tuple struct variant\n"
+"    Click { x: i64, y: i64 }, // Full struct variant\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"enum WebEvent {\n"
+"    PageLoad, // Variante sem payload\n"
+"    KeyPress(char), // Variante da estrutura da tupla\n"
+"    Click { x: i64, y: i64 }, // Variante de struct completa\n"
+"}"
+
+#: src/enums/variant-payloads.md:13
+#, fuzzy
+msgid ""
+"#[rustfmt::skip]\n"
+"fn inspect(event: WebEvent) {\n"
+"    match event {\n"
+"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
+"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
+"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
+"    }\n"
+"}"
+msgstr ""
+"#[rustfmt::pular]\n"
+"fn inspect(event: WebEvent) {\n"
+"    match event{\n"
+"        WebEvent::PageLoad => println!(\"página carregada\"),\n"
+"        WebEvent::KeyPress(c) => println!(\"pressionou '{c}'\"),\n"
+"        WebEvent::Click { x, y } => println!(\"clicou em x={x}, "
+"y={y}\"),\n"
+"    }\n"
+"}"
+
+#: src/enums/variant-payloads.md:22
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let load = WebEvent::PageLoad;\n"
+"    let press = WebEvent::KeyPress('x');\n"
+"    let click = WebEvent::Click { x: 20, y: 80 };"
+msgstr ""
+"fn main() {\n"
+"    let load = WebEvent::PageLoad;\n"
+"    let pressionar = WebEvent::KeyPress('x');\n"
+"    let click = WebEvent::Click { x: 20, y: 80 };"
+
+#: src/enums/variant-payloads.md:27
+#, fuzzy
+msgid ""
+"    inspect(load);\n"
+"    inspect(press);\n"
+"    inspect(click);\n"
+"}\n"
+"```"
+msgstr ""
+"    inspect(load);\n"
+"    inspect(press);\n"
+"    inspect(click);\n"
+"}\n"
+"```"
+
+#: src/enums/variant-payloads.md:35
+#, fuzzy
+msgid ""
+"* In the above example, accessing the `char` in `KeyPress`, or `x` and `y` "
+"in `Click` only works within a `match` statement.\n"
+"* `match` inspects a hidden discriminant field in the `enum`.\n"
+"* `WebEvent::Click { ... }` is not exactly the same as "
+"`WebEvent::Click(Click)` with a top level `struct Click { ... }`. The "
+"inlined version cannot implement traits, for example."
+msgstr ""
+"* No exemplo acima, acessar o `char` em `KeyPress`, ou `x` e `y` em `Click` "
+"só funciona dentro de uma instrução `match`.\n"
+"* `match` inspeciona um campo discriminante oculto no `enum`.\n"
+"* `WebEvent::Click { ... }` não é exatamente o mesmo que "
+"`WebEvent::Click(Click)` com um `struct Click { ... }` de nível superior. A "
+"versão embutida não pode implementar traits, por exemplo."
+
+#: src/enums/sizes.md:1
+#, fuzzy
+msgid "# Enum Sizes"
+msgstr "# Tamanhos de Enum"
+
+#: src/enums/sizes.md:3
+#, fuzzy
+msgid ""
+"Rust enums are packed tightly, taking constraints due to alignment into "
+"account:"
+msgstr ""
+"Rust enums são empacotados firmemente, levando em consideração as restrições "
+"devido ao alinhamento:"
+
+#: src/enums/sizes.md:5
+#, fuzzy
+msgid "```rust,editable\nuse std::mem::{align_of, size_of};"
+msgstr "```rust, editable\nuse std::mem::{align_of, size_of};"
+
+#: src/enums/sizes.md:8
+#, fuzzy
+msgid ""
+"macro_rules! dbg_size {\n"
+"    ($t:ty) => {\n"
+"        println!(\"{}: size {} bytes, align: {} bytes\",\n"
+"                 stringify!($t), size_of::<$t>(), align_of::<$t>());\n"
+"    };\n"
+"}"
+msgstr ""
+"macro_regras! dbg_size {\n"
+"    ($t:ty) => {\n"
+"        println!(\"{}: tamanho {} bytes, align: {} bytes\",\n"
+"                 stringify!($t), size_of::<$t>(), align_of::<$t>());\n"
+"    };\n"
+"}"
+
+#: src/enums/sizes.md:15
+#, fuzzy
+msgid ""
+"enum Foo {\n"
+"    A,\n"
+"    B,\n"
+"}"
+msgstr ""
+"enum Foo {\n"
+"    A,\n"
+"    B,\n"
+"}"
+
+#: src/enums/sizes.md:20
+#, fuzzy
+msgid ""
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}"
+msgstr ""
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A, // 0\n"
+"    B = 10000,\n"
+"    C, // 10001\n"
+"}"
+
+#: src/enums/sizes.md:27
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    dbg_size!(Foo);\n"
+"    dbg_size!(Bar);\n"
+"    dbg_size!(bool);\n"
+"    dbg_size!(Option<bool>);\n"
+"    dbg_size!(&i32);\n"
+"    dbg_size!(Option<&i32>);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    dbg_size!(Foo);\n"
+"    dbg_size!(Bar);\n"
+"    dbg_size!(bool);\n"
+"    dbg_size!(Option<bool>);\n"
+"    dbg_size!(&i32);\n"
+"    dbg_size!(Option<&i32>);\n"
+"}\n"
+"```"
+
+#: src/enums/sizes.md:37
+#, fuzzy
+msgid ""
+"* See the [Rust "
+"Reference](https://doc.rust-lang.org/reference/type-layout.html)."
+msgstr ""
+"* Consulte a [Referência "
+"Rust](https://doc.rust-lang.org/reference/type-layout.html)."
+
+#: src/enums/sizes.md:39
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points: \n"
+" * Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant.\n"
+" * `Bar` enum demonstrates that there is a way to control the discriminant "
+"value and type. If `repr` is removed, the discriminant type takes 2 bytes, "
+"becuase 10001 fits 2 bytes.\n"
+" * As a niche optimization an enum discriminant is merged with the pointer "
+"so that `Option<&Foo>` is the same size as `&Foo`.\n"
+" * `Option<bool>` is another example of tight packing.\n"
+" * For [some types](https://doc.rust-lang.org/std/option/#representation), "
+"Rust guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
+" * Zero-sized types allow for efficient implementation of `HashSet` using "
+"`HashMap` with `()` as the value."
+msgstr ""
+"<details>\n"
+"    \n"
+"Points chave:\n"
+" * Internamente Rust está usando um campo (discriminante) para acompanhar a "
+"variante enum.\n"
+" * A Enum `Bar` demonstra que existe uma maneira de controlar o valor "
+"e o tipo discriminante. Se `repr` for removido, o tipo discriminante ocupa 2 "
+"bytes, porque 10001 cabe 2 bytes.\n"
+" * Como uma otimização de nicho, um discriminante de Enum é mesclado "
+"com o ponteiro para que `Option<&Foo>` seja do mesmo tamanho que `&Foo`.\n"
+" * `Option<bool>` é outro exemplo de empacotamento compacto.\n"
+" * Para [alguns "
+"tipos](https://doc.rust-lang.org/std/option/#representation), Rust garante "
+"que `size_of::<T>()` é igual a `size_of::<Option<T> >()`.\n"
+" * Tipos de tamanho zero permitem a implementação eficiente de `HashSet` "
+"usando `HashMap` com `()` como valor."
+
+#: src/methods.md:3
+#, fuzzy
+msgid ""
+"Rust allows you to associate functions with your new types. You do this with "
+"an\n"
+"`impl` block:"
+msgstr ""
+"Rust permite que você associe funções aos seus novos tipos. Você faz isso "
+"com um\n"
+"bloco `impl`:"
+
+#: src/methods.md:13
+#, fuzzy
+msgid ""
+"impl Person {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Hello, my name is {}\", self.name);\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Person {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Olá, meu name é {}\", self.name);\n"
+"    }\n"
+"}"
+
+#: src/methods.md:19
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    peter.say_hello();\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    peter.say_hello();\n"
+"}\n"
+"```"
+
+#: src/methods.md:30
+#, fuzzy
+msgid ""
+"Key Points:\n"
+"* It can be helpful to introduce methods by comparing them to functions.\n"
+"  * Methods are called on an instance of a type (such as a struct or enum), "
+"the first parameter represents the instance as `self`.\n"
+"  * Developers may choose to use methods to take advantage of method "
+"receiver syntax and to help keep them more organized. By using methods we "
+"can keep all the implementation code in one predictable place.\n"
+"* Point out the use of the keyword `self`, a method receiver. \n"
+"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
+"how the struct name could also be used. \n"
+"  * Explain that Self is a type alias for the type the `impl` block is in "
+"and can be used elsewhere in the block.\n"
+"  * Note how self is used like other structs and dot notation can be used to "
+"refer to individual fields.\n"
+"  * This might be a good time to demonstrate how the `&self` differs from "
+"`self` by modifying the code and trying to run say_hello twice.  \n"
+"* We describe the distinction between method receivers next.\n"
+"   \n"
+"</details>"
+msgstr ""
+"Points chave:\n"
+"* Pode ser útil introduzir métodos comparando-os com funções.\n"
+"  * Métodos são chamados em uma instância de um tipo (como struct ou enum), "
+"o primeiro parâmetro representa a instância como `self`.\n"
+"  * Os desenvolvedores podem optar por usar métodos para aproveitar a "
+"sintaxe do receptor do método e ajudar a mantê-los mais organizados. Usando "
+"métodos, podemos manter todo o código de implementação em um local "
+"previsível.\n"
+"* Highlight o uso da palavra-chave `self`, um receptor de método.\n"
+"  * Mostre que é um termo abreviado para `self:&Self` e talvez mostre como o "
+"name struct também poderia ser usado.\n"
+"  * Explique que Self é um alias de tipo para o tipo em que o bloco `impl` "
+"está e pode ser usado em qualquer outro lugar no bloco.\n"
+"  * Observe como self é usado como outras Structs e a notação de Point "
+"pode ser usada para se referir a campos individuais.\n"
+"  * Este pode ser um bom momento para demonstrar como `&self` difere de "
+"`self` modificando o código e tentando executar say_hello duas vezes.\n"
+"* Descrevemos a distinção entre os receptores de método a seguir.\n"
+"   \n"
+"</details>"
+
+#: src/methods/receiver.md:1
+#, fuzzy
+msgid "# Method Receiver"
+msgstr "# Método Receptor"
+
+#: src/methods/receiver.md:3
+#, fuzzy
+msgid ""
+"The `&self` above indicates that the method borrows the object immutably. "
+"There\n"
+"are other possible receivers for a method:"
+msgstr ""
+"O `&self` acima indica que o método toma emprestado o objeto imutavelmente. "
+"Lá\n"
+"são outros receptores possíveis para um método:"
+
+#: src/methods/receiver.md:6
+#, fuzzy
+msgid ""
+"* `&self`: borrows the object from the caller using a shared and immutable\n"
+"  reference. The object can be used again afterwards.\n"
+"* `&mut self`: borrows the object from the caller using a unique and "
+"mutable\n"
+"  reference. The object can be used again afterwards.\n"
+"* `self`: takes ownership of the object and moves it away from the caller. "
+"The\n"
+"  method becomes the owner of the object. The object will be dropped "
+"(deallocated)\n"
+"  when the method returns, unless its ownership is explicitly\n"
+"  transmitted.\n"
+"* `mut self`: same as above, but while the method owns the object, it can\n"
+"  mutate it too. Complete ownership does not automatically mean mutability.\n"
+"* No receiver: this becomes a static method on the struct. Typically used "
+"to\n"
+"  create constructors which are called `new` by convention."
+msgstr ""
+"* `&self`: pega emprestado o objeto do chamador usando um compartilhado e "
+"imutável\n"
+"  referência. O objeto pode ser usado novamente depois.\n"
+"* `&mut self`: pega emprestado o objeto do chamador usando um único e "
+"mutável\n"
+"  referência. O objeto pode ser usado novamente depois.\n"
+"* `self`: toma posse do objeto e o afasta do chamador. o\n"
+"  O método se torna o proprietário do objeto. O objeto será descartado "
+"(desalocado)\n"
+"  quando o método retorna, a menos que sua ownership seja explicitamente\n"
+"  transmitido.\n"
+"* `mut self`: o mesmo que acima, mas enquanto o método possui o objeto, ele "
+"pode\n"
+"  transformá-lo também. A ownership completa não significa automaticamente "
+"mutabilage.\n"
+"* Sem receptor: isso se torna um método static na estrutura. Normalmente "
+"usado para\n"
+"  crie construtores que são chamados `new` por convenção."
+
+#: src/methods/receiver.md:19
+#, fuzzy
+msgid ""
+"Beyond variants on `self`, there are also\n"
+"[special wrapper "
+"types](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
+"allowed to be receiver types, such as `Box<Self>`."
+msgstr ""
+"Além das variantes de `self`, também existem\n"
+"[tipos especiais de "
+"wrapper](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
+"podem ser tipos de receptores, como `Box<Self>`."
+
+#: src/methods/receiver.md:23
+#, fuzzy
+msgid ""
+"<details>\n"
+"  \n"
+"Consider emphasizing on \"shared and immutable\" and \"unique and mutable\". "
+"These constraints always come\n"
+"together in Rust due to borrow checker rules, and `self` is no exception. It "
+"won't be possible to\n"
+"reference a struct from multiple locations and call a mutating (`&mut self`) "
+"method on it.\n"
+"  \n"
+"</details>"
+msgstr ""
+"<details>\n"
+"  \n"
+"Considere enfatizar \"compartilhado e imutável\" e \"único e mutável\". "
+"Essas restrições sempre vêm\n"
+"juntos no Rust devido às regras do verificador emprestado, e `self` não é "
+"exceção. Não será possível\n"
+"referenciar um struct de vários locais e chamar um método mutante (`&mut "
+"self`) nele.\n"
+"  \n"
+"</details>"
+
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
+#, fuzzy
+msgid "# Example"
+msgstr "# Exemplo"
+
+#: src/methods/example.md:3
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Race {\n"
+"    name: String,\n"
+"    laps: Vec<i32>,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug)]\n"
+"struct Raça {\n"
+"    name: String,\n"
+"    voltas: Vec<i32>,\n"
+"}"
+
+#: src/methods/example.md:10
+#, fuzzy
+msgid ""
+"impl Race {\n"
+"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
+"        Race { name: String::from(name), laps: Vec::new() }\n"
+"    }"
+msgstr ""
+"impl Raça {\n"
+"    fn new(name: &str) -> Race { // Sem receptor, um método static\n"
+"        Race { name: String::from(name), voltas: Vec::new() }\n"
+"    }"
+
+#: src/methods/example.md:15
+#, fuzzy
+msgid ""
+"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
+"access to self\n"
+"        self.laps.push(lap);\n"
+"    }"
+msgstr ""
+"    fn add_lap(&mut self, lap: i32) { // Acesso de leitura e gravação "
+"emprestado exclusivo para self\n"
+"        self.laps.push(volta);\n"
+"    }"
+
+#: src/methods/example.md:19
+#, fuzzy
+msgid ""
+"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
+"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
+"        for (idx, lap) in self.laps.iter().enumerate() {\n"
+"            println!(\"Lap {idx}: {lap} sec\");\n"
+"        }\n"
+"    }"
+msgstr ""
+"    fn print_laps(&self) { // Acesso emprestado compartilhado e somente "
+"leitura a si mesmo\n"
+"        println!(\"Gravadas {} voltas para {}:\", self.laps.len(), "
+"self.name);\n"
+"        for (idx, lap) in self.laps.iter().enumerate() {\n"
+"            println!(\"Volta {idx}: {volta} seg\");\n"
+"        }\n"
+"    }"
+
+#: src/methods/example.md:26
+#, fuzzy
+msgid ""
+"    fn finish(self) {  // Exclusive ownership of self\n"
+"        let total = self.laps.iter().sum::<i32>();\n"
+"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"total);\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn finish(self) { // ownership exclusiva de self\n"
+"        let total = self.laps.iter().sum::<i32>();\n"
+"        println!(\"A corrida {} terminou, tempo total da volta: {}\", "
+"self.name, total);\n"
+"    }\n"
+"}"
+
+#: src/methods/example.md:32
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
+"    race.add_lap(70);\n"
+"    race.add_lap(68);\n"
+"    race.print_laps();\n"
+"    race.add_lap(71);\n"
+"    race.print_laps();\n"
+"    race.finish();\n"
+"    // race.add_lap(42);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let mut race = Race::new(\"Grande Prêmio de Mônaco\");\n"
+"    corrida.add_lap(70);\n"
+"    corrida.add_lap(68);\n"
+"    corrida.print_laps();\n"
+"    corrida.add_lap(71);\n"
+"    corrida.print_laps();\n"
+"    race.finish();\n"
+"    // corrida.add_lap(42);\n"
+"}\n"
+"```"
+
+#: src/methods/example.md:44
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points:\n"
+"* All four methods here use a different method receiver.\n"
+"  * You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`.\n"
+"  * You can showcase the error that appears when trying to call `finish` "
+"twice.\n"
+"* Note, that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
+"* You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
+msgstr ""
+"<details>\n"
+"    \n"
+"Points chave:\n"
+"* Todos os quatro métodos aqui usam um receptor de método diferente.\n"
+"  * Você pode apontar como isso muda o que a função pode fazer com os "
+"valores das variáveis e se/como ela pode ser usada novamente em `main`.\n"
+"  * Você pode mostrar o erro que aparece ao tentar chamar `finish` duas "
+"vezes.\n"
+"* Observe que, embora os receptores do método sejam diferentes, as funções "
+"não estáticas são chamadas da mesma maneira no corpo principal. Rust permite "
+"referenciar e desreferenciar automaticamente ao chamar métodos. Rust "
+"adiciona automaticamente `&`, `*`, `muts` para que esse objeto corresponda à "
+"assinatura do método.\n"
+"* Você pode apontar que `print_laps` está usando um vetor iterado. "
+"Descrevemos os vetores com mais detalhes à tarde."
+
+#: src/pattern-matching.md:1
+#, fuzzy
+msgid "# Pattern Matching"
+msgstr "# Correspondência de padrões"
+
+#: src/pattern-matching.md:3
+#, fuzzy
+msgid ""
+"The `match` keyword let you match a value against one or more _patterns_. "
+"The\n"
+"comparisons are done from top to bottom and the first match wins."
+msgstr ""
+"A palavra-chave `match` permite que você corresponda um valor a um ou mais "
+"_patterns_. o\n"
+"as comparações são feitas de cima para baixo e a primeira partida vence."
+
+#: src/pattern-matching.md:6
+#, fuzzy
+msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
+msgstr ""
+"Os padrões podem ser valores simples, similarmente a `switch` em C e C++:"
+
+#: src/pattern-matching.md:8
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let input = 'x';"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let entrada = 'x';"
+
+#: src/pattern-matching.md:12
+#, fuzzy
+msgid ""
+"    match input {\n"
+"        'q'                   => println!(\"Quitting\"),\n"
+"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
+"        '0'..='9'             => println!(\"Number input\"),\n"
+"        _                     => println!(\"Something else\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    entrada correspondente {\n"
+"        'q' => println!(\"Sair\"),\n"
+"        'um' | 's' | 'w' | 'd' => println!(\"Movendo-se\"),\n"
+"        '0'..='9' => println!(\"Number input\"),\n"
+"        _ => println!(\"Algo mais\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching.md:21
+#, fuzzy
+msgid "The `_` pattern is a wildcard pattern which matches any value."
+msgstr "O padrão `_` é um padrão curinga que corresponde a qualquer valor."
+
+#: src/pattern-matching.md:23
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points:\n"
+"* You might point out how some specific characters are being used when in a "
+"patten\n"
+"  * `|` as an `or`\n"
+"  * `..` can expand as much as it needs to be\n"
+"  * `1..=5` represents an inclusive range\n"
+"  * `_` is a wild card\n"
+"* It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`.\n"
+"* You can demonstrate matching on a reference.\n"
+"* This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages.\n"
+"   \n"
+"</details>"
+msgstr ""
+"<details>\n"
+"    \n"
+"Points chave:\n"
+"* Você pode apontar como alguns caracteres específicos estão sendo usados "
+"quando em um patten\n"
+"  * `|` como um `ou`\n"
+"  * `..` pode expandir o quanto for necessário\n"
+"  * `1..=5` representa um intervalo inclusivo\n"
+"  * `_` é um curinga\n"
+"* Pode ser útil mostrar como funciona a vinculação, por exemplo, "
+"substituindo um caractere curinga por uma variável ou removendo as aspas ao "
+"redor de `q`.\n"
+"* Você pode demonstrar correspondência em uma referência.\n"
+"* Este pode ser um bom momento para trazer à tona o conceito de padrões "
+"irrefutáveis, já que o termo pode aparecer em mensagens de erro.\n"
+"   \n"
+"</details>"
+
+#: src/pattern-matching/destructuring-enums.md:1
+#, fuzzy
+msgid "# Destructuring Enums"
+msgstr "# Desestruturando Enums"
+
+#: src/pattern-matching/destructuring-enums.md:3
+#, fuzzy
+msgid ""
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how\n"
+"you inspect the structure of your types. Let us start with a simple `enum` "
+"type:"
+msgstr ""
+"Os padrões também podem ser usados para vincular variáveis a partes de seus "
+"valores. É assim\n"
+"você inspeciona a estrutura de seus tipos. Vamos começar com um tipo `enum` "
+"simples:"
+
+#: src/pattern-matching/destructuring-enums.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"enum Result {\n"
+"    Ok(i32),\n"
+"    Err(String),\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"enum Resultado {\n"
+"    ok(i32),\n"
+"    Err(String),\n"
+"}"
+
+#: src/pattern-matching/destructuring-enums.md:12
+#, fuzzy
+msgid ""
+"fn divide_in_two(n: i32) -> Result {\n"
+"    if n % 2 == 0 {\n"
+"        Result::Ok(n / 2)\n"
+"    } else {\n"
+"        Result::Err(format!(\"cannot divide {} into two equal parts\", n))\n"
+"    }\n"
+"}"
+msgstr ""
+"fn divide_in_two(n: i32) -> Resultado {\n"
+"    if n % 2 == 0 {\n"
+"        Resultado::Ok(n/2)\n"
+"    } else {\n"
+"        Resultado::Err(format!(\"não é possível dividir {} em duas partes "
+"iguais\", n))\n"
+"    }\n"
+"}"
+
+#: src/pattern-matching/destructuring-enums.md:20
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let n = 100;\n"
+"    match divide_in_two(n) {\n"
+"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
+"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let n = 100;\n"
+"    corresponde dividir_em_dois(n) {\n"
+"        Resultado::Ok(metade) => println!(\"{n} dividido em dois é "
+"{metade}\"),\n"
+"        Resultado::Err(msg) => println!(\"desculpe, ocorreu um erro: "
+"{msg}\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching/destructuring-enums.md:29
+#, fuzzy
+msgid ""
+"Here we have used the arms to _destructure_ the `Result` value. In the "
+"first\n"
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm,\n"
+"`msg` is bound to the error message."
+msgstr ""
+"Aqui usamos os braços para _desestruturar_ o valor `Resultado`. Em primeiro\n"
+"arm, `half` está vinculado ao valor dentro da variante `Ok`. No segundo "
+"braço,\n"
+"`msg` está vinculado à mensagem de erro."
+
+#: src/pattern-matching/destructuring-enums.md:35
+#, fuzzy
+msgid ""
+"Key points:\n"
+"* The `if`/`else` expression is returning an enum that is later unpacked "
+"with a `match`.\n"
+"* You can try adding a third variant to the enum definition and displaying "
+"the errors when running the code. Point out the places where your code is "
+"now inexhaustive and how the compiler trys to give you hints."
+msgstr ""
+"Points chave:\n"
+"* A expressão `if`/`else` está retornando um enum que é posteriormente "
+"descompactado com um `match`.\n"
+"* Você pode tentar adicionar uma terceira variante à definição de Enum "
+"e exibir os erros ao executar o código. Aponte os lugares onde seu código "
+"agora é inexaustivo e como o compilador tenta lhe dar dicas."
+
+#: src/pattern-matching/destructuring-structs.md:1
+#, fuzzy
+msgid "# Destructuring Structs"
+msgstr "# Desestruturando Structs"
+
+#: src/pattern-matching/destructuring-structs.md:3
+#, fuzzy
+msgid "You can also destructure `structs`:"
+msgstr "Você também pode desestruturar `structs`:"
+
+#: src/pattern-matching/destructuring-structs.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"struct Foo {\n"
+"    x: (u32, u32),\n"
+"    y: u32,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"struct Foo {\n"
+"    x: (u32, u32),\n"
+"    e: u32,\n"
+"}"
+
+#: src/pattern-matching/destructuring-structs.md:11
+#, fuzzy
+msgid ""
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let foo = Foo { x: (1, 2), y: 3 };\n"
+"    match foo {\n"
+"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
+"        Foo { y: 2, x: i }   => println!(\"y = 2, i = {i:?}\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"#[rustfmt::pular]\n"
+"fn main() {\n"
+"    let foo = Foo { x: (1, 2), y: 3 };\n"
+"    match foo {\n"
+"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
+"        Foo { y: 2, x: i } => println!(\"y = 2, i = {i:?}\"),\n"
+"        Foo { y, .. } => println!(\"y = {y}, outros campos foram "
+"ignorados\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching/destructuring-arrays.md:1
+#, fuzzy
+msgid "# Destructuring Arrays"
+msgstr "# Desestruturando Arrays"
+
+#: src/pattern-matching/destructuring-arrays.md:3
+#, fuzzy
+msgid ""
+"You can destructure arrays, tuples, and slices by matching on their elements:"
+msgstr ""
+"Você pode desestruturar arrays, tuplas e slices combinando seus elementos:"
+
+#: src/pattern-matching/destructuring-arrays.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let triple = [0, -2, 3];\n"
+"    println!(\"Tell me about {triple:?}\");\n"
+"    match triple {\n"
+"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _         => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"#[rustfmt::pular]\n"
+"fn main() {\n"
+"    let triplo = [0, -2, 3];\n"
+"    println!(\"Fale-me sobre {triplo:?}\");\n"
+"    match triplo {\n"
+"        [0, y, z] => println!(\"Primeiro é 0, y = {y} e z = {z}\"),\n"
+"        [1, ..] => println!(\"Primeiro é 1 e o resto foi ignorado\"),\n"
+"        _ => println!(\"Todos os elementos foram ignorados\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching/match-guards.md:1
+#, fuzzy
+msgid "# Match Guards"
+msgstr "# Guardas de jogo"
+
+#: src/pattern-matching/match-guards.md:3
+#, fuzzy
+msgid ""
+"When matching, you can add a _guard_ to a pattern. This is an arbitrary "
+"Boolean\n"
+"expression which will be executed if the pattern matches:"
+msgstr ""
+"Ao match, você pode adicionar um _guard_ a um padrão. Este é um booleano "
+"arbitrário\n"
+"expressão que será executada se o padrão corresponder:"
+
+#: src/pattern-matching/match-guards.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let pair = (2, -2);\n"
+"    println!(\"Tell me about {pair:?}\");\n"
+"    match pair {\n"
+"        (x, y) if x == y     => println!(\"These are twins\"),\n"
+"        (x, y) if x + y == 0 => println!(\"Antimatter, kaboom!\"),\n"
+"        (x, _) if x % 2 == 1 => println!(\"The first one is odd\"),\n"
+"        _                    => println!(\"No correlation...\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"#[rustfmt::pular]\n"
+"fn main() {\n"
+"    let par = (2, -2);\n"
+"    println!(\"Fale-me sobre {par:?}\");\n"
+"    match par {\n"
+"        (x, y) se x == y => println!(\"Estes são gêmeos\"),\n"
+"        (x, y) if x + y == 0 => println!(\"Antimatter, kaboom!\"),\n"
+"        (x, _) se x % 2 == 1 => println!(\"O primeiro é ímpar\"),\n"
+"        _ => println!(\"Sem correlação...\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching/match-guards.md:22
+#, fuzzy
+msgid ""
+"Key Points:\n"
+"* Match guards as a separate syntax feature are important and necessary.\n"
+"* They are not the same as separate `if` expression inside of the match arm. "
+"An `if` expression inside of the branch block (after `=>`) happens after the "
+"match arm is selected. Failing the `if` condition inside of that block won't "
+"result in other arms\n"
+"of the original `match` expression being considered.  \n"
+"* You can use the variables defined in the pattern in your if expression.\n"
+"* The condition defined in the guard applies to every expression in a "
+"pattern with an `|`.\n"
+"</details>"
+msgstr ""
+"Points chave:\n"
+"* Match guards como um recurso de sintaxe separado são importantes e "
+"necessários.\n"
+"* Eles não são iguais à expressão 'if' separada dentro do braço de "
+"correspondência. Uma expressão `if` dentro do bloco de ramificação (depois "
+"de `=>`) acontece depois que o braço de correspondência é selecionado. A "
+"falha na condição `if` dentro desse bloco não resultará em outros braços\n"
+"da expressão `match` original sendo considerada.\n"
+"* Você pode usar as variáveis definidas no padrão em sua expressão if.\n"
+"* A condição definida na guarda se aplica a todas as expressões em um padrão "
+"com um `|`.\n"
+"</details>"
+
+#: src/exercises/day-2/morning.md:1
+#, fuzzy
+msgid "# Day 2: Morning Exercises"
+msgstr "# Dia 2: Exercícios matinais"
+
+#: src/exercises/day-2/morning.md:3
+#, fuzzy
+msgid "We will look at implementing methods in two contexts:"
+msgstr "Veremos a implementação de métodos em dois contextos:"
+
+#: src/exercises/day-2/morning.md:5
+#, fuzzy
+msgid "* Simple struct which tracks health statistics."
+msgstr "* Estrutura simples que rastreia as estatísticas de saúde."
+
+#: src/exercises/day-2/morning.md:7
+#, fuzzy
+msgid "* Multiple structs and enums for a drawing library."
+msgstr "* Várias Structs e enumerações para uma biblioteca de desenho."
+
+#: src/exercises/day-2/health-statistics.md:1
+#, fuzzy
+msgid "# Health Statistics"
+msgstr "# Estatísticas de saúde"
+
+#: src/exercises/day-2/health-statistics.md:3
+#, fuzzy
+msgid ""
+"You're working on implementing a health-monitoring system. As part of that, "
+"you\n"
+"need to keep track of users' health statistics."
+msgstr ""
+"Você está trabalhando na implementação de um sistema de monitoramento de "
+"saúde. Como parte disso, você\n"
+"precisam acompanhar as estatísticas de saúde dos usuários."
+
+#: src/exercises/day-2/health-statistics.md:6
+#, fuzzy
+msgid ""
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User`\n"
+"struct definition. Your goal is to implement the stubbed out methods on the\n"
+"`User` `struct` defined in the `impl` block."
+msgstr ""
+"Você começará com algumas funções fragmentadas em um bloco `impl`, bem como "
+"em um bloco `User`\n"
+"definição de struct. Seu objetivo é implementar os métodos stubbed out no\n"
+"`User` `struct` definido no bloco `impl`."
+
+#: src/exercises/day-2/health-statistics.md:10
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"methods:"
+msgstr ""
+"Copie o código abaixo para <https://play.rust-lang.org/> e preencha os "
+"campos que faltam\n"
+"métodos:"
+
+#: src/exercises/day-2/health-statistics.md:17
+#, fuzzy
+msgid ""
+"struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    weight: f32,\n"
+"}"
+msgstr ""
+"struct Usuário {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    peso: f32,\n"
+"}"
+
+#: src/exercises/day-2/health-statistics.md:23
+#, fuzzy
+msgid ""
+"impl User {\n"
+"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"usuário impl {\n"
+"    pub fn new(name: String, age: u32, peso: f32) -> Self {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:28
+#, fuzzy
+msgid ""
+"    pub fn name(&self) -> &str {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn name(&self) -> &str {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:32
+#, fuzzy
+msgid ""
+"    pub fn age(&self) -> u32 {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn age(&self) -> u32 {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:36
+#, fuzzy
+msgid ""
+"    pub fn weight(&self) -> f32 {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn peso(&self) -> f32 {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:40
+#, fuzzy
+msgid ""
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:44
+#, fuzzy
+msgid ""
+"    pub fn set_weight(&mut self, new_weight: f32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"    pub fn set_weight(&mut self, new_weight: f32) {\n"
+"        não implementado!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/health-statistics.md:49
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}"
+msgstr ""
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"Tenho {} e minha age é {}\", bob.name(), bob.age());\n"
+"}"
+
+#: src/exercises/day-2/health-statistics.md:54
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_weight() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.weight(), 155.2);\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn peso_teste() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.weight(), 155.2);\n"
+"}"
+
+#: src/exercises/day-2/health-statistics.md:60
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_set_age() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.age(), 32);\n"
+"    bob.set_age(33);\n"
+"    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"```"
+msgstr ""
+"#[teste]\n"
+"fn test_set_age() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.age(), 32);\n"
+"    bob.set_age(33);\n"
+"    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"```"
+
+#: src/exercises/day-2/points-polygons.md:1
+#, fuzzy
+msgid "# Polygon Struct"
+msgstr "# Estrutura do Polígono"
+
+#: src/exercises/day-2/points-polygons.md:3
+#, fuzzy
+msgid ""
+"We will create a `Polygon` struct which contain some points. Copy the code "
+"below\n"
+"to <https://play.rust-lang.org/> and fill in the missing methods to make "
+"the\n"
+"tests pass:"
+msgstr ""
+"Vamos criar uma estrutura `Polygon` que contém alguns Points. Copie o código "
+"abaixo\n"
+"para <https://play.rust-lang.org/> e preencha os métodos que faltam para "
+"fazer o\n"
+"testes passam:"
+
+#: src/exercises/day-2/points-polygons.md:7 src/exercises/day-2/luhn.md:23
+#: src/exercises/day-2/strings-iterators.md:12
+#, fuzzy
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]"
+msgstr ""
+"```rust\n"
+"// TODO: remova isso quando terminar sua implementação.\n"
+"#![allow(unused_variables, dead_code)]"
+
+#: src/exercises/day-2/points-polygons.md:11
+#, fuzzy
+msgid ""
+"pub struct Point {\n"
+"    // add fields\n"
+"}"
+msgstr ""
+"pub struct Point {\n"
+"    // adiciona campos\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:15
+#, fuzzy
+msgid ""
+"impl Point {\n"
+"    // add methods\n"
+"}"
+msgstr ""
+"impl Point {\n"
+"    // adiciona métodos\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:19
+#, fuzzy
+msgid ""
+"pub struct Polygon {\n"
+"    // add fields\n"
+"}"
+msgstr ""
+"pub struct Polígono {\n"
+"    // adiciona campos\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:23
+#, fuzzy
+msgid ""
+"impl Polygon {\n"
+"    // add methods\n"
+"}"
+msgstr ""
+"impl Polígono {\n"
+"    // adiciona métodos\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:27
+#, fuzzy
+msgid ""
+"pub struct Circle {\n"
+"    // add fields\n"
+"}"
+msgstr ""
+"pub struct Círculo {\n"
+"    // adiciona campos\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:31
+#, fuzzy
+msgid ""
+"impl Circle {\n"
+"    // add methods\n"
+"}"
+msgstr ""
+"impl Círculo {\n"
+"    // adiciona métodos\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:35
+#, fuzzy
+msgid ""
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}"
+msgstr ""
+"pub enum Forma {\n"
+"    Polígono(Polígono),\n"
+"    Círculo(Círculo),\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:40 src/testing/test-modules.md:15
+#, fuzzy
+msgid ""
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;"
+msgstr ""
+"#[cfg(teste)]\n"
+"testes mod {\n"
+"    use super::*;"
+
+#: src/exercises/day-2/points-polygons.md:44
+#: src/exercises/day-2/solutions-morning.md:165
+#, fuzzy
+msgid ""
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100.0).round() / 100.0\n"
+"    }"
+msgstr ""
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100,0).round() / 100,0\n"
+"    }"
+
+#: src/exercises/day-2/points-polygons.md:48
+#: src/exercises/day-2/solutions-morning.md:169
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_point_magnitude() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"    }"
+msgstr ""
+"    #[teste]\n"
+"    fn test_point_magnitude() {\n"
+"        let p1 = Point::novo(12, 13);\n"
+"        assert_eq!(round_two_digits(p1.magnitude()), 17,69);\n"
+"    }"
+
+#: src/exercises/day-2/points-polygons.md:54
+#: src/exercises/day-2/solutions-morning.md:175
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_point_dist() {\n"
+"        let p1 = Point::new(10, 10);\n"
+"        let p2 = Point::new(14, 13);\n"
+"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"    }"
+msgstr ""
+"    #[teste]\n"
+"    fn test_point_dist() {\n"
+"        let p1 = Point::novo(10, 10);\n"
+"        let p2 = Point::novo(14, 13);\n"
+"        assert_eq!(round_two_digits(p1.dist(p2)), 5,00);\n"
+"    }"
+
+#: src/exercises/day-2/points-polygons.md:61
+#: src/exercises/day-2/solutions-morning.md:182
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_point_add() {\n"
+"        let p1 = Point::new(16, 16);\n"
+"        let p2 = p1 + Point::new(-4, 3);\n"
+"        assert_eq!(p2, Point::new(12, 19));\n"
+"    }"
+msgstr ""
+"    #[teste]\n"
+"    fn test_point_add() {\n"
+"        let p1 = Point::novo(16, 16);\n"
+"        let p2 = p1 + Point::new(-4, 3);\n"
+"        assert_eq!(p2, Point::new(12, 19));\n"
+"    }"
+
+#: src/exercises/day-2/points-polygons.md:68
+#: src/exercises/day-2/solutions-morning.md:189
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_polygon_left_most_point() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);"
+msgstr ""
+"    #[teste]\n"
+"    fn test_polygon_left_most_point() {\n"
+"        let p1 = Point::novo(12, 13);\n"
+"        let p2 = Point::novo(16, 16);"
+
+#: src/exercises/day-2/points-polygons.md:73
+#: src/exercises/day-2/solutions-morning.md:194
+#, fuzzy
+msgid ""
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"        assert_eq!(poly.left_most_point(), Some(p1));\n"
+"    }"
+msgstr ""
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"        assert_eq!(poly.left_most_point(), Some(p1));\n"
+"    }"
+
+#: src/exercises/day-2/points-polygons.md:79
+#: src/exercises/day-2/solutions-morning.md:200
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_polygon_iter() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);"
+msgstr ""
+"    #[teste]\n"
+"    fn test_polygon_iter() {\n"
+"        let p1 = Point::novo(12, 13);\n"
+"        let p2 = Point::novo(16, 16);"
+
+#: src/exercises/day-2/points-polygons.md:84
+#: src/exercises/day-2/solutions-morning.md:205
+#, fuzzy
+msgid ""
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);"
+msgstr ""
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);"
+
+#: src/exercises/day-2/points-polygons.md:88
+#: src/exercises/day-2/solutions-morning.md:209
+#, fuzzy
+msgid ""
+"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"    }"
+msgstr ""
+"        let Points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"        assert_eq!(Points, vec![Point::novo(12, 13), Point::novo(16, 16)]);\n"
+"    }"
+
+#: src/exercises/day-2/points-polygons.md:92
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}"
+msgstr ""
+"    #[teste]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let formas = vec![\n"
+"            Forma::de(poli),\n"
+"            Forma::de(Círculo::novo(Point::novo(10, 20), 5)),\n"
+"        ];\n"
+"        let perímetros = formas\n"
+"            .iter()\n"
+"            .map(Forma::perímetro)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perímetros, vec![15.48, 31.42]);\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:111 src/exercises/day-2/luhn.md:68
+#: src/exercises/day-2/solutions-morning.md:233
+#, fuzzy
+msgid ""
+"#[allow(dead_code)]\n"
+"fn main() {}\n"
+"```"
+msgstr ""
+"#[allow(dead_code)]\n"
+"fn main() {}\n"
+"```"
+
+#: src/exercises/day-2/points-polygons.md:117
+#, fuzzy
+msgid ""
+"Since the method signatures are missing from the problem statements, the key "
+"part\n"
+"of the exercise is to specify those correctly."
+msgstr ""
+"Como as assinaturas do método estão faltando nas declarações do problema, a "
+"parte principal\n"
+"do exercício é especificá-los corretamente."
+
+#: src/exercises/day-2/points-polygons.md:120
+#, fuzzy
+msgid ""
+"Other interesting parts of the exercise:\n"
+"    \n"
+"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments.\n"
+"* Discover that `Add` trait must be implemented for two objects to be "
+"addable via \"+\".    "
+msgstr ""
+"Outras partes interessantes do exercício:\n"
+"    \n"
+"* Derive um trait `Copy` para algumas Structs, já que em testes os "
+"métodos às vezes não emprestam seus argumentos.\n"
+"* Descubra que o trait `Add` deve ser implementado para que dois objetos "
+"sejam adicionados via \"+\"."
+
+#: src/control-flow.md:1
+#, fuzzy
+msgid "# Control Flow"
+msgstr "# Controle de fluxo"
+
+#: src/control-flow.md:3
+#, fuzzy
+msgid ""
+"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"evaluate one of two blocks, but the blocks can have a value which then "
+"becomes\n"
+"the value of the `if` expression. Other control flow expressions work "
+"similarly\n"
+"in Rust."
+msgstr ""
+"Como vimos, `if` é uma expressão em Rust. É usado para condicionalmente\n"
+"avaliar um dos dois blocos, mas os blocos podem ter um valor que então se "
+"torna\n"
+"o valor da expressão `if`. Outras expressões de fluxo de controle funcionam "
+"de forma semelhante\n"
+"em rust."
+
+#: src/control-flow/blocks.md:1
+#, fuzzy
+msgid "# Blocks"
+msgstr "# Blocos"
+
+#: src/control-flow/blocks.md:3
+#, fuzzy
+msgid ""
+"A block in Rust has a value and a type: the value is the last expression of "
+"the\n"
+"block:"
+msgstr ""
+"Um bloco em Rust tem um valor e um tipo: o valor é a última expressão do\n"
+"quadra:"
+
+#: src/control-flow/blocks.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let x = {\n"
+"        let y = 10;\n"
+"        println!(\"y: {y}\");\n"
+"        let z = {\n"
+"            let w = {\n"
+"                3 + 4\n"
+"            };\n"
+"            println!(\"w: {w}\");\n"
+"            y * w\n"
+"        };\n"
+"        println!(\"z: {z}\");\n"
+"        z - y\n"
+"    };\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let x = {\n"
+"        seja y = 10;\n"
+"        println!(\"y: {y}\");\n"
+"        seja z = {\n"
+"            seja w = {\n"
+"                3 + 4\n"
+"            };\n"
+"            println!(\"w: {w}\");\n"
+"            e * w\n"
+"        };\n"
+"        println!(\"z: {z}\");\n"
+"        z - y\n"
+"    };\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"```"
+
+#: src/control-flow/blocks.md:25
+#, fuzzy
+msgid ""
+"The same rule is used for functions: the value of the function body is the\n"
+"return value:"
+msgstr ""
+"A mesma regra é usada para funções: o valor do corpo da função é o\n"
+"valor de retorno:"
+
+#: src/control-flow/blocks.md:28
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn double(x: i32) -> i32 {\n"
+"    x + x\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn duplo(x: i32) -> i32 {\n"
+"    x + x\n"
+"}"
+
+#: src/control-flow/blocks.md:33
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    println!(\"doubled: {}\", double(7));\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    println!(\"doubled: {}\", double(7));\n"
+"}\n"
+"```"
+
+#: src/control-flow/blocks.md:38
+#, fuzzy
+msgid ""
+"However if the last expression ends with `;`, then the resulting value and "
+"type is `()`."
+msgstr ""
+"No entanto, se a última expressão terminar com `;`, o valor e o tipo "
+"resultante serão `()`."
+
+#: src/control-flow/blocks.md:42
+#, fuzzy
+msgid ""
+"Key Points:\n"
+"* The point of this slide is to show that blocks have a type and value in "
+"Rust. \n"
+"* You can show how the value of the block changes by changing the last line "
+"in the block. For instance, adding/removing a semicolon or using a "
+"`return`.\n"
+"   \n"
+"</details>"
+msgstr ""
+"Points chave:\n"
+"* O objetivo deste slide é mostrar que os blocos têm um tipo e valor em "
+"Rust.\n"
+"* Você pode mostrar como o valor do bloco muda alterando a última linha do "
+"bloco. Por exemplo, adicionar/remover um Point e vírgula ou usar um "
+"`return`.\n"
+"   \n"
+"</details>"
+
+#: src/control-flow/if-expressions.md:1
+#, fuzzy
+msgid "# `if` expressions"
+msgstr "# expressões `if`"
+
+#: src/control-flow/if-expressions.md:3
+#, fuzzy
+msgid "You use `if` very similarly to how you would in other languages:"
+msgstr "Você usa `if` de forma muito semelhante a como faria em outros idiomas:"
+
+#: src/control-flow/if-expressions.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    if x % 2 == 0 {\n"
+"        x = x / 2;\n"
+"    } else {\n"
+"        x = 3 * x + 1;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    if x % 2 == 0 {\n"
+"        x = x/2;\n"
+"    } else {\n"
+"        x = 3 * x + 1;\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/if-expressions.md:16
+#, fuzzy
+msgid ""
+"In addition, you can use it as an expression. This does the same as above:"
+msgstr ""
+"Além disso, você pode usá-lo como uma expressão. Isso faz o mesmo que acima:"
+
+#: src/control-flow/if-expressions.md:18
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    x = if x % 2 == 0 {\n"
+"        x / 2\n"
+"    } else {\n"
+"        3 * x + 1\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    x = se x % 2 == 0 {\n"
+"        x / 2\n"
+"    } else {\n"
+"        3 * x + 1\n"
+"    };\n"
+"}\n"
+"```"
+
+#: src/control-flow/if-expressions.md:31
+#, fuzzy
+msgid ""
+"Because `if` is an expression and must have a particular type, both of its "
+"branch blocks must have the same type. Consider showing what happens if you "
+"add `;` after `x / 2` in the second example.\n"
+"    \n"
+"</details>"
+msgstr ""
+"Como `if` é uma expressão e deve ter um tipo específico, ambos os blocos de "
+"ramificação devem ter o mesmo tipo. Considere mostrar o que acontece se você "
+"adicionar `;` depois de `x / 2` no segundo exemplo.\n"
+"    \n"
+"</details>"
+
+#: src/control-flow/if-let-expressions.md:1
+#, fuzzy
+msgid "# `if let` expressions"
+msgstr "# expressões `if let`"
+
+#: src/control-flow/if-let-expressions.md:3
+#, fuzzy
+msgid "If you want to match a value against a pattern, you can use `if let`:"
+msgstr "Se você deseja corresponder um valor a um padrão, pode usar `if let`:"
+
+#: src/control-flow/if-let-expressions.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let arg = std::env::args().next();\n"
+"    if let Some(value) = arg {\n"
+"        println!(\"Program name: {value}\");\n"
+"    } else {\n"
+"        println!(\"Missing name?\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let arg = std::env::args().next();\n"
+"    if let Some(valor) = arg {\n"
+"        println!(\"name do programa: {valor}\");\n"
+"    } else {\n"
+"        println!(\"Falta name?\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/if-let-expressions.md:16
+#: src/control-flow/while-let-expressions.md:21
+#: src/control-flow/match-expressions.md:22
+#, fuzzy
+msgid ""
+"See [pattern matching](../pattern-matching.md) for more details on patterns "
+"in\n"
+"Rust."
+msgstr ""
+"Consulte [correspondência de padrões](../pattern-matching.md) para obter "
+"mais detalhes sobre padrões em\n"
+"rust."
+
+#: src/control-flow/if-let-expressions.md:21
+#, fuzzy
+msgid ""
+"* `if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered.\n"
+"    * For the similar use case consider demonstrating a newly stabilized "
+"[`let else`](https://github.com/rust-lang/rust/pull/93628) feature.\n"
+"* A common usage is handling `Some` values when working with `Option`.\n"
+"* Unlike `match`, `if let` does not support guard clauses for pattern "
+"matching."
+msgstr ""
+"* `if let` pode ser mais conciso que `match`, por exemplo, quando apenas um "
+"caso é interessante. Em contraste, `match` requer que todas as ramificações "
+"sejam cobertas.\n"
+"    * Para o caso de uso semelhante, considere demonstrar um recurso [`let "
+"else`](https://github.com/rust-lang/rust/pull/93628) recentemente "
+"estabilizado.\n"
+"* Um uso comum é lidar com valores `Some` ao trabalhar com `Option`.\n"
+"* Ao contrário de `match`, `if let` não suporta cláusulas de guarda para "
+"casamento de padrões."
+
+#: src/control-flow/while-expressions.md:1
+#, fuzzy
+msgid "# `while` expressions"
+msgstr "# expressões `enquanto`"
+
+#: src/control-flow/while-expressions.md:3
+#, fuzzy
+msgid "The `while` keyword works very similar to other languages:"
+msgstr ""
+"A palavra-chave `while` funciona de maneira muito semelhante a outras "
+"linguagens:"
+
+#: src/control-flow/while-expressions.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    while x != 1 {\n"
+"        x = if x % 2 == 0 {\n"
+"            x / 2\n"
+"        } else {\n"
+"            3 * x + 1\n"
+"        };\n"
+"    }\n"
+"    println!(\"Final x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    enquanto x != 1 {\n"
+"        x = se x % 2 == 0 {\n"
+"            x / 2\n"
+"        } else {\n"
+"            3 * x + 1\n"
+"        };\n"
+"    }\n"
+"    println!(\"X final: {x}\");\n"
+"}\n"
+"```"
+
+#: src/control-flow/while-let-expressions.md:1
+#, fuzzy
+msgid "# `while let` expressions"
+msgstr "# expressões `while let`"
+
+#: src/control-flow/while-let-expressions.md:3
+#, fuzzy
+msgid ""
+"Like with `if`, there is a `while let` variant which repeatedly tests a "
+"value\n"
+"against a pattern:"
+msgstr ""
+"Como com `if`, há uma variante `while let` que testa repetidamente um valor\n"
+"contra um padrão:"
+
+#: src/control-flow/while-let-expressions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();"
+
+#: src/control-flow/while-let-expressions.md:11
+#, fuzzy
+msgid ""
+"    while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/while-let-expressions.md:17
+#, fuzzy
+msgid ""
+"Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
+"every\n"
+"call to `next()`. It returns `Some(x)` until it is done, after which it "
+"will\n"
+"return `None`. The `while let` lets us keep iterating through all items."
+msgstr ""
+"Aqui o iterador retornado por `v.iter()` retornará uma `Option<i32>` em "
+"cada\n"
+"chamada para `next ()`. Ele retorna `Some(x)` até que seja concluído, após o "
+"qual será\n"
+"retorna 'Nenhum'. O `while let` nos permite continuar iterando por todos os "
+"itens."
+
+#: src/control-flow/while-let-expressions.md:27
+#, fuzzy
+msgid ""
+"* Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern.\n"
+"* You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario.\n"
+"    \n"
+"</details>"
+msgstr ""
+"* Saliente que o loop `while let` continuará enquanto o valor corresponder "
+"ao padrão.\n"
+"* Você pode reescrever o loop `while let` como um loop infinito com uma "
+"instrução if que quebra quando não há valor para desempacotar para "
+"`iter.next()`. O `while let` fornece açúcar sintático para o cenário acima.\n"
+"    \n"
+"</details>"
+
+#: src/control-flow/for-expressions.md:1
+#, fuzzy
+msgid "# `for` expressions"
+msgstr "# expressões `for`"
+
+#: src/control-flow/for-expressions.md:3
+#, fuzzy
+msgid ""
+"The `for` expression is closely related to the `while let` expression. It "
+"will\n"
+"automatically call `into_iter()` on the expression and then iterate over it:"
+msgstr ""
+"A expressão `for` está intimamente relacionada com a expressão `while let`. "
+"Será\n"
+"chame automaticamente `into_iter()` na expressão e, em seguida, itere sobre "
+"ela:"
+
+#: src/control-flow/for-expressions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];"
+
+#: src/control-flow/for-expressions.md:10
+#, fuzzy
+msgid ""
+"    for x in v {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"    \n"
+"    for i in (0..10).step_by(2) {\n"
+"        println!(\"i: {i}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    for x em v {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"    \n"
+"    for i in (0..10).step_by(2) {\n"
+"        println!(\"i: {i}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/for-expressions.md:20
+#, fuzzy
+msgid "You can use `break` and `continue` here as usual."
+msgstr "Você pode usar `break` e `continue` aqui como de costume."
+
+#: src/control-flow/for-expressions.md:22
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"* Index iteration is not a special syntax in Rust for just that case.\n"
+"* `(0..10)` is a range that implements an `Iterator` trait. \n"
+"* `step_by` is a method that returns another `Iterator` that skips every "
+"other element. \n"
+"    \n"
+"</details>"
+msgstr ""
+"<details>\n"
+"    \n"
+"* A iteração de índice não é uma sintaxe especial no Rust apenas para esse "
+"caso.\n"
+"* `(0..10)` é um intervalo que implementa uma característica `Iterator`.\n"
+"* `step_by` é um método que retorna outro `Iterator` que pula todos os "
+"outros elementos.\n"
+"    \n"
+"</details>"
+
+#: src/control-flow/loop-expressions.md:1
+#, fuzzy
+msgid "# `loop` expressions"
+msgstr "# expressões `loop`"
+
+#: src/control-flow/loop-expressions.md:3
+#, fuzzy
+msgid ""
+"Finally, there is a `loop` keyword which creates an endless loop. Here you "
+"must\n"
+"either `break` or `return` to stop the loop:"
+msgstr ""
+"Finalmente, há uma palavra-chave `loop` que cria um loop infinito. Aqui você "
+"deve\n"
+"`break` ou `return` para parar o loop:"
+
+#: src/control-flow/loop-expressions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    loop {\n"
+"        x = if x % 2 == 0 {\n"
+"            x / 2\n"
+"        } else {\n"
+"            3 * x + 1\n"
+"        };\n"
+"        if x == 1 {\n"
+"            break;\n"
+"        }\n"
+"    }\n"
+"    println!(\"Final x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    ciclo {\n"
+"        x = se x % 2 == 0 {\n"
+"            x / 2\n"
+"        } else {\n"
+"            3 * x + 1\n"
+"        };\n"
+"        se x == 1 {\n"
+"            pausa;\n"
+"        }\n"
+"    }\n"
+"    println!(\"X final: {x}\");\n"
+"}\n"
+"```"
+
+#: src/control-flow/match-expressions.md:1
+#, fuzzy
+msgid "# `match` expressions"
+msgstr "# expressões `match`"
+
+#: src/control-flow/match-expressions.md:3
+#, fuzzy
+msgid ""
+"The `match` keyword is used to match a value against one or more patterns. "
+"In\n"
+"that sense, it works like a series of `if let` expressions:"
+msgstr ""
+"A palavra-chave `match` é usada para corresponder um valor a um ou mais "
+"padrões. No\n"
+"nesse sentido, funciona como uma série de expressões `if let`:"
+
+#: src/control-flow/match-expressions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    match std::env::args().next().as_deref() {\n"
+"        Some(\"cat\") => println!(\"Will do cat things\"),\n"
+"        Some(\"ls\")  => println!(\"Will ls some files\"),\n"
+"        Some(\"mv\")  => println!(\"Let's move some files\"),\n"
+"        Some(\"rm\")  => println!(\"Uh, dangerous!\"),\n"
+"        None        => println!(\"Hmm, no program name?\"),\n"
+"        _           => println!(\"Unknown program name!\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    match std::env::args().next().as_deref() {\n"
+"        Some(\"gato\") => println!(\"Vai fazer coisas de gato\"),\n"
+"        Some(\"ls\") => println!(\"Serão alguns arquivos\"),\n"
+"        Some(\"mv\") => println!(\"Vamos mover alguns arquivos\"),\n"
+"        Some(\"rm\") => println!(\"Uh, perigoso!\"),\n"
+"        Nenhum => println!(\"Hmm, nenhum name de programa?\"),\n"
+"        _ => println!(\"name de programa desconhecido!\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/match-expressions.md:19
+#, fuzzy
+msgid ""
+"Like `if let`, each match arm must have the same type. The type is the last\n"
+"expression of the block, if any. In the example above, the type is `()`."
+msgstr ""
+"Como `if let`, cada braço de correspondência deve ter o mesmo tipo. O tipo é "
+"o último\n"
+"expressão do bloco, se houver. No exemplo acima, o tipo é `()`."
+
+#: src/control-flow/break-continue.md:1
+#, fuzzy
+msgid "# `break` and `continue`"
+msgstr "# `interromper` e `continuar`"
+
+#: src/control-flow/break-continue.md:3
+#, fuzzy
+msgid ""
+"If you want to exit a loop early, use `break`, if you want to immediately "
+"start\n"
+"the next iteration use `continue`. Both `continue` and `break` can "
+"optionally\n"
+"take a label argument which is used to break out of nested loops:"
+msgstr ""
+"Se você quiser sair de um loop mais cedo, use `break`, se quiser iniciar "
+"imediatamente\n"
+"a próxima iteração usa `continue`. Ambos `continue` e `break` podem "
+"opcionalmente\n"
+"pegue um argumento de rótulo que é usado para sair de loops aninhados:"
+
+#: src/control-flow/break-continue.md:7
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();\n"
+"    'outer: while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"        let mut i = 0;\n"
+"        while i < x {\n"
+"            println!(\"x: {x}, i: {i}\");\n"
+"            i += 1;\n"
+"            if i == 3 {\n"
+"                break 'outer;\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();\n"
+"    'outer: while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"        seja mut i = 0;\n"
+"        enquanto i < x {\n"
+"            println!(\"x: {x}, i: {i}\");\n"
+"            i += 1;\n"
+"            se eu == 3 {\n"
+"                quebrar 'externo;\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/control-flow/break-continue.md:25
+#, fuzzy
+msgid ""
+"In this case we break the outer loop after 3 iterations of the inner loop."
+msgstr "Neste caso, quebramos o loop externo após 3 iterações do loop interno."
+
+#: src/std.md:1
+#, fuzzy
+msgid "# Standard Library"
+msgstr "# Biblioteca padrão"
+
+#: src/std.md:3
+#, fuzzy
+msgid ""
+"Rust comes with a standard library which helps establish a set of common "
+"types\n"
+"used by Rust library and programs. This way, two libraries can work "
+"together\n"
+"smoothly because they both use the same `String` type."
+msgstr ""
+"Rust vem com uma biblioteca padrão que ajuda a estabelecer um conjunto de "
+"tipos comuns\n"
+"usado pela biblioteca e programas Rust. Dessa forma, duas bibliotecas podem "
+"trabalhar juntas\n"
+"sem problemas porque ambos usam o mesmo tipo `String`."
+
+#: src/std.md:7
+#, fuzzy
+msgid "The common vocabulary types include:"
+msgstr "Os tipos de vocabulário comuns incluem:"
+
+#: src/std.md:9
+#, fuzzy
+msgid ""
+"* [`Option` and `Result`](std/option-result.md) types: used for optional "
+"values\n"
+"  and [error handling](error-handling.md)."
+msgstr ""
+"* Tipos [`Option` e `Result`](std/option-result.md): usados para valores "
+"opcionais\n"
+"  e [manipulação de erros](manipulação de erros.md)."
+
+#: src/std.md:12
+#, fuzzy
+msgid "* [`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+"* [`String`](std/string.md): o tipo de string padrão usado para dados de "
+"ownership."
+
+#: src/std.md:14
+#, fuzzy
+msgid "* [`Vec`](std/vec.md): a standard extensible vector."
+msgstr "* [`Vec`](std/vec.md): um vetor extensível padrão."
+
+#: src/std.md:16
+#, fuzzy
+msgid ""
+"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
+"  algorithm."
+msgstr ""
+"* [`HashMap`](std/hashmap.md): um tipo de mapa hash com um hashing "
+"configurável\n"
+"  algoritmo."
+
+#: src/std.md:19
+#, fuzzy
+msgid "* [`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr "* [`Box`](std/box.md): um ponteiro próprio para dados alocados em heap."
+
+#: src/std.md:21
+#, fuzzy
+msgid ""
+"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
+msgstr ""
+"* [`Rc`](std/rc.md): um ponteiro de contagem de referência compartilhado "
+"para dados alocados em heap."
+
+#: src/std.md:23
+#, fuzzy
+msgid ""
+"<details>\n"
+"  \n"
+"  * In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. \n"
+"  * `core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or\n"
+"    even the presence of an operating system. \n"
+"  * `alloc` includes types which require a global heap allocator, such as "
+"`Vec`, `Box` and `Arc`.\n"
+"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"<details>\n"
+"  \n"
+"  * Na verdade, Rust contém várias camadas da Biblioteca Padrão: `core`, "
+"`alloc` e `std`.\n"
+"  * `core` inclui os tipos e funções mais básicos que não dependem de "
+"`libc`, alocador ou\n"
+"    até mesmo a presença de um sistema operacional.\n"
+"  * `alloc` inclui tipos que requerem um alocador de heap global, como "
+"`Vec`, `Box` e `Arc`.\n"
+"  * Os aplicativos Rust integrados geralmente usam apenas `core` e, às "
+"vezes, `alloc`."
+
+#: src/std/option-result.md:1
+#, fuzzy
+msgid "# `Option` and `Result`"
+msgstr "# `Option` e `Resultado`"
+
+#: src/std/option-result.md:3
+#, fuzzy
+msgid "The types represent optional data:"
+msgstr "Os tipos representam dados opcionais:"
+
+#: src/std/option-result.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let numbers = vec![10, 20, 30];\n"
+"    let first: Option<&i8> = numbers.first();\n"
+"    println!(\"first: {first:?}\");"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let números = vec![10, 20, 30];\n"
+"    let primeiro: Option<&i8> = números.primeiro();\n"
+"    println!(\"primeiro: {primeiro:?}\");"
+
+#: src/std/option-result.md:11
+#, fuzzy
+msgid ""
+"    let idx: Result<usize, usize> = numbers.binary_search(&10);\n"
+"    println!(\"idx: {idx:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    let idx: Result<usar, usar> = números.binary_search(&10);\n"
+"    println!(\"idx: {idx:?}\");\n"
+"}\n"
+"```"
+
+#: src/std/option-result.md:18
+#, fuzzy
+msgid ""
+"* `Option` and `Result` are widely used not just in the standard library.\n"
+"* `Option<&T>` has zero space overhead compared to `&T`.\n"
+"* `Result` is the standard type to implement error handling as we will see "
+"on Day 3.\n"
+"* `binary_search` returns `Result<usize, usize>`.\n"
+"  * If found, `Result::Ok` holds the index where the element is found.\n"
+"  * Otherwise, `Result::Err` contains the index where such an element should "
+"be inserted."
+msgstr ""
+"* `Option` e `Result` são amplamente usados não apenas na biblioteca "
+"padrão.\n"
+"* `Option<&T>` tem sobrecargo de espaço zero em comparação com `&T`.\n"
+"* `Result` é o tipo padrão para implementar o tratamento de erros, como "
+"veremos no Dia 3.\n"
+"* `binary_search` retorna `Result<usize, usize>`.\n"
+"  * Se encontrado, `Result::Ok` contém o índice onde o elemento foi "
+"encontrado.\n"
+"  * Caso contrário, `Result::Err` contém o índice onde tal elemento deve ser "
+"inserido."
+
+#: src/std/string.md:1
+#, fuzzy
+msgid "# String"
+msgstr "# String"
+
+#: src/std/string.md:3
+#, fuzzy
+msgid ""
+"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+msgstr ""
+"[`String`][1] é o buffer de string UTF-8 expansível alocado por heap padrão:"
+
+#: src/std/string.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::new();\n"
+"    s1.push_str(\"Hello\");\n"
+"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut s1 = String::new();\n"
+"    s1.push_str(\"Olá\");\n"
+"    println!(\"s1: len = {}, capacage = {}\", s1.len(), s1.capacity());"
+
+#: src/std/string.md:11
+#, fuzzy
+msgid ""
+"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
+"    s2.push_str(&s1);\n"
+"    s2.push('!');\n"
+"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());"
+msgstr ""
+"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
+"    s2.push_str(&s1);\n"
+"    s2.push('!');\n"
+"    println!(\"s2: len = {}, capacage = {}\", s2.len(), s2.capacity());"
+
+#: src/std/string.md:16
+#, fuzzy
+msgid ""
+"    let s3 = String::from(\"🇨🇭\");\n"
+"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
+"             s3.chars().count());\n"
+"}\n"
+"```"
+msgstr ""
+"    let s3 = String::from(\"🇨🇭\");\n"
+"    println!(\"s3: len = {}, número de caracteres = {}\", s3.len(),\n"
+"             s3.chars().count());\n"
+"}\n"
+"```"
+
+#: src/std/string.md:22
+#, fuzzy
+msgid ""
+"`String` implements [`Deref<Target = str>`][2], which means that you can "
+"call all\n"
+"`str` methods on a `String`."
+msgstr ""
+"`String` implementa [`Deref<Target = str>`][2], o que significa que você "
+"pode chamar todos\n"
+"Métodos `str` em uma `String`."
+
+#: src/std/string.md:25
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str"
+
+#: src/std/string.md:30
+#, fuzzy
+msgid ""
+"* `len` returns the size of the `String` in bytes, not its length in "
+"characters.\n"
+"* `chars` returns an iterator over the actual characters.\n"
+"* `String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+"* `len` retorna o tamanho da `String` em bytes, não seu comprimento em "
+"caracteres.\n"
+"* `chars` retorna um iterador sobre os caracteres reais.\n"
+"* `String` implementa `Deref<Target = str>` que dá acesso transparente aos "
+"métodos de `str`."
+
+#: src/std/vec.md:1
+#, fuzzy
+msgid "# `Vec`"
+msgstr "# `Vec`"
+
+#: src/std/vec.md:3
+#, fuzzy
+msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
+msgstr "[`Vec`][1] é o buffer redimensionável padrão alocado em heap:"
+
+#: src/std/vec.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut v1 = Vec::new();\n"
+"    v1.push(42);\n"
+"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut v1 = Vec::new();\n"
+"    v1.push(42);\n"
+"    println!(\"v1: len = {}, capacage = {}\", v1.len(), v1.capacity());"
+
+#: src/std/vec.md:11
+#, fuzzy
+msgid ""
+"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
+"    v2.extend(v1.iter());\n"
+"    v2.push(9999);\n"
+"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
+"}\n"
+"```"
+msgstr ""
+"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
+"    v2.extend(v1.iter());\n"
+"    v2.push(9999);\n"
+"    println!(\"v2: len = {}, capacage = {}\", v2.len(), v2.capacity());\n"
+"}\n"
+"```"
+
+#: src/std/vec.md:18
+#, fuzzy
+msgid ""
+"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
+"slice\n"
+"methods on a `Vec`."
+msgstr ""
+"`Vec` implementa [`Deref<Target = [T]>`][2], o que significa que você pode "
+"chamar slice\n"
+"métodos em um `Vec`."
+
+#: src/std/vec.md:21
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
+
+#: src/std/vec.md:24
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored\n"
+"  on the heap. This means the amount of data doesn't need to be  known at "
+"compile time. It can grow\n"
+"  or shrink at runtime.\n"
+"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
+"`T` explicitly. As always\n"
+"  with Rust type inference, the `T` was established during the first `push` "
+"call.\n"
+"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial\n"
+"  elements to the vector. \n"
+"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using\n"
+"  `get` will return an `Option`. The `pop` function will remove the last "
+"element.\n"
+"* Show iterating over a vector and mutating the value:\n"
+"  `for e in &mut v { *e += 50; }`"
+msgstr ""
+"<details>\n"
+"    \n"
+"* `Vec` é um tipo de coleção, junto com `String` e `HashMap`. Os dados que "
+"ele contém são armazenados\n"
+"  na pilha. Isso significa que a quantage de dados não precisa ser "
+"conhecida em tempo de compilação. pode crescer\n"
+"  ou encolher em tempo de execução.\n"
+"* Observe como `Vec<T>` também é um tipo genérico, mas você não precisa "
+"especificar `T` explicitamente. Como sempre\n"
+"  com inferência de tipo Rust, o `T` foi estabelecido durante a primeira "
+"chamada `push`.\n"
+"* `vec![...]` é uma macro canônica para usar em vez de `Vec::new()` e "
+"suporta adicionar iniciais\n"
+"  elementos ao vetor.\n"
+"* Para indexar o vetor, você usa `[` `]`, mas eles entrarão em pânico se "
+"estiverem fora dos limites. Alternativamente, usando\n"
+"  `get` retornará uma `Option`. A função `pop` removerá o último elemento.\n"
+"* Mostrar iterando sobre um vetor e alterando o valor:\n"
+"  `for e in &mut v { *e += 50; }`"
+
+#: src/std/hashmap.md:1
+#, fuzzy
+msgid "# `HashMap`"
+msgstr "#`HashMap`"
+
+#: src/std/hashmap.md:3
+#, fuzzy
+msgid "Standard hash map with protection against HashDoS attacks:"
+msgstr "Mapa de hash padrão com proteção contra ataques HashDoS:"
+
+#: src/std/hashmap.md:5
+#, fuzzy
+msgid "```rust,editable\nuse std::collections::HashMap;"
+msgstr "```rust, editable\nuse std::coleções::HashMap;"
+
+#: src/std/hashmap.md:8
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut page_counts = HashMap::new();\n"
+"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
+"207);\n"
+"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
+"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);"
+msgstr ""
+"fn main() {\n"
+"    let mut page_counts = HashMap::new();\n"
+"    page_counts.insert(\"Aventuras de Huckleberry Finn\".to_string(), 207);\n"
+"    page_counts.insert(\"Contos de Fadas dos Grimms\".to_string(), 751);\n"
+"    page_counts.insert(\"Orgulho e Preconceito\".to_string(), 303);"
+
+#: src/std/hashmap.md:14
+#, fuzzy
+msgid ""
+"    if !page_counts.contains_key(\"Les Misérables\") {\n"
+"        println!(\"We've know about {} books, but not Les Misérables.\",\n"
+"                 page_counts.len());\n"
+"    }"
+msgstr ""
+"    if !page_counts.contains_key(\"Os Miseráveis\") {\n"
+"        println!(\"Conhecemos {} livros, mas não Os Miseráveis.\",\n"
+"                 page_counts.len());\n"
+"    }"
+
+#: src/std/hashmap.md:19
+#, fuzzy
+msgid ""
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        match page_counts.get(book) {\n"
+"            Some(count) => println!(\"{book}: {count} pages\"),\n"
+"            None => println!(\"{book} is unknown.\")\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    for livro em [\"Orgulho e Preconceito\", \"Alice no País das "
+"Maravilhas\"] {\n"
+"        match page_counts.get(livro) {\n"
+"            Some(count) => println!(\"{book}: {count} páginas\"),\n"
+"            Nenhum => println!(\"{livro} é desconhecido.\")\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/std/box.md:1
+#, fuzzy
+msgid "# `Box`"
+msgstr "# `Caixa`"
+
+#: src/std/box.md:3
+#, fuzzy
+msgid "[`Box`][1] is an owned pointer to data on the heap:"
+msgstr "[`Box`][1] é um ponteiro de ownership para dados no heap:"
+
+#: src/std/box.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let five = Box::new(5);\n"
+"    println!(\"five: {}\", *five);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let cinco = Box::new(5);\n"
+"    println!(\"cinco: {}\", *cinco);\n"
+"}\n"
+"```"
+
+#: src/std/box.md:13
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                     Heap\n"
+".- - - - - - -.     .- - - - - - -.\n"
+":             :     :             :\n"
+":    five     :     :             :\n"
+":   +-----+   :     :   +-----+   :\n"
+":   | o---|---+-----+-->|  5  |   :\n"
+":   +-----+   :     :   +-----+   :\n"
+":             :     :             :\n"
+":             :     :             :\n"
+"`- - - - - - -'     `- - - - - - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - -. .- - - - - - -.\n"
+": : : :\n"
+":    cinco     :     :             :\n"
+": +-----+ : : +-----+ :\n"
+": | o---|---+-----+-->| 5 | :\n"
+": +-----+ : : +-----+ :\n"
+": : : :\n"
+": : : :\n"
+"`- - - - - - -' `- - - - - -'\n"
+"```"
+
+#: src/std/box.md:26
+#, fuzzy
+msgid ""
+"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
+"methods\n"
+"from `T` directly on a `Box<T>`][2]."
+msgstr ""
+"`Box<T>` implementa `Deref<Target = T>`, o que significa que você pode "
+"[chamar métodos\n"
+"de `T` diretamente em um `Box<T>`][2]."
+
+#: src/std/box.md:29
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion"
+
+#: src/std/box.md:34
+#, fuzzy
+msgid ""
+"* `Box` is like `std::unique_ptr` in C++.\n"
+"* In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`."
+msgstr ""
+"* `Box` é como `std::unique_ptr` em C++.\n"
+"* No exemplo acima, você pode até deixar de fora o `*` na declaração "
+"`println!` graças a `Deref`."
+
+#: src/std/box-recursive.md:1
+#, fuzzy
+msgid "# Box with Recursive Data Structures"
+msgstr "# Caixa com Structs de Dados Recursivas"
+
+#: src/std/box-recursive.md:3
+#, fuzzy
+msgid ""
+"Recursive data types or data types with dynamic sizes need to use a `Box`:"
+msgstr ""
+"Tipos de dados recursivos ou tipos de dados com tamanhos dinâmicos precisam "
+"usar um `Box`:"
+
+#: src/std/box-recursive.md:5 src/std/box-niche.md:3
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"enum List<T> {\n"
+"    Cons(T, Box<List<T>>),\n"
+"    Nil,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug)]\n"
+"enum Lista<T> {\n"
+"    Cons(T, Caixa<Lista<T>>),\n"
+"    Nada,\n"
+"}"
+
+#: src/std/box-recursive.md:12 src/std/box-niche.md:10
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, "
+"Box::new(List::Nil))));\n"
+"    println!(\"{list:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, "
+"Box::new(List::Nil))));\n"
+"    println!(\"{lista:?}\");\n"
+"}\n"
+"```"
+
+#: src/std/box-recursive.md:18
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                         :     :                                            "
+"   :\n"
+":    list                 :     :                                            "
+"   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":   | Tag    | Cons  |    :     : .->| Tag    | Cons   | .->| Tag    | Nil  "
+"|   :\n"
+":   | 0      | 1     |    :     : |  | 0      | 2      | |  | ////// | //// "
+"|   :\n"
+":   | 1      | o-----+----+-----+-'  | 1      | o------+-'  | ////// | //// "
+"|   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":                         :     :                                            "
+"   :\n"
+":                         :     :                                            "
+"   :\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - -. .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+": : : :\n"
+":    Lista                 :     :                                           "
+"    :\n"
+": +--------+-------+ : : +--------+--------+ +--------+ ------+ :\n"
+": | Etiqueta | Contras | : : .->| Etiqueta | Contras | .->| Etiqueta | nada "
+"| :\n"
+": | 0 | 1 | : : | | 0 | 2 | | | ////// | //// | :\n"
+": | 1 | o-----+----+-----+-' | 1 | o------+-' | ////// | //// | :\n"
+": +--------+-------+ : : +--------+--------+ +--------+ ------+ :\n"
+": : : :\n"
+": : : :\n"
+"`- - - - - - - - - - - - -' '- - - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
+"```"
+
+#: src/std/box-recursive.md:33
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`,\n"
+"the compiler would not compute a fixed size of the struct in memory, it "
+"would look infinite.\n"
+"    \n"
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next\n"
+"element of the `List` in the heap.    \n"
+"    \n"
+"</details>"
+msgstr ""
+"<details>\n"
+"    \n"
+"Se a `Caixa` não foi usada aqui e tentamos incorporar uma `Lista` "
+"diretamente na `Lista`,\n"
+"o compilador não calcularia um tamanho fixo da estrutura na memória, "
+"pareceria infinito.\n"
+"    \n"
+"`Box` resolve esse problema, pois tem o mesmo tamanho de um ponteiro normal "
+"e apenas aponta para o próximo\n"
+"elemento da `Lista` na pilha.\n"
+"    \n"
+"</details>"
+
+#: src/std/box-niche.md:1
+#, fuzzy
+msgid "# Niche Optimization"
+msgstr "# Otimização de Nicho"
+
+#: src/std/box-niche.md:16
+#, fuzzy
+msgid ""
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
+"This\n"
+"allows the compiler to optimize the memory layout:"
+msgstr ""
+"Uma `Box` não pode estar vazia, então o ponteiro é sempre válido e não "
+"`nulo`. Esta\n"
+"permite que o compilador otimize o layout da memória:"
+
+#: src/std/box-niche.md:19
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                         :     :                                            "
+"   :\n"
+":    list                 :     :                                            "
+"   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":   | 0      | 1     |    :     : .->| 0      |  2     | .->| ////// | //// "
+"|   :\n"
+":   | \"1/Tag\"| o-----+----+-----+-'  | \"1/Tag\"|  o-----+-'  | \"1/Tag\"| "
+"null |   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":                         :     :                                            "
+"   :\n"
+":                         :     :                                            "
+"   :\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - -. .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+": : : :\n"
+":    Lista                 :     :                                           "
+"    :\n"
+": +--------+-------+ : : +--------+--------+ +--------+ ------+ :\n"
+": | 0 | 1 | : : .->| 0 | 2 | .->| ////// | //// | :\n"
+": | \"1/Etiqueta\"| o-----+----+-----+-' | \"1/Etiqueta\"| o-----+-' | "
+"\"1/Etiqueta\"| nulo | :\n"
+": +--------+-------+ : : +--------+--------+ +--------+ ------+ :\n"
+": : : :\n"
+": : : :\n"
+"`- - - - - - - - - - - - -' '- - - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
+"```"
+
+#: src/std/rc.md:1
+#, fuzzy
+msgid "# `Rc`"
+msgstr "#`Rc`"
+
+#: src/std/rc.md:3
+#, fuzzy
+msgid ""
+"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
+"refer\n"
+"to the same data from multiple places:"
+msgstr ""
+"[`Rc`][1] é um ponteiro compartilhado com contagem de referência. Use isso "
+"quando precisar consultar\n"
+"aos mesmos dados de vários lugares:"
+
+#: src/std/rc.md:6
+#, fuzzy
+msgid "```rust,editable\nuse std::rc::Rc;"
+msgstr "```rust, editable\nusar padrão::rc::Rc;"
+
+#: src/std/rc.md:9
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut a = Rc::new(10);\n"
+"    let mut b = a.clone();"
+msgstr ""
+"fn main() {\n"
+"    let mut a = Rc::new(10);\n"
+"    let mut b = a.clone();"
+
+#: src/std/rc.md:18
+#, fuzzy
+msgid ""
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in\n"
+"a type such as [`Cell` or `RefCell`][2]. See [`Arc`][3] if you are in a "
+"multi-threaded\n"
+"context."
+msgstr ""
+"Se você precisar alterar os dados dentro de um `Rc`, precisará agrupar os "
+"dados em\n"
+"um tipo como [`Cell` ou `RefCell`][2]. Veja [`Arc`][3] se você estiver em um "
+"multi-threaded\n"
+"contexto."
+
+#: src/std/rc.md:22
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[2]: https://doc.rust-lang.org/std/cell/index.html\n"
+"[3]: ../concurrency/shared_state/arc.md"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[2]: https://doc.rust-lang.org/std/cell/index.html\n"
+"[3]: ../concurrency/shared_state/arc.md"
+
+#: src/std/rc.md:28
+#, fuzzy
+msgid ""
+"* Like C++'s `std::shared_ptr`.\n"
+"* `clone` is cheap: creates a pointer to the same allocation and increases "
+"the reference count.\n"
+"* `make_mut` actually clones the inner value if necessary "
+"(\"clone-on-write\") and returns a mutable reference."
+msgstr ""
+"* Como `std::shared_ptr` do C++.\n"
+"* `clone` é barato: cria um ponteiro para a mesma alocação e aumenta a "
+"contagem de referência.\n"
+"* `make_mut` realmente clona o valor interno se necessário "
+"(\"clone-on-write\") e retorna uma referência mutável."
+
+#: src/modules.md:1
+#, fuzzy
+msgid "# Modules"
+msgstr "# Módulos"
+
+#: src/modules.md:3
+#, fuzzy
+msgid "We have seen how `impl` blocks let us namespace functions to a type."
+msgstr ""
+"Vimos como os blocos `impl` nos permitem funções de namespace para um tipo."
+
+#: src/modules.md:5
+#, fuzzy
+msgid "Similarly, `mod` lets us namespace types and functions:"
+msgstr "Da mesma forma, `mod` nos permite tipos e funções de namespace:"
+
+#: src/modules.md:7
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"mod foo {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the foo module\");\n"
+"    }\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"mod foo {\n"
+"    pub fn do_something() {\n"
+"        println!(\"No módulo foo\");\n"
+"    }\n"
+"}"
+
+#: src/modules.md:14
+#, fuzzy
+msgid ""
+"mod bar {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the bar module\");\n"
+"    }\n"
+"}"
+msgstr ""
+"barra de mods {\n"
+"    pub fn do_something() {\n"
+"        println!(\"No modulo da barra\");\n"
+"    }\n"
+"}"
+
+#: src/modules.md:20
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    foo::do_something();\n"
+"    bar::do_something();\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    foo::do_something();\n"
+"    bar::do_something();\n"
+"}\n"
+"```"
+
+#: src/modules/visibility.md:1
+#, fuzzy
+msgid "# Visibility"
+msgstr "# Visibilage"
+
+#: src/modules/visibility.md:3
+#, fuzzy
+msgid "Modules are a privacy boundary:"
+msgstr "Os módulos são um limite de privacage:"
+
+#: src/modules/visibility.md:5
+#, fuzzy
+msgid ""
+"* Module items are private by default (hides implementation details).\n"
+"* Parent and sibling items are always visible."
+msgstr ""
+"* Os itens do módulo são privados por padrão (oculta detalhes de "
+"implementação).\n"
+"* Os itens pai e irmão estão sempre visíveis."
+
+#: src/modules/visibility.md:8
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"mod outer {\n"
+"    fn private() {\n"
+"        println!(\"outer::private\");\n"
+"    }"
+msgstr ""
+"```rust, editable\n"
+"mod exterior {\n"
+"    fn privado() {\n"
+"        println!(\"externo::privado\");\n"
+"    }"
+
+#: src/modules/visibility.md:14
+#, fuzzy
+msgid ""
+"    pub fn public() {\n"
+"        println!(\"outer::public\");\n"
+"    }"
+msgstr ""
+"    pub fn public() {\n"
+"        println!(\"externo::público\");\n"
+"    }"
+
+#: src/modules/visibility.md:18
+#, fuzzy
+msgid ""
+"    mod inner {\n"
+"        fn private() {\n"
+"            println!(\"outer::inner::private\");\n"
+"        }"
+msgstr ""
+"    mod interior {\n"
+"        fn privado() {\n"
+"            println!(\"externo::interno::privado\");\n"
+"        }"
+
+#: src/modules/visibility.md:23
+#, fuzzy
+msgid ""
+"        pub fn public() {\n"
+"            println!(\"outer::inner::public\");\n"
+"            super::private();\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"        pub fn public() {\n"
+"            println!(\"externo::interno::público\");\n"
+"            super::privado();\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/modules/visibility.md:30
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    outer::public();\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    exterior::public();\n"
+"}\n"
+"```"
+
+#: src/modules/paths.md:1
+#, fuzzy
+msgid "# Paths"
+msgstr "# caminhos"
+
+#: src/modules/paths.md:3
+#, fuzzy
+msgid "Paths are resolved as follows:"
+msgstr "Os caminhos são resolvidos da seguinte forma:"
+
+#: src/modules/paths.md:5
+#, fuzzy
+msgid ""
+"1. As a relative path:\n"
+"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
+"   * `super::foo` refers to `foo` in the parent module."
+msgstr ""
+"1. Como caminho relativo:\n"
+"   * `foo` ou `self::foo` refere-se a `foo` no módulo atual,\n"
+"   * `super::foo` refere-se a `foo` no módulo pai."
+
+#: src/modules/paths.md:9
+#, fuzzy
+msgid ""
+"2. As an absolute path:\n"
+"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
+"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgstr ""
+"2. Como um caminho absoluto:\n"
+"   * `crate::foo` refere-se a `foo` na raiz da caixa atual,\n"
+"   * `bar::foo` refere-se a `foo` na caixa `bar`."
+
+#: src/modules/filesystem.md:1
+#, fuzzy
+msgid "# Filesystem Hierarchy"
+msgstr "# Hierarquia do sistema de arquivos"
+
+#: src/modules/filesystem.md:3
+#, fuzzy
+msgid "The module content can be omitted:"
+msgstr "O conteúdo do módulo pode ser omitido:"
+
+#: src/modules/filesystem.md:5
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"mod garden;\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"jardim mod;\n"
+"```"
+
+#: src/modules/filesystem.md:9
+#, fuzzy
+msgid "The `garden` module content is found at:"
+msgstr "O conteúdo do módulo `garden` é encontrado em:"
+
+#: src/modules/filesystem.md:11
+#, fuzzy
+msgid ""
+"* `src/garden.rs` (modern Rust 2018 style)\n"
+"* `src/garden/mod.rs` (older Rust 2015 style)"
+msgstr ""
+"* `src/garden.rs` (estilo Rust 2018 moderno)\n"
+"* `src/garden/mod.rs` (antigo estilo Rust 2015)"
+
+#: src/modules/filesystem.md:14
+#, fuzzy
+msgid "Similarly, a `garden::vegetables` module can be found at:"
+msgstr "Da mesma forma, um módulo `garden::vegetables` pode ser encontrado em:"
+
+#: src/modules/filesystem.md:16
+#, fuzzy
+msgid ""
+"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
+"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr ""
+"* `src/garden/vegetables.rs` (estilo Rust 2018 moderno)\n"
+"* `src/garden/vegetables/mod.rs` (antigo estilo Rust 2015)"
+
+#: src/modules/filesystem.md:19
+#, fuzzy
+msgid "The `crate` root is in:"
+msgstr "A raiz `crate` está em:"
+
+#: src/modules/filesystem.md:21
+#, fuzzy
+msgid ""
+"* `src/lib.rs` (for a library crate)\n"
+"* `src/main.rs` (for a binary crate)"
+msgstr ""
+"* `src/lib.rs` (para uma caixa de biblioteca)\n"
+"* `src/main.rs` (para uma caixa binária)"
+
+#: src/exercises/day-2/afternoon.md:1
+#, fuzzy
+msgid "# Day 2: Afternoon Exercises"
+msgstr "# Dia 2: Exercícios da Tarde"
+
+#: src/exercises/day-2/afternoon.md:3
+#, fuzzy
+msgid "The exercises for this afternoon will focus on strings and iterators."
+msgstr "Os exercícios desta tarde se concentrarão em strings e iteradores."
+
+#: src/exercises/day-2/luhn.md:1
+#, fuzzy
+msgid "# Luhn Algorithm"
+msgstr "# Algoritmo de Luhn"
+
+#: src/exercises/day-2/luhn.md:3
+#, fuzzy
+msgid ""
+"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
+"to\n"
+"validate credit card numbers. The algorithm takes a string as input and does "
+"the\n"
+"following to validate the credit card number:"
+msgstr ""
+"O [algoritmo Luhn](https://en.wikipedia.org/wiki/Luhn_algorithm) é usado "
+"para\n"
+"validar números de cartão de crédito. O algoritmo recebe uma string como "
+"entrada e faz o\n"
+"seguinte para validar o número do cartão de crédito:"
+
+#: src/exercises/day-2/luhn.md:7
+#, fuzzy
+msgid "* Ignore all spaces. Reject number with less than two digits."
+msgstr "* Ignore todos os espaços. Rejeitar número com menos de dois dígitos."
+
+#: src/exercises/day-2/luhn.md:9
+#, fuzzy
+msgid ""
+"* Moving from right to left, double every second digit: for the number "
+"`1234`,\n"
+"  we double `3` and `1`."
+msgstr ""
+"* Movendo-se da direita para a esquerda, dobre cada segundo dígito: para o "
+"número `1234`,\n"
+"  nós dobramos `3` e `1`."
+
+#: src/exercises/day-2/luhn.md:12
+#, fuzzy
+msgid ""
+"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
+"which\n"
+"  becomes `5`."
+msgstr ""
+"* Depois de dobrar um dígito, some os dígitos. Assim, duplicar `7` torna-se "
+"`14` que\n"
+"  torna-se '5'."
+
+#: src/exercises/day-2/luhn.md:15
+#, fuzzy
+msgid "* Sum all the undoubled and doubled digits."
+msgstr "* Some todos os dígitos duplicados e duplicados."
+
+#: src/exercises/day-2/luhn.md:17
+#, fuzzy
+msgid "* The credit card number is valid if the sum ends with `0`."
+msgstr "* O número do cartão de crédito é válido se a soma terminar em `0`."
+
+#: src/exercises/day-2/luhn.md:19
+#, fuzzy
+msgid ""
+"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"function:"
+msgstr ""
+"Copie o seguinte código para <https://play.rust-lang.org/> e implemente o\n"
+"função:"
+
+#: src/exercises/day-2/luhn.md:27
+#, fuzzy
+msgid ""
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    não implementado!()\n"
+"}"
+
+#: src/exercises/day-2/luhn.md:31
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_non_digit_cc_number() {\n"
+"    afirmar!(!luhn(\"foo\"));\n"
+"}"
+
+#: src/exercises/day-2/luhn.md:36 src/exercises/day-2/solutions-afternoon.md:64
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_empty_cc_number() {\n"
+"    afirmar!(!luhn(\"\"));\n"
+"    afirmar!(!luhn(\" \"));\n"
+"    afirmar!(!luhn(\" \"));\n"
+"    afirmar!(!luhn(\" \"));\n"
+"}"
+
+#: src/exercises/day-2/luhn.md:44 src/exercises/day-2/solutions-afternoon.md:72
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_single_digit_cc_number() {\n"
+"    afirmar!(!luhn(\"0\"));\n"
+"}"
+
+#: src/exercises/day-2/luhn.md:49 src/exercises/day-2/solutions-afternoon.md:77
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_two_digit_cc_number() {\n"
+"    afirmar!(luhn(\" 0 0 \"));\n"
+"}"
+
+#: src/exercises/day-2/luhn.md:54 src/exercises/day-2/solutions-afternoon.md:82
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_valid_cc_number() {\n"
+"    afirmar!(luhn(\"4263 9826 4026 9299\"));\n"
+"    afirmar!(luhn(\"4539 3195 0343 6467\"));\n"
+"    afirmar!(luhn(\"7992 7398 713\"));\n"
+"}"
+
+#: src/exercises/day-2/luhn.md:61
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_invalid_cc_number() {\n"
+"    afirmar!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    afirmar!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    afirmar!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}"
+
+#: src/exercises/day-2/strings-iterators.md:1
+#, fuzzy
+msgid "# Strings and Iterators"
+msgstr "# Strings e iteradores"
+
+#: src/exercises/day-2/strings-iterators.md:3
+#, fuzzy
+msgid ""
+"In this exercise, you are implementing a routing component of a web server. "
+"The\n"
+"server is configured with a number of _path prefixes_ which are matched "
+"against\n"
+"_request paths_. The path prefixes can contain a wildcard character which\n"
+"matches a full segment. See the unit tests below."
+msgstr ""
+"Neste exercício, você está implementando um componente de roteamento de um "
+"servidor web. o\n"
+"servidor está configurado com um número de _path prefixes_ que são "
+"comparados\n"
+"_pedir caminhos_. Os prefixos de caminho podem conter um caractere curinga "
+"que\n"
+"corresponde a um segmento completo. Veja os testes de unage abaixo."
+
+#: src/exercises/day-2/strings-iterators.md:8
+#, fuzzy
+msgid ""
+"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"pass. Try avoiding allocating a `Vec` for your intermediate results:"
+msgstr ""
+"Copie o seguinte código para <https://play.rust-lang.org/> e faça os testes\n"
+"passar. Tente evitar alocar um `Vec` para seus resultados intermediários:"
+
+#: src/exercises/day-2/strings-iterators.md:16
+#, fuzzy
+msgid ""
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+"pub fn prefix_matches(prefixo: &str, request_path: &str) -> bool {\n"
+"    não implementado!()\n"
+"}"
+
+#: src/exercises/day-2/strings-iterators.md:20
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));"
+msgstr ""
+"#[teste]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));"
+
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/solutions-afternoon.md:146
+#, fuzzy
+msgid ""
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", "
+"\"/v1/parent/publishers\"));\n"
+"}"
+msgstr ""
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publisherslivros\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", "
+"\"/v1/parent/publishers\"));\n"
+"}"
+
+#: src/exercises/day-2/strings-iterators.md:31
+#: src/exercises/day-2/solutions-afternoon.md:151
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));"
+msgstr ""
+"#[teste]\n"
+"fn test_matches_with_wildcard() {\n"
+"    afirmar!(prefix_matches(\n"
+"        \"/v1/editores/*/livros\",\n"
+"        \"/v1/editores/foo/livros\"\n"
+"    ));\n"
+"    afirmar!(prefix_matches(\n"
+"        \"/v1/editores/*/livros\",\n"
+"        \"/v1/editores/barra/livros\"\n"
+"    ));\n"
+"    afirmar!(prefix_matches(\n"
+"        \"/v1/editores/*/livros\",\n"
+"        \"/v1/editores/foo/livros/livro1\"\n"
+"    ));"
+
+#: src/exercises/day-2/strings-iterators.md:46
+#, fuzzy
+msgid ""
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"```"
+msgstr ""
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    afirmar!(!prefix_matches(\n"
+"        \"/v1/editores/*/livros\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"```"
+
+#: src/welcome-day-3.md:1
+#, fuzzy
+msgid "# Welcome to Day 3"
+msgstr "# Bem-vindo ao Dia 3"
+
+#: src/welcome-day-3.md:3
+#, fuzzy
+msgid "Today, we will cover some more advanced topics of Rust:"
+msgstr "Hoje, abordaremos alguns tópicos mais avançados do Rust:"
+
+#: src/welcome-day-3.md:5
+#, fuzzy
+msgid ""
+"* Traits: deriving traits, default methods, and important standard library\n"
+"  traits."
+msgstr ""
+"* Características: características derivadas, métodos padrão e importante "
+"biblioteca padrão\n"
+"  características."
+
+#: src/welcome-day-3.md:8
+#, fuzzy
+msgid ""
+"* Generics: generic data types, generic methods, monomorphization, and "
+"trait\n"
+"  objects."
+msgstr ""
+"* Genéricos: tipos de dados genéricos, métodos genéricos, monomorfização e "
+"trait\n"
+"  objetos."
+
+#: src/welcome-day-3.md:11
+#, fuzzy
+msgid "* Error handling: panics, `Result`, and the try operator `?`."
+msgstr "* Tratamento de erros: panics, `Result` e o operador try `?`."
+
+#: src/welcome-day-3.md:13
+#, fuzzy
+msgid "* Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+"* Testes: testes de unage, testes de documentação e testes de integração."
+
+#: src/welcome-day-3.md:15
+#, fuzzy
+msgid ""
+"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
+"  functions."
+msgstr ""
+"* Rust inseguro: ponteiros brutos, variáveis estáticas, funções inseguras e "
+"funções externas\n"
+"  funções."
+
+#: src/traits.md:1
+#, fuzzy
+msgid "# Traits"
+msgstr "# Características"
+
+#: src/traits.md:3
+#, fuzzy
+msgid ""
+"Rust lets you abstract over types with traits. They're similar to interfaces:"
+msgstr ""
+"Rust permite abstrair tipos com características. Eles são semelhantes às "
+"interfaces:"
+
+#: src/traits.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"trait Greet {\n"
+"    fn say_hello(&self);\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"característica Cumprimentar {\n"
+"    fn say_hello(&self);\n"
+"}"
+
+#: src/traits.md:10
+#, fuzzy
+msgid ""
+"struct Dog {\n"
+"    name: String,\n"
+"}"
+msgstr ""
+"struct Cachorro {\n"
+"    name: String,\n"
+"}"
+
+#: src/traits.md:14
+#, fuzzy
+msgid "struct Cat;  // No name, cats won't respond to it anyway."
+msgstr ""
+"Cat estrutura; // Sem name, os gatos não vão responder de qualquer maneira."
+
+#: src/traits.md:16
+#, fuzzy
+msgid ""
+"impl Greet for Dog {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Wuf, my name is {}!\", self.name);\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Cumprimente para Cachorro {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Wuf, meu name é {}!\", self.name);\n"
+"    }\n"
+"}"
+
+#: src/traits.md:22
+#, fuzzy
+msgid ""
+"impl Greet for Cat {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Miau!\");\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Cumprimente para o gato {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Miau!\");\n"
+"    }\n"
+"}"
+
+#: src/traits.md:28
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let pets: Vec<Box<dyn Greet>> = vec![\n"
+"        Box::new(Dog { name: String::from(\"Fido\") }),\n"
+"        Box::new(Cat),\n"
+"    ];\n"
+"    for pet in pets {\n"
+"        pet.say_hello();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let pets: Vec<Box<dyn Greet>> = vec![\n"
+"        Box::new(Cachorro { name: String::from(\"Fido\") }),\n"
+"        Caixa::novo(Gato),\n"
+"    ];\n"
+"    for animal de estimação em animais de estimação {\n"
+"        pet.say_hello();\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/traits.md:41
+#, fuzzy
+msgid ""
+"* Traits may specify pre-implemented (default) methods and methods that "
+"users are required to implement themselves. Methods with default "
+"implementations can rely on required methods.\n"
+"* Types that implement a given trait may be of different sizes. This makes "
+"it impossible to have things like `Vec<Greet>` in the example above.\n"
+"* `dyn Greet` is a way to tell the compiler about a dynamically sized type "
+"that implements `Greet`.\n"
+"* In the example, `pets` holds Fat Pointers to objects that implement "
+"`Greet`. The Fat Pointer consists of two components, a pointer to the actual "
+"object and a pointer to the virtual method table for the `Greet` "
+"implementation of that particular object."
+msgstr ""
+"* Traits podem especificar métodos pré-implementados (padrão) e métodos que "
+"os usuários devem implementar por conta própria. Os métodos com "
+"implementações padrão podem contar com os métodos necessários.\n"
+"* Os tipos que implementam uma determinada característica podem ser de "
+"tamanhos diferentes. Isso torna impossível ter coisas como `Vec<Greet>` no "
+"exemplo acima.\n"
+"* `dyn Greet` é uma maneira de dizer ao compilador sobre um tipo de tamanho "
+"dinâmico que implementa `Greet`.\n"
+"* No exemplo, `pets` mantém Fat Pointers para objetos que implementam "
+"`Greet`. O Fat Pointer consiste em dois componentes, um ponteiro para o "
+"objeto real e um ponteiro para a tabela de métodos virtuais para a "
+"implementação `Greet` desse objeto em particular."
+
+#: src/traits.md:46
+#, fuzzy
+msgid ""
+"Compare these outputs in the above example:\n"
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), "
+"std::mem::size_of::<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), "
+"std::mem::size_of::<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
+"```"
+msgstr ""
+"Compare essas saídas no exemplo acima:\n"
+"```rust, ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), "
+"std::mem::size_of::<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), "
+"std::mem::size_of::<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
+"```"
+
+#: src/traits/deriving-traits.md:1
+#, fuzzy
+msgid "# Deriving Traits"
+msgstr "# traits derivados"
+
+#: src/traits/deriving-traits.md:3
+#, fuzzy
+msgid "You can let the compiler derive a number of traits:"
+msgstr "Você pode deixar o compilador derivar uma série de características:"
+
+#: src/traits/deriving-traits.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Clone, PartialEq, Eq, Default)]\n"
+"struct Player {\n"
+"    name: String,\n"
+"    strength: u8,\n"
+"    hit_points: u8,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug, Clone, PartialEq, Eq, Default)]\n"
+"jogador struct {\n"
+"    name: String,\n"
+"    força: u8,\n"
+"    hit_points: u8,\n"
+"}"
+
+#: src/traits/deriving-traits.md:13
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let p1 = Player::default();\n"
+"    let p2 = p1.clone();\n"
+"    println!(\"Is {:?}\\n"
+"equal to {:?}?\\n"
+"The answer is {}!\", &p1, &p2,\n"
+"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let p1 = Player::default();\n"
+"    let p2 = p1.clone();\n"
+"    println!(\"É {:?}\\n"
+"egual a {:?}?\\n"
+"A resposta é {}!\", &p1, &p2,\n"
+"             if p1 == p2 { \"sim\" } else { \"não\" });\n"
+"}\n"
+"```"
+
+#: src/traits/default-methods.md:1
+#, fuzzy
+msgid "# Default Methods"
+msgstr "# Métodos Padrão"
+
+#: src/traits/default-methods.md:3
+#, fuzzy
+msgid "Traits can implement behavior in terms of other trait methods:"
+msgstr ""
+"As características podem implementar o comportamento em termos de outros "
+"métodos de característica:"
+
+#: src/traits/default-methods.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"trait Equals {\n"
+"    fn equal(&self, other: &Self) -> bool;\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"característica é igual a {\n"
+"    fn igual(&self, outro: &Self) -> bool;\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.igual(outro)\n"
+"    }\n"
+"}"
+
+#: src/traits/default-methods.md:13
+#, fuzzy
+msgid "#[derive(Debug)]\nstruct Centimeter(i16);"
+msgstr "#[derive(Debug)]\nstruct Centímetro(i16);"
+
+#: src/traits/default-methods.md:16
+#, fuzzy
+msgid ""
+"impl Equals for Centimeter {\n"
+"    fn equal(&self, other: &Centimeter) -> bool {\n"
+"        self.0 == other.0\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Equals for Centimeter {\n"
+"    fn equal(&self, other: &Centimeter) -> bool {\n"
+"        auto.0 == outro.0\n"
+"    }\n"
+"}"
+
+#: src/traits/default-methods.md:22
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let a = Centimeter(10);\n"
+"    let b = Centimeter(20);\n"
+"    println!(\"{a:?} equals {b:?}: {}\", a.equal(&b));\n"
+"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equal(&b));\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let a = Centímetro(10);\n"
+"    let b = Centímetro(20);\n"
+"    println!(\"{a:?} é igual a {b:?}: {}\", a.equal(&b));\n"
+"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equal(&b));\n"
+"}\n"
+"```"
+
+#: src/traits/important-traits.md:1
+#, fuzzy
+msgid "# Important Traits"
+msgstr "# traits importantes"
+
+#: src/traits/important-traits.md:3
+#, fuzzy
+msgid ""
+"We will now look at some of the most common traits of the Rust standard "
+"library:"
+msgstr ""
+"Veremos agora algumas das características mais comuns da biblioteca padrão "
+"do Rust:"
+
+#: src/traits/important-traits.md:5
+#, fuzzy
+msgid ""
+"* `Iterator` and `IntoIterator` used in `for` loops,\n"
+"* `From` and `Into` used to convert values,\n"
+"* `Read` and `Write` used for IO,\n"
+"* `Add`, `Mul`, ... used for operator overloading, and\n"
+"* `Drop` used for defining destructors."
+msgstr ""
+"* `Iterator` e `IntoIterator` usados em loops `for`,\n"
+"* `From` e `Into` usados para converter valores,\n"
+"* `Read` e `Write` usados para IO,\n"
+"* `Add`, `Mul`, ... usado para sobrecargo do operador e\n"
+"* `Drop` usado para definir destruidores."
+
+#: src/traits/iterator.md:1
+#, fuzzy
+msgid "# Iterators"
+msgstr "# Iteradores"
+
+#: src/traits/iterator.md:3
+#, fuzzy
+msgid "You can implement the `Iterator` trait on your own types:"
+msgstr "Você pode implementar o trait `Iterator` em seus próprios tipos:"
+
+#: src/traits/iterator.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"struct Fibonacci {\n"
+"    curr: u32,\n"
+"    next: u32,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"struct Fibonacci {\n"
+"    atual: u32,\n"
+"    próximo: u32,\n"
+"}"
+
+#: src/traits/iterator.md:11
+#, fuzzy
+msgid "impl Iterator for Fibonacci {\n    type Item = u32;"
+msgstr "impl Iterador para Fibonacci {\n    type Item = u32;"
+
+#: src/traits/iterator.md:14
+#, fuzzy
+msgid ""
+"    fn next(&mut self) -> Option<Self::Item> {\n"
+"        let new_next = self.curr + self.next;\n"
+"        self.curr = self.next;\n"
+"        self.next = new_next;\n"
+"        Some(self.curr)\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn next(&mut self) -> Option<Self::Item> {\n"
+"        let new_next = self.curr + self.next;\n"
+"        self.curr = self.next;\n"
+"        self.próximo = novo_próximo;\n"
+"        Some(self.curr)\n"
+"    }\n"
+"}"
+
+#: src/traits/iterator.md:22
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let fib = Fibonacci { curr: 0, next: 1 };\n"
+"    for (i, n) in fib.enumerate().take(5) {\n"
+"        println!(\"fib({i}): {n}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let fib = Fibonacci { atual: 0, próximo: 1 };\n"
+"    for (i, n) em fib.enumerate().take(5) {\n"
+"        println!(\"fib({i}): {n}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/traits/iterator.md:32
+#, fuzzy
+msgid ""
+"* `IntoIterator` is the trait that makes for loops work. It is implemented "
+"by collection types such as\n"
+"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
+"implement it.\n"
+"* The `Iterator` trait implements many common functional programming "
+"operations over collections \n"
+"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
+"find all the documentation\n"
+"  about them. In Rust these functions should produce the code as efficient "
+"as equivalent imperative\n"
+"  implementations.\n"
+"    \n"
+"</details>"
+msgstr ""
+"* `IntoIterator` é o recurso que faz com que os loops funcionem. É "
+"implementado por tipos de coleção, como\n"
+"  `Vec<T>` e referências a eles, como `&Vec<T>` e `&[T]`. Os intervalos "
+"também o implementam.\n"
+"* O trait `Iterator` implementa muitas operações de programação funcional "
+"comuns sobre coleções\n"
+"  (por exemplo, `mapa`, `filtro`, `redução`, etc). Este é o trait onde você "
+"pode encontrar toda a documentação\n"
+"  sobre eles. Em Rust, essas funções devem produzir o código tão eficiente "
+"quanto o imperativo equivalente\n"
+"  implementações.\n"
+"    \n"
+"</details>"
+
+#: src/traits/from-iterator.md:1
+#, fuzzy
+msgid "# FromIterator"
+msgstr "# FromIterator"
+
+#: src/traits/from-iterator.md:3
+#, fuzzy
+msgid "`FromIterator` lets you build a collection from an `Iterator`."
+msgstr "`FromIterator` permite construir uma coleção a partir de um `Iterator`."
+
+#: src/traits/from-iterator.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let primes = vec![2, 3, 5, 7];\n"
+"    let prime_squares = primes.into_iter().map(|prime| prime * "
+"prime).collect::<Vec<_>>();\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let primos = vec![2, 3, 5, 7];\n"
+"    let prime_squares = primes.into_iter().map(|prime| prime * "
+"prime).collect::<Vec<_>>();\n"
+"}\n"
+"```"
+
+#: src/traits/from-iterator.md:14
+#, fuzzy
+msgid ""
+"`Iterator` implements\n"
+"`fn collect<B>(self) -> B\n"
+"where\n"
+"    B: FromIterator<Self::Item>,\n"
+"    iflf: Sized`"
+msgstr ""
+"Implementações `Iterator`\n"
+"`fn coletar<B>(self) -> B\n"
+"Onde\n"
+"    B: FromIterator<Self::Item>,\n"
+"    Auto: Tamanho`"
+
+#: src/traits/from-iterator.md:20
+#, fuzzy
+msgid ""
+"There are also implementations which let you do cool things like convert an\n"
+"`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
+msgstr ""
+"Também existem implementações que permitem fazer coisas legais como "
+"converter um\n"
+"`Iterator<Item = Result<V, E>>` em um `Result<Vec<V>, E>`."
+
+#: src/traits/from-into.md:1
+#, fuzzy
+msgid "# `From` and `Into`"
+msgstr "# `De` e `Into`"
+
+#: src/traits/from-into.md:3
+#, fuzzy
+msgid "Types implement `From` and `Into` to facilitate type conversions:"
+msgstr ""
+"Os tipos implementam `From` e `Into` para facilitar as conversões de tipo:"
+
+#: src/traits/from-into.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s = String::from(\"hello\");\n"
+"    let addr = std::net::Ipv4Addr::from([127, 0, 0, 1]);\n"
+"    let one = i16::from(true);\n"
+"    let bigger = i32::from(123i16);\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let s = String::from(\"olá\");\n"
+"    let addr = std::net::Ipv4Addr::from([127, 0, 0, 1]);\n"
+"    let um = i16::from(true);\n"
+"    let maior = i32::from(123i16);\n"
+"    println!(\"{s}, {addr}, {um}, {maior}\");\n"
+"}\n"
+"```"
+
+#: src/traits/from-into.md:15
+#, fuzzy
+msgid "`Into` is automatically implemented when `From` is implemented:"
+msgstr "`Into` é implementado automaticamente quando `From` é implementado:"
+
+#: src/traits/from-into.md:17
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s: String = \"hello\".into();\n"
+"    let addr: std::net::Ipv4Addr = [127, 0, 0, 1].into();\n"
+"    let one: i16 = true.into();\n"
+"    let bigger: i32 = 123i16.into();\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let s: String = \"olá\".into();\n"
+"    let addr: std::net::Ipv4Addr = [127, 0, 0, 1].into();\n"
+"    let um: i16 = true.into();\n"
+"    let maior: i32 = 123i16.into();\n"
+"    println!(\"{s}, {addr}, {um}, {maior}\");\n"
+"}\n"
+"```"
+
+#: src/traits/from-into.md:27
+#, fuzzy
+msgid ""
+"<details>\n"
+"  \n"
+"* That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too.\n"
+"* When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
+"  Your function will accept types that implement `From` and those that "
+"_only_ implement `Into`.\n"
+"    \n"
+"</details>"
+msgstr ""
+"<details>\n"
+"  \n"
+"* É por isso que é comum implementar apenas `From`, já que seu tipo também "
+"receberá implementação `Into`.\n"
+"* Ao declarar um tipo de entrada de argumento de função como \"qualquer "
+"coisa que possa ser convertida em `String`\", a regra é oposta, você deve "
+"usar `Into`.\n"
+"  Sua função aceitará tipos que implementam `From` e aqueles que _apenas_ "
+"implementam `Into`.\n"
+"    \n"
+"</details>"
+
+#: src/traits/read-write.md:1
+#, fuzzy
+msgid "# `Read` and `Write`"
+msgstr "# `Ler` e `Escrever`"
+
+#: src/traits/read-write.md:3
+#, fuzzy
+msgid "Using `Read` and `BufRead`, you can abstract over `u8` sources:"
+msgstr "Usando `Read` e `BufRead`, você pode abstrair as fontes `u8`:"
+
+#: src/traits/read-write.md:5
+#, fuzzy
+msgid "```rust,editable\nuse std::io::{BufRead, BufReader, Read, Result};"
+msgstr "```rust, editable\nuse std::io::{BufRead, BufReader, Read, Result};"
+
+#: src/traits/read-write.md:8
+#, fuzzy
+msgid ""
+"fn count_lines<R: Read>(reader: R) -> usize {\n"
+"    let buf_reader = BufReader::new(reader);\n"
+"    buf_reader.lines().count()\n"
+"}"
+msgstr ""
+"fn count_lines<R: Read>(leitor: R) -> usize {\n"
+"    let buf_reader = BufReader::new(leitor);\n"
+"    buf_reader.lines().count()\n"
+"}"
+
+#: src/traits/read-write.md:13
+#, fuzzy
+msgid ""
+"fn main() -> Result<()> {\n"
+"    let slice: &[u8] = b\"foo\\n"
+"bar\\n"
+"baz\\n"
+"\";\n"
+"    println!(\"lines in slice: {}\", count_lines(slice));"
+msgstr ""
+"fn main() -> Resultado<()> {\n"
+"    let slice: &[u8] = b\"foo\\n"
+"bar\\n"
+"baz\\n"
+"\";\n"
+"    println!(\"linhas na slice: {}\", count_lines(slice));"
+
+#: src/traits/read-write.md:17
+#, fuzzy
+msgid ""
+"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
+"    println!(\"lines in file: {}\", count_lines(file));\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
+"    println!(\"linhas no arquivo: {}\", count_lines(arquivo));\n"
+"    OK(())\n"
+"}\n"
+"```"
+
+#: src/traits/read-write.md:23
+#, fuzzy
+msgid "Similarly, `Write` lets you abstract over `u8` sinks:"
+msgstr "Da mesma forma, `Write` permite abstrair sobre coletores `u8`:"
+
+#: src/traits/read-write.md:25
+#, fuzzy
+msgid "```rust,editable\nuse std::io::{Result, Write};"
+msgstr "```rust, editable\nuse std::io::{Resultado, Gravar};"
+
+#: src/traits/read-write.md:28
+#, fuzzy
+msgid ""
+"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
+"    writer.write_all(msg.as_bytes())?;\n"
+"    writer.write_all(\"\\n"
+"\".as_bytes())\n"
+"}"
+msgstr ""
+"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
+"    Writer.write_all(msg.as_bytes())?;\n"
+"    escritor.write_all(\"\\n"
+"\".as_bytes())\n"
+"}"
+
+#: src/traits/read-write.md:33
+#, fuzzy
+msgid ""
+"fn main() -> Result<()> {\n"
+"    let mut buffer = Vec::new();\n"
+"    log(&mut buffer, \"Hello\")?;\n"
+"    log(&mut buffer, \"World\")?;\n"
+"    println!(\"Logged: {:?}\", buffer);\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() -> Resultado<()> {\n"
+"    let mut buffer = Vec::new();\n"
+"    log(&mut buffer, \"Olá\"?);\n"
+"    log(&mut buffer, \"Mundo\"?);\n"
+"    println!(\"Logado: {:?}\", buffer);\n"
+"    OK(())\n"
+"}\n"
+"```"
+
+#: src/traits/operators.md:1
+#, fuzzy
+msgid "# `Add`, `Mul`, ..."
+msgstr "# `Adicionar`, `Mul`, ..."
+
+#: src/traits/operators.md:3
+#, fuzzy
+msgid "Operator overloading is implemented via traits in `std::ops`:"
+msgstr ""
+"A sobrecargo do operador é implementada por meio de características em "
+"`std::ops`:"
+
+#: src/traits/operators.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Copy, Clone)]\n"
+"struct Point { x: i32, y: i32 }"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug, Copiar, Clonar)]\n"
+"struct Point { x: i32, y: i32 }"
+
+#: src/traits/operators.md:9 src/exercises/day-2/solutions-morning.md:46
+#, fuzzy
+msgid "impl std::ops::Add for Point {\n    type Output = Self;"
+msgstr "impl std::ops::Adicionar para Point {\n    type Saída = Auto;"
+
+#: src/traits/operators.md:12
+#, fuzzy
+msgid ""
+"    fn add(self, other: Self) -> Self {\n"
+"        Self {x: self.x + other.x, y: self.y + other.y}\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn add(self, other: Self) -> Self {\n"
+"        Eu {x: eu.x + outro.x, y: eu.y + outro.y}\n"
+"    }\n"
+"}"
+
+#: src/traits/operators.md:17
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let p1 = Point { x: 10, y: 20 };\n"
+"    let p2 = Point { x: 100, y: 200 };\n"
+"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let p1 = Point { x: 10, y: 20 };\n"
+"    let p2 = Point { x: 100, y: 200 };\n"
+"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
+"}\n"
+"```"
+
+#: src/traits/operators.md:26 src/traits/drop.md:34
+#, fuzzy
+msgid "Discussion points:"
+msgstr "Points de discussão:"
+
+#: src/traits/operators.md:28
+#, fuzzy
+msgid ""
+"* You could implement `Add` for `&Point`. In which situations is that "
+"useful? \n"
+"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
+"        overloading the operator is not `Copy`, you should consider "
+"overloading\n"
+"        the operator for `&T` as well. This avoids unnecessary cloning on "
+"the\n"
+"        call site.\n"
+"* Why is `Output` an associated type? Could it be made a type parameter?\n"
+"    * Short answer: Type parameters are controlled by the caller, but\n"
+"        associated types (like `Output`) are controlled by the implementor "
+"of a\n"
+"        trait."
+msgstr ""
+"* Você pode implementar `Add` para `&Point`. Em quais situações isso é "
+"útil?\n"
+"    * Resposta: `Add:add` consome `self`. Se digitar `T` para o qual você "
+"está\n"
+"        sobrecarregar o operador não é `Copy`, você deve considerar "
+"sobrecarregar\n"
+"        o operador para `&T` também. Isso evita a clonagem desnecessária no\n"
+"        local de chamada.\n"
+"* Por que `Output` é um tipo associado? Poderia ser feito um parâmetro de "
+"tipo?\n"
+"    * Resposta curta: os parâmetros de tipo são controlados pelo chamador, "
+"mas\n"
+"        tipos associados (como `Output`) são controlados pelo implementador "
+"de um\n"
+"        característica."
+
+#: src/traits/drop.md:1
+#, fuzzy
+msgid "# The `Drop` Trait"
+msgstr "# A característica 'Drop'"
+
+#: src/traits/drop.md:3
+#, fuzzy
+msgid ""
+"Values which implement `Drop` can specify code to run when they go out of "
+"scope:"
+msgstr ""
+"Valores que implementam `Drop` podem especificar o código a ser executado "
+"quando saem do escopo:"
+
+#: src/traits/drop.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"struct Droppable {\n"
+"    name: &'static str,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"struct Soltável {\n"
+"    name: &'static str,\n"
+"}"
+
+#: src/traits/drop.md:10
+#, fuzzy
+msgid ""
+"impl Drop for Droppable {\n"
+"    fn drop(&mut self) {\n"
+"        println!(\"Dropping {}\", self.name);\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Drop para Droppable {\n"
+"    fn drop(&mut self) {\n"
+"        println!(\"Dropping {}\", self.name);\n"
+"    }\n"
+"}"
+
+#: src/traits/drop.md:16
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let a = Droppable { name: \"a\" };\n"
+"    {\n"
+"        let b = Droppable { name: \"b\" };\n"
+"        {\n"
+"            let c = Droppable { name: \"c\" };\n"
+"            let d = Droppable { name: \"d\" };\n"
+"            println!(\"Exiting block B\");\n"
+"        }\n"
+"        println!(\"Exiting block A\");\n"
+"    }\n"
+"    drop(a);\n"
+"    println!(\"Exiting main\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let a = Droppable { name: \"a\" };\n"
+"    {\n"
+"        let b = Droppable { name: \"b\" };\n"
+"        {\n"
+"            let c = Droppable { name: \"c\" };\n"
+"            let d = Droppable { name: \"d\" };\n"
+"            println!(\"Saindo do bloco B\");\n"
+"        }\n"
+"        println!(\"Saindo do bloco A\");\n"
+"    }\n"
+"    soltar(a);\n"
+"    println!(\"Saindo do main\");\n"
+"}\n"
+"```"
+
+#: src/traits/drop.md:36
+#, fuzzy
+msgid ""
+"* Why does not `Drop::drop` take `self`?\n"
+"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
+"of\n"
+"        the block, resulting in another call to `Drop::drop`, and a stack\n"
+"        overflow!\n"
+"* Try replacing `drop(a)` with `a.drop()`."
+msgstr ""
+"* Por que `Drop::drop` não leva `self`?\n"
+"    * Resposta curta: Se tivesse, `std::mem::drop` seria chamado no final "
+"de\n"
+"        o bloco, resultando em outra chamada para `Drop::drop`, e uma pilha\n"
+"        transbordar!\n"
+"* Tente substituir `drop(a)` por `a.drop()`."
+
+#: src/generics.md:1
+#, fuzzy
+msgid "# Generics"
+msgstr "# Genéricos"
+
+#: src/generics.md:3
+#, fuzzy
+msgid ""
+"Rust support generics, which lets you abstract an algorithm (such as "
+"sorting)\n"
+"over the types used in the algorithm."
+msgstr ""
+"Rust oferece suporte a genéricos, que permitem abstrair um algoritmo (como "
+"classificação)\n"
+"sobre os tipos usados no algoritmo."
+
+#: src/generics/data-types.md:1
+#, fuzzy
+msgid "# Generic Data Types"
+msgstr "# Tipos de dados genéricos"
+
+#: src/generics/data-types.md:3
+#, fuzzy
+msgid "You can use generics to abstract over the concrete field type:"
+msgstr "Você pode usar genéricos para abstrair sobre o tipo de campo concreto:"
+
+#: src/generics/data-types.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T> {\n"
+"    x: T,\n"
+"    y: T,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T> {\n"
+"    x: T,\n"
+"    e: T,\n"
+"}"
+
+#: src/generics/data-types.md:12
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let integer = Point { x: 5, y: 10 };\n"
+"    let float = Point { x: 1.0, y: 4.0 };\n"
+"    println!(\"{integer:?} and {float:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let integer = Point { x: 5, y: 10 };\n"
+"    let float = Point { x: 1.0, y: 4.0 };\n"
+"    println!(\"{integer:?} e {float:?}\");\n"
+"}\n"
+"```"
+
+#: src/generics/methods.md:1
+#, fuzzy
+msgid "# Generic Methods"
+msgstr "# Métodos Genéricos"
+
+#: src/generics/methods.md:3
+#, fuzzy
+msgid "You can declare a generic type on your `impl` block:"
+msgstr "Você pode declarar um tipo genérico em seu bloco `impl`:"
+
+#: src/generics/methods.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T>(T, T);"
+msgstr ""
+"```rust, editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T>(T, T);"
+
+#: src/generics/methods.md:9
+#, fuzzy
+msgid ""
+"impl<T> Point<T> {\n"
+"    fn x(&self) -> &T {\n"
+"        &self.0  // + 10\n"
+"    }"
+msgstr ""
+"impl<T> Point<T> {\n"
+"    fn x(&self) -> &T {\n"
+"        &self.0 // + 10\n"
+"    }"
+
+#: src/generics/methods.md:14
+#, fuzzy
+msgid "    // fn set_x(&mut self, x: T)\n}"
+msgstr "    // fn set_x(&mut self, x: T)\n}"
+
+#: src/generics/methods.md:17
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let p = Point(5, 10);\n"
+"    println!(\"p.x = {}\", p.x());\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let p = Point(5, 10);\n"
+"    println!(\"p.x = {}\", p.x());\n"
+"}\n"
+"```"
+
+#: src/generics/methods.md:25
+#, fuzzy
+msgid ""
+"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?\n"
+"    * This is because it is a generic implementation section for generic "
+"type. They are independently generic.\n"
+"    * It means these methods are defined for any `T`.\n"
+"    * It is possible to write `impl Point<u32> { .. }`. \n"
+"      * `Point` is still generic and you can use `Point<f64>`, but methods "
+"in this block will only be available for `Point<u32>`."
+msgstr ""
+"* *P:* Por que `T` é especificado duas vezes em `impl<T> Point<T> {}`? Isso "
+"não é redundante?\n"
+"    * Isso ocorre porque é uma seção de implementação genérica para tipo "
+"genérico. Eles são genéricos de forma independente.\n"
+"    * Significa que esses métodos são definidos para qualquer `T`.\n"
+"    * É possível escrever `Impl Point<u32> { .. }`.\n"
+"      * `Point` ainda é genérico e você pode usar `Point<f64>`, mas os "
+"métodos neste bloco só estarão disponíveis para `Point<u32>`."
+
+#: src/generics/trait-bounds.md:1
+#, fuzzy
+msgid "# Trait Bounds"
+msgstr "# Limites de traits"
+
+#: src/generics/trait-bounds.md:3
+#, fuzzy
+msgid ""
+"When working with generics, you often want to limit the types. You can do "
+"this\n"
+"with `T: Trait` or `impl Trait`:"
+msgstr ""
+"Ao trabalhar com genéricos, muitas vezes você deseja limitar os tipos. Você "
+"consegue fazer isso\n"
+"com `T:Trait` ou `impl Trait`:"
+
+#: src/generics/trait-bounds.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
+"    (a.clone(), a.clone())\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn duplicado<T: Clone>(a: T) -> (T, T) {\n"
+"    (a.clone(), a.clone())\n"
+"}"
+
+#: src/generics/trait-bounds.md:11
+#, fuzzy
+msgid "// struct NotClonable;"
+msgstr "// estrutura NotClonable;"
+
+#: src/generics/trait-bounds.md:13
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let foo = String::from(\"foo\");\n"
+"    let pair = duplicate(foo);\n"
+"    println!(\"{pair:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let foo = String::from(\"foo\");\n"
+"    let par = duplicar(foo);\n"
+"    println!(\"{par:?}\");\n"
+"}\n"
+"```"
+
+#: src/generics/trait-bounds.md:22
+#, fuzzy
+msgid ""
+"Show a `where` clause, students will encounter it when reading code.\n"
+"    \n"
+"```rust,ignore\n"
+"fn duplicate<T>(a: T) -> (T, T)\n"
+"where\n"
+"    T: Clone,\n"
+"{\n"
+"    (a.clone(), a.clone())\n"
+"}\n"
+"```"
+msgstr ""
+"Mostre uma cláusula `where`, os alunos a encontrarão ao ler o código.\n"
+"    \n"
+"```rust, ignore\n"
+"fn duplicado<T>(a: T) -> (T, T)\n"
+"Onde\n"
+"    T: Clone,\n"
+"{\n"
+"    (a.clone(), a.clone())\n"
+"}\n"
+"```"
+
+#: src/generics/trait-bounds.md:33
+#, fuzzy
+msgid ""
+"* It declutters the function signature if you have many parameters.\n"
+"* It has additional features making it more powerful.\n"
+"    * If someone asks, the extra feature is that the type on the left of "
+"\":\" can be arbitrary, like `Option<T>`.\n"
+"    \n"
+"</details>"
+msgstr ""
+"* Organiza a assinatura da função se você tiver muitos parâmetros.\n"
+"* Possui recursos adicionais tornando-o mais poderoso.\n"
+"    * Se alguém perguntar, o recurso extra é que o tipo à esquerda de \":\" "
+"pode ser arbitrário, como `Option<T>`.\n"
+"    \n"
+"</details>"
+
+#: src/generics/impl-trait.md:1
+#, fuzzy
+msgid "# `impl Trait`"
+msgstr "# `Impl Trait`"
+
+#: src/generics/impl-trait.md:3
+#, fuzzy
+msgid ""
+"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"arguments and return values:"
+msgstr ""
+"Semelhante aos limites do trait, uma sintaxe `impl Trait` pode ser usada na "
+"função\n"
+"argumentos e valores de retorno:"
+
+#: src/generics/impl-trait.md:6 src/generics/trait-objects.md:5
+#: src/generics/trait-objects.md:28
+#, fuzzy
+msgid "```rust,editable\nuse std::fmt::Display;"
+msgstr "```rust, editable\nuse std::fmt::Display;"
+
+#: src/generics/impl-trait.md:9
+#, fuzzy
+msgid ""
+"fn get_x(name: impl Display) -> impl Display {\n"
+"    format!(\"Hello {name}\")\n"
+"}"
+msgstr ""
+"fn get_x(name: display impl) -> display impl {\n"
+"    formato!(\"Olá {name}\")\n"
+"}"
+
+#: src/generics/impl-trait.md:13
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let x = get_x(\"foo\");\n"
+"    println!(\"{x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let x = get_x(\"foo\");\n"
+"    println!(\"{x}\");\n"
+"}\n"
+"```"
+
+#: src/generics/impl-trait.md:19
+#, fuzzy
+msgid ""
+"* `impl Trait` cannot be used with the `::<>` turbo fish syntax.\n"
+"* `impl Trait` allows you to work with types which you cannot name."
+msgstr ""
+"* `Impl Trait` não pode ser usado com a sintaxe `::<>` turbo fish.\n"
+"* `Impl Trait` permite que você trabalhe com tipos que você não pode namear."
+
+#: src/generics/impl-trait.md:24
+#, fuzzy
+msgid ""
+"The meaning of `impl Trait` is a bit different in the different positions."
+msgstr ""
+"O significado de 'impl Trait' é um pouco diferente nas diferentes posições."
+
+#: src/generics/impl-trait.md:26
+#, fuzzy
+msgid ""
+"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
+"a trait bound.\n"
+"* For a return type, it means that the return type is some concrete type "
+"that implements the trait,\n"
+"  without naming the type. This can be useful when you don't want to expose "
+"the concrete type in a\n"
+"  public API."
+msgstr ""
+"* Para um parâmetro, `impl Trait` é como um parâmetro genérico anônimo com "
+"um limite de característica.\n"
+"* Para um tipo de retorno, significa que o tipo de retorno é algum tipo "
+"concreto que implementa o trait,\n"
+"  sem namear o tipo. Isso pode ser útil quando você não deseja expor o tipo "
+"concreto em um\n"
+"  API pública."
+
+#: src/generics/impl-trait.md:31
+#, fuzzy
+msgid ""
+"This example is great, because it uses `impl Display` twice. It helps to "
+"explain that\n"
+"nothing here enforces that it is _the same_ `impl Display` type. If we used "
+"a single \n"
+"`T: Display`, it would enforce the constraint that input `T` and return `T` "
+"type are the same type.\n"
+"It would not work for this particular function, as the type we expect as "
+"input is likely not\n"
+"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
+"we'd need two\n"
+"independent generic parameters.\n"
+"    \n"
+"</details>"
+msgstr ""
+"Este exemplo é ótimo, porque usa `impl Display` duas vezes. Isso ajuda a "
+"explicar\n"
+"nada aqui impõe que seja _o mesmo_ tipo `impl Display`. Se usássemos um "
+"único\n"
+"`T: Display`, imporia a restrição de que o tipo `T` de entrada e o tipo `T` "
+"de retorno são do mesmo tipo.\n"
+"Não funcionaria para esta função específica, pois o tipo que esperamos como "
+"entrada provavelmente não é\n"
+"o que `format!` retorna. Se quiséssemos fazer o mesmo através da sintaxe `: "
+"Display`, precisaríamos de dois\n"
+"parâmetros genéricos independentes.\n"
+"    \n"
+"</details>"
+
+#: src/generics/closures.md:1
+#, fuzzy
+msgid "# Closures"
+msgstr "# fechamentos"
+
+#: src/generics/closures.md:3
+#, fuzzy
+msgid ""
+"Closures or lambda expressions have types which cannot be named. However, "
+"they\n"
+"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
+"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
+msgstr ""
+"Closures ou expressões lambda têm tipos que não podem ser nameados. No "
+"entanto, eles\n"
+"implementar especial "
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
+"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) e\n"
+"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) "
+"características:"
+
+#: src/generics/closures.md:8
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
+"    println!(\"Calling function on {input}\");\n"
+"    func(input)\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn apply_with_log(func: impl FnOnce(i32) -> i32, entrada: i32) -> i32 {\n"
+"    println!(\"Chamando função em {input}\");\n"
+"    função(entrada)\n"
+"}"
+
+#: src/generics/closures.md:14
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let add_3 = |x| x + 3;\n"
+"    let mul_5 = |x| x * 5;"
+msgstr ""
+"fn main() {\n"
+"    let add_3 = |x| x + 3;\n"
+"    let mul_5 = |x| x * 5;"
+
+#: src/generics/closures.md:18
+#, fuzzy
+msgid ""
+"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
+"    println!(\"mul_5: {}\", apply_with_log(mul_5, 20));\n"
+"}\n"
+"```"
+msgstr ""
+"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
+"    println!(\"mul_5: {}\", apply_with_log(mul_5, 20));\n"
+"}\n"
+"```"
+
+#: src/generics/closures.md:25
+#, fuzzy
+msgid ""
+"If you have an `FnOnce`, you may only call it once. It might consume "
+"captured values."
+msgstr ""
+"Se você tiver um `FnOnce`, poderá chamá-lo apenas uma vez. Pode consumir "
+"valores capturados."
+
+#: src/generics/closures.md:27
+#, fuzzy
+msgid ""
+"An `FnMut` might mutate captured values, so you can call it multiple times "
+"but not concurrently."
+msgstr ""
+"Um `FnMut` pode alterar os valores capturados, então você pode chamá-lo "
+"várias vezes, mas não simultaneamente."
+
+#: src/generics/closures.md:29
+#, fuzzy
+msgid ""
+"An `Fn` neither consumes nor mutates captured values, or perhaps captures "
+"nothing at all, so it can\n"
+"be called multiple times concurrently."
+msgstr ""
+"Um `Fn` não consome nem muda os valores capturados, ou talvez não capture "
+"nada, então pode\n"
+"ser chamado várias vezes simultaneamente."
+
+#: src/generics/closures.md:32
+#, fuzzy
+msgid ""
+"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
+"I.e. you can use an\n"
+"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
+"an `FnMut` or `FnOnce`\n"
+"is called for."
+msgstr ""
+"`FnMut` é um subtipo de `FnOnce`. `Fn` é um subtipo de `FnMut` e `FnOnce`. "
+"ou seja você pode usar um\n"
+"`FnMut` sempre que um `FnOnce` é chamado, e você pode usar um `Fn` sempre "
+"que um `FnMut` ou `FnOnce`\n"
+"é chamado."
+
+#: src/generics/closures.md:36
+#, fuzzy
+msgid "`move` closures only implement `FnOnce`."
+msgstr "Fechamentos `move` implementam apenas `FnOnce`."
+
+#: src/generics/monomorphization.md:1
+#, fuzzy
+msgid "# Monomorphization"
+msgstr "# Monomorfização"
+
+#: src/generics/monomorphization.md:3
+#, fuzzy
+msgid "Generic code is turned into non-generic code based on the call sites:"
+msgstr ""
+"O código genérico é transformado em código não genérico com base nos sites "
+"de chamadas:"
+
+#: src/generics/monomorphization.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let integer = Some(5);\n"
+"    let float = Some(5.0);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let integer = Some(5);\n"
+"    let flutuar = Some(5.0);\n"
+"}\n"
+"```"
+
+#: src/generics/monomorphization.md:12
+#, fuzzy
+msgid "behaves as if you wrote"
+msgstr "se comporta como se você tivesse escrito"
+
+#: src/generics/monomorphization.md:14
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"enum Option_i32 {\n"
+"    Some(i32),\n"
+"    None,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"enum Option_i32 {\n"
+"    Alguns (i32),\n"
+"    Nenhum,\n"
+"}"
+
+#: src/generics/monomorphization.md:20
+#, fuzzy
+msgid ""
+"enum Option_f64 {\n"
+"    Some(f64),\n"
+"    None,\n"
+"}"
+msgstr ""
+"enum Option_f64 {\n"
+"    Alguns (f64),\n"
+"    Nenhum,\n"
+"}"
+
+#: src/generics/monomorphization.md:25
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let integer = Option_i32::Some(5);\n"
+"    let float = Option_f64::Some(5.0);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let integer = Option_i32::Some(5);\n"
+"    let float = Option_f64::Some(5.0);\n"
+"}\n"
+"```"
+
+#: src/generics/monomorphization.md:31
+#, fuzzy
+msgid ""
+"This is a zero-cost abstraction: you get exactly the same result as if you "
+"had\n"
+"hand-coded the data structures without the abstraction."
+msgstr ""
+"Esta é uma abstração de custo zero: você obtém exatamente o mesmo resultado "
+"como se tivesse\n"
+"codificou manualmente as Structs de dados sem a abstração."
+
+#: src/generics/trait-objects.md:1
+#, fuzzy
+msgid "# Trait Objects"
+msgstr "# Objetos de característica"
+
+#: src/generics/trait-objects.md:3
+#, fuzzy
+msgid "We've seen how a function can take arguments which implement a trait:"
+msgstr ""
+"Vimos como uma função pode receber argumentos que implementam uma "
+"característica:"
+
+#: src/generics/trait-objects.md:8
+#, fuzzy
+msgid ""
+"fn print<T: Display>(x: T) {\n"
+"    println!(\"Your value: {}\", x);\n"
+"}"
+msgstr ""
+"fn print<T: Display>(x: T) {\n"
+"    println!(\"Seu valor: {}\", x);\n"
+"}"
+
+#: src/generics/trait-objects.md:12
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    print(123);\n"
+"    print(\"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    imprimir(123);\n"
+"    imprima(\"Olá\");\n"
+"}\n"
+"```"
+
+#: src/generics/trait-objects.md:18
+#, fuzzy
+msgid ""
+"However, how can we store a collection of mixed types which implement "
+"`Display`?"
+msgstr ""
+"No entanto, como podemos armazenar uma coleção de tipos mistos que "
+"implementam `Display`?"
+
+#: src/generics/trait-objects.md:20
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let xs = vec![123, \"Hello\"];\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let xs = vec![123, \"Olá\"];\n"
+"}\n"
+"```"
+
+#: src/generics/trait-objects.md:26
+#, fuzzy
+msgid "For this, we need _trait objects_:"
+msgstr "Para isso, precisamos de _trait objects_:"
+
+#: src/generics/trait-objects.md:31
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let xs: Vec<Box<dyn Display>> = vec![Box::new(123), "
+"Box::new(\"Hello\")];\n"
+"    for x in xs {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let xs: Vec<Box<dyn Display>> = vec![Box::new(123), "
+"Box::new(\"Hello\")];\n"
+"    for x em xs {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/generics/trait-objects.md:39
+#, fuzzy
+msgid "Memory layout after allocating `xs`:"
+msgstr "Layout da memória após alocar `xs`:"
+
+#: src/generics/trait-objects.md:41
+#, fuzzy
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- - -.\n"
+":                           :     :                                          "
+"     :\n"
+":    xs                     :     :                                          "
+"     :\n"
+":   +-----------+-------+   :     :   +-----+-----+                          "
+"     :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o |                          "
+"     :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-+                          "
+"     :\n"
+":   | capacity  |     2 |   :     :     | |   | |   "
+"+----+----+----+----+----+    :\n"
+":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  "
+"|    :\n"
+":                           :     :     | |   |     "
+"+----+----+----+----+----+    :\n"
+"`- - - - - - - - - - - - - -'     :     | |   |                              "
+"     :\n"
+"                                  :     | |   |     "
+"+-------------------------+   :\n"
+"                                  :     | |   '---->| \"<str as "
+"Display>::fmt\" |   :\n"
+"                                  :     | |         "
+"+-------------------------+   :\n"
+"                                  :     | |                                  "
+"     :\n"
+"                                  :     | |   +----+----+----+----+          "
+"     :\n"
+"                                  :     | '-->| 7b | 00 | 00 | 00 |          "
+"     :\n"
+"                                  :     |     +----+----+----+----+          "
+"     :\n"
+"                                  :     |                                    "
+"     :\n"
+"                                  :     |     +-------------------------+    "
+"     :\n"
+"                                  :     '---->| \"<i32 as Display>::fmt\" |  "
+"       :\n"
+"                                  :           +-------------------------+    "
+"     :\n"
+"                                  :                                          "
+"     :\n"
+"                                  :                                          "
+"     :\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- - -'\n"
+"```"
+msgstr ""
+"```bob\n"
+" Pilha\n"
+".- - - - - - - - - - - - - -. .- - - - - - - - - - - - - - - - - - - - - - "
+"-.\n"
+": : : :\n"
+": xs : : :\n"
+": +-----------+-------+ : : +-----+-----+ :\n"
+": | ptr | o---+---+-----+-->| oo | oo | :\n"
+": | len | 2 | : : +-|-|-+-|-|-+ :\n"
+": | capacage | 2 | : : | | | | +----+----+----+----+----+ :\n"
+": +-----------+-------+ : : | | | '-->| H | e | eu | eu | o | :\n"
+": : : | | | +----+----+----+----+----+:\n"
+"`- - - - - - - - - - - - - -' : | | | :\n"
+"                                  : | | | +-------------------------+ :\n"
+"                                  : | | '---->| \"<str as Display>::fmt\" | "
+":\n"
+"                                  : | | +-------------------------+ :\n"
+"                                  : | | :\n"
+"                                  : | | +----+----+----+----+:\n"
+"                                  : | '-->| 7b | 00 | 00 | 00 | :\n"
+"                                  : | +----+----+----+----+ :\n"
+"                                  : | :\n"
+"                                  : | +-------------------------+ :\n"
+"                                  : '---->| \"<i32 como Display>::fmt\" | :\n"
+"                                  : +-------------------------+ :\n"
+"                                  : :\n"
+"                                  : :\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- - -'\n"
+"```"
+
+#: src/generics/trait-objects.md:69
+#, fuzzy
+msgid ""
+"Similarly, you need a trait object if you want to return different values\n"
+"implementing a trait:"
+msgstr ""
+"Da mesma forma, você precisa de um objeto de característica se quiser "
+"retornar valores diferentes\n"
+"implementando uma característica:"
+
+#: src/generics/trait-objects.md:72
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn numbers(n: i32) -> Box<dyn Iterator<Item=i32>> {\n"
+"    if n > 0 {\n"
+"        Box::new(0..n)\n"
+"    } else {\n"
+"        Box::new((n..0).rev())\n"
+"    }\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"números fn(n: i32) -> Box<dyn Iterator<Item=i32>> {\n"
+"    if n > 0 {\n"
+"        Caixa::novo(0..n)\n"
+"    } else {\n"
+"        Caixa::novo((n..0).rev())\n"
+"    }\n"
+"}"
+
+#: src/generics/trait-objects.md:81
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    println!(\"{:?}\", numbers(-5).collect::<Vec<_>>());\n"
+"    println!(\"{:?}\", numbers(5).collect::<Vec<_>>());\n"
+"}"
+msgstr ""
+"fn main() {\n"
+"    println!(\"{:?}\", números(-5).collect::<Vec<_>>());\n"
+"    println!(\"{:?}\", números(5).collect::<Vec<_>>());\n"
+"}"
+
+#: src/exercises/day-3/morning.md:1
+#, fuzzy
+msgid "# Day 3: Morning Exercises"
+msgstr "# Dia 3: Exercícios matinais"
+
+#: src/exercises/day-3/morning.md:3
+#, fuzzy
+msgid "We will design a classical GUI library traits and trait objects."
+msgstr ""
+"Vamos projetar uma biblioteca clássica de traits de GUI e objetos de trait."
+
+#: src/exercises/day-3/simple-gui.md:1
+#, fuzzy
+msgid "# A Simple GUI Library"
+msgstr "# Uma biblioteca GUI simples"
+
+#: src/exercises/day-3/simple-gui.md:3
+#, fuzzy
+msgid ""
+"Let us design a classical GUI library using our new knowledge of traits and\n"
+"trait objects."
+msgstr ""
+"Vamos projetar uma biblioteca GUI clássica usando nosso novo conhecimento de "
+"características e\n"
+"objetos de traits."
+
+#: src/exercises/day-3/simple-gui.md:6
+#, fuzzy
+msgid "We will have a number of widgets in our library:"
+msgstr "Teremos vários widgets em nossa biblioteca:"
+
+#: src/exercises/day-3/simple-gui.md:8
+#, fuzzy
+msgid ""
+"* `Window`: has a `title` and contains other widgets.\n"
+"* `Button`: has a `label` and a callback function which is invoked when the\n"
+"  button is pressed.\n"
+"* `Label`: has a `label`."
+msgstr ""
+"* `Janela`: tem um `título` e contém outros widgets.\n"
+"* `Button`: tem um `label` e uma função de callback que é invocada quando o\n"
+"  botão é pressionado.\n"
+"* `Label`: tem um `label`."
+
+#: src/exercises/day-3/simple-gui.md:13
+#, fuzzy
+msgid "The widgets will implement a `Widget` trait, see below."
+msgstr "Os widgets irão implementar uma característica `Widget`, veja abaixo."
+
+#: src/exercises/day-3/simple-gui.md:15
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"`draw_into` methods so that you implement the `Widget` trait:"
+msgstr ""
+"Copie o código abaixo para <https://play.rust-lang.org/>, preencha os campos "
+"que faltam\n"
+"métodos `draw_into` para que você implemente o trait `Widget`:"
+
+#: src/exercises/day-3/simple-gui.md:18
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+#, fuzzy
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_imports, unused_variables, dead_code)]"
+msgstr ""
+"```rust,should_panic\n"
+"// TODO: remova isso quando terminar sua implementação.\n"
+"#![allow(unused_imports, used_variables, dead_code)]"
+
+#: src/exercises/day-3/simple-gui.md:22
+#, fuzzy
+msgid ""
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;"
+msgstr ""
+"Pub trait Widget {\n"
+"    /// Largura natural de `self`.\n"
+"    fn width(&self) -> usar;"
+
+#: src/exercises/day-3/simple-gui.md:26
+#: src/exercises/day-3/solutions-morning.md:27
+#, fuzzy
+msgid ""
+"    /// Draw the widget into a buffer.\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);"
+msgstr ""
+"    /// Desenha o widget em um buffer.\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);"
+
+#: src/exercises/day-3/simple-gui.md:29
+#: src/exercises/day-3/solutions-morning.md:30
+#, fuzzy
+msgid ""
+"    /// Draw the widget on standard output.\n"
+"    fn draw(&self) {\n"
+"        let mut buffer = String::new();\n"
+"        self.draw_into(&mut buffer);\n"
+"        println!(\"{}\", &buffer);\n"
+"    }\n"
+"}"
+msgstr ""
+"    /// Desenha o widget na saída padrão.\n"
+"    fn desenhar(&self) {\n"
+"        let buffer mudo = String::new();\n"
+"        self.draw_into(&mut buffer);\n"
+"        println!(\"{}\", &buffer);\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:37
+#: src/exercises/day-3/solutions-morning.md:38
+#, fuzzy
+msgid ""
+"pub struct Label {\n"
+"    label: String,\n"
+"}"
+msgstr ""
+"pub struct Rótulo {\n"
+"    rótulo: Cadeia de caracteres,\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:41
+#: src/exercises/day-3/solutions-morning.md:42
+#, fuzzy
+msgid ""
+"impl Label {\n"
+"    fn new(label: &str) -> Label {\n"
+"        Label {\n"
+"            label: label.to_owned(),\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Rótulo {\n"
+"    fn new(rótulo: &str) -> Rótulo {\n"
+"        Rótulo {\n"
+"            label: label.to_own(),\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:49
+#: src/exercises/day-3/solutions-morning.md:50
+#, fuzzy
+msgid ""
+"pub struct Button {\n"
+"    label: Label,\n"
+"    callback: Box<dyn FnMut()>,\n"
+"}"
+msgstr ""
+"Pub struct Botão {\n"
+"    etiqueta: etiqueta,\n"
+"    retorno de chamada: Box<dyn FnMut()>,\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:54
+#: src/exercises/day-3/solutions-morning.md:55
+#, fuzzy
+msgid ""
+"impl Button {\n"
+"    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
+"        Button {\n"
+"            label: Label::new(label),\n"
+"            callback,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"botão impl {\n"
+"    fn new(label: &str, callback: Box<dyn FnMut()>) -> Botão {\n"
+"        Botão {\n"
+"            rótulo: Rótulo::novo(rótulo),\n"
+"            ligar de volta,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:63
+#: src/exercises/day-3/solutions-morning.md:64
+#, fuzzy
+msgid ""
+"pub struct Window {\n"
+"    title: String,\n"
+"    widgets: Vec<Box<dyn Widget>>,\n"
+"}"
+msgstr ""
+"pub struct Janela {\n"
+"    título: String,\n"
+"    widgets: Vec<Box<dyn Widget>>,\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:68
+#: src/exercises/day-3/solutions-morning.md:69
+#, fuzzy
+msgid ""
+"impl Window {\n"
+"    fn new(title: &str) -> Window {\n"
+"        Window {\n"
+"            title: title.to_owned(),\n"
+"            widgets: Vec::new(),\n"
+"        }\n"
+"    }"
+msgstr ""
+"impl Janela {\n"
+"    fn new(título: &str) -> Janela {\n"
+"        Janela {\n"
+"            título: title.to_own(),\n"
+"            widgets: Vec::new(),\n"
+"        }\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:76
+#: src/exercises/day-3/solutions-morning.md:77
+#, fuzzy
+msgid ""
+"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"        self.widgets.push(widget);\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"        self.widgets.push(widget);\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:82
+#, fuzzy
+msgid ""
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl Widget para etiqueta {\n"
+"    fn width(&self) -> use {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:87 src/exercises/day-3/simple-gui.md:97
+#: src/exercises/day-3/simple-gui.md:107
+#, fuzzy
+msgid ""
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        não implementado!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:92
+#, fuzzy
+msgid ""
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl Widget para botão {\n"
+"    fn width(&self) -> use {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:102
+#, fuzzy
+msgid ""
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl Widget para Janela {\n"
+"    fn width(&self) -> use {\n"
+"        não implementado!()\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:112
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\",\n"
+"        Box::new(|| println!(\"You clicked the button!\")),\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"Esta é uma pequena demonstração "
+"de GUI de texto.\")));\n"
+"    window.add_widget(Caixa::novo(Botão::novo(\n"
+"        \"Clique em mim!\",\n"
+"        Box::new(|| println!(\"Você clicou no botão!\")),\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"```"
+
+#: src/exercises/day-3/simple-gui.md:123
+#, fuzzy
+msgid "The output of the above program can be something simple like this:"
+msgstr "A saída do programa acima pode ser algo simples como isto:"
+
+#: src/exercises/day-3/simple-gui.md:125
+#, fuzzy
+msgid ""
+"```text\n"
+"========\n"
+"Rust GUI Demo 1.23\n"
+"========"
+msgstr ""
+"```texto\n"
+"========\n"
+"Demonstração da GUI do Rust 1.23\n"
+"========"
+
+#: src/exercises/day-3/simple-gui.md:130
+#, fuzzy
+msgid "This is a small text GUI demo."
+msgstr "Esta é uma pequena demonstração de GUI de texto."
+
+#: src/exercises/day-3/simple-gui.md:132
+#, fuzzy
+msgid "| Click me! |\n```"
+msgstr "| Clique em mim! |\n```"
+
+#: src/exercises/day-3/simple-gui.md:135
+#, fuzzy
+msgid ""
+"If you want to draw aligned text, you can use the\n"
+"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
+"formatting operators. In particular, notice how you can pad with different\n"
+"characters (here a `'/'`) and how you can control alignment:"
+msgstr ""
+"Se você quiser desenhar texto alinhado, você pode usar o\n"
+"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
+"operadores de formatação. Em particular, observe como você pode preencher "
+"com diferentes\n"
+"caracteres (aqui um `'/'`) e como você pode controlar o alinhamento:"
+
+#: src/exercises/day-3/simple-gui.md:140
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let width = 10;\n"
+"    println!(\"left aligned:  |{:/<width$}|\", \"foo\");\n"
+"    println!(\"centered:      |{:/^width$}|\", \"foo\");\n"
+"    println!(\"right aligned: |{:/>width$}|\", \"foo\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    deixar largura = 10;\n"
+"    println!(\"alinhado à esquerda: |{:/<width$}|\", \"foo\");\n"
+"    println!(\"centralizado: |{:/^width$}|\", \"foo\");\n"
+"    println!(\"alinhado a direita: |{:/>width$}|\", \"foo\");\n"
+"}\n"
+"```"
+
+#: src/exercises/day-3/simple-gui.md:149
+#, fuzzy
+msgid ""
+"Using such alignment tricks, you can for example produce output like this:"
+msgstr ""
+"Usando esses truques de alinhamento, você pode, por exemplo, produzir uma "
+"saída como esta:"
+
+#: src/exercises/day-3/simple-gui.md:151
+#, fuzzy
+msgid ""
+"```text\n"
+"+--------------------------------+\n"
+"|       Rust GUI Demo 1.23       |\n"
+"+================================+\n"
+"| This is a small text GUI demo. |\n"
+"| +-----------+                  |\n"
+"| | Click me! |                  |\n"
+"| +-----------+                  |\n"
+"+--------------------------------+\n"
+"```"
+msgstr ""
+"```texto\n"
+"+--------------------------------+\n"
+"| Rust GUI Demonstração 1.23 |\n"
+"+==================================+\n"
+"| Esta é uma pequena demonstração de GUI de texto. |\n"
+"| +-----------+ |\n"
+"| | Clique em mim! | |\n"
+"| +-----------+ |\n"
+"+--------------------------------+\n"
+"```"
+
+#: src/error-handling.md:1
+#, fuzzy
+msgid "# Error Handling"
+msgstr "# Manipulação de erros"
+
+#: src/error-handling.md:3
+#, fuzzy
+msgid "Error handling in Rust is done using explicit control flow:"
+msgstr ""
+"O tratamento de erros no Rust é feito usando o fluxo de controle explícito:"
+
+#: src/error-handling.md:5
+#, fuzzy
+msgid ""
+"* Functions that can have errors list this in their return type,\n"
+"* There are no exceptions."
+msgstr ""
+"* As funções que podem ter erros listam isso em seu tipo de retorno,\n"
+"* Não há exceções."
+
+#: src/error-handling/panics.md:1
+#, fuzzy
+msgid "# Panics"
+msgstr "# Pânico"
+
+#: src/error-handling/panics.md:3
+#, fuzzy
+msgid "Rust will trigger a panic if a fatal error happens at runtime:"
+msgstr "O Rust acionará um pânico se um erro fatal ocorrer em tempo de execução:"
+
+#: src/error-handling/panics.md:5
+#, fuzzy
+msgid ""
+"```rust,editable,should_panic\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    println!(\"v[100]: {}\", v[100]);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable,should_panic\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    println!(\"v[100]: {}\", v[100]);\n"
+"}\n"
+"```"
+
+#: src/error-handling/panics.md:12
+#, fuzzy
+msgid ""
+"* Panics are for unrecoverable and unexpected errors.\n"
+"  * Panics are symptoms of bugs in the program.\n"
+"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+msgstr ""
+"* Panics são para erros irrecuperáveis e inesperados.\n"
+"  * Pânicos são sintomas de bugs no programa.\n"
+"* Use APIs sem pânico (como `Vec::get`) se travar não for aceitável."
+
+#: src/error-handling/panic-unwind.md:1
+#, fuzzy
+msgid "# Catching the Stack Unwinding"
+msgstr "# Pegando a pilha desenrolando"
+
+#: src/error-handling/panic-unwind.md:3
+#, fuzzy
+msgid ""
+"By default, a panic will cause the stack to unwind. The unwinding can be "
+"caught:"
+msgstr ""
+"Por padrão, um pânico fará com que a pilha se desenrole. O desenrolamento "
+"pode ser capturado:"
+
+#: src/error-handling/panic-unwind.md:5
+#, fuzzy
+msgid "```rust\nuse std::panic;"
+msgstr "```rust\nuse padrão::pânico;"
+
+#: src/error-handling/panic-unwind.md:8
+#, fuzzy
+msgid ""
+"let result = panic::catch_unwind(|| {\n"
+"    println!(\"hello!\");\n"
+"});\n"
+"assert!(result.is_ok());"
+msgstr ""
+"let result = panic::catch_unwind(|| {\n"
+"    println!(\"Olá!\");\n"
+"});\n"
+"assert!(result.is_ok());"
+
+#: src/error-handling/panic-unwind.md:13
+#, fuzzy
+msgid ""
+"let result = panic::catch_unwind(|| {\n"
+"    panic!(\"oh no!\");\n"
+"});\n"
+"assert!(result.is_err());\n"
+"```"
+msgstr ""
+"let result = panic::catch_unwind(|| {\n"
+"    pânico!(\"oh não!\");\n"
+"});\n"
+"assert!(result.is_err());\n"
+"```"
+
+#: src/error-handling/panic-unwind.md:19
+#, fuzzy
+msgid ""
+"* This can be useful in servers which should keep running even if a single\n"
+"  request crashes.\n"
+"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+"* Isso pode ser útil em servidores que devem continuar rodando mesmo se um "
+"único\n"
+"  pedido falha.\n"
+"* Isso não funciona se `panic = 'abort'` estiver definido em seu "
+"`Cargo.toml`."
+
+#: src/error-handling/result.md:1
+#, fuzzy
+msgid "# Structured Error Handling with `Result`"
+msgstr "# Tratamento de erro estruturado com `Result`"
+
+#: src/error-handling/result.md:3
+#, fuzzy
+msgid ""
+"We have already seen the `Result` enum. This is used pervasively when errors "
+"are\n"
+"expected as part of normal operation:"
+msgstr ""
+"Já vimos a Enum `Result`. Isso é usado amplamente quando os erros são\n"
+"esperado como parte da operação normal:"
+
+#: src/error-handling/result.md:6
+#, fuzzy
+msgid ""
+"```rust\n"
+"use std::fs::File;\n"
+"use std::io::Read;"
+msgstr ""
+"```rust\n"
+"use std::fs::Arquivo;\n"
+"use std::io::Read;"
+
+#: src/error-handling/result.md:10
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let file = File::open(\"diary.txt\");\n"
+"    match file {\n"
+"        Ok(mut file) => {\n"
+"            let mut contents = String::new();\n"
+"            file.read_to_string(&mut contents);\n"
+"            println!(\"Dear diary: {contents}\");\n"
+"        },\n"
+"        Err(err) => {\n"
+"            println!(\"The diary could not be opened: {err}\");\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let file = File::open(\"diary.txt\");\n"
+"    arquivo correspondente {\n"
+"        Ok(arquivo mut) => {\n"
+"            let mut content = String::new();\n"
+"            file.read_to_string(&mut contents);\n"
+"            println!(\"Querido diário: {conteúdo}\");\n"
+"        },\n"
+"        Err(err) => {\n"
+"            println!(\"Não foi possível abrir o diário: {err}\");\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/error-handling/result.md:27
+#, fuzzy
+msgid ""
+"  * As with `Option`, the successful value sits inside of `Result`, forcing "
+"the developer to\n"
+"    explicitly extract it. This encourages error checking. In the case where "
+"an error should never happen,\n"
+"    `unwrap()` or `expect()` can be called, and this is a signal of the "
+"developer intent too.  \n"
+"  * `Result` documentation is a recommended read. Not during the course, but "
+"it is worth mentioning. \n"
+"    It contains a lot of convenience methods and functions that help "
+"functional-style programming. \n"
+"    \n"
+"</details>"
+msgstr ""
+"  * Como em `Option`, o valor bem-sucedido fica dentro de `Result`, forçando "
+"o desenvolvedor a\n"
+"    extraí-lo explicitamente. Isso encoraja a verificação de erros. No caso "
+"em que um erro nunca deve acontecer,\n"
+"    `unwrap()` ou `expect()` podem ser chamados, e isso também é um sinal da "
+"intenção do desenvolvedor.\n"
+"  * A documentação do `Resultado` é uma leitura recomendada. Não durante o "
+"curso, mas vale a pena mencionar.\n"
+"    Ele contém muitos métodos e funções de conveniência que ajudam na "
+"programação de estilo funcional.\n"
+"    \n"
+"</details>"
+
+#: src/error-handling/try-operator.md:1
+#, fuzzy
+msgid "# Propagating Errors with `?`"
+msgstr "# Propagando erros com `?`"
+
+#: src/error-handling/try-operator.md:3
+#, fuzzy
+msgid ""
+"The try-operator `?` is used to return errors to the caller. It lets you "
+"turn\n"
+"the common"
+msgstr ""
+"O operador try `?` é usado para retornar erros ao chamador. Ele permite que "
+"você vire\n"
+"o comum"
+
+#: src/error-handling/try-operator.md:6
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"match some_expression {\n"
+"    Ok(value) => value,\n"
+"    Err(err) => return Err(err),\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, ignore\n"
+"corresponder a alguma_expressão {\n"
+"    Ok(valor) => valor,\n"
+"    Err(err) => retornar Err(err),\n"
+"}\n"
+"```"
+
+#: src/error-handling/try-operator.md:13
+#, fuzzy
+msgid "into the much simpler"
+msgstr "no muito mais simples"
+
+#: src/error-handling/try-operator.md:15
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"some_expression?\n"
+"```"
+msgstr ""
+"```rust, ignore\n"
+"alguma_expressão?\n"
+"```"
+
+#: src/error-handling/try-operator.md:19
+#, fuzzy
+msgid "We can use this to simplify our error handing code:"
+msgstr "Podemos usar isso para simplificar nosso código de tratamento de erros:"
+
+#: src/error-handling/try-operator.md:21
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::fs;\n"
+"use std::io::{self, Read};"
+msgstr ""
+"```rust, editable\n"
+"usar padrão::fs;\n"
+"use std::io::{self, Read};"
+
+#: src/error-handling/try-operator.md:25
+#, fuzzy
+msgid ""
+"fn read_username(path: &str) -> Result<String, io::Error> {\n"
+"    let username_file_result = fs::File::open(path);"
+msgstr ""
+"fn read_username(path: &str) -> Result<String, io::Error> {\n"
+"    let username_file_result = fs::File::open(path);"
+
+#: src/error-handling/try-operator.md:28
+#, fuzzy
+msgid ""
+"    let mut username_file = match username_file_result {\n"
+"        Ok(file) => file,\n"
+"        Err(e) => return Err(e),\n"
+"    };"
+msgstr ""
+"    let mut username_file = match username_file_result {\n"
+"        Ok(arquivo) => arquivo,\n"
+"        Err(e) => retornar Err(e),\n"
+"    };"
+
+#: src/error-handling/try-operator.md:33
+#, fuzzy
+msgid "    let mut username = String::new();"
+msgstr "    let mut name de usuário = String::new();"
+
+#: src/error-handling/try-operator.md:35
+#, fuzzy
+msgid ""
+"    match username_file.read_to_string(&mut username) {\n"
+"        Ok(_) => Ok(username),\n"
+"        Err(e) => Err(e),\n"
+"    }\n"
+"}"
+msgstr ""
+"    match username_file.read_to_string(&mut username) {\n"
+"        Ok(_) => Ok(name de usuário),\n"
+"        Err(e) => Err(e),\n"
+"    }\n"
+"}"
+
+#: src/error-handling/try-operator.md:41
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"name de usuário ou erro: {name de usuário:?}\");\n"
+"}\n"
+"```"
+
+#: src/error-handling/try-operator.md:52
+#: src/error-handling/converting-error-types.md:70
+#, fuzzy
+msgid ""
+"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
+"* Use the `fs::write` call to test out the different scenarios: no file, "
+"empty file, file with username."
+msgstr ""
+"* A variável `username` pode ser `Ok(string)` ou `Err(error)`.\n"
+"* Use a chamada `fs::write` para testar os diferentes cenários: nenhum "
+"arquivo, arquivo vazio, arquivo com name de usuário."
+
+#: src/error-handling/converting-error-types.md:1
+#, fuzzy
+msgid "# Converting Error Types"
+msgstr "# Convertendo Tipos de Erro"
+
+#: src/error-handling/converting-error-types.md:3
+#, fuzzy
+msgid ""
+"The effective expansion of `?` is a little more complicated than previously "
+"indicated:"
+msgstr ""
+"A expansão efetiva de `?` é um pouco mais complicada do que indicado "
+"anteriormente:"
+
+#: src/error-handling/converting-error-types.md:5
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"expression?\n"
+"```"
+msgstr ""
+"```rust, ignore\n"
+"expressão?\n"
+"```"
+
+#: src/error-handling/converting-error-types.md:9
+#, fuzzy
+msgid "works the same as"
+msgstr "funciona da mesma forma que"
+
+#: src/error-handling/converting-error-types.md:11
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"match expression {\n"
+"    Ok(value) => value,\n"
+"    Err(err)  => return Err(From::from(err)),\n"
+"}\n"
+"```"
+msgstr ""
+"```rust, ignore\n"
+"corresponder à expressão {\n"
+"    Ok(valor) => valor,\n"
+"    Err(err) => return Err(De::de(err)),\n"
+"}\n"
+"```"
+
+#: src/error-handling/converting-error-types.md:18
+#, fuzzy
+msgid ""
+"The `From::from` call here means we attempt to convert the error type to "
+"the\n"
+"type returned by the function:"
+msgstr ""
+"A chamada `From::from` aqui significa que tentamos converter o tipo de erro "
+"para o\n"
+"tipo retornado pela função:"
+
+#: src/error-handling/converting-error-types.md:21
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::error::Error;\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use std::fmt::{self, Display, Formatter};"
+msgstr ""
+"```rust, editable\n"
+"use padrão::erro::erro;\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use std::fmt::{self, Display, Formatter};"
+
+#: src/error-handling/converting-error-types.md:27
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"enum ReadUsernameError {\n"
+"    IoError(io::Error),\n"
+"    EmptyUsername(String),\n"
+"}"
+msgstr ""
+"#[derive(Debug)]\n"
+"enum ReadUsernameError {\n"
+"    IoError(io::Error),\n"
+"    name de usuário vazio(String),\n"
+"}"
+
+#: src/error-handling/converting-error-types.md:33
+#, fuzzy
+msgid "impl Error for ReadUsernameError {}"
+msgstr "erro impl para ReadUsernameError {}"
+
+#: src/error-handling/converting-error-types.md:35
+#, fuzzy
+msgid ""
+"impl Display for ReadUsernameError {\n"
+"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
+"        match self {\n"
+"            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
+"in {}\", filename),\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"exibição impl para ReadUsernameError {\n"
+"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
+"        corresponder a si mesmo {\n"
+"            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Não foi encontrado "
+"name de usuário em {}\", filename),\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/error-handling/converting-error-types.md:44
+#, fuzzy
+msgid ""
+"impl From<io::Error> for ReadUsernameError {\n"
+"    fn from(err: io::Error) -> ReadUsernameError {\n"
+"        ReadUsernameError::IoError(err)\n"
+"    }\n"
+"}"
+msgstr ""
+"impl De<io::Error> para ReadUsernameError {\n"
+"    fn from(err: io::Error) -> ReadUsernameError {\n"
+"        ReadUsernameError::IoError(err)\n"
+"    }\n"
+"}"
+
+#: src/error-handling/converting-error-types.md:50
+#: src/error-handling/deriving-error-enums.md:19
+#, fuzzy
+msgid ""
+"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
+"    }\n"
+"    Ok(username)\n"
+"}"
+msgstr ""
+"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::File::open(path)?.read_to_string(&mut name de usuário)?;\n"
+"    if name de usuário.is_empty() {\n"
+"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
+"    }\n"
+"    Ok (name de usuário)\n"
+"}"
+
+#: src/error-handling/converting-error-types.md:59
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"name de usuário ou erro: {name de usuário:?}\");\n"
+"}\n"
+"```"
+
+#: src/error-handling/converting-error-types.md:73
+#, fuzzy
+msgid ""
+"It is good practice for all error types to implement `std::error::Error`, "
+"which requires `Debug` and\n"
+"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
+"where possible, to make\n"
+"life easier for tests and consumers of your library. In this case we can't "
+"easily do so, because\n"
+"`io::Error` doesn't implement them."
+msgstr ""
+"É uma boa prática para todos os tipos de erro implementar "
+"`std::error::Error`, que requer `Debug` e\n"
+"`Mostrar`. Geralmente é útil para eles implementar `Clone` e `Eq` também "
+"quando possível, para fazer\n"
+"vida mais fácil para testes e consumidores de sua biblioteca. Neste caso, "
+"não podemos fazê-lo facilmente, porque\n"
+"`io::Error` não os implementa."
+
+#: src/error-handling/deriving-error-enums.md:1
+#, fuzzy
+msgid "# Deriving Error Enums"
+msgstr "# Derivando enumerações de erro"
+
+#: src/error-handling/deriving-error-enums.md:3
+#, fuzzy
+msgid ""
+"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
+"an\n"
+"error enum like we did on the previous page:"
+msgstr ""
+"A caixa [thiserror](https://docs.rs/thiserror/) é uma maneira popular de "
+"criar um\n"
+"error enum como fizemos na página anterior:"
+
+#: src/error-handling/deriving-error-enums.md:6
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use thiserror::Error;"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use este erro::Erro;"
+
+#: src/error-handling/deriving-error-enums.md:11
+#, fuzzy
+msgid ""
+"#[derive(Debug, Error)]\n"
+"enum ReadUsernameError {\n"
+"    #[error(\"Could not read: {0}\")]\n"
+"    IoError(#[from] io::Error),\n"
+"    #[error(\"Found no username in {0}\")]\n"
+"    EmptyUsername(String),\n"
+"}"
+msgstr ""
+"#[derive(Debug, Error)]\n"
+"enum ReadUsernameError {\n"
+"    #[error(\"Não foi possível ler: {0}\")]\n"
+"    IoError(#[from] io::Error),\n"
+"    #[error(\"Não foi encontrado name de usuário em {0}\")]\n"
+"    name de usuário vazio(String),\n"
+"}"
+
+#: src/error-handling/deriving-error-enums.md:28
+#: src/error-handling/dynamic-errors.md:25
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(name de usuário) => println!(\"name de usuário: {name de "
+"usuário}\"),\n"
+"        Err(err) => println!(\"Erro: {err}\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/error-handling/deriving-error-enums.md:39
+#, fuzzy
+msgid ""
+"`thiserror`'s derive macro automatically implements `std::error::Error`, and "
+"optionally `Display`\n"
+"(if the `#[error(...)]` attributes are provided) and `From` (if the "
+"`#[from]` attribute is added).\n"
+"It also works for structs."
+msgstr ""
+"A macro derivação do `thiserror` implementa automaticamente "
+"`std::error::Error`, e opcionalmente `Display`\n"
+"(se os atributos `#[error(...)]` forem fornecidos) e `From` (se o atributo "
+"`#[from]` for adicionado).\n"
+"Também funciona para structs."
+
+#: src/error-handling/deriving-error-enums.md:43
+#, fuzzy
+msgid "It doesn't affect your public API, which makes it good for libraries."
+msgstr "Não afeta sua API pública, o que a torna boa para bibliotecas."
+
+#: src/error-handling/dynamic-errors.md:1
+#, fuzzy
+msgid "# Dynamic Error Types"
+msgstr "# Tipos de erros dinâmicos"
+
+#: src/error-handling/dynamic-errors.md:3
+#, fuzzy
+msgid ""
+"Sometimes we want to allow any type of error to be returned without writing "
+"our own enum covering\n"
+"all the different possibilities. `std::error::Error` makes this easy."
+msgstr ""
+"Às vezes, queremos permitir que qualquer tipo de erro seja retornado sem "
+"escrever nossa própria cobertura de Enum\n"
+"todas as diferentes possibilages. `std::error::Error` torna isso fácil."
+
+#: src/error-handling/dynamic-errors.md:6
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::fs::{self, File};\n"
+"use std::io::Read;\n"
+"use thiserror::Error;\n"
+"use std::error::Error;"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"use std::fs::{self, File};\n"
+"use std::io::Read;\n"
+"use este erro::Erro;\n"
+"use padrão::erro::erro;"
+
+#: src/error-handling/dynamic-errors.md:12
+#, fuzzy
+msgid ""
+"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
+"#[error(\"Found no username in {0}\")]\n"
+"struct EmptyUsernameError(String);"
+msgstr ""
+"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
+"#[error(\"Não foi encontrado name de usuário em {0}\")]\n"
+"struct EmptyUsernameError(String);"
+
+#: src/error-handling/dynamic-errors.md:16
+#, fuzzy
+msgid ""
+"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(EmptyUsernameError(String::from(path)).into());\n"
+"    }\n"
+"    Ok(username)\n"
+"}"
+msgstr ""
+"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    File::open(path)?.read_to_string(&mut name de usuário)?;\n"
+"    if name de usuário.is_empty() {\n"
+"        return Err(EmptyUsernameError(String::from(path)).into());\n"
+"    }\n"
+"    Ok (name de usuário)\n"
+"}"
+
+#: src/error-handling/dynamic-errors.md:36
+#, fuzzy
+msgid ""
+"This saves on code, but gives up the ability to cleanly handle different "
+"error cases differently in\n"
+"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
+"in the public API of a\n"
+"library, but it can be a good option in a program where you just want to "
+"display the error message\n"
+"somewhere."
+msgstr ""
+"Isso economiza código, mas abre mão da capacage de lidar com diferentes "
+"casos de erro de maneira diferente em\n"
+"o programa. Como tal, geralmente não é uma boa ideia usar `Box<dyn Error>` "
+"na API pública de um\n"
+"biblioteca, mas pode ser uma boa Option em um programa onde você deseja "
+"apenas exibir a mensagem de erro\n"
+"algum lugar."
+
+#: src/error-handling/error-contexts.md:1
+#, fuzzy
+msgid "# Adding Context to Errors"
+msgstr "# Adicionando contexto aos erros"
+
+#: src/error-handling/error-contexts.md:3
+#, fuzzy
+msgid ""
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
+"contextual information to your errors and allows you to have fewer\n"
+"custom error types:"
+msgstr ""
+"A caixa de [anyhow](https://docs.rs/anyhow/) amplamente usada pode ajudá-lo "
+"a adicionar\n"
+"informações contextuais aos seus erros e permite que você tenha menos\n"
+"tipos de erro personalizados:"
+
+#: src/error-handling/error-contexts.md:7
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use anyhow::{Context, Result, bail};"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use de qualquer maneira::{Context, Result, bail};"
+
+#: src/error-handling/error-contexts.md:12
+#, fuzzy
+msgid ""
+"fn read_username(path: &str) -> Result<String> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::File::open(path)\n"
+"        .context(format!(\"Failed to open {path}\"))?\n"
+"        .read_to_string(&mut username)\n"
+"        .context(\"Failed to read\")?;\n"
+"    if username.is_empty() {\n"
+"        bail!(\"Found no username in {path}\");\n"
+"    }\n"
+"    Ok(username)\n"
+"}"
+msgstr ""
+"fn read_username(caminho: &str) -> Resultado<String> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::Arquivo::abrir(caminho)\n"
+"        .context(format!(\"Falha ao abrir {caminho}\"))?\n"
+"        .read_to_string(&mut name de usuário)\n"
+"        .context(\"Falha ao ler\"?);\n"
+"    if name de usuário.is_empty() {\n"
+"        fiança!(\"Não foi encontrado nenhum name de usuário em {path}\");\n"
+"    }\n"
+"    Ok (name de usuário)\n"
+"}"
+
+#: src/error-handling/error-contexts.md:24
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err:?}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(name de usuário) => println!(\"name de usuário: {name de "
+"usuário}\"),\n"
+"        Err(err) => println!(\"Erro: {err:?}\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/error-handling/error-contexts.md:35
+#, fuzzy
+msgid ""
+"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
+"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not\n"
+"  a good choice for the public API of a library, but is widely used in "
+"applications.\n"
+"* Actual error type inside of it can be extracted for examination if "
+"necessary.\n"
+"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides\n"
+"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgstr ""
+"* `anyhow::Result<V>` é um apelido de tipo para `Result<V, anyhow::Error>`.\n"
+"* `anyhow::Error` é essencialmente um wrapper em torno de `Box<dyn Error>`. "
+"Como tal, geralmente não é\n"
+"  uma boa escolha para a API pública de uma biblioteca, mas é amplamente "
+"utilizada em aplicações.\n"
+"* O tipo de erro real dentro dele pode ser extraído para exame, se "
+"necessário.\n"
+"* A funcionalage fornecida por `anyhow::Result<T>` pode ser familiar para "
+"desenvolvedores Go, pois fornece\n"
+"  padrões de uso e ergonomia semelhantes a `(T, error)` do Go."
+
+#: src/testing.md:1
+#, fuzzy
+msgid "# Testing"
+msgstr "# Teste"
+
+#: src/testing.md:3
+#, fuzzy
+msgid "Rust and Cargo come with a simple unit test framework:"
+msgstr "Rust e Cargo vêm com uma estrutura de teste de unage simples:"
+
+#: src/testing.md:5
+#, fuzzy
+msgid "* Unit tests are supported throughout your code."
+msgstr "* Os testes de unage são suportados em todo o seu código."
+
+#: src/testing.md:7
+#, fuzzy
+msgid "* Integration tests are supported via the `tests/` directory."
+msgstr "* Testes de integração são suportados através do diretório `tests/`."
+
+#: src/testing/unit-tests.md:1
+#, fuzzy
+msgid "# Unit Tests"
+msgstr "# Testes de unage"
+
+#: src/testing/unit-tests.md:3
+#, fuzzy
+msgid "Mark unit tests with `#[test]`:"
+msgstr "Marque os testes de unage com `#[teste]`:"
+
+#: src/testing/unit-tests.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn primeira_palavra(texto: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &texto[..idx],\n"
+"        Nenhum => &texto,\n"
+"    }\n"
+"}"
+
+#: src/testing/unit-tests.md:13
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn teste_vazio() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}"
+
+#: src/testing/unit-tests.md:18
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Olá\"), \"Olá\");\n"
+"}"
+
+#: src/testing/unit-tests.md:23
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_multiple_words() {\n"
+"    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+"#[teste]\n"
+"fn test_multiple_words() {\n"
+"    assert_eq!(first_word(\"Olá Mundo\"), \"Olá\");\n"
+"}\n"
+"```"
+
+#: src/testing/unit-tests.md:29
+#, fuzzy
+msgid "Use `cargo test` to find and run the unit tests."
+msgstr "Use `cargo test` para encontrar e executar os testes de unage."
+
+#: src/testing/test-modules.md:1
+#, fuzzy
+msgid "# Test Modules"
+msgstr "# Módulos de teste"
+
+#: src/testing/test-modules.md:3
+#, fuzzy
+msgid ""
+"Unit tests are often put in a nested module (run tests on the\n"
+"[Playground](https://play.rust-lang.org/)):"
+msgstr ""
+"Os testes de unage geralmente são colocados em um módulo aninhado "
+"(executar testes no\n"
+"[Playground](https://play.rust-lang.org/)):"
+
+#: src/testing/test-modules.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn helper(a: &str, b: &str) -> String {\n"
+"    format!(\"{a} {b}\")\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"fn helper(a: &str, b: &str) -> String {\n"
+"    formato!(\"{a} {b}\")\n"
+"}"
+
+#: src/testing/test-modules.md:11
+#, fuzzy
+msgid ""
+"pub fn main() {\n"
+"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
+"}"
+msgstr ""
+"pub fn main() {\n"
+"    println!(\"{}\", helper(\"Olá\", \"Mundo\"));\n"
+"}"
+
+#: src/testing/test-modules.md:19
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_helper() {\n"
+"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    #[teste]\n"
+"    fn test_helper() {\n"
+"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/testing/test-modules.md:26
+#, fuzzy
+msgid ""
+"* This lets you unit test private helpers.\n"
+"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr ""
+"* Isso permite que você teste unages auxiliares privadas.\n"
+"* O atributo `#[cfg(test)]` só fica ativo quando você executa `cargo test`."
+
+#: src/testing/doc-tests.md:1
+#, fuzzy
+msgid "# Documentation Tests"
+msgstr "# Testes de Documentação"
+
+#: src/testing/doc-tests.md:3
+#, fuzzy
+msgid "Rust has built-in support for documentation tests:"
+msgstr "Rust tem suporte embutido para testes de documentação:"
+
+#: src/testing/doc-tests.md:5
+#, fuzzy
+msgid ""
+"```rust\n"
+"/// Shortens a string to the given length.\n"
+"///\n"
+"/// ```\n"
+"/// use playground::shorten_string;\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
+"/// ```\n"
+"pub fn shorten_string(s: &str, length: usize) -> &str {\n"
+"    &s[..std::cmp::min(length, s.len())]\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"/// Encurta uma string para o comprimento especificado.\n"
+"///\n"
+"/// ```\n"
+"/// use playground::shorten_string;\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
+"/// assert_eq!(shorten_string(\"Olá Mundo\", 20), \"Olá Mundo\");\n"
+"/// ```\n"
+"pub fn short_string(s: &str, comprimento: usize) -> &str {\n"
+"    &s[..std::cmp::min(comprimento, s.len())]\n"
+"}\n"
+"```"
+
+#: src/testing/doc-tests.md:18
+#, fuzzy
+msgid ""
+"* Code blocks in `///` comments are automatically seen as Rust code.\n"
+"* The code will be compiled and executed as part of `cargo test`.\n"
+"* Test the above code on the [Rust "
+"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgstr ""
+"* Blocos de código em comentários `///` são vistos automaticamente como "
+"código Rust.\n"
+"* O código será compilado e executado como parte do `teste de cargo`.\n"
+"* Teste o código acima no [Rust "
+"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+
+#: src/testing/integration-tests.md:1
+#, fuzzy
+msgid "# Integration Tests"
+msgstr "# Testes de Integração"
+
+#: src/testing/integration-tests.md:3
+#, fuzzy
+msgid "If you want to test your library as a client, use an integration test."
+msgstr ""
+"Se quiser testar sua biblioteca como cliente, use um teste de integração."
+
+#: src/testing/integration-tests.md:5
+#, fuzzy
+msgid "Create a `.rs` file under `tests/`:"
+msgstr "Crie um arquivo `.rs` em `tests/`:"
+
+#: src/testing/integration-tests.md:7
+#, fuzzy
+msgid "```rust,ignore\nuse my_library::init;"
+msgstr "```rust, ignore\nuse minha_biblioteca::init;"
+
+#: src/testing/integration-tests.md:10
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_init() {\n"
+"    assert!(init().is_ok());\n"
+"}\n"
+"```"
+msgstr ""
+"#[teste]\n"
+"fn test_init() {\n"
+"    assert!(init().is_ok());\n"
+"}\n"
+"```"
+
+#: src/testing/integration-tests.md:16
+#, fuzzy
+msgid "These tests only have access to the public API of your crate."
+msgstr "Esses testes só têm acesso à API pública da sua caixa."
+
+#: src/unsafe.md:1
+#, fuzzy
+msgid "# Unsafe Rust"
+msgstr "# rust insegura"
+
+#: src/unsafe.md:3
+#, fuzzy
+msgid "The Rust language has two parts:"
+msgstr "A linguagem Rust tem duas partes:"
+
+#: src/unsafe.md:5
+#, fuzzy
+msgid ""
+"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
+"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"violated."
+msgstr ""
+"* **Safe Rust:** memória segura, nenhum comportamento indefinido é "
+"possível.\n"
+"* **Insafe Rust:** pode desencadear um comportamento indefinido se as "
+"pré-condições forem violadas."
+
+#: src/unsafe.md:8
+#, fuzzy
+msgid ""
+"We will be seeing mostly safe Rust in this course, but it's important to "
+"know\n"
+"what Unsafe Rust is."
+msgstr ""
+"Veremos principalmente Rust seguro neste curso, mas é importante saber\n"
+"o que é rust insegura."
+
+#: src/unsafe.md:11
+#, fuzzy
+msgid ""
+"Unsafe code is usually small and isolated, and its correctness should be "
+"carefully\n"
+"documented. It is usually wrapped in a safe abstraction layer."
+msgstr ""
+"Código inseguro é geralmente pequeno e isolado, e sua correção deve ser "
+"cuidadosamente\n"
+"documentado. Geralmente é envolto em uma camada de abstração segura."
+
+#: src/unsafe.md:14
+#, fuzzy
+msgid "Unsafe Rust gives you access to five new capabilities:"
+msgstr "O Unsafe Rust oferece acesso a cinco novos recursos:"
+
+#: src/unsafe.md:16
+#, fuzzy
+msgid ""
+"* Dereference raw pointers.\n"
+"* Access or modify mutable static variables.\n"
+"* Access `union` fields.\n"
+"* Call `unsafe` functions, including `extern` functions.\n"
+"* Implement `unsafe` traits."
+msgstr ""
+"* Dereference ponteiros brutos.\n"
+"* Acesse ou modifique variáveis estáticas mutáveis.\n"
+"* Acesse os campos `união`.\n"
+"* Chamar funções `inseguras`, incluindo funções `externas`.\n"
+"* Implementar traits `inseguros`."
+
+#: src/unsafe.md:22
+#, fuzzy
+msgid ""
+"We will briefly cover unsafe capabilities next. For full details, please "
+"see\n"
+"[Chapter 19.1 in the Rust "
+"Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
+"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+msgstr ""
+"A seguir, abordaremos brevemente os recursos inseguros. Para detalhes "
+"completos, consulte\n"
+"[Capítulo 19.1 no Rust "
+"Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
+"e o [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+
+#: src/unsafe.md:28
+#, fuzzy
+msgid ""
+"Unsafe Rust does not mean the code is incorrect. It means that developers "
+"have\n"
+"turned off the compiler safety features and have to write correct code by\n"
+"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"rules."
+msgstr ""
+"Rust inseguro não significa que o código está incorreto. Isso significa que "
+"os desenvolvedores têm\n"
+"desligou os recursos de segurança do compilador e tem que escrever o código "
+"correto\n"
+"eles mesmos. Isso significa que o compilador não impõe mais as regras de "
+"segurança de memória do Rust."
+
+#: src/unsafe/raw-pointers.md:1
+#, fuzzy
+msgid "# Dereferencing Raw Pointers"
+msgstr "# Desreferenciando ponteiros brutos"
+
+#: src/unsafe/raw-pointers.md:3
+#, fuzzy
+msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
+msgstr "Criar ponteiros é seguro, mas desreferenciá-los requer `unsafe`:"
+
+#: src/unsafe/raw-pointers.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut num = 5;"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let mut num = 5;"
+
+#: src/unsafe/raw-pointers.md:9
+#, fuzzy
+msgid "    let r1 = &mut num as *mut i32;\n    let r2 = &num as *const i32;"
+msgstr "    let r1 = &mut num as *mut i32;\n    let r2 = &num as *const i32;"
+
+#: src/unsafe/raw-pointers.md:12
+#, fuzzy
+msgid ""
+"    // Safe because r1 and r2 were obtained from references and so are "
+"guaranteed to be non-null and\n"
+"    // properly aligned, the objects underlying the references from which "
+"they were obtained are\n"
+"    // live throughout the whole unsafe block, and they are not accessed "
+"either through the\n"
+"    // references or concurrently through any other pointers.\n"
+"    unsafe {\n"
+"        println!(\"r1 is: {}\", *r1);\n"
+"        *r1 = 10;\n"
+"        println!(\"r2 is: {}\", *r2);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    // Seguro porque r1 e r2 foram obtidos de referências e, portanto, são "
+"garantidos como não nulos e\n"
+"    // devidamente alinhados, os objetos subjacentes às referências das "
+"quais foram obtidos são\n"
+"    // vivem em todo o bloco inseguro e não são acessados nem por meio do\n"
+"    // referências ou simultaneamente por meio de quaisquer outros "
+"ponteiros.\n"
+"    inseguro {\n"
+"        println!(\"r1 é: {}\", *r1);\n"
+"        *r1 = 10;\n"
+"        println!(\"r2 é: {}\", *r2);\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/unsafe/raw-pointers.md:26
+#, fuzzy
+msgid ""
+"It is good practice (and required by the Android Rust style guide) to write "
+"a comment for each\n"
+"`unsafe` block explaining how the code inside it satisfies the safety "
+"requirements of the unsafe\n"
+"operations it is doing."
+msgstr ""
+"É uma boa prática (e exigida pelo guia de estilo do Android Rust) escrever "
+"um comentário para cada\n"
+"Bloco `inseguro` explicando como o código dentro dele satisfaz os requisitos "
+"de segurança do inseguro\n"
+"operações que está fazendo."
+
+#: src/unsafe/raw-pointers.md:30
+#, fuzzy
+msgid ""
+"In the case of pointer dereferences, this means that the pointers must be\n"
+"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
+msgstr ""
+"No caso de desreferência de ponteiro, isso significa que os ponteiros devem "
+"ser\n"
+"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), ou seja:"
+
+#: src/unsafe/raw-pointers.md:33
+#, fuzzy
+msgid ""
+" * The pointer must be non-null.\n"
+" * The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object).\n"
+" * The object must not have been deallocated.\n"
+" * There must not be concurrent accesses to the same location.\n"
+" * If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no\n"
+"   reference may be used to access the memory."
+msgstr ""
+" * O ponteiro deve ser não nulo.\n"
+" * O ponteiro deve ser _desreferenciável_ (dentro dos limites de um único "
+"objeto alocado).\n"
+" * O objeto não deve ter sido desalocado.\n"
+" * Não deve haver acessos simultâneos ao mesmo local.\n"
+" * Se o ponteiro foi obtido lançando uma referência, o objeto subjacente "
+"deve estar ativo e não\n"
+"   referência pode ser usada para acessar a memória."
+
+#: src/unsafe/raw-pointers.md:40
+#, fuzzy
+msgid "In most cases the pointer must also be properly aligned."
+msgstr ""
+"Na maioria dos casos, o ponteiro também deve estar alinhado corretamente."
+
+#: src/unsafe/mutable-static-variables.md:1
+#, fuzzy
+msgid "# Mutable Static Variables"
+msgstr "# Variáveis estáticas mutáveis"
+
+#: src/unsafe/mutable-static-variables.md:3
+#, fuzzy
+msgid "It is safe to read an immutable static variable:"
+msgstr "É seguro ler uma variável estática imutável:"
+
+#: src/unsafe/mutable-static-variables.md:5
+#, fuzzy
+msgid "```rust,editable\nstatic HELLO_WORLD: &str = \"Hello, world!\";"
+msgstr "```rust, editable\nstatic HELLO_WORLD: &str = \"Olá, mundo!\";"
+
+#: src/unsafe/mutable-static-variables.md:8
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    println!(\"HELLO_WORLD: {}\", HELLO_WORLD);\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    println!(\"HELLO_WORLD: {}\", OLÁ_WORLD);\n"
+"}\n"
+"```"
+
+#: src/unsafe/mutable-static-variables.md:13
+#, fuzzy
+msgid ""
+"However, since data races can occur, it is unsafe to read and write mutable\n"
+"static variables:"
+msgstr ""
+"No entanto, como podem ocorrer corridas de dados, não é seguro ler e gravar "
+"dados mutáveis\n"
+"variáveis estáticas:"
+
+#: src/unsafe/mutable-static-variables.md:16
+#, fuzzy
+msgid "```rust,editable\nstatic mut COUNTER: u32 = 0;"
+msgstr "```rust, editable\nCONTADOR mut static: u32 = 0;"
+
+#: src/unsafe/mutable-static-variables.md:19
+#, fuzzy
+msgid ""
+"fn add_to_counter(inc: u32) {\n"
+"    unsafe { COUNTER += inc; }  // Potential data race!\n"
+"}"
+msgstr ""
+"fn add_to_counter(inc: u32) {\n"
+"    inseguro { CONTADOR += inc; } // Potencial corrida de dados!\n"
+"}"
+
+#: src/unsafe/mutable-static-variables.md:23
+#, fuzzy
+msgid "fn main() {\n    add_to_counter(42);"
+msgstr "fn main() {\n    add_to_counter(42);"
+
+#: src/unsafe/mutable-static-variables.md:26
+#, fuzzy
+msgid ""
+"    unsafe { println!(\"COUNTER: {}\", COUNTER); }  // Potential data race!\n"
+"}\n"
+"```"
+msgstr ""
+"    inseguro { println!(\"CONTADOR: {}\", CONTADOR); } // Potencial corrida "
+"de dados!\n"
+"}\n"
+"```"
+
+#: src/unsafe/mutable-static-variables.md:32
+#, fuzzy
+msgid ""
+"Using a mutable static is generally a bad idea, but there are some cases "
+"where it might make sense\n"
+"in low-level `no_std` code, such as implementing a heap allocator or working "
+"with some C APIs."
+msgstr ""
+"Usar uma estática mutável geralmente é uma má ideia, mas há alguns casos em "
+"que pode fazer sentido\n"
+"em código `no_std` de baixo nível, como implementar um alocador de heap ou "
+"trabalhar com algumas APIs C."
+
+#: src/unsafe/unions.md:1
+#, fuzzy
+msgid "# Unions"
+msgstr "# Sindicatos"
+
+#: src/unsafe/unions.md:3
+#, fuzzy
+msgid "Unions are like enums, but you need to track the active field yourself:"
+msgstr "As uniões são como enums, mas você mesmo precisa rastrear o campo ativo:"
+
+#: src/unsafe/unions.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[repr(C)]\n"
+"union MyUnion {\n"
+"    i: u8,\n"
+"    b: bool,\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"#[repr(C)]\n"
+"sindicato MyUnion {\n"
+"    eu: u8,\n"
+"    b: bool,\n"
+"}"
+
+#: src/unsafe/unions.md:12
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let u = MyUnion { i: 42 };\n"
+"    println!(\"int: {}\", unsafe { u.i });\n"
+"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let u = MyUnion { i: 42 };\n"
+"    println!(\"int: {}\", unsafe { u.i });\n"
+"    println!(\"bool: {}\", unsafe { u.b }); // Comportamento indefinido!\n"
+"}\n"
+"```"
+
+#: src/unsafe/unions.md:21
+#, fuzzy
+msgid ""
+"Unions are very rarely needed in Rust as you can usually use an enum. They "
+"are occasionally needed\n"
+"for interacting with C library APIs."
+msgstr ""
+"As uniões raramente são necessárias no Rust, pois geralmente você pode usar "
+"um enum. Eles são ocasionalmente necessários\n"
+"para interagir com as APIs da biblioteca C."
+
+#: src/unsafe/unions.md:24
+#, fuzzy
+msgid ""
+"If you just want to reinterpret bytes as a different type, you probably "
+"want\n"
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
+"or a safe\n"
+"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+msgstr ""
+"Se você deseja apenas reinterpretar os bytes como um tipo diferente, "
+"provavelmente deseja\n"
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
+"ou um cofre\n"
+"wrapper como a caixa [`zerocopy`](https://crates.io/crates/zerocopy)."
+
+#: src/unsafe/calling-unsafe-functions.md:1
+#, fuzzy
+msgid "# Calling Unsafe Functions"
+msgstr "# Chamando funções inseguras"
+
+#: src/unsafe/calling-unsafe-functions.md:3
+#, fuzzy
+msgid ""
+"A function or method can be marked `unsafe` if it has extra preconditions "
+"you\n"
+"must uphold to avoid undefined behaviour:"
+msgstr ""
+"Uma função ou método pode ser marcado como 'inseguro' se tiver pré-condições "
+"extras que você\n"
+"deve respeitar para evitar comportamentos indefinidos:"
+
+#: src/unsafe/calling-unsafe-functions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let emojis = \"🗻∈🌏\";"
+msgstr ""
+"```rust, editable\n"
+"fn main() {\n"
+"    let emojis = \"🗻∈🌏\";"
+
+#: src/unsafe/calling-unsafe-functions.md:10
+#, fuzzy
+msgid ""
+"    // Safe because the indices are in the correct order, within the bounds "
+"of\n"
+"    // the string slice, and lie on UTF-8 sequence boundaries.\n"
+"    unsafe {\n"
+"        println!(\"{}\", emojis.get_unchecked(0..4));\n"
+"        println!(\"{}\", emojis.get_unchecked(4..7));\n"
+"        println!(\"{}\", emojis.get_unchecked(7..11));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    // Seguro porque os índices estão na ordem correta, dentro dos limites "
+"de\n"
+"    // a slice da string e fica nos limites da sequência UTF-8.\n"
+"    inseguro {\n"
+"        println!(\"{}\", emojis.get_unchecked(0..4));\n"
+"        println!(\"{}\", emojis.get_unchecked(4..7));\n"
+"        println!(\"{}\", emojis.get_unchecked(7..11));\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/unsafe/writing-unsafe-functions.md:1
+#, fuzzy
+msgid "# Writing Unsafe Functions"
+msgstr "# Escrevendo Funções Inseguras"
+
+#: src/unsafe/writing-unsafe-functions.md:3
+#, fuzzy
+msgid ""
+"You can mark your own functions as `unsafe` if they require particular "
+"conditions to avoid undefined\n"
+"behaviour."
+msgstr ""
+"Você pode marcar suas próprias funções como `inseguras` se elas exigirem "
+"condições específicas para evitar\n"
+"comportamento."
+
+#: src/unsafe/writing-unsafe-functions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"/// Swaps the values pointed to by the given pointers.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// The pointers must be valid and properly aligned.\n"
+"unsafe fn swap(a: *mut u8, b: *mut u8) {\n"
+"    let temp = *a;\n"
+"    *a = *b;\n"
+"    *b = temp;\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"/// Troca os valores apontados pelos ponteiros fornecidos.\n"
+"///\n"
+"/// # Segurança\n"
+"///\n"
+"/// Os ponteiros devem ser válidos e devidamente alinhados.\n"
+"inseguro fn swap(a: *mut u8, b: *mut u8) {\n"
+"    let temp = *a;\n"
+"    *a = *b;\n"
+"    *b = temperatura;\n"
+"}"
+
+#: src/unsafe/writing-unsafe-functions.md:18
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut a = 42;\n"
+"    let mut b = 66;"
+msgstr ""
+"fn main() {\n"
+"    let mut a = 42;\n"
+"    let mut b = 66;"
+
+#: src/unsafe/writing-unsafe-functions.md:22
+#, fuzzy
+msgid ""
+"    // Safe because ...\n"
+"    unsafe {\n"
+"        swap(&mut a, &mut b);\n"
+"    }"
+msgstr ""
+"    // Seguro porque...\n"
+"    inseguro {\n"
+"        swap(&mut a, &mut b);\n"
+"    }"
+
+#: src/unsafe/writing-unsafe-functions.md:27
+#, fuzzy
+msgid ""
+"    println!(\"a = {}, b = {}\", a, b);\n"
+"}\n"
+"```"
+msgstr ""
+"    println!(\"a = {}, b = {}\", a, b);\n"
+"}\n"
+"```"
+
+#: src/unsafe/writing-unsafe-functions.md:33
+#, fuzzy
+msgid ""
+"We wouldn't actually use pointers for this because it can be done safely "
+"with references."
+msgstr ""
+"Na verdade, não usaríamos ponteiros para isso porque isso pode ser feito com "
+"segurança com referências."
+
+#: src/unsafe/writing-unsafe-functions.md:35
+#, fuzzy
+msgid ""
+"Note that unsafe code is allowed within an unsafe function without an "
+"`unsafe` block. We can\n"
+"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
+"what happens."
+msgstr ""
+"Observe que o código inseguro é permitido dentro de uma função insegura sem "
+"um bloco `inseguro`. Pudermos\n"
+"proibir isso com `#[deny(unsafe_op_in_unsafe_fn)]`. Tente adicioná-lo e veja "
+"o que acontece."
+
+#: src/unsafe/extern-functions.md:1
+#, fuzzy
+msgid "# Calling External Code"
+msgstr "# Chamando Código Externo"
+
+#: src/unsafe/extern-functions.md:3
+#, fuzzy
+msgid ""
+"Functions from other languages might violate the guarantees of Rust. "
+"Calling\n"
+"them is thus unsafe:"
+msgstr ""
+"Funções de outras linguagens podem violar as garantias do Rust. Chamando\n"
+"eles é, portanto, inseguro:"
+
+#: src/unsafe/extern-functions.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"extern \"C\" {\n"
+"    fn abs(input: i32) -> i32;\n"
+"}"
+msgstr ""
+"```rust, editable\n"
+"externo \"C\" {\n"
+"    fn abs(entrada: i32) -> i32;\n"
+"}"
+
+#: src/unsafe/extern-functions.md:11
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    unsafe {\n"
+"        // Undefined behavior if abs misbehaves.\n"
+"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    inseguro {\n"
+"        // Comportamento indefinido se o abs se comportar mal.\n"
+"        println!(\"Valor absoluto de -3 de acordo com C: {}\", abs(-3));\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/unsafe/extern-functions.md:21
+#, fuzzy
+msgid ""
+"This is usually only a problem for extern functions which do things with "
+"pointers which might\n"
+"violate Rust's memory model, but in general any C function might have "
+"undefined behaviour under any\n"
+"arbitrary circumstances."
+msgstr ""
+"Isso geralmente é apenas um problema para funções externas que fazem coisas "
+"com ponteiros que podem\n"
+"violam o modelo de memória do Rust, mas em geral qualquer função C pode ter "
+"comportamento indefinido sob qualquer\n"
+"circunstâncias arbitrárias."
+
+#: src/unsafe/extern-functions.md:25
+#, fuzzy
+msgid ""
+"The `\"C\"` in this example is the ABI;\n"
+"[other ABIs are available "
+"too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
+msgstr ""
+"O `\"C\"` neste exemplo é o ABI;\n"
+"[outros ABIs também estão "
+"disponíveis](https://doc.rust-lang.org/reference/items/external-blocks.html)."
+
+#: src/unsafe/unsafe-traits.md:1
+#, fuzzy
+msgid "# Implementing Unsafe Traits"
+msgstr "# Implementando traits Inseguros"
+
+#: src/unsafe/unsafe-traits.md:3
+#, fuzzy
+msgid ""
+"Like with functions, you can mark a trait as `unsafe` if the implementation "
+"must guarantee\n"
+"particular conditions to avoid undefined behaviour."
+msgstr ""
+"Assim como nas funções, você pode marcar uma característica como `insegura` "
+"se a implementação deve garantir\n"
+"condições particulares para evitar comportamento indefinido."
+
+#: src/unsafe/unsafe-traits.md:6
+#, fuzzy
+msgid ""
+"For example, the `zerocopy` crate has an unsafe trait that looks\n"
+"[something like "
+"this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+msgstr ""
+"Por exemplo, a caixa `zerocopy` tem uma característica insegura que parece\n"
+"[algo assim](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+
+#: src/unsafe/unsafe-traits.md:9
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::mem::size_of_val;\n"
+"use std::slice;"
+msgstr ""
+"```rust, editable\n"
+"use std::mem::size_of_val;\n"
+"use std::slice;"
+
+#: src/unsafe/unsafe-traits.md:13
+#, fuzzy
+msgid ""
+"/// ...\n"
+"/// # Safety\n"
+"/// The type must have a defined representation and no padding.\n"
+"pub unsafe trait AsBytes {\n"
+"    fn as_bytes(&self) -> &[u8] {\n"
+"        unsafe {\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"/// ...\n"
+"/// # Segurança\n"
+"/// O tipo deve ter uma representação definida e nenhum preenchimento.\n"
+"Pub trait inseguro AsBytes {\n"
+"    fn as_bytes(&self) -> &[u8] {\n"
+"        inseguro {\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/unsafe/unsafe-traits.md:24
+#, fuzzy
+msgid ""
+"// Safe because u32 has a defined representation and no padding.\n"
+"unsafe impl AsBytes for u32 {}\n"
+"```"
+msgstr ""
+"// Seguro porque u32 tem uma representação definida e nenhum preenchimento.\n"
+"impl inseguro AsBytes para u32 {}\n"
+"```"
+
+#: src/unsafe/unsafe-traits.md:30
+#, fuzzy
+msgid ""
+"There should be a `# Safety` section on the Rustdoc for the trait explaining "
+"the requirements for\n"
+"the trait to be safely implemented."
+msgstr ""
+"Deve haver uma seção `# Safety` no Rustdoc para a característica explicando "
+"os requisitos para\n"
+"a característica a ser implementada com segurança."
+
+#: src/unsafe/unsafe-traits.md:33
+#, fuzzy
+msgid ""
+"The actual safety section for `AsBytes` is rather longer and more "
+"complicated."
+msgstr "A seção de segurança real para `AsBytes` é bem mais longa e complicada."
+
+#: src/unsafe/unsafe-traits.md:35
+#, fuzzy
+msgid "The built-in `Send` and `Sync` traits are unsafe."
+msgstr "As características incorporadas `Send` e `Sync` não são seguras."
+
+#: src/exercises/day-3/afternoon.md:1
+#, fuzzy
+msgid "# Day 3: Afternoon Exercises"
+msgstr "# Dia 3: Exercícios da Tarde"
+
+#: src/exercises/day-3/afternoon.md:3
+#, fuzzy
+msgid "Let us build a safe wrapper for reading directory content!"
+msgstr "Vamos construir um wrapper seguro para ler o conteúdo do diretório!"
+
+#: src/exercises/day-3/afternoon.md:7
+#, fuzzy
+msgid "After looking at the exercise, you can look at the [solution] provided."
+msgstr "Depois de ver o exercício, você pode ver a [Solution] fornecida."
+
+#: src/exercises/day-3/afternoon.md:9
+#, fuzzy
+msgid "[solution]: solutions-afternoon.md"
+msgstr "[Solution]: soluções-tarde.md"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:1
+#, fuzzy
+msgid "# Safe FFI Wrapper"
+msgstr "# Invólucro FFI seguro"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:3
+#, fuzzy
+msgid ""
+"Rust has great support for calling functions through a _foreign function\n"
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"functions you would use from C to read the filenames of a directory."
+msgstr ""
+"Rust tem ótimo suporte para chamar funções por meio de uma função _foreign\n"
+"interface_ (FFI). Usaremos isso para construir um wrapper seguro para a "
+"`libc`\n"
+"funções que você usaria de C para ler os names de arquivo de um diretório."
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:7
+#, fuzzy
+msgid "You will want to consult the manual pages:"
+msgstr "Você vai querer consultar as páginas de manual:"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:9
+#, fuzzy
+msgid ""
+"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
+"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
+"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr ""
+"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
+"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
+"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:13
+#, fuzzy
+msgid ""
+"You will also want to browse the [`std::ffi`] module, particular for "
+"[`CStr`]\n"
+"and [`CString`] types which are used to hold NUL-terminated strings coming "
+"from\n"
+"C. The [Nomicon] also has a very useful chapter about FFI."
+msgstr ""
+"Você também deve procurar o módulo [`std::ffi`], especialmente para "
+"[`CStr`]\n"
+"e tipos [`CString`] que são usados para armazenar strings terminadas em NUL "
+"vindas de\n"
+"C. O [Nomicon] também tem um capítulo muito útil sobre FFI."
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:17
+#, fuzzy
+msgid ""
+"[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
+"[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
+"[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
+"[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
+msgstr ""
+"[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
+"[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
+"[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
+"[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:22
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"functions and methods:"
+msgstr ""
+"Copie o código abaixo para <https://play.rust-lang.org/> e preencha os "
+"campos que faltam\n"
+"funções e métodos:"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:29
+#, fuzzy
+msgid ""
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+msgstr ""
+"modo ffi {\n"
+"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:32
+#: src/exercises/day-3/solutions-afternoon.md:26
+#, fuzzy
+msgid ""
+"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"    #[repr(C)]\n"
+"    pub struct DIR {\n"
+"        _data: [u8; 0],\n"
+"        _marker: core::marker::PhantomData<(*mut u8, "
+"core::marker::PhantomPinned)>,\n"
+"    }"
+msgstr ""
+"    // Tipo opaco. Consulte https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"    #[repr(C)]\n"
+"    pub struct DIR {\n"
+"        _dados: [u8; 0],\n"
+"        _marker: core::marker::PhantomData<(*mut u8, "
+"core::marker::PhantomPinned)>,\n"
+"    }"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:39
+#: src/exercises/day-3/solutions-afternoon.md:33
+#, fuzzy
+msgid ""
+"    // Layout as per readdir(3) and definitions in "
+"/usr/include/x86_64-linux-gnu.\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_ino: c_long,\n"
+"        pub d_off: c_ulong,\n"
+"        pub d_reclen: c_ushort,\n"
+"        pub d_type: c_char,\n"
+"        pub d_name: [c_char; 256],\n"
+"    }"
+msgstr ""
+"    // Layout conforme readdir(3) e definições em "
+"/usr/include/x86_64-linux-gnu.\n"
+"    #[repr(C)]\n"
+"    pub struct direto {\n"
+"        pub d_ino: c_long,\n"
+"        pub d_off: c_ulong,\n"
+"        pub d_reclen: c_ushort,\n"
+"        pub d_type: c_char,\n"
+"        pub d_name: [c_char; 256],\n"
+"    }"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:49
+#: src/exercises/day-3/solutions-afternoon.md:43
+#, fuzzy
+msgid ""
+"    extern \"C\" {\n"
+"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"        pub fn closedir(s: *mut DIR) -> c_int;\n"
+"    }\n"
+"}"
+msgstr ""
+"    externo \"C\" {\n"
+"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"        pub fn closedir(s: *mut DIR) -> c_int;\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:56
+#: src/exercises/day-3/solutions-afternoon.md:50
+#, fuzzy
+msgid ""
+"use std::ffi::{CStr, CString, OsStr, OsString};\n"
+"use std::os::unix::ffi::OsStrExt;"
+msgstr ""
+"use std::ffi::{CStr, CString, OsStr, OsString};\n"
+"use std::os::unix::ffi::OsStrExt;"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:59
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}"
+msgstr ""
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    caminho: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:65
+#, fuzzy
+msgid ""
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
+"        // otherwise return Err with a message.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Chame opendir e retorne um valor Ok se funcionou,\n"
+"        // caso contrário, retorna Err com uma mensagem.\n"
+"        não implementado!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:73
+#, fuzzy
+msgid ""
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Iterator para DirectoryIterator {\n"
+"    tipo Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Continue chamando readdir até obtermos um ponteiro NULL de "
+"volta.\n"
+"        não implementado!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:81
+#, fuzzy
+msgid ""
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Drop para DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Chama closedir conforme necessário.\n"
+"        não implementado!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:88
+#, fuzzy
+msgid ""
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() -> Resultado<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"arquivos: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    OK(())\n"
+"}\n"
+"```"
+
+#: src/welcome-day-4.md:1
+#, fuzzy
+msgid "# Welcome to Day 4"
+msgstr "# Bem-vindo ao Dia 4"
+
+#: src/welcome-day-4.md:3
+#, fuzzy
+msgid "Today we will look at two main topics:"
+msgstr "Hoje veremos dois tópicos principais:"
+
+#: src/welcome-day-4.md:5
+#, fuzzy
+msgid "* Concurrency: threads, channels, shared state, `Send` and `Sync`."
+msgstr ""
+"* Simultaneage: threads, canais, estado compartilhado, `Send` e `Sync`."
+
+#: src/welcome-day-4.md:7
+#, fuzzy
+msgid ""
+"* Android: building binaries and libraries, using AIDL, logging, and\n"
+"  interoperability with C, C++, and Java."
+msgstr ""
+"* Android: construindo binários e bibliotecas, usando AIDL, log e\n"
+"  interoperabilage com C, C++ e Java."
+
+#: src/welcome-day-4.md:10
+#, fuzzy
+msgid ""
+"> We will attempt to call Rust from one of your own projects today. So try "
+"to\n"
+"> find a little corner of your code base where we can move some lines of "
+"code to\n"
+"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that\n"
+"> parses some raw bytes would be ideal."
+msgstr ""
+"> Tentaremos chamar Rust de um de seus próprios projetos hoje. Então tente\n"
+"> encontre um pequeno canto da sua base de código onde podemos mover algumas "
+"linhas de código para\n"
+"> rust. Quanto menos dependências e tipos \"exóticos\", melhor. Algo "
+"que\n"
+"> analisa alguns bytes brutos seria o ideal."
+
+#: src/concurrency.md:1
+#, fuzzy
+msgid "# Fearless Concurrency"
+msgstr "# Simultaneage sem medo"
+
+#: src/concurrency.md:3
+#, fuzzy
+msgid ""
+"Rust has full support for concurrency using OS threads with mutexes and\n"
+"channels."
+msgstr ""
+"Rust tem suporte total para simultaneage usando threads do SO com mutexes "
+"e\n"
+"canais."
+
+#: src/concurrency.md:6
+#, fuzzy
+msgid ""
+"The Rust type system plays an important role in making many concurrency "
+"bugs\n"
+"compile time bugs. This is often referred to as _fearless concurrency_ since "
+"you\n"
+"can rely on the compiler to ensure correctness at runtime."
+msgstr ""
+"O sistema de tipo Rust desempenha um papel importante na criação de muitos "
+"bugs de simultaneage\n"
+"erros de tempo de compilação. Isso geralmente é chamado de _simultaneage "
+"sem medo_, pois você\n"
+"pode confiar no compilador para garantir a exatidão no tempo de execução."
+
+#: src/concurrency/threads.md:1
+#, fuzzy
+msgid "# Threads"
+msgstr "# Tópicos"
+
+#: src/concurrency/threads.md:3
+#, fuzzy
+msgid "Rust threads work similarly to threads in other languages:"
+msgstr ""
+"Os encadeamentos Rust funcionam de maneira semelhante aos encadeamentos em "
+"outras linguagens:"
+
+#: src/concurrency/threads.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+"```rust, editable\n"
+"use std::thread;\n"
+"use padrão::tempo::Duração;"
+
+#: src/concurrency/threads.md:9
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    thread::spawn(|| {\n"
+"        for i in 1..10 {\n"
+"            println!(\"Count in thread: {i}!\");\n"
+"            thread::sleep(Duration::from_millis(5));\n"
+"        }\n"
+"    });"
+msgstr ""
+"fn main() {\n"
+"    thread::spawn(|| {\n"
+"        para i em 1..10 {\n"
+"            println!(\"Contagem na thread: {i}!\");\n"
+"            thread::sleep(Duração::from_millis(5));\n"
+"        }\n"
+"    });"
+
+#: src/concurrency/threads.md:17
+#, fuzzy
+msgid ""
+"    for i in 1..5 {\n"
+"        println!(\"Main thread: {i}\");\n"
+"        thread::sleep(Duration::from_millis(5));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    for i em 1..5 {\n"
+"        println!(\"Tópico principal: {i}\");\n"
+"        thread::sleep(Duração::from_millis(5));\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/concurrency/threads.md:24
+#, fuzzy
+msgid ""
+"* Threads are all daemon threads, the main thread does not wait for them.\n"
+"* Thread panics are independent of each other.\n"
+"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr ""
+"* Threads são todos threads daemon, o thread principal não espera por eles.\n"
+"* Thread panics são independentes uns dos outros.\n"
+"  * Os pânicos podem carregar uma cargo útil, que pode ser descompactada com "
+"`downcast_ref`."
+
+#: src/concurrency/threads.md:32
+#, fuzzy
+msgid ""
+"* Notice that the thread is stopped before it reaches 10 — the main thread "
+"is\n"
+"  not waiting."
+msgstr ""
+"* Observe que o thread é interrompido antes de atingir 10 — o thread "
+"principal é\n"
+"  não esperando."
+
+#: src/concurrency/threads.md:35
+#, fuzzy
+msgid ""
+"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
+"for\n"
+"  the thread to finish."
+msgstr ""
+"* Use `let handle = thread::spawn(...)` e posteriormente `handle.join()` "
+"para aguardar\n"
+"  o fio para terminar."
+
+#: src/concurrency/threads.md:38
+#, fuzzy
+msgid "* Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr "* Acionar um pânico no tópico, observe como isso não afeta `main`."
+
+#: src/concurrency/threads.md:40
+#, fuzzy
+msgid ""
+"* Use the `Result` return value from `handle.join()` to get access to the "
+"panic\n"
+"  payload. This is a good time to talk about [`Any`]."
+msgstr ""
+"* Use o valor de retorno `Result` de `handle.join()` para obter acesso ao "
+"pânico\n"
+"  payload. Este é um bom momento para falar sobre [`Any`]."
+
+#: src/concurrency/threads.md:43
+#, fuzzy
+msgid "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
+msgstr "[`Qualquer`]: https://doc.rust-lang.org/std/any/index.html"
+
+#: src/concurrency/scoped-threads.md:1
+#, fuzzy
+msgid "# Scoped Threads"
+msgstr "# Tópicos com Escopo"
+
+#: src/concurrency/scoped-threads.md:3
+#, fuzzy
+msgid "Normal threads cannot borrow from their environment:"
+msgstr "Threads normais não podem pedir emprestado de seu ambiente:"
+
+#: src/concurrency/scoped-threads.md:5
+#, fuzzy
+msgid "```rust,editable,compile_fail\nuse std::thread;"
+msgstr "```rust,editable,compile_fail\nuse std::thread;"
+
+#: src/concurrency/scoped-threads.md:8 src/concurrency/scoped-threads.md:22
+#, fuzzy
+msgid "fn main() {\n    let s = String::from(\"Hello\");"
+msgstr "fn main() {\n    let s = String::from(\"Olá\");"
+
+#: src/concurrency/scoped-threads.md:11
+#, fuzzy
+msgid ""
+"    thread::spawn(|| {\n"
+"        println!(\"Length: {}\", s.len());\n"
+"    });\n"
+"}\n"
+"```"
+msgstr ""
+"    thread::spawn(|| {\n"
+"        println!(\"Comprimento: {}\", s.len());\n"
+"    });\n"
+"}\n"
+"```"
+
+#: src/concurrency/scoped-threads.md:17
+#, fuzzy
+msgid "However, you can use a [scoped thread][1] for this:"
+msgstr "No entanto, você pode usar um [tópico com escopo] [1] para isso:"
+
+#: src/concurrency/scoped-threads.md:19
+#, fuzzy
+msgid "```rust,editable\nuse std::thread;"
+msgstr "```rust, editable\nuse std::thread;"
+
+#: src/concurrency/scoped-threads.md:25
+#, fuzzy
+msgid ""
+"    thread::scope(|scope| {\n"
+"        scope.spawn(|| {\n"
+"            println!(\"Length: {}\", s.len());\n"
+"        });\n"
+"    });\n"
+"}\n"
+"```"
+msgstr ""
+"    thread::escopo(|escopo| {\n"
+"        escopo.spawn(|| {\n"
+"            println!(\"Comprimento: {}\", s.len());\n"
+"        });\n"
+"    });\n"
+"}\n"
+"```"
+
+#: src/concurrency/scoped-threads.md:33
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
+msgstr "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
+
+#: src/concurrency/scoped-threads.md:35
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"* The reason for that is that when the `thread::scope` function completes, "
+"all the threads are guaranteed to be joined, so they can return borrowed "
+"data.\n"
+"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads.\n"
+"    \n"
+"</details>"
+msgstr ""
+"<details>\n"
+"    \n"
+"* A razão para isso é que, quando a função `thread::scope` for concluída, "
+"todas as threads serão unidas, para que possam retornar dados emprestados.\n"
+"* Aplicam-se as regras normais de empréstimo do Rust: você pode emprestar "
+"mutável por um encadeamento ou imutavelmente por qualquer número de "
+"encadeamentos.\n"
+"    \n"
+"</details>"
+
+#: src/concurrency/channels.md:1
+#, fuzzy
+msgid "# Channels"
+msgstr "# Canais"
+
+#: src/concurrency/channels.md:3
+#, fuzzy
+msgid ""
+"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
+"parts\n"
+"are connected via the channel, but you only see the end-points."
+msgstr ""
+"Os canais Rust têm duas partes: um `Sender<T>` e um `Receiver<T>`. as duas "
+"partes\n"
+"estão conectados através do canal, mas você só vê os Points finais."
+
+#: src/concurrency/channels.md:6
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;"
+msgstr ""
+"```rust, editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;"
+
+#: src/concurrency/channels.md:10 src/concurrency/channels/unbounded.md:10
+#, fuzzy
+msgid "fn main() {\n    let (tx, rx) = mpsc::channel();"
+msgstr "fn main() {\n    let (tx, rx) = mpsc::canal();"
+
+#: src/concurrency/channels.md:13
+#, fuzzy
+msgid "    tx.send(10).unwrap();\n    tx.send(20).unwrap();"
+msgstr "    tx.send(10).unwrap();\n    tx.send(20).unwrap();"
+
+#: src/concurrency/channels.md:16
+#, fuzzy
+msgid ""
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"    println!(\"Received: {:?}\", rx.recv());"
+msgstr ""
+"    println!(\"Recebido: {:?}\", rx.recv());\n"
+"    println!(\"Recebido: {:?}\", rx.recv());"
+
+#: src/concurrency/channels.md:19
+#, fuzzy
+msgid ""
+"    let tx2 = tx.clone();\n"
+"    tx2.send(30).unwrap();\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"}\n"
+"```"
+msgstr ""
+"    let tx2 = tx.clone();\n"
+"    tx2.send(30).unwrap();\n"
+"    println!(\"Recebido: {:?}\", rx.recv());\n"
+"}\n"
+"```"
+
+#: src/concurrency/channels.md:27
+#, fuzzy
+msgid ""
+"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
+"`SyncSender` implement `Clone` (so\n"
+"  you can make multiple producers) but `Receiver` does not.\n"
+"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or\n"
+"  `Receiver` is dropped and the channel is closed."
+msgstr ""
+"* `mpsc` significa Multi-Produtor, Único-Consumidor. `Sender` e `SyncSender` "
+"implementam `Clone` (então\n"
+"  você pode criar vários produtores), mas `Receiver` não.\n"
+"* `send()` e `recv()` retornam `Result`. Se retornarem `Err`, significa a "
+"contraparte `Sender` ou\n"
+"  `Receiver` é descartado e o canal é fechado."
+
+#: src/concurrency/channels/unbounded.md:1
+#, fuzzy
+msgid "# Unbounded Channels"
+msgstr "# canais ilimitados"
+
+#: src/concurrency/channels/unbounded.md:3
+#, fuzzy
+msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
+msgstr "Você obtém um canal ilimitado e assíncrono com `mpsc::channel()`:"
+
+#: src/concurrency/channels/unbounded.md:5
+#: src/concurrency/channels/bounded.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+"```rust, editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use padrão::tempo::Duração;"
+
+#: src/concurrency/channels/unbounded.md:13
+#: src/concurrency/channels/bounded.md:13
+#, fuzzy
+msgid ""
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));"
+msgstr ""
+"    thread::spawn(mover || {\n"
+"        let thread_id = thread::current().id();\n"
+"        para i em 1..10 {\n"
+"            tx.send(format!(\"Mensagem {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: mensagem enviada {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: feito\");\n"
+"    });\n"
+"    thread::sleep(Duração::from_millis(100));"
+
+#: src/concurrency/channels/unbounded.md:23
+#: src/concurrency/channels/bounded.md:23
+#, fuzzy
+msgid ""
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {}\", msg);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    for msg em rx.iter() {\n"
+"        println!(\"Principal: obteve {}\", msg);\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/concurrency/channels/bounded.md:1
+#, fuzzy
+msgid "# Bounded Channels"
+msgstr "# Canais Delimitados"
+
+#: src/concurrency/channels/bounded.md:3
+#, fuzzy
+msgid "Bounded and synchronous channels make `send` block the current thread:"
+msgstr "Canais limitados e síncronos fazem `send` bloquear o thread atual:"
+
+#: src/concurrency/channels/bounded.md:10
+#, fuzzy
+msgid "fn main() {\n    let (tx, rx) = mpsc::sync_channel(3);"
+msgstr "fn main() {\n    let (tx, rx) = mpsc::sync_channel(3);"
+
+#: src/concurrency/shared_state.md:1
+#, fuzzy
+msgid "# Shared State"
+msgstr "# Estado Compartilhado"
+
+#: src/concurrency/shared_state.md:3
+#, fuzzy
+msgid ""
+"Rust uses the type system to enforce synchronization of shared data. This "
+"is\n"
+"primarily done via two types:"
+msgstr ""
+"Rust usa o sistema de tipos para impor a sincronização de dados "
+"compartilhados. Isso é\n"
+"feito principalmente através de dois tipos:"
+
+#: src/concurrency/shared_state.md:6
+#, fuzzy
+msgid ""
+"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
+"threads and\n"
+"  takes care to deallocate `T` when the last reference is dropped,\n"
+"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+msgstr ""
+"* [`Arc<T>`][1], referência atômica contada `T`: manipula o compartilhamento "
+"entre threads e\n"
+"  toma o cuidado de desalocar `T` quando a última referência é descartada,\n"
+"* [`Mutex<T>`][2]: garante acesso mutuamente exclusivo ao valor `T`."
+
+#: src/concurrency/shared_state.md:10
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
+
+#: src/concurrency/shared_state/arc.md:1
+#, fuzzy
+msgid "# `Arc`"
+msgstr "# `Arc`"
+
+#: src/concurrency/shared_state/arc.md:3
+#, fuzzy
+msgid "[`Arc<T>`][1] allows shared read-only access via its `clone` method:"
+msgstr ""
+"[`Arc<T>`][1] permite acesso somente leitura compartilhado por meio de seu "
+"método `clone`:"
+
+#: src/concurrency/shared_state/arc.md:5
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::sync::Arc;"
+msgstr ""
+"```rust, editable\n"
+"use std::thread;\n"
+"use std::sync::Arc;"
+
+#: src/concurrency/shared_state/arc.md:9
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let v = Arc::new(vec![10, 20, 30]);\n"
+"    let mut handles = Vec::new();\n"
+"    for _ in 1..5 {\n"
+"        let v = v.clone();\n"
+"        handles.push(thread::spawn(move || {\n"
+"            let thread_id = thread::current().id();\n"
+"            println!(\"{thread_id:?}: {v:?}\");\n"
+"        }));\n"
+"    }"
+msgstr ""
+"fn main() {\n"
+"    let v = Arc::new(vec![10, 20, 30]);\n"
+"    let mut handles = Vec::new();\n"
+"    for _ em 1..5 {\n"
+"        let v = v.clone();\n"
+"        handles.push(thread::spawn(move || {\n"
+"            let thread_id = thread::current().id();\n"
+"            println!(\"{thread_id:?}: {v:?}\");\n"
+"        }));\n"
+"    }"
+
+#: src/concurrency/shared_state/arc.md:20
+#, fuzzy
+msgid ""
+"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+
+#: src/concurrency/shared_state/arc.md:25
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+msgstr "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+
+#: src/concurrency/shared_state/arc.md:29
+#, fuzzy
+msgid ""
+"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
+"`Rc` that uses atomic\n"
+"  operations.\n"
+"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T`\n"
+"  implements them both.\n"
+"* `Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the\n"
+"  `T` is free.\n"
+"* Beware of reference cycles, `Arc` does not use a garbage collector to "
+"detect them.\n"
+"    * `std::sync::Weak` can help."
+msgstr ""
+"* `Arc` significa \"Atomic Reference Counted\", uma versão thread-safe de "
+"`Rc` que usa dados atômicos\n"
+"  operações.\n"
+"* `Arc<T>` implementa `Clone` quer `T` o faça ou não. Ele implementa `Send` "
+"e `Sync` iff `T`\n"
+"  implementa os dois.\n"
+"* `Arc::clone()` tem o custo de operações atômicas que são executadas, mas "
+"depois disso o uso do\n"
+"  `T` é gratuito.\n"
+"* Cuidado com os ciclos de referência, `Arc` não usa um coletor de lixo para "
+"detectá-los.\n"
+"    * `std::sync::Weak` pode ajudar."
+
+#: src/concurrency/shared_state/mutex.md:1
+#, fuzzy
+msgid "# `Mutex`"
+msgstr "# `Mutex`"
+
+#: src/concurrency/shared_state/mutex.md:3
+#, fuzzy
+msgid ""
+"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
+"behind a read-only interface:"
+msgstr ""
+"[`Mutex<T>`][1] garante exclusão mútua _e_ permite acesso mutável a `T`\n"
+"por trás de uma interface somente leitura:"
+
+#: src/concurrency/shared_state/mutex.md:6
+#, fuzzy
+msgid "```rust,editable\nuse std::sync::Mutex;"
+msgstr "```rust, editable\nuse std::sync::Mutex;"
+
+#: src/concurrency/shared_state/mutex.md:9
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let v: Mutex<Vec<i32>> = Mutex::new(vec![10, 20, 30]);\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());"
+msgstr ""
+"fn main() {\n"
+"    let v: Mutex<Vec<i32>> = Mutex::new(vec![10, 20, 30]);\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());"
+
+#: src/concurrency/shared_state/mutex.md:13
+#, fuzzy
+msgid ""
+"    {\n"
+"        let v: &Mutex<Vec<i32>> = &v;\n"
+"        let mut guard = v.lock().unwrap();\n"
+"        guard.push(40);\n"
+"    }"
+msgstr ""
+"    {\n"
+"        let v: &Mutex<Vec<i32>> = &v;\n"
+"        let mut guard = v.lock().unwrap();\n"
+"        guard.push(40);\n"
+"    }"
+
+#: src/concurrency/shared_state/mutex.md:19
+#, fuzzy
+msgid ""
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"}\n"
+"```"
+msgstr ""
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"}\n"
+"```"
+
+#: src/concurrency/shared_state/mutex.md:23
+#, fuzzy
+msgid ""
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"implementation."
+msgstr ""
+"Observe como temos um cobertor [`impl<T: Send> Sync for Mutex<T>`][2]\n"
+"implementação."
+
+#: src/concurrency/shared_state/mutex.md:26
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E\n"
+"[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E\n"
+"[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+
+#: src/concurrency/shared_state/mutex.md:30
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"* `Mutex` in Rust looks like a collection with just one element - the "
+"protected data.\n"
+"    * It is not possible to forget to acquire the mutex before accessing the "
+"protected data.\n"
+"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the\n"
+"  `&mut T` doesn't outlive the lock being held.\n"
+"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
+"* A read-write lock counterpart - `RwLock`.\n"
+"* Why does `lock()` return a `Result`? \n"
+"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that\n"
+"      the data it protected might be in an inconsistent state. Calling "
+"`lock()` on a poisoned mutex\n"
+"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
+"to recover the data\n"
+"      regardless."
+msgstr ""
+"<details>\n"
+"    \n"
+"* `Mutex` em Rust parece uma coleção com apenas um elemento - os dados "
+"protegidos.\n"
+"    * Não é possível esquecer de adquirir o mutex antes de acessar os dados "
+"protegidos.\n"
+"* Você pode obter um `&mut T` de um `&Mutex<T>` pegando o bloqueio. O "
+"`MutexGuard` garante que o\n"
+"  `&mut T` não sobrevive ao bloqueio sendo mantido.\n"
+"* `Mutex<T>` implementa `Send` e `Sync` se `T` implementa `Send`.\n"
+"* Uma contraparte de bloqueio de leitura e gravação - `RwLock`.\n"
+"* Por que `lock()` retorna um `Result`?\n"
+"    * Se o thread que manteve o `Mutex` entrou em pânico, o `Mutex` torna-se "
+"\"envenenado\" para sinalizar que\n"
+"      os dados protegidos podem estar em um estado inconsistente. Chamando "
+"`lock ()` em um mutex envenenado\n"
+"      falha com um [`PoisonError`]. Você pode chamar `into_inner()` no erro "
+"para recuperar os dados\n"
+"      independentemente."
+
+#: src/concurrency/shared_state/mutex.md:44
+#, fuzzy
+msgid ""
+"[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html  "
+"\n"
+"    \n"
+"</details>"
+msgstr ""
+"[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html\n"
+"    \n"
+"</details>"
+
+#: src/concurrency/shared_state/example.md:3
+#, fuzzy
+msgid "Let us see `Arc` and `Mutex` in action:"
+msgstr "Vamos ver `Arc` e `Mutex` em ação:"
+
+#: src/concurrency/shared_state/example.md:5
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"// use std::sync::{Arc, Mutex};"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"// usa std::sync::{Arc, Mutex};"
+
+#: src/concurrency/shared_state/example.md:9
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let mut v = vec![10, 20, 30];\n"
+"    let handle = thread::spawn(|| {\n"
+"        v.push(10);\n"
+"    });\n"
+"    v.push(1000);"
+msgstr ""
+"fn main() {\n"
+"    let mut v = vec![10, 20, 30];\n"
+"    let handle = thread::spawn(|| {\n"
+"        v.push(10);\n"
+"    });\n"
+"    v.push(1000);"
+
+#: src/concurrency/shared_state/example.md:16
+#, fuzzy
+msgid ""
+"    handle.join().unwrap();\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"    handle.join().unwrap();\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+
+#: src/concurrency/shared_state/example.md:23
+#, fuzzy
+msgid ""
+"Possible solution:\n"
+"    \n"
+"```rust,editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;"
+msgstr ""
+"Solução possível:\n"
+"    \n"
+"```rust, editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;"
+
+#: src/concurrency/shared_state/example.md:29
+#, fuzzy
+msgid "fn main() {\n    let v = Arc::new(Mutex::new(vec![10, 20, 30]));"
+msgstr "fn main() {\n    let v = Arc::new(Mutex::new(vec![10, 20, 30]));"
+
+#: src/concurrency/shared_state/example.md:32
+#, fuzzy
+msgid ""
+"    let v2 = v.clone();\n"
+"    let handle = thread::spawn(move || {\n"
+"        let mut v2 = v2.lock().unwrap();\n"
+"        v2.push(10);\n"
+"    });"
+msgstr ""
+"    let v2 = v.clone();\n"
+"    let handle = thread::spawn(move || {\n"
+"        let mut v2 = v2.lock().unwrap();\n"
+"        v2.push(10);\n"
+"    });"
+
+#: src/concurrency/shared_state/example.md:38
+#, fuzzy
+msgid ""
+"    {\n"
+"        let mut v = v.lock().unwrap();\n"
+"        v.push(1000);\n"
+"    }"
+msgstr ""
+"    {\n"
+"        let mut v = v.lock().unwrap();\n"
+"        v.push(1000);\n"
+"    }"
+
+#: src/concurrency/shared_state/example.md:43
+#, fuzzy
+msgid "    handle.join().unwrap();"
+msgstr "    handle.join().unwrap();"
+
+#: src/concurrency/shared_state/example.md:45
+#, fuzzy
+msgid ""
+"    {\n"
+"        let v = v.lock().unwrap();\n"
+"        println!(\"v: {v:?}\");\n"
+"    }\n"
+"}\n"
+"```\n"
+"    \n"
+"Notable parts:"
+msgstr ""
+"    {\n"
+"        let v = v.lock().unwrap();\n"
+"        println!(\"v: {v:?}\");\n"
+"    }\n"
+"}\n"
+"```\n"
+"    \n"
+"Partes notáveis:"
+
+#: src/concurrency/shared_state/example.md:54
+#, fuzzy
+msgid ""
+"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal.\n"
+"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
+"state between threads.\n"
+"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature.\n"
+"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible.\n"
+"* We still need to acquire the `Mutex` to print our `Vec`."
+msgstr ""
+"* `v` é agrupado em ambos `Arc` e `Mutex`, porque seus interesses são "
+"ortogonais.\n"
+"  * Envolver um `Mutex` em um `Arc` é um padrão comum para compartilhar o "
+"estado mutável entre threads.\n"
+"* `v: Arc<_>` precisa ser clonado como `v2` antes que possa ser movido para "
+"outro thread. A nota `move` foi adicionada à assinatura lambda.\n"
+"* Os blocos são introduzidos para restringir o escopo do `LockGuard` tanto "
+"quanto possível.\n"
+"* Ainda precisamos adquirir o `Mutex` para imprimir nosso `Vec`."
+
+#: src/concurrency/send-sync.md:1
+#, fuzzy
+msgid "# `Send` and `Sync`"
+msgstr "# `Enviar` e `Sincronizar`"
+
+#: src/concurrency/send-sync.md:3
+#, fuzzy
+msgid ""
+"How does Rust know to forbid shared access across thread? The answer is in "
+"two traits:"
+msgstr ""
+"Como o Rust sabe proibir o acesso compartilhado entre threads? A resposta "
+"está em duas características:"
+
+#: src/concurrency/send-sync.md:5
+#, fuzzy
+msgid ""
+"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
+"thread\n"
+"  boundary.\n"
+"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
+"thread\n"
+"  boundary."
+msgstr ""
+"* [`Send`][1]: um tipo `T` é `Send` se for seguro mover um `T` através de um "
+"thread\n"
+"  fronteira.\n"
+"* [`Sync`][2]: um tipo `T` é `Sync` se for seguro mover um `&T` através de "
+"um thread\n"
+"  fronteira."
+
+#: src/concurrency/send-sync.md:10
+#, fuzzy
+msgid ""
+"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
+"derive them for your types\n"
+"as long as they only contain `Send` and `Sync` types. You can also implement "
+"them manually when you\n"
+"know it is valid."
+msgstr ""
+"`Send` e `Sync` são [características inseguras][3]. O compilador os derivará "
+"automaticamente para seus tipos\n"
+"desde que contenham apenas os tipos `Send` e `Sync`. Você também pode "
+"implementá-los manualmente quando\n"
+"saiba que é válido."
+
+#: src/concurrency/send-sync.md:14
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
+"[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
+"[3]: ../unsafe/unsafe-traits.md"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
+"[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
+"[3]: ../unsafe/unsafe-traits.md"
+
+#: src/concurrency/send-sync.md:20
+#, fuzzy
+msgid ""
+"* One can think of these traits as markers that the type has certain "
+"thread-safety properties.\n"
+"* They can be used in the generic constraints as normal traits.\n"
+"  \n"
+"</details>"
+msgstr ""
+"* Pode-se pensar nessas características como marcadores de que o tipo possui "
+"certas ownerships de segurança de encadeamento.\n"
+"* Eles podem ser usados nas restrições genéricas como características "
+"normais.\n"
+"  \n"
+"</details>"
+
+#: src/concurrency/send-sync/send.md:1
+#, fuzzy
+msgid "# `Send`"
+msgstr "# `Enviar`"
+
+#: src/concurrency/send-sync/send.md:3
+#, fuzzy
+msgid ""
+"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
+"thread."
+msgstr ""
+"> Um tipo `T` é [`Send`][1] se for seguro mover um valor `T` para outro "
+"thread."
+
+#: src/concurrency/send-sync/send.md:5
+#, fuzzy
+msgid ""
+"The effect of moving ownership to another thread is that _destructors_ will "
+"run\n"
+"in that thread. So the question is when you can allocate a value in one "
+"thread\n"
+"and deallocate it in another."
+msgstr ""
+"O efeito de mover a ownership para outro thread é que os _destructors_ "
+"serão executados\n"
+"nesse fio. Então a questão é quando você pode alocar um valor em um thread\n"
+"e desalocá-lo em outro."
+
+#: src/concurrency/send-sync/send.md:9
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
+msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
+
+#: src/concurrency/send-sync/sync.md:1
+#, fuzzy
+msgid "# `Sync`"
+msgstr "# `Sincronizar`"
+
+#: src/concurrency/send-sync/sync.md:3
+#, fuzzy
+msgid ""
+"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
+"multiple\n"
+"> threads at the same time."
+msgstr ""
+"> Um tipo `T` é [`Sync`][1] se for seguro acessar um valor `T` de vários\n"
+"> tópicos ao mesmo tempo."
+
+#: src/concurrency/send-sync/sync.md:6
+#, fuzzy
+msgid "More precisely, the definition is:"
+msgstr "Mais precisamente, a definição é:"
+
+#: src/concurrency/send-sync/sync.md:8
+#, fuzzy
+msgid "> `T` is `Sync` if and only if `&T` is `Send`"
+msgstr "> `T` é `Sync` se e somente se `&T` é `Send`"
+
+#: src/concurrency/send-sync/sync.md:10
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
+msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
+
+#: src/concurrency/send-sync/sync.md:14
+#, fuzzy
+msgid ""
+"This statement is essentially a shorthand way of saying that if a type is "
+"thread-safe for shared use, it is also thread-safe to pass references of it "
+"across threads."
+msgstr ""
+"Essa instrução é essencialmente uma maneira abreviada de dizer que, se um "
+"tipo é thread-safe para uso compartilhado, também é thread-safe passar "
+"referências a ele entre threads."
+
+#: src/concurrency/send-sync/sync.md:16
+#, fuzzy
+msgid ""
+"This is because if a type is Sync it means that it can be shared across "
+"multiple threads without the risk of data races or other synchronization "
+"issues, so it is safe to move it to another thread. A reference to the type "
+"is also safe to move to another thread, because the data it references can "
+"be accessed from any thread safely."
+msgstr ""
+"Isso ocorre porque, se um tipo for Sync, significa que ele pode ser "
+"compartilhado entre vários encadeamentos sem o risco de corridas de dados ou "
+"outros problemas de sincronização, portanto, é seguro movê-lo para outro "
+"encadeamento. Uma referência ao tipo também é segura para mover para outro "
+"thread, porque os dados a que ele faz referência podem ser acessados de "
+"qualquer thread com segurança."
+
+#: src/concurrency/send-sync/examples.md:1
+#, fuzzy
+msgid "# Examples"
+msgstr "# Exemplos"
+
+#: src/concurrency/send-sync/examples.md:3
+#, fuzzy
+msgid "## `Send + Sync`"
+msgstr "## `Enviar + Sincronizar`"
+
+#: src/concurrency/send-sync/examples.md:5
+#, fuzzy
+msgid "Most types you come across are `Send + Sync`:"
+msgstr "A maioria dos tipos que você encontra são `Enviar + Sincronizar`:"
+
+#: src/concurrency/send-sync/examples.md:7
+#, fuzzy
+msgid ""
+"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
+"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
+"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
+"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
+"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
+"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgstr ""
+"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
+"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
+"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
+"* `Arc<T>`: Explicitamente thread-safe via contagem de referência atômica.\n"
+"* `Mutex<T>`: Explicitamente thread-safe via bloqueio interno.\n"
+"* `AtomicBool`, `AtomicU8`, ...: Usa instruções atômicas especiais."
+
+#: src/concurrency/send-sync/examples.md:14
+#, fuzzy
+msgid ""
+"The generic types are typically `Send + Sync` when the type parameters are\n"
+"`Send + Sync`."
+msgstr ""
+"Os tipos genéricos são tipicamente `Send + Sync` quando os parâmetros de "
+"tipo são\n"
+"`Enviar + Sincronizar`."
+
+#: src/concurrency/send-sync/examples.md:17
+#, fuzzy
+msgid "## `Send + !Sync`"
+msgstr "## `Enviar + !Sync`"
+
+#: src/concurrency/send-sync/examples.md:19
+#, fuzzy
+msgid ""
+"These types can be moved to other threads, but they're not thread-safe.\n"
+"Typically because of interior mutability:"
+msgstr ""
+"Esses tipos podem ser movidos para outros encadeamentos, mas não são seguros "
+"para encadeamentos.\n"
+"Normalmente por causa da mutabilage interior:"
+
+#: src/concurrency/send-sync/examples.md:22
+#, fuzzy
+msgid ""
+"* `mpsc::Sender<T>`\n"
+"* `mpsc::Receiver<T>`\n"
+"* `Cell<T>`\n"
+"* `RefCell<T>`"
+msgstr ""
+"* `mpsc::Sender<T>`\n"
+"* `mpsc::Receptor<T>`\n"
+"* `Célula<T>`\n"
+"* `RefCell<T>`"
+
+#: src/concurrency/send-sync/examples.md:27
+#, fuzzy
+msgid "## `!Send + Sync`"
+msgstr "## `!Enviar + Sincronizar`"
+
+#: src/concurrency/send-sync/examples.md:29
+#, fuzzy
+msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgstr ""
+"Esses tipos são thread-safe, mas não podem ser movidos para outro thread:"
+
+#: src/concurrency/send-sync/examples.md:31
+#, fuzzy
+msgid ""
+"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
+"the\n"
+"  thread which created them."
+msgstr ""
+"* `MutexGuard<T>`: Usa primitivas de nível de sistema operacional que devem "
+"ser desalocadas no\n"
+"  discussão que os criou."
+
+#: src/concurrency/send-sync/examples.md:34
+#, fuzzy
+msgid "## `!Send + !Sync`"
+msgstr "## `!Enviar + !Sincronizar`"
+
+#: src/concurrency/send-sync/examples.md:36
+#, fuzzy
+msgid "These types are not thread-safe and cannot be moved to other threads:"
+msgstr ""
+"Esses tipos não são thread-safe e não podem ser movidos para outros threads:"
+
+#: src/concurrency/send-sync/examples.md:38
+#, fuzzy
+msgid ""
+"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
+"  non-atomic reference count.\n"
+"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
+"  concurrency considerations."
+msgstr ""
+"* `Rc<T>`: cada `Rc<T>` tem uma referência a um `RcBox<T>`, que contém um\n"
+"  contagem de referência não atômica.\n"
+"* `*const T`, `*mut T`: Rust assume que ponteiros brutos podem ter\n"
+"  considerações de simultaneage."
+
+#: src/exercises/day-4/morning.md:1 src/exercises/day-4/afternoon.md:1
+#, fuzzy
+msgid "# Exercises"
+msgstr "# Exercícios"
+
+#: src/exercises/day-4/morning.md:3
+#, fuzzy
+msgid "Let us practice our new concurrency skills with"
+msgstr "Vamos praticar nossas novas habilages de simultaneage com"
+
+#: src/exercises/day-4/morning.md:5
+#, fuzzy
+msgid "* Dining philosophers: a classic problem in concurrency."
+msgstr "* Dining filósofos: um problema clássico em concorrência."
+
+#: src/exercises/day-4/morning.md:7
+#, fuzzy
+msgid ""
+"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
+"  download dependencies and then check links in parallel."
+msgstr ""
+"* Verificador de link multiencadeado: um projeto maior em que você usará o "
+"Cargo para\n"
+"  baixe as dependências e verifique os links em paralelo."
+
+#: src/exercises/day-4/dining-philosophers.md:1
+#, fuzzy
+msgid "# Dining Philosophers"
+msgstr "# Dining Philosophers"
+
+#: src/exercises/day-4/dining-philosophers.md:3
+#, fuzzy
+msgid "The dining philosophers problem is a classic problem in concurrency:"
+msgstr ""
+"O problema dos filósofos jantando é um problema clássico em concorrência:"
+
+#: src/exercises/day-4/dining-philosophers.md:5
+#, fuzzy
+msgid ""
+"> Five philosophers dine together at the same table. Each philosopher has "
+"their\n"
+"> own place at the table. There is a fork between each plate. The dish "
+"served is\n"
+"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
+"can\n"
+"> only alternately think and eat. Moreover, a philosopher can only eat "
+"their\n"
+"> spaghetti when they have both a left and right fork. Thus two forks will "
+"only\n"
+"> be available when their two nearest neighbors are thinking, not eating. "
+"After\n"
+"> an individual philosopher finishes eating, they will put down both forks."
+msgstr ""
+"> Cinco filósofos jantam juntos na mesma mesa. Cada filósofo tem sua\n"
+"> próprio lugar à mesa. Há um garfo entre cada prato. O prato servido é\n"
+"> uma espécie de esparguete que se come com dois garfos. Cada filósofo pode\n"
+"> só pensa e come alternadamente. Além disso, um filósofo só pode comer sua\n"
+"> espaguete quando eles têm garfo esquerdo e direito. Assim, dois garfos só\n"
+"> estar disponível quando seus dois vizinhos mais próximos estiverem "
+"pensando, não comendo. Depois de\n"
+"> um filósofo individual termina de comer, eles abaixam os dois garfos."
+
+#: src/exercises/day-4/dining-philosophers.md:13
+#, fuzzy
+msgid ""
+"You will need a local [Cargo installation](../../cargo/running-locally.md) "
+"for\n"
+"this exercise. Copy the code below to `src/main.rs` file, fill out the "
+"blanks,\n"
+"and test that `cargo run` does not deadlock:"
+msgstr ""
+"Você precisará de uma [instalação do Cargo] local "
+"(../../cargo/running-locally.md) para\n"
+"esse exercício. Copie o código abaixo para o arquivo `src/main.rs`, preencha "
+"os espaços em branco,\n"
+"e teste se `cargo run` não trava:"
+
+#: src/exercises/day-4/dining-philosophers.md:17
+#, fuzzy
+msgid ""
+"```rust,compile_fail\n"
+"use std::sync::mpsc;\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+"```rust,compile_fail\n"
+"use std::sync::mpsc;\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"use padrão::tempo::Duração;"
+
+#: src/exercises/day-4/dining-philosophers.md:23
+#: src/exercises/day-4/solutions-morning.md:28
+#, fuzzy
+msgid "struct Fork;"
+msgstr "struct Fork;"
+
+#: src/exercises/day-4/dining-philosophers.md:25
+#, fuzzy
+msgid ""
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // thoughts: ...\n"
+"}"
+msgstr ""
+"struct Filósofo {\n"
+"    name: String,\n"
+"    // bifurcação_esquerda: ...\n"
+"    // bifurcação direita: ...\n"
+"    // pensamentos: ...\n"
+"}"
+
+#: src/exercises/day-4/dining-philosophers.md:32
+#, fuzzy
+msgid ""
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }"
+msgstr ""
+"impl Filósofo {\n"
+"    fn pense(&self) {\n"
+"        auto.pensamentos\n"
+"            .send(format!(\"Eureka! {} tem uma nova ideia!\", &self.name))\n"
+"            .desembrulhar();\n"
+"    }"
+
+#: src/exercises/day-4/dining-philosophers.md:39
+#, fuzzy
+msgid ""
+"    fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn come(&self) {\n"
+"        // Pegar garfos...\n"
+"        println!(\"{} está comendo...\", &self.name);\n"
+"        thread::sleep(Duração::from_millis(10));\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-4/dining-philosophers.md:46
+#: src/exercises/day-4/solutions-morning.md:60
+#, fuzzy
+msgid ""
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];"
+msgstr ""
+"FILÓSOFOS statics: &[&str] =\n"
+"    &[\"Sócrates\", \"Platão\", \"Aristóteles\", \"Tales\", \"Pitágoras\"];"
+
+#: src/exercises/day-4/dining-philosophers.md:49
+#, fuzzy
+msgid "fn main() {\n    // Create forks"
+msgstr "fn main() {\n    // Cria bifurcações"
+
+#: src/exercises/day-4/dining-philosophers.md:52
+#, fuzzy
+msgid "    // Create philosophers"
+msgstr "    // Criar filósofos"
+
+#: src/exercises/day-4/dining-philosophers.md:54
+#, fuzzy
+msgid "    // Make them think and eat"
+msgstr "    // Faça-os pensar e comer"
+
+#: src/exercises/day-4/dining-philosophers.md:56
+#, fuzzy
+msgid ""
+"    // Output their thoughts\n"
+"}\n"
+"```"
+msgstr ""
+"    // Saída de seus pensamentos\n"
+"}\n"
+"```"
+
+#: src/exercises/day-4/link-checker.md:1
+#, fuzzy
+msgid "# Multi-threaded Link Checker"
+msgstr "# Verificador de links multiencadeados"
+
+#: src/exercises/day-4/link-checker.md:3
+#, fuzzy
+msgid ""
+"Let us use our new knowledge to create a multi-threaded link checker. It "
+"should\n"
+"start at a webpage and check that links on the page are valid. It should\n"
+"recursively check other pages on the same domain and keep doing this until "
+"all\n"
+"pages have been validated."
+msgstr ""
+"Vamos usar nosso novo conhecimento para criar um verificador de links "
+"multiencadeados. Deveria\n"
+"comece em uma página da web e verifique se os links na página são válidos. "
+"Deveria\n"
+"verifique recursivamente outras páginas no mesmo domínio e continue fazendo "
+"isso até que todas\n"
+"as páginas foram validadas."
+
+#: src/exercises/day-4/link-checker.md:8
+#, fuzzy
+msgid ""
+"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
+"Cargo project and `reqwest` it as a dependency with:"
+msgstr ""
+"Para isso, você precisará de um cliente HTTP como [`reqwest`][1]. Crie um "
+"novo\n"
+"Cargo project e `reqwest` como uma dependência com:"
+
+#: src/exercises/day-4/link-checker.md:11
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ cargo new link-checker\n"
+"$ cd link-checker\n"
+"$ cargo add --features blocking,rustls-tls reqwest\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo new verificador de link\n"
+"$ cd link-checker\n"
+"$ cargo add --features blocking,rustls-tls reqwest\n"
+"```"
+
+#: src/exercises/day-4/link-checker.md:17
+#, fuzzy
+msgid ""
+"> If `cargo add` fails with `error: no such subcommand`, then please edit "
+"the\n"
+"> `Cargo.toml` file by hand. Add the dependencies listed below."
+msgstr ""
+"> Se `cargo add` falhar com `error: no such subcommand`, edite o\n"
+"> Arquivo `Cargo.toml` à mão. Adicione as dependências listadas abaixo."
+
+#: src/exercises/day-4/link-checker.md:20
+#, fuzzy
+msgid ""
+"You will also need a way to find links. We can use [`scraper`][2] for that:"
+msgstr ""
+"Você também precisará de uma maneira de encontrar links. Podemos usar "
+"[`scraper`][2] para isso:"
+
+#: src/exercises/day-4/link-checker.md:22
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ cargo add scraper\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo adicionar raspador\n"
+"```"
+
+#: src/exercises/day-4/link-checker.md:26
+#, fuzzy
+msgid ""
+"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
+"for\n"
+"that:"
+msgstr ""
+"Por fim, precisaremos de alguma forma de lidar com os erros. Usamos "
+"[`thiserror`][3] para\n"
+"que:"
+
+#: src/exercises/day-4/link-checker.md:29
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ cargo add thiserror\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo adicionar este erro\n"
+"```"
+
+#: src/exercises/day-4/link-checker.md:33
+#, fuzzy
+msgid ""
+"The `cargo add` calls will update the `Cargo.toml` file to look like this:"
+msgstr ""
+"As chamadas `cargo add` irão atualizar o arquivo `Cargo.toml` para ficar "
+"assim:"
+
+#: src/exercises/day-4/link-checker.md:35
+#, fuzzy
+msgid ""
+"```toml\n"
+"[dependencies]\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] "
+"}\n"
+"scraper = \"0.13.0\"\n"
+"thiserror = \"1.0.37\"\n"
+"```"
+msgstr ""
+"```toml\n"
+"[dependências]\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] "
+"}\n"
+"raspador = \"0.13.0\"\n"
+"este erro = \"1.0.37\"\n"
+"```"
+
+#: src/exercises/day-4/link-checker.md:42
+#, fuzzy
+msgid ""
+"You can now download the start page. Try with a small site such as\n"
+"`https://www.google.org/`."
+msgstr ""
+"Agora você pode baixar a página inicial. Tente com um pequeno site como\n"
+"`https://www.google.org/`."
+
+#: src/exercises/day-4/link-checker.md:45
+#, fuzzy
+msgid "Your `src/main.rs` file should look something like this:"
+msgstr "Seu arquivo `src/main.rs` deve se parecer com isto:"
+
+#: src/exercises/day-4/link-checker.md:47
+#, fuzzy
+msgid ""
+"```rust,compile_fail\n"
+"use reqwest::blocking::{get, Response};\n"
+"use reqwest::Url;\n"
+"use scraper::{Html, Selector};\n"
+"use thiserror::Error;"
+msgstr ""
+"```rust,compile_fail\n"
+"use reqwest::blocking::{get, Response};\n"
+"use reqwest::Url;\n"
+"use raspador::{Html, Seletor};\n"
+"use este erro::Erro;"
+
+#: src/exercises/day-4/link-checker.md:53
+#, fuzzy
+msgid ""
+"#[derive(Error, Debug)]\n"
+"enum Error {\n"
+"    #[error(\"request error: {0}\")]\n"
+"    ReqwestError(#[from] reqwest::Error),\n"
+"}"
+msgstr ""
+"#[derive(erro, depuração)]\n"
+"Erro de Enum {\n"
+"    #[error(\"erro de solicitação: {0}\")]\n"
+"    ReqwestError(#[from] reqwest::Error),\n"
+"}"
+
+#: src/exercises/day-4/link-checker.md:59
+#, fuzzy
+msgid ""
+"fn extract_links(response: Response) -> Result<Vec<Url>, Error> {\n"
+"    let base_url = response.url().to_owned();\n"
+"    let document = response.text()?;\n"
+"    let html = Html::parse_document(&document);\n"
+"    let selector = Selector::parse(\"a\").unwrap();"
+msgstr ""
+"fn extract_links(resposta: Resposta) -> Resultado<Vec<Url>, Erro> {\n"
+"    let base_url = response.url().to_owned();\n"
+"    let document = response.text()?;\n"
+"    let html = Html::parse_document(&document);\n"
+"    let selector = Selector::parse(\"a\").unwrap();"
+
+#: src/exercises/day-4/link-checker.md:65
+#, fuzzy
+msgid ""
+"    let mut valid_urls = Vec::new();\n"
+"    for element in html.select(&selector) {\n"
+"        if let Some(href) = element.value().attr(\"href\") {\n"
+"            match base_url.join(href) {\n"
+"                Ok(url) => valid_urls.push(url),\n"
+"                Err(err) => {\n"
+"                    println!(\"On {base_url}: could not parse {href:?}: "
+"{err} (ignored)\",);\n"
+"                }\n"
+"            }\n"
+"        }\n"
+"    }"
+msgstr ""
+"    let mut valid_urls = Vec::new();\n"
+"    for elemento em html.select(&seletor) {\n"
+"        if let Some(href) = element.value().attr(\"href\") {\n"
+"            match base_url.join(href) {\n"
+"                Ok(url) => valid_urls.push(url),\n"
+"                Err(err) => {\n"
+"                    println!(\"Em {base_url}: não foi possível analisar "
+"{href:?}: {err} (ignorado)\",);\n"
+"                }\n"
+"            }\n"
+"        }\n"
+"    }"
+
+#: src/exercises/day-4/link-checker.md:77
+#, fuzzy
+msgid "    Ok(valid_urls)\n}"
+msgstr "    Ok(valid_urls)\n}"
+
+#: src/exercises/day-4/link-checker.md:80
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let response = get(start_url).unwrap();\n"
+"    match extract_links(response) {\n"
+"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
+"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let response = get(start_url).unwrap();\n"
+"    match extract_links(resposta) {\n"
+"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
+"        Err(err) => println!(\"Não foi possível extrair links: {err:#}\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/exercises/day-4/link-checker.md:90
+#, fuzzy
+msgid "Run the code in `src/main.rs` with"
+msgstr "Execute o código em `src/main.rs` com"
+
+#: src/exercises/day-4/link-checker.md:92
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"```"
+msgstr ""
+"```shell\n"
+"corrida de cargo $\n"
+"```"
+
+#: src/exercises/day-4/link-checker.md:96
+#, fuzzy
+msgid "## Tasks"
+msgstr "## Tarefas"
+
+#: src/exercises/day-4/link-checker.md:98
+#, fuzzy
+msgid ""
+"* Use threads to check the links in parallel: send the URLs to be checked to "
+"a\n"
+"  channel and let a few threads check the URLs in parallel.\n"
+"* Extend this to recursively extract links from all pages on the\n"
+"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
+"you\n"
+"  don't end up being blocked by the site."
+msgstr ""
+"* Use threads para verificar os links em paralelo: envie as URLs a serem "
+"verificadas para um\n"
+"  channel e deixe alguns threads verificarem as URLs em paralelo.\n"
+"* Estenda isso para extrair recursivamente links de todas as páginas no\n"
+"  domínio `www.google.org`. Coloque um limite máximo de 100 páginas ou mais "
+"para que você\n"
+"  não acabe sendo bloqueado pelo site."
+
+#: src/exercises/day-4/link-checker.md:104
+#, fuzzy
+msgid ""
+"[1]: https://docs.rs/reqwest/\n"
+"[2]: https://docs.rs/scraper/\n"
+"[3]: https://docs.rs/thiserror/"
+msgstr ""
+"[1]: https://docs.rs/reqwest/\n"
+"[2]: https://docs.rs/scraper/\n"
+"[3]: https://docs.rs/thiserror/"
+
+#: src/android.md:1
+#, fuzzy
+msgid "# Android"
+msgstr "#Android"
+
+#: src/android.md:3
+#, fuzzy
+msgid ""
+"Rust is supported for native platform development on Android. This means "
+"that\n"
+"you can write new operating system services in Rust, as well as extending\n"
+"existing services."
+msgstr ""
+"Rust tem suporte para desenvolvimento de plataforma nativa no Android. Isso "
+"significa que\n"
+"você pode escrever novos serviços de sistema operacional em Rust, bem como "
+"estender\n"
+"serviços existentes."
+
+#: src/android/setup.md:1
+#, fuzzy
+msgid "# Setup"
+msgstr "# Configurar"
+
+#: src/android/setup.md:3
+#, fuzzy
+msgid ""
+"We will be using an Android Virtual Device to test our code. Make sure you "
+"have\n"
+"access to one or create a new one with:"
+msgstr ""
+"Estaremos usando um dispositivo virtual Android para testar nosso código. "
+"Assegure-se de ter\n"
+"acesso a um ou crie um novo com:"
+
+#: src/android/setup.md:6
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ source build/envsetup.sh\n"
+"$ lunch aosp_cf_x86_64_phone-userdebug\n"
+"$ acloud create\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ source build/envsetup.sh\n"
+"$ almoço aosp_cf_x86_64_phone-userdebug\n"
+"$ acloud criar\n"
+"```"
+
+#: src/android/setup.md:12
+#, fuzzy
+msgid ""
+"Please see the [Android Developer\n"
+"Codelab](https://source.android.com/docs/setup/start) for details."
+msgstr ""
+"Consulte o [Desenvolvedor Android\n"
+"Codelab](https://source.android.com/docs/setup/start) para obter detalhes."
+
+#: src/android/build-rules.md:1
+#, fuzzy
+msgid "# Build Rules"
+msgstr "# Regras de construção"
+
+#: src/android/build-rules.md:3
+#, fuzzy
+msgid "The Android build system (Soong) supports Rust via a number of modules:"
+msgstr ""
+"O sistema de compilação do Android (Soong) oferece suporte ao Rust por meio "
+"de vários módulos:"
+
+#: src/android/build-rules.md:5
+#, fuzzy
+msgid ""
+"| Module Type       | Description                                            "
+"                                            |\n"
+"|-------------------|----------------------------------------------------------------------------------------------------|\n"
+"| `rust_binary`     | Produces a Rust binary.                                "
+"                                            |\n"
+"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
+"`dylib` variants.                            |\n"
+"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
+"provides both static and shared variants.    |\n"
+"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
+"analogous to compiler plugins.                     |\n"
+"| `rust_test`       | Produces a Rust test binary that uses the standard "
+"Rust test harness.                              |\n"
+"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging `libfuzzer`.    "
+"                                            |\n"
+"| `rust_protobuf`   | Generates source and produces a Rust library that "
+"provides an interface for a particular protobuf. |\n"
+"| `rust_bindgen`    | Generates source and produces a Rust library "
+"containing Rust bindings to C libraries.              |"
+msgstr ""
+"| Tipo de módulo | Descrição |\n"
+"|-------------------|---------------------------- "
+"-------------------------------------------------- ---------------------|\n"
+"| `rust_binary` | Produz um binário Rust. |\n"
+"| `rust_library` | Produz uma biblioteca Rust e fornece as variantes `rlib` "
+"e `dylib`. |\n"
+"| `rust_ffi` | Produz uma biblioteca Rust C utilizável por módulos `cc` e "
+"fornece variantes estáticas e compartilhadas. |\n"
+"| `rust_proc_macro` | Produz uma biblioteca Rust `proc-macro`. Estes são "
+"análogos aos plugins do compilador. |\n"
+"| `teste_rust` | Produz um binário de teste Rust que usa o equipamento "
+"de teste Rust padrão. |\n"
+"| `rust_fuzz` | Produz um binário Rust fuzz aproveitando `libfuzzer`. |\n"
+"| `rust_protobuf` | Gera o código-fonte e produz uma biblioteca Rust que "
+"fornece uma interface para um protobuf específico. |\n"
+"| `rust_bindgen` | Gera fonte e produz uma biblioteca Rust contendo ligações "
+"Rust para bibliotecas C. |"
+
+#: src/android/build-rules.md:16
+#, fuzzy
+msgid "We will look at `rust_binary` and `rust_library` next."
+msgstr "Veremos `rust_binary` e `rust_library` a seguir."
+
+#: src/android/build-rules/binary.md:1
+#, fuzzy
+msgid "# Rust Binaries"
+msgstr "# Binários Rust"
+
+#: src/android/build-rules/binary.md:3
+#, fuzzy
+msgid ""
+"Let us start with a simple application. At the root of an AOSP checkout, "
+"create\n"
+"the following files:"
+msgstr ""
+"Vamos começar com um aplicativo simples. Na raiz de um checkout AOSP, crie\n"
+"os seguintes arquivos:"
+
+#: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
+#, fuzzy
+msgid "_hello_rust/Android.bp_:"
+msgstr "_hello_rust/Android.bp_:"
+
+#: src/android/build-rules/binary.md:8
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust\",\n"
+"    crate_name: \"hello_rust\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binário {\n"
+"    name: \"olá_rust\",\n"
+"    crate_name: \"hello_rust\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
+#, fuzzy
+msgid "_hello_rust/src/main.rs_:"
+msgstr "_hello_rust/src/main.rs_:"
+
+#: src/android/build-rules/binary.md:18
+#, fuzzy
+msgid "```rust\n//! Rust demo."
+msgstr "```rust\n//! Demonstração de rust."
+
+#: src/android/build-rules/binary.md:21
+#, fuzzy
+msgid ""
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"Hello from Rust!\");\n"
+"}\n"
+"```"
+msgstr ""
+"/// Imprime uma saudação na saída padrão.\n"
+"fn main() {\n"
+"    println!(\"Olá do Rust!\");\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/binary.md:27
+#, fuzzy
+msgid "You can now build, push, and run the binary:"
+msgstr "Agora você pode compilar, enviar e executar o binário:"
+
+#: src/android/build-rules/binary.md:29
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m hello_rust\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust /data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust\n"
+"Hello from Rust!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m olá_rust\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust /data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust\n"
+"Saudações da Rust!\n"
+"```"
+
+#: src/android/build-rules/library.md:1
+#, fuzzy
+msgid "# Rust Libraries"
+msgstr "# Bibliotecas de rust"
+
+#: src/android/build-rules/library.md:3
+#, fuzzy
+msgid "You use `rust_library` to create a new Rust library for Android."
+msgstr ""
+"Você usa `rust_library` para criar uma nova biblioteca Rust para Android."
+
+#: src/android/build-rules/library.md:5
+#, fuzzy
+msgid "Here we declare a dependency on two libraries:"
+msgstr "Aqui declaramos uma dependência em duas bibliotecas:"
+
+#: src/android/build-rules/library.md:7
+#, fuzzy
+msgid ""
+"* `libgreeting`, which we define below,\n"
+"* `libtextwrap`, which is a crate already vendored in\n"
+"  [`external/rust/crates/`][crates]."
+msgstr ""
+"* `libgreeting`, que definimos abaixo,\n"
+"* `libtextwrap`, que é uma caixa já vendida em\n"
+"  [`externo/rust/caixas/`][caixas]."
+
+#: src/android/build-rules/library.md:11
+#, fuzzy
+msgid ""
+"[crates]: "
+"https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/"
+msgstr ""
+"[caixas]: "
+"https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/"
+
+#: src/android/build-rules/library.md:15
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}"
+msgstr ""
+"```javascript\n"
+"rust_binário {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefere_rlib: true,\n"
+"}"
+
+#: src/android/build-rules/library.md:27
+#, fuzzy
+msgid ""
+"rust_library {\n"
+"    name: \"libgreetings\",\n"
+"    crate_name: \"greetings\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"}\n"
+"```"
+msgstr ""
+"rust_library {\n"
+"    name: \"libgreetings\",\n"
+"    crate_name: \"saudações\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/library.md:36
+#, fuzzy
+msgid "```rust,ignore\n//! Rust demo."
+msgstr "```rust, ignore\n//! Demonstração de rust."
+
+#: src/android/build-rules/library.md:39
+#, fuzzy
+msgid "use greetings::greeting;\nuse textwrap::fill;"
+msgstr "usar saudações::saudação;\nuse textwrap::fill;"
+
+#: src/android/build-rules/library.md:42
+#, fuzzy
+msgid ""
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
+"}\n"
+"```"
+msgstr ""
+"/// Imprime uma saudação na saída padrão.\n"
+"fn main() {\n"
+"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/library.md:48
+#, fuzzy
+msgid "_hello_rust/src/lib.rs_:"
+msgstr "_hello_rust/src/lib.rs_:"
+
+#: src/android/build-rules/library.md:50
+#, fuzzy
+msgid "```rust,ignore\n//! Greeting library."
+msgstr "```rust, ignore\n//! Saudação biblioteca."
+
+#: src/android/build-rules/library.md:53
+#, fuzzy
+msgid ""
+"/// Greet `name`.\n"
+"pub fn greeting(name: &str) -> String {\n"
+"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
+"}\n"
+"```"
+msgstr ""
+"/// Saudação `name`.\n"
+"pub fn saudação(name: &str) -> String {\n"
+"    format!(\"Olá {name}, prazer em conhecê-lo!\")\n"
+"}\n"
+"```"
+
+#: src/android/build-rules/library.md:59
+#, fuzzy
+msgid "You build, push, and run the binary like before:"
+msgstr "Você constrói, envia e executa o binário como antes:"
+
+#: src/android/build-rules/library.md:61
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m hello_rust_with_dep\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep "
+"/data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust_with_dep\n"
+"Hello Bob, it is very\n"
+"nice to meet you!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m hello_rust_with_dep\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep "
+"/data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust_with_dep\n"
+"Olá Bob, é muito\n"
+"prazer em conhecê-lo!\n"
+"```"
+
+#: src/android/aidl.md:1
+#, fuzzy
+msgid "# AIDL"
+msgstr "#AIDL"
+
+#: src/android/aidl.md:3
+#, fuzzy
+msgid ""
+"The [Android Interface Definition Language\n"
+"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
+"Rust:"
+msgstr ""
+"A [Linguagem de Definição de Interface Android\n"
+"(AIDL)](https://developer.android.com/guide/components/aidl) é compatível "
+"com Rust:"
+
+#: src/android/aidl.md:6
+#, fuzzy
+msgid ""
+"* Rust code can call existing AIDL servers,\n"
+"* You can create new AIDL servers in Rust."
+msgstr ""
+"* O código Rust pode chamar servidores AIDL existentes,\n"
+"* Você pode criar novos servidores AIDL em Rust."
+
+#: src/android/aidl/interface.md:1
+#, fuzzy
+msgid "# AIDL Interfaces"
+msgstr "# Interfaces AIDL"
+
+#: src/android/aidl/interface.md:3
+#, fuzzy
+msgid "You declare the API of your service using an AIDL interface:"
+msgstr "Você declara a API do seu serviço usando uma interface AIDL:"
+
+#: src/android/aidl/interface.md:5
+#, fuzzy
+msgid ""
+"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+msgstr ""
+"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+
+#: src/android/aidl/interface.md:7 src/android/aidl/changing.md:6
+#, fuzzy
+msgid "```java\npackage com.example.birthdayservice;"
+msgstr "```java\npackage com.example.birthdayservice;"
+
+#: src/android/aidl/interface.md:10
+#, fuzzy
+msgid ""
+"/** Birthday service interface. */\n"
+"interface IBirthdayService {\n"
+"    /** Generate a Happy Birthday message. */\n"
+"    String wishHappyBirthday(String name, int years);\n"
+"}\n"
+"```"
+msgstr ""
+"/** Interface de serviço de aniversário. */\n"
+"interface IBirthdayService {\n"
+"    /** Gera uma mensagem de feliz aniversário. */\n"
+"    String desejoFelizAniversário(String name, int anos);\n"
+"}\n"
+"```"
+
+#: src/android/aidl/interface.md:17
+#, fuzzy
+msgid "*birthday_service/aidl/Android.bp*:"
+msgstr "*aniversário_service/aidl/Android.bp*:"
+
+#: src/android/aidl/interface.md:19
+#, fuzzy
+msgid ""
+"```javascript\n"
+"aidl_interface {\n"
+"    name: \"com.example.birthdayservice\",\n"
+"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
+"    unstable: true,\n"
+"    backend: {\n"
+"        rust: { // Rust is not enabled by default\n"
+"            enabled: true,\n"
+"        },\n"
+"    },\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"aidl_interface {\n"
+"    name: \"com.example.birthdayservice\",\n"
+"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
+"    instável: true,\n"
+"    Processo interno: {\n"
+"        rust: { // Rust não está ativado por padrão\n"
+"            ativado: true,\n"
+"        },\n"
+"    },\n"
+"}\n"
+"```"
+
+#: src/android/aidl/interface.md:32
+#, fuzzy
+msgid ""
+"Add `vendor_available: true` if your AIDL file is used by a binary in the "
+"vendor\n"
+"partition."
+msgstr ""
+"Adicione `vendor_available: true` se seu arquivo AIDL for usado por um "
+"binário no fornecedor\n"
+"partição."
+
+#: src/android/aidl/implementation.md:1
+#, fuzzy
+msgid "# Service Implementation"
+msgstr "# Implementação de serviço"
+
+#: src/android/aidl/implementation.md:3
+#, fuzzy
+msgid "We can now implement the AIDL service:"
+msgstr "Agora podemos implementar o serviço AIDL:"
+
+#: src/android/aidl/implementation.md:5
+#, fuzzy
+msgid "*birthday_service/src/lib.rs*:"
+msgstr "*aniversário_serviço/src/lib.rs*:"
+
+#: src/android/aidl/implementation.md:7
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"//! Implementation of the `IBirthdayService` AIDL interface.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+msgstr ""
+"```rust, ignore\n"
+"//! Implementação da interface AIDL `IBirthdayService`.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+
+#: src/android/aidl/implementation.md:12
+#, fuzzy
+msgid "/// The `IBirthdayService` implementation.\npub struct BirthdayService;"
+msgstr "/// A implementação `IBirthdayService`.\npub struct BirthdayService;"
+
+#: src/android/aidl/implementation.md:15
+#, fuzzy
+msgid "impl binder::Interface for BirthdayService {}"
+msgstr "impl binder::Interface para BirthdayService {}"
+
+#: src/android/aidl/implementation.md:17
+#, fuzzy
+msgid ""
+"impl IBirthdayService for BirthdayService {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
+"binder::Result<String> {\n"
+"        Ok(format!(\n"
+"            \"Happy Birthday {name}, congratulations with the {years} "
+"years!\"\n"
+"        ))\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"impl IBirthdayService para BirthdayService {\n"
+"    fn wishHappyBirthday(&self, name: &str, anos: i32) -> "
+"fichário::Resultado<String> {\n"
+"        Ok(formato!(\n"
+"            \"Feliz Aniversário {name}, parabéns pelos {anos} anos!\"\n"
+"        ))\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
+#: src/android/aidl/client.md:37
+#, fuzzy
+msgid "*birthday_service/Android.bp*:"
+msgstr "*aniversário_serviço/Android.bp*:"
+
+#: src/android/aidl/implementation.md:28
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_library {\n"
+"    name: \"libbirthdayservice\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    crate_name: \"birthdayservice\",\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_library {\n"
+"    name: \"libbirthdayservice\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    crate_name: \"aniversário\",\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"}\n"
+"```"
+
+#: src/android/aidl/server.md:1
+#, fuzzy
+msgid "# AIDL Server"
+msgstr "# Servidor AIDL"
+
+#: src/android/aidl/server.md:3
+#, fuzzy
+msgid "Finally, we can create a server which exposes the service:"
+msgstr "Finalmente, podemos criar um servidor que exponha o serviço:"
+
+#: src/android/aidl/server.md:5
+#, fuzzy
+msgid "*birthday_service/src/server.rs*:"
+msgstr "*aniversário_serviço/src/servidor.rs*:"
+
+#: src/android/aidl/server.md:7
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use birthdayservice::BirthdayService;\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+msgstr ""
+"```rust, ignore\n"
+"//! Serviço de aniversário.\n"
+"usaraniversárioserviço::AniversárioServiço;\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+
+#: src/android/aidl/server.md:13 src/android/aidl/client.md:12
+#, fuzzy
+msgid "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";"
+msgstr "const SERVICE_IDENTIFIER: &str = \"aniversário\";"
+
+#: src/android/aidl/server.md:15
+#, fuzzy
+msgid ""
+"/// Entry point for birthday service.\n"
+"fn main() {\n"
+"    let birthday_service = BirthdayService;\n"
+"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
+"        birthday_service,\n"
+"        binder::BinderFeatures::default(),\n"
+"    );\n"
+"    binder::add_service(SERVICE_IDENTIFIER, "
+"birthday_service_binder.as_binder())\n"
+"        .expect(\"Failed to register service\");\n"
+"    binder::ProcessState::join_thread_pool()\n"
+"}\n"
+"```"
+msgstr ""
+"/// Point de entrada para serviço de aniversário.\n"
+"fn main() {\n"
+"    let serviço_aniversário = ServiçoAniversário;\n"
+"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
+"        aniversário_serviço,\n"
+"        fichário::BinderFeatures::default(),\n"
+"    );\n"
+"    fichário::add_service(SERVICE_IDENTIFIER, "
+"birthday_service_binder.as_binder())\n"
+"        .expect(\"Falha ao registrar o serviço\");\n"
+"    fichário::ProcessState::join_thread_pool()\n"
+"}\n"
+"```"
+
+#: src/android/aidl/server.md:30
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_server\",\n"
+"    crate_name: \"birthday_server\",\n"
+"    srcs: [\"src/server.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"        \"libbirthdayservice\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binário {\n"
+"    name: \"aniversário_servidor\",\n"
+"    crate_name: \"aniversário_servidor\",\n"
+"    srcs: [\"src/servidor.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"        \"libbirthdayservice\",\n"
+"    ],\n"
+"    prefere_rlib: true,\n"
+"}\n"
+"```"
+
+#: src/android/aidl/deploy.md:1
+#, fuzzy
+msgid "# Deploy"
+msgstr "# Implantar"
+
+#: src/android/aidl/deploy.md:3
+#, fuzzy
+msgid "We can now build, push, and start the service:"
+msgstr "Agora podemos construir, enviar e iniciar o serviço:"
+
+#: src/android/aidl/deploy.md:5
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m birthday_server\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/tmp\n"
+"$ adb shell /data/local/tmp/birthday_server\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m aniversário_servidor\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/tmp\n"
+"$ adb shell /data/local/tmp/birthday_server\n"
+"```"
+
+#: src/android/aidl/deploy.md:11
+#, fuzzy
+msgid "In another terminal, check that the service runs:"
+msgstr "Em outro terminal, verifique se o serviço é executado:"
+
+#: src/android/aidl/deploy.md:13
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ adb shell service check birthdayservice\n"
+"Service birthdayservice: found\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ adb shell service check birthdayservice\n"
+"Serviço de aniversário: encontrado\n"
+"```"
+
+#: src/android/aidl/deploy.md:18
+#, fuzzy
+msgid "You can also call the service with `service call`:"
+msgstr "Você também pode chamar o serviço com `service call`:"
+
+#: src/android/aidl/deploy.md:20
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ $ adb shell service call birthdayservice 1 s16 Bob i32 24\n"
+"Result: Parcel(\n"
+"  0x00000000: 00000000 00000036 00610048 00700070 '....6...H.a.p.p.'\n"
+"  0x00000010: 00200079 00690042 00740072 00640068 'y. .B.i.r.t.h.d.'\n"
+"  0x00000020: 00790061 00420020 0062006f 0020002c 'a.y. .B.o.b.,. .'\n"
+"  0x00000030: 006f0063 0067006e 00610072 00750074 'c.o.n.g.r.a.t.u.'\n"
+"  0x00000040: 0061006c 00690074 006e006f 00200073 'l.a.t.i.o.n.s. .'\n"
+"  0x00000050: 00690077 00680074 00740020 00650068 'w.i.t.h. .t.h.e.'\n"
+"  0x00000060: 00320020 00200034 00650079 00720061 ' .2.4. .y.e.a.r.'\n"
+"  0x00000070: 00210073 00000000                   's.!.....        ')\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ $ adb shell service call birthdayservice 1 s16 Bob i32 24\n"
+"Resultado: Parcel(\n"
+"  0x00000000: 00000000 00000036 00610048 00700070 '....6...H.a.p.p.'\n"
+"  0x00000010: 00200079 00690042 00740072 00640068 'y. .B.i.r.t.h.d.'\n"
+"  0x00000020: 00790061 00420020 0062006f 0020002c 'a.y. .Prumo.,. .'\n"
+"  0x00000030: 006f0063 0067006e 00610072 00750074 'c.o.n.g.r.a.t.u.'\n"
+"  0x00000040: 0061006c 00690074 006e006f 00200073 'l.a.t.i.o.n.s. .'\n"
+"  0x00000050: 00690077 00680074 00740020 00650068 'w.i.t.h. .a.'\n"
+"  0x00000060: 00320020 00200034 00650079 00720061 ' .2.4. .ano.'\n"
+"  0x00000070: 00210073 00000000 's.!..... ')\n"
+"```"
+
+#: src/android/aidl/client.md:1
+#, fuzzy
+msgid "# AIDL Client"
+msgstr "# Cliente AIDL"
+
+#: src/android/aidl/client.md:3
+#, fuzzy
+msgid "Finally, we can create a Rust client for our new service."
+msgstr "Por fim, podemos criar um cliente Rust para nosso novo serviço."
+
+#: src/android/aidl/client.md:5
+#, fuzzy
+msgid "*birthday_service/src/client.rs*:"
+msgstr "*aniversário_service/src/client.rs*:"
+
+#: src/android/aidl/client.md:7
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+msgstr ""
+"```rust, ignore\n"
+"//! Serviço de aniversário.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+
+#: src/android/aidl/client.md:14
+#, fuzzy
+msgid ""
+"/// Connect to the BirthdayService.\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
+"binder::StatusCode> {\n"
+"    binder::get_interface(SERVICE_IDENTIFIER)\n"
+"}"
+msgstr ""
+"/// Conecte-se ao Serviço de Aniversário.\n"
+"pub fn connect() -> Resultado<binder::Strong<dyn IBirthdayService>, "
+"binder::StatusCode> {\n"
+"    fichário::get_interface(SERVICE_IDENTIFIER)\n"
+"}"
+
+#: src/android/aidl/client.md:19
+#, fuzzy
+msgid ""
+"/// Call the birthday service.\n"
+"fn main() -> Result<(), binder::Status> {\n"
+"    let name = std::env::args()\n"
+"        .nth(1)\n"
+"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
+"    let years = std::env::args()\n"
+"        .nth(2)\n"
+"        .and_then(|arg| arg.parse::<i32>().ok())\n"
+"        .unwrap_or(42);"
+msgstr ""
+"/// Ligue para o serviço de aniversário.\n"
+"fn main() -> Resultado<(), fichário::Status> {\n"
+"    let name = std::env::args()\n"
+"        .nth(1)\n"
+"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
+"    let anos = std::env::args()\n"
+"        .nth(2)\n"
+"        .and_then(|arg| arg.parse::<i32>().ok())\n"
+"        .unwrap_or(42);"
+
+#: src/android/aidl/client.md:29
+#, fuzzy
+msgid ""
+"    binder::ProcessState::start_thread_pool();\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
+"    let msg = service.wishHappyBirthday(&name, years)?;\n"
+"    println!(\"{msg}\");\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+"    fichário::ProcessState::start_thread_pool();\n"
+"    let service = connect().expect(\"Falha ao conectar ao "
+"BirthdayService\");\n"
+"    let msg = service.wishHappyBirthday(&name, anos)?;\n"
+"    println!(\"{msg}\");\n"
+"    OK(())\n"
+"}\n"
+"```"
+
+#: src/android/aidl/client.md:39
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_client\",\n"
+"    crate_name: \"birthday_client\",\n"
+"    srcs: [\"src/client.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binário {\n"
+"    name: \"aniversario_cliente\",\n"
+"    crate_name: \"aniversário_cliente\",\n"
+"    srcs: [\"src/client.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"    prefere_rlib: true,\n"
+"}\n"
+"```"
+
+#: src/android/aidl/client.md:52
+#, fuzzy
+msgid "Notice that the client does not depend on `libbirthdayservice`."
+msgstr "Observe que o cliente não depende de `libbirthdayservice`."
+
+#: src/android/aidl/client.md:54
+#, fuzzy
+msgid "Build, push, and run the client on your device:"
+msgstr "Crie, envie e execute o cliente em seu dispositivo:"
+
+#: src/android/aidl/client.md:56
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m birthday_client\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/tmp\n"
+"$ adb shell /data/local/tmp/birthday_client Charlie 60\n"
+"Happy Birthday Charlie, congratulations with the 60 years!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m aniversário_cliente\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/tmp\n"
+"$ adb shell /data/local/tmp/birthday_client Charlie 60\n"
+"Parabéns Charlie, parabéns pelos 60 anos!\n"
+"```"
+
+#: src/android/aidl/changing.md:1
+#, fuzzy
+msgid "# Changing API"
+msgstr "# Alterando API"
+
+#: src/android/aidl/changing.md:3
+#, fuzzy
+msgid ""
+"Let us extend the API with more functionality: we want to let clients "
+"specify a\n"
+"list of lines for the birthday card:"
+msgstr ""
+"Vamos estender a API com mais funcionalage: queremos permitir que os "
+"clientes especifiquem um\n"
+"lista de linhas para o cartão de aniversário:"
+
+#: src/android/aidl/changing.md:9
+#, fuzzy
+msgid ""
+"/** Birthday service interface. */\n"
+"interface IBirthdayService {\n"
+"    /** Generate a Happy Birthday message. */\n"
+"    String wishHappyBirthday(String name, int years, in String[] text);\n"
+"}\n"
+"```"
+msgstr ""
+"/** Interface de serviço de aniversário. */\n"
+"interface IBirthdayService {\n"
+"    /** Gera uma mensagem de feliz aniversário. */\n"
+"    String wishHappyBirthday(String name, int years, in String[] text);\n"
+"}\n"
+"```"
+
+#: src/android/logging.md:1
+#, fuzzy
+msgid "# Logging"
+msgstr "# Exploração madeireira"
+
+#: src/android/logging.md:3
+#, fuzzy
+msgid ""
+"You should use the `log` crate to automatically log to `logcat` (on-device) "
+"or\n"
+"`stdout` (on-host):"
+msgstr ""
+"Você deve usar a caixa `log` para logar automaticamente no `logcat` (no "
+"dispositivo) ou\n"
+"`stdout` (no host):"
+
+#: src/android/logging.md:6
+#, fuzzy
+msgid "_hello_rust_logs/Android.bp_:"
+msgstr "_hello_rust_logs/Android.bp_:"
+
+#: src/android/logging.md:8
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_logs\",\n"
+"    crate_name: \"hello_rust_logs\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"liblog_rust\",\n"
+"        \"liblogger\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"    host_supported: true,\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binário {\n"
+"    name: \"hello_rust_logs\",\n"
+"    crate_name: \"hello_rust_logs\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"liblog_rust\",\n"
+"        \"blogueiro\",\n"
+"    ],\n"
+"    prefere_rlib: true,\n"
+"    host_supported: true,\n"
+"}\n"
+"```"
+
+#: src/android/logging.md:22
+#, fuzzy
+msgid "_hello_rust_logs/src/main.rs_:"
+msgstr "_hello_rust_logs/src/main.rs_:"
+
+#: src/android/logging.md:24
+#, fuzzy
+msgid "```rust,ignore\n//! Rust logging demo."
+msgstr "```rust, ignore\n//! Demonstração de registro de rust."
+
+#: src/android/logging.md:27
+#, fuzzy
+msgid "use log::{debug, error, info};"
+msgstr "use log::{debug, error, info};"
+
+#: src/android/logging.md:29
+#, fuzzy
+msgid ""
+"/// Logs a greeting.\n"
+"fn main() {\n"
+"    logger::init(\n"
+"        logger::Config::default()\n"
+"            .with_tag_on_device(\"rust\")\n"
+"            .with_min_level(log::Level::Trace),\n"
+"    );\n"
+"    debug!(\"Starting program.\");\n"
+"    info!(\"Things are going fine.\");\n"
+"    error!(\"Something went wrong!\");\n"
+"}\n"
+"```"
+msgstr ""
+"/// Registra uma saudação.\n"
+"fn main() {\n"
+"    logger::init(\n"
+"        logger::Config::default()\n"
+"            .with_tag_on_device(\"rust\")\n"
+"            .with_min_level(log::Level::Trace),\n"
+"    );\n"
+"    debug!(\"Iniciando programa.\");\n"
+"    info!(\"As coisas estão indo bem.\");\n"
+"    erro!(\"Algo deu errado!\");\n"
+"}\n"
+"```"
+
+#: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
+#: src/android/interoperability/with-c/rust.md:73
+#, fuzzy
+msgid "Build, push, and run the binary on your device:"
+msgstr "Crie, envie e execute o binário em seu dispositivo:"
+
+#: src/android/logging.md:44
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m hello_rust_logs\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust_logs\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m hello_rust_logs\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust_logs\n"
+"```"
+
+#: src/android/logging.md:50
+#, fuzzy
+msgid "The logs show up in `adb logcat`:"
+msgstr "Os logs aparecem em `adb logcat`:"
+
+#: src/android/logging.md:52
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ adb logcat -s rust\n"
+"09-08 08:38:32.454  2420  2420 D rust: hello_rust_logs: Starting program.\n"
+"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going "
+"fine.\n"
+"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went "
+"wrong!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ adb logcat -s rust\n"
+"09-08 08:38:32.454 2420 2420 D rust: hello_rust_logs: Iniciando o programa.\n"
+"09-08 08:38:32.454 2420 2420 I rust: hello_rust_logs: As coisas estão indo "
+"bem.\n"
+"09-08 08:38:32.454 2420 2420 E rust: hello_rust_logs: Algo deu errado!\n"
+"```"
+
+#: src/android/interoperability.md:1
+#, fuzzy
+msgid "# Interoperability"
+msgstr "# Interoperabilage"
+
+#: src/android/interoperability.md:3
+#, fuzzy
+msgid ""
+"Rust has excellent support for interoperability with other languages. This "
+"means\n"
+"that you can:"
+msgstr ""
+"Rust tem excelente suporte para interoperabilage com outras linguagens. "
+"Isso significa\n"
+"isso você pode:"
+
+#: src/android/interoperability.md:6
+#, fuzzy
+msgid ""
+"* Call Rust functions from other languages.\n"
+"* Call functions written in other languages from Rust."
+msgstr ""
+"* Chame funções Rust de outros idiomas.\n"
+"* Chama funções escritas em outras linguagens do Rust."
+
+#: src/android/interoperability.md:9
+#, fuzzy
+msgid ""
+"When you call functions in a foreign language we say that you're using a\n"
+"_foreign function interface_, also known as FFI."
+msgstr ""
+"Quando você chama funções em um idioma estrangeiro, dizemos que você está "
+"usando um\n"
+"_interface de função externa_, também conhecida como FFI."
+
+#: src/android/interoperability/with-c.md:1
+#, fuzzy
+msgid "# Interoperability with C"
+msgstr "# Interoperabilage com C"
+
+#: src/android/interoperability/with-c.md:3
+#, fuzzy
+msgid ""
+"Rust has full support for linking object files with a C calling convention.\n"
+"Similarly, you can export Rust functions and call them from C."
+msgstr ""
+"Rust tem suporte completo para vincular arquivos de objeto com uma convenção "
+"de chamada C.\n"
+"Da mesma forma, você pode exportar funções Rust e chamá-las de C."
+
+#: src/android/interoperability/with-c.md:6
+#, fuzzy
+msgid "You can do it by hand if you want:"
+msgstr "Você pode fazer isso manualmente se quiser:"
+
+#: src/android/interoperability/with-c.md:8
+#, fuzzy
+msgid ""
+"```rust\n"
+"extern \"C\" {\n"
+"    fn abs(x: i32) -> i32;\n"
+"}"
+msgstr ""
+"```rust\n"
+"externo \"C\" {\n"
+"    fn abs(x: i32) -> i32;\n"
+"}"
+
+#: src/android/interoperability/with-c.md:13
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let x = -42;\n"
+"    let abs_x = unsafe { abs(x) };\n"
+"    println!(\"{x}, {abs_x}\");\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let x = -42;\n"
+"    let abs_x = inseguro { abs(x) };\n"
+"    println!(\"{x}, {abs_x}\");\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c.md:20
+#, fuzzy
+msgid ""
+"We already saw this in the [Safe FFI Wrapper\n"
+"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+msgstr ""
+"Já vimos isso no [Safe FFI Wrapper\n"
+"exercício](../../exercises/day-3/safe-ffi-wrapper.md)."
+
+#: src/android/interoperability/with-c.md:23
+#, fuzzy
+msgid ""
+"> This assumes full knowledge of the target platform. Not recommended for\n"
+"> production."
+msgstr ""
+"> Isso pressupõe conhecimento total da plataforma de destino. Não "
+"recomendado para\n"
+"> produção."
+
+#: src/android/interoperability/with-c.md:26
+#, fuzzy
+msgid "We will look at better options next."
+msgstr "Veremos opções melhores a seguir."
+
+#: src/android/interoperability/with-c/bindgen.md:1
+#, fuzzy
+msgid "# Using Bindgen"
+msgstr "# Usando Bingen"
+
+#: src/android/interoperability/with-c/bindgen.md:3
+#, fuzzy
+msgid ""
+"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
+"tool\n"
+"can auto-generate bindings from a C header file."
+msgstr ""
+"A ferramenta "
+"[bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html)\n"
+"pode gerar ligações automaticamente a partir de um arquivo de cabeçalho C."
+
+#: src/android/interoperability/with-c/bindgen.md:6
+#, fuzzy
+msgid "First create a small C library:"
+msgstr "Primeiro crie uma pequena biblioteca C:"
+
+#: src/android/interoperability/with-c/bindgen.md:8
+#, fuzzy
+msgid "_interoperability/bindgen/libbirthday.h_:"
+msgstr "_interoperabilage/bindgen/libbirthday.h_:"
+
+#: src/android/interoperability/with-c/bindgen.md:10
+#, fuzzy
+msgid ""
+"```c\n"
+"typedef struct card {\n"
+"  const char* name;\n"
+"  int years;\n"
+"} card;"
+msgstr ""
+"```c\n"
+"cartão struct typedef {\n"
+"  const char * name;\n"
+"  int anos;\n"
+"} cartão;"
+
+#: src/android/interoperability/with-c/bindgen.md:16
+#, fuzzy
+msgid "void print_card(const card* card);\n```"
+msgstr "void print_card(const card* card);\n```"
+
+#: src/android/interoperability/with-c/bindgen.md:19
+#, fuzzy
+msgid "_interoperability/bindgen/libbirthday.c_:"
+msgstr "_interoperabilage/bindgen/libbirthday.c_:"
+
+#: src/android/interoperability/with-c/bindgen.md:21
+#, fuzzy
+msgid ""
+"```c\n"
+"#include <stdio.h>\n"
+"#include \"libbirthday.h\""
+msgstr ""
+"```c\n"
+"#include <stdio.h>\n"
+"#include \"libaniversário.h\""
+
+#: src/android/interoperability/with-c/bindgen.md:25
+#, fuzzy
+msgid ""
+"void print_card(const card* card) {\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"  printf(\"| Happy Birthday %s!\\n"
+"\", card->name);\n"
+"  printf(\"| Congratulations with the %i years!\\n"
+"\", card->years);\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"}\n"
+"```"
+msgstr ""
+"void print_card(const card* card) {\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"  printf(\"| Feliz Aniversário %s!\\n"
+"\", cartão->name);\n"
+"  printf(\"| Parabéns pelos %i anos!\\n"
+"\", cartão->anos);\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:33
+#, fuzzy
+msgid "Add this to your `Android.bp` file:"
+msgstr "Adicione isto ao seu arquivo `Android.bp`:"
+
+#: src/android/interoperability/with-c/bindgen.md:35
+#: src/android/interoperability/with-c/bindgen.md:55
+#: src/android/interoperability/with-c/bindgen.md:69
+#: src/android/interoperability/with-c/bindgen.md:108
+#, fuzzy
+msgid "_interoperability/bindgen/Android.bp_:"
+msgstr "_interoperabilage/bindgen/Android.bp_:"
+
+#: src/android/interoperability/with-c/bindgen.md:37
+#, fuzzy
+msgid ""
+"```javascript\n"
+"cc_library {\n"
+"    name: \"libbirthday\",\n"
+"    srcs: [\"libbirthday.c\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"cc_library {\n"
+"    name: \"libaniversário\",\n"
+"    srcs: [\"libbirthday.c\"],\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:44
+#, fuzzy
+msgid ""
+"Create a wrapper header file for the library (not strictly needed in this\n"
+"example):"
+msgstr ""
+"Crie um arquivo de cabeçalho wrapper para a biblioteca (não estritamente "
+"necessário neste\n"
+"exemplo):"
+
+#: src/android/interoperability/with-c/bindgen.md:47
+#, fuzzy
+msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
+msgstr "_interoperabilage/bindgen/libbirthday_wrapper.h_:"
+
+#: src/android/interoperability/with-c/bindgen.md:49
+#, fuzzy
+msgid ""
+"```c\n"
+"#include \"libbirthday.h\"\n"
+"```"
+msgstr ""
+"```c\n"
+"#include \"libaniversário.h\"\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:53
+#, fuzzy
+msgid "You can now auto-generate the bindings:"
+msgstr "Agora você pode gerar automaticamente as vinculações:"
+
+#: src/android/interoperability/with-c/bindgen.md:57
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_bindgen {\n"
+"    name: \"libbirthday_bindgen\",\n"
+"    crate_name: \"birthday_bindgen\",\n"
+"    wrapper_src: \"libbirthday_wrapper.h\",\n"
+"    source_stem: \"bindings\",\n"
+"    static_libs: [\"libbirthday\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_bindgen {\n"
+"    name: \"libbirthday_bindgen\",\n"
+"    crate_name: \"aniversário_bindgen\",\n"
+"    wrapper_src: \"libbirthday_wrapper.h\",\n"
+"    source_stem: \"vinculações\",\n"
+"    static_libs: [\"libaniversário\"],\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:67
+#, fuzzy
+msgid "Finally, we can use the bindings in our Rust program:"
+msgstr "Finalmente, podemos usar as ligações em nosso programa Rust:"
+
+#: src/android/interoperability/with-c/bindgen.md:71
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"print_birthday_card\",\n"
+"    srcs: [\"main.rs\"],\n"
+"    rustlibs: [\"libbirthday_bindgen\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_binário {\n"
+"    name: \"print_birthday_card\",\n"
+"    srcs: [\"main.rs\"],\n"
+"    rustlibs: [\"libbirthday_bindgen\"],\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:79
+#, fuzzy
+msgid "_interoperability/bindgen/main.rs_:"
+msgstr "_interoperabilage/bindgen/main.rs_:"
+
+#: src/android/interoperability/with-c/bindgen.md:81
+#, fuzzy
+msgid "```rust,compile_fail\n//! Bindgen demo."
+msgstr "```rust,compile_fail\n//! Demonstração do Bingen."
+
+#: src/android/interoperability/with-c/bindgen.md:84
+#, fuzzy
+msgid "use birthday_bindgen::{card, print_card};"
+msgstr "use birthday_bindgen::{card, print_card};"
+
+#: src/android/interoperability/with-c/bindgen.md:86
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
+"    let card = card {\n"
+"        name: name.as_ptr(),\n"
+"        years: 42,\n"
+"    };\n"
+"    unsafe {\n"
+"        print_card(&card as *const card);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"fn main() {\n"
+"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
+"    let card = card {\n"
+"        name: name.as_ptr(),\n"
+"        anos: 42,\n"
+"    };\n"
+"    inseguro {\n"
+"        print_card(&card as *const card);\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:100
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m print_birthday_card\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card "
+"/data/local/tmp\n"
+"$ adb shell /data/local/tmp/print_birthday_card\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m print_birthday_card\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card "
+"/data/local/tmp\n"
+"$ adb shell /data/local/tmp/print_birthday_card\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:106
+#, fuzzy
+msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
+msgstr ""
+"Por fim, podemos executar testes gerados automaticamente para garantir que "
+"as vinculações funcionem:"
+
+#: src/android/interoperability/with-c/bindgen.md:110
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_test {\n"
+"    name: \"libbirthday_bindgen_test\",\n"
+"    srcs: [\":libbirthday_bindgen\"],\n"
+"    crate_name: \"libbirthday_bindgen_test\",\n"
+"    test_suites: [\"general-tests\"],\n"
+"    auto_gen_config: true,\n"
+"    clippy_lints: \"none\", // Generated file, skip linting\n"
+"    lints: \"none\",\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_teste {\n"
+"    name: \"libbirthday_bindgen_test\",\n"
+"    srcs: [\":libbirthday_bindgen\"],\n"
+"    crate_name: \"libbirthday_bindgen_test\",\n"
+"    test_suites: [\"testes gerais\"],\n"
+"    auto_gen_config: true,\n"
+"    clippy_lints: \"none\", // Arquivo gerado, pule o linting\n"
+"    lints: \"nenhum\",\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/bindgen.md:122
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ atest libbirthday_bindgen_test\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ atest libbirthday_bindgen_test\n"
+"```"
+
+#: src/android/interoperability/with-c/rust.md:1
+#, fuzzy
+msgid "# Calling Rust"
+msgstr "# Chamando Rust"
+
+#: src/android/interoperability/with-c/rust.md:3
+#, fuzzy
+msgid "Exporting Rust functions and types to C is easy:"
+msgstr "Exportar funções e tipos do Rust para C é fácil:"
+
+#: src/android/interoperability/with-c/rust.md:5
+#, fuzzy
+msgid "_interoperability/rust/libanalyze/analyze.rs_"
+msgstr "_interoperabilage/rust/libanalyze/analyze.rs_"
+
+#: src/android/interoperability/with-c/rust.md:7
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"//! Rust FFI demo.\n"
+"#![deny(improper_ctypes_definitions)]"
+msgstr ""
+"```rust, editable\n"
+"//! Rust FFI demonstração.\n"
+"#![negar(improper_ctypes_definitions)]"
+
+#: src/android/interoperability/with-c/rust.md:11
+#, fuzzy
+msgid "use std::os::raw::c_int;"
+msgstr "use std::os::raw::c_int;"
+
+#: src/android/interoperability/with-c/rust.md:13
+#, fuzzy
+msgid ""
+"/// Analyze the numbers.\n"
+"#[no_mangle]\n"
+"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
+"    if x < y {\n"
+"        println!(\"x ({x}) is smallest!\");\n"
+"    } else {\n"
+"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"/// Analisar os números.\n"
+"#[no_mangle]\n"
+"pub extern \"C\" fn analise_números(x: c_int, y: c_int) {\n"
+"    if x < y {\n"
+"        println!(\"x ({x}) é o menor!\");\n"
+"    } else {\n"
+"        println!(\"y ({y}) é provavelmente maior que x ({x})\");\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/rust.md:24
+#, fuzzy
+msgid "_interoperability/rust/libanalyze/analyze.h_"
+msgstr "_interoperabilage/rust/libanalyze/analyze.h_"
+
+#: src/android/interoperability/with-c/rust.md:26
+#, fuzzy
+msgid ""
+"```c\n"
+"#ifndef ANALYSE_H\n"
+"#define ANALYSE_H"
+msgstr ""
+"```c\n"
+"#ifndef ANALYSE_H\n"
+"#define ANALYSE_H"
+
+#: src/android/interoperability/with-c/rust.md:30
+#, fuzzy
+msgid ""
+"extern \"C\" {\n"
+"void analyze_numbers(int x, int y);\n"
+"}"
+msgstr ""
+"externo \"C\" {\n"
+"void analizar_números(int x, int y);\n"
+"}"
+
+#: src/android/interoperability/with-c/rust.md:34
+#, fuzzy
+msgid "#endif\n```"
+msgstr "#fim se\n```"
+
+#: src/android/interoperability/with-c/rust.md:37
+#, fuzzy
+msgid "_interoperability/rust/libanalyze/Android.bp_"
+msgstr "_interoperabilage/rust/libanalyze/Android.bp_"
+
+#: src/android/interoperability/with-c/rust.md:39
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_ffi {\n"
+"    name: \"libanalyze_ffi\",\n"
+"    crate_name: \"analyze_ffi\",\n"
+"    srcs: [\"analyze.rs\"],\n"
+"    include_dirs: [\".\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_ffi {\n"
+"    name: \"libanalyze_ffi\",\n"
+"    crate_name: \"analyze_ffi\",\n"
+"    srcs: [\"analisar.rs\"],\n"
+"    include_dirs: [\".\"],\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/rust.md:48
+#, fuzzy
+msgid "We can now call this from a C binary:"
+msgstr "Agora podemos chamar isso de um binário C:"
+
+#: src/android/interoperability/with-c/rust.md:50
+#, fuzzy
+msgid "_interoperability/rust/analyze/main.c_"
+msgstr "_interoperabilage/rust/analisar/main.c_"
+
+#: src/android/interoperability/with-c/rust.md:52
+#, fuzzy
+msgid "```c\n#include \"analyze.h\""
+msgstr "```c\n#include \"analisar.h\""
+
+#: src/android/interoperability/with-c/rust.md:55
+#, fuzzy
+msgid ""
+"int main() {\n"
+"  analyze_numbers(10, 20);\n"
+"  analyze_numbers(123, 123);\n"
+"  return 0;\n"
+"}\n"
+"```"
+msgstr ""
+"int principal() {\n"
+"  analise_números(10, 20);\n"
+"  analise_números(123, 123);\n"
+"  retorna 0;\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/rust.md:62
+#, fuzzy
+msgid "_interoperability/rust/analyze/Android.bp_"
+msgstr "_interoperabilage/rust/analyze/Android.bp_"
+
+#: src/android/interoperability/with-c/rust.md:64
+#, fuzzy
+msgid ""
+"```javascript\n"
+"cc_binary {\n"
+"    name: \"analyze_numbers\",\n"
+"    srcs: [\"main.c\"],\n"
+"    static_libs: [\"libanalyze_ffi\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"cc_binary {\n"
+"    name: \"analisar_números\",\n"
+"    srcs: [\"main.c\"],\n"
+"    static_libs: [\"libanalyze_ffi\"],\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/with-c/rust.md:75
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m analyze_numbers\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/tmp\n"
+"$ adb shell /data/local/tmp/analyze_numbers\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m analizar_números\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/tmp\n"
+"$ adb shell /data/local/tmp/analyze_numbers\n"
+"```"
+
+#: src/android/interoperability/with-c/rust.md:83
+#, fuzzy
+msgid ""
+"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
+"will just be the name of\n"
+"the function. You can also use `#[export_name = \"some_name\"]` to specify "
+"whatever name you want."
+msgstr ""
+"`#[no_mangle]` desativa a alteração de name usual do Rust, então o símbolo "
+"exportado será apenas o name de\n"
+"a função. Você também pode usar `#[export_name = \"some_name\"]` para "
+"especificar qualquer name que desejar."
+
+#: src/android/interoperability/cpp.md:1
+#, fuzzy
+msgid "# With C++"
+msgstr "# Com C++"
+
+#: src/android/interoperability/cpp.md:3
+#, fuzzy
+msgid ""
+"The [CXX crate][1] makes it possible to do safe interoperability between "
+"Rust\n"
+"and C++."
+msgstr ""
+"A [caixa CXX] [1] possibilita a interoperabilage segura entre Rust\n"
+"e C++."
+
+#: src/android/interoperability/cpp.md:6
+#, fuzzy
+msgid "The overall approach looks like this:"
+msgstr "A abordagem geral é assim:"
+
+#: src/android/interoperability/cpp.md:8
+#, fuzzy
+msgid "<img src=\"cpp/overview.svg\">"
+msgstr "<img src=\"cpp/overview.svg\">"
+
+#: src/android/interoperability/cpp.md:10
+#, fuzzy
+msgid "See the [CXX tutorial][2] for an full example of using this."
+msgstr "Veja o [tutorial CXX][2] para um exemplo completo de como usar isso."
+
+#: src/android/interoperability/cpp.md:12
+#, fuzzy
+msgid "[1]: https://cxx.rs/\n[2]: https://cxx.rs/tutorial.html"
+msgstr "[1]: https://cxx.rs/\n[2]: https://cxx.rs/tutorial.html"
+
+#: src/android/interoperability/java.md:1
+#, fuzzy
+msgid "# Interoperability with Java"
+msgstr "# Interoperabilage com Java"
+
+#: src/android/interoperability/java.md:3
+#, fuzzy
+msgid ""
+"Java can load shared objects via [Java Native Interface\n"
+"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
+"crate](https://docs.rs/jni/) allows you to create a compatible library."
+msgstr ""
+"Java pode carregar objetos compartilhados via [Java Native Interface\n"
+"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). O [`jni`\n"
+"crate](https://docs.rs/jni/) permite que você crie uma biblioteca compatível."
+
+#: src/android/interoperability/java.md:7
+#, fuzzy
+msgid "First, we create a Rust function to export to Java:"
+msgstr "Primeiro, criamos uma função Rust para exportar para Java:"
+
+#: src/android/interoperability/java.md:9
+#, fuzzy
+msgid "_interoperability/java/src/lib.rs_:"
+msgstr "_interoperabilage/java/src/lib.rs_:"
+
+#: src/android/interoperability/java.md:11
+#, fuzzy
+msgid "```rust,compile_fail\n//! Rust <-> Java FFI demo."
+msgstr "```rust,compile_fail\n//! Rust <-> Demonstração Java FFI."
+
+#: src/android/interoperability/java.md:14
+#, fuzzy
+msgid ""
+"use jni::objects::{JClass, JString};\n"
+"use jni::sys::jstring;\n"
+"use jni::JNIEnv;"
+msgstr ""
+"use jni::objects::{JClass, JString};\n"
+"use jni::sys::jstring;\n"
+"use jni::JNIEnv;"
+
+#: src/android/interoperability/java.md:18
+#, fuzzy
+msgid ""
+"/// HelloWorld::hello method implementation.\n"
+"#[no_mangle]\n"
+"pub extern \"system\" fn Java_HelloWorld_hello(\n"
+"    env: JNIEnv,\n"
+"    _class: JClass,\n"
+"    name: JString,\n"
+") -> jstring {\n"
+"    let input: String = env.get_string(name).unwrap().into();\n"
+"    let greeting = format!(\"Hello, {input}!\");\n"
+"    let output = env.new_string(greeting).unwrap();\n"
+"    output.into_inner()\n"
+"}\n"
+"```"
+msgstr ""
+"/// Implementação do método HelloWorld::hello.\n"
+"#[no_mangle]\n"
+"pub extern \"sistema\" fn Java_HelloWorld_hello(\n"
+"    env: JNIEnv,\n"
+"    _class: JClass,\n"
+"    name: JString,\n"
+") -> jstring {\n"
+"    let input: String = env.get_string(name).unwrap().into();\n"
+"    let saudação = format!(\"Olá, {input}!\");\n"
+"    let output = env.new_string(greeting).unwrap();\n"
+"    output.into_inner()\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/java.md:32
+#: src/android/interoperability/java.md:62
+#, fuzzy
+msgid "_interoperability/java/Android.bp_:"
+msgstr "_interoperabilage/java/Android.bp_:"
+
+#: src/android/interoperability/java.md:34
+#, fuzzy
+msgid ""
+"```javascript\n"
+"rust_ffi_shared {\n"
+"    name: \"libhello_jni\",\n"
+"    crate_name: \"hello_jni\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    rustlibs: [\"libjni\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"rust_ffi_shared {\n"
+"    name: \"libhello_jni\",\n"
+"    crate_name: \"hello_jni\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    rustlibs: [\"libjni\"],\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/java.md:43
+#, fuzzy
+msgid "Finally, we can call this function from Java:"
+msgstr "Finalmente, podemos chamar esta função do Java:"
+
+#: src/android/interoperability/java.md:45
+#, fuzzy
+msgid "_interoperability/java/HelloWorld.java_:"
+msgstr "_interoperabilage/java/HelloWorld.java_:"
+
+#: src/android/interoperability/java.md:47
+#, fuzzy
+msgid ""
+"```java\n"
+"class HelloWorld {\n"
+"    private static native String hello(String name);"
+msgstr ""
+"```java\n"
+"classe AlôMundo {\n"
+"    private static nativo String hello(String name);"
+
+#: src/android/interoperability/java.md:51
+#, fuzzy
+msgid ""
+"    static {\n"
+"        System.loadLibrary(\"hello_jni\");\n"
+"    }"
+msgstr ""
+"    static {\n"
+"        System.loadLibrary(\"hello_jni\");\n"
+"    }"
+
+#: src/android/interoperability/java.md:55
+#, fuzzy
+msgid ""
+"    public static void main(String[] args) {\n"
+"        String output = HelloWorld.hello(\"Alice\");\n"
+"        System.out.println(output);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    public static void main(String[] args) {\n"
+"        String output = HelloWorld.hello(\"Alice\");\n"
+"        System.out.println(saída);\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/java.md:64
+#, fuzzy
+msgid ""
+"```javascript\n"
+"java_binary {\n"
+"    name: \"helloworld_jni\",\n"
+"    srcs: [\"HelloWorld.java\"],\n"
+"    main_class: \"HelloWorld\",\n"
+"    required: [\"libhello_jni\"],\n"
+"}\n"
+"```"
+msgstr ""
+"```javascript\n"
+"java_binary {\n"
+"    name: \"helloworld_jni\",\n"
+"    srcs: [\"HelloWorld.java\"],\n"
+"    main_class: \"OláMundo\",\n"
+"    necessário: [\"libhello_jni\"],\n"
+"}\n"
+"```"
+
+#: src/android/interoperability/java.md:73
+#, fuzzy
+msgid "Finally, you can build, sync, and run the binary:"
+msgstr "Por fim, você pode criar, sincronizar e executar o binário:"
+
+#: src/android/interoperability/java.md:75
+#, fuzzy
+msgid ""
+"```shell\n"
+"$ m helloworld_jni\n"
+"$ adb sync  # requires adb root && adb remount\n"
+"$ adb shell /system/bin/helloworld_jni\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ m helloworld_jni\n"
+"$ adb sync # requer adb root && adb remount\n"
+"$ adb shell /system/bin/helloworld_jni\n"
+"```"
+
+#: src/exercises/day-4/afternoon.md:3
+#, fuzzy
+msgid ""
+"For the last exercise, we will look at one of the projects you work with. "
+"Let us\n"
+"group up and do this together. Some suggestions:"
+msgstr ""
+"No último exercício, veremos um dos projetos com os quais você trabalha. "
+"let-nos\n"
+"agrupe-se e faça isso juntos. Algumas sugestões:"
+
+#: src/exercises/day-4/afternoon.md:6
+#, fuzzy
+msgid "* Call your AIDL service with a client written in Rust."
+msgstr "* Chame seu serviço AIDL com um cliente escrito em Rust."
+
+#: src/exercises/day-4/afternoon.md:8
+#, fuzzy
+msgid "* Move a function from your project to Rust and call it."
+msgstr "* Mova uma função do seu projeto para o Rust e chame-a."
+
+#: src/exercises/day-4/afternoon.md:12
+#, fuzzy
+msgid ""
+"No solution is provided here since this is open-ended: it relies on someone "
+"in\n"
+"the class having a piece of code which you can turn in to Rust on the fly."
+msgstr ""
+"Nenhuma solução é fornecida aqui, pois isso é aberto: depende de alguém em\n"
+"a classe tendo um pedaço de código que você pode transformar em Rust em "
+"tempo real."
+
+#: src/thanks.md:1
+#, fuzzy
+msgid "# Thanks!"
+msgstr "# Obrigado!"
+
+#: src/thanks.md:3
+#, fuzzy
+msgid ""
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
+"it\n"
+"was useful."
+msgstr ""
+"_Obrigado por fazer o Comprehensive Rust 🦀!_ Esperamos que tenha gostado e "
+"que\n"
+"foi útil."
+
+#: src/thanks.md:6
+#, fuzzy
+msgid ""
+"We've had a lot of fun putting the course together. The course is not "
+"perfect,\n"
+"so if you spotted any mistakes or have ideas for improvements, please get "
+"in\n"
+"[contact with us on\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
+"love\n"
+"to hear from you."
+msgstr ""
+"Nós nos divertimos muito montando o curso. O curso não é perfeito,\n"
+"portanto, se você identificou algum erro ou tem ideias para melhorias, entre "
+"em\n"
+"[entre em contato conosco em\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). nós "
+"adoraríamos\n"
+"ouvir de você."
+
+#: src/other-resources.md:1
+#, fuzzy
+msgid "# Other Rust Resources"
+msgstr "# Outros recursos de rust"
+
+#: src/other-resources.md:3
+#, fuzzy
+msgid ""
+"The Rust community has created a wealth of high-quality and free resources\n"
+"online."
+msgstr ""
+"A comunage Rust criou uma riqueza de recursos gratuitos e de alta "
+"qualage\n"
+"on-line."
+
+#: src/other-resources.md:6
+#, fuzzy
+msgid "## Official Documentation"
+msgstr "## Documentação Oficial"
+
+#: src/other-resources.md:8
+#, fuzzy
+msgid "The Rust project hosts many resources. These cover Rust in general:"
+msgstr "O projeto Rust hospeda muitos recursos. Estes cobrem Rust em geral:"
+
+#: src/other-resources.md:10
+#, fuzzy
+msgid ""
+"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
+"  canonical free book about Rust. Covers the language in detail and includes "
+"a\n"
+"  few projects for people to build.\n"
+"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust\n"
+"  syntax via a series of examples which showcase different constructs. "
+"Sometimes\n"
+"  includes small exercises where you are asked to expand on the code in the\n"
+"  examples.\n"
+"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
+"documentation of\n"
+"  the standard library for Rust.\n"
+"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book\n"
+"  which describes the Rust grammar and memory model."
+msgstr ""
+"* [A Linguagem de Programação Rust](https://doc.rust-lang.org/book/): o\n"
+"  livro gratuito canônico sobre Rust. Abrange o idioma em detalhes e inclui "
+"um\n"
+"  poucos projetos para as Persons construírem.\n"
+"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): abrange o "
+"Rust\n"
+"  sintaxe por meio de uma série de exemplos que mostram diferentes "
+"construções. As vezes\n"
+"  inclui pequenos exercícios onde você é solicitado a expandir o código no\n"
+"  exemplos.\n"
+"* [Rust Standard Library](https://doc.rust-lang.org/std/): documentação "
+"completa de\n"
+"  a biblioteca padrão para Rust.\n"
+"* [The Rust Reference](https://doc.rust-lang.org/reference/): um livro "
+"incompleto\n"
+"  que descreve a gramática Rust e o modelo de memória."
+
+#: src/other-resources.md:22
+#, fuzzy
+msgid "More specialized guides hosted on the official Rust site:"
+msgstr "Mais guias especializados hospedados no site oficial do Rust:"
+
+#: src/other-resources.md:24
+#, fuzzy
+msgid ""
+"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
+"Rust,\n"
+"  including working with raw pointers and interfacing with other languages\n"
+"  (FFI).\n"
+"* [Asynchronous Programming in "
+"Rust](https://rust-lang.github.io/async-book/):\n"
+"  covers the new asynchronous programming model which was introduced after "
+"the\n"
+"  Rust Book was written.\n"
+"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an\n"
+"  introduction to using Rust on embedded devices without an operating system."
+msgstr ""
+"* [O Rustonomicon](https://doc.rust-lang.org/nomicon/): cobre Rust "
+"inseguro,\n"
+"  incluindo trabalhar com ponteiros brutos e fazer interface com outros "
+"idiomas\n"
+"  (FFI).\n"
+"* [Programação assíncrona em "
+"Rust](https://rust-lang.github.io/async-book/):\n"
+"  abrange o novo modelo de programação assíncrona que foi introduzido após "
+"o\n"
+"  Rust Book foi escrito.\n"
+"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"um\n"
+"  introdução ao uso do Rust em dispositivos embarcados sem um sistema "
+"operacional."
+
+#: src/other-resources.md:33
+#, fuzzy
+msgid "## Unofficial Learning Material"
+msgstr "## Material de aprendizagem não oficial"
+
+#: src/other-resources.md:35
+#, fuzzy
+msgid "A small selection of other guides and tutorial for Rust:"
+msgstr "Uma pequena seleção de outros guias e tutoriais para Rust:"
+
+#: src/other-resources.md:37
+#, fuzzy
+msgid ""
+"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
+"Rust\n"
+"  from the perspective of low-level C programmers.\n"
+"* [Rust for Embedded C\n"
+"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
+"from\n"
+"  the perspective of developers who write firmware in C.\n"
+"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
+"  covers the syntax of Rust using side-by-side comparisons with other "
+"languages\n"
+"  such as C, C++, Java, JavaScript, and Python.\n"
+"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
+"help\n"
+"  you learn Rust.\n"
+"* [Ferrous Teaching\n"
+"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
+"a\n"
+"  series of small presentations covering both basic and advanced part of "
+"the\n"
+"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
+"  covered.\n"
+"* [Beginner's Series to\n"
+"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
+"and\n"
+"  [Take your first steps with\n"
+"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
+"two\n"
+"  Rust guides aimed at new developers. The first is a set of 35 videos and "
+"the\n"
+"  second is a set of 11 modules which covers Rust syntax and basic "
+"constructs."
+msgstr ""
+"* [Aprenda Rust da maneira perigosa](http://cliffle.com/p/dangerust/): cobre "
+"Rust\n"
+"  da perspectiva de programadores C de baixo nível.\n"
+"* [Rust for Embedded C\n"
+"  Programadores](https://docs.opentitan.org/doc/ug/rust_for_c/): cobre Rust "
+"de\n"
+"  a perspectiva dos desenvolvedores que escrevem firmware em C.\n"
+"* [Rust para profissionais](https://overexact.com/rust-for-professionals/):\n"
+"  cobre a sintaxe do Rust usando comparações lado a lado com outras "
+"linguagens\n"
+"  como C, C++, Java, JavaScript e Python.\n"
+"* [Rust on Exercism](https://exercism.org/tracks/rust): mais de 100 "
+"exercícios para ajudar\n"
+"  você aprende Rust.\n"
+"* [Ensino Ferroso\n"
+"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
+"a\n"
+"  série de pequenas apresentações abrangendo tanto a parte básica quanto a "
+"avançada do\n"
+"  Linguagem de rust. Outros tópicos como WebAssembly e async/await "
+"também são\n"
+"  abordado.\n"
+"* [Série Iniciante a\n"
+"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) e\n"
+"  [Dê seus primeiros passos com\n"
+"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
+"dois\n"
+"  Rust guias voltados para novos desenvolvedores. O primeiro é um conjunto "
+"de 35 vídeos e o\n"
+"  o segundo é um conjunto de 11 módulos que cobrem a sintaxe Rust e as "
+"construções básicas."
+
+#: src/other-resources.md:59
+#, fuzzy
+msgid ""
+"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
+"for\n"
+"even more Rust books."
+msgstr ""
+"Consulte o [Little Book of Rust Books](https://lborb.github.io/book/) para\n"
+"ainda mais livros Rust."
+
+#: src/credits.md:1
+#, fuzzy
+msgid "# Credits"
+msgstr "# Créditos"
+
+#: src/credits.md:3
+#, fuzzy
+msgid ""
+"The material here builds on top of the many great sources of Rust "
+"documentation.\n"
+"See the page on [other resources](other-resources.md) for a full list of "
+"useful\n"
+"resources."
+msgstr ""
+"O material aqui se baseia em muitas fontes excelentes de documentação do "
+"Rust.\n"
+"Consulte a página em [outros recursos](outros-recursos.md) para obter uma "
+"lista completa de recursos úteis\n"
+"Recursos."
+
+#: src/credits.md:7
+#, fuzzy
+msgid ""
+"The material of Comprehensive Rust is licensed under the terms of the Apache "
+"2.0\n"
+"license, please see [`LICENSE`](../LICENSE) for details."
+msgstr ""
+"O material do Comprehensive Rust é licenciado sob os termos do Apache 2.0\n"
+"licença, consulte [`LICENSE`](../LICENSE) para obter detalhes."
+
+#: src/credits.md:10
+#, fuzzy
+msgid "## Rust by Example"
+msgstr "## Rust by Example"
+
+#: src/credits.md:12
+#, fuzzy
+msgid ""
+"Some examples and exercises have been copied and adapted from [Rust by\n"
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
+"`third_party/rust-by-example/` directory for details, including the license\n"
+"terms."
+msgstr ""
+"Alguns exemplos e exercícios foram copiados e adaptados de [Rust by\n"
+"Exemplo](https://doc.rust-lang.org/rust-by-example/). por favor veja o\n"
+"diretório `third_party/rust-by-example/` para detalhes, incluindo a licença\n"
+"termos."
+
+#: src/credits.md:17
+#, fuzzy
+msgid "## Rust on Exercism"
+msgstr "## Rust on Exercism"
+
+#: src/credits.md:19
+#, fuzzy
+msgid ""
+"Some exercises have been copied and adapted from [Rust on\n"
+"Exercism](https://exercism.org/tracks/rust). Please see the\n"
+"`third_party/rust-on-exercism/` directory for details, including the "
+"license\n"
+"terms."
+msgstr ""
+"Alguns exercícios foram copiados e adaptados de [Rust on\n"
+"Exercism](https://exercism.org/tracks/rust). por favor veja o\n"
+"diretório `third_party/rust-on-exercism/` para obter detalhes, incluindo a "
+"licença\n"
+"termos."
+
+#: src/credits.md:24
+#, fuzzy
+msgid "## CXX"
+msgstr "## CXX"
+
+#: src/credits.md:26
+#, fuzzy
+msgid ""
+"The [Interoperability with C++](android/interoperability/cpp.md) section "
+"uses an\n"
+"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory\n"
+"for details, including the license terms."
+msgstr ""
+"A seção [Interoperability with C++](android/interoperability/cpp.md) usa um\n"
+"imagem de [CXX](https://cxx.rs/). Consulte o diretório `third_party/cxx/`\n"
+"para obter detalhes, incluindo os termos da licença."
+
+#: src/exercises/solutions.md:1
+#, fuzzy
+msgid "# Solutions"
+msgstr "# Soluções"
+
+#: src/exercises/solutions.md:3
+#, fuzzy
+msgid "You will find solutions to the exercises on the following pages."
+msgstr "Você encontrará soluções para os exercícios nas páginas seguintes."
+
+#: src/exercises/solutions.md:5
+#, fuzzy
+msgid ""
+"Feel free to ask questions about the solutions [on\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
+"know\n"
+"if you have a different or better solution than what is presented here."
+msgstr ""
+"Sinta-se à vontade para fazer perguntas sobre as soluções [no\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). Nos "
+"informe\n"
+"se você tiver uma solução diferente ou melhor do que a apresentada aqui."
+
+#: src/exercises/solutions.md:10
+#, fuzzy
+msgid ""
+"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
+"> comments you see in the solutions. They are there to make it possible to\n"
+"> re-use parts of the solutions as the exercises."
+msgstr ""
+"> **Nota:** Ignore `// ANCHOR: label` e `// ANCHOR_END: label`\n"
+"> comentários que você vê nas soluções. Eles estão lá para tornar possível\n"
+"> reutilizar partes das soluções como exercícios."
+
+#: src/exercises/day-1/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 1 Morning Exercises"
+msgstr "# Dia 1 Exercícios matinais"
+
+#: src/exercises/day-1/solutions-morning.md:3
+#, fuzzy
+msgid "## Arrays and `for` Loops"
+msgstr "## Arrays e loops `for`"
+
+#: src/exercises/day-1/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](for-loops.md))"
+msgstr "([voltar ao exercício](for-loops.md))"
+
+#: src/exercises/day-1/solutions-morning.md:7
+#: src/exercises/day-1/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-morning.md:7
+#: src/exercises/day-2/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-afternoon.md:102
+#: src/exercises/day-3/solutions-morning.md:7
+#: src/exercises/day-3/solutions-afternoon.md:7
+#: src/exercises/day-4/solutions-morning.md:7
+#, fuzzy
+msgid ""
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License."
+msgstr ""
+"```rust\n"
+"// Direitos autorais 2022 Google LLC\n"
+"//\n"
+"// Licenciado sob a Licença Apache, Versão 2.0 (a \"Licença\");\n"
+"// você não pode usar este arquivo exceto em conformage com a Licença.\n"
+"// Você pode obter uma cópia da Licença em\n"
+"//\n"
+"// http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// A menos que exigido pela lei aplicável ou aStringdo por escrito, o "
+"software\n"
+"// distribuído sob a Licença é distribuído em uma BASE \"COMO ESTÁ\",\n"
+"// SEM GARANTIAS OU CONDIÇÕES DE QUALQUER TIPO, expressas ou implícitas.\n"
+"// Consulte a Licença para obter as permissões de controle do idioma "
+"específico e\n"
+"// limitações sob a Licença."
+
+#: src/exercises/day-1/solutions-morning.md:22
+#, fuzzy
+msgid ""
+"// ANCHOR: transpose\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    // ANCHOR_END: transpose\n"
+"    let mut result = [[0; 3]; 3];\n"
+"    for i in 0..3 {\n"
+"        for j in 0..3 {\n"
+"            result[j][i] = matrix[i][j];\n"
+"        }\n"
+"    }\n"
+"    return result;\n"
+"}"
+msgstr ""
+"// ANCHOR: transpose\n"
+"fn transpose(array: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    // ANCHOR_END: transpose\n"
+"    let mut resultado = [[0; 3]; 3];\n"
+"    for i em 0..3 {\n"
+"        para j em 0..3 {\n"
+"            resultado[j][i] = array[i][j];\n"
+"        }\n"
+"    }\n"
+"    resultado de retorno;\n"
+"}"
+
+#: src/exercises/day-1/solutions-morning.md:34
+#, fuzzy
+msgid ""
+"// ANCHOR: pretty_print\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    // ANCHOR_END: pretty_print\n"
+"    for row in matrix {\n"
+"        println!(\"{row:?}\");\n"
+"    }\n"
+"}"
+msgstr ""
+"// ÂNCORA: pretty_print\n"
+"fn pretty_print(array: &[[i32; 3]; 3]) {\n"
+"    // ANCHOR_END: pretty_print\n"
+"    for linha na array {\n"
+"        println!(\"{linha:?}\");\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-1/solutions-morning.md:42
+#, fuzzy
+msgid ""
+"// ANCHOR: tests\n"
+"#[test]\n"
+"fn test_transpose() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], //\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"    let transposed = transpose(matrix);\n"
+"    assert_eq!(\n"
+"        transposed,\n"
+"        [\n"
+"            [101, 201, 301], //\n"
+"            [102, 202, 302],\n"
+"            [103, 203, 303],\n"
+"        ]\n"
+"    );\n"
+"}\n"
+"// ANCHOR_END: tests"
+msgstr ""
+"// ANCHOR: testes\n"
+"#[teste]\n"
+"fn test_transpose() {\n"
+"    let array = [\n"
+"        [101, 102, 103], //\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"    let transposed = transpose(array);\n"
+"    assert_eq!(\n"
+"        transposto,\n"
+"        [\n"
+"            [101, 201, 301], //\n"
+"            [102, 202, 302],\n"
+"            [103, 203, 303],\n"
+"        ]\n"
+"    );\n"
+"}\n"
+"// ANCHOR_END: testes"
+
+#: src/exercises/day-1/solutions-morning.md:62
+#, fuzzy
+msgid ""
+"// ANCHOR: main\n"
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];"
+msgstr ""
+"// ÂNCORA: principal\n"
+"fn main() {\n"
+"    let array = [\n"
+"        [101, 102, 103], // <-- o comentário faz com que o rustfmt adicione "
+"uma nova linha\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];"
+
+#: src/exercises/day-1/solutions-morning.md:73
+#, fuzzy
+msgid ""
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```\n"
+"### Bonus question"
+msgstr ""
+"    let transposed = transpose(array);\n"
+"    println!(\"transposto:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```\n"
+"### Pergunta bônus"
+
+#: src/exercises/day-1/solutions-morning.md:80
+#, fuzzy
+msgid ""
+"It honestly doesn't work so well. It might seem that we could use a "
+"slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make "
+"our function handle any size of matrix. However, this quickly breaks down: "
+"the return type cannot be `&[&[i32]]` since it needs to own the data you "
+"return."
+msgstr ""
+"Sinceramente não funciona tão bem. Pode parecer que poderíamos usar uma "
+"slice de slices (`&[&[i32]]`) como o tipo de entrada para transpose e, assim, "
+"fazer nossa função lidar com qualquer tamanho de array. No entanto, isso "
+"falha rapidamente: o tipo de retorno não pode ser `&[&[i32]]`, pois ele "
+"precisa possuir os dados que você retorna."
+
+#: src/exercises/day-1/solutions-morning.md:82
+#, fuzzy
+msgid ""
+"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work "
+"very well either: it's hard to convert from `Vec<Vec<i32>>` to `&[&[i32]]` "
+"so now you cannot easily use `pretty_print` either."
+msgstr ""
+"Você pode tentar usar algo como `Vec<Vec<i32>>`, mas isso também não "
+"funciona muito bem: é difícil converter de `Vec<Vec<i32>>` para `&[&[i32]] ` "
+"então agora você também não pode usar `pretty_print` facilmente."
+
+#: src/exercises/day-1/solutions-morning.md:84
+#, fuzzy
+msgid ""
+"In addition, the type itself would not enforce that the child slices are of "
+"the same length, so such variable could contain an invalid matrix."
+msgstr ""
+"Além disso, o próprio tipo não imporia que as slices filhas tenham o mesmo "
+"comprimento, portanto, tal variável poderia conter uma array inválida."
+
+#: src/exercises/day-1/solutions-afternoon.md:1
+#, fuzzy
+msgid "# Day 1 Afternoon Exercises"
+msgstr "# Dia 1 Exercícios da Tarde"
+
+#: src/exercises/day-1/solutions-afternoon.md:3
+#, fuzzy
+msgid "## Designing a Library"
+msgstr "## Projetando uma biblioteca"
+
+#: src/exercises/day-1/solutions-afternoon.md:5
+#, fuzzy
+msgid "([back to exercise](book-library.md))"
+msgstr "([voltar ao exercício](book-library.md))"
+
+#: src/exercises/day-1/solutions-afternoon.md:22
+#, fuzzy
+msgid ""
+"// ANCHOR: setup\n"
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}"
+msgstr ""
+"// ANCHOR: configuração\n"
+"biblioteca struct {\n"
+"    livros: Vec<Livro>,\n"
+"}"
+
+#: src/exercises/day-1/solutions-afternoon.md:42
+#, fuzzy
+msgid ""
+"// This makes it possible to print Book values with {}.\n"
+"impl std::fmt::Display for Book {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        write!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: setup"
+msgstr ""
+"// Isso torna possível imprimir valores de livros com {}.\n"
+"impl std::fmt::Display for Book {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        escreva!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: configuração"
+
+#: src/exercises/day-1/solutions-afternoon.md:50
+#, fuzzy
+msgid ""
+"// ANCHOR: Library_new\n"
+"impl Library {\n"
+"    fn new() -> Library {\n"
+"        // ANCHOR_END: Library_new\n"
+"        Library { books: Vec::new() }\n"
+"    }"
+msgstr ""
+"// ANCHOR: Library_new\n"
+"biblioteca impl {\n"
+"    fn new() -> Biblioteca {\n"
+"        // ANCHOR_END: Library_new\n"
+"        Biblioteca { livros: Vec::new() }\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:57
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_len\n"
+"    //fn len(self) -> usize {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_len\n"
+"    fn len(&self) -> usize {\n"
+"        self.books.len()\n"
+"    }"
+msgstr ""
+"    // ANCHOR: Library_len\n"
+"    //fn len(self) -> usize {\n"
+"    // não implementado!()\n"
+"    ///}\n"
+"    // ANCHOR_END: Library_len\n"
+"    fn len(&self) -> usize {\n"
+"        self.books.len()\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:66
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_is_empty\n"
+"    //fn is_empty(self) -> bool {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_is_empty\n"
+"    fn is_empty(&self) -> bool {\n"
+"        self.books.is_empty()\n"
+"    }"
+msgstr ""
+"    // ANCHOR: Library_is_empty\n"
+"    //fn is_empty(self) -> bool {\n"
+"    // não implementado!()\n"
+"    ///}\n"
+"    // ANCHOR_END: Library_is_empty\n"
+"    fn is_empty(&self) -> bool {\n"
+"        self.books.is_empty()\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:75
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_add_book\n"
+"    //fn add_book(self, book: Book) {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_add_book\n"
+"    fn add_book(&mut self, book: Book) {\n"
+"        self.books.push(book)\n"
+"    }"
+msgstr ""
+"    // ANCHOR: Library_add_book\n"
+"    //fn add_book(self, book: Book) {\n"
+"    // não implementado!()\n"
+"    ///}\n"
+"    // ANCHOR_END: Library_add_book\n"
+"    fn add_book(&mut self, livro: Livro) {\n"
+"        self.books.push(livro)\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:84
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_print_books\n"
+"    //fn print_books(self) {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_print_books\n"
+"    fn print_books(&self) {\n"
+"        for book in &self.books {\n"
+"            println!(\"{}\", book);\n"
+"        }\n"
+"    }"
+msgstr ""
+"    // ANCHOR: Library_print_books\n"
+"    //fn print_books(self) {\n"
+"    // não implementado!()\n"
+"    ///}\n"
+"    // ANCHOR_END: Library_print_books\n"
+"    fn print_books(&self) {\n"
+"        para livro em &self.books {\n"
+"            println!(\"{}\", livro);\n"
+"        }\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:95
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_oldest_book\n"
+"    //fn oldest_book(self) -> Option<&Book> {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_oldest_book\n"
+"    fn oldest_book(&self) -> Option<&Book> {\n"
+"        self.books.iter().min_by_key(|book| book.year)\n"
+"    }\n"
+"}"
+msgstr ""
+"    // ANCHOR: Library_oldest_book\n"
+"    //fn livro_mais antigo(self) -> Option<&Livro> {\n"
+"    // não implementado!()\n"
+"    ///}\n"
+"    // ANCHOR_END: Library_oldest_book\n"
+"    fn livro_mais antigo(&self) -> Option<&Livro> {\n"
+"        self.books.iter().min_by_key(|livro| livro.ano)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-1/solutions-afternoon.md:105
+#, fuzzy
+msgid ""
+"// ANCHOR: main\n"
+"// This shows the desired behavior. Uncomment the code below and\n"
+"// implement the missing methods. You will need to update the\n"
+"// method signatures, including the \"self\" parameter! You may\n"
+"// also need to update the variable bindings within main.\n"
+"fn main() {\n"
+"    let library = Library::new();"
+msgstr ""
+"// ÂNCORA: principal\n"
+"// Isso mostra o comportamento desejado. Descomente o código abaixo e\n"
+"// implementa os métodos ausentes. Você precisará atualizar o\n"
+"// assinaturas de método, incluindo o parâmetro \"self\"! Você pode\n"
+"// também precisa atualizar as ligações de variáveis dentro de main.\n"
+"fn main() {\n"
+"    let library = Library::new();"
+
+#: src/exercises/day-1/solutions-afternoon.md:113
+#, fuzzy
+msgid ""
+"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
+"    //\n"
+"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    //\n"
+"    //library.print_books();\n"
+"    //\n"
+"    //match library.oldest_book() {\n"
+"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
+"    //    None => println!(\"My library is empty!\"),\n"
+"    //}\n"
+"    //\n"
+"    //println!(\"Our library has {} books\", library.len());\n"
+"}\n"
+"// ANCHOR_END: main"
+msgstr ""
+"    //println!(\"Nossa biblioteca está vazia: {}\", library.is_empty());\n"
+"    //\n"
+"    //library.add_book(Livro::new(\"O Senhor dos Anéis\", 1954));\n"
+"    //library.add_book(Livro::new(\"As Aventuras de Alice no País das "
+"Maravilhas\", 1865));\n"
+"    //\n"
+"    //library.print_books();\n"
+"    //\n"
+"    //corresponde à biblioteca.oldest_book() {\n"
+"    // Some(livro) => println!(\"Meu livro mais antigo é {livro}\"),\n"
+"    // Nenhum => println!(\"Minha biblioteca está vazia!\"),\n"
+"    ///}\n"
+"    //\n"
+"    //println!(\"Nossa biblioteca tem {} livros\", library.len());\n"
+"}\n"
+"// ANCHOR_END: principal"
+
+#: src/exercises/day-1/solutions-afternoon.md:129
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_library_len() {\n"
+"    let mut library = Library::new();\n"
+"    assert_eq!(library.len(), 0);\n"
+"    assert!(library.is_empty());"
+msgstr ""
+"#[teste]\n"
+"fn test_library_len() {\n"
+"    let mut library = Library::new();\n"
+"    assert_eq!(library.len(), 0);\n"
+"    assert!(library.is_empty());"
+
+#: src/exercises/day-1/solutions-afternoon.md:135
+#, fuzzy
+msgid ""
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(library.len(), 2);\n"
+"    assert!(!library.is_empty());\n"
+"}"
+msgstr ""
+"    library.add_book(Livro::new(\"O Senhor dos Anéis\", 1954));\n"
+"    library.add_book(Livro::new(\"As Aventuras de Alice no País das "
+"Maravilhas\", 1865));\n"
+"    assert_eq!(library.len(), 2);\n"
+"    assert!(!library.is_empty());\n"
+"}"
+
+#: src/exercises/day-1/solutions-afternoon.md:141
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_library_is_empty() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.is_empty());"
+msgstr ""
+"#[teste]\n"
+"fn test_library_is_empty() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.is_empty());"
+
+#: src/exercises/day-1/solutions-afternoon.md:146
+#, fuzzy
+msgid ""
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert!(!library.is_empty());\n"
+"}"
+msgstr ""
+"    library.add_book(Livro::new(\"O Senhor dos Anéis\", 1954));\n"
+"    assert!(!library.is_empty());\n"
+"}"
+
+#: src/exercises/day-1/solutions-afternoon.md:150
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_library_print_books() {\n"
+"    let mut library = Library::new();\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    // We could try and capture stdout, but let us just call the\n"
+"    // method to start with.\n"
+"    library.print_books();\n"
+"}"
+msgstr ""
+"#[teste]\n"
+"fn test_library_print_books() {\n"
+"    let mut library = Library::new();\n"
+"    library.add_book(Livro::new(\"O Senhor dos Anéis\", 1954));\n"
+"    library.add_book(Livro::new(\"As Aventuras de Alice no País das "
+"Maravilhas\", 1865));\n"
+"    // Poderíamos tentar capturar stdout, mas vamos apenas chamar o\n"
+"    // método para começar.\n"
+"    biblioteca.print_books();\n"
+"}"
+
+#: src/exercises/day-1/solutions-afternoon.md:160
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_library_oldest_book() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.oldest_book().is_none());"
+msgstr ""
+"#[teste]\n"
+"fn test_library_oldest_book() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.oldest_book().is_none());"
+
+#: src/exercises/day-1/solutions-afternoon.md:165
+#, fuzzy
+msgid ""
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Lord of the Rings\")\n"
+"    );"
+msgstr ""
+"    library.add_book(Livro::new(\"O Senhor dos Anéis\", 1954));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"O Senhor dos Anéis\")\n"
+"    );"
+
+#: src/exercises/day-1/solutions-afternoon.md:171
+#, fuzzy
+msgid ""
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Alice's Adventures in Wonderland\")\n"
+"    );\n"
+"}\n"
+"```"
+msgstr ""
+"    library.add_book(Livro::new(\"As Aventuras de Alice no País das "
+"Maravilhas\", 1865));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"As Aventuras de Alice no País das Maravilhas\")\n"
+"    );\n"
+"}\n"
+"```"
+
+#: src/exercises/day-2/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 2 Morning Exercises"
+msgstr "# Dia 2 Exercícios matinais"
+
+#: src/exercises/day-2/solutions-morning.md:3
+#, fuzzy
+msgid "## Points and Polygons"
+msgstr "## Points e Polígonos"
+
+#: src/exercises/day-2/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](points-polygons.md))"
+msgstr "([voltar ao exercício](points-polygons.md))"
+
+#: src/exercises/day-2/solutions-morning.md:22
+#, fuzzy
+msgid ""
+"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
+"// ANCHOR: Point\n"
+"pub struct Point {\n"
+"    // ANCHOR_END: Point\n"
+"    x: i32,\n"
+"    y: i32,\n"
+"}"
+msgstr ""
+"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
+"// ÂNCORA: Point\n"
+"pub struct Point {\n"
+"    // ANCHOR_END: Point\n"
+"    x: i32,\n"
+"    e: i32,\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:30
+#, fuzzy
+msgid ""
+"// ANCHOR: Point-impl\n"
+"impl Point {\n"
+"    // ANCHOR_END: Point-impl\n"
+"    pub fn new(x: i32, y: i32) -> Point {\n"
+"        Point { x, y }\n"
+"    }"
+msgstr ""
+"// ANCHOR: Point-impl\n"
+"impl Point {\n"
+"    // ANCHOR_END: implementação de Point\n"
+"    pub fn novo(x: i32, y: i32) -> Point {\n"
+"        Point { x, y }\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:37
+#, fuzzy
+msgid ""
+"    pub fn magnitude(self) -> f64 {\n"
+"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"    }"
+msgstr ""
+"    pub fn magnitude(auto) -> f64 {\n"
+"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:41
+#, fuzzy
+msgid ""
+"    pub fn dist(self, other: Point) -> f64 {\n"
+"        (self - other).magnitude()\n"
+"    }\n"
+"}"
+msgstr ""
+"    pub fn dist(self, other: Point) -> f64 {\n"
+"        (próprio - outro).magnitude()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:49
+#, fuzzy
+msgid ""
+"    fn add(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x + other.x,\n"
+"            y: self.y + other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn add(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x + other.x,\n"
+"            y: self.y + other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:57
+#, fuzzy
+msgid "impl std::ops::Sub for Point {\n    type Output = Self;"
+msgstr "impl std::ops::Sub para Point {\n    type Saída = Auto;"
+
+#: src/exercises/day-2/solutions-morning.md:60
+#, fuzzy
+msgid ""
+"    fn sub(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x - other.x,\n"
+"            y: self.y - other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn sub(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: auto.x - outro.x,\n"
+"            y: self.y - other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:68
+#, fuzzy
+msgid ""
+"// ANCHOR: Polygon\n"
+"pub struct Polygon {\n"
+"    // ANCHOR_END: Polygon\n"
+"    points: Vec<Point>,\n"
+"}"
+msgstr ""
+"// ÂNCORA: Polígono\n"
+"pub struct Polígono {\n"
+"    // ANCHOR_END: Polígono\n"
+"    Points: Vec<Point>,\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:74
+#, fuzzy
+msgid ""
+"// ANCHOR: Polygon-impl\n"
+"impl Polygon {\n"
+"    // ANCHOR_END: Polygon-impl\n"
+"    pub fn new() -> Polygon {\n"
+"        Polygon { points: Vec::new() }\n"
+"    }"
+msgstr ""
+"// ANCHOR: Polygon-impl\n"
+"impl Polígono {\n"
+"    // ANCHOR_END: implementação de polígono\n"
+"    pub fn new() -> Polígono {\n"
+"        Polígono { Points: Vec::new() }\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:81
+#, fuzzy
+msgid ""
+"    pub fn add_point(&mut self, point: Point) {\n"
+"        self.points.push(point);\n"
+"    }"
+msgstr ""
+"    pub fn add_point(&mut self, point: Point) {\n"
+"        self.points.push(point);\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:85
+#, fuzzy
+msgid ""
+"    pub fn left_most_point(&self) -> Option<Point> {\n"
+"        self.points.iter().min_by_key(|p| p.x).copied()\n"
+"    }"
+msgstr ""
+"    pub fn left_most_point(&self) -> Option<Point> {\n"
+"        self.points.iter().min_by_key(|p| p.x).copied()\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:89
+#, fuzzy
+msgid ""
+"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"        self.points.iter()\n"
+"    }"
+msgstr ""
+"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"        self.points.iter()\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:93
+#, fuzzy
+msgid ""
+"    pub fn length(&self) -> f64 {\n"
+"        if self.points.is_empty() {\n"
+"            return 0.0;\n"
+"        }"
+msgstr ""
+"    pub fn length(&self) -> f64 {\n"
+"        if self.points.is_empty() {\n"
+"            retornar 0,0;\n"
+"        }"
+
+#: src/exercises/day-2/solutions-morning.md:98
+#, fuzzy
+msgid ""
+"        let mut result = 0.0;\n"
+"        let mut last_point = self.points[0];\n"
+"        for point in &self.points[1..] {\n"
+"            result += last_point.dist(*point);\n"
+"            last_point = *point;\n"
+"        }\n"
+"        result += last_point.dist(self.points[0]);\n"
+"        result\n"
+"    }\n"
+"}"
+msgstr ""
+"        let mut resultado = 0,0;\n"
+"        let mut last_point = self.points[0];\n"
+"        para Point em &self.points[1..] {\n"
+"            resultado += last_point.dist(*point);\n"
+"            último_Point = *Point;\n"
+"        }\n"
+"        resultado += last_point.dist(self.points[0]);\n"
+"        resultado\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:109
+#, fuzzy
+msgid ""
+"// ANCHOR: Circle\n"
+"pub struct Circle {\n"
+"    // ANCHOR_END: Circle\n"
+"    center: Point,\n"
+"    radius: i32,\n"
+"}"
+msgstr ""
+"// ÂNCORA: Círculo\n"
+"pub struct Círculo {\n"
+"    // ANCHOR_END: Círculo\n"
+"    Point central,\n"
+"    raio: i32,\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:116
+#, fuzzy
+msgid ""
+"// ANCHOR: Circle-impl\n"
+"impl Circle {\n"
+"    // ANCHOR_END: Circle-impl\n"
+"    pub fn new(center: Point, radius: i32) -> Circle {\n"
+"        Circle { center, radius }\n"
+"    }"
+msgstr ""
+"// ANCHOR: Circle-impl\n"
+"impl Círculo {\n"
+"    // ANCHOR_END: Implantação do círculo\n"
+"    pub fn new(center: Point, radius: i32) -> Circle {\n"
+"        Círculo { centro, raio }\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:123
+#, fuzzy
+msgid ""
+"    pub fn circumference(&self) -> f64 {\n"
+"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"    }"
+msgstr ""
+"    pub fn circunferência(&self) -> f64 {\n"
+"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:127
+#, fuzzy
+msgid ""
+"    pub fn dist(&self, other: &Self) -> f64 {\n"
+"        self.center.dist(other.center)\n"
+"    }\n"
+"}"
+msgstr ""
+"    pub fn dist(&self, outro: &Self) -> f64 {\n"
+"        self.center.dist(outro.centro)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:132
+#, fuzzy
+msgid ""
+"// ANCHOR: Shape\n"
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}\n"
+"// ANCHOR_END: Shape"
+msgstr ""
+"// ÂNCORA: Forma\n"
+"pub enum Forma {\n"
+"    Polígono(Polígono),\n"
+"    Círculo(Círculo),\n"
+"}\n"
+"// ANCHOR_END: Forma"
+
+#: src/exercises/day-2/solutions-morning.md:139
+#, fuzzy
+msgid ""
+"impl From<Polygon> for Shape {\n"
+"    fn from(poly: Polygon) -> Self {\n"
+"        Shape::Polygon(poly)\n"
+"    }\n"
+"}"
+msgstr ""
+"impl De<Polígono> para Forma {\n"
+"    fn from(poly: Polygon) -> Self {\n"
+"        Forma:: Polígono (poli)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:145
+#, fuzzy
+msgid ""
+"impl From<Circle> for Shape {\n"
+"    fn from(circle: Circle) -> Self {\n"
+"        Shape::Circle(circle)\n"
+"    }\n"
+"}"
+msgstr ""
+"impl De<Círculo> para Forma {\n"
+"    fn from(circle: Circle) -> Self {\n"
+"        Forma:: Círculo (círculo)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:151
+#, fuzzy
+msgid ""
+"impl Shape {\n"
+"    pub fn perimeter(&self) -> f64 {\n"
+"        match self {\n"
+"            Shape::Polygon(poly) => poly.length(),\n"
+"            Shape::Circle(circle) => circle.circumference(),\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Forma {\n"
+"    pub fn perímetro(&self) -> f64 {\n"
+"        corresponder a si mesmo {\n"
+"            Forma::Polygon(poly) => poly.length(),\n"
+"            Forma::Círculo(círculo) => círculo.circunferência(),\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:160
+#, fuzzy
+msgid ""
+"// ANCHOR: unit-tests\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;"
+msgstr ""
+"// ANCHOR: testes unitários\n"
+"#[cfg(teste)]\n"
+"testes mod {\n"
+"    use super::*;"
+
+#: src/exercises/day-2/solutions-morning.md:213
+#, fuzzy
+msgid ""
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: unit-tests"
+msgstr ""
+"    #[teste]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let formas = vec![\n"
+"            Forma::de(poli),\n"
+"            Forma::de(Círculo::novo(Point::novo(10, 20), 5)),\n"
+"        ];\n"
+"        let perímetros = formas\n"
+"            .iter()\n"
+"            .map(Forma::perímetro)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perímetros, vec![15.48, 31.42]);\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: testes unitários"
+
+#: src/exercises/day-2/solutions-afternoon.md:1
+#, fuzzy
+msgid "# Day 2 Afternoon Exercises"
+msgstr "# Dia 2 Exercícios da Tarde"
+
+#: src/exercises/day-2/solutions-afternoon.md:3
+#, fuzzy
+msgid "## Luhn Algorithm"
+msgstr "## Algoritmo de Luhn"
+
+#: src/exercises/day-2/solutions-afternoon.md:5
+#, fuzzy
+msgid "([back to exercise](luhn.md))"
+msgstr "([voltar ao exercício](luhn.md))"
+
+#: src/exercises/day-2/solutions-afternoon.md:22
+#, fuzzy
+msgid ""
+"// ANCHOR: luhn\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    // ANCHOR_END: luhn\n"
+"    let mut digits_seen = 0;\n"
+"    let mut sum = 0;\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' "
+"').enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Some(d) => {\n"
+"                sum += if i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd / 10 + dd % 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                digits_seen += 1;\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }"
+msgstr ""
+"// ÂNCORA: luhn\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    // ANCHOR_END: luhn\n"
+"    let mut digits_seen = 0;\n"
+"    let mut soma = 0;\n"
+"    for (i, ch) em cc_number.chars().rev().filter(|&ch| ch != ' "
+"').enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Algum(d) => {\n"
+"                soma += se i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd/10 + dd% 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                dígitos_vistos += 1;\n"
+"            }\n"
+"            Nenhum => retorna false,\n"
+"        }\n"
+"    }"
+
+#: src/exercises/day-2/solutions-afternoon.md:42
+#, fuzzy
+msgid ""
+"    if digits_seen < 2 {\n"
+"        return false;\n"
+"    }"
+msgstr ""
+"    if dígitos_vistos < 2 {\n"
+"        return false;\n"
+"    }"
+
+#: src/exercises/day-2/solutions-afternoon.md:46
+#, fuzzy
+msgid "    sum % 10 == 0\n}"
+msgstr "    soma % 10 == 0\n}"
+
+#: src/exercises/day-2/solutions-afternoon.md:49
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    let cc_number = \"1234 5678 1234 5670\";\n"
+"    println!(\n"
+"        \"Is {} a valid credit card number? {}\",\n"
+"        cc_number,\n"
+"        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
+"    );\n"
+"}"
+msgstr ""
+"fn main() {\n"
+"    let cc_number = \"1234 5678 1234 5670\";\n"
+"    println!(\n"
+"        \"{} é um número de cartão de crédito válido? {}\",\n"
+"        número_cc,\n"
+"        if luhn(cc_number) { \"sim\" } else { \"não\" }\n"
+"    );\n"
+"}"
+
+#: src/exercises/day-2/solutions-afternoon.md:58
+#, fuzzy
+msgid ""
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"}"
+msgstr ""
+"// ANCHOR: testes unitários\n"
+"#[teste]\n"
+"fn test_non_digit_cc_number() {\n"
+"    afirmar!(!luhn(\"foo\"));\n"
+"}"
+
+#: src/exercises/day-2/solutions-afternoon.md:89
+#, fuzzy
+msgid ""
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"// ANCHOR_END: unit-tests\n"
+"```"
+msgstr ""
+"#[teste]\n"
+"fn test_invalid_cc_number() {\n"
+"    afirmar!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    afirmar!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    afirmar!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"// ANCHOR_END: testes unitários\n"
+"```"
+
+#: src/exercises/day-2/solutions-afternoon.md:98
+#, fuzzy
+msgid "## Strings and Iterators"
+msgstr "## Strings e iteradores"
+
+#: src/exercises/day-2/solutions-afternoon.md:100
+#, fuzzy
+msgid "([back to exercise](strings-iterators.md))"
+msgstr "([voltar ao exercício](strings-iterators.md))"
+
+#: src/exercises/day-2/solutions-afternoon.md:117
+#, fuzzy
+msgid ""
+"// ANCHOR: prefix_matches\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    // ANCHOR_END: prefix_matches\n"
+"    let prefixes = prefix.split('/');\n"
+"    let request_paths = request_path\n"
+"        .split('/')\n"
+"        .map(|p| Some(p))\n"
+"        .chain(std::iter::once(None));"
+msgstr ""
+"// ANCHOR: prefix_matches\n"
+"pub fn prefix_matches(prefixo: &str, request_path: &str) -> bool {\n"
+"    // ANCHOR_END: prefix_matches\n"
+"    let prefixos = prefix.split('/');\n"
+"    let request_paths = request_path\n"
+"        .dividir('/')\n"
+"        .map(|p| Some(p))\n"
+"        .chain(std::iter::once(None));"
+
+#: src/exercises/day-2/solutions-afternoon.md:126
+#, fuzzy
+msgid ""
+"    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"        match request_path {\n"
+"            Some(request_path) => {\n"
+"                if (prefix != \"*\") && (prefix != request_path) {\n"
+"                    return false;\n"
+"                }\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"}"
+msgstr ""
+"    for (prefixo, request_path) em prefixes.zip(request_paths) {\n"
+"        corresponder request_path {\n"
+"            Some(request_path) => {\n"
+"                if (prefixo != \"*\") && (prefixo != request_path) {\n"
+"                    retorna false;\n"
+"                }\n"
+"            }\n"
+"            Nenhum => retorna false,\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"}"
+
+#: src/exercises/day-2/solutions-afternoon.md:139
+#, fuzzy
+msgid ""
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));"
+msgstr ""
+"// ANCHOR: testes unitários\n"
+"#[teste]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));"
+
+#: src/exercises/day-2/solutions-afternoon.md:166
+#, fuzzy
+msgid ""
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"// ANCHOR_END: unit-tests\n"
+"```"
+msgstr ""
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    afirmar!(!prefix_matches(\n"
+"        \"/v1/editores/*/livros\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"// ANCHOR_END: testes unitários\n"
+"```"
+
+#: src/exercises/day-3/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 3 Morning Exercise"
+msgstr "# Dia 3 Exercício matinal"
+
+#: src/exercises/day-3/solutions-morning.md:3
+#, fuzzy
+msgid "## A Simple GUI Library"
+msgstr "## Uma biblioteca GUI simples"
+
+#: src/exercises/day-3/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](simple-gui.md))"
+msgstr "([voltar ao exercício](simples-gui.md))"
+
+#: src/exercises/day-3/solutions-morning.md:22
+#, fuzzy
+msgid ""
+"// ANCHOR: setup\n"
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;"
+msgstr ""
+"// ANCHOR: configuração\n"
+"Pub trait Widget {\n"
+"    /// Largura natural de `self`.\n"
+"    fn width(&self) -> usar;"
+
+#: src/exercises/day-3/solutions-morning.md:82
+#, fuzzy
+msgid "// ANCHOR_END: setup"
+msgstr "// ANCHOR_END: configuração"
+
+#: src/exercises/day-3/solutions-morning.md:84
+#, fuzzy
+msgid ""
+"// ANCHOR: Window-width\n"
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        // ANCHOR_END: Window-width\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }"
+msgstr ""
+"// ANCHOR: largura da janela\n"
+"impl Widget para Janela {\n"
+"    fn width(&self) -> use {\n"
+"        // ANCHOR_END: largura da janela\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }"
+
+#: src/exercises/day-3/solutions-morning.md:94
+#, fuzzy
+msgid ""
+"    // ANCHOR: Window-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Window-draw_into\n"
+"        let mut inner = String::new();\n"
+"        for widget in &self.widgets {\n"
+"            widget.draw_into(&mut inner);\n"
+"        }"
+msgstr ""
+"    // ANCHOR: Window-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Window-draw_into\n"
+"        let mut interno = String::new();\n"
+"        para widget em &self.widgets {\n"
+"            widget.draw_into(&mut interior);\n"
+"        }"
+
+#: src/exercises/day-3/solutions-morning.md:102
+#, fuzzy
+msgid "        let window_width = self.width();"
+msgstr "        let window_width = self.width();"
+
+#: src/exercises/day-3/solutions-morning.md:104
+#, fuzzy
+msgid ""
+"        // TODO: after learning about error handling, you can change\n"
+"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
+"        // the ?-operator here instead of .unwrap().\n"
+"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"        writeln!(buffer, \"| {:^window_width$} |\", &self.title).unwrap();\n"
+"        writeln!(buffer, \"+={:=<window_width$}=+\", \"\").unwrap();\n"
+"        for line in inner.lines() {\n"
+"            writeln!(buffer, \"| {:window_width$} |\", line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"    }\n"
+"}"
+msgstr ""
+"        // TODO: depois de aprender sobre tratamento de erros, você pode "
+"alterar\n"
+"        // draw_into para retornar Result<(), std::fmt::Error>. Então use\n"
+"        // o operador ? aqui em vez de .unwrap().\n"
+"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"        writeln!(buffer, \"| {:^window_width$} |\", &self.title).unwrap();\n"
+"        writeln!(buffer, \"+={:=<window_width$}=+\", \"\").unwrap();\n"
+"        para a linha em inner.lines() {\n"
+"            writeln!(buffer, \"| {:window_width$} |\", linha).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/solutions-morning.md:117
+#, fuzzy
+msgid ""
+"// ANCHOR: Button-width\n"
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        // ANCHOR_END: Button-width\n"
+"        self.label.width() + 8 // add a bit of padding\n"
+"    }"
+msgstr ""
+"// ANCHOR: Largura do botão\n"
+"impl Widget para botão {\n"
+"    fn width(&self) -> use {\n"
+"        // ANCHOR_END: largura do botão\n"
+"        self.label.width() + 8 // adiciona um pouco de preenchimento\n"
+"    }"
+
+#: src/exercises/day-3/solutions-morning.md:124
+#, fuzzy
+msgid ""
+"    // ANCHOR: Button-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Button-draw_into\n"
+"        let width = self.width();\n"
+"        let mut label = String::new();\n"
+"        self.label.draw_into(&mut label);"
+msgstr ""
+"    // ANCHOR: Button-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Button-draw_into\n"
+"        let width = self.width();\n"
+"        let mut label = String::new();\n"
+"        self.label.draw_into(&mut label);"
+
+#: src/exercises/day-3/solutions-morning.md:131
+#, fuzzy
+msgid ""
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"        for line in label.lines() {\n"
+"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    }\n"
+"}"
+msgstr ""
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"        para linha em label.lines() {\n"
+"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/solutions-morning.md:139
+#, fuzzy
+msgid ""
+"// ANCHOR: Label-width\n"
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        // ANCHOR_END: Label-width\n"
+"        self.label\n"
+"            .lines()\n"
+"            .map(|line| line.chars().count())\n"
+"            .max()\n"
+"            .unwrap_or(0)\n"
+"    }"
+msgstr ""
+"// ANCHOR: Largura do rótulo\n"
+"impl Widget para etiqueta {\n"
+"    fn width(&self) -> use {\n"
+"        // ANCHOR_END: Largura do rótulo\n"
+"        self.label\n"
+"            .linhas()\n"
+"            .map(|linha| linha.chars().count())\n"
+"            .max()\n"
+"            .unwrap_or(0)\n"
+"    }"
+
+#: src/exercises/day-3/solutions-morning.md:150
+#, fuzzy
+msgid ""
+"    // ANCHOR: Label-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Label-draw_into\n"
+"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"    }\n"
+"}"
+msgstr ""
+"    // ANCHOR: Label-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Label-draw_into\n"
+"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/solutions-morning.md:157
+#, fuzzy
+msgid ""
+"// ANCHOR: main\n"
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\",\n"
+"        Box::new(|| println!(\"You clicked the button!\")),\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"// ANCHOR_END: main\n"
+"```"
+msgstr ""
+"// ÂNCORA: principal\n"
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"Esta é uma pequena demonstração "
+"de GUI de texto.\")));\n"
+"    window.add_widget(Caixa::novo(Botão::novo(\n"
+"        \"Clique em mim!\",\n"
+"        Box::new(|| println!(\"Você clicou no botão!\")),\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"// ANCHOR_END: principal\n"
+"```"
+
+#: src/exercises/day-3/solutions-afternoon.md:1
+#, fuzzy
+msgid "# Day 3 Afternoon Exercises"
+msgstr "# Dia 3 Exercícios da Tarde"
+
+#: src/exercises/day-3/solutions-afternoon.md:3
+#, fuzzy
+msgid "## Safe FFI Wrapper"
+msgstr "## Invólucro FFI Seguro"
+
+#: src/exercises/day-3/solutions-afternoon.md:5
+#, fuzzy
+msgid "([back to exercise](safe-ffi-wrapper.md))"
+msgstr "([voltar ao exercício](safe-ffi-wrapper.md))"
+
+#: src/exercises/day-3/solutions-afternoon.md:22
+#, fuzzy
+msgid ""
+"// ANCHOR: ffi\n"
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+msgstr ""
+"// ÂNCORA: ffi\n"
+"modo ffi {\n"
+"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+
+#: src/exercises/day-3/solutions-afternoon.md:53
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"// ANCHOR_END: ffi"
+msgstr ""
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    caminho: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"// ANCHOR_END: ffi"
+
+#: src/exercises/day-3/solutions-afternoon.md:60
+#, fuzzy
+msgid ""
+"// ANCHOR: DirectoryIterator\n"
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
+"        // otherwise return Err with a message.\n"
+"        // ANCHOR_END: DirectoryIterator\n"
+"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
+"{err}\"))?;\n"
+"        // SAFETY: path.as_ptr() cannot be NULL.\n"
+"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
+"        if dir.is_null() {\n"
+"            Err(format!(\"Could not open {:?}\", path))\n"
+"        } else {\n"
+"            Ok(DirectoryIterator { path, dir })\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"// ANCHOR: DirectoryIterator\n"
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Chame opendir e retorne um valor Ok se funcionou,\n"
+"        // caso contrário, retorna Err com uma mensagem.\n"
+"        // ANCHOR_END: DirectoryIterator\n"
+"        let path = CString::new(path).map_err(|err| format!(\"Caminho "
+"inválido: {err}\"))?;\n"
+"        // SEGURANÇA: path.as_ptr() não pode ser NULL.\n"
+"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
+"        if dir.is_null() {\n"
+"            Err(format!(\"Não foi possível abrir {:?}\", caminho))\n"
+"        } else {\n"
+"            Ok(DirectoryIterator { path, dir })\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/solutions-afternoon.md:77
+#, fuzzy
+msgid ""
+"// ANCHOR: Iterator\n"
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
+"        // ANCHOR_END: Iterator\n"
+"        // SAFETY: self.dir is never NULL.\n"
+"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
+"        if dirent.is_null() {\n"
+"            // We have reached the end of the directory.\n"
+"            return None;\n"
+"        }\n"
+"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
+"        // terminated.\n"
+"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
+"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
+"        Some(os_str.to_owned())\n"
+"    }\n"
+"}"
+msgstr ""
+"// ÂNCORA: Iterador\n"
+"impl Iterator para DirectoryIterator {\n"
+"    tipo Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Continue chamando readdir até obtermos um ponteiro NULL de "
+"volta.\n"
+"        // ANCHOR_END: iterador\n"
+"        // SEGURANÇA: self.dir nunca é NULL.\n"
+"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
+"        if dirent.is_null() {\n"
+"            // Chegamos ao final do diretório.\n"
+"            retornar Nenhum;\n"
+"        }\n"
+"        // SEGURANÇA: dirent não é NULL e dirent.d_name é NUL\n"
+"        // encerrado.\n"
+"        let d_name = inseguro { CStr::from_ptr((*dirent).d_name.as_ptr()) "
+"};\n"
+"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
+"        Some(os_str.to_owned())\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/solutions-afternoon.md:97
+#, fuzzy
+msgid ""
+"// ANCHOR: Drop\n"
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        // ANCHOR_END: Drop\n"
+"        if !self.dir.is_null() {\n"
+"            // SAFETY: self.dir is not NULL.\n"
+"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
+"                panic!(\"Could not close {:?}\", self.path);\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"// ANCHOR: Drop\n"
+"impl Drop para DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Chama closedir conforme necessário.\n"
+"        // ANCHOR_END: Largar\n"
+"        if !self.dir.is_null() {\n"
+"            // SEGURANÇA: self.dir não é NULL.\n"
+"            se inseguro { ffi::closedir(self.dir) } != 0 {\n"
+"                panic!(\"Não foi possível fechar {:?}\", self.path);\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/solutions-afternoon.md:111
+#, fuzzy
+msgid ""
+"// ANCHOR: main\n"
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"// ANCHOR_END: main\n"
+"```"
+msgstr ""
+"// ÂNCORA: principal\n"
+"fn main() -> Resultado<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"arquivos: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    OK(())\n"
+"}\n"
+"// ANCHOR_END: principal\n"
+"```"
+
+#: src/exercises/day-4/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 4 Morning Exercise"
+msgstr "# Dia 4 Exercício matinal"
+
+#: src/exercises/day-4/solutions-morning.md:3
+#, fuzzy
+msgid "## Dining Philosophers"
+msgstr "## Jantar com filósofos"
+
+#: src/exercises/day-4/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](dining-philosophers.md))"
+msgstr "([voltar ao exercício](dining-philosophers.md))"
+
+#: src/exercises/day-4/solutions-morning.md:22
+#, fuzzy
+msgid ""
+"// ANCHOR: Philosopher\n"
+"use std::sync::mpsc;\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+"// ÂNCORA: Filósofo\n"
+"use std::sync::mpsc;\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"use padrão::tempo::Duração;"
+
+#: src/exercises/day-4/solutions-morning.md:30
+#, fuzzy
+msgid ""
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // ANCHOR_END: Philosopher\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    thoughts: mpsc::SyncSender<String>,\n"
+"}"
+msgstr ""
+"struct Filósofo {\n"
+"    name: String,\n"
+"    // ANCHOR_END: Filósofo\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    pensamentos: mpsc::SyncSender<String>,\n"
+"}"
+
+#: src/exercises/day-4/solutions-morning.md:38
+#, fuzzy
+msgid ""
+"// ANCHOR: Philosopher-think\n"
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }\n"
+"    // ANCHOR_END: Philosopher-think"
+msgstr ""
+"// ÂNCORA: pensamento-filósofo\n"
+"impl Filósofo {\n"
+"    fn pense(&self) {\n"
+"        auto.pensamentos\n"
+"            .send(format!(\"Eureka! {} tem uma nova ideia!\", &self.name))\n"
+"            .desembrulhar();\n"
+"    }\n"
+"    // ANCHOR_END: pensamento filosófico"
+
+#: src/exercises/day-4/solutions-morning.md:47
+#, fuzzy
+msgid ""
+"    // ANCHOR: Philosopher-eat\n"
+"    fn eat(&self) {\n"
+"        // ANCHOR_END: Philosopher-eat\n"
+"        println!(\"{} is trying to eat\", &self.name);\n"
+"        let left = self.left_fork.lock().unwrap();\n"
+"        let right = self.right_fork.lock().unwrap();"
+msgstr ""
+"    // ÂNCORA: Filósofo-comer\n"
+"    fn come(&self) {\n"
+"        // ANCHOR_END: Comer filósofo\n"
+"        println!(\"{} está tentando comer\", &self.name);\n"
+"        let left = self.left_fork.lock().unwrap();\n"
+"        let right = self.right_fork.lock().unwrap();"
+
+#: src/exercises/day-4/solutions-morning.md:54
+#, fuzzy
+msgid ""
+"        // ANCHOR: Philosopher-eat-end\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}"
+msgstr ""
+"        // ÂNCORA: Filósofo-come-end\n"
+"        println!(\"{} está comendo...\", &self.name);\n"
+"        thread::sleep(Duração::from_millis(10));\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-4/solutions-morning.md:63
+#, fuzzy
+msgid ""
+"fn main() {\n"
+"    // ANCHOR_END: Philosopher-eat-end\n"
+"    let (tx, rx) = mpsc::sync_channel(10);"
+msgstr ""
+"fn main() {\n"
+"    // ANCHOR_END: fim-comer-filósofo\n"
+"    let (tx, rx) = mpsc::sync_channel(10);"
+
+#: src/exercises/day-4/solutions-morning.md:67
+#, fuzzy
+msgid ""
+"    let forks = (0..PHILOSOPHERS.len())\n"
+"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
+"        .collect::<Vec<_>>();"
+msgstr ""
+"    let garfos = (0..PHILOSOPHERS.len())\n"
+"        .map(|_| Arc::novo(Mutex::novo(Forquilha)))\n"
+"        .collect::<Vec<_>>();"
+
+#: src/exercises/day-4/solutions-morning.md:71
+#, fuzzy
+msgid ""
+"    for i in 0..forks.len() {\n"
+"        let tx = tx.clone();\n"
+"        let mut left_fork = forks[i].clone();\n"
+"        let mut right_fork = forks[(i + 1) % forks.len()].clone();"
+msgstr ""
+"    for i em 0..forks.len() {\n"
+"        let tx = tx.clone();\n"
+"        let mut forquilha_esquerda = forks[i].clone();\n"
+"        let mut right_fork = forks[(i + 1) % forks.len()].clone();"
+
+#: src/exercises/day-4/solutions-morning.md:76
+#, fuzzy
+msgid ""
+"        // To avoid a deadlock, we have to break the symmetry\n"
+"        // somewhere. This will swap the forks without deinitializing\n"
+"        // either of them.\n"
+"        if i == forks.len() - 1 {\n"
+"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"        }"
+msgstr ""
+"        // Para evitar um impasse, temos que quebrar a simetria\n"
+"        // algum lugar. Isso irá trocar os garfos sem desinicializar\n"
+"        // qualquer um deles.\n"
+"        if i == forks.len() - 1 {\n"
+"            std::mem::swap(&mut forquilha_esquerda, &mut "
+"forquilha_direita);\n"
+"        }"
+
+#: src/exercises/day-4/solutions-morning.md:83
+#, fuzzy
+msgid ""
+"        let philosopher = Philosopher {\n"
+"            name: PHILOSOPHERS[i].to_string(),\n"
+"            thoughts: tx,\n"
+"            left_fork,\n"
+"            right_fork,\n"
+"        };"
+msgstr ""
+"        let filósofo = Filósofo {\n"
+"            name: FILÓSOFOS[i].to_string(),\n"
+"            pensamentos: tx,\n"
+"            bifurcação_esquerda,\n"
+"            bifurcação direita,\n"
+"        };"
+
+#: src/exercises/day-4/solutions-morning.md:90
+#, fuzzy
+msgid ""
+"        thread::spawn(move || {\n"
+"            for _ in 0..100 {\n"
+"                philosopher.eat();\n"
+"                philosopher.think();\n"
+"            }\n"
+"        });\n"
+"    }"
+msgstr ""
+"        thread::spawn(mover || {\n"
+"            para _ em 0..100 {\n"
+"                filósofo.comer();\n"
+"                filósofo.pensar();\n"
+"            }\n"
+"        });\n"
+"    }"
+
+#: src/exercises/day-4/solutions-morning.md:98
+#, fuzzy
+msgid ""
+"    drop(tx);\n"
+"    for thought in rx {\n"
+"        println!(\"{}\", thought);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"    drop(tx);\n"
+"    for pensamento em rx {\n"
+"        println!(\"{}\", pensamento);\n"
+"    }\n"
+"}\n"
+"```"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -194,7 +194,6 @@ msgstr "Escopos e Sombra"
 msgid "Memory Management"
 msgstr "Gerenciamento de memória"
 
-****TODO check vocab****
 #: src/SUMMARY.md:46
 #, fuzzy
 msgid "Stack vs Heap"
@@ -270,19 +269,16 @@ msgstr "Empréstimo"
 msgid "Shared and Unique Borrows"
 msgstr "Empréstimos Compartilhados e Únicos"
 
-****TODO check vocab. vidas?****
 #: src/SUMMARY.md:61
 #, fuzzy
 msgid "Lifetimes"
 msgstr "Tempos de vida (Lifetimes)"
 
-****TODO check vocab****
 #: src/SUMMARY.md:62
 #, fuzzy
 msgid "Lifetimes in Function Calls"
 msgstr "Tempos de vida (Lifetimes) em chamadas de função"
 
-****TODO check vocab****
 #: src/SUMMARY.md:63
 #, fuzzy
 msgid "Lifetimes in Data Structures"


### PR DESCRIPTION
Adds Brazilian Portuguese translation. Day 1 is respectable and the most glaring machine translation errors are removed throughout all days. There will of course be exceptions at this early stage.

Conventions: followed standards of the Rust Book translation at https://rust-br.github.io/rust-book-pt-br/ for guidance on Anglicization of programming vocab. Generally where words refer to a type, method etc in Rust, I switch the translation to English (eg 'Enum', 'read') and stick to the Portuguese when the word refers to an abstract concept (eg shadowing, sombreamento). 

The entire 20k lines have been parsed to remove all over-eager translations, many of course of which were in the code blocks ('let mut x / deixe mut x) however there undoubtedly will be some I didn't catch. Variable / struct names (eg Pessoa -> Person) have been translated so the code runs, comments and some print statements are left in Portuguese. Assistance welcomed!

Fixes #317.