### PR TITLE
Setup redirects after #120 and #177

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -42,3 +42,7 @@ level = 0
 
 [output.html.playground]
 editable = true
+
+[output.html.redirect]
+"structure.html" = "running-the-course/course-structure.html"
+"unsafe/unsafe-functions.html" = "calling-unsafe-functions.html"


### PR DESCRIPTION
This makes `mdbook` output a simple redirect at the location of the old pages. I’ll try to add such pages when we shuffle around our pages to make sure external links stay valid.