### PR TITLE
Save translation artifacts for each PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,5 +124,11 @@ jobs:
       - name: Build course with ${{ matrix.language }} translation
         run: mdbook build
 
+      - name: Upload ${{ matrix.language }} translation
+        uses: actions/upload-artifact@v3
+        with:
+          name: comprehensive-rust-${{ matrix.language }}
+          path: book/
+
       - name: Test code snippets with ${{ matrix.language }} translation
         run: mdbook test


### PR DESCRIPTION
This makes it super easy for translators to see the results of their work: every PR will now have a list of artifacts, one per translation.