### PR TITLE
Remove unused main() function in day-2.morning exercise.

### DIFF
--- a/src/exercises/day-2/points-polygons.md
+++ b/src/exercises/day-2/points-polygons.md
@@ -35,9 +35,6 @@ tests pass:
 {{#include points-polygons.rs:Shape}}
 
 {{#include points-polygons.rs:unit-tests}}
-
-#[allow(dead_code)]
-fn main() {}
 ```
 
 <details>

--- a/src/exercises/day-2/points-polygons.rs
+++ b/src/exercises/day-2/points-polygons.rs
@@ -222,5 +222,3 @@ mod tests {
     }
 }
 // ANCHOR_END: unit-tests
-
-fn main() {}


### PR DESCRIPTION
This exercise is about making the unit tests pass, so we can remove the `main()` function, which is empty and unused. Otherwise the Rust playground complains about dead code.