### PR TITLE
Add highly-unsafe speaker notes to inspect the memory layout of string.

### DIFF
--- a/src/memory-management/stack.md
+++ b/src/memory-management/stack.md
@@ -29,6 +29,23 @@ fn main() {
 
 * If students ask about it, you can mention that the underlying memory is heap allocated using the [System Allocator] and custom allocators can be implemented using the [Allocator API]
 
+* We can inspect the memory layout with `unsafe` code. However, you should point out that this is rightfully unsafe!
+
+```rust,editable
+fn main() {
+    let mut s1 = String::from("Hello");
+    s1.push(' ');
+    s1.push_str("world");
+    // DON'T DO THIS AT HOME! For educational purposes only.
+    // String provides no guarantees about its layout, so this could lead to
+    // undefined behavior.
+    unsafe {
+        let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);
+        println!("ptr = {ptr:#x}, len = {len}, capacity = {capacity}");
+    }
+}
+```
+
 </details>
 
 [System Allocator]: https://doc.rust-lang.org/std/alloc/struct.System.html


### PR DESCRIPTION
The slide shows the assumed memory layout of a String, so we can use some `unsafe` code to check that (and see that the capacity is actually laid out first - although Rust provides no guarantees about that).