### PR TITLE
Start of the German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,16964 @@
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Comprehensive Rust 🦀\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-02-03 11:26+0100\n"
+"Last-Translator: Ronald Wotzlaw <wotzlaw@google.com>\n"
+"Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/SUMMARY.md:3
+msgid "Welcome to Comprehensive Rust 🦀"
+msgstr "Willkommen bei Comprehensive Rust 🦀"
+
+#: src/SUMMARY.md:4
+msgid "Running the Course"
+msgstr "Ablauf des Kurses"
+
+#: src/SUMMARY.md:5
+msgid "Course Structure"
+msgstr "Kursstruktur"
+
+#: src/SUMMARY.md:6
+msgid "Keyboard Shortcuts"
+msgstr "Tastaturkürzel"
+
+#: src/SUMMARY.md:7
+msgid "Using Cargo"
+msgstr "Cargo verwenden"
+
+#: src/SUMMARY.md:8
+msgid "Rust Ecosystem"
+msgstr "Rust Ökosystem"
+
+#: src/SUMMARY.md:9
+msgid "Code Samples"
+msgstr "Codebeispiele"
+
+#: src/SUMMARY.md:10
+msgid "Running Cargo Locally"
+msgstr "Cargo lokal ausführen"
+
+#: src/SUMMARY.md:13
+msgid "Day 1: Morning"
+msgstr "Tag 1: Morgens"
+
+#: src/SUMMARY.md:17 src/SUMMARY.md:73 src/SUMMARY.md:126 src/SUMMARY.md:180
+msgid "Welcome"
+msgstr "Willkommen"
+
+#: src/SUMMARY.md:18
+msgid "What is Rust?"
+msgstr "Was ist Rust?"
+
+#: src/SUMMARY.md:19
+msgid "Hello World!"
+msgstr "Hallo Welt!"
+
+#: src/SUMMARY.md:20
+msgid "Small Example"
+msgstr "Ein kleines Beispiel"
+
+#: src/SUMMARY.md:21
+msgid "Why Rust?"
+msgstr "Warum Rust?"
+
+#: src/SUMMARY.md:22
+msgid "Compile Time Guarantees"
+msgstr "Kompilierzeitgarantien"
+
+#: src/SUMMARY.md:23
+msgid "Runtime Guarantees"
+msgstr "Laufzeitgarantien"
+
+#: src/SUMMARY.md:24
+msgid "Modern Features"
+msgstr "Moderne Merkmale"
+
+#: src/SUMMARY.md:25
+msgid "Basic Syntax"
+msgstr "Grundlegende Syntax"
+
+#: src/SUMMARY.md:26
+msgid "Scalar Types"
+msgstr "Skalare Typen"
+
+#: src/SUMMARY.md:27
+msgid "Compound Types"
+msgstr "Verbundtypen"
+
+#: src/SUMMARY.md:28
+msgid "References"
+msgstr "Referenzen"
+
+#: src/SUMMARY.md:29
+msgid "Dangling References"
+msgstr "Hängende Referenzen"
+
+#: src/SUMMARY.md:30
+msgid "Slices"
+msgstr "Anteilstypen"
+
+#: src/SUMMARY.md:31
+msgid "String vs str"
+msgstr "String vs. str"
+
+#: src/SUMMARY.md:32
+msgid "Functions"
+msgstr "Funktionen"
+
+#: src/SUMMARY.md:33 src/SUMMARY.md:80
+msgid "Methods"
+msgstr "Methoden"
+
+#: src/SUMMARY.md:34
+msgid "Overloading"
+msgstr "Überladen"
+
+#: src/SUMMARY.md:35 src/SUMMARY.md:64 src/SUMMARY.md:88 src/SUMMARY.md:117
+#: src/SUMMARY.md:145 src/SUMMARY.md:172 src/SUMMARY.md:195 src/SUMMARY.md:222
+msgid "Exercises"
+msgstr "Übungen"
+
+#: src/SUMMARY.md:36
+msgid "Implicit Conversions"
+msgstr "Implizite Konvertierungen"
+
+#: src/SUMMARY.md:37
+msgid "Arrays and for Loops"
+msgstr "Arrays und for-Schleifen"
+
+#: src/SUMMARY.md:39
+msgid "Day 1: Afternoon"
+msgstr "Tag 1: Nachmittags"
+
+#: src/SUMMARY.md:41
+msgid "Variables"
+msgstr "Variablen"
+
+#: src/SUMMARY.md:42
+msgid "Type Inference"
+msgstr "Typinferenz"
+
+#: src/SUMMARY.md:43
+msgid "static & const"
+msgstr "static & const"
+
+#: src/SUMMARY.md:44
+msgid "Scopes and Shadowing"
+msgstr "Gültigkeitsbereiche und Beschatten"
+
+#: src/SUMMARY.md:45
+msgid "Memory Management"
+msgstr "Speicherverwaltung"
+
+#: src/SUMMARY.md:46
+msgid "Stack vs Heap"
+msgstr "Stapelspeicher vs. Haldenspeicher"
+
+#: src/SUMMARY.md:47
+msgid "Stack Memory"
+msgstr "Stapelspeicher"
+
+#: src/SUMMARY.md:48
+msgid "Manual Memory Management"
+msgstr "Manuelle Speicherverwaltung"
+
+#: src/SUMMARY.md:49
+msgid "Scope-Based Memory Management"
+msgstr "Gültigkeitsbereichbasierte Speicherverwaltung"
+
+#: src/SUMMARY.md:50
+msgid "Garbage Collection"
+msgstr "Automatische Speicherbereinigung"
+
+#: src/SUMMARY.md:51
+msgid "Rust Memory Management"
+msgstr "Rust Speicherverwaltung"
+
+#: src/SUMMARY.md:52
+msgid "Comparison"
+msgstr "Vergleich"
+
+#: src/SUMMARY.md:53
+msgid "Ownership"
+msgstr "Eigentümerschaft"
+
+#: src/SUMMARY.md:54
+msgid "Move Semantics"
+msgstr "Semantik des Verschiebens"
+
+#: src/SUMMARY.md:55
+msgid "Moved Strings in Rust"
+msgstr "Verschieben von String in Rust"
+
+#: src/SUMMARY.md:56
+msgid "Double Frees in Modern C++"
+msgstr "Doppel-Freigabe-Fehler in modernem C++"
+
+#: src/SUMMARY.md:57
+msgid "Moves in Function Calls"
+msgstr "Verschieben in Funktionsaufrufen"
+
+#: src/SUMMARY.md:58
+msgid "Copying and Cloning"
+msgstr "Kopieren und Klonen"
+
+#: src/SUMMARY.md:59
+msgid "Borrowing"
+msgstr "Ausleihen"
+
+#: src/SUMMARY.md:60
+msgid "Shared and Unique Borrows"
+msgstr "Geteiltes und einmaliges Ausleihen"
+
+#: src/SUMMARY.md:61
+msgid "Lifetimes"
+msgstr "Lebensdauern"
+
+#: src/SUMMARY.md:62
+msgid "Lifetimes in Function Calls"
+msgstr "Lebensdauern in Funktionsaufrufen"
+
+#: src/SUMMARY.md:63
+msgid "Lifetimes in Data Structures"
+msgstr "Lebensdauern in Datenstrukturen"
+
+#: src/SUMMARY.md:65
+msgid "Designing a Library"
+msgstr "Entwerfen einer Bibliothek"
+
+#: src/SUMMARY.md:66
+msgid "Iterators and Ownership"
+msgstr "Iteratoren und Eigentümerschaft"
+
+#: src/SUMMARY.md:69
+msgid "Day 2: Morning"
+msgstr "Tag 2: Morgens"
+
+#: src/SUMMARY.md:74
+msgid "Structs"
+msgstr "Strukturen"
+
+#: src/SUMMARY.md:75
+msgid "Tuple Structs"
+msgstr "Tupelstrukturen"
+
+#: src/SUMMARY.md:76
+msgid "Field Shorthand Syntax"
+msgstr "Feld Abkürzungs Syntax"
+
+#: src/SUMMARY.md:77
+msgid "Enums"
+msgstr "Aufzählungstypen"
+
+#: src/SUMMARY.md:78
+msgid "Variant Payloads"
+msgstr "Varianteninhalte"
+
+#: src/SUMMARY.md:79
+msgid "Enum Sizes"
+msgstr "Größen von Aufzählungstypen"
+
+#: src/SUMMARY.md:81
+msgid "Method Receiver"
+msgstr "Methodenempfänger"
+
+#: src/SUMMARY.md:82 src/SUMMARY.md:190
+msgid "Example"
+msgstr "Beispiel"
+
+#: src/SUMMARY.md:83
+msgid "Pattern Matching"
+msgstr "Musterabgleich"
+
+#: src/SUMMARY.md:84
+msgid "Destructuring Enums"
+msgstr "Aufzählungstypen destrukturieren"
+
+#: src/SUMMARY.md:85
+msgid "Destructuring Structs"
+msgstr "Strukturen destrukturieren"
+
+#: src/SUMMARY.md:86
+msgid "Destructuring Arrays"
+msgstr "Arrays destrukturieren"
+
+#: src/SUMMARY.md:87
+msgid "Match Guards"
+msgstr "Abgleichsbedingungen"
+
+#: src/SUMMARY.md:89
+msgid "Health Statistics"
+msgstr "Gesundheitsstatistiken"
+
+#: src/SUMMARY.md:90
+msgid "Points and Polygons"
+msgstr "Punkte und Polygone"
+
+#: src/SUMMARY.md:92
+msgid "Day 2: Afternoon"
+msgstr "Tag 2: Nachmittags"
+
+#: src/SUMMARY.md:94
+msgid "Control Flow"
+msgstr "Kontrollfluss"
+
+#: src/SUMMARY.md:95
+msgid "Blocks"
+msgstr "Blöcke"
+
+#: src/SUMMARY.md:96
+msgid "if expressions"
+msgstr "if-Ausdrücke"
+
+#: src/SUMMARY.md:97
+msgid "if let expressions"
+msgstr "if let-Ausdrücke"
+
+#: src/SUMMARY.md:98
+msgid "while expressions"
+msgstr "while-Ausdrücke"
+
+#: src/SUMMARY.md:99
+msgid "while let expressions"
+msgstr "while let-Ausdrücke"
+
+#: src/SUMMARY.md:100
+msgid "for expressions"
+msgstr "for-Ausdrücke"
+
+#: src/SUMMARY.md:101
+msgid "loop expressions"
+msgstr "loop-Ausdrücke"
+
+#: src/SUMMARY.md:102
+msgid "match expressions"
+msgstr "match-Ausdrücke"
+
+#: src/SUMMARY.md:103
+msgid "break & continue"
+msgstr "break & continue"
+
+#: src/SUMMARY.md:104
+msgid "Standard Library"
+msgstr "Standardbibliothek"
+
+#: src/SUMMARY.md:105
+msgid "Option and Result"
+msgstr "Option und Result"
+
+#: src/SUMMARY.md:106
+msgid "String"
+msgstr "String"
+
+#: src/SUMMARY.md:107
+msgid "Vec"
+msgstr "Vec"
+
+#: src/SUMMARY.md:108
+msgid "HashMap"
+msgstr "HashMap"
+
+#: src/SUMMARY.md:109
+msgid "Box"
+msgstr "Box"
+
+#: src/SUMMARY.md:110
+msgid "Recursive Data Types"
+msgstr "Rekursive Datentypen"
+
+#: src/SUMMARY.md:111
+#, fuzzy
+msgid "Niche Optimization"
+msgstr "Nischenoptimierung"
+
+#: src/SUMMARY.md:112
+msgid "Rc"
+msgstr "Rc"
+
+#: src/SUMMARY.md:113
+msgid "Modules"
+msgstr "Module"
+
+#: src/SUMMARY.md:114
+msgid "Visibility"
+msgstr "Sichtbarkeit"
+
+#: src/SUMMARY.md:115
+msgid "Paths"
+msgstr "Pfade"
+
+#: src/SUMMARY.md:116
+msgid "Filesystem Hierarchy"
+msgstr "Dateisystemhierarchie"
+
+#: src/SUMMARY.md:118
+msgid "Luhn Algorithm"
+msgstr "Luhn-Algorithmus"
+
+#: src/SUMMARY.md:119
+msgid "Strings and Iterators"
+msgstr "Strings und Iteratoren"
+
+#: src/SUMMARY.md:122
+msgid "Day 3: Morning"
+msgstr "Tag 3: Morgens"
+
+#: src/SUMMARY.md:127
+msgid "Traits"
+msgstr "Merkmale"
+
+#: src/SUMMARY.md:128
+msgid "Deriving Traits"
+msgstr "Ableitung von Merkmalen"
+
+#: src/SUMMARY.md:129
+msgid "Default Methods"
+msgstr "Standardmethoden"
+
+#: src/SUMMARY.md:130
+msgid "Important Traits"
+msgstr "Wichtige Merkmale"
+
+#: src/SUMMARY.md:131
+msgid "Iterator"
+msgstr "Iterator"
+
+#: src/SUMMARY.md:132
+msgid "FromIterator"
+msgstr "FromIterator"
+
+#: src/SUMMARY.md:133
+msgid "From and Into"
+msgstr "From und Into"
+
+#: src/SUMMARY.md:134
+msgid "Read and Write"
+msgstr "Read und Write"
+
+#: src/SUMMARY.md:135
+msgid "Add, Mul, ..."
+msgstr "Add, Mul, ..."
+
+#: src/SUMMARY.md:136
+msgid "Drop"
+msgstr "Drop"
+
+#: src/SUMMARY.md:137
+msgid "Generics"
+msgstr "Generische Datentypen und Methoden"
+
+#: src/SUMMARY.md:138
+msgid "Generic Data Types"
+msgstr "Generische Datentypen"
+
+#: src/SUMMARY.md:139
+msgid "Generic Methods"
+msgstr "Generische Methoden"
+
+#: src/SUMMARY.md:140
+msgid "Trait Bounds"
+msgstr "Merkmalsgrenzen"
+
+#: src/SUMMARY.md:141
+msgid "impl Trait"
+msgstr "impl Merkmal"
+
+#: src/SUMMARY.md:142
+msgid "Closures"
+msgstr "Funktionsabschlüsse"
+
+#: src/SUMMARY.md:143
+msgid "Monomorphization"
+msgstr "Monomorphisierung"
+
+#: src/SUMMARY.md:144
+msgid "Trait Objects"
+msgstr "Merkmalsobjekte"
+
+#: src/SUMMARY.md:146
+msgid "A Simple GUI Library"
+msgstr "Eine einfache GUI-Bibliothek"
+
+#: src/SUMMARY.md:148
+msgid "Day 3: Afternoon"
+msgstr "Tag 3: Nachmittags"
+
+#: src/SUMMARY.md:150
+msgid "Error Handling"
+msgstr "Fehlerbehandlung"
+
+#: src/SUMMARY.md:151
+msgid "Panics"
+msgstr "Laufzeitabbrüche"
+
+#: src/SUMMARY.md:152
+msgid "Catching Stack Unwinding"
+msgstr "Abfangen des Auflösen des Stapelspeichers"
+
+#: src/SUMMARY.md:153
+msgid "Structured Error Handling"
+msgstr "Strukturierte Fehlerbehandlung"
+
+#: src/SUMMARY.md:154
+msgid "Propagating Errors with ?"
+msgstr "Weitergabe von Fehlern mit ?"
+
+#: src/SUMMARY.md:155
+msgid "Converting Error Types"
+msgstr "Fehlertypen konvertieren"
+
+#: src/SUMMARY.md:156
+msgid "Deriving Error Enums"
+msgstr "Ableiten von Fehleraufzählungen"
+
+#: src/SUMMARY.md:157
+msgid "Dynamic Error Types"
+msgstr "Dynamische Fehlertypen"
+
+#: src/SUMMARY.md:158
+msgid "Adding Context to Errors"
+msgstr "Kontext zu Fehlern hinzufügen"
+
+#: src/SUMMARY.md:159
+msgid "Testing"
+msgstr "Testen"
+
+#: src/SUMMARY.md:160
+msgid "Unit Tests"
+msgstr "Unit-Tests"
+
+#: src/SUMMARY.md:161
+msgid "Test Modules"
+msgstr "Testmodule"
+
+#: src/SUMMARY.md:162
+msgid "Documentation Tests"
+msgstr "Dokumentationstests"
+
+#: src/SUMMARY.md:163
+msgid "Integration Tests"
+msgstr "Integrationstests"
+
+#: src/SUMMARY.md:164
+msgid "Unsafe Rust"
+msgstr "Unsicheres Rust"
+
+#: src/SUMMARY.md:165
+msgid "Dereferencing Raw Pointers"
+msgstr "Roh-zeiger dereferenzieren"
+
+#: src/SUMMARY.md:166
+msgid "Mutable Static Variables"
+msgstr "Veränderbare statische Variablen"
+
+#: src/SUMMARY.md:167
+msgid "Unions"
+msgstr "Vereinigungen"
+
+#: src/SUMMARY.md:168
+msgid "Calling Unsafe Functions"
+msgstr "Unsichere Funktionen aufrufen"
+
+#: src/SUMMARY.md:169
+msgid "Writing Unsafe Functions"
+msgstr "Unsichere Funktionen schreiben"
+
+#: src/SUMMARY.md:170
+msgid "Extern Functions"
+msgstr "Externe Funktionen"
+
+#: src/SUMMARY.md:171
+msgid "Implementing Unsafe Traits"
+msgstr "Unsichere Merkmale implementieren"
+
+#: src/SUMMARY.md:173
+msgid "Safe FFI Wrapper"
+msgstr "Sicherer FFI-Wrapper"
+
+#: src/SUMMARY.md:176
+msgid "Day 4: Morning"
+msgstr "Tag 4: Morgens"
+
+#: src/SUMMARY.md:181
+msgid "Concurrency"
+msgstr "Nebenläufigkeit"
+
+#: src/SUMMARY.md:182
+msgid "Threads"
+msgstr "Ausführungsstrang"
+
+#: src/SUMMARY.md:183
+msgid "Scoped Threads"
+msgstr "Ausführungsstrang mit Sichtbarkeitsbereich"
+
+#: src/SUMMARY.md:184
+msgid "Channels"
+msgstr "Kanäle"
+
+#: src/SUMMARY.md:185
+msgid "Unbounded Channels"
+msgstr "Unbegrenzte Kanäle"
+
+#: src/SUMMARY.md:186
+msgid "Bounded Channels"
+msgstr "Unbeschränkte Kanäle"
+
+#: src/SUMMARY.md:187
+msgid "Shared State"
+msgstr "Geteilter Zustand"
+
+#: src/SUMMARY.md:188
+msgid "Arc"
+msgstr "Arc"
+
+#: src/SUMMARY.md:189
+msgid "Mutex"
+msgstr "Mutex"
+
+#: src/SUMMARY.md:191
+msgid "Send and Sync"
+msgstr "Send und Sync"
+
+#: src/SUMMARY.md:191
+msgid "Send"
+msgstr "Send"
+
+#: src/SUMMARY.md:191
+msgid "Sync"
+msgstr "Sync"
+
+#: src/SUMMARY.md:194
+msgid "Examples"
+msgstr "Beispiele"
+
+#: src/SUMMARY.md:196
+msgid "Dining Philosophers"
+msgstr "Philosophenproblem"
+
+#: src/SUMMARY.md:197
+msgid "Multi-threaded Link Checker"
+msgstr "Link Überprüfung mit mehreren Ausführungssträngen"
+
+#: src/SUMMARY.md:199
+msgid "Day 4: Afternoon"
+msgstr "Tag 4: Nachmittags"
+
+#: src/SUMMARY.md:203
+msgid "Android"
+msgstr "Android"
+
+#: src/SUMMARY.md:204
+msgid "Setup"
+msgstr "Einrichtung"
+
+#: src/SUMMARY.md:205
+msgid "Build Rules"
+msgstr "Regeln beim Bauen"
+
+#: src/SUMMARY.md:206
+msgid "Binary"
+msgstr "Binärdatei"
+
+#: src/SUMMARY.md:207
+msgid "Library"
+msgstr "Bibliothek"
+
+#: src/SUMMARY.md:208
+msgid "AIDL"
+msgstr "AIDL"
+
+#: src/SUMMARY.md:209
+msgid "Interface"
+msgstr "Schnittstelle"
+
+#: src/SUMMARY.md:210
+msgid "Implementation"
+msgstr "Implementierung"
+
+#: src/SUMMARY.md:211
+msgid "Server"
+msgstr "Server"
+
+#: src/SUMMARY.md:212
+msgid "Deploy"
+msgstr "Einsetzen"
+
+#: src/SUMMARY.md:213
+msgid "Client"
+msgstr "Klient"
+
+#: src/SUMMARY.md:214
+msgid "Changing API"
+msgstr "API verändern"
+
+#: src/SUMMARY.md:215
+msgid "Logging"
+msgstr "Protokollierung"
+
+#: src/SUMMARY.md:216
+msgid "Interoperability"
+msgstr "Interoperabilität"
+
+#: src/SUMMARY.md:217
+msgid "With C"
+msgstr "Mit C"
+
+#: src/SUMMARY.md:218
+msgid "Calling C with Bindgen"
+msgstr "Aufruf von C-Funktionen mit Bindgen"
+
+#: src/SUMMARY.md:219
+msgid "Calling Rust from C"
+msgstr "Aufruf von Rust aus C"
+
+#: src/SUMMARY.md:220
+msgid "With C++"
+msgstr "Mit C++"
+
+#: src/SUMMARY.md:221
+msgid "With Java"
+msgstr "Mit Java"
+
+#: src/SUMMARY.md:224
+msgid "Final Words"
+msgstr "Letzte Worte"
+
+#: src/SUMMARY.md:226
+msgid "Thanks!"
+msgstr "Danke!"
+
+#: src/SUMMARY.md:227
+msgid "Other Resources"
+msgstr "Andere Ressourcen"
+
+#: src/SUMMARY.md:228
+msgid "Credits"
+msgstr "Würdigungen"
+
+#: src/SUMMARY.md:232
+msgid "Solutions"
+msgstr "Lösungen"
+
+#: src/SUMMARY.md:237
+msgid "Day 1 Morning"
+msgstr "Tag 1 Morgens"
+
+#: src/SUMMARY.md:238
+msgid "Day 1 Afternoon"
+msgstr "Tag 1 Nachmittags"
+
+#: src/SUMMARY.md:239
+msgid "Day 2 Morning"
+msgstr "Tag 2 Morgens"
+
+#: src/SUMMARY.md:240
+msgid "Day 2 Afternoon"
+msgstr "Tag 2 Nachmittags"
+
+#: src/SUMMARY.md:241
+msgid "Day 3 Morning"
+msgstr "Tag 3 Morgens"
+
+#: src/SUMMARY.md:242
+msgid "Day 3 Afternoon"
+msgstr "Tag 3 Nachmittags"
+
+#: src/SUMMARY.md:243
+msgid "Day 4 Morning"
+msgstr "Tag 4 Morgens"
+
+#: src/welcome.md:1
+msgid "# Welcome to Comprehensive Rust 🦀"
+msgstr "# Willkommen bei Comprehensive Rust 🦀"
+
+#: src/welcome.md:3
+msgid ""
+"This is a four day Rust course developed by the Android team. The course "
+"covers\n"
+"the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics\n"
+"and error handling. It also includes Android-specific content on the last "
+"day."
+msgstr ""
+"Dies ist ein viertägiger Rust-Kurs, der vom Android-Team entwickelt wurde. "
+"Der Kurs umfasst\n"
+"das gesamte Spektrum von Rust, von grundlegender Syntax bis hin zu "
+"fortgeschrittenen Themen wie generischen Methoden und Datentypen\n"
+"sowie Fehlerbehandlung. Am letzten Tag werden auch Android-spezifische Inhalte "
+"behandelt."
+
+#: src/welcome.md:7
+msgid ""
+"The goal of the course is to teach you Rust. We assume you don't know "
+"anything\n"
+"about Rust and hope to:"
+msgstr ""
+"Das Ziel des Kurses ist es, Dir Rust beizubringen. Wie setzen keine "
+"Vorkenntnisse über Rust voraus, "
+"und hoffen das Folgende zu erreichen:"
+
+#: src/welcome.md:10
+msgid ""
+"* Give you a comprehensive understanding of the Rust syntax and language.\n"
+"* Enable you to modify existing programs and write new programs in Rust.\n"
+"* Show you common Rust idioms."
+msgstr ""
+"* Dir ein umfassendes Verständnis der Rust-Syntax und -Sprache "
+" zu vermitteln.\n"
+"* Es dir ermöglichen, bestehende Programme zu modifizieren und neue "
+"Programme in Rust zu schreiben.\n"
+"* Dir gängige Rust-Idiome zu zeigen."
+
+#: src/welcome.md:14
+msgid "On Day 4, we will cover Android-specific things such as:"
+msgstr "An Tag 4 behandeln wir Android-spezifische Dinge wie:"
+
+#: src/welcome.md:16
+msgid ""
+"* Building Android components in Rust.\n"
+"* AIDL servers and clients.\n"
+"* Interoperability with C, C++, and Java."
+msgstr ""
+"* Erstellen von Android-Komponenten in Rust.\n"
+"* AIDL-Server und -Klienten.\n"
+"* Interoperabilität mit C, C++ und Java."
+
+#: src/welcome.md:20
+msgid ""
+"It is important to note that this course does not cover Android "
+"**application** \n"
+"development in Rust, and that the Android-specific parts are specifically "
+"about\n"
+"writing code for Android itself, the operating system. "
+msgstr ""
+"Es ist wichtig zu beachten, dass dieser Kurs keine Android "
+"**Anwendungsentwicklung** abdeckt \n"
+"und dass es bei den Android-spezifischen Teilen um das \n"
+"Schreiben von Code für das Betriebssystem Android geht."
+
+#: src/welcome.md:24
+msgid "## Non-Goals"
+msgstr "## Nicht-Ziele"
+
+#: src/welcome.md:26
+msgid ""
+"Rust is a large language and we won't be able to cover all of it in a few "
+"days.\n"
+"Some non-goals of this course are:"
+msgstr ""
+"Rust ist eine große Sprache und wir werden sie in ein paar Tagen nicht "
+"vollständig abdecken können.\n"
+"Einige Nicht-Ziele dieses Kurses sind:"
+
+#: src/welcome.md:29
+msgid ""
+"* Learn how to use async Rust --- we'll only mention async Rust when\n"
+"  covering traditional concurrency primitives. Please see [Asynchronous\n"
+"  Programming in Rust](https://rust-lang.github.io/async-book/) instead for\n"
+"  details on this topic.\n"
+"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
+"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
+"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+msgstr ""
+"* Lernen, wie man asynchrones Rust verwendet – wir erwähnen "
+"asynchrones Rust nur dann, wenn\n"
+"  wir traditionelle Nebenläufigkeitsprimitive abdecken. Siehe [Asynchronous\n"
+"  Programmierung in Rust](https://rust-lang.github.io/async-book/) "
+"für\n"
+"  Details zu diesem Thema.\n"
+"* Lernen, wie man Makros entwickelt, siehe [Kapitel 19.5 im Rust\n"
+"  Buch](https://rust-lang-de.github.io/rustbook-de/ch19-06-macros.html) und [Rust by\n"
+"  Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
+
+#: src/welcome.md:37
+msgid "## Assumptions"
+msgstr "## Annahmen"
+
+#: src/welcome.md:39
+msgid ""
+"The course assumes that you already know how to program. Rust is a "
+"statically\n"
+"typed language and we will sometimes make comparisons with C and C++ to "
+"better\n"
+"explain or contrast the Rust approach."
+msgstr ""
+"Der Kurs setzt voraus, dass Du bereits Programmierkenntnisse besitzt. Rust "
+"ist eine statisch\n"
+"typisierte Sprache und wir werden manchmal Vergleiche mit C und C++ "
+"machen, um besser den Rust-Ansatz zu erklären oder gegenüberzustellen."
+
+#: src/welcome.md:43
+msgid ""
+"If you know how to program in a dynamically typed language such as Python "
+"or\n"
+"JavaScript, then you will be able to follow along just fine too."
+msgstr ""
+"Aber auch wenn Du Vorwissen in einer dynamisch typisierten Sprache wie Python "
+"oder\n"
+"JavaScript hast, wirst Du problemlos folgen können."
+
+#: src/welcome.md:46 src/cargo/rust-ecosystem.md:19
+#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
+#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
+#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
+#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
+#: src/why-rust/modern.md:19 src/basic-syntax/compound-types.md:28
+#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
+#: src/basic-syntax/functions.md:33 src/basic-syntax/functions-interlude.md:25
+#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
+#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
+#: src/basic-syntax/static-and-const.md:46
+#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
+#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
+#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
+#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
+#: src/ownership/lifetimes-function-calls.md:27
+#: src/ownership/lifetimes-data-structures.md:23
+#: src/exercises/day-1/afternoon.md:9 src/structs/tuple-structs.md:35
+#: src/structs/field-shorthand.md:25 src/enums/variant-payloads.md:33
+#: src/methods.md:28 src/pattern-matching/destructuring-enums.md:33
+#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
+#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
+#: src/control-flow/if-expressions.md:29
+#: src/control-flow/if-let-expressions.md:19
+#: src/control-flow/while-let-expressions.md:25 src/std/option-result.md:16
+#: src/std/string.md:28 src/std/box.md:32 src/std/rc.md:26
+#: src/exercises/day-2/afternoon.md:5 src/traits.md:39
+#: src/traits/iterator.md:30 src/traits/from-iterator.md:12
+#: src/traits/operators.md:24 src/traits/drop.md:32 src/generics/methods.md:23
+#: src/generics/trait-bounds.md:20 src/generics/impl-trait.md:22
+#: src/generics/closures.md:23 src/exercises/day-3/morning.md:5
+#: src/error-handling/result.md:25 src/error-handling/try-operator.md:48
+#: src/error-handling/converting-error-types.md:66
+#: src/error-handling/deriving-error-enums.md:37
+#: src/error-handling/dynamic-errors.md:34
+#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
+#: src/unsafe/raw-pointers.md:24 src/unsafe/mutable-static-variables.md:30
+#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
+#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
+#: src/exercises/day-3/afternoon.md:5 src/concurrency/threads.md:28
+#: src/concurrency/channels.md:25 src/concurrency/shared_state/arc.md:27
+#: src/concurrency/shared_state/example.md:21 src/concurrency/send-sync.md:18
+#: src/concurrency/send-sync/sync.md:12 src/exercises/day-4/morning.md:10
+#: src/android/interoperability/with-c/rust.md:81
+#: src/exercises/day-4/afternoon.md:10
+#, fuzzy
+msgid "<details>"
+msgstr "<Details>"
+
+#: src/welcome.md:48
+#, fuzzy
+msgid ""
+"This is an example of a _speaker note_. We will use these to add additional\n"
+"information to the slides. This could be key points which the instructor "
+"should\n"
+"cover as well as answers to typical questions which come up in class."
+msgstr ""
+"Dies ist ein Beispiel für eine _Sprechernotiz_. Wir werden diese verwenden, "
+"um weitere hinzuzufügen\n"
+"Informationen zu den Folien. Dies könnten Schlüsselpunkte sein, die der "
+"Ausbilder haben sollte\n"
+"sowie Antworten auf typische Fragen, die im Unterricht auftauchen."
+
+#: src/welcome.md:52 src/cargo/rust-ecosystem.md:67
+#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
+#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
+#: src/hello-world.md:36 src/hello-world/small-example.md:44 src/why-rust.md:24
+#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
+#: src/why-rust/modern.md:66 src/basic-syntax/compound-types.md:62
+#: src/basic-syntax/references.md:28 src/basic-syntax/slices.md:36
+#: src/basic-syntax/functions.md:54 src/exercises/day-1/morning.md:28
+#: src/exercises/day-1/for-loops.md:95 src/basic-syntax/variables.md:20
+#: src/basic-syntax/type-inference.md:48
+#: src/basic-syntax/static-and-const.md:52
+#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:32
+#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
+#: src/ownership/moves-function-calls.md:26 src/ownership/borrowing.md:51
+#: src/ownership/shared-unique-borrows.md:29
+#: src/ownership/lifetimes-function-calls.md:60
+#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:103
+#: src/structs.md:40 src/enums/variant-payloads.md:39 src/enums/sizes.md:49
+#: src/methods/example.md:53 src/pattern-matching/destructuring-enums.md:39
+#: src/exercises/day-2/morning.md:15 src/exercises/day-2/points-polygons.md:125
+#: src/control-flow/if-let-expressions.md:26 src/std.md:31
+#: src/std/option-result.md:25 src/std/string.md:34 src/std/vec.md:38
+#: src/std/box.md:37 src/std/rc.md:32 src/exercises/day-2/afternoon.md:11
+#: src/traits.md:54 src/traits/from-iterator.md:23 src/traits/operators.md:38
+#: src/traits/drop.md:42 src/generics/methods.md:31 src/generics/closures.md:38
+#: src/exercises/day-3/morning.md:11 src/error-handling/try-operator.md:55
+#: src/error-handling/converting-error-types.md:78
+#: src/error-handling/deriving-error-enums.md:45
+#: src/error-handling/dynamic-errors.md:41
+#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
+#: src/unsafe/raw-pointers.md:42 src/unsafe/mutable-static-variables.md:35
+#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
+#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
+#: src/exercises/day-3/afternoon.md:11 src/concurrency/threads.md:45
+#: src/concurrency/channels.md:32 src/concurrency/shared_state/arc.md:38
+#: src/concurrency/shared_state/example.md:60
+#: src/concurrency/send-sync/sync.md:18 src/exercises/day-4/morning.md:16
+#: src/android/interoperability/with-c/rust.md:86
+#: src/exercises/day-4/afternoon.md:15
+#, fuzzy
+msgid "</details>"
+msgstr "</details>"
+
+#: src/running-the-course.md:1
+#, fuzzy
+msgid "# Running the Course"
+msgstr "# Ausführen des Kurses"
+
+#: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
+#, fuzzy
+msgid "> This page is for the course instructor."
+msgstr "> Diese Seite ist für den Kursleiter."
+
+#: src/running-the-course.md:5
+#, fuzzy
+msgid ""
+"Here is a bit of background information about how we've been running the "
+"course\n"
+"internally at Google."
+msgstr ""
+"Hier ein paar Hintergrundinformationen darüber, wie wir den Kurs "
+"durchgeführt haben\n"
+"intern bei Google."
+
+#: src/running-the-course.md:8
+#, fuzzy
+msgid "To run the course, you need to:"
+msgstr "Um den Kurs durchzuführen, müssen Sie:"
+
+#: src/running-the-course.md:10
+#, fuzzy
+msgid ""
+"1. Make yourself familiar with the course material. We've included speaker "
+"notes\n"
+"   on some of the pages to help highlight the key points (please help us by\n"
+"   contributing more speaker notes!). You should make sure to open the "
+"speaker\n"
+"   notes in a popup (click the link with a little arrow next to \"Speaker\n"
+"   Notes\"). This way you have a clean screen to present to the class."
+msgstr ""
+"1. Machen Sie sich mit dem Kursmaterial vertraut. Wir haben Rednernotizen "
+"beigefügt\n"
+"   auf einigen Seiten, um die wichtigsten Punkte hervorzuheben (bitte helfen "
+"Sie uns, indem Sie uns helfen\n"
+"   weitere Sprechernotizen beisteuern!). Sie sollten darauf achten, den "
+"Lautsprecher zu öffnen\n"
+"   Notizen in einem Popup (klicken Sie auf den Link mit einem kleinen Pfeil "
+"neben \"Speaker\n"
+"   Notes\"). Auf diese Weise haben Sie einen sauberen Bildschirm, den Sie "
+"der Klasse präsentieren können."
+
+#: src/running-the-course.md:16
+#, fuzzy
+msgid ""
+"2. Decide on the dates. Since the course is large, we recommend that you\n"
+"   schedule the four days over two weeks. Course participants have said "
+"that\n"
+"   they find it helpful to have a gap in the course since it helps them "
+"process\n"
+"   all the information we give them."
+msgstr ""
+"2. Legen Sie die Termine fest. Da der Kurs groß ist, empfehlen wir Ihnen\n"
+"   Planen Sie die vier Tage über zwei Wochen. Das haben Kursteilnehmer "
+"gesagt\n"
+"   sie finden es hilfreich, eine Lücke im Kurs zu haben, da sie ihnen bei "
+"der Verarbeitung hilft\n"
+"   alle Informationen, die wir ihnen geben."
+
+#: src/running-the-course.md:21
+#, fuzzy
+msgid ""
+"3. Find a room large enough for your in-person participants. We recommend a\n"
+"   class size of 15-20 people. That's small enough that people are "
+"comfortable\n"
+"   asking questions --- it's also small enough that one instructor will "
+"have\n"
+"   time to answer the questions."
+msgstr ""
+"3. Finden Sie einen Raum, der groß genug für Ihre persönlichen Teilnehmer "
+"ist. Wir empfehlen eine\n"
+"   Klassengröße von 15-20 Personen. Das ist klein genug, dass sich die Leute "
+"wohlfühlen\n"
+"   Fragen stellen --- es ist auch klein genug, dass ein Lehrer es haben "
+"kann\n"
+"   Zeit, die Fragen zu beantworten."
+
+#: src/running-the-course.md:26
+#, fuzzy
+msgid ""
+"4. On the day of your course, show up to the room a little early to set "
+"things\n"
+"   up. We recommend presenting directly using `mdbook serve` running on "
+"your\n"
+"   laptop. This ensures optimal performance with no lag as you change "
+"pages.\n"
+"   Using your laptop will also allow you to fix typos as you or the course\n"
+"   participants spot them."
+msgstr ""
+"4. Erscheinen Sie am Tag Ihres Kurses etwas früher im Raum, um die Dinge "
+"vorzubereiten\n"
+"   hoch. Wir empfehlen, direkt mit `mdbook serve` zu präsentieren, das auf "
+"Ihrem läuft\n"
+"   Laptop. Dies gewährleistet eine optimale Leistung ohne Verzögerung beim "
+"Seitenwechsel.\n"
+"   Mit Ihrem Laptop können Sie auch Tippfehler während des Kurses "
+"korrigieren\n"
+"   Teilnehmer entdecken sie."
+
+#: src/running-the-course.md:32
+#, fuzzy
+msgid ""
+"5. Let people solve the exercises by themselves or in small groups. Make "
+"sure to\n"
+"   ask people if they're stuck or if there is anything you can help with. "
+"When\n"
+"   you see that several people have the same problem, call it out to the "
+"class\n"
+"   and offer a solution, e.g., by showing people where to find the relevant\n"
+"   information in the standard library."
+msgstr ""
+"5. Lassen Sie die Teilnehmer die Übungen alleine oder in kleinen Gruppen "
+"lösen. Stellen Sie sicher, dass\n"
+"   Fragen Sie die Leute, ob sie nicht weiterkommen oder ob es irgendetwas "
+"gibt, bei dem Sie helfen können. Wenn\n"
+"   Sie sehen, dass mehrere Personen das gleiche Problem haben, sprechen Sie "
+"es in der Klasse an\n"
+"   und eine Lösung anbieten, z. B. indem Sie zeigen, wo das Relevante zu "
+"finden ist\n"
+"   Informationen in der Standardbibliothek."
+
+#: src/running-the-course.md:38
+#, fuzzy
+msgid ""
+"6. If you don't skip the Android specific parts on Day 4, you will need an "
+"[AOSP\n"
+"   checkout][1]. Make a checkout of the [course repository][2] on the same\n"
+"   machine and move the `src/android/` directory into the root of your AOSP\n"
+"   checkout. This will ensure that the Android build system sees the\n"
+"   `Android.bp` files in `src/android/`."
+msgstr ""
+"6. Wenn Sie die Android-spezifischen Teile an Tag 4 nicht überspringen, "
+"benötigen Sie eine [AOSP\n"
+"   Kasse][1]. Machen Sie einen Checkout des [Kurs-Repositorys] [2] auf "
+"demselben\n"
+"   Maschine und verschieben Sie das Verzeichnis `src/android/` in das "
+"Stammverzeichnis Ihres AOSP\n"
+"   Kasse. Dadurch wird sichergestellt, dass das Android-Buildsystem die "
+"sieht\n"
+"   `Android.bp`-Dateien in `src/android/`."
+
+#: src/running-the-course.md:44
+#, fuzzy
+msgid ""
+"   Ensure that `adb sync` works with your emulator or real device and "
+"pre-build\n"
+"   all Android examples using `src/android/build_all.sh`. Read the script to "
+"see\n"
+"   the commands it runs and make sure they work when you run them by hand."
+msgstr ""
+"   Stellen Sie sicher, dass \"adb sync\" mit Ihrem Emulator oder realen "
+"Gerät und Pre-Build funktioniert\n"
+"   alle Android-Beispiele mit `src/android/build_all.sh`. Lesen Sie das "
+"Skript, um zu sehen\n"
+"   die Befehle, die es ausführt, und stellen Sie sicher, dass sie "
+"funktionieren, wenn Sie sie von Hand ausführen."
+
+#: src/running-the-course.md:48
+#, fuzzy
+msgid ""
+"That is all, good luck running the course! We hope it will be as much fun "
+"for\n"
+"you as it has been for us!"
+msgstr ""
+"Das ist alles, viel Glück beim Laufen des Kurses! Wir hoffen, dass es "
+"genauso viel Spaß machen wird\n"
+"Sie, wie es für uns war!"
+
+#: src/running-the-course.md:51
+#, fuzzy
+msgid ""
+"Please [provide feedback][3] afterwards so that we can keep improving the\n"
+"course. We would love to hear what worked well for you and what can be made\n"
+"better. Your students are also very welcome to [send us feedback][4]!"
+msgstr ""
+"Bitte [geben Sie anschließend Feedback][3], damit wir die weiter verbessern "
+"können\n"
+"Kurs. Wir würden gerne hören, was für Sie gut funktioniert hat und was "
+"gemacht werden kann\n"
+"besser. Auch Ihre Schüler sind herzlich willkommen, [senden Sie uns "
+"Feedback][4]!"
+
+#: src/running-the-course.md:55
+#, fuzzy
+msgid ""
+"[1]: https://source.android.com/docs/setup/download/downloading\n"
+"[2]: https://github.com/google/comprehensive-rust\n"
+"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
+"[4]: https://github.com/google/comprehensive-rust/discussions/100"
+msgstr ""
+"[1]: https://source.android.com/docs/setup/download/downloading\n"
+"[2]: https://github.com/google/comprehensive-rust\n"
+"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
+"[4]: https://github.com/google/comprehensive-rust/discussions/100"
+
+#: src/running-the-course/course-structure.md:1
+#, fuzzy
+msgid "# Course Structure"
+msgstr "# Kursstruktur"
+
+#: src/running-the-course/course-structure.md:5
+#, fuzzy
+msgid "The course is fast paced and covers a lot of ground:"
+msgstr "Der Kurs ist schnelllebig und deckt viel Boden ab:"
+
+#: src/running-the-course/course-structure.md:7
+#, fuzzy
+msgid ""
+"* Day 1: Basic Rust, ownership and the borrow checker.\n"
+"* Day 2: Compound data types,  pattern matching, the standard library.\n"
+"* Day 3: Traits and generics, error handling, testing, unsafe Rust.\n"
+"* Day 4: Concurrency in Rust and interoperability with other languages"
+msgstr ""
+"* Tag 1: Basic Rust, Eigentum und der Leihenprüfer.\n"
+"* Tag 2: Zusammengesetzte Datentypen, Mustervergleich, die "
+"Standardbibliothek.\n"
+"* Tag 3: Traits und Generika, Fehlerbehandlung, Testen, unsicheres Rust.\n"
+"* Tag 4: Parallelität in Rust und Interoperabilität mit anderen Sprachen"
+
+#: src/running-the-course/course-structure.md:12
+#, fuzzy
+msgid ""
+"> **Exercise for Day 4:** Do you interface with some C/C++ code in your "
+"project\n"
+"> which we could attempt to move to Rust? The fewer dependencies the "
+"better.\n"
+"> Parsing code would be ideal."
+msgstr ""
+"> **Übung für Tag 4:** Arbeiten Sie in Ihrem Projekt mit C/C++-Code "
+"zusammen?\n"
+"> die wir versuchen könnten, nach Rust zu verlegen? Je weniger "
+"Abhängigkeiten, desto besser.\n"
+"> Parsing-Code wäre ideal."
+
+#: src/running-the-course/course-structure.md:16
+#, fuzzy
+msgid "## Format"
+msgstr "## Format"
+
+#: src/running-the-course/course-structure.md:18
+#, fuzzy
+msgid ""
+"The course is meant to be very interactive and we recommend letting the\n"
+"questions drive the exploration of Rust!"
+msgstr ""
+"Der Kurs soll sehr interaktiv sein und wir empfehlen, die\n"
+"Fragen treiben die Erkundung von Rust voran!"
+
+#: src/running-the-course/keyboard-shortcuts.md:1
+#, fuzzy
+msgid "# Keyboard Shortcuts"
+msgstr "# Tastatürkürzel"
+
+#: src/running-the-course/keyboard-shortcuts.md:3
+#, fuzzy
+msgid "There are several useful keyboard shortcuts in mdBook:"
+msgstr "Es gibt mehrere nützliche Tastaturkürzel in mdBook:"
+
+#: src/running-the-course/keyboard-shortcuts.md:5
+#, fuzzy
+msgid ""
+"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
+"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
+"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
+"* <kbd>s</kbd>: Activate the search bar."
+msgstr ""
+"* <kbd>Pfeil-links</kbd>: Zur vorherigen Seite navigieren.\n"
+"* <kbd>Pfeil-rechts</kbd>: Zur nächsten Seite navigieren.\n"
+"* <kbd>Strg + Eingabe</kbd>: Führt das Codebeispiel aus, das den Fokus hat.\n"
+"* <kbd>s</kbd>: Suchleiste aktivieren."
+
+#: src/cargo.md:1
+#, fuzzy
+msgid "# Using Cargo"
+msgstr "# Verwenden von Fracht"
+
+#: src/cargo.md:3
+#, fuzzy
+msgid ""
+"When you start reading about Rust, you will soon meet "
+"[Cargo](https://doc.rust-lang.org/cargo/), the standard tool\n"
+"used in the Rust ecosystem to build and run Rust applications. Here we want "
+"to\n"
+"give a brief overview of what Cargo is and how it fits into the wider "
+"ecosystem\n"
+"and how it fits into this training."
+msgstr ""
+"Wenn Sie anfangen, über Rust zu lesen, werden Sie bald "
+"[Cargo](https://doc.rust-lang.org/cargo/), das Standardwerkzeug, "
+"kennenlernen\n"
+"Wird im Rust-Ökosystem verwendet, um Rust-Anwendungen zu erstellen und "
+"auszuführen. Hier wollen wir\n"
+"geben einen kurzen Überblick darüber, was Cargo ist und wie es in das "
+"breitere Ökosystem passt\n"
+"und wie es in dieses Training passt."
+
+#: src/cargo.md:8
+#, fuzzy
+msgid "## Installation"
+msgstr "## Installation"
+
+#: src/cargo.md:10
+#, fuzzy
+msgid "### Rustup (Recommended)"
+msgstr "### Rustup (empfohlen)"
+
+#: src/cargo.md:12
+#, fuzzy
+msgid ""
+"You can follow the instructions to install cargo and rust compiler, among "
+"other standard ecosystem tools with the [rustup][3] tool, which is "
+"maintained by the Rust Foundation."
+msgstr ""
+"Sie können den Anweisungen zur Installation des Cargo- und Rust-Compilers "
+"sowie anderer Standard-Ökosystem-Tools mit dem Tool [rustup][3] folgen, das "
+"von der Rust Foundation verwaltet wird."
+
+#: src/cargo.md:14
+#, fuzzy
+msgid ""
+"Along with cargo and rustc, Rustup will install itself as a command line "
+"utility that you can use to install/switch toolchains, setup cross "
+"compilation, etc."
+msgstr ""
+"Zusammen mit Cargo und Rustc installiert sich Rustup selbst als "
+"Befehlszeilendienstprogramm, mit dem Sie Toolchains installieren/wechseln, "
+"Cross-Compilation einrichten usw. können."
+
+#: src/cargo.md:16
+#, fuzzy
+msgid "### Package Managers"
+msgstr "### Paketmanager"
+
+#: src/cargo.md:18
+#, fuzzy
+msgid "#### Debian"
+msgstr "#### Debian"
+
+#: src/cargo.md:20
+#, fuzzy
+msgid "On Debian/Ubuntu, you can install Cargo and the Rust source with"
+msgstr "Auf Debian/Ubuntu können Sie Cargo und die Rust-Quelle mit installieren"
+
+#: src/cargo.md:22
+msgid ""
+"```shell\n"
+"$ sudo apt install cargo rust-src\n"
+"```"
+msgstr ""
+
+#: src/cargo.md:26
+#, fuzzy
+msgid ""
+"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
+"using\n"
+"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+msgstr ""
+"Dadurch kann [rust-analyzer][1] zu den Definitionen springen. Wir empfehlen "
+"die Verwendung\n"
+"[VS Code][2], um den Code zu bearbeiten (aber jeder LSP-kompatible Editor "
+"funktioniert)."
+
+#: src/cargo.md:29
+#, fuzzy
+msgid ""
+"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
+"their own analysis but have their own tradeoffs. If you prefer them, you can "
+"install the [Rust Plugin][5]. Please take note that as of January 2023 "
+"debugging only works on the CLion version of the JetBrains IDEA suite."
+msgstr ""
+"Einige Leute verwenden auch gerne die [JetBrains][4]-Familie von IDEs, die "
+"ihre eigene Analyse durchführen, aber ihre eigenen Kompromisse haben. Wenn "
+"Sie sie bevorzugen, können Sie das [Rust-Plugin] [5] installieren. Bitte "
+"beachten Sie, dass das Debuggen ab Januar 2023 nur auf der CLion-Version der "
+"JetBrains IDEA-Suite funktioniert."
+
+#: src/cargo.md:31
+#, fuzzy
+msgid ""
+"[1]: https://rust-analyzer.github.io/\n"
+"[2]: https://code.visualstudio.com/\n"
+"[3]: https://rustup.rs/\n"
+"[4]: https://www.jetbrains.com/clion/\n"
+"[5]: https://www.jetbrains.com/rust/"
+msgstr ""
+"[1]: https://rust-analyzer.github.io/\n"
+"[2]: https://code.visualstudio.com/\n"
+"[3]: https://rustup.rs/\n"
+"[4]: https://www.jetbrains.com/clion/\n"
+"[5]: https://www.jetbrains.com/rust/"
+
+#: src/cargo/rust-ecosystem.md:1
+#, fuzzy
+msgid "# The Rust Ecosystem"
+msgstr "# Das Rost-Ökosystem"
+
+#: src/cargo/rust-ecosystem.md:3
+#, fuzzy
+msgid ""
+"The Rust ecosystem consists of a number of tools, of which the main ones are:"
+msgstr ""
+"Das Rust-Ökosystem besteht aus einer Reihe von Tools, von denen die "
+"wichtigsten sind:"
+
+#: src/cargo/rust-ecosystem.md:5
+#, fuzzy
+msgid ""
+"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
+"other\n"
+"  intermediate formats[^rustc]."
+msgstr ""
+"* „rustc“: der Rust-Compiler, der „.rs“-Dateien in Binärdateien und andere "
+"umwandelt\n"
+"  Zwischenformate[^rustc]."
+
+#: src/cargo/rust-ecosystem.md:8
+#, fuzzy
+msgid ""
+"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
+"  download dependencies hosted on <https://crates.io> and it will pass them "
+"to\n"
+"  `rustc` when building your project. Cargo also comes with a built-in test\n"
+"  runner which is used to execute unit tests[^cargo]."
+msgstr ""
+"* `cargo`: der Rust-Abhängigkeitsmanager und Build-Tool. Cargo weiß, wie es "
+"geht\n"
+"  Laden Sie Abhängigkeiten herunter, die auf <https://crates.io> gehostet "
+"werden, und es wird sie an sie weitergeben\n"
+"  `rustc`, wenn Sie Ihr Projekt erstellen. Cargo kommt auch mit einem "
+"eingebauten Test\n"
+"  Runner, der zum Ausführen von Unit-Tests[^cargo] verwendet wird."
+
+#: src/cargo/rust-ecosystem.md:13
+#, fuzzy
+msgid ""
+"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
+"  install and update `rustc` and `cargo` when new versions of Rust is "
+"released.\n"
+"  In addition, `rustup` can also download documentation for the standard\n"
+"  library. You can have multiple versions of Rust installed at once and "
+"`rustup`\n"
+"  will let you switch between them as needed."
+msgstr ""
+"* `rustup`: der Rust Toolchain Installer und Updater. Dieses Werkzeug ist "
+"gewöhnungsbedürftig\n"
+"  Installieren und aktualisieren Sie `rustc` und `cargo`, wenn neue "
+"Versionen von Rust veröffentlicht werden.\n"
+"  Darüber hinaus kann `rustup` auch Dokumentationen für den Standard "
+"herunterladen\n"
+"  Bibliothek. Sie können mehrere Versionen von Rust gleichzeitig "
+"installieren und „rustup“ ausführen\n"
+"  können Sie nach Bedarf zwischen ihnen wechseln."
+
+#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
+#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
+#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:30
+#: src/error-handling/try-operator.md:50
+#: src/error-handling/converting-error-types.md:68
+#: src/concurrency/threads.md:30
+#, fuzzy
+msgid "Key points:"
+msgstr "Kernpunkte:"
+
+#: src/cargo/rust-ecosystem.md:23
+#, fuzzy
+msgid ""
+"* Rust has a rapid release schedule with a new release coming out\n"
+"  every six weeks. New releases maintain backwards compatibility with\n"
+"  old releases --- plus they enable new functionality."
+msgstr ""
+"* Rust hat einen schnellen Veröffentlichungszeitplan mit einer neuen "
+"Veröffentlichung, die herauskommt\n"
+"  alle sechs Wochen. Neue Releases behalten die Abwärtskompatibilität mit\n"
+"  alte Versionen --- und sie ermöglichen neue Funktionen."
+
+#: src/cargo/rust-ecosystem.md:27
+#, fuzzy
+msgid ""
+"* There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "* Es gibt drei Veröffentlichungskanäle: „Stable“, „Beta“ und „Nightly“."
+
+#: src/cargo/rust-ecosystem.md:29
+#, fuzzy
+msgid ""
+"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
+"  \"stable\" every six weeks."
+msgstr ""
+"* Neue Funktionen werden auf \"Nightly\" getestet, \"Beta\" ist das, was "
+"wird\n"
+"  \"stabil\" alle sechs Wochen."
+
+#: src/cargo/rust-ecosystem.md:32
+#, fuzzy
+msgid ""
+"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
+"  editions were Rust 2015 and Rust 2018."
+msgstr ""
+"* Rust hat auch [Editionen]: Die aktuelle Edition ist Rust 2021. Zurück\n"
+"  Editionen waren Rust 2015 und Rust 2018."
+
+#: src/cargo/rust-ecosystem.md:35
+#, fuzzy
+msgid ""
+"  * The editions are allowed to make backwards incompatible changes to\n"
+"    the language."
+msgstr ""
+"  * Die Editionen dürfen rückwärtsinkompatible Änderungen vornehmen\n"
+"    die Sprache."
+
+#: src/cargo/rust-ecosystem.md:38
+#, fuzzy
+msgid ""
+"  * To prevent breaking code, editions are opt-in: you select the\n"
+"    edition for your crate via the `Cargo.toml` file."
+msgstr ""
+"  * Um das Brechen von Code zu verhindern, sind Editionen Opt-in: Sie wählen "
+"die aus\n"
+"    Edition für Ihre Kiste über die Datei `Cargo.toml`."
+
+#: src/cargo/rust-ecosystem.md:41
+#, fuzzy
+msgid ""
+"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
+"    written for different editions."
+msgstr ""
+"  * Um eine Aufspaltung des Ökosystems zu vermeiden, können Rust-Compiler "
+"Code mischen\n"
+"    für verschiedene Editionen geschrieben."
+
+#: src/cargo/rust-ecosystem.md:44
+#, fuzzy
+msgid ""
+"  * Mention that it is quite rare to ever use the compiler directly not "
+"through `cargo` (most users never do)."
+msgstr ""
+"  * Erwähnen Sie, dass es ziemlich selten vorkommt, den Compiler jemals "
+"direkt zu verwenden, nicht über `cargo` (die meisten Benutzer tun dies nie)."
+
+#: src/cargo/rust-ecosystem.md:46
+#, fuzzy
+msgid ""
+"  * It might be worth alluding that Cargo itself is an extremely powerful "
+"and comprehensive tool.  It is capable of many advanced features including "
+"but not limited to: \n"
+"      * Project/package structure\n"
+"      * [workspaces]\n"
+"      * Dev Dependencies and Runtime Dependency management/caching\n"
+"      * [build scripting]\n"
+"      * [global installation]\n"
+"      * It is also extensible with sub command plugins as well (such as "
+"[cargo clippy]).\n"
+"  * Read more from the [official Cargo Book]"
+msgstr ""
+"  * Es könnte erwähnenswert sein, dass Cargo selbst ein äußerst "
+"leistungsfähiges und umfassendes Werkzeug ist. Es verfügt über viele "
+"erweiterte Funktionen, einschließlich, aber nicht beschränkt auf:\n"
+"      * Projekt-/Paketstruktur\n"
+"      * [Arbeitsbereiche]\n"
+"      * Verwaltung/Caching von Entwicklungsabhängigkeiten und "
+"Laufzeitabhängigkeiten\n"
+"      * [Skript erstellen]\n"
+"      * [globale Installation]\n"
+"      * Es ist auch mit Unterbefehls-Plugins erweiterbar (wie [cargo "
+"clippy]).\n"
+"  * Lesen Sie mehr aus dem [offiziellen Frachtbuch]"
+
+#: src/cargo/rust-ecosystem.md:55
+#, fuzzy
+msgid "[editions]: https://doc.rust-lang.org/edition-guide/"
+msgstr "[Ausgaben]: https://doc.rust-lang.org/edition-guide/"
+
+#: src/cargo/rust-ecosystem.md:57
+#, fuzzy
+msgid "[workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
+msgstr ""
+"[Arbeitsbereiche]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
+
+#: src/cargo/rust-ecosystem.md:59
+#, fuzzy
+msgid ""
+"[build scripting]: "
+"https://doc.rust-lang.org/cargo/reference/build-scripts.html"
+msgstr ""
+"[Build-Scripting]: "
+"https://doc.rust-lang.org/cargo/reference/build-scripts.html"
+
+#: src/cargo/rust-ecosystem.md:61
+#, fuzzy
+msgid ""
+"[global installation]: "
+"https://doc.rust-lang.org/cargo/commands/cargo-install.html"
+msgstr ""
+"[globale Installation]: "
+"https://doc.rust-lang.org/cargo/commands/cargo-install.html"
+
+#: src/cargo/rust-ecosystem.md:63
+#, fuzzy
+msgid "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
+msgstr "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
+
+#: src/cargo/rust-ecosystem.md:65
+#, fuzzy
+msgid "[official Cargo Book]: https://doc.rust-lang.org/cargo/"
+msgstr "[offizielles Frachtbuch]: https://doc.rust-lang.org/cargo/"
+
+#: src/cargo/code-samples.md:1
+#, fuzzy
+msgid "# Code Samples in This Training"
+msgstr "# Codebeispiele in diesem Training"
+
+#: src/cargo/code-samples.md:3
+#, fuzzy
+msgid ""
+"For this training, we will mostly explore the Rust language through "
+"examples\n"
+"which can be executed through your browser. This makes the setup much easier "
+"and\n"
+"ensures a consistent experience for everyone."
+msgstr ""
+"In diesem Training werden wir die Rust-Sprache hauptsächlich anhand von "
+"Beispielen erkunden\n"
+"die über Ihren Browser ausgeführt werden können. Dies erleichtert die "
+"Einrichtung erheblich und\n"
+"sorgt für ein konsistentes Erlebnis für alle."
+
+#: src/cargo/code-samples.md:7
+#, fuzzy
+msgid ""
+"Installing Cargo is still encouraged: it will make it easier for you to do "
+"the\n"
+"exercises. On the last day, we will do a larger exercise which shows you how "
+"to\n"
+"work with dependencies and for that you need Cargo."
+msgstr ""
+"Die Installation von Cargo wird dennoch empfohlen: Es wird Ihnen die Arbeit "
+"erleichtern\n"
+"Übungen. Am letzten Tag werden wir eine größere Übung machen, die Ihnen "
+"zeigt, wie es geht\n"
+"Arbeiten Sie mit Abhängigkeiten und dafür benötigen Sie Cargo."
+
+#: src/cargo/code-samples.md:11
+#, fuzzy
+msgid "The code blocks in this course are fully interactive:"
+msgstr "Die Codeblöcke in diesem Kurs sind vollständig interaktiv:"
+
+#: src/cargo/code-samples.md:13
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/cargo/code-samples.md:19
+#, fuzzy
+msgid ""
+"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
+"the\n"
+"text box."
+msgstr ""
+"Sie können <kbd>Strg + Eingabe</kbd> verwenden, um den Code auszuführen, "
+"wenn der Fokus auf der ist\n"
+"Textfeld."
+
+#: src/cargo/code-samples.md:24
+#, fuzzy
+msgid ""
+"Most code samples are editable like shown above. A few code samples\n"
+"are not editable for various reasons:"
+msgstr ""
+"Die meisten Codebeispiele können wie oben gezeigt bearbeitet werden. Ein "
+"paar Codebeispiele\n"
+"sind aus verschiedenen Gründen nicht editierbar:"
+
+#: src/cargo/code-samples.md:27
+#, fuzzy
+msgid ""
+"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
+"  code and open it in the real Playground to demonstrate unit tests."
+msgstr ""
+"* Die eingebetteten Playgrounds können keine Unit-Tests ausführen. Kopieren "
+"Sie die\n"
+"  code und öffnen Sie ihn im realen Playground, um Unit-Tests zu "
+"demonstrieren."
+
+#: src/cargo/code-samples.md:30
+#, fuzzy
+msgid ""
+"* The embedded playgrounds lose their state the moment you navigate\n"
+"  away from the page! This is the reason that the students should\n"
+"  solve the exercises using a local Rust installation or via the\n"
+"  Playground."
+msgstr ""
+"* Die eingebetteten Playgrounds verlieren ihren Zustand, sobald Sie "
+"navigieren\n"
+"  Weg von der Seite! Aus diesem Grund sollten die Schüler\n"
+"  Lösen Sie die Aufgaben mit einer lokalen Rust-Installation oder über die\n"
+"  Spielplatz."
+
+#: src/cargo/running-locally.md:1
+#, fuzzy
+msgid "# Running Code Locally with Cargo"
+msgstr "# Code lokal mit Cargo ausführen"
+
+#: src/cargo/running-locally.md:3
+#, fuzzy
+msgid ""
+"If you want to experiment with the code on your own system, then you will "
+"need\n"
+"to first install Rust. Do this by following the [instructions in the Rust\n"
+"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
+"of\n"
+"writing, the latest stable Rust release has these version numbers:"
+msgstr ""
+"Wenn Sie mit dem Code auf Ihrem eigenen System experimentieren möchten, "
+"benötigen Sie\n"
+"zuerst Rust zu installieren. Befolgen Sie dazu die [Anweisungen in Rust\n"
+"Buch 1]. Dies sollte Ihnen ein funktionierendes `rustc` und `cargo` geben. "
+"Zur Zeit von\n"
+"Schreiben hat die neueste stabile Rust-Version diese Versionsnummern:"
+
+#: src/cargo/running-locally.md:8
+msgid ""
+"```shell\n"
+"% rustc --version\n"
+"rustc 1.61.0 (fe5b13d68 2022-05-18)\n"
+"% cargo --version\n"
+"cargo 1.61.0 (a028ae4 2022-04-29)\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:15
+#, fuzzy
+msgid ""
+"With this is in place, then follow these steps to build a Rust binary from "
+"one\n"
+"of the examples in this training:"
+msgstr ""
+"Wenn dies vorhanden ist, befolgen Sie diese Schritte, um eine "
+"Rust-Binärdatei aus einer zu erstellen\n"
+"der Beispiele in diesem Training:"
+
+#: src/cargo/running-locally.md:18
+#, fuzzy
+msgid ""
+"1. Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr ""
+"1. Klicken Sie bei dem Beispiel, das Sie kopieren möchten, auf die "
+"Schaltfläche \"In die Zwischenablage kopieren\"."
+
+#: src/cargo/running-locally.md:20
+#, fuzzy
+msgid ""
+"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
+"code:"
+msgstr ""
+"2. Verwenden Sie `cargo new Exercise`, um ein neues `exercise/`-Verzeichnis "
+"für Ihren Code zu erstellen:"
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"    ```shell\n"
+"    $ cargo new exercise\n"
+"         Created binary (application) `exercise` package\n"
+"    ```"
+msgstr ""
+
+#: src/cargo/running-locally.md:27
+#, fuzzy
+msgid ""
+"3. Navigate into `exercise/` and use `cargo run` to build and run your "
+"binary:"
+msgstr ""
+"3. Navigieren Sie zu „exercise/“ und verwenden Sie „cargo run“, um Ihre "
+"Binärdatei zu erstellen und auszuführen:"
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"    ```shell\n"
+"    $ cd exercise\n"
+"    $ cargo run\n"
+"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"         Running `target/debug/exercise`\n"
+"    Hello, world!\n"
+"    ```"
+msgstr ""
+
+#: src/cargo/running-locally.md:38
+#, fuzzy
+msgid ""
+"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
+"   example, using the example on the previous page, make `src/main.rs` look "
+"like"
+msgstr ""
+"4. Ersetzen Sie den Standardcode in `src/main.rs` durch Ihren eigenen Code. "
+"Für\n"
+"   Verwenden Sie beispielsweise das Beispiel auf der vorherigen Seite und "
+"lassen Sie `src/main.rs` so aussehen"
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"    ```rust\n"
+"    fn main() {\n"
+"        println!(\"Edit me!\");\n"
+"    }\n"
+"    ```"
+msgstr ""
+
+#: src/cargo/running-locally.md:47
+#, fuzzy
+msgid "5. Use `cargo run` to build and run your updated binary:"
+msgstr ""
+"5. Verwenden Sie „cargo run“, um Ihre aktualisierte Binärdatei zu erstellen "
+"und auszuführen:"
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"    ```shell\n"
+"    $ cargo run\n"
+"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"         Running `target/debug/exercise`\n"
+"    Edit me!\n"
+"    ```"
+msgstr ""
+
+#: src/cargo/running-locally.md:57
+#, fuzzy
+msgid ""
+"6. Use `cargo check` to quickly check your project for errors, use `cargo "
+"build`\n"
+"   to compile it without running it. You will find the output in "
+"`target/debug/`\n"
+"   for a normal debug build. Use `cargo build --release` to produce an "
+"optimized\n"
+"   release build in `target/release/`."
+msgstr ""
+"6. Verwenden Sie „Cargo Check“, um Ihr Projekt schnell auf Fehler zu "
+"überprüfen, verwenden Sie „Cargo Build“.\n"
+"   um es zu kompilieren, ohne es auszuführen. Die Ausgabe finden Sie in "
+"`target/debug/`\n"
+"   für einen normalen Debug-Build. Verwenden Sie `cargo build --release`, um "
+"eine optimierte\n"
+"   Release-Build in `target/release/`."
+
+#: src/cargo/running-locally.md:62
+#, fuzzy
+msgid ""
+"7. You can add dependencies for your project by editing `Cargo.toml`. When "
+"you\n"
+"   run `cargo` commands, it will automatically download and compile missing\n"
+"   dependencies for you."
+msgstr ""
+"7. Sie können Abhängigkeiten für Ihr Projekt hinzufügen, indem Sie "
+"`Cargo.toml` bearbeiten. Wenn du\n"
+"   Führen Sie \"Cargo\"-Befehle aus, es wird automatisch heruntergeladen und "
+"kompiliert\n"
+"   Abhängigkeiten für Sie."
+
+#: src/cargo/running-locally.md:66
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
+msgstr "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
+
+#: src/cargo/running-locally.md:70
+#, fuzzy
+msgid ""
+"Try to encourage the class participants to install Cargo and use a\n"
+"local editor. It will make their life easier since they will have a\n"
+"normal development environment."
+msgstr ""
+"Versuchen Sie, die Kursteilnehmer zu ermutigen, Cargo zu installieren und a\n"
+"lokaler Redakteur. Es wird ihr Leben einfacher machen, da sie a haben "
+"werden\n"
+"normale Entwicklungsumgebung."
+
+#: src/welcome-day-1.md:1
+#, fuzzy
+msgid "# Welcome to Day 1"
+msgstr "# Willkommen zu Tag 1"
+
+#: src/welcome-day-1.md:3
+#, fuzzy
+msgid ""
+"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"today:"
+msgstr ""
+"Dies ist der erste Tag von Comprehensive Rust. Wir werden viel Boden "
+"abdecken\n"
+"Heute:"
+
+#: src/welcome-day-1.md:6
+#, fuzzy
+msgid ""
+"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
+"  references, functions, and methods."
+msgstr ""
+"* Grundlegende Rust-Syntax: Variablen, skalare und zusammengesetzte Typen, "
+"Aufzählungen, Strukturen,\n"
+"  Referenzen, Funktionen und Methoden."
+
+#: src/welcome-day-1.md:9
+#, fuzzy
+msgid ""
+"* Memory management: stack vs heap, manual memory management, scope-based "
+"memory\n"
+"  management, and garbage collection."
+msgstr ""
+"* Speicherverwaltung: Stack vs. Heap, manuelle Speicherverwaltung, "
+"bereichsbasierter Speicher\n"
+"  Verwaltung und Garbage Collection."
+
+#: src/welcome-day-1.md:12
+#, fuzzy
+msgid ""
+"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"* Eigentum: Verschieben von Semantik, Kopieren und Klonen, Ausleihen und "
+"Lebensdauern."
+
+#: src/welcome-day-1.md:16
+#, fuzzy
+msgid "Please remind the students that:"
+msgstr "Bitte erinnern Sie die Schüler daran:"
+
+#: src/welcome-day-1.md:18
+#, fuzzy
+msgid ""
+"* They should ask questions when they get them, don't save them to the end.\n"
+"* The class is meant to be interactive and discussions are very much "
+"encouraged!\n"
+"  * As an instructor, you should try to keep the discussions relevant, "
+"i.e.,\n"
+"    keep the related to how Rust does things vs some other language. It can "
+"be\n"
+"    hard to find the right balance, but err on the side of allowing "
+"discussions\n"
+"    since they engage people much more than one-way communication.\n"
+"* The questions will likely mean that we about things ahead of the slides.\n"
+"  * This is perfectly okay! Repetition is an important part of leaning. "
+"Remember\n"
+"    that the slides are just a support and you are free to skip them as you\n"
+"    like."
+msgstr ""
+"* Sie sollten Fragen stellen, wenn sie sie bekommen, und sie nicht bis zum "
+"Ende aufheben.\n"
+"* Der Unterricht soll interaktiv sein und Diskussionen sind sehr erwünscht!\n"
+"  * Als Dozent sollten Sie versuchen, die Diskussionen relevant zu halten, "
+"d. h.\n"
+"    Behalten Sie den Bezug dazu bei, wie Rust Dinge im Vergleich zu einer "
+"anderen Sprache tut. Es kann sein\n"
+"    schwer, die richtige Balance zu finden, aber lieber Diskussionen "
+"zulassen\n"
+"    da sie Menschen viel mehr einbeziehen als nur eine Einbahnstraße.\n"
+"* Die Fragen werden wahrscheinlich bedeuten, dass wir über die Dinge vor den "
+"Folien sprechen.\n"
+"  * Das ist vollkommen in Ordnung! Wiederholung ist ein wichtiger Teil des "
+"Lernens. Erinnern\n"
+"    dass die Folien nur eine Unterstützung sind und Sie sie nach Belieben "
+"überspringen können\n"
+"    wie."
+
+#: src/welcome-day-1.md:29
+#, fuzzy
+msgid ""
+"The idea for the first day is to show _just enough_ of Rust to be able to "
+"speak\n"
+"about the famous borrow checker. The way Rust handles memory is a major "
+"feature\n"
+"and we should show students this right away."
+msgstr ""
+"Die Idee für den ersten Tag ist, Rust _gerade genug_ zu zeigen, um sprechen "
+"zu können\n"
+"über den berühmten Kreditprüfer. Die Art und Weise, wie Rust mit Speicher "
+"umgeht, ist ein wichtiges Merkmal\n"
+"und das sollten wir den Schülern gleich zeigen."
+
+#: src/welcome-day-1.md:33
+#, fuzzy
+msgid ""
+"If you're teaching this in a classroom, this is a good place to go over the\n"
+"schedule. We suggest splitting the day into two parts (following the slides):"
+msgstr ""
+"Wenn Sie dies in einem Klassenzimmer unterrichten, ist dies ein guter Ort, "
+"um darüber nachzudenken\n"
+"Zeitplan. Wir empfehlen, den Tag in zwei Teile aufzuteilen (nach den Folien):"
+
+#: src/welcome-day-1.md:36
+#, fuzzy
+msgid "* Morning: 9:00 to 12:00,\n* Afternoon: 13:00 to 16:00."
+msgstr "* Morgens: 9:00 bis 12:00 Uhr,\n* Nachmittag: 13:00 bis 16:00 Uhr."
+
+#: src/welcome-day-1.md:39
+#, fuzzy
+msgid ""
+"You can of course adjust this as necessary. Please make sure to include "
+"breaks,\n"
+"we recommend a break every hour!"
+msgstr ""
+"Dies können Sie natürlich bei Bedarf anpassen. Bitte achten Sie darauf, "
+"Pausen einzuplanen,\n"
+"Wir empfehlen jede Stunde eine Pause!"
+
+#: src/welcome-day-1/what-is-rust.md:1
+#, fuzzy
+msgid "# What is Rust?"
+msgstr "# Was ist Rost?"
+
+#: src/welcome-day-1/what-is-rust.md:3
+#, fuzzy
+msgid "Rust is a new programming language which had its 1.0 release in 2015:"
+msgstr "Rust ist eine neue Programmiersprache, die 2015 ihre Version 1.0 hatte:"
+
+#: src/welcome-day-1/what-is-rust.md:5
+#, fuzzy
+msgid ""
+"* Rust is a statically compiled language in a similar role as C++\n"
+"  * `rustc` uses LLVM as its backend.\n"
+"* Rust supports many [platforms and\n"
+"  "
+"architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
+"  * x86, ARM, WebAssembly, ...\n"
+"  * Linux, Mac, Windows, ...\n"
+"* Rust is used for a wide range of devices:\n"
+"  * firmware and boot loaders,\n"
+"  * smart displays,\n"
+"  * mobile phones,\n"
+"  * desktops,\n"
+"  * servers."
+msgstr ""
+"* Rust ist eine statisch kompilierte Sprache in einer ähnlichen Rolle wie "
+"C++\n"
+"  * `rustc` verwendet LLVM als Backend.\n"
+"* Rust unterstützt viele [Plattformen und\n"
+"  Architekturen] "
+"(https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
+"  * x86, ARM, WebAssembly, ...\n"
+"  * Linux, Mac, Windows, ...\n"
+"* Rust wird für eine Vielzahl von Geräten verwendet:\n"
+"  * Firmware und Bootloader,\n"
+"  * intelligente Displays,\n"
+"  * Mobiltelefone,\n"
+"  * Desktops,\n"
+"  * Server."
+
+#: src/welcome-day-1/what-is-rust.md:21
+#, fuzzy
+msgid "Rust fits in the same area as C++:"
+msgstr "Rust passt in den gleichen Bereich wie C++:"
+
+#: src/welcome-day-1/what-is-rust.md:23
+#, fuzzy
+msgid ""
+"* High flexibility.\n"
+"* High level of control.\n"
+"* Can be scaled down to very constrained devices like mobile phones.\n"
+"* Has no runtime or garbage collection.\n"
+"* Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"* Hohe Flexibilität.\n"
+"* Hohes Maß an Kontrolle.\n"
+"* Kann auf sehr eingeschränkte Geräte wie Mobiltelefone herunterskaliert "
+"werden.\n"
+"* Hat keine Laufzeit oder Garbage Collection.\n"
+"* Konzentriert sich auf Zuverlässigkeit und Sicherheit ohne "
+"Leistungseinbußen."
+
+#: src/hello-world.md:1
+#, fuzzy
+msgid "# Hello World!"
+msgstr "# Hallo Welt!"
+
+#: src/hello-world.md:3
+#, fuzzy
+msgid ""
+"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"program:"
+msgstr ""
+"Lassen Sie uns in das einfachste Rust-Programm einsteigen, ein klassisches "
+"Hello World\n"
+"Programm:"
+
+#: src/hello-world.md:6
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Hello 🌍!\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/hello-world.md:12
+#, fuzzy
+msgid "What you see:"
+msgstr "Was Sie sehen:"
+
+#: src/hello-world.md:14
+#, fuzzy
+msgid ""
+"* Functions are introduced with `fn`.\n"
+"* Blocks are delimited by curly braces like in C and C++.\n"
+"* The `main` function is the entry point of the program.\n"
+"* Rust has hygienic macros, `println!` is an example of this.\n"
+"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr ""
+"* Funktionen werden mit `fn` eingeleitet.\n"
+"* Blöcke werden wie in C und C++ durch geschweifte Klammern getrennt.\n"
+"* Die Hauptfunktion ist der Einstiegspunkt des Programms.\n"
+"* Rust hat hygienische Makros, `println!` ist ein Beispiel dafür.\n"
+"* Rust-Strings sind UTF-8-codiert und können beliebige Unicode-Zeichen "
+"enthalten."
+
+#: src/hello-world.md:22
+#, fuzzy
+msgid ""
+"This slide tries to make the students comfortable with Rust code. They will "
+"see\n"
+"a ton of it over the next four days so we start small with something "
+"familiar."
+msgstr ""
+"Diese Folie versucht, die Schüler mit Rust-Code vertraut zu machen. Sie "
+"werden sehen\n"
+"eine Tonne davon in den nächsten vier Tagen, also fangen wir klein mit etwas "
+"Vertrautem an."
+
+#: src/hello-world.md:27
+#, fuzzy
+msgid ""
+"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
+"  imperative (not functional) and it doesn't try to reinvent things unless\n"
+"  absolutely necessary."
+msgstr ""
+"* Rust ist anderen Sprachen in der C/C++/Java-Tradition sehr ähnlich. Es "
+"ist\n"
+"  Imperativ (nicht funktional) und es versucht nicht, Dinge neu zu erfinden, "
+"es sei denn\n"
+"  absolut notwendig."
+
+#: src/hello-world.md:31
+#, fuzzy
+msgid "* Rust is modern with full support for things like Unicode."
+msgstr "* Rust ist modern mit voller Unterstützung für Dinge wie Unicode."
+
+#: src/hello-world.md:33
+#, fuzzy
+msgid ""
+"* Rust uses macros for situations where you want to have a variable number "
+"of\n"
+"  arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"* Rust verwendet Makros für Situationen, in denen Sie eine variable Anzahl "
+"von Makros haben möchten\n"
+"  Argumente (keine Funktion [Überladen] "
+"(Grundsyntax/Funktionen-Zwischenspiel.md))."
+
+#: src/hello-world/small-example.md:1
+#, fuzzy
+msgid "# Small Example"
+msgstr "# Kleines Beispiel"
+
+#: src/hello-world/small-example.md:3
+#, fuzzy
+msgid "Here is a small example program in Rust:"
+msgstr "Hier ein kleines Beispielprogramm in Rust:"
+
+#: src/hello-world/small-example.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {              // Program entry point\n"
+"    let mut x: i32 = 6;  // Mutable variable binding\n"
+"    print!(\"{x}\");       // Macro for printing, like printf\n"
+"    while x != 1 {       // No parenthesis around expression\n"
+"        if x % 2 == 0 {  // Math like in other languages\n"
+"            x = x / 2;\n"
+"        } else {\n"
+"            x = 3 * x + 1;\n"
+"        }\n"
+"        print!(\" -> {x}\");\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/hello-world/small-example.md:23
+#, fuzzy
+msgid ""
+"The code implements the Collatz conjecture: it is believed that the loop "
+"will\n"
+"always end, but this is not yet proved. Edit the code and play with "
+"different\n"
+"inputs."
+msgstr ""
+"Der Code implementiert die Collatz-Vermutung: Es wird angenommen, dass die "
+"Schleife dies tut\n"
+"immer enden, aber das ist noch nicht bewiesen. Bearbeiten Sie den Code und "
+"spielen Sie mit verschiedenen\n"
+"Eingänge."
+
+#: src/hello-world/small-example.md:29
+#, fuzzy
+msgid ""
+"* Explain that all variables are statically typed. Try removing `i32` to "
+"trigger\n"
+"  type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
+msgstr ""
+"* Erklären Sie, dass alle Variablen statisch typisiert sind. Versuchen Sie, "
+"„i32“ zu entfernen, um auszulösen\n"
+"  Typ Inferenz. Versuchen Sie es stattdessen mit \"i8\" und lösen Sie einen "
+"Integer-Überlauf zur Laufzeit aus."
+
+#: src/hello-world/small-example.md:32
+#, fuzzy
+msgid "* Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "* Ändere `let mut x` in `let x`, diskutiere den Compiler-Fehler."
+
+#: src/hello-world/small-example.md:34
+#, fuzzy
+msgid ""
+"* Show how `print!` gives a compilation error if the arguments don't match "
+"the\n"
+"  format string."
+msgstr ""
+"* Zeigen Sie, wie `print!` einen Kompilierungsfehler ausgibt, wenn die "
+"Argumente nicht übereinstimmen\n"
+"  Zeichenfolge formatieren."
+
+#: src/hello-world/small-example.md:37
+#, fuzzy
+msgid ""
+"* Show how you need to use `{}` as a placeholder if you want to print an\n"
+"  expression which is more complex than just a single variable."
+msgstr ""
+"* Zeigen Sie, wie Sie `{}` als Platzhalter verwenden müssen, wenn Sie eine "
+"drucken möchten\n"
+"  Ausdruck, der komplexer ist als nur eine einzelne Variable."
+
+#: src/hello-world/small-example.md:40
+#, fuzzy
+msgid ""
+"* Show the students the standard library, show them how to search for "
+"`std::fmt`\n"
+"  which has the rules of the formatting mini-language. It's important that "
+"the\n"
+"  students become familiar with searching in the standard library."
+msgstr ""
+"* Zeigen Sie den Schülern die Standardbibliothek, zeigen Sie ihnen, wie man "
+"nach `std::fmt` sucht\n"
+"  die die Regeln der Formatierungsminisprache hat. Wichtig ist, dass die\n"
+"  Die Schüler lernen die Suche in der Standardbibliothek kennen."
+
+#: src/why-rust.md:1
+#, fuzzy
+msgid "# Why Rust?"
+msgstr "# Warum Rost?"
+
+#: src/why-rust.md:3
+#, fuzzy
+msgid "Some unique selling points of Rust:"
+msgstr "Einige Alleinstellungsmerkmale von Rust:"
+
+#: src/why-rust.md:5
+#, fuzzy
+msgid ""
+"* Compile time memory safety.\n"
+"* Lack of undefined runtime behavior.\n"
+"* Modern language features."
+msgstr ""
+"* Kompilierzeit-Speichersicherheit.\n"
+"* Mangel an undefiniertem Laufzeitverhalten.\n"
+"* Moderne Sprachfunktionen."
+
+#: src/why-rust.md:11
+#, fuzzy
+msgid ""
+"Make sure to ask the class which languages they have experience with. "
+"Depending\n"
+"on the answer you can highlight different features of Rust:"
+msgstr ""
+"Fragen Sie die Klasse unbedingt, mit welchen Sprachen sie Erfahrung haben. "
+"Abhängig\n"
+"Auf der Antwort können Sie verschiedene Funktionen von Rust hervorheben:"
+
+#: src/why-rust.md:14
+#, fuzzy
+msgid ""
+"* Experience with C or C++: Rust eliminates a whole class of _runtime "
+"errors_\n"
+"  via the borrow checker. You get performance like in C and C++, but you "
+"don't\n"
+"  have the memory unsafety issues. In addition, you get a modern language "
+"with\n"
+"  constructs like pattern matching and built-in dependency management."
+msgstr ""
+"* Erfahrung mit C oder C++: Rust eliminiert eine ganze Klasse von "
+"_Laufzeitfehlern_\n"
+"  über den Ausleihprüfer. Sie erhalten eine Leistung wie in C und C++, aber "
+"Sie tun es nicht\n"
+"  habe die Speicherunsicherheitsprobleme. Außerdem bekommt man eine moderne "
+"Sprache mit\n"
+"  Konstrukte wie Musterabgleich und integriertes Abhängigkeitsmanagement."
+
+#: src/why-rust.md:19
+#, fuzzy
+msgid ""
+"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety\n"
+"  as in those languages, plus a similar high-level language feeling. In "
+"addition\n"
+"  you get fast and predictable performance like C and C++ (no garbage "
+"collector)\n"
+"  as well as access to low-level hardware (should you need it)"
+msgstr ""
+"* Erfahrung mit Java, Go, Python, JavaScript...: Sie erhalten die gleiche "
+"Speichersicherheit\n"
+"  wie in diesen Sprachen, dazu ein ähnliches Hochsprachengefühl. Zusätzlich\n"
+"  Sie erhalten eine schnelle und vorhersehbare Leistung wie C und C++ (kein "
+"Garbage Collector)\n"
+"  sowie Zugriff auf Low-Level-Hardware (falls erforderlich)"
+
+#: src/why-rust/compile-time.md:1
+#, fuzzy
+msgid "# Compile Time Guarantees"
+msgstr "# Kompilierzeitgarantien"
+
+#: src/why-rust/compile-time.md:3
+#, fuzzy
+msgid "Static memory management at compile time:"
+msgstr "Statische Speicherverwaltung zur Kompilierzeit:"
+
+#: src/why-rust/compile-time.md:5
+#, fuzzy
+msgid ""
+"* No uninitialized variables.\n"
+"* No memory leaks (_mostly_, see notes).\n"
+"* No double-frees.\n"
+"* No use-after-free.\n"
+"* No `NULL` pointers.\n"
+"* No forgotten locked mutexes.\n"
+"* No data races between threads.\n"
+"* No iterator invalidation."
+msgstr ""
+"* Keine nicht initialisierten Variablen.\n"
+"* Keine Speicherlecks (_meistens_, siehe Anmerkungen).\n"
+"* Keine Doppelbefreiungen.\n"
+"* Keine Nachnutzung.\n"
+"* Keine `NULL`-Zeiger.\n"
+"* Keine vergessenen gesperrten Mutexe.\n"
+"* Keine Datenrennen zwischen Threads.\n"
+"* Keine Invalidierung des Iterators."
+
+#: src/why-rust/compile-time.md:16
+#, fuzzy
+msgid ""
+"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
+"are:"
+msgstr ""
+"Es ist möglich, Speicherlecks in (sicherem) Rust zu erzeugen. Einige "
+"Beispiele\n"
+"Sind:"
+
+#: src/why-rust/compile-time.md:19
+#, fuzzy
+msgid ""
+"* You can for use [`Box::leak`] to leak a pointer. A use of this could\n"
+"  be to get runtime-initialized and runtime-sized static variables\n"
+"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
+"  a value (meaning the destructor is never run).\n"
+"* You can also accidentally create a [reference cycle] with `Rc` or\n"
+"  `Arc`.\n"
+"* In fact, some will consider infinitely populating a collection a memory\n"
+"  leak and Rust does not protect from those."
+msgstr ""
+"* Sie können [`Box::leak`] verwenden, um einen Zeiger zu verlieren. Eine "
+"Nutzung dieser könnte\n"
+"  sein, um zur Laufzeit initialisierte statische Variablen in Laufzeitgröße "
+"zu erhalten\n"
+"* Sie können [`std::mem::forget`] verwenden, um den Compiler \"vergessen\" "
+"zu lassen\n"
+"  ein Wert (was bedeutet, dass der Destruktor niemals ausgeführt wird).\n"
+"* Sie können auch versehentlich einen [Referenzzyklus] mit `Rc` oder "
+"erstellen\n"
+"  \"Bogen\".\n"
+"* In der Tat werden einige in Betracht ziehen, eine Sammlung unendlich als "
+"Erinnerung zu füllen\n"
+"  Leck und Rost schützt nicht vor denen."
+
+#: src/why-rust/compile-time.md:28
+#, fuzzy
+msgid ""
+"For the purpose of this course, \"No memory leaks\" should be understood\n"
+"as \"Pretty much no *accidental* memory leaks\"."
+msgstr ""
+"Für die Zwecke dieses Kurses sollte \"Keine Speicherlecks\" verstanden "
+"werden\n"
+"als \"so gut wie keine *versehentlichen* Speicherlecks\"."
+
+#: src/why-rust/compile-time.md:31
+#, fuzzy
+msgid ""
+"[`Box::leak`]: "
+"https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
+"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
+"[reference cycle]: "
+"https://doc.rust-lang.org/book/ch15-06-reference-cycles.html"
+msgstr ""
+"[`Box::leak`]: "
+"https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
+"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
+"[Referenzzyklus]: "
+"https://doc.rust-lang.org/book/ch15-06-reference-cycles.html"
+
+#: src/why-rust/runtime.md:1
+#, fuzzy
+msgid "# Runtime Guarantees"
+msgstr "# Laufzeitgarantien"
+
+#: src/why-rust/runtime.md:3
+#, fuzzy
+msgid "No undefined behavior at runtime:"
+msgstr "Kein undefiniertes Verhalten zur Laufzeit:"
+
+#: src/why-rust/runtime.md:5
+#, fuzzy
+msgid "* Array access is bounds checked.\n* Integer overflow is defined."
+msgstr ""
+"* Der Array-Zugriff wird auf Grenzen geprüft.\n"
+"* Ganzzahlüberlauf ist definiert."
+
+#: src/why-rust/runtime.md:12
+#, fuzzy
+msgid ""
+"* Integer overflow is defined via a compile-time flag. The options are\n"
+"  either a panic (a controlled crash of the program) or wrap-around\n"
+"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
+"  and wrap-around in release mode (`cargo build --release`)."
+msgstr ""
+"* Ganzzahlüberlauf wird über ein Flag zur Kompilierzeit definiert. Die "
+"Optionen sind\n"
+"  entweder eine Panik (ein kontrollierter Absturz des Programms) oder ein "
+"Wrap-Around\n"
+"  Semantik. Standardmäßig erhalten Sie Panik im Debug-Modus (`cargo build`)\n"
+"  und Wrap-Around im Release-Modus (`cargo build --release`)."
+
+#: src/why-rust/runtime.md:17
+#, fuzzy
+msgid ""
+"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
+"  not be disabled directly with the `unsafe` keyword. However,\n"
+"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
+"  which does not do bounds checking."
+msgstr ""
+"* Die Begrenzungsprüfung kann nicht mit einem Compiler-Flag deaktiviert "
+"werden. Es kann auch\n"
+"  nicht direkt mit dem Schlüsselwort „unsafe“ deaktiviert werden. Jedoch,\n"
+"  `unsafe` erlaubt Ihnen, Funktionen wie `slice::get_unchecked` aufzurufen\n"
+"  die keine Begrenzungsprüfung durchführt."
+
+#: src/why-rust/modern.md:1
+#, fuzzy
+msgid "# Modern Features"
+msgstr "# Moderne Funktionen"
+
+#: src/why-rust/modern.md:3
+#, fuzzy
+msgid "Rust is built with all the experience gained in the last 40 years."
+msgstr "Rust wird mit all den Erfahrungen der letzten 40 Jahre gebaut."
+
+#: src/why-rust/modern.md:5
+#, fuzzy
+msgid "## Language Features"
+msgstr "## Sprachmerkmale"
+
+#: src/why-rust/modern.md:7
+#, fuzzy
+msgid ""
+"* Enums and pattern matching.\n"
+"* Generics.\n"
+"* No overhead FFI.\n"
+"* Zero-cost abstractions."
+msgstr ""
+"* Enums und Musterabgleich.\n"
+"* Generika.\n"
+"* Kein Overhead-FFI.\n"
+"* Nullkosten-Abstraktionen."
+
+#: src/why-rust/modern.md:12
+#, fuzzy
+msgid "## Tooling"
+msgstr "## Werkzeuge"
+
+#: src/why-rust/modern.md:14
+#, fuzzy
+msgid ""
+"* Great compiler errors.\n"
+"* Built-in dependency manager.\n"
+"* Built-in support for testing.\n"
+"* Excellent Language Server Protocol support."
+msgstr ""
+"* Große Compiler-Fehler.\n"
+"* Eingebauter Abhängigkeitsmanager.\n"
+"* Eingebaute Unterstützung zum Testen.\n"
+"* Hervorragende Unterstützung des Language Server Protocol."
+
+#: src/why-rust/modern.md:23
+#, fuzzy
+msgid ""
+"* Zero-cost abstractions, similar to C++, means that you don't have to "
+"'pay'\n"
+"  for higher-level programming constructs with memory or CPU. For example,\n"
+"  writing a loop using `for` should result in roughly the same low level\n"
+"  instructions as using the `.iter().fold()` construct."
+msgstr ""
+"* Zero-Cost-Abstraktionen, ähnlich wie C++, bedeutet, dass Sie nicht "
+"„bezahlen“ müssen\n"
+"  für übergeordnete Programmierkonstrukte mit Speicher oder CPU. Zum "
+"Beispiel,\n"
+"  Das Schreiben einer Schleife mit `for` sollte ungefähr den gleichen "
+"niedrigen Pegel ergeben\n"
+"  Anweisungen wie die Verwendung des `.iter().fold()`-Konstrukts."
+
+#: src/why-rust/modern.md:28
+#, fuzzy
+msgid ""
+"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
+"also\n"
+"  known as 'sum types', which allow the type system to express things like\n"
+"  `Option<T>` and `Result<T, E>`."
+msgstr ""
+"* Es sollte erwähnt werden, dass Rust-Enumerationen auch 'algebraische "
+"Datentypen' sind\n"
+"  bekannt als \"Summentypen\", die es dem Typsystem ermöglichen, Dinge wie "
+"auszudrücken\n"
+"  `Option<T>` und `Ergebnis<T, E>`."
+
+#: src/why-rust/modern.md:32
+#, fuzzy
+msgid ""
+"* Remind people to read the errors --- many developers have gotten used to\n"
+"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
+"  talkative than other compilers. It will often provide you with "
+"_actionable_\n"
+"  feedback, ready to copy-paste into your code."
+msgstr ""
+"* Erinnere die Leute daran, die Fehler zu lesen --- viele Entwickler haben "
+"sich daran gewöhnt\n"
+"  Ignoriere lange Compiler-Ausgaben. Der Rust-Compiler ist deutlich mehr\n"
+"  gesprächiger als andere Compiler. Es wird Ihnen oft _umsetzbare_\n"
+"  Feedback, bereit zum Kopieren und Einfügen in Ihren Code."
+
+#: src/why-rust/modern.md:37
+#, fuzzy
+msgid ""
+"* The Rust standard library is small compared to languages like Java, "
+"Python,\n"
+"  and Go. Rust does not come with several things you might consider standard "
+"and\n"
+"  essential:"
+msgstr ""
+"* Die Rust-Standardbibliothek ist klein im Vergleich zu Sprachen wie Java, "
+"Python,\n"
+"  Los geht. Rust kommt nicht mit einigen Dingen, die Sie als Standard "
+"betrachten könnten und\n"
+"  essentiell:"
+
+#: src/why-rust/modern.md:41
+#, fuzzy
+msgid ""
+"  * a random number generator, but see [rand].\n"
+"  * support for SSL or TLS, but see [rusttls].\n"
+"  * support for JSON, but see [serde_json]."
+msgstr ""
+"  * ein Zufallszahlengenerator, aber siehe [rand].\n"
+"  * Unterstützung für SSL oder TLS, aber siehe [rusttls].\n"
+"  * Unterstützung für JSON, aber siehe [serde_json]."
+
+#: src/why-rust/modern.md:45
+#, fuzzy
+msgid ""
+"  The reasoning behind this is that functionality in the standard library "
+"cannot\n"
+"  go away, so it has to be very stable. For the examples above, the Rust\n"
+"  community is still working on finding the best solution --- and perhaps "
+"there\n"
+"  isn't a single \"best solution\" for some of these things."
+msgstr ""
+"  Der Grund dafür ist, dass die Funktionalität in der Standardbibliothek "
+"dies nicht kann\n"
+"  weggehen, also muss es sehr stabil sein. Für die obigen Beispiele ist die "
+"Rust\n"
+"  Die Community arbeitet immer noch daran, die beste Lösung zu finden --- "
+"und vielleicht gibt es sie\n"
+"  ist für einige dieser Dinge keine einzige \"beste Lösung\"."
+
+#: src/why-rust/modern.md:50
+#, fuzzy
+msgid ""
+"  Rust comes with a built-in package manager in the form of Cargo and this "
+"makes\n"
+"  it trivial to download and compile third-party crates. A consequence of "
+"this\n"
+"  is that the standard library can be smaller."
+msgstr ""
+"  Rust kommt mit einem eingebauten Paketmanager in Form von Cargo und macht "
+"das\n"
+"  Es ist trivial, Crates von Drittanbietern herunterzuladen und zu "
+"kompilieren. Eine Folge davon\n"
+"  ist, dass die Standardbibliothek kleiner sein kann."
+
+#: src/why-rust/modern.md:54
+#, fuzzy
+msgid ""
+"  Discovering good third-party crates can be a problem. Sites like\n"
+"  <https://lib.rs/> help with this by letting you compare health metrics "
+"for\n"
+"  crates to find a good and trusted one.\n"
+"  \n"
+"* [rust-analyzer] is a well supported LSP implementation used in major\n"
+"  IDEs and text editors."
+msgstr ""
+"  Das Entdecken guter Kisten von Drittanbietern kann ein Problem sein. "
+"Seiten wie\n"
+"  <https://lib.rs/> hilft dabei, indem es Ihnen ermöglicht, "
+"Gesundheitsmetriken für zu vergleichen\n"
+"  Kisten, um eine gute und vertrauenswürdige zu finden.\n"
+"  \n"
+"* [rust-analyzer] ist eine gut unterstützte LSP-Implementierung, die in "
+"Major verwendet wird\n"
+"  IDEs und Texteditoren."
+
+#: src/why-rust/modern.md:61
+#, fuzzy
+msgid ""
+"[rand]: https://docs.rs/rand/\n"
+"[rusttls]: https://docs.rs/rustls/\n"
+"[serde_json]: https://docs.rs/serde_json/\n"
+"[rust-analyzer]: https://rust-analyzer.github.io/"
+msgstr ""
+"[rand]: https://docs.rs/rand/\n"
+"[rusttls]: https://docs.rs/rustls/\n"
+"[serde_json]: https://docs.rs/serde_json/\n"
+"[Rostanalyzer]: https://rust-analyzer.github.io/"
+
+#: src/basic-syntax.md:1
+#, fuzzy
+msgid "# Basic Syntax"
+msgstr "# Grundlegende Syntax"
+
+#: src/basic-syntax.md:3
+#, fuzzy
+msgid "Much of the Rust syntax will be familiar to you from C or C++:"
+msgstr "Ein Großteil der Rust-Syntax wird Ihnen aus C oder C++ vertraut sein:"
+
+#: src/basic-syntax.md:5
+#, fuzzy
+msgid ""
+"* Blocks and scopes are delimited by curly braces.\n"
+"* Line comments are started with `//`, block comments are delimited by `/* "
+"...\n"
+"  */`.\n"
+"* Keywords like `if` and `while` work the same.\n"
+"* Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+"* Blöcke und Bereiche werden durch geschweifte Klammern getrennt.\n"
+"* Zeilenkommentare beginnen mit `//`, Blockkommentare werden mit `/* "
+"begrenzt ...\n"
+"  */`.\n"
+"* Schlüsselwörter wie „if“ und „while“ funktionieren gleich.\n"
+"* Variablenzuweisung erfolgt mit `=`, Vergleich erfolgt mit `==`."
+
+#: src/basic-syntax/scalar-types.md:1
+#, fuzzy
+msgid "# Scalar Types"
+msgstr "# Skalare Typen"
+
+#: src/basic-syntax/scalar-types.md:3
+#, fuzzy
+msgid ""
+"|                        | Types                                      | "
+"Literals                      |\n"
+"|------------------------|--------------------------------------------|-------------------------------|\n"
+"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
+"`-10`, `0`, `1_000`, `123i64` |\n"
+"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
+"`123`, `10u16`           |\n"
+"| Floating point numbers | `f32`, `f64`                               | "
+"`3.14`, `-10.0e20`, `2f32`    |\n"
+"| Strings                | `&str`                                     | "
+"`\"foo\"`, `r#\"\\\\\"#`            |\n"
+"| Unicode scalar values  | `char`                                     | "
+"`'a'`, `'α'`, `'∞'`           |\n"
+"| Byte strings           | `&[u8]`                                    | "
+"`b\"abc\"`, `br#\" \" \"#`         |\n"
+"| Booleans               | `bool`                                     | "
+"`true`, `false`               |"
+msgstr ""
+"| | Typen | Literale |\n"
+"|------------------------|------------------------ "
+"--------------------|------------------------------------- --|\n"
+"| Ganzzahlen mit Vorzeichen | „i8“, „i16“, „i32“, „i64“, „i128“, „Größe“ | "
+"„-10“, „0“, „1_000“, „123i64“ |\n"
+"| Ganzzahlen ohne Vorzeichen | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | "
+"`0`, `123`, `10u16` |\n"
+"| Fließkommazahlen | „f32“, „f64“ | `3.14`, `-10.0e20`, `2f32` |\n"
+"| Saiten | `&str` | `\"foo\"`, `r#\"\\\\\"#` |\n"
+"| Unicode-Skalarwerte | \"char\" | `'a'`, `'α'`, `'∞'` |\n"
+"| Byte-Strings | `&[u8]` | `b\"abc\"`, `br#\" \" \"#` |\n"
+"| Boolesche Werte | „Bool“ | „wahr“, „falsch“ |"
+
+#: src/basic-syntax/scalar-types.md:13
+#, fuzzy
+msgid "The types have widths as follows:"
+msgstr "Die Typen haben folgende Breiten:"
+
+#: src/basic-syntax/scalar-types.md:15
+#, fuzzy
+msgid ""
+"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
+"* `isize` and `usize` are the width of a pointer,\n"
+"* `char` is 32 bit wide,\n"
+"* `bool` is 8 bit wide."
+msgstr ""
+"* `iN`, `uN` und `fN` sind _N_ Bits breit,\n"
+"* `isize` und `usize` sind die Breite eines Zeigers,\n"
+"* `char` ist 32 Bit breit,\n"
+"* `bool` ist 8 Bit breit."
+
+#: src/basic-syntax/compound-types.md:1
+#, fuzzy
+msgid "# Compound Types"
+msgstr "# Verbundtypen"
+
+#: src/basic-syntax/compound-types.md:3
+msgid ""
+"|        | Types                         | Literals                          "
+"|\n"
+"|--------|-------------------------------|-----------------------------------|\n"
+"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
+"|\n"
+"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
+"|"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:8
+#, fuzzy
+msgid "Array assignment and access:"
+msgstr "Array-Zuordnung und Zugriff:"
+
+#: src/basic-syntax/compound-types.md:10
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut a: [i8; 10] = [42; 10];\n"
+"    a[5] = 0;\n"
+"    println!(\"a: {:?}\", a);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:18
+#, fuzzy
+msgid "Tuple assignment and access:"
+msgstr "Tupelzuweisung und Zugriff:"
+
+#: src/basic-syntax/compound-types.md:20
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let t: (i8, bool) = (7, true);\n"
+"    println!(\"1st index: {}\", t.0);\n"
+"    println!(\"2nd index: {}\", t.1);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:32
+#, fuzzy
+msgid "Arrays:"
+msgstr "Arrays:"
+
+#: src/basic-syntax/compound-types.md:34
+msgid ""
+"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant.\n"
+"  Note that the length of the array is *part of its type*, which means that "
+"`[u8; 3]` and\n"
+"  `[u8; 4]` are considered two different types."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:38
+#, fuzzy
+msgid "* We can use literals to assign values to arrays."
+msgstr "* Wir können Literale verwenden, um Arrays Werte zuzuweisen."
+
+#: src/basic-syntax/compound-types.md:40
+#, fuzzy
+msgid ""
+"* In the main function, the print statement asks for the debug "
+"implementation with the `?` format\n"
+"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
+"We\n"
+"  could also have used `{a}` and `{a:?}` without specifying the value after "
+"the\n"
+"  format string."
+msgstr ""
+"* In der main-Funktion fragt die print-Anweisung nach der "
+"Debug-Implementierung mit dem `?`-Format\n"
+"  Parameter: `{}` gibt die Standardausgabe, `{:?}` gibt die Debug-Ausgabe. "
+"Wir\n"
+"  hätte auch `{a}` und `{a:?}` verwenden können, ohne den Wert nach dem "
+"anzugeben\n"
+"  Zeichenfolge formatieren."
+
+#: src/basic-syntax/compound-types.md:45
+#, fuzzy
+msgid ""
+"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
+"be easier to read."
+msgstr ""
+"* Das Hinzufügen von `#`, z. B. `{a:#?}`, ruft ein \"hübsches Druckformat\" "
+"auf, das einfacher zu lesen sein kann."
+
+#: src/basic-syntax/compound-types.md:47
+#, fuzzy
+msgid "Tuples:"
+msgstr "Tupel:"
+
+#: src/basic-syntax/compound-types.md:49
+#, fuzzy
+msgid "* Like arrays, tuples have a fixed length."
+msgstr "* Tupel haben wie Arrays eine feste Länge."
+
+#: src/basic-syntax/compound-types.md:51
+#, fuzzy
+msgid "* Tuples group together values of different types into a compound type."
+msgstr ""
+"* Tupel fassen Werte verschiedener Typen zu einem zusammengesetzten Typ "
+"zusammen."
+
+#: src/basic-syntax/compound-types.md:53
+#, fuzzy
+msgid ""
+"* Fields of a tuple can be accessed by the period and the index of the "
+"value, e.g. `t.0`, `t.1`."
+msgstr ""
+"* Auf Felder eines Tupels kann über den Punkt und den Index des Werts "
+"zugegriffen werden, z. „t.0“, „t.1“."
+
+#: src/basic-syntax/compound-types.md:55
+#, fuzzy
+msgid ""
+"* The empty tuple `()` is also known as the \"unit type\". It is both a "
+"type, and\n"
+"  the only valid value of that type - that is to say both the type and its "
+"value\n"
+"  are expressed as `()`. It is used to indicate, for example, that a "
+"function or\n"
+"  expression has no return value, as we'll see in a future slide. \n"
+"    * You can think of it as `void` that can be familiar to you from other \n"
+"      programming languages."
+msgstr ""
+"* Das leere Tupel `()` ist auch als \"Einheitstyp\" bekannt. Es ist sowohl "
+"ein Typ als auch\n"
+"  der einzig gültige Wert dieses Typs - also sowohl der Typ als auch sein "
+"Wert\n"
+"  werden als `()` ausgedrückt. Es wird zum Beispiel verwendet, um "
+"anzuzeigen, dass eine Funktion oder\n"
+"  Ausdruck hat keinen Rückgabewert, wie wir auf einer zukünftigen Folie "
+"sehen werden.\n"
+"    * Sie können es sich als „Leere“ vorstellen, die Ihnen von anderen "
+"bekannt sein kann\n"
+"      Programmiersprachen."
+
+#: src/basic-syntax/references.md:1
+#, fuzzy
+msgid "# References"
+msgstr "# Verweise"
+
+#: src/basic-syntax/references.md:3
+#, fuzzy
+msgid "Like C++, Rust has references:"
+msgstr "Wie C++ hat Rust Referenzen:"
+
+#: src/basic-syntax/references.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x: i32 = 10;\n"
+"    let ref_x: &mut i32 = &mut x;\n"
+"    *ref_x = 20;\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/references.md:14
+#, fuzzy
+msgid "Some notes:"
+msgstr "Einige Notizen:"
+
+#: src/basic-syntax/references.md:16
+#, fuzzy
+msgid ""
+"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers.\n"
+"* Rust will auto-dereference in some cases, in particular when invoking\n"
+"  methods (try `ref_x.count_ones()`).\n"
+"* References that are declared as `mut` can be bound to different values "
+"over their lifetime."
+msgstr ""
+"* Wir müssen `ref_x` beim Zuweisen dereferenzieren, ähnlich wie bei C- und "
+"C++-Zeigern.\n"
+"* Rust wird in einigen Fällen automatisch dereferenzieren, insbesondere beim "
+"Aufrufen\n"
+"  Methoden (probieren Sie `ref_x.count_ones()`).\n"
+"* Referenzen, die als `mut` deklariert sind, können über ihre Lebensdauer an "
+"unterschiedliche Werte gebunden werden."
+
+#: src/basic-syntax/references.md:21
+#, fuzzy
+msgid "<details>\nKey points:"
+msgstr "<Details>\nKernpunkte:"
+
+#: src/basic-syntax/references.md:24
+#, fuzzy
+msgid ""
+"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
+"ref_x:\n"
+"  &mut i32`. The first one represents a mutable reference which can be bound "
+"to\n"
+"  different values, while the second represents a reference to a mutable "
+"value."
+msgstr ""
+"* Beachten Sie unbedingt den Unterschied zwischen `let mut ref_x: &i32` und "
+"`let ref_x:\n"
+"  &mut i32`. Der erste stellt eine veränderliche Referenz dar, an die "
+"gebunden werden kann\n"
+"  unterschiedliche Werte, während der zweite einen Verweis auf einen "
+"veränderlichen Wert darstellt."
+
+#: src/basic-syntax/references-dangling.md:1
+#, fuzzy
+msgid "# Dangling References"
+msgstr "# Dangling-Referenzen"
+
+#: src/basic-syntax/references-dangling.md:3
+#, fuzzy
+msgid "Rust will statically forbid dangling references:"
+msgstr "Rust wird baumelnde Referenzen statisch verbieten:"
+
+#: src/basic-syntax/references-dangling.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let ref_x: &i32;\n"
+"    {\n"
+"        let x: i32 = 10;\n"
+"        ref_x = &x;\n"
+"    }\n"
+"    println!(\"ref_x: {ref_x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/references-dangling.md:16
+#, fuzzy
+msgid ""
+"* A reference is said to \"borrow\" the value it refers to.\n"
+"* Rust is tracking the lifetimes of all references to ensure they live long\n"
+"  enough.\n"
+"* We will talk more about borrowing when we get to ownership."
+msgstr ""
+"* Eine Referenz soll den Wert, auf den sie sich bezieht, \"leihen\".\n"
+"* Rust verfolgt die Lebensdauer aller Referenzen, um sicherzustellen, dass "
+"sie lange leben\n"
+"  genug.\n"
+"* Wir werden mehr über das Ausleihen sprechen, wenn wir zum Eigentum kommen."
+
+#: src/basic-syntax/slices.md:1
+#, fuzzy
+msgid "# Slices"
+msgstr "# Scheiben"
+
+#: src/basic-syntax/slices.md:3
+#, fuzzy
+msgid "A slice gives you a view into a larger collection:"
+msgstr "Ein Slice gibt Ihnen einen Einblick in eine größere Sammlung:"
+
+#: src/basic-syntax/slices.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];\n"
+"    println!(\"a: {a:?}\");"
+msgstr ""
+
+#: src/basic-syntax/slices.md:10
+msgid ""
+"    let s: &[i32] = &a[2..4];\n"
+"    println!(\"s: {s:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/slices.md:15
+#, fuzzy
+msgid ""
+"* Slices borrow data from the sliced type.\n"
+"* Question: What happens if you modify `a[3]`?"
+msgstr ""
+"* Slices borgen Daten vom Sliced-Typ.\n"
+"* Frage: Was passiert, wenn Sie `a[3]` ändern?"
+
+#: src/basic-syntax/slices.md:20
+#, fuzzy
+msgid ""
+"* We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr ""
+"* Wir erstellen einen Slice, indem wir `a` ausleihen und den Anfangs- und "
+"Endindex in Klammern angeben."
+
+#: src/basic-syntax/slices.md:22
+#, fuzzy
+msgid ""
+"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical.\n"
+"    \n"
+"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"* Wenn der Slice bei Index 0 beginnt, erlaubt uns die Range-Syntax von Rust, "
+"den Startindex wegzulassen, was bedeutet, dass `&a[0..a.len()]` und "
+"`&a[..a.len()]` identisch sind .\n"
+"    \n"
+"* Dasselbe gilt für den letzten Index, also sind `&a[2..a.len()]` und "
+"`&a[2..]` identisch."
+
+#: src/basic-syntax/slices.md:26
+#, fuzzy
+msgid ""
+"* To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+"* Um einfach einen Teil des gesamten Arrays zu erstellen, können wir daher "
+"`&a[..]` verwenden."
+
+#: src/basic-syntax/slices.md:28
+#, fuzzy
+msgid ""
+"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes.\n"
+" \n"
+"* Slices always borrow from another object. In this example, `a` has to "
+"remain 'alive' (in scope) for at least as long as our slice. \n"
+"    \n"
+"* The question about modifying `a[3]` can spark an interesting discussion, "
+"but the answer is that for memory safety reasons\n"
+"  you cannot do it through `a` after you created a slice, but you can read "
+"the data from both `a` and `s` safely. \n"
+"  More details will be explained in the borrow checker section."
+msgstr ""
+"* `s` ist ein Verweis auf einen Slice von `i32`s. Beachten Sie, dass der Typ "
+"von `s` (`&[i32]`) die Array-Länge nicht mehr erwähnt. Dies ermöglicht es "
+"uns, Berechnungen für Scheiben unterschiedlicher Größe durchzuführen.\n"
+" \n"
+"* Slices leihen sich immer von einem anderen Objekt. In diesem Beispiel muss "
+"„a“ mindestens so lange „lebendig“ (im Geltungsbereich) bleiben wie unser "
+"Slice.\n"
+"    \n"
+"* Die Frage nach dem Modifizieren von `a[3]` kann eine interessante "
+"Diskussion auslösen, aber die Antwort ist aus Gründen der "
+"Speichersicherheit\n"
+"  Sie können dies nicht über `a` tun, nachdem Sie einen Slice erstellt "
+"haben, aber Sie können die Daten sowohl von `a` als auch von `s` sicher "
+"lesen.\n"
+"  Weitere Details werden im Abschnitt zum Ausleihen von Prüfern erklärt."
+
+#: src/basic-syntax/string-slices.md:1
+#, fuzzy
+msgid "# `String` vs `str`"
+msgstr "# `String` gegen `str`"
+
+#: src/basic-syntax/string-slices.md:3
+#, fuzzy
+msgid "We can now understand the two string types in Rust:"
+msgstr "Wir können jetzt die beiden String-Typen in Rust verstehen:"
+
+#: src/basic-syntax/string-slices.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: &str = \"World\";\n"
+"    println!(\"s1: {s1}\");"
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:10
+msgid ""
+"    let mut s2: String = String::from(\"Hello \");\n"
+"    println!(\"s2: {s2}\");\n"
+"    s2.push_str(s1);\n"
+"    println!(\"s2: {s2}\");\n"
+"    \n"
+"    let s3: &str = &s2[6..];\n"
+"    println!(\"s3: {s3}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:20
+#, fuzzy
+msgid "Rust terminology:"
+msgstr "Rost-Terminologie:"
+
+#: src/basic-syntax/string-slices.md:22
+#, fuzzy
+msgid ""
+"* `&str` an immutable reference to a string slice.\n"
+"* `String` a mutable string buffer."
+msgstr ""
+"* `&str` eine unveränderliche Referenz auf einen String-Slice.\n"
+"* `String` ein veränderlicher String-Puffer."
+
+#: src/basic-syntax/string-slices.md:27
+#, fuzzy
+msgid ""
+"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data \n"
+"  stored in a block of memory. String literals (`”Hello”`), are stored in "
+"the program’s binary."
+msgstr ""
+"* `&str` führt ein String-Slice ein, das eine unveränderliche Referenz auf "
+"UTF-8-codierte String-Daten ist\n"
+"  in einem Speicherblock gespeichert. String-Literale (`”Hallo”`) werden in "
+"der Binärdatei des Programms gespeichert."
+
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned.\n"
+"    \n"
+"* As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()` \n"
+"  creates a new empty string, to which string data can be added using the "
+"`push()` and `push_str()` methods."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:35
+#, fuzzy
+msgid ""
+"* The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It \n"
+"  accepts the same format specification as `println!()`.\n"
+"    \n"
+"* You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection.\n"
+"    \n"
+"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
+"one that always points \n"
+"  to a valid string in memory. Rust `String` is a rough equivalent of "
+"`std::string` from C++ \n"
+"  (main difference: it can only contain UTF-8 encoded bytes and will never "
+"use a small-string optimization).\n"
+"    \n"
+"</details>"
+msgstr ""
+"* Das `format!()`-Makro ist eine bequeme Möglichkeit, einen eigenen String "
+"aus dynamischen Werten zu generieren. Es\n"
+"  akzeptiert die gleiche Formatspezifikation wie `println!()`.\n"
+"    \n"
+"* Sie können `&str`-Slices von `String` über `&` und optional "
+"Bereichsauswahl ausleihen.\n"
+"    \n"
+"* Für C++-Programmierer: Stellen Sie sich `&str` als `const char*` von C++ "
+"vor, aber dasjenige, das immer zeigt\n"
+"  zu einer gültigen Zeichenfolge im Speicher. Rust `String` ist ein grobes "
+"Äquivalent zu `std::string` aus C++\n"
+"  (Hauptunterschied: Es kann nur UTF-8-codierte Bytes enthalten und "
+"verwendet niemals eine Small-String-Optimierung).\n"
+"    \n"
+"</details>"
+
+#: src/basic-syntax/functions.md:1
+#, fuzzy
+msgid "# Functions"
+msgstr "# Funktionen"
+
+#: src/basic-syntax/functions.md:3
+#, fuzzy
+msgid ""
+"A Rust version of the famous "
+"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
+msgstr ""
+"Eine Rust-Version der berühmten "
+"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) Interviewfrage:"
+
+#: src/basic-syntax/functions.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    fizzbuzz_to(20);   // Defined below, no forward declaration needed\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/functions.md:10
+msgid ""
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
+"    if rhs == 0 {\n"
+"        return false;  // Corner case, early return\n"
+"    }\n"
+"    lhs % rhs == 0     // The last expression in a block is the return "
+"value\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/functions.md:17
+#, fuzzy
+msgid ""
+"fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit "
+"type `()`\n"
+"    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
+"        (true,  true)  => println!(\"fizzbuzz\"),\n"
+"        (true,  false) => println!(\"fizz\"),\n"
+"        (false, true)  => println!(\"buzz\"),\n"
+"        (false, false) => println!(\"{n}\"),\n"
+"    }\n"
+"}"
+msgstr ""
+"fn fizzbuzz(n: u32) -> () { // Kein Rückgabewert bedeutet Rückgabe des "
+"Einheitentyps `()`\n"
+"    Übereinstimmung (ist_teilbar_durch(n, 3), ist_teilbar_durch(n, 5)) {\n"
+"        (true, true) => println!(\"fizzbuzz\"),\n"
+"        (wahr, falsch) => println!(\"fizz\"),\n"
+"        (falsch, wahr) => println!(\"summen\"),\n"
+"        (falsch, falsch) => println!(\"{n}\"),\n"
+"    }\n"
+"}"
+
+#: src/basic-syntax/functions.md:26
+msgid ""
+"fn fizzbuzz_to(n: u32) {  // `-> ()` is normally omitted\n"
+"    for i in 1..=n {\n"
+"        fizzbuzz(i);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/functions.md:35
+msgid ""
+"* We refer in `main` to a function written below. Neither forward "
+"declarations nor headers are necessary. \n"
+"* Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type.\n"
+"* The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression.\n"
+"* Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted.\n"
+"* The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
+"which causes it to include the upper bound.\n"
+"* The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
+"expanded below to show what is happening."
+msgstr ""
+
+#: src/basic-syntax/functions.md:42
+#, fuzzy
+msgid "  (Type annotations added for clarity, but they can be elided.)"
+msgstr ""
+"  (Typ-Anmerkungen wurden der Übersichtlichkeit halber hinzugefügt, können "
+"aber entfernt werden.)"
+
+#: src/basic-syntax/functions.md:44
+msgid ""
+"  ```rust,ignore\n"
+"  let by_3: bool = is_divisible_by(n, 3);\n"
+"  let by_5: bool = is_divisible_by(n, 5);\n"
+"  let by_35: (bool, bool) = (by_3, by_5);\n"
+"  match by_35 {\n"
+"    // ...\n"
+"  ```"
+msgstr ""
+
+#: src/basic-syntax/functions.md:52
+msgid "  "
+msgstr ""
+
+#: src/basic-syntax/methods.md:1 src/methods.md:1
+#, fuzzy
+msgid "# Methods"
+msgstr "# Methoden"
+
+#: src/basic-syntax/methods.md:3
+#, fuzzy
+msgid ""
+"Rust has methods, they are simply functions that are associated with a "
+"particular type. The\n"
+"first argument of a method is an instance of the type it is associated with:"
+msgstr ""
+"Rust hat Methoden, das sind einfach Funktionen, die einem bestimmten Typ "
+"zugeordnet sind. Der\n"
+"Das erste Argument einer Methode ist eine Instanz des Typs, dem sie "
+"zugeordnet ist:"
+
+#: src/basic-syntax/methods.md:6
+msgid ""
+"```rust,editable\n"
+"struct Rectangle {\n"
+"    width: u32,\n"
+"    height: u32,\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/methods.md:12
+#, fuzzy
+msgid ""
+"impl Rectangle {\n"
+"    fn area(&self) -> u32 {\n"
+"        self.width * self.height\n"
+"    }"
+msgstr ""
+"impl Rechteck {\n"
+"    fn-Bereich(&self) -> u32 {\n"
+"        selbst.Breite * selbst.Höhe\n"
+"    }"
+
+#: src/basic-syntax/methods.md:17
+msgid ""
+"    fn inc_width(&mut self, delta: u32) {\n"
+"        self.width += delta;\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/methods.md:22
+msgid ""
+"fn main() {\n"
+"    let mut rect = Rectangle { width: 10, height: 5 };\n"
+"    println!(\"old area: {}\", rect.area());\n"
+"    rect.inc_width(5);\n"
+"    println!(\"new area: {}\", rect.area());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/methods.md:30
+#, fuzzy
+msgid ""
+"* We will look much more at methods in today's exercise and in tomorrow's "
+"class."
+msgstr ""
+"* Wir werden uns in der heutigen Übung und im morgigen Unterricht viel mehr "
+"mit Methoden befassen."
+
+#: src/basic-syntax/functions-interlude.md:1
+#, fuzzy
+msgid "# Function Overloading"
+msgstr "# Funktionsüberladung"
+
+#: src/basic-syntax/functions-interlude.md:3
+#, fuzzy
+msgid "Overloading is not supported:"
+msgstr "Überladen wird nicht unterstützt:"
+
+#: src/basic-syntax/functions-interlude.md:5
+#, fuzzy
+msgid ""
+"* Each function has a single implementation:\n"
+"  * Always takes a fixed number of parameters.\n"
+"  * Always takes a single set of parameter types.\n"
+"* Default values are not supported:\n"
+"  * All call sites have the same number of arguments.\n"
+"  * Macros are sometimes used as an alternative."
+msgstr ""
+"* Jede Funktion hat eine einzige Implementierung:\n"
+"  * Akzeptiert immer eine feste Anzahl von Parametern.\n"
+"  * Akzeptiert immer einen einzelnen Satz von Parametertypen.\n"
+"* Standardwerte werden nicht unterstützt:\n"
+"  * Alle Aufrufseiten haben die gleiche Anzahl von Argumenten.\n"
+"  * Makros werden manchmal als Alternative verwendet."
+
+#: src/basic-syntax/functions-interlude.md:12
+#, fuzzy
+msgid "However, function parameters can be generic:"
+msgstr "Funktionsparameter können jedoch generisch sein:"
+
+#: src/basic-syntax/functions-interlude.md:14
+msgid ""
+"```rust,editable\n"
+"fn pick_one<T>(a: T, b: T) -> T {\n"
+"    if std::process::id() % 2 == 0 { a } else { b }\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:19
+msgid ""
+"fn main() {\n"
+"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
+"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:27
+#, fuzzy
+msgid ""
+"* When using generics, the standard library's `Into<T>` can provide a kind "
+"of limited\n"
+"  polymorphism on argument types. We will see more details in a later "
+"section."
+msgstr ""
+"* Bei Verwendung von Generics kann das `Into<T>` der Standardbibliothek eine "
+"Art Limitierung bieten\n"
+"  Polymorphismus auf Argumenttypen. Wir werden mehr Details in einem "
+"späteren Abschnitt sehen."
+
+#: src/basic-syntax/functions-interlude.md:30
+#, fuzzy
+msgid "</defails>"
+msgstr "</defails>"
+
+#: src/exercises/day-1/morning.md:1
+#, fuzzy
+msgid "# Day 1: Morning Exercises"
+msgstr "# Tag 1: Morgengymnastik"
+
+#: src/exercises/day-1/morning.md:3
+#, fuzzy
+msgid "In these exercises, we will explore two parts of Rust:"
+msgstr "In diesen Übungen werden wir zwei Teile von Rust erkunden:"
+
+#: src/exercises/day-1/morning.md:5
+#, fuzzy
+msgid "* Implicit conversions between types."
+msgstr "* Implizite Konvertierungen zwischen Typen."
+
+#: src/exercises/day-1/morning.md:7
+#, fuzzy
+msgid "* Arrays and `for` loops."
+msgstr "* Arrays und „for“-Schleifen."
+
+#: src/exercises/day-1/morning.md:11
+#, fuzzy
+msgid "A few things to consider while solving the exercises:"
+msgstr "Ein paar Dinge, die Sie beim Lösen der Aufgaben beachten sollten:"
+
+#: src/exercises/day-1/morning.md:13
+#, fuzzy
+msgid ""
+"* Use a local Rust installation, if possible. This way you can get\n"
+"  auto-completion in your editor. See the page about [Using Cargo] for "
+"details\n"
+"  on installing Rust."
+msgstr ""
+"* Verwenden Sie nach Möglichkeit eine lokale Rust-Installation. Auf diese "
+"Weise können Sie erhalten\n"
+"  Autovervollständigung in Ihrem Editor. Weitere Informationen finden Sie "
+"auf der Seite über [Fracht verwenden].\n"
+"  bei der Installation von Rust."
+
+#: src/exercises/day-1/morning.md:17
+#, fuzzy
+msgid "* Alternatively, use the Rust Playground."
+msgstr "* Benutze alternativ den Rust Playground."
+
+#: src/exercises/day-1/morning.md:19
+#, fuzzy
+msgid ""
+"The code snippets are not editable on purpose: the inline code snippets "
+"lose\n"
+"their state if you navigate away from the page."
+msgstr ""
+"Die Code-Snippets sind absichtlich nicht editierbar: die "
+"Inline-Code-Snippets gehen verloren\n"
+"ihren Zustand, wenn Sie von der Seite wegnavigieren."
+
+#: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
+#: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
+#: src/exercises/day-3/morning.md:7 src/exercises/day-4/morning.md:12
+#, fuzzy
+msgid "After looking at the exercises, you can look at the [solutions] provided."
+msgstr ""
+"Nachdem Sie sich die Übungen angesehen haben, können Sie sich die "
+"bereitgestellten [Lösungen] ansehen."
+
+#: src/exercises/day-1/morning.md:24 src/exercises/day-2/morning.md:13
+#: src/exercises/day-3/morning.md:9 src/exercises/day-4/morning.md:14
+#, fuzzy
+msgid "[solutions]: solutions-morning.md"
+msgstr "[Lösungen]: Lösungen-Morgen.md"
+
+#: src/exercises/day-1/morning.md:26
+#, fuzzy
+msgid "[Using Cargo]: ../../cargo.md"
+msgstr "[Fracht verwenden]: ../../cargo.md"
+
+#: src/exercises/day-1/implicit-conversions.md:1
+#, fuzzy
+msgid "# Implicit Conversions"
+msgstr "# Implizite Konvertierungen"
+
+#: src/exercises/day-1/implicit-conversions.md:3
+#, fuzzy
+msgid ""
+"Rust will not automatically apply _implicit conversions_ between types "
+"([unlike\n"
+"C++][3]). You can see this in a program like this:"
+msgstr ""
+"Rust wendet nicht automatisch _implizite Konvertierungen_ zwischen Typen an "
+"([anders als\n"
+"C++[3]). Sie können dies in einem Programm wie diesem sehen:"
+
+#: src/exercises/day-1/implicit-conversions.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn multiply(x: i16, y: i16) -> i16 {\n"
+"    x * y\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/implicit-conversions.md:11
+msgid ""
+"fn main() {\n"
+"    let x: i8 = 15;\n"
+"    let y: i16 = 1000;"
+msgstr ""
+
+#: src/exercises/day-1/implicit-conversions.md:15
+msgid ""
+"    println!(\"{x} * {y} = {}\", multiply(x, y));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/implicit-conversions.md:19
+#, fuzzy
+msgid ""
+"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
+"traits to let us convert between them. The `From<T>` trait has a single "
+"`from()`\n"
+"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
+"Implementing these traits is how a type expresses that it can be converted "
+"into\n"
+"another type."
+msgstr ""
+"Die Rust-Integer-Typen implementieren alle [`From<T>`][1] und "
+"[`Into<T>`][2]\n"
+"Eigenschaften, um uns zwischen ihnen umwandeln zu lassen. Das "
+"`From<T>`-Merkmal hat ein einzelnes `from()`\n"
+"-Methode und ähnlich hat das `Into<T>`-Merkmal eine einzige "
+"`into()`-Methode.\n"
+"Durch die Implementierung dieser Merkmale drückt ein Typ aus, in was er "
+"umgewandelt werden kann\n"
+"ein anderer Typ."
+
+#: src/exercises/day-1/implicit-conversions.md:25
+#, fuzzy
+msgid ""
+"The standard library has an implementation of `From<i8> for i16`, which "
+"means\n"
+"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
+"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
+"implementation automatically create an implementation of `Into<i16> for i8`."
+msgstr ""
+"Die Standardbibliothek hat eine Implementierung von `From<i8> for i16`, was "
+"bedeutet\n"
+"dass wir eine Variable `x` vom Typ `i8` per Aufruf in ein `i16` umwandeln "
+"können\n"
+"`i16::von(x)`. Oder einfacher mit `x.into()`, denn `From<i8> for i16`\n"
+"implementierung automatisch eine Implementierung von `Into<i16> for i8` "
+"erstellen."
+
+#: src/exercises/day-1/implicit-conversions.md:30
+#, fuzzy
+msgid ""
+"The same applies for your own `From` implementations for your own types, so "
+"it is\n"
+"sufficient to only implement `From` to get a respective `Into` "
+"implementation automatically."
+msgstr ""
+"Dasselbe gilt für Ihre eigenen `From`-Implementierungen für Ihre eigenen "
+"Typen, so ist es\n"
+"Es reicht aus, nur `From` zu implementieren, um automatisch eine "
+"entsprechende `Into`-Implementierung zu erhalten."
+
+#: src/exercises/day-1/implicit-conversions.md:33
+#, fuzzy
+msgid "1. Execute the above program and look at the compiler error."
+msgstr ""
+"1. Führen Sie das obige Programm aus und sehen Sie sich den Compiler-Fehler "
+"an."
+
+#: src/exercises/day-1/implicit-conversions.md:35
+#, fuzzy
+msgid "2. Update the code above to use `into()` to do the conversion."
+msgstr ""
+"2. Aktualisieren Sie den obigen Code, um `into()` zu verwenden, um die "
+"Konvertierung durchzuführen."
+
+#: src/exercises/day-1/implicit-conversions.md:37
+#, fuzzy
+msgid ""
+"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
+"   `i128`) to see which types you can convert to which other types. Try\n"
+"   converting small types to big types and the other way around. Check the\n"
+"   [standard library documentation][1] to see if `From<T>` is implemented "
+"for\n"
+"   the pairs you check."
+msgstr ""
+"3. Ändern Sie die Typen von `x` und `y` in andere Dinge (wie `f32`, `bool`,\n"
+"   `i128`), um zu sehen, welche Typen Sie in welche anderen Typen "
+"konvertieren können. Versuchen\n"
+"   Umwandlung kleiner Typen in große Typen und umgekehrt. Überprüf den\n"
+"   [Dokumentation der Standardbibliothek][1], um zu sehen, ob \"From<T>\" "
+"für implementiert ist\n"
+"   die Paare, die Sie überprüfen."
+
+#: src/exercises/day-1/implicit-conversions.md:43
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
+"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
+"[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
+"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
+"[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
+
+#: src/exercises/day-1/for-loops.md:1
+#, fuzzy
+msgid "# Arrays and `for` Loops"
+msgstr "# Arrays und `for`-Schleifen"
+
+#: src/exercises/day-1/for-loops.md:3
+#, fuzzy
+msgid "We saw that an array can be declared like this:"
+msgstr "Wir haben gesehen, dass ein Array wie folgt deklariert werden kann:"
+
+#: src/exercises/day-1/for-loops.md:5
+msgid ""
+"```rust\n"
+"let array = [10, 20, 30];\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:9
+#, fuzzy
+msgid ""
+"You can print such an array by asking for its debug representation with "
+"`{:?}`:"
+msgstr ""
+"Sie können ein solches Array drucken, indem Sie mit `{:?}` nach seiner "
+"Debug-Darstellung fragen:"
+
+#: src/exercises/day-1/for-loops.md:11
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    println!(\"array: {array:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:18
+#, fuzzy
+msgid ""
+"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"keyword:"
+msgstr ""
+"Mit Rust können Sie über Dinge wie Arrays und Ranges iterieren, indem Sie "
+"das `for` verwenden\n"
+"Stichwort:"
+
+#: src/exercises/day-1/for-loops.md:21
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let array = [10, 20, 30];\n"
+"    print!(\"Iterating over array:\");\n"
+"    for n in array {\n"
+"        print!(\" {n}\");\n"
+"    }\n"
+"    println!();"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:30
+msgid ""
+"    print!(\"Iterating over range:\");\n"
+"    for i in 0..3 {\n"
+"        print!(\" {}\", array[i]);\n"
+"    }\n"
+"    println!();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:38
+#, fuzzy
+msgid ""
+"Use the above to write a function `pretty_print` which pretty-print a matrix "
+"and\n"
+"a function `transpose` which will transpose a matrix (turn rows into "
+"columns):"
+msgstr ""
+"Verwenden Sie das Obige, um eine Funktion \"pretty_print\" zu schreiben, die "
+"eine Matrix hübsch druckt und\n"
+"eine Funktion \"transpose\", die eine Matrix transponiert (Zeilen in Spalten "
+"umwandelt):"
+
+#: src/exercises/day-1/for-loops.md:41
+msgid ""
+"```bob\n"
+"           ⎛⎡1 2 3⎤⎞      ⎡1 4 7⎤\n"
+"\"transpose\"⎜⎢4 5 6⎥⎟  \"==\"⎢2 5 8⎥\n"
+"           ⎝⎣7 8 9⎦⎠      ⎣3 6 9⎦\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:47
+#, fuzzy
+msgid "Hard-code both functions to operate on 3 × 3 matrices."
+msgstr "Kodieren Sie beide Funktionen fest, um mit 3 × 3-Matrizen zu arbeiten."
+
+#: src/exercises/day-1/for-loops.md:49
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"functions:"
+msgstr ""
+"Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
+"implementieren Sie die\n"
+"Funktionen:"
+
+#: src/exercises/day-1/for-loops.md:52 src/exercises/day-1/book-library.md:20
+#: src/exercises/day-2/health-statistics.md:13
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:56
+msgid ""
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:60
+msgid ""
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:64
+msgid ""
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:71
+#: src/exercises/day-1/solutions-morning.md:70
+msgid "    println!(\"matrix:\");\n    pretty_print(&matrix);"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:74
+msgid ""
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/for-loops.md:80
+#, fuzzy
+msgid "## Bonus Question"
+msgstr "## Bonus-Frage"
+
+#: src/exercises/day-1/for-loops.md:82
+#, fuzzy
+msgid ""
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"slice-of-slices. Why or why not?"
+msgstr ""
+"Könnten Sie `&[i32]`-Slices anstelle von fest codierten 3 × 3-Matrizen für "
+"Ihre verwenden\n"
+"Argument- und Rückgabetypen? Etwas wie `&[&[i32]]` für ein "
+"zweidimensionales\n"
+"Scheibe-von-Scheiben. Warum oder warum nicht?"
+
+#: src/exercises/day-1/for-loops.md:87
+#, fuzzy
+msgid ""
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
+"quality\n"
+"implementation."
+msgstr ""
+"Siehe die [`ndarray`-Kiste](https://docs.rs/ndarray/) für eine "
+"Produktionsqualität\n"
+"Implementierung."
+
+#: src/exercises/day-1/for-loops.md:92
+#, fuzzy
+msgid ""
+"The solution and the answer to the bonus section are available in the \n"
+"[Solution](solutions-morning.md#arrays-and-for-loops) section."
+msgstr ""
+"Die Lösung und die Antwort zum Bonusteil finden Sie im\n"
+"Abschnitt [Solution](solutions-morning.md#arrays-and-for-loops)."
+
+#: src/basic-syntax/variables.md:1
+#, fuzzy
+msgid "# Variables"
+msgstr "# Variablen"
+
+#: src/basic-syntax/variables.md:3
+#, fuzzy
+msgid ""
+"Rust provides type safety via static typing. Variable bindings are immutable "
+"by\n"
+"default:"
+msgstr ""
+"Rust bietet Typsicherheit durch statische Typisierung. Variable Bindungen "
+"sind unveränderlich durch\n"
+"Standard:"
+
+#: src/basic-syntax/variables.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let x: i32 = 10;\n"
+"    println!(\"x: {x}\");\n"
+"    // x = 20;\n"
+"    // println!(\"x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/variables.md:17
+#, fuzzy
+msgid ""
+"* Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the type progresses.\n"
+"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"function like syntax of `println!(\"x: {}\", x)`"
+msgstr ""
+"* Aufgrund von Typrückschlüssen ist `i32` optional. Wir werden die Typen "
+"nach und nach immer weniger zeigen, je weiter der Typ fortschreitet.\n"
+"* Beachten Sie, dass, da `println!` ein Makro ist, `x` nicht verschoben "
+"wird, selbst wenn die funktionsähnliche Syntax von `println!(\"x: {}\", x)` "
+"verwendet wird"
+
+#: src/basic-syntax/type-inference.md:1
+#, fuzzy
+msgid "# Type Inference"
+msgstr "# Geben Sie Inferenz ein"
+
+#: src/basic-syntax/type-inference.md:3
+#, fuzzy
+msgid "Rust will look at how the variable is _used_ to determine the type:"
+msgstr ""
+"Rust wird sich ansehen, wie die Variable _verwendet_ wird, um den Typ zu "
+"bestimmen:"
+
+#: src/basic-syntax/type-inference.md:5
+msgid ""
+"```rust,editable\n"
+"fn takes_u32(x: u32) {\n"
+"    println!(\"u32: {x}\");\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:10
+msgid ""
+"fn takes_i8(y: i8) {\n"
+"    println!(\"i8: {y}\");\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:14
+msgid ""
+"fn main() {\n"
+"    let x = 10;\n"
+"    let y = 20;"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:18
+msgid ""
+"    takes_u32(x);\n"
+"    takes_i8(y);\n"
+"    // takes_u32(y);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:26
+#, fuzzy
+msgid ""
+"This slide demonstrates how the Rust compiler infers types based on "
+"constraints given by variable declarations and usages.\n"
+"    \n"
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can\n"
+"hold any data. The machine code generated by such declaration is identical "
+"to the explicit declaration of a type.\n"
+"The compiler does the job for us and helps us to write a more concise code."
+msgstr ""
+"Diese Folie zeigt, wie der Rust-Compiler Typen basierend auf Einschränkungen "
+"ableitet, die durch Variablendeklarationen und Verwendungen gegeben sind.\n"
+"    \n"
+"Es ist sehr wichtig zu betonen, dass auf diese Weise deklarierte Variablen "
+"nicht von einer Art dynamischem \"beliebigen Typ\" sind, der dies kann\n"
+"irgendwelche Daten halten. Der durch eine solche Deklaration erzeugte "
+"Maschinencode ist identisch mit der expliziten Deklaration eines Typs.\n"
+"Der Compiler erledigt die Arbeit für uns und hilft uns, einen prägnanteren "
+"Code zu schreiben."
+
+#: src/basic-syntax/type-inference.md:32
+#, fuzzy
+msgid ""
+"The following code tells the compiler to copy into a certain generic "
+"container without the code ever explicitly specifying the contained type, "
+"using `_` as a placeholder:"
+msgstr ""
+"Der folgende Code weist den Compiler an, in einen bestimmten generischen "
+"Container zu kopieren, ohne dass der Code jemals explizit den enthaltenen "
+"Typ angibt, wobei `_` als Platzhalter verwendet wird:"
+
+#: src/basic-syntax/type-inference.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut v = Vec::new();\n"
+"    v.push((10, false));\n"
+"    v.push((20, true));\n"
+"    println!(\"v: {v:?}\");"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:41
+msgid ""
+"    let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
+"    println!(\"vv: {vv:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:46
+#, fuzzy
+msgid ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
+"relies on `FromIterator`, which "
+"[`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"implements."
+msgstr ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
+"stützt sich auf `FromIterator`, das [`HashSet`](https:/ "
+"/doc.rust-lang.org/std/iter/trait.FromIterator.html) implementiert."
+
+#: src/basic-syntax/static-and-const.md:1
+#, fuzzy
+msgid "# Static and Constant Variables"
+msgstr "# Statische und konstante Variablen"
+
+#: src/basic-syntax/static-and-const.md:3
+#, fuzzy
+msgid "Global state is managed with static and constant variables."
+msgstr ""
+"Der globale Status wird mit statischen und konstanten Variablen verwaltet."
+
+#: src/basic-syntax/static-and-const.md:5
+#, fuzzy
+msgid "## `const`"
+msgstr "## `const`"
+
+#: src/basic-syntax/static-and-const.md:7
+#, fuzzy
+msgid "You can declare compile-time constants:"
+msgstr "Sie können Kompilierzeitkonstanten deklarieren:"
+
+#: src/basic-syntax/static-and-const.md:9
+msgid ""
+"```rust,editable\n"
+"const DIGEST_SIZE: usize = 3;\n"
+"const ZERO: Option<u8> = Some(42);"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:13
+msgid ""
+"fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
+"    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
+"    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
+"        digest[idx % DIGEST_SIZE] = digest[idx % "
+"DIGEST_SIZE].wrapping_add(b);\n"
+"    }\n"
+"    digest\n"
+"}"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:21
+msgid ""
+"fn main() {\n"
+"    let digest = compute_digest(\"Hello\");\n"
+"    println!(\"Digest: {digest:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:27
+#, fuzzy
+msgid "According the the [Rust RFC Book][1] these are inlined upon use."
+msgstr "Gemäß dem [Rust RFC Book][1] werden diese bei der Verwendung eingefügt."
+
+#: src/basic-syntax/static-and-const.md:29
+#, fuzzy
+msgid "## `static`"
+msgstr "## `statisch`"
+
+#: src/basic-syntax/static-and-const.md:31
+#, fuzzy
+msgid "You can also declare static variables:"
+msgstr "Sie können auch statische Variablen deklarieren:"
+
+#: src/basic-syntax/static-and-const.md:33
+msgid "```rust,editable\nstatic BANNER: &str = \"Welcome to RustOS 3.14\";"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:36
+msgid ""
+"fn main() {\n"
+"    println!(\"{BANNER}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:41
+#, fuzzy
+msgid ""
+"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
+"an actual associated memory location.  This is useful for unsafe and "
+"embedded code, and the variable lives through the entirety of the program "
+"execution."
+msgstr ""
+"Wie im [Rust RFC Book][1] erwähnt, werden diese bei der Verwendung nicht "
+"inliniert und haben einen tatsächlich zugeordneten Speicherort. Dies ist "
+"nützlich für unsicheren und eingebetteten Code, und die Variable lebt "
+"während der gesamten Programmausführung."
+
+#: src/basic-syntax/static-and-const.md:44
+#, fuzzy
+msgid ""
+"We will look at mutating static data in the [chapter on Unsafe "
+"Rust](../unsafe.md)."
+msgstr ""
+"Wir werden uns im [Kapitel über Unsafe Rust](../unsafe.md) mit mutierenden "
+"statischen Daten befassen."
+
+#: src/basic-syntax/static-and-const.md:48
+#, fuzzy
+msgid ""
+"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
+"* `static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++.\n"
+"* It isn't super common that one would need a runtime evaluated constant, "
+"but it is helpful and safer than using a static."
+msgstr ""
+"* Erwähnen Sie, dass sich `const` semantisch ähnlich wie `constexpr` von C++ "
+"verhält.\n"
+"* „Static“ hingegen ist einer „const“ oder veränderlichen globalen Variable "
+"in C++ viel ähnlicher.\n"
+"* Es kommt nicht sehr häufig vor, dass man eine zur Laufzeit ausgewertete "
+"Konstante benötigt, aber es ist hilfreich und sicherer als die Verwendung "
+"einer statischen."
+
+#: src/basic-syntax/static-and-const.md:54
+#, fuzzy
+msgid "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
+msgstr "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
+
+#: src/basic-syntax/scopes-shadowing.md:1
+#, fuzzy
+msgid "# Scopes and Shadowing"
+msgstr "# Bereiche und Shadowing"
+
+#: src/basic-syntax/scopes-shadowing.md:3
+#, fuzzy
+msgid ""
+"You can shadow variables, both those from outer scopes and variables from "
+"the\n"
+"same scope:"
+msgstr ""
+"Sie können Variablen schattieren, sowohl solche aus äußeren "
+"Gültigkeitsbereichen als auch Variablen aus dem\n"
+"gleicher Umfang:"
+
+#: src/basic-syntax/scopes-shadowing.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a = 10;\n"
+"    println!(\"before: {a}\");"
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:11
+msgid ""
+"    {\n"
+"        let a = \"hello\";\n"
+"        println!(\"inner scope: {a}\");"
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:15
+msgid ""
+"        let a = true;\n"
+"        println!(\"shadowed in inner scope: {a}\");\n"
+"    }"
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:19
+msgid ""
+"    println!(\"after: {a}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:25
+#, fuzzy
+msgid ""
+"* Definition: Shadowing is different from mutation, because after shadowing "
+"both variable's memory locations exist at the same time. Both are available "
+"under the same name, depending where you use it in the code. \n"
+"* A shadowing variable can have a different type. \n"
+"* Shadowing looks obscure at first, but is convenient for holding on to "
+"values after `.unwrap()`.\n"
+"* The following code demonstrates why the compiler can't simply reuse memory "
+"locations when shadowing an immutable variable in a scope, even if the type "
+"does not change."
+msgstr ""
+"* Definition: Shadowing unterscheidet sich von Mutation, da nach dem "
+"Shadowing die Speicherplätze beider Variablen gleichzeitig existieren. Beide "
+"sind unter demselben Namen verfügbar, je nachdem, wo Sie ihn im Code "
+"verwenden.\n"
+"* Eine Shadowing-Variable kann einen anderen Typ haben.\n"
+"* Shadowing sieht zunächst obskur aus, ist aber praktisch, um Werte nach "
+"`.unwrap()` festzuhalten.\n"
+"* Der folgende Code demonstriert, warum der Compiler Speicherorte nicht "
+"einfach wiederverwenden kann, wenn er eine unveränderliche Variable in einem "
+"Bereich schattiert, selbst wenn sich der Typ nicht ändert."
+
+#: src/basic-syntax/scopes-shadowing.md:30
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let a = 1;\n"
+"    let b = &a;\n"
+"    let a = a + 1;\n"
+"    println!(\"{a} {b}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/memory-management.md:1
+#, fuzzy
+msgid "# Memory Management"
+msgstr "# Speicherverwaltung"
+
+#: src/memory-management.md:3
+#, fuzzy
+msgid "Traditionally, languages have fallen into two broad categories:"
+msgstr "Traditionell fallen Sprachen in zwei große Kategorien:"
+
+#: src/memory-management.md:5
+#, fuzzy
+msgid ""
+"* Full control via manual memory management: C, C++, Pascal, ...\n"
+"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Haskell, ..."
+msgstr ""
+"* Volle Kontrolle über manuelle Speicherverwaltung: C, C++, Pascal, ...\n"
+"* Volle Sicherheit durch automatische Speicherverwaltung zur Laufzeit: Java, "
+"Python, Go, Haskell, ..."
+
+#: src/memory-management.md:8
+#, fuzzy
+msgid "Rust offers a new mix:"
+msgstr "Rust bietet eine neue Mischung:"
+
+#: src/memory-management.md:10
+#, fuzzy
+msgid ""
+"> Full control *and* safety via compile time enforcement of correct memory\n"
+"> management."
+msgstr ""
+"> Volle Kontrolle *und* Sicherheit durch Erzwingung des korrekten Speichers "
+"zur Kompilierzeit\n"
+"> Verwaltung."
+
+#: src/memory-management.md:13
+#, fuzzy
+msgid "It does this with an explicit ownership concept."
+msgstr "Dies geschieht mit einem expliziten Eigentumskonzept."
+
+#: src/memory-management.md:15
+#, fuzzy
+msgid "First, let's refresh how memory management works."
+msgstr ""
+"Lassen Sie uns zunächst die Funktionsweise der Speicherverwaltung "
+"auffrischen."
+
+#: src/memory-management/stack-vs-heap.md:1
+#, fuzzy
+msgid "# The Stack vs The Heap"
+msgstr "# Der Stapel gegen den Haufen"
+
+#: src/memory-management/stack-vs-heap.md:3
+#, fuzzy
+msgid ""
+"* Stack: Continuous area of memory for local variables.\n"
+"  * Values have fixed sizes known at compile time.\n"
+"  * Extremely fast: just move a stack pointer.\n"
+"  * Easy to manage: follows function calls.\n"
+"  * Great memory locality."
+msgstr ""
+"* Stack: Kontinuierlicher Speicherbereich für lokale Variablen.\n"
+"  * Werte haben feste Größen, die zur Kompilierzeit bekannt sind.\n"
+"  * Extrem schnell: Bewegen Sie einfach einen Stapelzeiger.\n"
+"  * Einfach zu verwalten: folgt Funktionsaufrufen.\n"
+"  * Große Gedächtnislokalität."
+
+#: src/memory-management/stack-vs-heap.md:9
+#, fuzzy
+msgid ""
+"* Heap: Storage of values outside of function calls.\n"
+"  * Values have dynamic sizes determined at runtime.\n"
+"  * Slightly slower than the stack: some book-keeping needed.\n"
+"  * No guarantee of memory locality."
+msgstr ""
+"* Heap: Speicherung von Werten außerhalb von Funktionsaufrufen.\n"
+"  * Werte haben dynamische Größen, die zur Laufzeit bestimmt werden.\n"
+"  * Etwas langsamer als der Stapel: Etwas Buchhaltung erforderlich.\n"
+"  * Keine Garantie auf Speicherort."
+
+#: src/memory-management/stack.md:1
+#, fuzzy
+msgid "# Stack Memory"
+msgstr "# Stapelspeicher"
+
+#: src/memory-management/stack.md:3
+#, fuzzy
+msgid ""
+"Creating a `String` puts fixed-sized data on the stack and dynamically "
+"sized\n"
+"data on the heap:"
+msgstr ""
+"Das Erstellen eines \"Strings\" legt Daten mit fester Größe auf den Stapel "
+"und dynamisch in der Größe\n"
+"Daten auf dem Haufen:"
+
+#: src/memory-management/stack.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1 = String::from(\"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/memory-management/stack.md:12
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.\n"
+":                           :     :                               :\n"
+":    s1                     :     :                               :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+----+  :\n"
+":   | ptr       |   o---+---+-----+-->| H  | e  | l  | l  | o  |  :\n"
+":   | len       |     5 |   :     :   +----+----+----+----+----+  :\n"
+":   | capacity  |     5 |   :     :                               :\n"
+":   +-----------+-------+   :     :                               :\n"
+":                           :     `- - - - - - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/memory-management/stack.md:28
+#, fuzzy
+msgid ""
+"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
+msgstr ""
+"* Erwähnen Sie, dass ein `String` von einem `Vec` unterstützt wird, sodass "
+"er eine Kapazität und Länge hat und wachsen kann, wenn er durch Neuzuweisung "
+"auf dem Haufen veränderbar ist."
+
+#: src/memory-management/stack.md:30
+#, fuzzy
+msgid ""
+"* If students ask about it, you can mention that the underlying memory is "
+"heap allocated using the [System Allocator] and custom allocators can be "
+"implemented using the [Allocator API]"
+msgstr ""
+"* Wenn die Schüler danach fragen, können Sie erwähnen, dass der zugrunde "
+"liegende Speicher mit dem [System Allocator] Heap zugewiesen wird und "
+"benutzerdefinierte Allokatoren mit der [Allocator API] implementiert werden "
+"können."
+
+#: src/memory-management/stack.md:34
+#, fuzzy
+msgid ""
+"[System Allocator]: https://doc.rust-lang.org/std/alloc/struct.System.html\n"
+"[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
+msgstr ""
+"[Systemzuordner]: https://doc.rust-lang.org/std/alloc/struct.System.html\n"
+"[Allocator-API]: https://doc.rust-lang.org/std/alloc/index.html"
+
+#: src/memory-management/manual.md:1
+#, fuzzy
+msgid "# Manual Memory Management"
+msgstr "# Manuelle Speicherverwaltung"
+
+#: src/memory-management/manual.md:3
+#, fuzzy
+msgid "You allocate and deallocate heap memory yourself."
+msgstr "Heap-Speicher können Sie selbst zuweisen und freigeben."
+
+#: src/memory-management/manual.md:5
+#, fuzzy
+msgid ""
+"If not done with care, this can lead to crashes, bugs, security "
+"vulnerabilities, and memory leaks."
+msgstr ""
+"Wenn dies nicht sorgfältig durchgeführt wird, kann dies zu Abstürzen, "
+"Fehlern, Sicherheitslücken und Speicherlecks führen."
+
+#: src/memory-management/manual.md:7
+#, fuzzy
+msgid "## C Example"
+msgstr "##C Beispiel"
+
+#: src/memory-management/manual.md:9
+#, fuzzy
+msgid "You must call `free` on every pointer you allocate with `malloc`:"
+msgstr ""
+"Sie müssen `free` auf jedem Zeiger aufrufen, den Sie mit `malloc` zuweisen:"
+
+#: src/memory-management/manual.md:11
+msgid ""
+"```c\n"
+"void foo(size_t n) {\n"
+"    int* int_array = (int*)malloc(n * sizeof(int));\n"
+"    //\n"
+"    // ... lots of code\n"
+"    //\n"
+"    free(int_array);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/memory-management/manual.md:21
+#, fuzzy
+msgid ""
+"Memory is leaked if the function returns early between `malloc` and `free`: "
+"the\n"
+"pointer is lost and we cannot deallocate the memory."
+msgstr ""
+"Speicherverlust, wenn die Funktion früh zwischen `malloc` und `free` "
+"zurückkehrt: the\n"
+"Zeiger geht verloren und wir können den Speicher nicht freigeben."
+
+#: src/memory-management/scope-based.md:1
+#, fuzzy
+msgid "# Scope-Based Memory Management"
+msgstr "# Bereichsbasierte Speicherverwaltung"
+
+#: src/memory-management/scope-based.md:3
+#, fuzzy
+msgid "Constructors and destructors let you hook into the lifetime of an object."
+msgstr ""
+"Mit Konstruktoren und Destruktoren können Sie sich in die Lebensdauer eines "
+"Objekts einklinken."
+
+#: src/memory-management/scope-based.md:5
+#, fuzzy
+msgid ""
+"By wrapping a pointer in an object, you can free memory when the object is\n"
+"destroyed. The compiler guarantees that this happens, even if an exception "
+"is\n"
+"raised."
+msgstr ""
+"Indem Sie einen Zeiger in ein Objekt einschließen, können Sie Speicher "
+"freigeben, wenn das Objekt vorhanden ist\n"
+"zerstört. Der Compiler garantiert, dass dies geschieht, auch wenn es sich um "
+"eine Ausnahme handelt\n"
+"erzogen."
+
+#: src/memory-management/scope-based.md:9
+#, fuzzy
+msgid ""
+"This is often called _resource acquisition is initialization_ (RAII) and "
+"gives\n"
+"you smart pointers."
+msgstr ""
+"Dies wird oft als _Ressourcenerwerb ist Initialisierung_ (RAII) bezeichnet "
+"und gibt\n"
+"ihr klugen zeiger."
+
+#: src/memory-management/scope-based.md:12
+#, fuzzy
+msgid "## C++ Example"
+msgstr "## C++-Beispiel"
+
+#: src/memory-management/scope-based.md:14
+msgid ""
+"```c++\n"
+"void say_hello(std::unique_ptr<Person> person) {\n"
+"  std::cout << \"Hello \" << person->name << std::endl;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/memory-management/scope-based.md:20
+#, fuzzy
+msgid ""
+"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
+"  memory allocated on the heap.\n"
+"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
+"* The destructor frees the `Person` object it points to."
+msgstr ""
+"* Das `std::unique_ptr`-Objekt wird auf dem Stack allokiert und zeigt auf\n"
+"  auf dem Heap zugewiesener Speicher.\n"
+"* Am Ende von `say_hello` wird der Destruktor `std::unique_ptr` ausgeführt.\n"
+"* Der Destruktor gibt das `Person`-Objekt frei, auf das er zeigt."
+
+#: src/memory-management/scope-based.md:25
+#, fuzzy
+msgid "Special move constructors are used when passing ownership to a function:"
+msgstr ""
+"Spezielle Move-Konstruktoren werden verwendet, wenn der Besitz an eine "
+"Funktion übergeben wird:"
+
+#: src/memory-management/scope-based.md:27
+msgid ""
+"```c++\n"
+"std::unique_ptr<Person> person = find_person(\"Carla\");\n"
+"say_hello(std::move(person));\n"
+"```"
+msgstr ""
+
+#: src/memory-management/garbage-collection.md:1
+#, fuzzy
+msgid "# Automatic Memory Management"
+msgstr "# Automatische Speicherverwaltung"
+
+#: src/memory-management/garbage-collection.md:3
+#, fuzzy
+msgid ""
+"An alternative to manual and scope-based memory management is automatic "
+"memory\n"
+"management:"
+msgstr ""
+"Eine Alternative zur manuellen und bereichsbasierten Speicherverwaltung ist "
+"der automatische Speicher\n"
+"Management:"
+
+#: src/memory-management/garbage-collection.md:6
+#, fuzzy
+msgid ""
+"* The programmer never allocates or deallocates memory explicitly.\n"
+"* A garbage collector finds unused memory and deallocates it for the "
+"programmer."
+msgstr ""
+"* Der Programmierer weist Speicher nie explizit zu oder gibt ihn nicht mehr "
+"frei.\n"
+"* Ein Garbage Collector findet ungenutzten Speicher und gibt ihn für den "
+"Programmierer frei."
+
+#: src/memory-management/garbage-collection.md:9
+#, fuzzy
+msgid "## Java Example"
+msgstr "## Java-Beispiel"
+
+#: src/memory-management/garbage-collection.md:11
+#, fuzzy
+msgid "The `person` object is not deallocated after `sayHello` returns:"
+msgstr ""
+"Das `person`-Objekt wird nicht freigegeben, nachdem `sayHello` zurückgegeben "
+"wird:"
+
+#: src/memory-management/garbage-collection.md:13
+msgid ""
+"```java\n"
+"void sayHello(Person person) {\n"
+"  System.out.println(\"Hello \" + person.getName());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/memory-management/rust.md:1
+#, fuzzy
+msgid "# Memory Management in Rust"
+msgstr "# Speicherverwaltung in Rust"
+
+#: src/memory-management/rust.md:3
+#, fuzzy
+msgid "Memory management in Rust is a mix:"
+msgstr "Die Speicherverwaltung in Rust ist eine Mischung:"
+
+#: src/memory-management/rust.md:5
+#, fuzzy
+msgid ""
+"* Safe and correct like Java, but without a garbage collector.\n"
+"* Depending on which abstraction (or combination of abstractions) you "
+"choose, can be a single unique pointer, reference counted, or atomically "
+"reference counted.\n"
+"* Scope-based like C++, but the compiler enforces full adherence.\n"
+"* A Rust user can choose the right abstraction for the situation, some even "
+"have no cost at runtime like C."
+msgstr ""
+"* Sicher und korrekt wie Java, aber ohne Garbage Collector.\n"
+"* Je nachdem, welche Abstraktion (oder Kombination von Abstraktionen) Sie "
+"wählen, kann es sich um einen einzelnen eindeutigen Zeiger, eine "
+"Referenzzählung oder eine atomare Referenzzählung handeln.\n"
+"* Bereichsbasiert wie C++, aber der Compiler erzwingt die vollständige "
+"Einhaltung.\n"
+"* Ein Rust-Benutzer kann die richtige Abstraktion für die Situation "
+"auswählen, einige haben sogar keine Kosten zur Laufzeit wie C."
+
+#: src/memory-management/rust.md:10
+#, fuzzy
+msgid "It achieves this by modeling _ownership_ explicitly."
+msgstr "Dies wird erreicht, indem _Eigentum_ explizit modelliert wird."
+
+#: src/memory-management/rust.md:14
+#, fuzzy
+msgid ""
+"* If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
+"encapsulate ownership and memory allocation via various means, and prevent "
+"the potential errors in C."
+msgstr ""
+"* Wenn Sie an dieser Stelle fragen, wie das geht, können Sie erwähnen, dass "
+"dies in Rust normalerweise von RAII-Wrapper-Typen wie [Box], [Vec], [Rc] "
+"oder [Arc] gehandhabt wird. Diese kapseln den Besitz und die "
+"Speicherzuweisung auf verschiedene Weise und verhindern die potenziellen "
+"Fehler in C."
+
+#: src/memory-management/rust.md:16
+#, fuzzy
+msgid ""
+"* You may be asked about destructors here, the [Drop] trait is the Rust "
+"equivalent."
+msgstr ""
+"* Möglicherweise werden Sie hier nach Destruktoren gefragt, die Eigenschaft "
+"[Drop] ist das Rust-Äquivalent."
+
+#: src/memory-management/rust.md:20
+#, fuzzy
+msgid ""
+"[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
+msgstr ""
+"[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[Bogen]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
+
+#: src/memory-management/comparison.md:1
+#, fuzzy
+msgid "# Comparison"
+msgstr "# Vergleich"
+
+#: src/memory-management/comparison.md:3
+#, fuzzy
+msgid "Here is a rough comparison of the memory management techniques."
+msgstr "Hier ist ein grober Vergleich der Speicherverwaltungstechniken."
+
+#: src/memory-management/comparison.md:5
+#, fuzzy
+msgid "## Pros of Different Memory Management Techniques"
+msgstr "## Vorteile verschiedener Speicherverwaltungstechniken"
+
+#: src/memory-management/comparison.md:7
+#, fuzzy
+msgid ""
+"* Manual like C:\n"
+"  * No runtime overhead.\n"
+"* Automatic like Java:\n"
+"  * Fully automatic.\n"
+"  * Safe and correct.\n"
+"* Scope-based like C++:\n"
+"  * Partially automatic.\n"
+"  * No runtime overhead.\n"
+"* Compiler-enforced scope-based like Rust:\n"
+"  * Enforced by compiler.\n"
+"  * No runtime overhead.\n"
+"  * Safe and correct."
+msgstr ""
+"* Handbuch wie C:\n"
+"  * Kein Laufzeitaufwand.\n"
+"* Automatisch wie Java:\n"
+"  * Komplett automatisch.\n"
+"  * Sicher und korrekt.\n"
+"* Bereichsbasiert wie C++:\n"
+"  * Teilautomatisch.\n"
+"  * Kein Laufzeitaufwand.\n"
+"* Vom Compiler erzwungener Geltungsbereich wie Rust:\n"
+"  * Vom Compiler erzwungen.\n"
+"  * Kein Laufzeitaufwand.\n"
+"  * Sicher und korrekt."
+
+#: src/memory-management/comparison.md:20
+#, fuzzy
+msgid "## Cons of Different Memory Management Techniques"
+msgstr "## Nachteile verschiedener Techniken zur Speicherverwaltung"
+
+#: src/memory-management/comparison.md:22
+#, fuzzy
+msgid ""
+"* Manual like C:\n"
+"  * Use-after-free.\n"
+"  * Double-frees.\n"
+"  * Memory leaks.\n"
+"* Automatic like Java:\n"
+"  * Garbage collection pauses.\n"
+"  * Destructor delays.\n"
+"* Scope-based like C++:\n"
+"  * Complex, opt-in by programmer.\n"
+"  * Potential for use-after-free.\n"
+"* Compiler-enforced and scope-based like Rust:\n"
+"  * Some upfront complexity.\n"
+"  * Can reject valid programs."
+msgstr ""
+"* Handbuch wie C:\n"
+"  * Use-after-free.\n"
+"  * Double-frees.\n"
+"  * Speicherlecks.\n"
+"* Automatisch wie Java:\n"
+"  * Garbage Collection pausiert.\n"
+"  * Destruktorverzögerungen.\n"
+"* Bereichsbasiert wie C++:\n"
+"  * Komplex, Opt-in durch Programmierer.\n"
+"  * Potenzial für die Nutzung nach dem Kostenlos.\n"
+"* Compiler-erzwungen und bereichsbasiert wie Rust:\n"
+"  * Etwas Komplexität im Voraus.\n"
+"  * Kann gültige Programme ablehnen."
+
+#: src/ownership.md:1
+#, fuzzy
+msgid "# Ownership"
+msgstr "# Eigentum"
+
+#: src/ownership.md:3
+#, fuzzy
+msgid ""
+"All variable bindings have a _scope_ where they are valid and it is an error "
+"to\n"
+"use a variable outside its scope:"
+msgstr ""
+"Alle Variablenbindungen haben einen _Geltungsbereich_, wo sie gültig sind "
+"und es ein Fehler ist\n"
+"Verwenden Sie eine Variable außerhalb ihres Gültigkeitsbereichs:"
+
+#: src/ownership.md:6
+msgid "```rust,editable,compile_fail\nstruct Point(i32, i32);"
+msgstr ""
+
+#: src/ownership.md:9
+msgid ""
+"fn main() {\n"
+"    {\n"
+"        let p = Point(3, 4);\n"
+"        println!(\"x: {}\", p.0);\n"
+"    }\n"
+"    println!(\"y: {}\", p.1);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership.md:18
+#, fuzzy
+msgid ""
+"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
+"* A destructor can run here to free up resources.\n"
+"* We say that the variable _owns_ the value."
+msgstr ""
+"* Am Ende des Gültigkeitsbereichs wird die Variable _gelöscht_ und die Daten "
+"werden freigegeben.\n"
+"* Hier kann ein Destruktor laufen, um Ressourcen freizugeben.\n"
+"* Wir sagen, dass die Variable den Wert _besitzt_."
+
+#: src/ownership/move-semantics.md:1
+#, fuzzy
+msgid "# Move Semantics"
+msgstr "# Bewegungssemantik"
+
+#: src/ownership/move-semantics.md:3
+#, fuzzy
+msgid "An assignment will transfer ownership between variables:"
+msgstr "Eine Zuweisung überträgt den Besitz zwischen Variablen:"
+
+#: src/ownership/move-semantics.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Hello!\");\n"
+"    let s2: String = s1;\n"
+"    println!(\"s2: {s2}\");\n"
+"    // println!(\"s1: {s1}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/move-semantics.md:14
+#, fuzzy
+msgid ""
+"* The assignment of `s1` to `s2` transfers ownership.\n"
+"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
+"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
+"* When `s2` goes out of scope, the string data is freed.\n"
+"* There is always _exactly_ one variable binding which owns a value."
+msgstr ""
+"* Die Zuweisung von `s1` an `s2` überträgt das Eigentum.\n"
+"* Die Daten wurden von `s1` _verschoben_ und `s1` ist nicht mehr "
+"zugänglich.\n"
+"* Wenn `s1` den Gültigkeitsbereich verlässt, passiert nichts: Es hat keinen "
+"Besitz.\n"
+"* Wenn `s2` den Geltungsbereich verlässt, werden die String-Daten "
+"freigegeben.\n"
+"* Es gibt immer _genau_ eine Variablenbindung, die einen Wert besitzt."
+
+#: src/ownership/move-semantics.md:22
+#, fuzzy
+msgid ""
+"* Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
+msgstr ""
+"* Erwähnen Sie, dass dies das Gegenteil der Standardeinstellungen in C++ "
+"ist, die nach Wert kopieren, es sei denn, Sie verwenden `std::move` (und der "
+"Move-Konstruktor ist definiert!)."
+
+#: src/ownership/move-semantics.md:24
+#, fuzzy
+msgid "* In Rust, you clones are explicit (by using `clone`)."
+msgstr "* In Rust sind Klone explizit (durch Verwendung von `clone`)."
+
+#: src/ownership/moved-strings-rust.md:1
+#, fuzzy
+msgid "# Moved Strings in Rust"
+msgstr "# Bewegte Saiten in Rost"
+
+#: src/ownership/moved-strings-rust.md:3
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s1: String = String::from(\"Rust\");\n"
+"    let s2: String = s1;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/moved-strings-rust.md:10
+#, fuzzy
+msgid ""
+"* The heap data from `s1` is reused for `s2`.\n"
+"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgstr ""
+"* Die Heap-Daten von „s1“ werden für „s2“ wiederverwendet.\n"
+"* Wenn `s1` den Gültigkeitsbereich verlässt, passiert nichts (es wurde "
+"verschoben)."
+
+#: src/ownership/moved-strings-rust.md:13
+#, fuzzy
+msgid "Before move to `s2`:"
+msgstr "Vor dem Wechsel zu `s2`:"
+
+#: src/ownership/moved-strings-rust.md:15
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1                     :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+-----+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :     :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :     :                           :\n"
+":   +-----------+-------+   :     :                           :\n"
+":                           :     `- - - - - - - - - - - - - -'\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/ownership/moved-strings-rust.md:30
+#, fuzzy
+msgid "After move to `s2`:"
+msgstr "Nach Umzug nach `s2`:"
+
+#: src/ownership/moved-strings-rust.md:32
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1 \"(inaccessible)\"    :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :  |  :                           :\n"
+":   +-----------+-------+   :  |  :                           :\n"
+":                           :  |  `- - - - - - - - - - - - - -'\n"
+":    s2                     :  |\n"
+":   +-----------+-------+   :  |\n"
+":   | ptr       |   o---+---+--'\n"
+":   | len       |     4 |   :\n"
+":   | capacity  |     4 |   :\n"
+":   +-----------+-------+   :\n"
+":                           :\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:1
+#, fuzzy
+msgid "# Double Frees in Modern C++"
+msgstr "# Double Frees in modernem C++"
+
+#: src/ownership/double-free-modern-cpp.md:3
+#, fuzzy
+msgid "Modern C++ solves this differently:"
+msgstr "Modernes C++ löst dies anders:"
+
+#: src/ownership/double-free-modern-cpp.md:5
+msgid ""
+"```c++\n"
+"std::string s1 = \"Cpp\";\n"
+"std::string s2 = s1;  // Duplicate the data in s1.\n"
+"```"
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:10
+#, fuzzy
+msgid ""
+"* The heap data from `s1` is duplicated and `s2` gets its own independent "
+"copy.\n"
+"* When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"* Die Heap-Daten von `s1` werden dupliziert und `s2` bekommt seine eigene "
+"unabhängige Kopie.\n"
+"* Wenn `s1` und `s2` den Geltungsbereich verlassen, geben sie jeweils ihren "
+"eigenen Speicher frei."
+
+#: src/ownership/double-free-modern-cpp.md:13
+#, fuzzy
+msgid "Before copy-assignment:"
+msgstr "Vor Kopierauftrag:"
+
+#: src/ownership/double-free-modern-cpp.md:16
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - -.\n"
+":                           :     :                       :\n"
+":    s1                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+--+--+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     `- - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:30
+#, fuzzy
+msgid "After copy-assignment:"
+msgstr "Nach der Kopierzuweisung:"
+
+#: src/ownership/double-free-modern-cpp.md:32
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - -.\n"
+":                           :     :                       :\n"
+":    s1                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+--+--+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     :                       :\n"
+":    s2                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+-----+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     `- - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:1
+#, fuzzy
+msgid "# Moves in Function Calls"
+msgstr "# Bewegungen in Funktionsaufrufen"
+
+#: src/ownership/moves-function-calls.md:3
+#, fuzzy
+msgid ""
+"When you pass a value to a function, the value is assigned to the function\n"
+"parameter. This transfers ownership:"
+msgstr ""
+"Wenn Sie einer Funktion einen Wert übergeben, wird der Wert der Funktion "
+"zugewiesen\n"
+"Parameter. Dadurch wird das Eigentum übertragen:"
+
+#: src/ownership/moves-function-calls.md:6
+msgid ""
+"```rust,editable\n"
+"fn say_hello(name: String) {\n"
+"    println!(\"Hello {name}\")\n"
+"}"
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:11
+msgid ""
+"fn main() {\n"
+"    let name = String::from(\"Alice\");\n"
+"    say_hello(name);\n"
+"    // say_hello(name);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:20
+#, fuzzy
+msgid ""
+"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`.\n"
+"* The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function.\n"
+"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
+"and if `say_hello` accepts a reference as a parameter.\n"
+"* Alternatively, `main` can pass a clone of `name` in the first call "
+"(`name.clone()`).\n"
+"* Rust makes it harder than C++ to inadvertently create copies by making "
+"move semantics the default, and by forcing programmers to make clones "
+"explicit."
+msgstr ""
+"* Mit dem ersten Aufruf von `say_hello` gibt `main` den Besitz von `name` "
+"auf. Danach kann `name` nicht mehr innerhalb von `main` verwendet werden.\n"
+"* Der für `name` zugewiesene Heap-Speicher wird am Ende der "
+"`say_hello`-Funktion freigegeben.\n"
+"* `main` kann den Besitz behalten, wenn es `name` als Referenz (`&name`) "
+"übergibt und wenn `say_hello` eine Referenz als Parameter akzeptiert.\n"
+"* Alternativ kann `main` beim ersten Aufruf (`name.clone()`) einen Klon von "
+"`name` übergeben.\n"
+"* Rust macht es schwieriger als C++, versehentlich Kopien zu erstellen, "
+"indem es die Bewegungssemantik zum Standard macht und Programmierer dazu "
+"zwingt, Klone explizit zu machen."
+
+#: src/ownership/copy-clone.md:1
+#, fuzzy
+msgid "# Copying and Cloning"
+msgstr "# Kopieren und Klonen"
+
+#: src/ownership/copy-clone.md:3
+#, fuzzy
+msgid ""
+"While move semantics are the default, certain types are copied by default:"
+msgstr ""
+"Während die Bewegungssemantik der Standard ist, werden bestimmte Typen "
+"standardmäßig kopiert:"
+
+#: src/ownership/copy-clone.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let x = 42;\n"
+"    let y = x;\n"
+"    println!(\"x: {x}\");\n"
+"    println!(\"y: {y}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/copy-clone.md:14
+#, fuzzy
+msgid "These types implement the `Copy` trait."
+msgstr "Diese Typen implementieren das `Copy`-Merkmal."
+
+#: src/ownership/copy-clone.md:16
+#, fuzzy
+msgid "You can opt-in your own types to use copy semantics:"
+msgstr ""
+"Sie können Ihre eigenen Typen für die Verwendung von Kopiersemantik "
+"aktivieren:"
+
+#: src/ownership/copy-clone.md:18
+msgid ""
+"```rust,editable\n"
+"#[derive(Copy, Clone, Debug)]\n"
+"struct Point(i32, i32);"
+msgstr ""
+
+#: src/ownership/copy-clone.md:22
+msgid ""
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = p1;\n"
+"    println!(\"p1: {p1:?}\");\n"
+"    println!(\"p2: {p2:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/copy-clone.md:30
+#, fuzzy
+msgid ""
+"* After the assignment, both `p1` and `p2` own their own data.\n"
+"* We can also use `p1.clone()` to explicitly copy the data."
+msgstr ""
+"* Nach der Zuweisung besitzen sowohl `p1` als auch `p2` ihre eigenen Daten.\n"
+"* Wir können auch `p1.clone()` verwenden, um die Daten explizit zu kopieren."
+
+#: src/ownership/copy-clone.md:35
+#, fuzzy
+msgid "Copying and cloning are not the same thing:"
+msgstr "Kopieren und Klonen sind nicht dasselbe:"
+
+#: src/ownership/copy-clone.md:37
+#, fuzzy
+msgid ""
+"* Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects.\n"
+"* Copying does not allow for custom logic (unlike copy constructors in "
+"C++).\n"
+"* Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait.\n"
+"* Copying does not work on types that implement the `Drop` trait."
+msgstr ""
+"* Kopieren bezieht sich auf bitweises Kopieren von Speicherbereichen und "
+"funktioniert nicht mit beliebigen Objekten.\n"
+"* Beim Kopieren ist keine benutzerdefinierte Logik möglich (im Gegensatz zu "
+"Kopierkonstruktoren in C++).\n"
+"* Klonen ist eine allgemeinere Operation und ermöglicht auch "
+"benutzerdefiniertes Verhalten durch Implementieren der Eigenschaft "
+"\"Klonen\".\n"
+"* Das Kopieren funktioniert nicht bei Typen, die das `Drop`-Merkmal "
+"implementieren."
+
+#: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
+#, fuzzy
+msgid "In the above example, try the following:"
+msgstr "Versuchen Sie im obigen Beispiel Folgendes:"
+
+#: src/ownership/copy-clone.md:44
+#, fuzzy
+msgid ""
+"* Add a `String` field to `struct Point`. It will not compile because "
+"`String` is not a `Copy` type.\n"
+"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
+"the `println!` for  `p1`.\n"
+"* Show that it works if you clone `p1` instead."
+msgstr ""
+"* Fügen Sie ein `String`-Feld zu `struct Point` hinzu. Es wird nicht "
+"kompiliert, da `String` kein `Copy`-Typ ist.\n"
+"* Entfernen Sie „Copy“ aus dem „derive“-Attribut. Der Compiler-Fehler steht "
+"jetzt im `println!` für `p1`.\n"
+"* Zeigen Sie, dass es funktioniert, wenn Sie stattdessen `p1` klonen."
+
+#: src/ownership/copy-clone.md:48
+#, fuzzy
+msgid ""
+"If students ask about `derive`, it is sufficient to say that this is a way "
+"to generate code in Rust\n"
+"at compile time. In this case the default implementations of `Copy` and "
+"`Clone` traits are generated.\n"
+"    \n"
+"</details>"
+msgstr ""
+"Wenn Schüler nach „derive“ fragen, reicht es zu sagen, dass dies eine "
+"Möglichkeit ist, Code in Rust zu generieren\n"
+"zur Kompilierzeit. In diesem Fall werden die Standardimplementierungen der "
+"Merkmale „Kopieren“ und „Klonen“ generiert.\n"
+"    \n"
+"</details>"
+
+#: src/ownership/borrowing.md:1
+#, fuzzy
+msgid "# Borrowing"
+msgstr "# Ausleihen"
+
+#: src/ownership/borrowing.md:3
+#, fuzzy
+msgid ""
+"Instead of transferring ownership when calling a function, you can let a\n"
+"function _borrow_ the value:"
+msgstr ""
+"Anstatt den Besitz beim Aufruf einer Funktion zu übertragen, können Sie a\n"
+"function _borrow_ den Wert:"
+
+#: src/ownership/borrowing.md:6 src/ownership/lifetimes-function-calls.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);"
+msgstr ""
+
+#: src/ownership/borrowing.md:10
+#, fuzzy
+msgid ""
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
+"}"
+msgstr ""
+"fn add(p1: &Punkt, p2: &Punkt) -> Punkt {\n"
+"    Punkt(p1.0 + p2.0, p1.1 + p2.1)\n"
+"}"
+
+#: src/ownership/borrowing.md:14
+msgid ""
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/borrowing.md:22
+#, fuzzy
+msgid ""
+"* The `add` function _borrows_ two points and returns a new point.\n"
+"* The caller retains ownership of the inputs."
+msgstr ""
+"* Die `add`-Funktion _leiht_ zwei Punkte und gibt einen neuen Punkt zurück.\n"
+"* Der Aufrufer behält das Eigentum an den Eingaben."
+
+#: src/ownership/borrowing.md:27
+#, fuzzy
+msgid ""
+"Notes on stack returns:\n"
+"* Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
+"addresses should change, while the stay the same when changing to the "
+"\"RELEASE\" setting:"
+msgstr ""
+"Hinweise zur Stapelrückgabe:\n"
+"* Zeigen Sie, dass die Rückgabe von `add` billig ist, weil der Compiler den "
+"Kopiervorgang eliminieren kann. Ändern Sie den obigen Code, um "
+"Stapeladressen zu drucken, und führen Sie ihn auf dem [Playground] aus. In "
+"der Optimierungsstufe „DEBUG“ sollen sich die Adressen ändern, während sie "
+"beim Wechsel in die Einstellung „RELEASE“ gleich bleiben:"
+
+#: src/ownership/borrowing.md:30
+msgid ""
+"  ```rust,editable\n"
+"  #[derive(Debug)]\n"
+"  struct Point(i32, i32);"
+msgstr ""
+
+#: src/ownership/borrowing.md:34
+msgid ""
+"  fn add(p1: &Point, p2: &Point) -> Point {\n"
+"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"      println!(\"&p.0: {:p}\", &p.0);\n"
+"      p\n"
+"  }"
+msgstr ""
+
+#: src/ownership/borrowing.md:40
+msgid ""
+"  fn main() {\n"
+"      let p1 = Point(3, 4);\n"
+"      let p2 = Point(10, 20);\n"
+"      let p3 = add(&p1, &p2);\n"
+"      println!(\"&p3.0: {:p}\", &p3.0);\n"
+"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"  }\n"
+"  ```\n"
+"* The Rust compiler can do return value optimization (RVO).\n"
+"* In C++, copy elision has to be defined in the language specification "
+"because constructors can have side effects. In Rust, this is not an issue at "
+"all. If RVO did not happen, Rust will always performs a simple and efficient "
+"`memcpy` copy."
+msgstr ""
+
+#: src/ownership/borrowing.md:53
+#, fuzzy
+msgid "[Playground]: https://play.rust-lang.org/"
+msgstr "[Spielplatz]: https://play.rust-lang.org/"
+
+#: src/ownership/shared-unique-borrows.md:1
+#, fuzzy
+msgid "# Shared and Unique Borrows"
+msgstr "# Gemeinsame und einzigartige Ausleihen"
+
+#: src/ownership/shared-unique-borrows.md:3
+#, fuzzy
+msgid "Rust puts constraints on the ways you can borrow values:"
+msgstr "Rust schränkt die Art und Weise ein, wie Sie Werte ausleihen können:"
+
+#: src/ownership/shared-unique-borrows.md:5
+#, fuzzy
+msgid ""
+"* You can have one or more `&T` values at any given time, _or_\n"
+"* You can have exactly one `&mut T` value."
+msgstr ""
+"* Sie können jederzeit einen oder mehrere `&T`-Werte haben, _oder_\n"
+"* Sie können genau einen `&mut T`-Wert haben."
+
+#: src/ownership/shared-unique-borrows.md:8
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let mut a: i32 = 10;\n"
+"    let b: &i32 = &a;"
+msgstr ""
+
+#: src/ownership/shared-unique-borrows.md:13
+msgid ""
+"    {\n"
+"        let c: &mut i32 = &mut a;\n"
+"        *c = 20;\n"
+"    }"
+msgstr ""
+
+#: src/ownership/shared-unique-borrows.md:18 src/std/rc.md:13
+msgid ""
+"    println!(\"a: {a}\");\n"
+"    println!(\"b: {b}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/shared-unique-borrows.md:25
+#, fuzzy
+msgid ""
+"* The above code does not compile because `a` is borrowed as mutable "
+"(through `c`) and as immutable (through `b`) at the same time.\n"
+"* Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile.\n"
+"* After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
+msgstr ""
+"* Der obige Code lässt sich nicht kompilieren, da `a` gleichzeitig als "
+"veränderlich (durch `c`) und als unveränderlich (durch `b`) ausgeliehen "
+"wird.\n"
+"* Verschieben Sie die `println!`-Anweisung für `b` vor den "
+"Gültigkeitsbereich, der `c` einführt, um den Code zu kompilieren.\n"
+"* Nach dieser Änderung erkennt der Compiler, dass `b` immer nur vor dem "
+"neuen änderbaren Borgen von `a` bis `c` verwendet wird. Dies ist eine "
+"Funktion des Borrow-Checkers, die als \"nicht-lexikalische Lebensdauern\" "
+"bezeichnet wird."
+
+#: src/ownership/lifetimes.md:1
+#, fuzzy
+msgid "# Lifetimes"
+msgstr "# Lebensdauer"
+
+#: src/ownership/lifetimes.md:3
+#, fuzzy
+msgid "A borrowed value has a _lifetime_:"
+msgstr "Ein geliehener Wert hat eine _Lebensdauer_:"
+
+#: src/ownership/lifetimes.md:5
+msgid ""
+"* The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`.\n"
+"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
+"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
+"  lifetime `a`\".\n"
+"* Lifetimes are always inferred by the compiler: you cannot assign a "
+"lifetime\n"
+"  yourself.\n"
+"  * Lifetime annotations create constraints; the compiler verifies that "
+"there is\n"
+"    a valid solution."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:1
+#, fuzzy
+msgid "# Lifetimes in Function Calls"
+msgstr "# Lebensdauer in Funktionsaufrufen"
+
+#: src/ownership/lifetimes-function-calls.md:3
+#, fuzzy
+msgid ""
+"In addition to borrowing its arguments, a function can return a borrowed "
+"value:"
+msgstr ""
+"Zusätzlich zum Ausleihen ihrer Argumente kann eine Funktion einen geliehenen "
+"Wert zurückgeben:"
+
+#: src/ownership/lifetimes-function-calls.md:9
+#, fuzzy
+msgid ""
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}"
+msgstr ""
+"fn left_most<'a>(p1: &'a Punkt, p2: &'a Punkt) -> &'a Punkt {\n"
+"    wenn p1.0 < p2.0 { p1 } sonst { p2 }\n"
+"}"
+
+#: src/ownership/lifetimes-function-calls.md:13
+msgid ""
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p2: Point = Point(20, 20);\n"
+"    let p3: &Point = left_most(&p1, &p2);\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:21
+#, fuzzy
+msgid ""
+"* `'a` is a generic parameter, it is inferred by the compiler.\n"
+"* Lifetimes start with `'` and `'a` is a typical default name.\n"
+"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
+"  lifetime `a`\".\n"
+"  * The _at least_ part is important when parameters are in different scopes."
+msgstr ""
+"* „a“ ist ein generischer Parameter, er wird vom Compiler abgeleitet.\n"
+"* Lebensdauern beginnen mit `'` und `'a` ist ein typischer Standardname.\n"
+"* Lesen Sie `&'einen Punkt` als \"einen geliehenen `Punkt`, der mindestens "
+"für den gilt\n"
+"  Lebenszeit `a`\".\n"
+"  * Der Teil _at least_ ist wichtig, wenn sich Parameter in "
+"unterschiedlichen Geltungsbereichen befinden."
+
+#: src/ownership/lifetimes-function-calls.md:31
+msgid ""
+"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:\n"
+"  ```rust,ignore\n"
+"  #[derive(Debug)]\n"
+"  struct Point(i32, i32);"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:36
+#, fuzzy
+msgid ""
+"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"      if p1.0 < p2.0 { p1 } else { p2 }\n"
+"  }"
+msgstr ""
+"  fn left_most<'a>(p1: &'a Punkt, p2: &'a Punkt) -> &'a Punkt {\n"
+"      wenn p1.0 < p2.0 { p1 } sonst { p2 }\n"
+"  }"
+
+#: src/ownership/lifetimes-function-calls.md:40
+msgid ""
+"  fn main() {\n"
+"      let p1: Point = Point(10, 10);\n"
+"      let p3: &Point;\n"
+"      {\n"
+"          let p2: Point = Point(20, 20);\n"
+"          p3 = left_most(&p1, &p2);\n"
+"      }\n"
+"      println!(\"left-most point: {:?}\", p3);\n"
+"  }\n"
+"  ```\n"
+"  Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:52
+#, fuzzy
+msgid ""
+"* Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
+"* Another way to explain it:\n"
+"  * Two references to two values are borrowed by a function and the function "
+"returns\n"
+"    another reference.\n"
+"  * It must have come from one of those two inputs (or from a global "
+"variable).\n"
+"  * Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used\n"
+"    for longer than a variable from where the reference came from."
+msgstr ""
+"* Setzen Sie den Arbeitsbereich zurück und ändern Sie die Funktionssignatur "
+"zu `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. Dies "
+"wird nicht kompiliert, da die Beziehung zwischen den Lebensdauern „a“ und "
+"„b“ unklar ist.\n"
+"* Eine andere Möglichkeit, es zu erklären:\n"
+"  * Zwei Referenzen auf zwei Werte werden von einer Funktion ausgeliehen und "
+"die Funktion kehrt zurück\n"
+"    eine andere Referenz.\n"
+"  * Es muss von einem dieser beiden Eingänge stammen (oder von einer "
+"globalen Variablen).\n"
+"  * Welches ist es? Der Compiler muss es wissen, damit die zurückgegebene "
+"Referenz auf der Aufrufseite nicht verwendet wird\n"
+"    länger als eine Variable, von der die Referenz stammt."
+
+#: src/ownership/lifetimes-data-structures.md:1
+#, fuzzy
+msgid "# Lifetimes in Data Structures"
+msgstr "# Lebensdauern in Datenstrukturen"
+
+#: src/ownership/lifetimes-data-structures.md:3
+#, fuzzy
+msgid ""
+"If a data type stores borrowed data, it must be annotated with a lifetime:"
+msgstr ""
+"Wenn ein Datentyp geliehene Daten speichert, muss er mit einer Lebensdauer "
+"versehen werden:"
+
+#: src/ownership/lifetimes-data-structures.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);"
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:9
+msgid ""
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}"
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:13
+msgid ""
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy "
+"dog.\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(text);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:25
+#, fuzzy
+msgid ""
+"* In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data.\n"
+"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error.\n"
+"* Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use.\n"
+"* When possible, make data structures own their data directly.\n"
+"* Some structs with multiple references inside can have more than one "
+"lifetime annotation. This can be necessary if there is a need to describe "
+"lifetime relationships between the references themselves, in addition to the "
+"lifetime of the struct itself. Those are very advanced use cases.\n"
+"</details>"
+msgstr ""
+"* Im obigen Beispiel erzwingt die Anmerkung zu `Highlight`, dass die Daten, "
+"die dem enthaltenen `&str` zugrunde liegen, mindestens so lange leben wie "
+"jede Instanz von `Highlight`, die diese Daten verwendet.\n"
+"* Wenn `text` vor dem Ende der Lebensdauer von `fox` (oder `dog`) verbraucht "
+"wird, wirft der Borrow-Checker einen Fehler.\n"
+"* Typen mit geliehenen Daten zwingen Benutzer, an den Originaldaten "
+"festzuhalten. Dies kann nützlich sein, um einfache Ansichten zu erstellen, "
+"macht sie jedoch im Allgemeinen etwas schwieriger zu verwenden.\n"
+"* Wenn möglich, machen Sie Datenstrukturen direkt Eigentümer ihrer Daten.\n"
+"* Einige Strukturen mit mehreren darin enthaltenen Referenzen können mehr "
+"als eine lebenslange Anmerkung haben. Dies kann erforderlich sein, wenn "
+"zusätzlich zur Lebensdauer der Struktur selbst Lebensdauerbeziehungen "
+"zwischen den Referenzen selbst beschrieben werden müssen. Das sind sehr "
+"fortgeschrittene Anwendungsfälle.\n"
+"</Details>"
+
+#: src/exercises/day-1/afternoon.md:1
+#, fuzzy
+msgid "# Day 1: Afternoon Exercises"
+msgstr "# Tag 1: Nachmittagsübungen"
+
+#: src/exercises/day-1/afternoon.md:3
+#, fuzzy
+msgid "We will look at two things:"
+msgstr "Wir werden uns zwei Dinge ansehen:"
+
+#: src/exercises/day-1/afternoon.md:5
+#, fuzzy
+msgid "* A small book library,"
+msgstr "* Eine kleine Buchbibliothek,"
+
+#: src/exercises/day-1/afternoon.md:7
+#, fuzzy
+msgid "* Iterators and ownership (hard)."
+msgstr "* Iteratoren und Besitz (schwer)."
+
+#: src/exercises/day-1/afternoon.md:13 src/exercises/day-2/afternoon.md:9
+#, fuzzy
+msgid "[solutions]: solutions-afternoon.md"
+msgstr "[Lösungen]: Lösungen-Nachmittag.md"
+
+#: src/exercises/day-1/book-library.md:1
+#, fuzzy
+msgid "# Designing a Library"
+msgstr "# Entwerfen einer Bibliothek"
+
+#: src/exercises/day-1/book-library.md:3
+#, fuzzy
+msgid ""
+"We will learn much more about structs and the `Vec<T>` type tomorrow. For "
+"now,\n"
+"you just need to know part of its API:"
+msgstr ""
+"Wir werden morgen viel mehr über Strukturen und den Typ `Vec<T>` lernen. Zur "
+"Zeit,\n"
+"Sie müssen nur einen Teil seiner API kennen:"
+
+#: src/exercises/day-1/book-library.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut vec = vec![10, 20];\n"
+"    vec.push(30);\n"
+"    println!(\"middle value: {}\", vec[vec.len() / 2]);\n"
+"    for item in vec.iter() {\n"
+"        println!(\"item: {item}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/book-library.md:17
+#, fuzzy
+msgid ""
+"Use this to create a library application. Copy the code below to\n"
+"<https://play.rust-lang.org/> and update the types to make it compile:"
+msgstr ""
+"Verwenden Sie dies, um eine Bibliotheksanwendung zu erstellen. Kopieren Sie "
+"den folgenden Code nach\n"
+"<https://play.rust-lang.org/> und aktualisieren Sie die Typen, damit es "
+"kompiliert wird:"
+
+#: src/exercises/day-1/book-library.md:24
+#, fuzzy
+msgid ""
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}"
+msgstr ""
+"Struktur Bibliothek {\n"
+"    Bücher: Vec<Buch>,\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:28
+#: src/exercises/day-1/solutions-afternoon.md:27
+#, fuzzy
+msgid ""
+"struct Book {\n"
+"    title: String,\n"
+"    year: u16,\n"
+"}"
+msgstr ""
+"struct Buch {\n"
+"    Titel: Zeichenkette,\n"
+"    Jahr: u16,\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:33
+#: src/exercises/day-1/solutions-afternoon.md:32
+#, fuzzy
+msgid ""
+"impl Book {\n"
+"    // This is a constructor, used below.\n"
+"    fn new(title: &str, year: u16) -> Book {\n"
+"        Book {\n"
+"            title: String::from(title),\n"
+"            year,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Buch {\n"
+"    // Dies ist ein Konstruktor, der unten verwendet wird.\n"
+"    fn neu(titel: &str, jahr: u16) -> Buch {\n"
+"        Buch {\n"
+"            Titel: Zeichenkette::von(Titel),\n"
+"            Jahr,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:43
+#, fuzzy
+msgid ""
+"// This makes it possible to print Book values with {}.\n"
+"impl std::fmt::Display for Book {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        write!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}"
+msgstr ""
+"// Dadurch ist es möglich, Buchwerte mit {} zu drucken.\n"
+"impl std::fmt::Anzeige für Buch {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        schreibe!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:50
+#, fuzzy
+msgid ""
+"impl Library {\n"
+"    fn new() -> Library {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl-Bibliothek {\n"
+"    fn new() -> Bibliothek {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-1/book-library.md:55
+#, fuzzy
+msgid ""
+"    //fn len(self) -> usize {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn len(self) -> verwenden {\n"
+"    // nicht implementiert!()\n"
+"    //}"
+
+#: src/exercises/day-1/book-library.md:59
+#, fuzzy
+msgid ""
+"    //fn is_empty(self) -> bool {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn is_empty(self) -> bool {\n"
+"    // nicht implementiert!()\n"
+"    //}"
+
+#: src/exercises/day-1/book-library.md:63
+#, fuzzy
+msgid ""
+"    //fn add_book(self, book: Book) {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn add_book(selbst, Buch: Buch) {\n"
+"    // nicht implementiert!()\n"
+"    //}"
+
+#: src/exercises/day-1/book-library.md:67
+#, fuzzy
+msgid ""
+"    //fn print_books(self) {\n"
+"    //    unimplemented!()\n"
+"    //}"
+msgstr ""
+"    //fn print_books(selbst) {\n"
+"    // nicht implementiert!()\n"
+"    //}"
+
+#: src/exercises/day-1/book-library.md:71
+#, fuzzy
+msgid ""
+"    //fn oldest_book(self) -> Option<&Book> {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"}"
+msgstr ""
+"    //fn ältestes_buch(selbst) -> Option<&Buch> {\n"
+"    // nicht implementiert!()\n"
+"    //}\n"
+"}"
+
+#: src/exercises/day-1/book-library.md:76
+msgid ""
+"// This shows the desired behavior. Uncomment the code below and\n"
+"// implement the missing methods. You will need to update the\n"
+"// method signatures, including the \"self\" parameter! You may\n"
+"// also need to update the variable bindings within main.\n"
+"fn main() {\n"
+"    let library = Library::new();"
+msgstr ""
+
+#: src/exercises/day-1/book-library.md:83
+msgid ""
+"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
+"    //\n"
+"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    //\n"
+"    //library.print_books();\n"
+"    //\n"
+"    //match library.oldest_book() {\n"
+"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
+"    //    None => println!(\"My library is empty!\"),\n"
+"    //}\n"
+"    //\n"
+"    //println!(\"Our library has {} books\", library.len());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/book-library.md:99
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"[Solution](solutions-afternoon.md#designing-a-library)"
+msgstr ""
+"<Details>\n"
+"    \n"
+"[Lösung](solutions-afternoon.md#designing-a-library)"
+
+#: src/exercises/day-1/iterators-and-ownership.md:1
+#, fuzzy
+msgid "# Iterators and Ownership"
+msgstr "# Iteratoren und Eigentum"
+
+#: src/exercises/day-1/iterators-and-ownership.md:3
+#, fuzzy
+msgid ""
+"The ownership model of Rust affects many APIs. An example of this is the\n"
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"traits."
+msgstr ""
+"Das Eigentumsmodell von Rust betrifft viele APIs. Ein Beispiel hierfür ist "
+"die\n"
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) und\n"
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"Züge."
+
+#: src/exercises/day-1/iterators-and-ownership.md:8
+#, fuzzy
+msgid "## `Iterator`"
+msgstr "## `Iterator`"
+
+#: src/exercises/day-1/iterators-and-ownership.md:10
+#, fuzzy
+msgid ""
+"Traits are like interfaces: they describe behavior (methods) for a type. "
+"The\n"
+"`Iterator` trait simply says that you can call `next` until you get `None` "
+"back:"
+msgstr ""
+"Merkmale sind wie Schnittstellen: Sie beschreiben das Verhalten (Methoden) "
+"für einen Typ. Der\n"
+"Das `Iterator`-Merkmal sagt einfach, dass Sie `next` aufrufen können, bis "
+"Sie `None` zurückbekommen:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:13
+msgid ""
+"```rust\n"
+"pub trait Iterator {\n"
+"    type Item;\n"
+"    fn next(&mut self) -> Option<Self::Item>;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:20
+#, fuzzy
+msgid "You use this trait like this:"
+msgstr "Sie verwenden diese Eigenschaft wie folgt:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:22
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:27
+msgid ""
+"    println!(\"v[0]: {:?}\", iter.next());\n"
+"    println!(\"v[1]: {:?}\", iter.next());\n"
+"    println!(\"v[2]: {:?}\", iter.next());\n"
+"    println!(\"No more items: {:?}\", iter.next());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:34
+#, fuzzy
+msgid "What is the type returned by the iterator? Test your answer here:"
+msgstr "Welchen Typ gibt der Iterator zurück? Testen Sie Ihre Antwort hier:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:36
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<i8> = vec![10, 20, 30];\n"
+"    let mut iter = v.iter();"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:41
+#: src/exercises/day-1/iterators-and-ownership.md:78
+msgid ""
+"    let v0: Option<..> = iter.next();\n"
+"    println!(\"v0: {v0:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:46
+#, fuzzy
+msgid "Why is this type used?"
+msgstr "Warum wird dieser Typ verwendet?"
+
+#: src/exercises/day-1/iterators-and-ownership.md:48
+#, fuzzy
+msgid "## `IntoIterator`"
+msgstr "## `IntoIterator`"
+
+#: src/exercises/day-1/iterators-and-ownership.md:50
+#, fuzzy
+msgid ""
+"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"iterator. The related trait `IntoIterator` tells you how to create the "
+"iterator:"
+msgstr ""
+"Die Eigenschaft „Iterator“ sagt Ihnen, wie Sie _iteraten_, sobald Sie eine "
+"erstellt haben\n"
+"Iterator. Die zugehörige Eigenschaft `IntoIterator` sagt Ihnen, wie Sie den "
+"Iterator erstellen:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:53
+msgid ""
+"```rust\n"
+"pub trait IntoIterator {\n"
+"    type Item;\n"
+"    type IntoIter: Iterator<Item = Self::Item>;"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:58
+msgid ""
+"    fn into_iter(self) -> Self::IntoIter;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:62
+#, fuzzy
+msgid ""
+"The syntax here means that every implementation of `IntoIterator` must\n"
+"declare two types:"
+msgstr ""
+"Die Syntax hier bedeutet, dass jede Implementierung von `IntoIterator` muss\n"
+"deklarieren Sie zwei Arten:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:65
+#, fuzzy
+msgid ""
+"* `Item`: the type we iterate over, such as `i8`,\n"
+"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr ""
+"* `Item`: der Typ, über den wir iterieren, wie z. B. `i8`,\n"
+"* `IntoIter`: der `Iterator`-Typ, der von der `into_iter`-Methode "
+"zurückgegeben wird."
+
+#: src/exercises/day-1/iterators-and-ownership.md:68
+#, fuzzy
+msgid ""
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"`Item` type, which means that it returns `Option<Item>`"
+msgstr ""
+"Beachten Sie, dass „IntoIter“ und „Item“ verknüpft sind: Der Iterator muss "
+"dasselbe haben\n"
+"`Item`-Typ, was bedeutet, dass es `Option<Item>` zurückgibt"
+
+#: src/exercises/day-1/iterators-and-ownership.md:71
+#, fuzzy
+msgid "Like before, what  is the type returned by the iterator?"
+msgstr "Welchen Typ gibt der Iterator wie zuvor zurück?"
+
+#: src/exercises/day-1/iterators-and-ownership.md:73
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), "
+"String::from(\"bar\")];\n"
+"    let mut iter = v.into_iter();"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:83
+#, fuzzy
+msgid "## `for` Loops"
+msgstr "## `for`-Schleifen"
+
+#: src/exercises/day-1/iterators-and-ownership.md:85
+#, fuzzy
+msgid ""
+"Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
+"loops.\n"
+"They call `into_iter()` on an expression and iterates over the resulting\n"
+"iterator:"
+msgstr ""
+"Jetzt, da wir sowohl „Iterator“ als auch „IntoIterator“ kennen, können wir "
+"„for“-Schleifen bauen.\n"
+"Sie rufen `into_iter()` für einen Ausdruck auf und iterieren über das "
+"Ergebnis\n"
+"Iterator:"
+
+#: src/exercises/day-1/iterators-and-ownership.md:89
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:93
+msgid ""
+"    for word in &v {\n"
+"        println!(\"word: {word}\");\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:97
+msgid ""
+"    for word in v {\n"
+"        println!(\"word: {word}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:103
+#, fuzzy
+msgid "What is the type of `word` in each loop?"
+msgstr "Was ist die Art von „Wort“ in jeder Schleife?"
+
+#: src/exercises/day-1/iterators-and-ownership.md:105
+#, fuzzy
+msgid ""
+"Experiment with the code above and then consult the documentation for "
+"[`impl\n"
+"IntoIterator for\n"
+"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
+"and [`impl IntoIterator for\n"
+"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
+"to check your answers."
+msgstr ""
+"Experimentieren Sie mit dem obigen Code und konsultieren Sie dann die "
+"Dokumentation für [`impl\n"
+"IntoIterator für\n"
+"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
+"und [`impl IntoIterator for\n"
+"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
+"um Ihre Antworten zu überprüfen."
+
+#: src/welcome-day-2.md:1
+#, fuzzy
+msgid "# Welcome to Day 2"
+msgstr "# Willkommen zu Tag 2"
+
+#: src/welcome-day-2.md:3
+#, fuzzy
+msgid "Now that we have seen a fair amount of Rust, we will continue with:"
+msgstr ""
+"Nachdem wir nun eine ganze Menge Rust gesehen haben, fahren wir fort mit:"
+
+#: src/welcome-day-2.md:5
+#, fuzzy
+msgid "* Structs, enums, methods."
+msgstr "* Strukturen, Aufzählungen, Methoden."
+
+#: src/welcome-day-2.md:7
+#, fuzzy
+msgid "* Pattern matching: destructuring enums, structs, and arrays."
+msgstr ""
+"* Mustervergleich: Destrukturierung von Aufzählungen, Strukturen und Arrays."
+
+#: src/welcome-day-2.md:9
+#, fuzzy
+msgid ""
+"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
+"and\n"
+"  `continue`."
+msgstr ""
+"* Kontrollflusskonstrukte: `if`, `if let`, `while`, `while let`, `break` "
+"und\n"
+"  \"weitermachen\"."
+
+#: src/welcome-day-2.md:12
+#, fuzzy
+msgid ""
+"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc`\n"
+"  and `Arc`."
+msgstr ""
+"* Die Standardbibliothek: `String`, `Option` und `Result`, `Vec`, `HashMap`, "
+"`Rc`\n"
+"  und \"Bogen\"."
+
+#: src/welcome-day-2.md:15
+#, fuzzy
+msgid "* Modules: visibility, paths, and filesystem hierarchy."
+msgstr "* Module: Sichtbarkeit, Pfade und Dateisystemhierarchie."
+
+#: src/structs.md:1
+#, fuzzy
+msgid "# Structs"
+msgstr "# Strukturen"
+
+#: src/structs.md:3
+#, fuzzy
+msgid "Like C and C++, Rust has support for custom structs:"
+msgstr "Wie C und C++ unterstützt Rust benutzerdefinierte Strukturen:"
+
+#: src/structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}"
+msgstr ""
+
+#: src/structs.md:11
+msgid ""
+"fn main() {\n"
+"    let mut peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    peter.age = 28;\n"
+"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"    \n"
+"    let jackie = Person {\n"
+"        name: String::from(\"Jackie\"),\n"
+"        ..peter\n"
+"    };\n"
+"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs.md:29
+#, fuzzy
+msgid "<details>\nKey Points: "
+msgstr "<Details>\nWichtige Punkte:"
+
+#: src/structs.md:32
+msgid ""
+"* Structs work like in C or C++.\n"
+"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
+"  * Unlike in C++, there is no inheritance between structs.\n"
+"* Methods are defined in an `impl` block, which we will see in following "
+"slides.\n"
+"* This may be a good time to let people know there are different types of "
+"structs. \n"
+"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself. \n"
+"  * The next slide will introduce Tuple structs."
+msgstr ""
+
+#: src/structs/tuple-structs.md:1
+#, fuzzy
+msgid "# Tuple Structs"
+msgstr "# Tupelstrukturen"
+
+#: src/structs/tuple-structs.md:3
+#, fuzzy
+msgid "If the field names are unimportant, you can use a tuple struct:"
+msgstr ""
+"Wenn die Feldnamen unwichtig sind, können Sie eine Tupelstruktur verwenden:"
+
+#: src/structs/tuple-structs.md:5
+msgid "```rust,editable\nstruct Point(i32, i32);"
+msgstr ""
+
+#: src/structs/tuple-structs.md:8
+msgid ""
+"fn main() {\n"
+"    let p = Point(17, 23);\n"
+"    println!(\"({}, {})\", p.0, p.1);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/tuple-structs.md:14
+#, fuzzy
+msgid "This is often used for single-field wrappers (called newtypes):"
+msgstr "Dies wird häufig für Einzelfeld-Wrapper (genannt Newtypes) verwendet:"
+
+#: src/structs/tuple-structs.md:16
+msgid ""
+"```rust,editable,compile_fail\n"
+"struct PoundOfForce(f64);\n"
+"struct Newtons(f64);"
+msgstr ""
+
+#: src/structs/tuple-structs.md:20
+#, fuzzy
+msgid ""
+"fn compute_thruster_force() -> PoundOfForce {\n"
+"    todo!(\"Ask a rocket scientist at NASA\")\n"
+"}"
+msgstr ""
+"fn compute_thruster_force() -> PoundOfForce {\n"
+"    todo! (\"Fragen Sie einen Raketenwissenschaftler bei der NASA\")\n"
+"}"
+
+#: src/structs/tuple-structs.md:24
+#, fuzzy
+msgid ""
+"fn set_thruster_force(force: Newtons) {\n"
+"    // ...\n"
+"}"
+msgstr ""
+"fn set_thruster_force(Kraft: Newton) {\n"
+"    // ...\n"
+"}"
+
+#: src/structs/tuple-structs.md:28
+msgid ""
+"fn main() {\n"
+"    let force = compute_thruster_force();\n"
+"    set_thruster_force(force);\n"
+"}"
+msgstr ""
+
+#: src/structs/tuple-structs.md:33 src/generics/trait-objects.md:86
+msgid "```"
+msgstr ""
+
+#: src/structs/tuple-structs.md:37
+#, fuzzy
+msgid ""
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:\n"
+"  * The number is measured in some units: `Newtons` in the example above.\n"
+"  * The value passed some validation when it was created, so you no longer "
+"have to validate it again at every use: 'PhoneNumber(String)` or "
+"`OddNumber(u32)`.\n"
+"    \n"
+"</details>"
+msgstr ""
+"Newtypes sind eine großartige Möglichkeit, zusätzliche Informationen über "
+"den Wert in einem primitiven Typ zu codieren, zum Beispiel:\n"
+"  * Die Zahl wird in einigen Einheiten gemessen: „Newton“ im obigen "
+"Beispiel.\n"
+"  * Der Wert hat bei seiner Erstellung einige Validierungen durchlaufen, "
+"sodass Sie ihn nicht mehr bei jeder Verwendung erneut validieren müssen: "
+"'PhoneNumber(String)' oder 'OddNumber(u32)'.\n"
+"    \n"
+"</Details>"
+
+#: src/structs/field-shorthand.md:1
+#, fuzzy
+msgid "# Field Shorthand Syntax"
+msgstr "# Feld-Kurzsyntax"
+
+#: src/structs/field-shorthand.md:3
+#, fuzzy
+msgid ""
+"If you already have variables with the right names, then you can create the\n"
+"struct using a shorthand:"
+msgstr ""
+"Wenn Sie bereits Variablen mit den richtigen Namen haben, können Sie die "
+"erstellen\n"
+"struct mit einer Abkürzung:"
+
+#: src/structs/field-shorthand.md:6 src/methods.md:6
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}"
+msgstr ""
+
+#: src/structs/field-shorthand.md:13
+#, fuzzy
+msgid ""
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Person {\n"
+"        Person { name, age }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Person {\n"
+"        Person { Name, Alter }\n"
+"    }\n"
+"}"
+
+#: src/structs/field-shorthand.md:19
+msgid ""
+"fn main() {\n"
+"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
+"    println!(\"{peter:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:27
+#, fuzzy
+msgid ""
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
+msgstr ""
+"Die „neue“ Funktion könnte unter Verwendung von „Self“ als Typ geschrieben "
+"werden, da sie mit dem Namen des Strukturtyps austauschbar ist"
+
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,ignore\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```\n"
+"    \n"
+"</details>"
+msgstr ""
+
+#: src/enums.md:1
+#, fuzzy
+msgid "# Enums"
+msgstr "# Aufzählungen"
+
+#: src/enums.md:3
+#, fuzzy
+msgid ""
+"The `enum` keyword allows the creation of a type which has a few\n"
+"different variants:"
+msgstr ""
+"Das Schlüsselwort „enum“ ermöglicht die Erstellung eines Typs, der mehrere "
+"hat\n"
+"verschiedene Varianten:"
+
+#: src/enums.md:6
+msgid ""
+"```rust,editable\n"
+"fn generate_random_number() -> i32 {\n"
+"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
+"}"
+msgstr ""
+
+#: src/enums.md:11
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"enum CoinFlip {\n"
+"    Heads,\n"
+"    Tails,\n"
+"}"
+msgstr ""
+"#[ableiten(Debuggen)]\n"
+"enum CoinFlip {\n"
+"    Köpfe,\n"
+"    Schwänze,\n"
+"}"
+
+#: src/enums.md:17
+msgid ""
+"fn flip_coin() -> CoinFlip {\n"
+"    let random_number = generate_random_number();\n"
+"    if random_number % 2 == 0 {\n"
+"        return CoinFlip::Heads;\n"
+"    } else {\n"
+"        return CoinFlip::Tails;\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/enums.md:26
+msgid ""
+"fn main() {\n"
+"    println!(\"You got: {:?}\", flip_coin());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums.md:31
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points:"
+msgstr ""
+"<Details>\n"
+"    \n"
+"Wichtige Punkte:"
+
+#: src/enums.md:35
+#, fuzzy
+msgid ""
+"* Enumerations allow you to collect a set of values under one type\n"
+"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants.\n"
+"* This might be a good time to compare Structs and Enums:\n"
+"  * In both, you can have a simple version without fields (unit struct) or "
+"one with different types of fields (variant payloads). \n"
+"  * In both, associated functions are defined within an `impl` block.\n"
+"  * You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. \n"
+"</details>"
+msgstr ""
+"* Aufzählungen ermöglichen es Ihnen, eine Reihe von Werten unter einem Typ "
+"zu sammeln\n"
+"* Diese Seite bietet einen Aufzählungstyp `CoinFlip` mit zwei Varianten "
+"`Heads` und `Tail`. Beachten Sie bei der Verwendung von Varianten "
+"möglicherweise den Namensraum.\n"
+"* Dies könnte ein guter Zeitpunkt sein, um Structs und Enums zu "
+"vergleichen:\n"
+"  * In beiden Fällen können Sie eine einfache Version ohne Felder (unit "
+"struct) oder eine mit unterschiedlichen Feldtypen (variant payloads) haben.\n"
+"  * In beiden werden zugehörige Funktionen innerhalb eines `impl`-Blocks "
+"definiert.\n"
+"  * Sie könnten sogar die verschiedenen Varianten einer Aufzählung mit "
+"separaten Structs implementieren, aber dann wären sie nicht vom gleichen "
+"Typ, wie wenn sie alle in einer Aufzählung definiert wären.\n"
+"</details>"
+
+#: src/enums/variant-payloads.md:1
+#, fuzzy
+msgid "# Variant Payloads"
+msgstr "# Variantennutzlasten"
+
+#: src/enums/variant-payloads.md:3
+#, fuzzy
+msgid ""
+"You can define richer enums where the variants carry data. You can then use "
+"the\n"
+"`match` statement to extract the data from each variant:"
+msgstr ""
+"Sie können reichhaltigere Aufzählungen definieren, bei denen die Varianten "
+"Daten enthalten. Sie können dann die verwenden\n"
+"`match`-Anweisung, um die Daten aus jeder Variante zu extrahieren:"
+
+#: src/enums/variant-payloads.md:6
+msgid ""
+"```rust,editable\n"
+"enum WebEvent {\n"
+"    PageLoad,                 // Variant without payload\n"
+"    KeyPress(char),           // Tuple struct variant\n"
+"    Click { x: i64, y: i64 }, // Full struct variant\n"
+"}"
+msgstr ""
+
+#: src/enums/variant-payloads.md:13
+#, fuzzy
+msgid ""
+"#[rustfmt::skip]\n"
+"fn inspect(event: WebEvent) {\n"
+"    match event {\n"
+"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
+"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
+"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
+"    }\n"
+"}"
+msgstr ""
+"#[rustfmt::skip]\n"
+"fn inspect(event: WebEvent) {\n"
+"    Spielereignis {\n"
+"        WebEvent::PageLoad => println!(\"Seite geladen\"),\n"
+"        WebEvent::KeyPress(c) => println!(\"pressed '{c}'\"),\n"
+"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
+"    }\n"
+"}"
+
+#: src/enums/variant-payloads.md:22
+msgid ""
+"fn main() {\n"
+"    let load = WebEvent::PageLoad;\n"
+"    let press = WebEvent::KeyPress('x');\n"
+"    let click = WebEvent::Click { x: 20, y: 80 };"
+msgstr ""
+
+#: src/enums/variant-payloads.md:27
+msgid ""
+"    inspect(load);\n"
+"    inspect(press);\n"
+"    inspect(click);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/variant-payloads.md:35
+#, fuzzy
+msgid ""
+"* In the above example, accessing the `char` in `KeyPress`, or `x` and `y` "
+"in `Click` only works within a `match` statement.\n"
+"* `match` inspects a hidden discriminant field in the `enum`.\n"
+"* `WebEvent::Click { ... }` is not exactly the same as "
+"`WebEvent::Click(Click)` with a top level `struct Click { ... }`. The "
+"inlined version cannot implement traits, for example."
+msgstr ""
+"* Im obigen Beispiel funktioniert der Zugriff auf „char“ in „KeyPress“ oder "
+"„x“ und „y“ in „Click“ nur innerhalb einer „match“-Anweisung.\n"
+"* „match“ untersucht ein verstecktes Diskriminanzfeld in „enum“.\n"
+"* `WebEvent::Click { ... }` ist nicht genau dasselbe wie "
+"`WebEvent::Click(Click)` mit einem Top-Level-`struct Click { ... }`. Die "
+"Inline-Version kann beispielsweise keine Traits implementieren."
+
+#: src/enums/sizes.md:1
+#, fuzzy
+msgid "# Enum Sizes"
+msgstr "# Aufzählungsgrößen"
+
+#: src/enums/sizes.md:3
+#, fuzzy
+msgid ""
+"Rust enums are packed tightly, taking constraints due to alignment into "
+"account:"
+msgstr ""
+"Rust-Aufzählungen sind dicht gepackt, wobei Einschränkungen aufgrund der "
+"Ausrichtung berücksichtigt werden:"
+
+#: src/enums/sizes.md:5
+msgid "```rust,editable\nuse std::mem::{align_of, size_of};"
+msgstr ""
+
+#: src/enums/sizes.md:8
+msgid ""
+"macro_rules! dbg_size {\n"
+"    ($t:ty) => {\n"
+"        println!(\"{}: size {} bytes, align: {} bytes\",\n"
+"                 stringify!($t), size_of::<$t>(), align_of::<$t>());\n"
+"    };\n"
+"}"
+msgstr ""
+
+#: src/enums/sizes.md:15
+#, fuzzy
+msgid ""
+"enum Foo {\n"
+"    A,\n"
+"    B,\n"
+"}"
+msgstr ""
+"Aufzählung Foo {\n"
+"    A,\n"
+"    B,\n"
+"}"
+
+#: src/enums/sizes.md:20
+#, fuzzy
+msgid ""
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}"
+msgstr ""
+"#[repr(u32)]\n"
+"Aufzählungsbalken {\n"
+"    A, // 0\n"
+"    B = 10000,\n"
+"    C, // 10001\n"
+"}"
+
+#: src/enums/sizes.md:27
+msgid ""
+"fn main() {\n"
+"    dbg_size!(Foo);\n"
+"    dbg_size!(Bar);\n"
+"    dbg_size!(bool);\n"
+"    dbg_size!(Option<bool>);\n"
+"    dbg_size!(&i32);\n"
+"    dbg_size!(Option<&i32>);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:37
+#, fuzzy
+msgid ""
+"* See the [Rust "
+"Reference](https://doc.rust-lang.org/reference/type-layout.html)."
+msgstr ""
+"* Siehe die [Rust-Referenz] "
+"(https://doc.rust-lang.org/reference/type-layout.html)."
+
+#: src/enums/sizes.md:39
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points: \n"
+" * Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant.\n"
+" * `Bar` enum demonstrates that there is a way to control the discriminant "
+"value and type. If `repr` is removed, the discriminant type takes 2 bytes, "
+"becuase 10001 fits 2 bytes.\n"
+" * As a niche optimization an enum discriminant is merged with the pointer "
+"so that `Option<&Foo>` is the same size as `&Foo`.\n"
+" * `Option<bool>` is another example of tight packing.\n"
+" * For [some types](https://doc.rust-lang.org/std/option/#representation), "
+"Rust guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
+" * Zero-sized types allow for efficient implementation of `HashSet` using "
+"`HashMap` with `()` as the value."
+msgstr ""
+"<Details>\n"
+"    \n"
+"Wichtige Punkte:\n"
+" * Rust verwendet intern ein Feld (Discriminant), um die Enum-Variante zu "
+"verfolgen.\n"
+" * `Bar` enum demonstriert, dass es eine Möglichkeit gibt, den "
+"Diskriminanzwert und -typ zu steuern. Wenn \"repr\" entfernt wird, nimmt der "
+"Diskriminantentyp 2 Bytes ein, da 10001 auf 2 Bytes passt.\n"
+" * Als Nischenoptimierung wird eine Enum-Diskriminante mit dem Zeiger "
+"zusammengeführt, sodass `Option<&Foo>` die gleiche Größe wie `&Foo` hat.\n"
+" * `Option<bool>` ist ein weiteres Beispiel für Tight Packing.\n"
+" * Für [einige Typen](https://doc.rust-lang.org/std/option/#representation) "
+"garantiert Rust, dass „size_of::<T>()“ gleich „size_of::<Option<T>“ ist "
+">()`.\n"
+" * Typen mit der Größe Null ermöglichen eine effiziente Implementierung von "
+"`HashSet` unter Verwendung von `HashMap` mit `()` als Wert."
+
+#: src/methods.md:3
+#, fuzzy
+msgid ""
+"Rust allows you to associate functions with your new types. You do this with "
+"an\n"
+"`impl` block:"
+msgstr ""
+"Mit Rust können Sie Ihren neuen Typen Funktionen zuordnen. Das machst du mit "
+"einem\n"
+"`impl`-Block:"
+
+#: src/methods.md:13
+msgid ""
+"impl Person {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Hello, my name is {}\", self.name);\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/methods.md:19
+msgid ""
+"fn main() {\n"
+"    let peter = Person {\n"
+"        name: String::from(\"Peter\"),\n"
+"        age: 27,\n"
+"    };\n"
+"    peter.say_hello();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/methods.md:30
+#, fuzzy
+msgid ""
+"Key Points:\n"
+"* It can be helpful to introduce methods by comparing them to functions.\n"
+"  * Methods are called on an instance of a type (such as a struct or enum), "
+"the first parameter represents the instance as `self`.\n"
+"  * Developers may choose to use methods to take advantage of method "
+"receiver syntax and to help keep them more organized. By using methods we "
+"can keep all the implementation code in one predictable place.\n"
+"* Point out the use of the keyword `self`, a method receiver. \n"
+"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
+"how the struct name could also be used. \n"
+"  * Explain that Self is a type alias for the type the `impl` block is in "
+"and can be used elsewhere in the block.\n"
+"  * Note how self is used like other structs and dot notation can be used to "
+"refer to individual fields.\n"
+"  * This might be a good time to demonstrate how the `&self` differs from "
+"`self` by modifying the code and trying to run say_hello twice.  \n"
+"* We describe the distinction between method receivers next.\n"
+"   \n"
+"</details>"
+msgstr ""
+"Wichtige Punkte:\n"
+"* Es kann hilfreich sein, Methoden einzuführen, indem man sie mit Funktionen "
+"vergleicht.\n"
+"  * Methoden werden für eine Instanz eines Typs aufgerufen (z. B. eine "
+"Struktur oder Aufzählung), der erste Parameter repräsentiert die Instanz als "
+"„self“.\n"
+"  * Entwickler können sich dafür entscheiden, Methoden zu verwenden, um die "
+"Methodenempfängersyntax zu nutzen und sie besser organisiert zu halten. "
+"Durch die Verwendung von Methoden können wir den gesamten "
+"Implementierungscode an einem vorhersehbaren Ort aufbewahren.\n"
+"* Weisen Sie auf die Verwendung des Schlüsselworts „self“ hin, einem "
+"Methodenempfänger.\n"
+"  * Zeigen Sie, dass es sich um eine Abkürzung für `self:&Self` handelt und "
+"zeigen Sie vielleicht, wie der Strukturname auch verwendet werden könnte.\n"
+"  * Erklären Sie, dass Self ein Typ-Alias für den Typ ist, in dem sich der "
+"„impl“-Block befindet, und an anderer Stelle im Block verwendet werden "
+"kann.\n"
+"  * Beachten Sie, dass self wie andere Strukturen verwendet wird und die "
+"Punktnotation verwendet werden kann, um auf einzelne Felder zu verweisen.\n"
+"  * Dies könnte ein guter Zeitpunkt sein, um zu demonstrieren, wie sich "
+"`&self` von `self` unterscheidet, indem Sie den Code ändern und versuchen, "
+"say_hello zweimal auszuführen.\n"
+"* Als nächstes beschreiben wir die Unterscheidung zwischen "
+"Methodenempfängern.\n"
+"   \n"
+"</details>"
+
+#: src/methods/receiver.md:1
+#, fuzzy
+msgid "# Method Receiver"
+msgstr "# Methodenempfänger"
+
+#: src/methods/receiver.md:3
+#, fuzzy
+msgid ""
+"The `&self` above indicates that the method borrows the object immutably. "
+"There\n"
+"are other possible receivers for a method:"
+msgstr ""
+"Das obige `&self` gibt an, dass die Methode das Objekt unveränderlich "
+"ausleiht. Dort\n"
+"sind weitere mögliche Empfänger für eine Methode:"
+
+#: src/methods/receiver.md:6
+#, fuzzy
+msgid ""
+"* `&self`: borrows the object from the caller using a shared and immutable\n"
+"  reference. The object can be used again afterwards.\n"
+"* `&mut self`: borrows the object from the caller using a unique and "
+"mutable\n"
+"  reference. The object can be used again afterwards.\n"
+"* `self`: takes ownership of the object and moves it away from the caller. "
+"The\n"
+"  method becomes the owner of the object. The object will be dropped "
+"(deallocated)\n"
+"  when the method returns, unless its ownership is explicitly\n"
+"  transmitted.\n"
+"* `mut self`: same as above, but while the method owns the object, it can\n"
+"  mutate it too. Complete ownership does not automatically mean mutability.\n"
+"* No receiver: this becomes a static method on the struct. Typically used "
+"to\n"
+"  create constructors which are called `new` by convention."
+msgstr ""
+"* `&self`: leiht sich das Objekt vom Aufrufer unter Verwendung eines Shared "
+"und Immutable\n"
+"  Referenz. Das Objekt kann danach wieder verwendet werden.\n"
+"* `&mut self`: leiht sich das Objekt vom Aufrufer unter Verwendung eines "
+"Unique und Mutable\n"
+"  Referenz. Das Objekt kann danach wieder verwendet werden.\n"
+"* `self`: übernimmt den Besitz des Objekts und verschiebt es vom Aufrufer "
+"weg. Der\n"
+"  Die Methode wird Eigentümer des Objekts. Das Objekt wird gelöscht "
+"(deallocated)\n"
+"  wenn die Methode zurückkehrt, es sei denn, ihr Besitz ist explizit\n"
+"  übermittelt.\n"
+"* `mut self`: wie oben, aber während die Methode das Objekt besitzt, kann "
+"sie es\n"
+"  mutiere es auch. Vollständiges Eigentum bedeutet nicht automatisch "
+"Wandelbarkeit.\n"
+"* Kein Empfänger: Dies wird zu einer statischen Methode für die Struktur. "
+"Typischerweise gewohnt\n"
+"  Erstellen Sie Konstruktoren, die per Konvention \"neu\" genannt werden."
+
+#: src/methods/receiver.md:19
+#, fuzzy
+msgid ""
+"Beyond variants on `self`, there are also\n"
+"[special wrapper "
+"types](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
+"allowed to be receiver types, such as `Box<Self>`."
+msgstr ""
+"Neben Varianten von „self“ gibt es auch\n"
+"[spezielle "
+"Wrapper-Typen](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
+"dürfen Empfängertypen sein, wie z. B. `Box<Self>`."
+
+#: src/methods/receiver.md:23
+#, fuzzy
+msgid ""
+"<details>\n"
+"  \n"
+"Consider emphasizing on \"shared and immutable\" and \"unique and mutable\". "
+"These constraints always come\n"
+"together in Rust due to borrow checker rules, and `self` is no exception. It "
+"won't be possible to\n"
+"reference a struct from multiple locations and call a mutating (`&mut self`) "
+"method on it.\n"
+"  \n"
+"</details>"
+msgstr ""
+"<Details>\n"
+"  \n"
+"Erwägen Sie, die Betonung auf „gemeinsam und unveränderlich“ und "
+"„einzigartig und veränderlich“ zu legen. Diese Einschränkungen kommen immer\n"
+"zusammen in Rust aufgrund der Borrow-Checker-Regeln, und `self` ist keine "
+"Ausnahme. Es wird nicht möglich sein\n"
+"Verweisen Sie auf eine Struktur von mehreren Stellen und rufen Sie eine "
+"Mutationsmethode (`&mut self`) darauf auf.\n"
+"  \n"
+"</details>"
+
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
+#, fuzzy
+msgid "# Example"
+msgstr "# Beispiel"
+
+#: src/methods/example.md:3
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Race {\n"
+"    name: String,\n"
+"    laps: Vec<i32>,\n"
+"}"
+msgstr ""
+
+#: src/methods/example.md:10
+#, fuzzy
+msgid ""
+"impl Race {\n"
+"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
+"        Race { name: String::from(name), laps: Vec::new() }\n"
+"    }"
+msgstr ""
+"impl Rennen {\n"
+"    fn new(name: &str) -> Race { // Kein Empfänger, eine statische Methode\n"
+"        Rennen { Name: String::from(Name), Runden: Vec::new() }\n"
+"    }"
+
+#: src/methods/example.md:15
+msgid ""
+"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
+"access to self\n"
+"        self.laps.push(lap);\n"
+"    }"
+msgstr ""
+
+#: src/methods/example.md:19
+msgid ""
+"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
+"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
+"        for (idx, lap) in self.laps.iter().enumerate() {\n"
+"            println!(\"Lap {idx}: {lap} sec\");\n"
+"        }\n"
+"    }"
+msgstr ""
+
+#: src/methods/example.md:26
+msgid ""
+"    fn finish(self) {  // Exclusive ownership of self\n"
+"        let total = self.laps.iter().sum::<i32>();\n"
+"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"total);\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/methods/example.md:32
+msgid ""
+"fn main() {\n"
+"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
+"    race.add_lap(70);\n"
+"    race.add_lap(68);\n"
+"    race.print_laps();\n"
+"    race.add_lap(71);\n"
+"    race.print_laps();\n"
+"    race.finish();\n"
+"    // race.add_lap(42);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/methods/example.md:44
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points:\n"
+"* All four methods here use a different method receiver.\n"
+"  * You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`.\n"
+"  * You can showcase the error that appears when trying to call `finish` "
+"twice.\n"
+"* Note, that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
+"* You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
+msgstr ""
+"<Details>\n"
+"    \n"
+"Wichtige Punkte:\n"
+"* Alle vier Methoden hier verwenden einen anderen Methodenempfänger.\n"
+"  * Sie können darauf hinweisen, wie sich das ändert, was die Funktion mit "
+"den Variablenwerten machen kann und ob/wie sie wieder in `main` verwendet "
+"werden kann.\n"
+"  * Sie können den Fehler zeigen, der auftritt, wenn Sie versuchen, zweimal "
+"„finish“ aufzurufen.\n"
+"* Beachten Sie, dass, obwohl die Methodenempfänger unterschiedlich sind, die "
+"nicht statischen Funktionen im Hauptteil auf die gleiche Weise aufgerufen "
+"werden. Rust ermöglicht die automatische Referenzierung und Dereferenzierung "
+"beim Methodenaufruf. Rust fügt automatisch die `&`, `*`, `muts` hinzu, "
+"sodass dieses Objekt mit der Methodensignatur übereinstimmt.\n"
+"* Sie könnten darauf hinweisen, dass `print_laps` einen Vektor verwendet, "
+"der iteriert wird. Am Nachmittag beschreiben wir Vektoren genauer."
+
+#: src/pattern-matching.md:1
+#, fuzzy
+msgid "# Pattern Matching"
+msgstr "# Musterabgleich"
+
+#: src/pattern-matching.md:3
+#, fuzzy
+msgid ""
+"The `match` keyword let you match a value against one or more _patterns_. "
+"The\n"
+"comparisons are done from top to bottom and the first match wins."
+msgstr ""
+"Mit dem Schlüsselwort „match“ können Sie einen Wert mit einem oder mehreren "
+"_Mustern_ abgleichen. Der\n"
+"Vergleiche werden von oben nach unten durchgeführt und das erste Match "
+"gewinnt."
+
+#: src/pattern-matching.md:6
+#, fuzzy
+msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
+msgstr ""
+"Die Muster können einfache Werte sein, ähnlich wie `switch` in C und C++:"
+
+#: src/pattern-matching.md:8
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let input = 'x';"
+msgstr ""
+
+#: src/pattern-matching.md:12
+msgid ""
+"    match input {\n"
+"        'q'                   => println!(\"Quitting\"),\n"
+"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
+"        '0'..='9'             => println!(\"Number input\"),\n"
+"        _                     => println!(\"Something else\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching.md:21
+#, fuzzy
+msgid "The `_` pattern is a wildcard pattern which matches any value."
+msgstr "Das `_`-Muster ist ein Platzhaltermuster, das jedem Wert entspricht."
+
+#: src/pattern-matching.md:23
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"Key Points:\n"
+"* You might point out how some specific characters are being used when in a "
+"patten\n"
+"  * `|` as an `or`\n"
+"  * `..` can expand as much as it needs to be\n"
+"  * `1..=5` represents an inclusive range\n"
+"  * `_` is a wild card\n"
+"* It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`.\n"
+"* You can demonstrate matching on a reference.\n"
+"* This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages.\n"
+"   \n"
+"</details>"
+msgstr ""
+"<Details>\n"
+"    \n"
+"Wichtige Punkte:\n"
+"* Sie können darauf hinweisen, wie bestimmte Zeichen in einem Muster "
+"verwendet werden\n"
+"  * `|` als `oder`\n"
+"  * `..` kann beliebig erweitert werden\n"
+"  * „1..=5“ steht für einen inklusiven Bereich\n"
+"  * „_“ ist ein Platzhalter\n"
+"* Es kann nützlich sein, zu zeigen, wie die Bindung funktioniert, indem Sie "
+"zum Beispiel ein Platzhalterzeichen durch eine Variable ersetzen oder die "
+"Anführungszeichen um `q` entfernen.\n"
+"* Sie können die Übereinstimmung anhand einer Referenz nachweisen.\n"
+"* Dies könnte ein guter Zeitpunkt sein, um das Konzept der unwiderlegbaren "
+"Muster anzusprechen, da der Begriff in Fehlermeldungen auftauchen kann.\n"
+"   \n"
+"</Details>"
+
+#: src/pattern-matching/destructuring-enums.md:1
+#, fuzzy
+msgid "# Destructuring Enums"
+msgstr "# Destrukturierung von Enums"
+
+#: src/pattern-matching/destructuring-enums.md:3
+#, fuzzy
+msgid ""
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how\n"
+"you inspect the structure of your types. Let us start with a simple `enum` "
+"type:"
+msgstr ""
+"Muster können auch verwendet werden, um Variablen an Teile Ihrer Werte zu "
+"binden. Das ist wie\n"
+"Sie inspizieren die Struktur Ihrer Typen. Beginnen wir mit einem einfachen "
+"`enum`-Typ:"
+
+#: src/pattern-matching/destructuring-enums.md:6
+msgid ""
+"```rust,editable\n"
+"enum Result {\n"
+"    Ok(i32),\n"
+"    Err(String),\n"
+"}"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:12
+#, fuzzy
+msgid ""
+"fn divide_in_two(n: i32) -> Result {\n"
+"    if n % 2 == 0 {\n"
+"        Result::Ok(n / 2)\n"
+"    } else {\n"
+"        Result::Err(format!(\"cannot divide {} into two equal parts\", n))\n"
+"    }\n"
+"}"
+msgstr ""
+"fn divide_in_two(n: i32) -> Ergebnis {\n"
+"    wenn n % 2 == 0 {\n"
+"        Ergebnis::Okay(n / 2)\n"
+"    } anders {\n"
+"        Ergebnis::Err(format!(\"kann {} nicht in zwei gleiche Teile "
+"teilen\", n))\n"
+"    }\n"
+"}"
+
+#: src/pattern-matching/destructuring-enums.md:20
+msgid ""
+"fn main() {\n"
+"    let n = 100;\n"
+"    match divide_in_two(n) {\n"
+"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
+"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:29
+#, fuzzy
+msgid ""
+"Here we have used the arms to _destructure_ the `Result` value. In the "
+"first\n"
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm,\n"
+"`msg` is bound to the error message."
+msgstr ""
+"Hier haben wir die Arme verwendet, um den „Result“-Wert zu "
+"_destrukturieren_. In der ersten\n"
+"arm, `half` ist an den Wert innerhalb der `Ok`-Variante gebunden. Im zweiten "
+"Arm,\n"
+"`msg` wird an die Fehlermeldung gebunden."
+
+#: src/pattern-matching/destructuring-enums.md:35
+#, fuzzy
+msgid ""
+"Key points:\n"
+"* The `if`/`else` expression is returning an enum that is later unpacked "
+"with a `match`.\n"
+"* You can try adding a third variant to the enum definition and displaying "
+"the errors when running the code. Point out the places where your code is "
+"now inexhaustive and how the compiler trys to give you hints."
+msgstr ""
+"Kernpunkte:\n"
+"* Der `if`/`else`-Ausdruck gibt eine Aufzählung zurück, die später mit einem "
+"`match` entpackt wird.\n"
+"* Sie können versuchen, der Enum-Definition eine dritte Variante "
+"hinzuzufügen und die Fehler beim Ausführen des Codes anzuzeigen. Weisen Sie "
+"auf die Stellen hin, an denen Ihr Code jetzt unerschöpflich ist und wie der "
+"Compiler versucht, Ihnen Hinweise zu geben."
+
+#: src/pattern-matching/destructuring-structs.md:1
+#, fuzzy
+msgid "# Destructuring Structs"
+msgstr "# Destrukturierende Strukturen"
+
+#: src/pattern-matching/destructuring-structs.md:3
+#, fuzzy
+msgid "You can also destructure `structs`:"
+msgstr "Sie können `structs` auch destrukturieren:"
+
+#: src/pattern-matching/destructuring-structs.md:5
+msgid ""
+"```rust,editable\n"
+"struct Foo {\n"
+"    x: (u32, u32),\n"
+"    y: u32,\n"
+"}"
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:11
+msgid ""
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let foo = Foo { x: (1, 2), y: 3 };\n"
+"    match foo {\n"
+"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
+"        Foo { y: 2, x: i }   => println!(\"y = 2, i = {i:?}\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:1
+#, fuzzy
+msgid "# Destructuring Arrays"
+msgstr "# Destrukturieren von Arrays"
+
+#: src/pattern-matching/destructuring-arrays.md:3
+#, fuzzy
+msgid ""
+"You can destructure arrays, tuples, and slices by matching on their elements:"
+msgstr ""
+"Sie können Arrays, Tupel und Slices destrukturieren, indem Sie ihre Elemente "
+"abgleichen:"
+
+#: src/pattern-matching/destructuring-arrays.md:5
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let triple = [0, -2, 3];\n"
+"    println!(\"Tell me about {triple:?}\");\n"
+"    match triple {\n"
+"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _         => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:1
+#, fuzzy
+msgid "# Match Guards"
+msgstr "# Match Guards"
+
+#: src/pattern-matching/match-guards.md:3
+#, fuzzy
+msgid ""
+"When matching, you can add a _guard_ to a pattern. This is an arbitrary "
+"Boolean\n"
+"expression which will be executed if the pattern matches:"
+msgstr ""
+"Beim Abgleich können Sie einem Muster einen _Wächter_ hinzufügen. Dies ist "
+"ein beliebiger boolescher Wert\n"
+"Ausdruck, der ausgeführt wird, wenn das Muster übereinstimmt:"
+
+#: src/pattern-matching/match-guards.md:6
+msgid ""
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let pair = (2, -2);\n"
+"    println!(\"Tell me about {pair:?}\");\n"
+"    match pair {\n"
+"        (x, y) if x == y     => println!(\"These are twins\"),\n"
+"        (x, y) if x + y == 0 => println!(\"Antimatter, kaboom!\"),\n"
+"        (x, _) if x % 2 == 1 => println!(\"The first one is odd\"),\n"
+"        _                    => println!(\"No correlation...\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:22
+#, fuzzy
+msgid ""
+"Key Points:\n"
+"* Match guards as a separate syntax feature are important and necessary.\n"
+"* They are not the same as separate `if` expression inside of the match arm. "
+"An `if` expression inside of the branch block (after `=>`) happens after the "
+"match arm is selected. Failing the `if` condition inside of that block won't "
+"result in other arms\n"
+"of the original `match` expression being considered.  \n"
+"* You can use the variables defined in the pattern in your if expression.\n"
+"* The condition defined in the guard applies to every expression in a "
+"pattern with an `|`.\n"
+"</details>"
+msgstr ""
+"Wichtige Punkte:\n"
+"* Match Guards als separates Syntax-Feature sind wichtig und notwendig.\n"
+"* Sie sind nicht dasselbe wie ein separater „if“-Ausdruck innerhalb des "
+"Match-Arms. Ein „if“-Ausdruck innerhalb des Verzweigungsblocks (nach „=>“) "
+"erfolgt, nachdem der Match-Arm ausgewählt wurde. Wenn die 'if'-Bedingung "
+"innerhalb dieses Blocks nicht bestanden wird, führt dies nicht zu anderen "
+"Armen\n"
+"des betrachteten ursprünglichen \"Match\"-Ausdrucks.\n"
+"* Sie können die im Muster definierten Variablen in Ihrem if-Ausdruck "
+"verwenden.\n"
+"* Die im Guard definierte Bedingung gilt für jeden Ausdruck in einem Muster "
+"mit einem `|`.\n"
+"</details>"
+
+#: src/exercises/day-2/morning.md:1
+#, fuzzy
+msgid "# Day 2: Morning Exercises"
+msgstr "# Tag 2: Morgengymnastik"
+
+#: src/exercises/day-2/morning.md:3
+#, fuzzy
+msgid "We will look at implementing methods in two contexts:"
+msgstr "Wir werden Implementierungsmethoden in zwei Kontexten betrachten:"
+
+#: src/exercises/day-2/morning.md:5
+#, fuzzy
+msgid "* Simple struct which tracks health statistics."
+msgstr "* Einfache Struktur, die Gesundheitsstatistiken verfolgt."
+
+#: src/exercises/day-2/morning.md:7
+#, fuzzy
+msgid "* Multiple structs and enums for a drawing library."
+msgstr "* Mehrere Strukturen und Aufzählungen für eine Zeichnungsbibliothek."
+
+#: src/exercises/day-2/health-statistics.md:1
+#, fuzzy
+msgid "# Health Statistics"
+msgstr "# Gesundheitsstatistik"
+
+#: src/exercises/day-2/health-statistics.md:3
+#, fuzzy
+msgid ""
+"You're working on implementing a health-monitoring system. As part of that, "
+"you\n"
+"need to keep track of users' health statistics."
+msgstr ""
+"Sie arbeiten an der Implementierung eines Gesundheitsüberwachungssystems. "
+"Als Teil davon Sie\n"
+"müssen die Gesundheitsstatistiken der Benutzer verfolgen."
+
+#: src/exercises/day-2/health-statistics.md:6
+#, fuzzy
+msgid ""
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User`\n"
+"struct definition. Your goal is to implement the stubbed out methods on the\n"
+"`User` `struct` defined in the `impl` block."
+msgstr ""
+"Sie beginnen mit einigen Stub-Funktionen in einem `impl`-Block sowie einem "
+"`User`\n"
+"Strukturdefinition. Ihr Ziel ist es, die Stubbed-out-Methoden auf dem zu "
+"implementieren\n"
+"`User` `struct` definiert im `impl` Block."
+
+#: src/exercises/day-2/health-statistics.md:10
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"methods:"
+msgstr ""
+"Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
+"füllen Sie die fehlenden aus\n"
+"Methoden:"
+
+#: src/exercises/day-2/health-statistics.md:17
+#, fuzzy
+msgid ""
+"struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    weight: f32,\n"
+"}"
+msgstr ""
+"Struktur Benutzer {\n"
+"    Name: Zeichenfolge,\n"
+"    Alter: u32,\n"
+"    Gewicht: f32,\n"
+"}"
+
+#: src/exercises/day-2/health-statistics.md:23
+#, fuzzy
+msgid ""
+"impl User {\n"
+"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl Benutzer {\n"
+"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:28
+#, fuzzy
+msgid ""
+"    pub fn name(&self) -> &str {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn name(&self) -> &str {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:32
+#, fuzzy
+msgid ""
+"    pub fn age(&self) -> u32 {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn alter(&selbst) -> u32 {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:36
+#, fuzzy
+msgid ""
+"    pub fn weight(&self) -> f32 {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn Gewicht(&self) -> f32 {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:40
+#, fuzzy
+msgid ""
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"    pub fn set_age(&mut selbst, new_age: u32) {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-2/health-statistics.md:44
+#, fuzzy
+msgid ""
+"    pub fn set_weight(&mut self, new_weight: f32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"    pub fn set_weight(&mut self, new_weight: f32) {\n"
+"        nicht implementiert!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/health-statistics.md:49
+msgid ""
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:54
+msgid ""
+"#[test]\n"
+"fn test_weight() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.weight(), 155.2);\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:60
+msgid ""
+"#[test]\n"
+"fn test_set_age() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.age(), 32);\n"
+"    bob.set_age(33);\n"
+"    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:1
+#, fuzzy
+msgid "# Polygon Struct"
+msgstr "# Polygonstruktur"
+
+#: src/exercises/day-2/points-polygons.md:3
+#, fuzzy
+msgid ""
+"We will create a `Polygon` struct which contain some points. Copy the code "
+"below\n"
+"to <https://play.rust-lang.org/> and fill in the missing methods to make "
+"the\n"
+"tests pass:"
+msgstr ""
+"Wir werden eine \"Polygon\"-Struktur erstellen, die einige Punkte enthält. "
+"Kopieren Sie den Code unten\n"
+"zu <https://play.rust-lang.org/> und füllen Sie die fehlenden Methoden aus, "
+"um die\n"
+"Tests bestehen:"
+
+#: src/exercises/day-2/points-polygons.md:7 src/exercises/day-2/luhn.md:23
+#: src/exercises/day-2/strings-iterators.md:12
+msgid ""
+"```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:11
+#, fuzzy
+msgid ""
+"pub struct Point {\n"
+"    // add fields\n"
+"}"
+msgstr ""
+"pub struct Punkt {\n"
+"    // Felder hinzufügen\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:15
+#, fuzzy
+msgid ""
+"impl Point {\n"
+"    // add methods\n"
+"}"
+msgstr ""
+"impl Punkt {\n"
+"    // Methoden hinzufügen\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:19
+#, fuzzy
+msgid ""
+"pub struct Polygon {\n"
+"    // add fields\n"
+"}"
+msgstr ""
+"pub struct Polygon {\n"
+"    // Felder hinzufügen\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:23
+#, fuzzy
+msgid ""
+"impl Polygon {\n"
+"    // add methods\n"
+"}"
+msgstr ""
+"impl Polygon {\n"
+"    // Methoden hinzufügen\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:27
+#, fuzzy
+msgid ""
+"pub struct Circle {\n"
+"    // add fields\n"
+"}"
+msgstr ""
+"pub struct Kreis {\n"
+"    // Felder hinzufügen\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:31
+#, fuzzy
+msgid ""
+"impl Circle {\n"
+"    // add methods\n"
+"}"
+msgstr ""
+"impl Kreis {\n"
+"    // Methoden hinzufügen\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:35
+#, fuzzy
+msgid ""
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}"
+msgstr ""
+"Pub-Aufzählung Form {\n"
+"    Vieleck(Vieleck),\n"
+"    Kreis (Kreis),\n"
+"}"
+
+#: src/exercises/day-2/points-polygons.md:40 src/testing/test-modules.md:15
+msgid ""
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:44
+#: src/exercises/day-2/solutions-morning.md:165
+#, fuzzy
+msgid ""
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100.0).round() / 100.0\n"
+"    }"
+msgstr ""
+"    fn round_two_digits(x: f64) -> f64 {\n"
+"        (x * 100.0).round() / 100.0\n"
+"    }"
+
+#: src/exercises/day-2/points-polygons.md:48
+#: src/exercises/day-2/solutions-morning.md:169
+msgid ""
+"    #[test]\n"
+"    fn test_point_magnitude() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:54
+#: src/exercises/day-2/solutions-morning.md:175
+msgid ""
+"    #[test]\n"
+"    fn test_point_dist() {\n"
+"        let p1 = Point::new(10, 10);\n"
+"        let p2 = Point::new(14, 13);\n"
+"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:61
+#: src/exercises/day-2/solutions-morning.md:182
+msgid ""
+"    #[test]\n"
+"    fn test_point_add() {\n"
+"        let p1 = Point::new(16, 16);\n"
+"        let p2 = p1 + Point::new(-4, 3);\n"
+"        assert_eq!(p2, Point::new(12, 19));\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:68
+#: src/exercises/day-2/solutions-morning.md:189
+msgid ""
+"    #[test]\n"
+"    fn test_polygon_left_most_point() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:73
+#: src/exercises/day-2/solutions-morning.md:194
+msgid ""
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);\n"
+"        assert_eq!(poly.left_most_point(), Some(p1));\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:79
+#: src/exercises/day-2/solutions-morning.md:200
+msgid ""
+"    #[test]\n"
+"    fn test_polygon_iter() {\n"
+"        let p1 = Point::new(12, 13);\n"
+"        let p2 = Point::new(16, 16);"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:84
+#: src/exercises/day-2/solutions-morning.md:205
+msgid ""
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(p1);\n"
+"        poly.add_point(p2);"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:88
+#: src/exercises/day-2/solutions-morning.md:209
+msgid ""
+"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:92
+msgid ""
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:111 src/exercises/day-2/luhn.md:68
+#: src/exercises/day-2/solutions-morning.md:233
+msgid ""
+"#[allow(dead_code)]\n"
+"fn main() {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:117
+#, fuzzy
+msgid ""
+"Since the method signatures are missing from the problem statements, the key "
+"part\n"
+"of the exercise is to specify those correctly."
+msgstr ""
+"Da die Methodensignaturen in den Problembeschreibungen fehlen, ist der "
+"Schlüsselteil\n"
+"der Übung ist es, diese richtig anzugeben."
+
+#: src/exercises/day-2/points-polygons.md:120
+#, fuzzy
+msgid ""
+"Other interesting parts of the exercise:\n"
+"    \n"
+"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments.\n"
+"* Discover that `Add` trait must be implemented for two objects to be "
+"addable via \"+\".    "
+msgstr ""
+"Weitere interessante Teile der Übung:\n"
+"    \n"
+"* Leiten Sie ein `Copy`-Merkmal für einige Strukturen ab, da die Methoden in "
+"Tests ihre Argumente manchmal nicht ausleihen.\n"
+"* Entdecken Sie, dass die Eigenschaft „Hinzufügen“ implementiert werden "
+"muss, damit zwei Objekte über „+“ hinzugefügt werden können."
+
+#: src/control-flow.md:1
+#, fuzzy
+msgid "# Control Flow"
+msgstr "# Kontrollfluss"
+
+#: src/control-flow.md:3
+#, fuzzy
+msgid ""
+"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"evaluate one of two blocks, but the blocks can have a value which then "
+"becomes\n"
+"the value of the `if` expression. Other control flow expressions work "
+"similarly\n"
+"in Rust."
+msgstr ""
+"Wie wir gesehen haben, ist `if` ein Ausdruck in Rust. Es ist bedingt "
+"gewohnt\n"
+"einen von zwei Blöcken auswerten, aber die Blöcke können einen Wert haben, "
+"der dann wird\n"
+"der Wert des `if`-Ausdrucks. Andere Ablaufsteuerungsausdrücke funktionieren "
+"ähnlich\n"
+"in Rost."
+
+#: src/control-flow/blocks.md:1
+#, fuzzy
+msgid "# Blocks"
+msgstr "# Blöcke"
+
+#: src/control-flow/blocks.md:3
+#, fuzzy
+msgid ""
+"A block in Rust has a value and a type: the value is the last expression of "
+"the\n"
+"block:"
+msgstr ""
+"Ein Block in Rust hat einen Wert und einen Typ: Der Wert ist der letzte "
+"Ausdruck der\n"
+"Block:"
+
+#: src/control-flow/blocks.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let x = {\n"
+"        let y = 10;\n"
+"        println!(\"y: {y}\");\n"
+"        let z = {\n"
+"            let w = {\n"
+"                3 + 4\n"
+"            };\n"
+"            println!(\"w: {w}\");\n"
+"            y * w\n"
+"        };\n"
+"        println!(\"z: {z}\");\n"
+"        z - y\n"
+"    };\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/blocks.md:25
+#, fuzzy
+msgid ""
+"The same rule is used for functions: the value of the function body is the\n"
+"return value:"
+msgstr ""
+"Die gleiche Regel gilt für Funktionen: Der Wert des Funktionskörpers ist "
+"der\n"
+"Rückgabewert:"
+
+#: src/control-flow/blocks.md:28
+msgid ""
+"```rust,editable\n"
+"fn double(x: i32) -> i32 {\n"
+"    x + x\n"
+"}"
+msgstr ""
+
+#: src/control-flow/blocks.md:33
+msgid ""
+"fn main() {\n"
+"    println!(\"doubled: {}\", double(7));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/blocks.md:38
+msgid ""
+"However if the last expression ends with `;`, then the resulting value and "
+"type is `()`."
+msgstr ""
+
+#: src/control-flow/blocks.md:42
+#, fuzzy
+msgid ""
+"Key Points:\n"
+"* The point of this slide is to show that blocks have a type and value in "
+"Rust. \n"
+"* You can show how the value of the block changes by changing the last line "
+"in the block. For instance, adding/removing a semicolon or using a "
+"`return`.\n"
+"   \n"
+"</details>"
+msgstr ""
+"Wichtige Punkte:\n"
+"* Der Zweck dieser Folie ist es zu zeigen, dass Blöcke in Rust einen Typ und "
+"einen Wert haben.\n"
+"* Sie können zeigen, wie sich der Wert des Blocks ändert, indem Sie die "
+"letzte Zeile im Block ändern. Zum Beispiel das Hinzufügen/Entfernen eines "
+"Semikolons oder die Verwendung eines `Return`.\n"
+"   \n"
+"</Details>"
+
+#: src/control-flow/if-expressions.md:1
+#, fuzzy
+msgid "# `if` expressions"
+msgstr "# `if`-Ausdrücke"
+
+#: src/control-flow/if-expressions.md:3
+#, fuzzy
+msgid "You use `if` very similarly to how you would in other languages:"
+msgstr "Sie verwenden \"if\" sehr ähnlich wie in anderen Sprachen:"
+
+#: src/control-flow/if-expressions.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    if x % 2 == 0 {\n"
+"        x = x / 2;\n"
+"    } else {\n"
+"        x = 3 * x + 1;\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/if-expressions.md:16
+#, fuzzy
+msgid ""
+"In addition, you can use it as an expression. This does the same as above:"
+msgstr ""
+"Darüber hinaus können Sie es als Ausdruck verwenden. Das macht dasselbe wie "
+"oben:"
+
+#: src/control-flow/if-expressions.md:18
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    x = if x % 2 == 0 {\n"
+"        x / 2\n"
+"    } else {\n"
+"        3 * x + 1\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/if-expressions.md:31
+msgid ""
+"Because `if` is an expression and must have a particular type, both of its "
+"branch blocks must have the same type. Consider showing what happens if you "
+"add `;` after `x / 2` in the second example.\n"
+"    \n"
+"</details>"
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:1
+#, fuzzy
+msgid "# `if let` expressions"
+msgstr "# `if let`-Ausdrücke"
+
+#: src/control-flow/if-let-expressions.md:3
+#, fuzzy
+msgid "If you want to match a value against a pattern, you can use `if let`:"
+msgstr ""
+"Wenn Sie einen Wert mit einem Muster abgleichen möchten, können Sie `if let` "
+"verwenden:"
+
+#: src/control-flow/if-let-expressions.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let arg = std::env::args().next();\n"
+"    if let Some(value) = arg {\n"
+"        println!(\"Program name: {value}\");\n"
+"    } else {\n"
+"        println!(\"Missing name?\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:16
+#: src/control-flow/while-let-expressions.md:21
+#: src/control-flow/match-expressions.md:22
+#, fuzzy
+msgid ""
+"See [pattern matching](../pattern-matching.md) for more details on patterns "
+"in\n"
+"Rust."
+msgstr ""
+"Siehe [pattern matching](../pattern-matching.md) für weitere Details zu "
+"Mustern in\n"
+"Rost."
+
+#: src/control-flow/if-let-expressions.md:21
+#, fuzzy
+msgid ""
+"* `if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered.\n"
+"    * For the similar use case consider demonstrating a newly stabilized "
+"[`let else`](https://github.com/rust-lang/rust/pull/93628) feature.\n"
+"* A common usage is handling `Some` values when working with `Option`.\n"
+"* Unlike `match`, `if let` does not support guard clauses for pattern "
+"matching."
+msgstr ""
+"* `if let` kann prägnanter sein als `match`, z. B. wenn nur ein Fall "
+"interessant ist. Im Gegensatz dazu erfordert \"Match\", dass alle Zweige "
+"abgedeckt werden.\n"
+"    * Ziehen Sie für einen ähnlichen Anwendungsfall in Betracht, eine neu "
+"stabilisierte [`let "
+"else`](https://github.com/rust-lang/rust/pull/93628)-Funktion zu "
+"demonstrieren.\n"
+"* Eine übliche Verwendung ist die Handhabung von `Some`-Werten bei der "
+"Arbeit mit `Option`.\n"
+"* Im Gegensatz zu `match` unterstützt `if let` keine Schutzklauseln für den "
+"Mustervergleich."
+
+#: src/control-flow/while-expressions.md:1
+#, fuzzy
+msgid "# `while` expressions"
+msgstr "# `while`-Ausdrücke"
+
+#: src/control-flow/while-expressions.md:3
+#, fuzzy
+msgid "The `while` keyword works very similar to other languages:"
+msgstr ""
+"Das Schlüsselwort „while“ funktioniert sehr ähnlich wie in anderen Sprachen:"
+
+#: src/control-flow/while-expressions.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    while x != 1 {\n"
+"        x = if x % 2 == 0 {\n"
+"            x / 2\n"
+"        } else {\n"
+"            3 * x + 1\n"
+"        };\n"
+"    }\n"
+"    println!(\"Final x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/while-let-expressions.md:1
+#, fuzzy
+msgid "# `while let` expressions"
+msgstr "# `while let`-Ausdrücke"
+
+#: src/control-flow/while-let-expressions.md:3
+#, fuzzy
+msgid ""
+"Like with `if`, there is a `while let` variant which repeatedly tests a "
+"value\n"
+"against a pattern:"
+msgstr ""
+"Wie bei `if` gibt es eine `while let`-Variante, die einen Wert wiederholt "
+"testet\n"
+"gegen ein Muster:"
+
+#: src/control-flow/while-let-expressions.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();"
+msgstr ""
+
+#: src/control-flow/while-let-expressions.md:11
+msgid ""
+"    while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/while-let-expressions.md:17
+#, fuzzy
+msgid ""
+"Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
+"every\n"
+"call to `next()`. It returns `Some(x)` until it is done, after which it "
+"will\n"
+"return `None`. The `while let` lets us keep iterating through all items."
+msgstr ""
+"Hier gibt der von `v.iter()` zurückgegebene Iterator bei jedem eine "
+"`Option<i32>` zurück\n"
+"Aufruf von `next()`. Es gibt `Some(x)` zurück, bis es fertig ist, danach "
+"wird es\n"
+"gibt \"Keine\" zurück. Das `while let` lässt uns alle Elemente durchlaufen."
+
+#: src/control-flow/while-let-expressions.md:27
+#, fuzzy
+msgid ""
+"* Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern.\n"
+"* You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario.\n"
+"    \n"
+"</details>"
+msgstr ""
+"* Weisen Sie darauf hin, dass die „while let“-Schleife so lange läuft, wie "
+"der Wert mit dem Muster übereinstimmt.\n"
+"* Sie könnten die „while let“-Schleife als Endlosschleife mit einer "
+"if-Anweisung umschreiben, die abbricht, wenn es keinen Wert zum Auspacken "
+"für „iter.next()“ gibt. Das `while let` liefert syntaktischen Zucker für das "
+"obige Szenario.\n"
+"    \n"
+"</details>"
+
+#: src/control-flow/for-expressions.md:1
+#, fuzzy
+msgid "# `for` expressions"
+msgstr "# `for`-Ausdrücke"
+
+#: src/control-flow/for-expressions.md:3
+#, fuzzy
+msgid ""
+"The `for` expression is closely related to the `while let` expression. It "
+"will\n"
+"automatically call `into_iter()` on the expression and then iterate over it:"
+msgstr ""
+"Der „for“-Ausdruck ist eng verwandt mit dem „while let“-Ausdruck. Es wird\n"
+"Rufen Sie automatisch `into_iter()` für den Ausdruck auf und iterieren Sie "
+"dann darüber:"
+
+#: src/control-flow/for-expressions.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];"
+msgstr ""
+
+#: src/control-flow/for-expressions.md:10
+msgid ""
+"    for x in v {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"    \n"
+"    for i in (0..10).step_by(2) {\n"
+"        println!(\"i: {i}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/for-expressions.md:20
+#, fuzzy
+msgid "You can use `break` and `continue` here as usual."
+msgstr "Sie können hier wie gewohnt `break` und `continue` verwenden."
+
+#: src/control-flow/for-expressions.md:22
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"* Index iteration is not a special syntax in Rust for just that case.\n"
+"* `(0..10)` is a range that implements an `Iterator` trait. \n"
+"* `step_by` is a method that returns another `Iterator` that skips every "
+"other element. \n"
+"    \n"
+"</details>"
+msgstr ""
+"<Details>\n"
+"    \n"
+"* Index-Iteration ist in Rust keine spezielle Syntax für genau diesen Fall.\n"
+"* „(0..10)“ ist ein Bereich, der ein „Iterator“-Merkmal implementiert.\n"
+"* „step_by“ ist eine Methode, die einen weiteren „Iterator“ zurückgibt, der "
+"jedes andere Element überspringt.\n"
+"    \n"
+"</details>"
+
+#: src/control-flow/loop-expressions.md:1
+#, fuzzy
+msgid "# `loop` expressions"
+msgstr "# `loop`-Ausdrücke"
+
+#: src/control-flow/loop-expressions.md:3
+#, fuzzy
+msgid ""
+"Finally, there is a `loop` keyword which creates an endless loop. Here you "
+"must\n"
+"either `break` or `return` to stop the loop:"
+msgstr ""
+"Schließlich gibt es noch ein „loop“-Schlüsselwort, das eine Endlosschleife "
+"erzeugt. Hier müssen Sie\n"
+"entweder `break` oder `return`, um die Schleife zu stoppen:"
+
+#: src/control-flow/loop-expressions.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut x = 10;\n"
+"    loop {\n"
+"        x = if x % 2 == 0 {\n"
+"            x / 2\n"
+"        } else {\n"
+"            3 * x + 1\n"
+"        };\n"
+"        if x == 1 {\n"
+"            break;\n"
+"        }\n"
+"    }\n"
+"    println!(\"Final x: {x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/match-expressions.md:1
+#, fuzzy
+msgid "# `match` expressions"
+msgstr "# `Match`-Ausdrücke"
+
+#: src/control-flow/match-expressions.md:3
+#, fuzzy
+msgid ""
+"The `match` keyword is used to match a value against one or more patterns. "
+"In\n"
+"that sense, it works like a series of `if let` expressions:"
+msgstr ""
+"Das Schlüsselwort „match“ wird verwendet, um einen Wert mit einem oder "
+"mehreren Mustern abzugleichen. In\n"
+"In diesem Sinne funktioniert es wie eine Reihe von `if let`-Ausdrücken:"
+
+#: src/control-flow/match-expressions.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    match std::env::args().next().as_deref() {\n"
+"        Some(\"cat\") => println!(\"Will do cat things\"),\n"
+"        Some(\"ls\")  => println!(\"Will ls some files\"),\n"
+"        Some(\"mv\")  => println!(\"Let's move some files\"),\n"
+"        Some(\"rm\")  => println!(\"Uh, dangerous!\"),\n"
+"        None        => println!(\"Hmm, no program name?\"),\n"
+"        _           => println!(\"Unknown program name!\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/match-expressions.md:19
+#, fuzzy
+msgid ""
+"Like `if let`, each match arm must have the same type. The type is the last\n"
+"expression of the block, if any. In the example above, the type is `()`."
+msgstr ""
+"Wie bei „if let“ muss jeder Match-Arm denselben Typ haben. Der Typ ist der "
+"letzte\n"
+"Ausdruck des Blocks, falls vorhanden. Im obigen Beispiel ist der Typ `()`."
+
+#: src/control-flow/break-continue.md:1
+#, fuzzy
+msgid "# `break` and `continue`"
+msgstr "# `break` und `continue`"
+
+#: src/control-flow/break-continue.md:3
+#, fuzzy
+msgid ""
+"If you want to exit a loop early, use `break`, if you want to immediately "
+"start\n"
+"the next iteration use `continue`. Both `continue` and `break` can "
+"optionally\n"
+"take a label argument which is used to break out of nested loops:"
+msgstr ""
+"Wenn Sie eine Schleife vorzeitig verlassen möchten, verwenden Sie `break`, "
+"wenn Sie sofort beginnen möchten\n"
+"Verwenden Sie für die nächste Iteration \"Continue\". Sowohl `Continue` als "
+"auch `Break` können optional verwendet werden\n"
+"Nehmen Sie ein Label-Argument, das zum Ausbrechen aus verschachtelten "
+"Schleifen verwendet wird:"
+
+#: src/control-flow/break-continue.md:7
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    let mut iter = v.into_iter();\n"
+"    'outer: while let Some(x) = iter.next() {\n"
+"        println!(\"x: {x}\");\n"
+"        let mut i = 0;\n"
+"        while i < x {\n"
+"            println!(\"x: {x}, i: {i}\");\n"
+"            i += 1;\n"
+"            if i == 3 {\n"
+"                break 'outer;\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/control-flow/break-continue.md:25
+#, fuzzy
+msgid ""
+"In this case we break the outer loop after 3 iterations of the inner loop."
+msgstr ""
+"In diesem Fall brechen wir die äußere Schleife nach 3 Iterationen der "
+"inneren Schleife."
+
+#: src/std.md:1
+#, fuzzy
+msgid "# Standard Library"
+msgstr "# Standardbibliothek"
+
+#: src/std.md:3
+#, fuzzy
+msgid ""
+"Rust comes with a standard library which helps establish a set of common "
+"types\n"
+"used by Rust library and programs. This way, two libraries can work "
+"together\n"
+"smoothly because they both use the same `String` type."
+msgstr ""
+"Rust wird mit einer Standardbibliothek geliefert, die dabei hilft, eine "
+"Reihe gängiger Typen zu erstellen\n"
+"Wird von Rust-Bibliotheken und -Programmen verwendet. Auf diese Weise können "
+"zwei Bibliotheken zusammenarbeiten\n"
+"reibungslos, da beide den gleichen `String`-Typ verwenden."
+
+#: src/std.md:7
+#, fuzzy
+msgid "The common vocabulary types include:"
+msgstr "Zu den gängigen Wortschatztypen gehören:"
+
+#: src/std.md:9
+#, fuzzy
+msgid ""
+"* [`Option` and `Result`](std/option-result.md) types: used for optional "
+"values\n"
+"  and [error handling](error-handling.md)."
+msgstr ""
+"* Typen von [`Option` und `Result`](std/option-result.md): Wird für "
+"optionale Werte verwendet\n"
+"  und [Fehlerbehandlung](error-handling.md)."
+
+#: src/std.md:12
+#, fuzzy
+msgid "* [`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+"* [`String`](std/string.md): der Standard-String-Typ, der für eigene Daten "
+"verwendet wird."
+
+#: src/std.md:14
+#, fuzzy
+msgid "* [`Vec`](std/vec.md): a standard extensible vector."
+msgstr "* [`Vec`](std/vec.md): ein erweiterbarer Standardvektor."
+
+#: src/std.md:16
+#, fuzzy
+msgid ""
+"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
+"  algorithm."
+msgstr ""
+"* [`HashMap`](std/hashmap.md): ein Hash-Map-Typ mit konfigurierbarem "
+"Hashing\n"
+"  Algorithmus."
+
+#: src/std.md:19
+#, fuzzy
+msgid "* [`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr "* [`Box`](std/box.md): ein eigener Zeiger für Heap-zugewiesene Daten."
+
+#: src/std.md:21
+#, fuzzy
+msgid ""
+"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
+msgstr ""
+"* [`Rc`](std/rc.md): ein gemeinsam genutzter referenzgezählter Zeiger für "
+"Heap-zugeordnete Daten."
+
+#: src/std.md:23
+#, fuzzy
+msgid ""
+"<details>\n"
+"  \n"
+"  * In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. \n"
+"  * `core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or\n"
+"    even the presence of an operating system. \n"
+"  * `alloc` includes types which require a global heap allocator, such as "
+"`Vec`, `Box` and `Arc`.\n"
+"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"<Details>\n"
+"  \n"
+"  * Tatsächlich enthält Rust mehrere Schichten der Standardbibliothek: "
+"`core`, `alloc` und `std`.\n"
+"  * `core` enthält die grundlegendsten Typen und Funktionen, die nicht von "
+"`libc`, allocator oder abhängen\n"
+"    sogar das Vorhandensein eines Betriebssystems.\n"
+"  * „alloc“ umfasst Typen, die einen globalen Heap-Zuordner erfordern, wie "
+"etwa „Vec“, „Box“ und „Arc“.\n"
+"  * Eingebettete Rust-Anwendungen verwenden oft nur `core` und manchmal "
+"`alloc`."
+
+#: src/std/option-result.md:1
+#, fuzzy
+msgid "# `Option` and `Result`"
+msgstr "# `Option` und `Ergebnis`"
+
+#: src/std/option-result.md:3
+#, fuzzy
+msgid "The types represent optional data:"
+msgstr "Die Typen stellen optionale Daten dar:"
+
+#: src/std/option-result.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let numbers = vec![10, 20, 30];\n"
+"    let first: Option<&i8> = numbers.first();\n"
+"    println!(\"first: {first:?}\");"
+msgstr ""
+
+#: src/std/option-result.md:11
+msgid ""
+"    let idx: Result<usize, usize> = numbers.binary_search(&10);\n"
+"    println!(\"idx: {idx:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/option-result.md:18
+#, fuzzy
+msgid ""
+"* `Option` and `Result` are widely used not just in the standard library.\n"
+"* `Option<&T>` has zero space overhead compared to `&T`.\n"
+"* `Result` is the standard type to implement error handling as we will see "
+"on Day 3.\n"
+"* `binary_search` returns `Result<usize, usize>`.\n"
+"  * If found, `Result::Ok` holds the index where the element is found.\n"
+"  * Otherwise, `Result::Err` contains the index where such an element should "
+"be inserted."
+msgstr ""
+"* „Option“ und „Ergebnis“ werden nicht nur in der Standardbibliothek häufig "
+"verwendet.\n"
+"* `Option<&T>` hat im Vergleich zu `&T` keinen Speicherplatz-Overhead.\n"
+"* „Ergebnis“ ist der Standardtyp zur Implementierung der Fehlerbehandlung, "
+"wie wir an Tag 3 sehen werden.\n"
+"* `binary_search` gibt `Result<usize, usesize>` zurück.\n"
+"  * Falls gefunden, enthält `Result::Ok` den Index, wo das Element gefunden "
+"wurde.\n"
+"  * Andernfalls enthält `Result::Err` den Index, wo ein solches Element "
+"eingefügt werden soll."
+
+#: src/std/string.md:1
+#, fuzzy
+msgid "# String"
+msgstr "# Zeichenfolge"
+
+#: src/std/string.md:3
+#, fuzzy
+msgid ""
+"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+msgstr ""
+"[`String`][1] ist der Standard-Heap-zugewiesene erweiterbare "
+"UTF-8-String-Puffer:"
+
+#: src/std/string.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::new();\n"
+"    s1.push_str(\"Hello\");\n"
+"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());"
+msgstr ""
+
+#: src/std/string.md:11
+msgid ""
+"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
+"    s2.push_str(&s1);\n"
+"    s2.push('!');\n"
+"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());"
+msgstr ""
+
+#: src/std/string.md:16
+msgid ""
+"    let s3 = String::from(\"🇨🇭\");\n"
+"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
+"             s3.chars().count());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/string.md:22
+#, fuzzy
+msgid ""
+"`String` implements [`Deref<Target = str>`][2], which means that you can "
+"call all\n"
+"`str` methods on a `String`."
+msgstr ""
+"`String` implementiert [`Deref<Target = str>`][2], was bedeutet, dass Sie "
+"alle aufrufen können\n"
+"`str`-Methoden auf einem `String`."
+
+#: src/std/string.md:25
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str"
+
+#: src/std/string.md:30
+#, fuzzy
+msgid ""
+"* `len` returns the size of the `String` in bytes, not its length in "
+"characters.\n"
+"* `chars` returns an iterator over the actual characters.\n"
+"* `String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+"* `len` gibt die Größe des `String` in Bytes zurück, nicht seine Länge in "
+"Zeichen.\n"
+"* `chars` gibt einen Iterator über die eigentlichen Zeichen zurück.\n"
+"* `String` implementiert `Deref<Target = str>`, wodurch es transparent "
+"Zugriff auf die Methoden von `str` erhält."
+
+#: src/std/vec.md:1
+#, fuzzy
+msgid "# `Vec`"
+msgstr "# `Vec`"
+
+#: src/std/vec.md:3
+#, fuzzy
+msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
+msgstr "[`Vec`][1] ist der Standardpuffer mit anpassbarer Heapzuweisung:"
+
+#: src/std/vec.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut v1 = Vec::new();\n"
+"    v1.push(42);\n"
+"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());"
+msgstr ""
+
+#: src/std/vec.md:11
+msgid ""
+"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
+"    v2.extend(v1.iter());\n"
+"    v2.push(9999);\n"
+"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/vec.md:18
+#, fuzzy
+msgid ""
+"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
+"slice\n"
+"methods on a `Vec`."
+msgstr ""
+"`Vec` implementiert [`Deref<Target = [T]>`][2], was bedeutet, dass Sie Slice "
+"aufrufen können\n"
+"Methoden auf einem `Vec`."
+
+#: src/std/vec.md:21
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
+"[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
+
+#: src/std/vec.md:24
+msgid ""
+"<details>\n"
+"    \n"
+"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored\n"
+"  on the heap. This means the amount of data doesn't need to be  known at "
+"compile time. It can grow\n"
+"  or shrink at runtime.\n"
+"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
+"`T` explicitly. As always\n"
+"  with Rust type inference, the `T` was established during the first `push` "
+"call.\n"
+"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial\n"
+"  elements to the vector. \n"
+"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using\n"
+"  `get` will return an `Option`. The `pop` function will remove the last "
+"element.\n"
+"* Show iterating over a vector and mutating the value:\n"
+"  `for e in &mut v { *e += 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1
+#, fuzzy
+msgid "# `HashMap`"
+msgstr "# `HashMap`"
+
+#: src/std/hashmap.md:3
+#, fuzzy
+msgid "Standard hash map with protection against HashDoS attacks:"
+msgstr "Standard-Hash-Map mit Schutz vor HashDoS-Angriffen:"
+
+#: src/std/hashmap.md:5
+msgid "```rust,editable\nuse std::collections::HashMap;"
+msgstr ""
+
+#: src/std/hashmap.md:8
+msgid ""
+"fn main() {\n"
+"    let mut page_counts = HashMap::new();\n"
+"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
+"207);\n"
+"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
+"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);"
+msgstr ""
+
+#: src/std/hashmap.md:14
+msgid ""
+"    if !page_counts.contains_key(\"Les Misérables\") {\n"
+"        println!(\"We've know about {} books, but not Les Misérables.\",\n"
+"                 page_counts.len());\n"
+"    }"
+msgstr ""
+
+#: src/std/hashmap.md:19
+msgid ""
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        match page_counts.get(book) {\n"
+"            Some(count) => println!(\"{book}: {count} pages\"),\n"
+"            None => println!(\"{book} is unknown.\")\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/box.md:1
+#, fuzzy
+msgid "# `Box`"
+msgstr "# `Kasten`"
+
+#: src/std/box.md:3
+#, fuzzy
+msgid "[`Box`][1] is an owned pointer to data on the heap:"
+msgstr "[`Box`][1] ist ein eigener Zeiger auf Daten auf dem Heap:"
+
+#: src/std/box.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let five = Box::new(5);\n"
+"    println!(\"five: {}\", *five);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/box.md:13
+msgid ""
+"```bob\n"
+" Stack                     Heap\n"
+".- - - - - - -.     .- - - - - - -.\n"
+":             :     :             :\n"
+":    five     :     :             :\n"
+":   +-----+   :     :   +-----+   :\n"
+":   | o---|---+-----+-->|  5  |   :\n"
+":   +-----+   :     :   +-----+   :\n"
+":             :     :             :\n"
+":             :     :             :\n"
+"`- - - - - - -'     `- - - - - - -'\n"
+"```"
+msgstr ""
+
+#: src/std/box.md:26
+#, fuzzy
+msgid ""
+"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
+"methods\n"
+"from `T` directly on a `Box<T>`][2]."
+msgstr ""
+"`Box<T>` implementiert `Deref<Target = T>`, was bedeutet, dass Sie [Methoden "
+"aufrufen können\n"
+"von `T` direkt auf eine `Box<T>`][2]."
+
+#: src/std/box.md:29
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion"
+
+#: src/std/box.md:34
+#, fuzzy
+msgid ""
+"* `Box` is like `std::unique_ptr` in C++.\n"
+"* In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`."
+msgstr ""
+"* `Box` ist wie `std::unique_ptr` in C++.\n"
+"* Im obigen Beispiel können Sie dank `Deref` sogar das `*` in der "
+"`println!`-Anweisung weglassen."
+
+#: src/std/box-recursive.md:1
+#, fuzzy
+msgid "# Box with Recursive Data Structures"
+msgstr "# Box mit rekursiven Datenstrukturen"
+
+#: src/std/box-recursive.md:3
+#, fuzzy
+msgid ""
+"Recursive data types or data types with dynamic sizes need to use a `Box`:"
+msgstr ""
+"Rekursive Datentypen oder Datentypen mit dynamischer Größe müssen eine `Box` "
+"verwenden:"
+
+#: src/std/box-recursive.md:5 src/std/box-niche.md:3
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"enum List<T> {\n"
+"    Cons(T, Box<List<T>>),\n"
+"    Nil,\n"
+"}"
+msgstr ""
+
+#: src/std/box-recursive.md:12 src/std/box-niche.md:10
+msgid ""
+"fn main() {\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, "
+"Box::new(List::Nil))));\n"
+"    println!(\"{list:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/std/box-recursive.md:18
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                         :     :                                            "
+"   :\n"
+":    list                 :     :                                            "
+"   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":   | Tag    | Cons  |    :     : .->| Tag    | Cons   | .->| Tag    | Nil  "
+"|   :\n"
+":   | 0      | 1     |    :     : |  | 0      | 2      | |  | ////// | //// "
+"|   :\n"
+":   | 1      | o-----+----+-----+-'  | 1      | o------+-'  | ////// | //// "
+"|   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":                         :     :                                            "
+"   :\n"
+":                         :     :                                            "
+"   :\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
+msgstr ""
+
+#: src/std/box-recursive.md:33
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`,\n"
+"the compiler would not compute a fixed size of the struct in memory, it "
+"would look infinite.\n"
+"    \n"
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next\n"
+"element of the `List` in the heap.    \n"
+"    \n"
+"</details>"
+msgstr ""
+"<Details>\n"
+"    \n"
+"Wenn die `Box` hier nicht verwendet wurde und wir versucht haben, eine "
+"`List` direkt in die `List` einzubetten,\n"
+"Der Compiler würde keine feste Größe der Struktur im Speicher berechnen, es "
+"würde unendlich aussehen.\n"
+"    \n"
+"`Box` löst dieses Problem, da es die gleiche Größe wie ein normaler Zeiger "
+"hat und nur auf den nächsten zeigt\n"
+"Element der `Liste` im Heap.\n"
+"    \n"
+"</details>"
+
+#: src/std/box-niche.md:1
+#, fuzzy
+msgid "# Niche Optimization"
+msgstr "# Nischenoptimierung"
+
+#: src/std/box-niche.md:16
+#, fuzzy
+msgid ""
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
+"This\n"
+"allows the compiler to optimize the memory layout:"
+msgstr ""
+"Eine „Box“ kann nicht leer sein, daher ist der Zeiger immer gültig und nicht "
+"„null“. Das\n"
+"ermöglicht dem Compiler, das Speicherlayout zu optimieren:"
+
+#: src/std/box-niche.md:19
+msgid ""
+"```bob\n"
+" Stack                           Heap\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
+":                         :     :                                            "
+"   :\n"
+":    list                 :     :                                            "
+"   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":   | 0      | 1     |    :     : .->| 0      |  2     | .->| ////// | //// "
+"|   :\n"
+":   | \"1/Tag\"| o-----+----+-----+-'  | \"1/Tag\"|  o-----+-'  | \"1/Tag\"| "
+"null |   :\n"
+":   +--------+-------+    :     :    +--------+--------+    "
+"+--------+------+   :\n"
+":                         :     :                                            "
+"   :\n"
+":                         :     :                                            "
+"   :\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
+"```"
+msgstr ""
+
+#: src/std/rc.md:1
+#, fuzzy
+msgid "# `Rc`"
+msgstr "# `Rc`"
+
+#: src/std/rc.md:3
+#, fuzzy
+msgid ""
+"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
+"refer\n"
+"to the same data from multiple places:"
+msgstr ""
+"[`Rc`][1] ist ein referenzgezählter gemeinsamer Zeiger. Verwenden Sie dies, "
+"wenn Sie verweisen müssen\n"
+"auf dieselben Daten von mehreren Orten:"
+
+#: src/std/rc.md:6
+msgid "```rust,editable\nuse std::rc::Rc;"
+msgstr ""
+
+#: src/std/rc.md:9
+msgid ""
+"fn main() {\n"
+"    let mut a = Rc::new(10);\n"
+"    let mut b = a.clone();"
+msgstr ""
+
+#: src/std/rc.md:18
+#, fuzzy
+msgid ""
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in\n"
+"a type such as [`Cell` or `RefCell`][2]. See [`Arc`][3] if you are in a "
+"multi-threaded\n"
+"context."
+msgstr ""
+"Wenn Sie die Daten innerhalb eines „Rc“ mutieren müssen, müssen Sie die "
+"Daten einschließen\n"
+"ein Typ wie [`Cell` oder `RefCell`][2]. Siehe [`Arc`][3], wenn Sie sich in "
+"einem Multithreading befinden\n"
+"Kontext."
+
+#: src/std/rc.md:22
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[2]: https://doc.rust-lang.org/std/cell/index.html\n"
+"[3]: ../concurrency/shared_state/arc.md"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
+"[2]: https://doc.rust-lang.org/std/cell/index.html\n"
+"[3]: ../concurrency/shared_state/arc.md"
+
+#: src/std/rc.md:28
+#, fuzzy
+msgid ""
+"* Like C++'s `std::shared_ptr`.\n"
+"* `clone` is cheap: creates a pointer to the same allocation and increases "
+"the reference count.\n"
+"* `make_mut` actually clones the inner value if necessary "
+"(\"clone-on-write\") and returns a mutable reference."
+msgstr ""
+"* Wie `std::shared_ptr` von C++.\n"
+"* `clone` ist billig: erstellt einen Zeiger auf die gleiche Zuweisung und "
+"erhöht die Referenzanzahl.\n"
+"* `make_mut` klont bei Bedarf tatsächlich den inneren Wert "
+"(\"clone-on-write\") und gibt eine veränderliche Referenz zurück."
+
+#: src/modules.md:1
+#, fuzzy
+msgid "# Modules"
+msgstr "# Module"
+
+#: src/modules.md:3
+#, fuzzy
+msgid "We have seen how `impl` blocks let us namespace functions to a type."
+msgstr ""
+"Wir haben gesehen, wie `impl`-Blöcke Namensraumfunktionen zu einem Typ "
+"machen."
+
+#: src/modules.md:5
+#, fuzzy
+msgid "Similarly, `mod` lets us namespace types and functions:"
+msgstr "In ähnlicher Weise lässt uns `mod` Namespace-Typen und -Funktionen zu:"
+
+#: src/modules.md:7
+msgid ""
+"```rust,editable\n"
+"mod foo {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the foo module\");\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/modules.md:14
+msgid ""
+"mod bar {\n"
+"    pub fn do_something() {\n"
+"        println!(\"In the bar module\");\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/modules.md:20
+msgid ""
+"fn main() {\n"
+"    foo::do_something();\n"
+"    bar::do_something();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/modules/visibility.md:1
+#, fuzzy
+msgid "# Visibility"
+msgstr "# Sichtbarkeit"
+
+#: src/modules/visibility.md:3
+#, fuzzy
+msgid "Modules are a privacy boundary:"
+msgstr "Module sind eine Datenschutzgrenze:"
+
+#: src/modules/visibility.md:5
+#, fuzzy
+msgid ""
+"* Module items are private by default (hides implementation details).\n"
+"* Parent and sibling items are always visible."
+msgstr ""
+"* Modulelemente sind standardmäßig privat (versteckt "
+"Implementierungsdetails).\n"
+"* Übergeordnete und gleichgeordnete Elemente sind immer sichtbar."
+
+#: src/modules/visibility.md:8
+msgid ""
+"```rust,editable\n"
+"mod outer {\n"
+"    fn private() {\n"
+"        println!(\"outer::private\");\n"
+"    }"
+msgstr ""
+
+#: src/modules/visibility.md:14
+msgid ""
+"    pub fn public() {\n"
+"        println!(\"outer::public\");\n"
+"    }"
+msgstr ""
+
+#: src/modules/visibility.md:18
+msgid ""
+"    mod inner {\n"
+"        fn private() {\n"
+"            println!(\"outer::inner::private\");\n"
+"        }"
+msgstr ""
+
+#: src/modules/visibility.md:23
+msgid ""
+"        pub fn public() {\n"
+"            println!(\"outer::inner::public\");\n"
+"            super::private();\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/modules/visibility.md:30
+msgid ""
+"fn main() {\n"
+"    outer::public();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/modules/paths.md:1
+#, fuzzy
+msgid "# Paths"
+msgstr "# Pfade"
+
+#: src/modules/paths.md:3
+#, fuzzy
+msgid "Paths are resolved as follows:"
+msgstr "Pfade werden wie folgt aufgelöst:"
+
+#: src/modules/paths.md:5
+#, fuzzy
+msgid ""
+"1. As a relative path:\n"
+"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
+"   * `super::foo` refers to `foo` in the parent module."
+msgstr ""
+"1. Als relativer Pfad:\n"
+"   * `foo` oder `self::foo` bezieht sich auf `foo` im aktuellen Modul,\n"
+"   * „super::foo“ bezieht sich auf „foo“ im übergeordneten Modul."
+
+#: src/modules/paths.md:9
+#, fuzzy
+msgid ""
+"2. As an absolute path:\n"
+"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
+"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgstr ""
+"2. Als absoluter Pfad:\n"
+"   * `crate::foo` bezieht sich auf `foo` im Stammverzeichnis der aktuellen "
+"Kiste,\n"
+"   * `bar::foo` bezieht sich auf `foo` in der `bar`-Crate."
+
+#: src/modules/filesystem.md:1
+#, fuzzy
+msgid "# Filesystem Hierarchy"
+msgstr "# Dateisystemhierarchie"
+
+#: src/modules/filesystem.md:3
+#, fuzzy
+msgid "The module content can be omitted:"
+msgstr "Der Modulinhalt kann weggelassen werden:"
+
+#: src/modules/filesystem.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"mod garden;\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:9
+#, fuzzy
+msgid "The `garden` module content is found at:"
+msgstr "Die Inhalte des Moduls „Garten“ finden Sie unter:"
+
+#: src/modules/filesystem.md:11
+#, fuzzy
+msgid ""
+"* `src/garden.rs` (modern Rust 2018 style)\n"
+"* `src/garden/mod.rs` (older Rust 2015 style)"
+msgstr ""
+"* `src/garden.rs` (moderner Rust 2018-Stil)\n"
+"* `src/garden/mod.rs` (älterer Rust 2015-Stil)"
+
+#: src/modules/filesystem.md:14
+#, fuzzy
+msgid "Similarly, a `garden::vegetables` module can be found at:"
+msgstr ""
+"In ähnlicher Weise kann ein `garden::vegetables`-Modul gefunden werden unter:"
+
+#: src/modules/filesystem.md:16
+#, fuzzy
+msgid ""
+"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
+"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr ""
+"* `src/garden/vegetables.rs` (moderner Rust 2018-Stil)\n"
+"* `src/garden/vegetables/mod.rs` (älterer Rust 2015 Stil)"
+
+#: src/modules/filesystem.md:19
+#, fuzzy
+msgid "The `crate` root is in:"
+msgstr "Die „Kiste“-Wurzel befindet sich in:"
+
+#: src/modules/filesystem.md:21
+#, fuzzy
+msgid ""
+"* `src/lib.rs` (for a library crate)\n"
+"* `src/main.rs` (for a binary crate)"
+msgstr ""
+"* `src/lib.rs` (für eine Bibliothekskiste)\n"
+"* `src/main.rs` (für eine Binärkiste)"
+
+#: src/exercises/day-2/afternoon.md:1
+#, fuzzy
+msgid "# Day 2: Afternoon Exercises"
+msgstr "# Tag 2: Nachmittagsübungen"
+
+#: src/exercises/day-2/afternoon.md:3
+#, fuzzy
+msgid "The exercises for this afternoon will focus on strings and iterators."
+msgstr ""
+"Die Übungen für diesen Nachmittag konzentrieren sich auf Strings und "
+"Iteratoren."
+
+#: src/exercises/day-2/luhn.md:1
+#, fuzzy
+msgid "# Luhn Algorithm"
+msgstr "# Luhn-Algorithmus"
+
+#: src/exercises/day-2/luhn.md:3
+#, fuzzy
+msgid ""
+"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
+"to\n"
+"validate credit card numbers. The algorithm takes a string as input and does "
+"the\n"
+"following to validate the credit card number:"
+msgstr ""
+"Dazu dient der "
+"[Luhn-Algorithmus](https://en.wikipedia.org/wiki/Luhn_algorithm).\n"
+"Kreditkartennummern validieren. Der Algorithmus nimmt eine Zeichenfolge als "
+"Eingabe und führt die aus\n"
+"Folgendes, um die Kreditkartennummer zu validieren:"
+
+#: src/exercises/day-2/luhn.md:7
+#, fuzzy
+msgid "* Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+"* Ignoriere alle Leerzeichen. Ablehnungsnummer mit weniger als zwei Ziffern."
+
+#: src/exercises/day-2/luhn.md:9
+#, fuzzy
+msgid ""
+"* Moving from right to left, double every second digit: for the number "
+"`1234`,\n"
+"  we double `3` and `1`."
+msgstr ""
+"* Bewegen Sie sich von rechts nach links, verdoppeln Sie jede zweite Ziffer: "
+"für die Zahl \"1234\",\n"
+"  wir verdoppeln `3` und `1`."
+
+#: src/exercises/day-2/luhn.md:12
+#, fuzzy
+msgid ""
+"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
+"which\n"
+"  becomes `5`."
+msgstr ""
+"* Nachdem Sie eine Ziffer verdoppelt haben, addieren Sie die Ziffern. Das "
+"Verdoppeln von '7' wird also zu '14', was\n"
+"  wird \"5\"."
+
+#: src/exercises/day-2/luhn.md:15
+#, fuzzy
+msgid "* Sum all the undoubled and doubled digits."
+msgstr "* Summiere alle unverdoppelten und verdoppelten Ziffern."
+
+#: src/exercises/day-2/luhn.md:17
+#, fuzzy
+msgid "* The credit card number is valid if the sum ends with `0`."
+msgstr "* Die Kreditkartennummer ist gültig, wenn die Summe mit `0` endet."
+
+#: src/exercises/day-2/luhn.md:19
+#, fuzzy
+msgid ""
+"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"function:"
+msgstr ""
+"Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
+"implementieren Sie die\n"
+"Funktion:"
+
+#: src/exercises/day-2/luhn.md:27
+#, fuzzy
+msgid ""
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    nicht implementiert!()\n"
+"}"
+
+#: src/exercises/day-2/luhn.md:31
+msgid ""
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:36 src/exercises/day-2/solutions-afternoon.md:64
+msgid ""
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:44 src/exercises/day-2/solutions-afternoon.md:72
+msgid ""
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:49 src/exercises/day-2/solutions-afternoon.md:77
+msgid ""
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:54 src/exercises/day-2/solutions-afternoon.md:82
+msgid ""
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:61
+msgid ""
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:1
+#, fuzzy
+msgid "# Strings and Iterators"
+msgstr "# Strings und Iteratoren"
+
+#: src/exercises/day-2/strings-iterators.md:3
+#, fuzzy
+msgid ""
+"In this exercise, you are implementing a routing component of a web server. "
+"The\n"
+"server is configured with a number of _path prefixes_ which are matched "
+"against\n"
+"_request paths_. The path prefixes can contain a wildcard character which\n"
+"matches a full segment. See the unit tests below."
+msgstr ""
+"In dieser Übung implementieren Sie eine Routing-Komponente eines Webservers. "
+"Der\n"
+"Der Server ist mit einer Reihe von _Pfadpräfixen_ konfiguriert, die "
+"abgeglichen werden\n"
+"_Anfragepfade_. Die Pfadpräfixe können ein Platzhalterzeichen enthalten, "
+"das\n"
+"entspricht einem vollständigen Segment. Siehe die Unit-Tests unten."
+
+#: src/exercises/day-2/strings-iterators.md:8
+#, fuzzy
+msgid ""
+"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"pass. Try avoiding allocating a `Vec` for your intermediate results:"
+msgstr ""
+"Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
+"führen Sie die Tests durch\n"
+"passieren. Versuchen Sie, Ihren Zwischenergebnissen kein „Vec“ zuzuweisen:"
+
+#: src/exercises/day-2/strings-iterators.md:16
+#, fuzzy
+msgid ""
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    unimplemented!()\n"
+"}"
+msgstr ""
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    nicht implementiert!()\n"
+"}"
+
+#: src/exercises/day-2/strings-iterators.md:20
+msgid ""
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));"
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/solutions-afternoon.md:146
+msgid ""
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", "
+"\"/v1/parent/publishers\"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:31
+#: src/exercises/day-2/solutions-afternoon.md:151
+msgid ""
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));"
+msgstr ""
+
+#: src/exercises/day-2/strings-iterators.md:46
+msgid ""
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/welcome-day-3.md:1
+#, fuzzy
+msgid "# Welcome to Day 3"
+msgstr "# Willkommen zu Tag 3"
+
+#: src/welcome-day-3.md:3
+#, fuzzy
+msgid "Today, we will cover some more advanced topics of Rust:"
+msgstr "Heute werden wir einige fortgeschrittenere Themen von Rust behandeln:"
+
+#: src/welcome-day-3.md:5
+#, fuzzy
+msgid ""
+"* Traits: deriving traits, default methods, and important standard library\n"
+"  traits."
+msgstr ""
+"* Merkmale: Ableitung von Merkmalen, Standardmethoden und wichtige "
+"Standardbibliothek\n"
+"  Züge."
+
+#: src/welcome-day-3.md:8
+#, fuzzy
+msgid ""
+"* Generics: generic data types, generic methods, monomorphization, and "
+"trait\n"
+"  objects."
+msgstr ""
+"* Generics: generische Datentypen, generische Methoden, Monomorphisierung "
+"und Eigenschaften\n"
+"  Objekte."
+
+#: src/welcome-day-3.md:11
+#, fuzzy
+msgid "* Error handling: panics, `Result`, and the try operator `?`."
+msgstr "* Fehlerbehandlung: Panics, `Result` und der Try-Operator `?`."
+
+#: src/welcome-day-3.md:13
+#, fuzzy
+msgid "* Testing: unit tests, documentation tests, and integration tests."
+msgstr "* Testen: Einheitentests, Dokumentationstests und Integrationstests."
+
+#: src/welcome-day-3.md:15
+#, fuzzy
+msgid ""
+"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
+"  functions."
+msgstr ""
+"* Unsicherer Rost: rohe Zeiger, statische Variablen, unsichere Funktionen "
+"und extern\n"
+"  Funktionen."
+
+#: src/traits.md:1
+#, fuzzy
+msgid "# Traits"
+msgstr "# Züge"
+
+#: src/traits.md:3
+#, fuzzy
+msgid ""
+"Rust lets you abstract over types with traits. They're similar to interfaces:"
+msgstr ""
+"Mit Rust können Sie über Typen mit Merkmalen abstrahieren. Sie ähneln "
+"Schnittstellen:"
+
+#: src/traits.md:5
+msgid ""
+"```rust,editable\n"
+"trait Greet {\n"
+"    fn say_hello(&self);\n"
+"}"
+msgstr ""
+
+#: src/traits.md:10
+#, fuzzy
+msgid ""
+"struct Dog {\n"
+"    name: String,\n"
+"}"
+msgstr ""
+"struct Hund {\n"
+"    Name: Zeichenfolge,\n"
+"}"
+
+#: src/traits.md:14
+msgid "struct Cat;  // No name, cats won't respond to it anyway."
+msgstr ""
+
+#: src/traits.md:16
+msgid ""
+"impl Greet for Dog {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Wuf, my name is {}!\", self.name);\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/traits.md:22
+msgid ""
+"impl Greet for Cat {\n"
+"    fn say_hello(&self) {\n"
+"        println!(\"Miau!\");\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/traits.md:28
+msgid ""
+"fn main() {\n"
+"    let pets: Vec<Box<dyn Greet>> = vec![\n"
+"        Box::new(Dog { name: String::from(\"Fido\") }),\n"
+"        Box::new(Cat),\n"
+"    ];\n"
+"    for pet in pets {\n"
+"        pet.say_hello();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits.md:41
+#, fuzzy
+msgid ""
+"* Traits may specify pre-implemented (default) methods and methods that "
+"users are required to implement themselves. Methods with default "
+"implementations can rely on required methods.\n"
+"* Types that implement a given trait may be of different sizes. This makes "
+"it impossible to have things like `Vec<Greet>` in the example above.\n"
+"* `dyn Greet` is a way to tell the compiler about a dynamically sized type "
+"that implements `Greet`.\n"
+"* In the example, `pets` holds Fat Pointers to objects that implement "
+"`Greet`. The Fat Pointer consists of two components, a pointer to the actual "
+"object and a pointer to the virtual method table for the `Greet` "
+"implementation of that particular object."
+msgstr ""
+"* Merkmale können vorimplementierte (Standard-)Methoden und Methoden "
+"spezifizieren, die Benutzer selbst implementieren müssen. Methoden mit "
+"Standardimplementierungen können sich auf erforderliche Methoden stützen.\n"
+"* Typen, die ein bestimmtes Merkmal implementieren, können unterschiedlich "
+"groß sein. Das macht es unmöglich Dinge wie `Vec<Greet>` im obigen Beispiel "
+"zu haben.\n"
+"* „dyn Greet“ ist eine Möglichkeit, dem Compiler einen Typ mit dynamischer "
+"Größe mitzuteilen, der „Greet“ implementiert.\n"
+"* Im Beispiel enthält `pets` Fat Pointer auf Objekte, die `Greet` "
+"implementieren. Der Fat Pointer besteht aus zwei Komponenten, einem Zeiger "
+"auf das tatsächliche Objekt und einem Zeiger auf die virtuelle "
+"Methodentabelle für die \"Greet\"-Implementierung dieses bestimmten Objekts."
+
+#: src/traits.md:46
+msgid ""
+"Compare these outputs in the above example:\n"
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), "
+"std::mem::size_of::<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), "
+"std::mem::size_of::<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
+"```"
+msgstr ""
+
+#: src/traits/deriving-traits.md:1
+#, fuzzy
+msgid "# Deriving Traits"
+msgstr "# Ableitung von Merkmalen"
+
+#: src/traits/deriving-traits.md:3
+#, fuzzy
+msgid "You can let the compiler derive a number of traits:"
+msgstr "Sie können den Compiler eine Reihe von Merkmalen ableiten lassen:"
+
+#: src/traits/deriving-traits.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Clone, PartialEq, Eq, Default)]\n"
+"struct Player {\n"
+"    name: String,\n"
+"    strength: u8,\n"
+"    hit_points: u8,\n"
+"}"
+msgstr ""
+
+#: src/traits/deriving-traits.md:13
+msgid ""
+"fn main() {\n"
+"    let p1 = Player::default();\n"
+"    let p2 = p1.clone();\n"
+"    println!(\"Is {:?}\\n"
+"equal to {:?}?\\n"
+"The answer is {}!\", &p1, &p2,\n"
+"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:1
+#, fuzzy
+msgid "# Default Methods"
+msgstr "# Standardmethoden"
+
+#: src/traits/default-methods.md:3
+#, fuzzy
+msgid "Traits can implement behavior in terms of other trait methods:"
+msgstr "Traits können Verhalten im Sinne anderer Trait-Methoden implementieren:"
+
+#: src/traits/default-methods.md:5
+msgid ""
+"```rust,editable\n"
+"trait Equals {\n"
+"    fn equal(&self, other: &Self) -> bool;\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/traits/default-methods.md:13
+msgid "#[derive(Debug)]\nstruct Centimeter(i16);"
+msgstr ""
+
+#: src/traits/default-methods.md:16
+#, fuzzy
+msgid ""
+"impl Equals for Centimeter {\n"
+"    fn equal(&self, other: &Centimeter) -> bool {\n"
+"        self.0 == other.0\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Gleich für Zentimeter {\n"
+"    fn gleich(&selbst, andere: &Zentimeter) -> bool {\n"
+"        self.0 == andere.0\n"
+"    }\n"
+"}"
+
+#: src/traits/default-methods.md:22
+msgid ""
+"fn main() {\n"
+"    let a = Centimeter(10);\n"
+"    let b = Centimeter(20);\n"
+"    println!(\"{a:?} equals {b:?}: {}\", a.equal(&b));\n"
+"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equal(&b));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/important-traits.md:1
+#, fuzzy
+msgid "# Important Traits"
+msgstr "# Wichtige Eigenschaften"
+
+#: src/traits/important-traits.md:3
+#, fuzzy
+msgid ""
+"We will now look at some of the most common traits of the Rust standard "
+"library:"
+msgstr ""
+"Wir werden uns nun einige der häufigsten Merkmale der "
+"Rust-Standardbibliothek ansehen:"
+
+#: src/traits/important-traits.md:5
+#, fuzzy
+msgid ""
+"* `Iterator` and `IntoIterator` used in `for` loops,\n"
+"* `From` and `Into` used to convert values,\n"
+"* `Read` and `Write` used for IO,\n"
+"* `Add`, `Mul`, ... used for operator overloading, and\n"
+"* `Drop` used for defining destructors."
+msgstr ""
+"* `Iterator` und `IntoIterator` werden in `for`-Schleifen verwendet,\n"
+"* `From` und `Into` werden verwendet, um Werte zu konvertieren,\n"
+"* `Lesen` und `Schreiben` für IO verwendet,\n"
+"* `Add`, `Mul`, ... wird zum Überladen von Operatoren verwendet, und\n"
+"* `Drop` wird zum Definieren von Destruktoren verwendet."
+
+#: src/traits/iterator.md:1
+#, fuzzy
+msgid "# Iterators"
+msgstr "# Iteratoren"
+
+#: src/traits/iterator.md:3
+#, fuzzy
+msgid "You can implement the `Iterator` trait on your own types:"
+msgstr "Sie können das `Iterator`-Merkmal für Ihre eigenen Typen implementieren:"
+
+#: src/traits/iterator.md:5
+msgid ""
+"```rust,editable\n"
+"struct Fibonacci {\n"
+"    curr: u32,\n"
+"    next: u32,\n"
+"}"
+msgstr ""
+
+#: src/traits/iterator.md:11
+msgid "impl Iterator for Fibonacci {\n    type Item = u32;"
+msgstr ""
+
+#: src/traits/iterator.md:14
+msgid ""
+"    fn next(&mut self) -> Option<Self::Item> {\n"
+"        let new_next = self.curr + self.next;\n"
+"        self.curr = self.next;\n"
+"        self.next = new_next;\n"
+"        Some(self.curr)\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/traits/iterator.md:22
+msgid ""
+"fn main() {\n"
+"    let fib = Fibonacci { curr: 0, next: 1 };\n"
+"    for (i, n) in fib.enumerate().take(5) {\n"
+"        println!(\"fib({i}): {n}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/iterator.md:32
+#, fuzzy
+msgid ""
+"* `IntoIterator` is the trait that makes for loops work. It is implemented "
+"by collection types such as\n"
+"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
+"implement it.\n"
+"* The `Iterator` trait implements many common functional programming "
+"operations over collections \n"
+"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
+"find all the documentation\n"
+"  about them. In Rust these functions should produce the code as efficient "
+"as equivalent imperative\n"
+"  implementations.\n"
+"    \n"
+"</details>"
+msgstr ""
+"* `IntoIterator` ist die Eigenschaft, die dafür sorgt, dass for-Schleifen "
+"funktionieren. Es wird durch Sammlungstypen wie implementiert\n"
+"  `Vec<T>` und Verweise darauf wie `&Vec<T>` und `&[T]`. Ranges "
+"implementieren es auch.\n"
+"* Die Eigenschaft „Iterator“ implementiert viele gängige funktionale "
+"Programmieroperationen über Sammlungen\n"
+"  (z. B. `map`, `filter`, `reduce`, etc). Dies ist die Eigenschaft, in der "
+"Sie die gesamte Dokumentation finden können\n"
+"  über sie. In Rust sollten diese Funktionen den Code so effizient wie "
+"gleichwertig erzeugen\n"
+"  Implementierungen.\n"
+"    \n"
+"</Details>"
+
+#: src/traits/from-iterator.md:1
+#, fuzzy
+msgid "# FromIterator"
+msgstr "# FromIterator"
+
+#: src/traits/from-iterator.md:3
+#, fuzzy
+msgid "`FromIterator` lets you build a collection from an `Iterator`."
+msgstr ""
+"Mit „FromIterator“ können Sie eine Sammlung aus einem „Iterator“ erstellen."
+
+#: src/traits/from-iterator.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let primes = vec![2, 3, 5, 7];\n"
+"    let prime_squares = primes.into_iter().map(|prime| prime * "
+"prime).collect::<Vec<_>>();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/from-iterator.md:14
+#, fuzzy
+msgid ""
+"`Iterator` implements\n"
+"`fn collect<B>(self) -> B\n"
+"where\n"
+"    B: FromIterator<Self::Item>,\n"
+"    Self: Sized`"
+msgstr ""
+"`Iterator`-Implementierungen\n"
+"`fn collect<B>(selbst) -> B\n"
+"Wo\n"
+"    B: FromIterator<Self::Item>,\n"
+"    Selbst: Sized'"
+
+#: src/traits/from-iterator.md:20
+#, fuzzy
+msgid ""
+"There are also implementations which let you do cool things like convert an\n"
+"`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
+msgstr ""
+"Es gibt auch Implementierungen, mit denen Sie coole Dinge tun können, wie z\n"
+"`Iterator<Item = Result<V, E>>` in ein `Result<Vec<V>, E>`."
+
+#: src/traits/from-into.md:1
+#, fuzzy
+msgid "# `From` and `Into`"
+msgstr "# `Von` und `Nach`"
+
+#: src/traits/from-into.md:3
+#, fuzzy
+msgid "Types implement `From` and `Into` to facilitate type conversions:"
+msgstr ""
+"Typen implementieren „From“ und „Into“, um Typkonvertierungen zu erleichtern:"
+
+#: src/traits/from-into.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s = String::from(\"hello\");\n"
+"    let addr = std::net::Ipv4Addr::from([127, 0, 0, 1]);\n"
+"    let one = i16::from(true);\n"
+"    let bigger = i32::from(123i16);\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/from-into.md:15
+#, fuzzy
+msgid "`Into` is automatically implemented when `From` is implemented:"
+msgstr "„Into“ wird automatisch implementiert, wenn „From“ implementiert wird:"
+
+#: src/traits/from-into.md:17
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let s: String = \"hello\".into();\n"
+"    let addr: std::net::Ipv4Addr = [127, 0, 0, 1].into();\n"
+"    let one: i16 = true.into();\n"
+"    let bigger: i32 = 123i16.into();\n"
+"    println!(\"{s}, {addr}, {one}, {bigger}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/from-into.md:27
+#, fuzzy
+msgid ""
+"<details>\n"
+"  \n"
+"* That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too.\n"
+"* When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
+"  Your function will accept types that implement `From` and those that "
+"_only_ implement `Into`.\n"
+"    \n"
+"</details>"
+msgstr ""
+"<Details>\n"
+"  \n"
+"* Aus diesem Grund ist es üblich, nur `From` zu implementieren, da Ihr Typ "
+"auch die `Into`-Implementierung erhält.\n"
+"* Beim Deklarieren eines Funktionsargument-Eingabetyps wie „alles, was in "
+"einen „String“ konvertiert werden kann“, ist die Regel umgekehrt, Sie "
+"sollten „Into“ verwenden.\n"
+"  Ihre Funktion akzeptiert Typen, die `From` implementieren, und solche, die "
+"_nur_ `Into` implementieren.\n"
+"    \n"
+"</Details>"
+
+#: src/traits/read-write.md:1
+#, fuzzy
+msgid "# `Read` and `Write`"
+msgstr "# `Lesen` und `Schreiben`"
+
+#: src/traits/read-write.md:3
+#, fuzzy
+msgid "Using `Read` and `BufRead`, you can abstract over `u8` sources:"
+msgstr "Mit `Read` und `BufRead` können Sie über `u8`-Quellen abstrahieren:"
+
+#: src/traits/read-write.md:5
+msgid "```rust,editable\nuse std::io::{BufRead, BufReader, Read, Result};"
+msgstr ""
+
+#: src/traits/read-write.md:8
+msgid ""
+"fn count_lines<R: Read>(reader: R) -> usize {\n"
+"    let buf_reader = BufReader::new(reader);\n"
+"    buf_reader.lines().count()\n"
+"}"
+msgstr ""
+
+#: src/traits/read-write.md:13
+msgid ""
+"fn main() -> Result<()> {\n"
+"    let slice: &[u8] = b\"foo\\n"
+"bar\\n"
+"baz\\n"
+"\";\n"
+"    println!(\"lines in slice: {}\", count_lines(slice));"
+msgstr ""
+
+#: src/traits/read-write.md:17
+msgid ""
+"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
+"    println!(\"lines in file: {}\", count_lines(file));\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/read-write.md:23
+#, fuzzy
+msgid "Similarly, `Write` lets you abstract over `u8` sinks:"
+msgstr ""
+"In ähnlicher Weise können Sie mit \"Write\" über \"u8\"-Senken abstrahieren:"
+
+#: src/traits/read-write.md:25
+msgid "```rust,editable\nuse std::io::{Result, Write};"
+msgstr ""
+
+#: src/traits/read-write.md:28
+msgid ""
+"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
+"    writer.write_all(msg.as_bytes())?;\n"
+"    writer.write_all(\"\\n"
+"\".as_bytes())\n"
+"}"
+msgstr ""
+
+#: src/traits/read-write.md:33
+msgid ""
+"fn main() -> Result<()> {\n"
+"    let mut buffer = Vec::new();\n"
+"    log(&mut buffer, \"Hello\")?;\n"
+"    log(&mut buffer, \"World\")?;\n"
+"    println!(\"Logged: {:?}\", buffer);\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/operators.md:1
+#, fuzzy
+msgid "# `Add`, `Mul`, ..."
+msgstr "# `Hinzufügen`, `Mul`, ..."
+
+#: src/traits/operators.md:3
+#, fuzzy
+msgid "Operator overloading is implemented via traits in `std::ops`:"
+msgstr ""
+"Das Überladen von Operatoren wird über Traits in `std::ops` implementiert:"
+
+#: src/traits/operators.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug, Copy, Clone)]\n"
+"struct Point { x: i32, y: i32 }"
+msgstr ""
+
+#: src/traits/operators.md:9 src/exercises/day-2/solutions-morning.md:46
+msgid "impl std::ops::Add for Point {\n    type Output = Self;"
+msgstr ""
+
+#: src/traits/operators.md:12
+#, fuzzy
+msgid ""
+"    fn add(self, other: Self) -> Self {\n"
+"        Self {x: self.x + other.x, y: self.y + other.y}\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn add(self, other: Self) -> Self {\n"
+"        Selbst {x: selbst.x + andere.x, y: selbst.y + andere.y}\n"
+"    }\n"
+"}"
+
+#: src/traits/operators.md:17
+msgid ""
+"fn main() {\n"
+"    let p1 = Point { x: 10, y: 20 };\n"
+"    let p2 = Point { x: 100, y: 200 };\n"
+"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/operators.md:26 src/traits/drop.md:34
+#, fuzzy
+msgid "Discussion points:"
+msgstr "Diskussionspunkte:"
+
+#: src/traits/operators.md:28
+#, fuzzy
+msgid ""
+"* You could implement `Add` for `&Point`. In which situations is that "
+"useful? \n"
+"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
+"        overloading the operator is not `Copy`, you should consider "
+"overloading\n"
+"        the operator for `&T` as well. This avoids unnecessary cloning on "
+"the\n"
+"        call site.\n"
+"* Why is `Output` an associated type? Could it be made a type parameter?\n"
+"    * Short answer: Type parameters are controlled by the caller, but\n"
+"        associated types (like `Output`) are controlled by the implementor "
+"of a\n"
+"        trait."
+msgstr ""
+"* Sie könnten `Add` für `&Point` implementieren. In welchen Situationen ist "
+"das sinnvoll?\n"
+"    * Antwort: `Add:add` verbraucht `self`. Geben Sie \"T\" ein, für das Sie "
+"sind\n"
+"        Das Überladen des Operators ist nicht \"Kopieren\", Sie sollten das "
+"Überladen in Betracht ziehen\n"
+"        auch der Operator für `&T`. Dies vermeidet unnötiges Klonen auf der\n"
+"        Website aufrufen.\n"
+"* Warum ist `Output` ein assoziierter Typ? Könnte es ein Typparameter "
+"gemacht werden?\n"
+"    * Kurze Antwort: Typparameter werden vom Aufrufer gesteuert, aber\n"
+"        Zugehörige Typen (wie `Output`) werden vom Implementierer von a "
+"gesteuert\n"
+"        Merkmal."
+
+#: src/traits/drop.md:1
+#, fuzzy
+msgid "# The `Drop` Trait"
+msgstr "# Die `Drop`-Eigenschaft"
+
+#: src/traits/drop.md:3
+#, fuzzy
+msgid ""
+"Values which implement `Drop` can specify code to run when they go out of "
+"scope:"
+msgstr ""
+"Werte, die \"Drop\" implementieren, können Code angeben, der ausgeführt "
+"werden soll, wenn sie den Gültigkeitsbereich verlassen:"
+
+#: src/traits/drop.md:5
+msgid ""
+"```rust,editable\n"
+"struct Droppable {\n"
+"    name: &'static str,\n"
+"}"
+msgstr ""
+
+#: src/traits/drop.md:10
+msgid ""
+"impl Drop for Droppable {\n"
+"    fn drop(&mut self) {\n"
+"        println!(\"Dropping {}\", self.name);\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/traits/drop.md:16
+msgid ""
+"fn main() {\n"
+"    let a = Droppable { name: \"a\" };\n"
+"    {\n"
+"        let b = Droppable { name: \"b\" };\n"
+"        {\n"
+"            let c = Droppable { name: \"c\" };\n"
+"            let d = Droppable { name: \"d\" };\n"
+"            println!(\"Exiting block B\");\n"
+"        }\n"
+"        println!(\"Exiting block A\");\n"
+"    }\n"
+"    drop(a);\n"
+"    println!(\"Exiting main\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/drop.md:36
+#, fuzzy
+msgid ""
+"* Why does not `Drop::drop` take `self`?\n"
+"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
+"of\n"
+"        the block, resulting in another call to `Drop::drop`, and a stack\n"
+"        overflow!\n"
+"* Try replacing `drop(a)` with `a.drop()`."
+msgstr ""
+"* Warum nimmt `Drop::drop` nicht `self`?\n"
+"    * Kurzantwort: Wenn ja, würde `std::mem::drop` am Ende von aufgerufen "
+"werden\n"
+"        den Block, was zu einem weiteren Aufruf von `Drop::drop` und einem "
+"Stack führt\n"
+"        Überlauf!\n"
+"* Versuchen Sie, `drop(a)` durch `a.drop()` zu ersetzen."
+
+#: src/generics.md:1
+#, fuzzy
+msgid "# Generics"
+msgstr "# Generika"
+
+#: src/generics.md:3
+#, fuzzy
+msgid ""
+"Rust support generics, which lets you abstract an algorithm (such as "
+"sorting)\n"
+"over the types used in the algorithm."
+msgstr ""
+"Rust unterstützt Generika, mit denen Sie einen Algorithmus abstrahieren "
+"können (z. B. Sortieren)\n"
+"über die im Algorithmus verwendeten Typen."
+
+#: src/generics/data-types.md:1
+#, fuzzy
+msgid "# Generic Data Types"
+msgstr "# Generische Datentypen"
+
+#: src/generics/data-types.md:3
+#, fuzzy
+msgid "You can use generics to abstract over the concrete field type:"
+msgstr "Mit Generika können Sie über den konkreten Feldtyp abstrahieren:"
+
+#: src/generics/data-types.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T> {\n"
+"    x: T,\n"
+"    y: T,\n"
+"}"
+msgstr ""
+
+#: src/generics/data-types.md:12
+msgid ""
+"fn main() {\n"
+"    let integer = Point { x: 5, y: 10 };\n"
+"    let float = Point { x: 1.0, y: 4.0 };\n"
+"    println!(\"{integer:?} and {float:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/methods.md:1
+#, fuzzy
+msgid "# Generic Methods"
+msgstr "# Generische Methoden"
+
+#: src/generics/methods.md:3
+#, fuzzy
+msgid "You can declare a generic type on your `impl` block:"
+msgstr "Sie können einen generischen Typ in Ihrem `impl`-Block deklarieren:"
+
+#: src/generics/methods.md:5
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point<T>(T, T);"
+msgstr ""
+
+#: src/generics/methods.md:9
+#, fuzzy
+msgid ""
+"impl<T> Point<T> {\n"
+"    fn x(&self) -> &T {\n"
+"        &self.0  // + 10\n"
+"    }"
+msgstr ""
+"imple<T> Punkt<T> {\n"
+"    fn x(&selbst) -> &T {\n"
+"        &self.0 // + 10\n"
+"    }"
+
+#: src/generics/methods.md:14
+#, fuzzy
+msgid "    // fn set_x(&mut self, x: T)\n}"
+msgstr "    // fn set_x(&mut selbst, x: T)\n}"
+
+#: src/generics/methods.md:17
+msgid ""
+"fn main() {\n"
+"    let p = Point(5, 10);\n"
+"    println!(\"p.x = {}\", p.x());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/methods.md:25
+#, fuzzy
+msgid ""
+"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?\n"
+"    * This is because it is a generic implementation section for generic "
+"type. They are independently generic.\n"
+"    * It means these methods are defined for any `T`.\n"
+"    * It is possible to write `impl Point<u32> { .. }`. \n"
+"      * `Point` is still generic and you can use `Point<f64>`, but methods "
+"in this block will only be available for `Point<u32>`."
+msgstr ""
+"* *F:* Warum wird `T` zweimal in `impl<T> Point<T> {}` angegeben? Ist das "
+"nicht überflüssig?\n"
+"    * Dies liegt daran, dass es sich um einen generischen "
+"Implementierungsabschnitt für einen generischen Typ handelt. Sie sind "
+"unabhängig generisch.\n"
+"    * Dies bedeutet, dass diese Methoden für jedes `T` definiert sind.\n"
+"    * Es ist möglich `impl Point<u32> { .. }` zu schreiben.\n"
+"      * „Point“ ist immer noch generisch und Sie können „Point<f64>“ "
+"verwenden, aber Methoden in diesem Block sind nur für „Point<u32>“ verfügbar."
+
+#: src/generics/trait-bounds.md:1
+#, fuzzy
+msgid "# Trait Bounds"
+msgstr "# Eigenschaftsgrenzen"
+
+#: src/generics/trait-bounds.md:3
+#, fuzzy
+msgid ""
+"When working with generics, you often want to limit the types. You can do "
+"this\n"
+"with `T: Trait` or `impl Trait`:"
+msgstr ""
+"Wenn Sie mit Generika arbeiten, möchten Sie häufig die Typen einschränken. "
+"Du kannst das\n"
+"mit `T:Trait` oder `impl Trait`:"
+
+#: src/generics/trait-bounds.md:6
+msgid ""
+"```rust,editable\n"
+"fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
+"    (a.clone(), a.clone())\n"
+"}"
+msgstr ""
+
+#: src/generics/trait-bounds.md:11
+msgid "// struct NotClonable;"
+msgstr ""
+
+#: src/generics/trait-bounds.md:13
+msgid ""
+"fn main() {\n"
+"    let foo = String::from(\"foo\");\n"
+"    let pair = duplicate(foo);\n"
+"    println!(\"{pair:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/trait-bounds.md:22
+msgid ""
+"Show a `where` clause, students will encounter it when reading code.\n"
+"    \n"
+"```rust,ignore\n"
+"fn duplicate<T>(a: T) -> (T, T)\n"
+"where\n"
+"    T: Clone,\n"
+"{\n"
+"    (a.clone(), a.clone())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/trait-bounds.md:33
+#, fuzzy
+msgid ""
+"* It declutters the function signature if you have many parameters.\n"
+"* It has additional features making it more powerful.\n"
+"    * If someone asks, the extra feature is that the type on the left of "
+"\":\" can be arbitrary, like `Option<T>`.\n"
+"    \n"
+"</details>"
+msgstr ""
+"* Es entrümpelt die Funktionssignatur, wenn Sie viele Parameter haben.\n"
+"* Es hat zusätzliche Funktionen, die es leistungsfähiger machen.\n"
+"    * Wenn jemand fragt, das zusätzliche Feature ist, dass der Typ links von "
+"\":\" beliebig sein kann, wie `Option<T>`.\n"
+"    \n"
+"</Details>"
+
+#: src/generics/impl-trait.md:1
+#, fuzzy
+msgid "# `impl Trait`"
+msgstr "# `imple Merkmal`"
+
+#: src/generics/impl-trait.md:3
+#, fuzzy
+msgid ""
+"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"arguments and return values:"
+msgstr ""
+"Ähnlich wie Merkmalsgrenzen kann eine \"impl Trait\"-Syntax in Funktion "
+"verwendet werden\n"
+"Argumente und Rückgabewerte:"
+
+#: src/generics/impl-trait.md:6 src/generics/trait-objects.md:5
+#: src/generics/trait-objects.md:28
+msgid "```rust,editable\nuse std::fmt::Display;"
+msgstr ""
+
+#: src/generics/impl-trait.md:9
+#, fuzzy
+msgid ""
+"fn get_x(name: impl Display) -> impl Display {\n"
+"    format!(\"Hello {name}\")\n"
+"}"
+msgstr ""
+"fn get_x(name: impl Display) -> impl Display {\n"
+"    format!(\"Hallo {Name}\")\n"
+"}"
+
+#: src/generics/impl-trait.md:13
+msgid ""
+"fn main() {\n"
+"    let x = get_x(\"foo\");\n"
+"    println!(\"{x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/impl-trait.md:19
+#, fuzzy
+msgid ""
+"* `impl Trait` cannot be used with the `::<>` turbo fish syntax.\n"
+"* `impl Trait` allows you to work with types which you cannot name."
+msgstr ""
+"* `impl Trait` kann nicht mit der `::<>` Turbofish-Syntax verwendet werden.\n"
+"* `impl Trait` ermöglicht es Ihnen, mit Typen zu arbeiten, die Sie nicht "
+"benennen können."
+
+#: src/generics/impl-trait.md:24
+#, fuzzy
+msgid ""
+"The meaning of `impl Trait` is a bit different in the different positions."
+msgstr ""
+"Die Bedeutung von „impl Trait“ ist in den verschiedenen Positionen etwas "
+"unterschiedlich."
+
+#: src/generics/impl-trait.md:26
+#, fuzzy
+msgid ""
+"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
+"a trait bound.\n"
+"* For a return type, it means that the return type is some concrete type "
+"that implements the trait,\n"
+"  without naming the type. This can be useful when you don't want to expose "
+"the concrete type in a\n"
+"  public API."
+msgstr ""
+"* Für einen Parameter ist `impl Trait` wie ein anonymer generischer "
+"Parameter mit einer Eigenschaftsbindung.\n"
+"* Für einen Rückgabetyp bedeutet dies, dass der Rückgabetyp ein konkreter "
+"Typ ist, der die Eigenschaft implementiert,\n"
+"  ohne den Typ zu nennen. Dies kann nützlich sein, wenn Sie den konkreten "
+"Typ in a nicht verfügbar machen möchten\n"
+"  öffentliche API."
+
+#: src/generics/impl-trait.md:31
+#, fuzzy
+msgid ""
+"This example is great, because it uses `impl Display` twice. It helps to "
+"explain that\n"
+"nothing here enforces that it is _the same_ `impl Display` type. If we used "
+"a single \n"
+"`T: Display`, it would enforce the constraint that input `T` and return `T` "
+"type are the same type.\n"
+"It would not work for this particular function, as the type we expect as "
+"input is likely not\n"
+"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
+"we'd need two\n"
+"independent generic parameters.\n"
+"    \n"
+"</details>"
+msgstr ""
+"Dieses Beispiel ist großartig, weil es `impl Display` zweimal verwendet. Es "
+"hilft, das zu erklären\n"
+"nichts hier erzwingt, dass es _derselbe_ `impl Display`-Typ ist. Wenn wir "
+"eine Single benutzten\n"
+"`T: Display`, es würde die Einschränkung erzwingen, dass der Eingabe-`T`- "
+"und der Rückgabe-`T-Typ derselbe Typ sind.\n"
+"Es würde für diese spezielle Funktion nicht funktionieren, da der Typ, den "
+"wir als Eingabe erwarten, wahrscheinlich nicht der Fall ist\n"
+"welches `format!` zurückgibt. Wenn wir dasselbe über die `: Display`-Syntax "
+"machen wollten, bräuchten wir zwei\n"
+"unabhängige generische Parameter.\n"
+"    \n"
+"</details>"
+
+#: src/generics/closures.md:1
+#, fuzzy
+msgid "# Closures"
+msgstr "# Schließungen"
+
+#: src/generics/closures.md:3
+#, fuzzy
+msgid ""
+"Closures or lambda expressions have types which cannot be named. However, "
+"they\n"
+"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
+"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
+msgstr ""
+"Closures oder Lambda-Ausdrücke haben Typen, die nicht benannt werden können. "
+"Allerdings sie\n"
+"spezielles [`Fn`] implementieren "
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
+"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) und\n"
+"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) "
+"Eigenschaften:"
+
+#: src/generics/closures.md:8
+msgid ""
+"```rust,editable\n"
+"fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
+"    println!(\"Calling function on {input}\");\n"
+"    func(input)\n"
+"}"
+msgstr ""
+
+#: src/generics/closures.md:14
+msgid ""
+"fn main() {\n"
+"    let add_3 = |x| x + 3;\n"
+"    let mul_5 = |x| x * 5;"
+msgstr ""
+
+#: src/generics/closures.md:18
+msgid ""
+"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
+"    println!(\"mul_5: {}\", apply_with_log(mul_5, 20));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/closures.md:25
+#, fuzzy
+msgid ""
+"If you have an `FnOnce`, you may only call it once. It might consume "
+"captured values."
+msgstr ""
+"Wenn Sie ein `FnOnce` haben, können Sie es nur einmal aufrufen. Es kann "
+"erfasste Werte verbrauchen."
+
+#: src/generics/closures.md:27
+#, fuzzy
+msgid ""
+"An `FnMut` might mutate captured values, so you can call it multiple times "
+"but not concurrently."
+msgstr ""
+"Ein `FnMut` kann erfasste Werte mutieren, sodass Sie es mehrmals, aber nicht "
+"gleichzeitig aufrufen können."
+
+#: src/generics/closures.md:29
+#, fuzzy
+msgid ""
+"An `Fn` neither consumes nor mutates captured values, or perhaps captures "
+"nothing at all, so it can\n"
+"be called multiple times concurrently."
+msgstr ""
+"Ein „Fn“ verbraucht oder mutiert erfasste Werte nicht oder erfasst "
+"vielleicht gar nichts, also kann es das\n"
+"mehrmals gleichzeitig aufgerufen werden."
+
+#: src/generics/closures.md:32
+#, fuzzy
+msgid ""
+"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
+"I.e. you can use an\n"
+"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
+"an `FnMut` or `FnOnce`\n"
+"is called for."
+msgstr ""
+"`FnMut` ist ein Untertyp von `FnOnce`. „Fn“ ist ein Untertyp von „FnMut“ und "
+"„FnOnce“. D.h. Sie können eine verwenden\n"
+"„FnMut“, wo immer ein „FnOnce“ verlangt wird, und Sie können ein „Fn“ "
+"überall dort verwenden, wo ein „FnMut“ oder „FnOnce“ steht\n"
+"ist angesagt."
+
+#: src/generics/closures.md:36
+#, fuzzy
+msgid "`move` closures only implement `FnOnce`."
+msgstr "`move`-Closures implementieren nur `FnOnce`."
+
+#: src/generics/monomorphization.md:1
+#, fuzzy
+msgid "# Monomorphization"
+msgstr "# Monomorphisierung"
+
+#: src/generics/monomorphization.md:3
+#, fuzzy
+msgid "Generic code is turned into non-generic code based on the call sites:"
+msgstr ""
+"Basierend auf den Aufrufseiten wird generischer Code in nicht generischen "
+"Code umgewandelt:"
+
+#: src/generics/monomorphization.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let integer = Some(5);\n"
+"    let float = Some(5.0);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/monomorphization.md:12
+#, fuzzy
+msgid "behaves as if you wrote"
+msgstr "verhält sich so, als hättest du geschrieben"
+
+#: src/generics/monomorphization.md:14
+msgid ""
+"```rust,editable\n"
+"enum Option_i32 {\n"
+"    Some(i32),\n"
+"    None,\n"
+"}"
+msgstr ""
+
+#: src/generics/monomorphization.md:20
+#, fuzzy
+msgid ""
+"enum Option_f64 {\n"
+"    Some(f64),\n"
+"    None,\n"
+"}"
+msgstr ""
+"Aufzählung Option_f64 {\n"
+"    Einige (f64),\n"
+"    Keiner,\n"
+"}"
+
+#: src/generics/monomorphization.md:25
+msgid ""
+"fn main() {\n"
+"    let integer = Option_i32::Some(5);\n"
+"    let float = Option_f64::Some(5.0);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/monomorphization.md:31
+#, fuzzy
+msgid ""
+"This is a zero-cost abstraction: you get exactly the same result as if you "
+"had\n"
+"hand-coded the data structures without the abstraction."
+msgstr ""
+"Dies ist eine Null-Kosten-Abstraktion: Sie erhalten genau das gleiche "
+"Ergebnis, als ob Sie es hätten\n"
+"die Datenstrukturen ohne die Abstraktion von Hand codiert."
+
+#: src/generics/trait-objects.md:1
+#, fuzzy
+msgid "# Trait Objects"
+msgstr "# Eigenschaftsobjekte"
+
+#: src/generics/trait-objects.md:3
+#, fuzzy
+msgid "We've seen how a function can take arguments which implement a trait:"
+msgstr ""
+"Wir haben gesehen, wie eine Funktion Argumente annehmen kann, die ein "
+"Merkmal implementieren:"
+
+#: src/generics/trait-objects.md:8
+msgid ""
+"fn print<T: Display>(x: T) {\n"
+"    println!(\"Your value: {}\", x);\n"
+"}"
+msgstr ""
+
+#: src/generics/trait-objects.md:12
+msgid ""
+"fn main() {\n"
+"    print(123);\n"
+"    print(\"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/trait-objects.md:18
+#, fuzzy
+msgid ""
+"However, how can we store a collection of mixed types which implement "
+"`Display`?"
+msgstr ""
+"Wie können wir jedoch eine Sammlung gemischter Typen speichern, die "
+"\"Display\" implementieren?"
+
+#: src/generics/trait-objects.md:20
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn main() {\n"
+"    let xs = vec![123, \"Hello\"];\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/trait-objects.md:26
+#, fuzzy
+msgid "For this, we need _trait objects_:"
+msgstr "Dafür brauchen wir _trait objects_:"
+
+#: src/generics/trait-objects.md:31
+msgid ""
+"fn main() {\n"
+"    let xs: Vec<Box<dyn Display>> = vec![Box::new(123), "
+"Box::new(\"Hello\")];\n"
+"    for x in xs {\n"
+"        println!(\"x: {x}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/generics/trait-objects.md:39
+#, fuzzy
+msgid "Memory layout after allocating `xs`:"
+msgstr "Speicherlayout nach Zuweisung von `xs`:"
+
+#: src/generics/trait-objects.md:41
+msgid ""
+"```bob\n"
+" Stack                             Heap\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- - -.\n"
+":                           :     :                                          "
+"     :\n"
+":    xs                     :     :                                          "
+"     :\n"
+":   +-----------+-------+   :     :   +-----+-----+                          "
+"     :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o |                          "
+"     :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-+                          "
+"     :\n"
+":   | capacity  |     2 |   :     :     | |   | |   "
+"+----+----+----+----+----+    :\n"
+":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  "
+"|    :\n"
+":                           :     :     | |   |     "
+"+----+----+----+----+----+    :\n"
+"`- - - - - - - - - - - - - -'     :     | |   |                              "
+"     :\n"
+"                                  :     | |   |     "
+"+-------------------------+   :\n"
+"                                  :     | |   '---->| \"<str as "
+"Display>::fmt\" |   :\n"
+"                                  :     | |         "
+"+-------------------------+   :\n"
+"                                  :     | |                                  "
+"     :\n"
+"                                  :     | |   +----+----+----+----+          "
+"     :\n"
+"                                  :     | '-->| 7b | 00 | 00 | 00 |          "
+"     :\n"
+"                                  :     |     +----+----+----+----+          "
+"     :\n"
+"                                  :     |                                    "
+"     :\n"
+"                                  :     |     +-------------------------+    "
+"     :\n"
+"                                  :     '---->| \"<i32 as Display>::fmt\" |  "
+"       :\n"
+"                                  :           +-------------------------+    "
+"     :\n"
+"                                  :                                          "
+"     :\n"
+"                                  :                                          "
+"     :\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- - -'\n"
+"```"
+msgstr ""
+
+#: src/generics/trait-objects.md:69
+#, fuzzy
+msgid ""
+"Similarly, you need a trait object if you want to return different values\n"
+"implementing a trait:"
+msgstr ""
+"Ebenso benötigen Sie ein Trait-Objekt, wenn Sie andere Werte zurückgeben "
+"möchten\n"
+"Implementieren eines Merkmals:"
+
+#: src/generics/trait-objects.md:72
+msgid ""
+"```rust,editable\n"
+"fn numbers(n: i32) -> Box<dyn Iterator<Item=i32>> {\n"
+"    if n > 0 {\n"
+"        Box::new(0..n)\n"
+"    } else {\n"
+"        Box::new((n..0).rev())\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/generics/trait-objects.md:81
+msgid ""
+"fn main() {\n"
+"    println!(\"{:?}\", numbers(-5).collect::<Vec<_>>());\n"
+"    println!(\"{:?}\", numbers(5).collect::<Vec<_>>());\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/morning.md:1
+#, fuzzy
+msgid "# Day 3: Morning Exercises"
+msgstr "# Tag 3: Morgengymnastik"
+
+#: src/exercises/day-3/morning.md:3
+#, fuzzy
+msgid "We will design a classical GUI library traits and trait objects."
+msgstr ""
+"Wir werden Traits und Trait-Objekte einer klassischen GUI-Bibliothek "
+"entwerfen."
+
+#: src/exercises/day-3/simple-gui.md:1
+#, fuzzy
+msgid "# A Simple GUI Library"
+msgstr "# Eine einfache GUI-Bibliothek"
+
+#: src/exercises/day-3/simple-gui.md:3
+#, fuzzy
+msgid ""
+"Let us design a classical GUI library using our new knowledge of traits and\n"
+"trait objects."
+msgstr ""
+"Lassen Sie uns eine klassische GUI-Bibliothek mit unserem neuen Wissen über "
+"Traits und entwerfen\n"
+"Eigenschaftsobjekte."
+
+#: src/exercises/day-3/simple-gui.md:6
+#, fuzzy
+msgid "We will have a number of widgets in our library:"
+msgstr "Wir werden eine Reihe von Widgets in unserer Bibliothek haben:"
+
+#: src/exercises/day-3/simple-gui.md:8
+#, fuzzy
+msgid ""
+"* `Window`: has a `title` and contains other widgets.\n"
+"* `Button`: has a `label` and a callback function which is invoked when the\n"
+"  button is pressed.\n"
+"* `Label`: has a `label`."
+msgstr ""
+"* „Fenster“: hat einen „Titel“ und enthält andere Widgets.\n"
+"* `Button`: hat ein `Label` und eine Callback-Funktion, die aufgerufen wird, "
+"wenn die\n"
+"  Taste gedrückt wird.\n"
+"* `Label`: hat ein `Label`."
+
+#: src/exercises/day-3/simple-gui.md:13
+#, fuzzy
+msgid "The widgets will implement a `Widget` trait, see below."
+msgstr "Die Widgets implementieren ein „Widget“-Merkmal, siehe unten."
+
+#: src/exercises/day-3/simple-gui.md:15
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"`draw_into` methods so that you implement the `Widget` trait:"
+msgstr ""
+"Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
+"füllen Sie die fehlenden aus\n"
+"`draw_into`-Methoden, sodass Sie das `Widget`-Merkmal implementieren:"
+
+#: src/exercises/day-3/simple-gui.md:18
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid ""
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_imports, unused_variables, dead_code)]"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:22
+msgid ""
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:26
+#: src/exercises/day-3/solutions-morning.md:27
+msgid ""
+"    /// Draw the widget into a buffer.\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:29
+#: src/exercises/day-3/solutions-morning.md:30
+msgid ""
+"    /// Draw the widget on standard output.\n"
+"    fn draw(&self) {\n"
+"        let mut buffer = String::new();\n"
+"        self.draw_into(&mut buffer);\n"
+"        println!(\"{}\", &buffer);\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:37
+#: src/exercises/day-3/solutions-morning.md:38
+#, fuzzy
+msgid ""
+"pub struct Label {\n"
+"    label: String,\n"
+"}"
+msgstr ""
+"Pub-Struktur Label {\n"
+"    Label: Zeichenkette,\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:41
+#: src/exercises/day-3/solutions-morning.md:42
+#, fuzzy
+msgid ""
+"impl Label {\n"
+"    fn new(label: &str) -> Label {\n"
+"        Label {\n"
+"            label: label.to_owned(),\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Label {\n"
+"    fn new(label: &str) -> Label {\n"
+"        Etikett {\n"
+"            Bezeichnung: label.to_owned(),\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:49
+#: src/exercises/day-3/solutions-morning.md:50
+#, fuzzy
+msgid ""
+"pub struct Button {\n"
+"    label: Label,\n"
+"    callback: Box<dyn FnMut()>,\n"
+"}"
+msgstr ""
+"pub struct Schaltfläche {\n"
+"    Etikett: Etikett,\n"
+"    Rückruf: Box<dyn FnMut()>,\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:54
+#: src/exercises/day-3/solutions-morning.md:55
+#, fuzzy
+msgid ""
+"impl Button {\n"
+"    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
+"        Button {\n"
+"            label: Label::new(label),\n"
+"            callback,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl-Schaltfläche {\n"
+"    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
+"        Taste {\n"
+"            Label: Label::neu(Label),\n"
+"            Ruf zurück,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:63
+#: src/exercises/day-3/solutions-morning.md:64
+#, fuzzy
+msgid ""
+"pub struct Window {\n"
+"    title: String,\n"
+"    widgets: Vec<Box<dyn Widget>>,\n"
+"}"
+msgstr ""
+"pub struct Fenster {\n"
+"    Titel: Zeichenkette,\n"
+"    Widgets: Vec<Box<dyn Widget>>,\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:68
+#: src/exercises/day-3/solutions-morning.md:69
+#, fuzzy
+msgid ""
+"impl Window {\n"
+"    fn new(title: &str) -> Window {\n"
+"        Window {\n"
+"            title: title.to_owned(),\n"
+"            widgets: Vec::new(),\n"
+"        }\n"
+"    }"
+msgstr ""
+"impl-Fenster {\n"
+"    fn new(title: &str) -> Fenster {\n"
+"        Fenster {\n"
+"            Titel: title.to_owned(),\n"
+"            Widgets: Vec::new(),\n"
+"        }\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:76
+#: src/exercises/day-3/solutions-morning.md:77
+msgid ""
+"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"        self.widgets.push(widget);\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:82
+#, fuzzy
+msgid ""
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl-Widget für Label {\n"
+"    fn width(&self) -> use {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:87 src/exercises/day-3/simple-gui.md:97
+#: src/exercises/day-3/simple-gui.md:107
+#, fuzzy
+msgid ""
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        nicht implementiert!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/simple-gui.md:92
+#, fuzzy
+msgid ""
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl-Widget für Schaltfläche {\n"
+"    fn width(&self) -> use {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:102
+#, fuzzy
+msgid ""
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        unimplemented!()\n"
+"    }"
+msgstr ""
+"impl-Widget für Fenster {\n"
+"    fn width(&self) -> use {\n"
+"        nicht implementiert!()\n"
+"    }"
+
+#: src/exercises/day-3/simple-gui.md:112
+msgid ""
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\",\n"
+"        Box::new(|| println!(\"You clicked the button!\")),\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:123
+#, fuzzy
+msgid "The output of the above program can be something simple like this:"
+msgstr "Die Ausgabe des obigen Programms kann so einfach sein:"
+
+#: src/exercises/day-3/simple-gui.md:125
+msgid ""
+"```text\n"
+"========\n"
+"Rust GUI Demo 1.23\n"
+"========"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:130
+#, fuzzy
+msgid "This is a small text GUI demo."
+msgstr "Dies ist eine kleine Text-GUI-Demo."
+
+#: src/exercises/day-3/simple-gui.md:132
+msgid "| Click me! |\n```"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:135
+#, fuzzy
+msgid ""
+"If you want to draw aligned text, you can use the\n"
+"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
+"formatting operators. In particular, notice how you can pad with different\n"
+"characters (here a `'/'`) and how you can control alignment:"
+msgstr ""
+"Wenn Sie ausgerichteten Text zeichnen möchten, können Sie die verwenden\n"
+"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
+"Formatierungsoperatoren. Beachten Sie insbesondere, wie Sie mit "
+"verschiedenen auffüllen können\n"
+"Zeichen (hier ein `'/'`) und wie Sie die Ausrichtung steuern können:"
+
+#: src/exercises/day-3/simple-gui.md:140
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let width = 10;\n"
+"    println!(\"left aligned:  |{:/<width$}|\", \"foo\");\n"
+"    println!(\"centered:      |{:/^width$}|\", \"foo\");\n"
+"    println!(\"right aligned: |{:/>width$}|\", \"foo\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:149
+#, fuzzy
+msgid ""
+"Using such alignment tricks, you can for example produce output like this:"
+msgstr ""
+"Mit solchen Ausrichtungstricks können Sie beispielsweise eine Ausgabe wie "
+"diese erzeugen:"
+
+#: src/exercises/day-3/simple-gui.md:151
+msgid ""
+"```text\n"
+"+--------------------------------+\n"
+"|       Rust GUI Demo 1.23       |\n"
+"+================================+\n"
+"| This is a small text GUI demo. |\n"
+"| +-----------+                  |\n"
+"| | Click me! |                  |\n"
+"| +-----------+                  |\n"
+"+--------------------------------+\n"
+"```"
+msgstr ""
+
+#: src/error-handling.md:1
+#, fuzzy
+msgid "# Error Handling"
+msgstr "# Fehlerbehandlung"
+
+#: src/error-handling.md:3
+#, fuzzy
+msgid "Error handling in Rust is done using explicit control flow:"
+msgstr ""
+"Die Fehlerbehandlung in Rust erfolgt über einen expliziten Kontrollfluss:"
+
+#: src/error-handling.md:5
+#, fuzzy
+msgid ""
+"* Functions that can have errors list this in their return type,\n"
+"* There are no exceptions."
+msgstr ""
+"* Funktionen, die Fehler haben können, führen dies in ihrem Rückgabetyp "
+"auf,\n"
+"* Es gibt keine Ausnahmen."
+
+#: src/error-handling/panics.md:1
+#, fuzzy
+msgid "# Panics"
+msgstr "# Panik"
+
+#: src/error-handling/panics.md:3
+#, fuzzy
+msgid "Rust will trigger a panic if a fatal error happens at runtime:"
+msgstr ""
+"Rust löst eine Panik aus, wenn zur Laufzeit ein schwerwiegender Fehler "
+"auftritt:"
+
+#: src/error-handling/panics.md:5
+msgid ""
+"```rust,editable,should_panic\n"
+"fn main() {\n"
+"    let v = vec![10, 20, 30];\n"
+"    println!(\"v[100]: {}\", v[100]);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/panics.md:12
+#, fuzzy
+msgid ""
+"* Panics are for unrecoverable and unexpected errors.\n"
+"  * Panics are symptoms of bugs in the program.\n"
+"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+msgstr ""
+"* Paniken sind für nicht behebbare und unerwartete Fehler.\n"
+"  * Paniken sind Symptome von Fehlern im Programm.\n"
+"* Verwenden Sie Anti-Panik-APIs (wie `Vec::get`), wenn ein Absturz nicht "
+"akzeptabel ist."
+
+#: src/error-handling/panic-unwind.md:1
+#, fuzzy
+msgid "# Catching the Stack Unwinding"
+msgstr "# Auffangen des Stapels beim Abwickeln"
+
+#: src/error-handling/panic-unwind.md:3
+#, fuzzy
+msgid ""
+"By default, a panic will cause the stack to unwind. The unwinding can be "
+"caught:"
+msgstr ""
+"Standardmäßig führt eine Panik dazu, dass der Stack abgewickelt wird. Die "
+"Abwicklung kann gefangen werden:"
+
+#: src/error-handling/panic-unwind.md:5
+msgid "```rust\nuse std::panic;"
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:8
+msgid ""
+"let result = panic::catch_unwind(|| {\n"
+"    println!(\"hello!\");\n"
+"});\n"
+"assert!(result.is_ok());"
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:13
+msgid ""
+"let result = panic::catch_unwind(|| {\n"
+"    panic!(\"oh no!\");\n"
+"});\n"
+"assert!(result.is_err());\n"
+"```"
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:19
+#, fuzzy
+msgid ""
+"* This can be useful in servers which should keep running even if a single\n"
+"  request crashes.\n"
+"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+"* Dies kann bei Servern nützlich sein, die auch bei einem einzigen "
+"weiterlaufen sollen\n"
+"  Anfrage stürzt ab.\n"
+"* Dies funktioniert nicht, wenn in Ihrer `Cargo.toml` `panic = 'abort'` "
+"gesetzt ist."
+
+#: src/error-handling/result.md:1
+#, fuzzy
+msgid "# Structured Error Handling with `Result`"
+msgstr "# Strukturierte Fehlerbehandlung mit `Result`"
+
+#: src/error-handling/result.md:3
+#, fuzzy
+msgid ""
+"We have already seen the `Result` enum. This is used pervasively when errors "
+"are\n"
+"expected as part of normal operation:"
+msgstr ""
+"Wir haben bereits die Aufzählung `Result` gesehen. Dies wird häufig "
+"verwendet, wenn Fehler vorhanden sind\n"
+"erwartet im Rahmen des Normalbetriebs:"
+
+#: src/error-handling/result.md:6
+msgid ""
+"```rust\n"
+"use std::fs::File;\n"
+"use std::io::Read;"
+msgstr ""
+
+#: src/error-handling/result.md:10
+msgid ""
+"fn main() {\n"
+"    let file = File::open(\"diary.txt\");\n"
+"    match file {\n"
+"        Ok(mut file) => {\n"
+"            let mut contents = String::new();\n"
+"            file.read_to_string(&mut contents);\n"
+"            println!(\"Dear diary: {contents}\");\n"
+"        },\n"
+"        Err(err) => {\n"
+"            println!(\"The diary could not be opened: {err}\");\n"
+"        }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/result.md:27
+#, fuzzy
+msgid ""
+"  * As with `Option`, the successful value sits inside of `Result`, forcing "
+"the developer to\n"
+"    explicitly extract it. This encourages error checking. In the case where "
+"an error should never happen,\n"
+"    `unwrap()` or `expect()` can be called, and this is a signal of the "
+"developer intent too.  \n"
+"  * `Result` documentation is a recommended read. Not during the course, but "
+"it is worth mentioning. \n"
+"    It contains a lot of convenience methods and functions that help "
+"functional-style programming. \n"
+"    \n"
+"</details>"
+msgstr ""
+"  * Wie bei `Option` befindet sich der erfolgreiche Wert innerhalb von "
+"`Result`, was den Entwickler dazu zwingt\n"
+"    explizit extrahieren. Dies fördert die Fehlerprüfung. Für den Fall, dass "
+"niemals ein Fehler passieren sollte,\n"
+"    `unwrap()` oder `expect()` können aufgerufen werden, und dies ist auch "
+"ein Signal für die Absicht des Entwicklers.\n"
+"  * Die `Result`-Dokumentation ist eine empfohlene Lektüre. Nicht während "
+"des Kurses, aber es ist erwähnenswert.\n"
+"    Es enthält viele bequeme Methoden und Funktionen, die bei der "
+"funktionalen Programmierung helfen.\n"
+"    \n"
+"</Details>"
+
+#: src/error-handling/try-operator.md:1
+#, fuzzy
+msgid "# Propagating Errors with `?`"
+msgstr "# Propagieren von Fehlern mit `?`"
+
+#: src/error-handling/try-operator.md:3
+#, fuzzy
+msgid ""
+"The try-operator `?` is used to return errors to the caller. It lets you "
+"turn\n"
+"the common"
+msgstr ""
+"Der Try-Operator `?` wird verwendet, um Fehler an den Aufrufer "
+"zurückzugeben. Es lässt dich drehen\n"
+"das gemeine"
+
+#: src/error-handling/try-operator.md:6
+msgid ""
+"```rust,ignore\n"
+"match some_expression {\n"
+"    Ok(value) => value,\n"
+"    Err(err) => return Err(err),\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/try-operator.md:13
+#, fuzzy
+msgid "into the much simpler"
+msgstr "ins viel einfachere"
+
+#: src/error-handling/try-operator.md:15
+msgid ""
+"```rust,ignore\n"
+"some_expression?\n"
+"```"
+msgstr ""
+
+#: src/error-handling/try-operator.md:19
+#, fuzzy
+msgid "We can use this to simplify our error handing code:"
+msgstr ""
+"Wir können dies verwenden, um unseren Fehlerbehandlungscode zu vereinfachen:"
+
+#: src/error-handling/try-operator.md:21
+msgid ""
+"```rust,editable\n"
+"use std::fs;\n"
+"use std::io::{self, Read};"
+msgstr ""
+
+#: src/error-handling/try-operator.md:25
+msgid ""
+"fn read_username(path: &str) -> Result<String, io::Error> {\n"
+"    let username_file_result = fs::File::open(path);"
+msgstr ""
+
+#: src/error-handling/try-operator.md:28
+msgid ""
+"    let mut username_file = match username_file_result {\n"
+"        Ok(file) => file,\n"
+"        Err(e) => return Err(e),\n"
+"    };"
+msgstr ""
+
+#: src/error-handling/try-operator.md:33
+msgid "    let mut username = String::new();"
+msgstr ""
+
+#: src/error-handling/try-operator.md:35
+#, fuzzy
+msgid ""
+"    match username_file.read_to_string(&mut username) {\n"
+"        Ok(_) => Ok(username),\n"
+"        Err(e) => Err(e),\n"
+"    }\n"
+"}"
+msgstr ""
+"    match username_file.read_to_string(&mut username) {\n"
+"        Ok(_) => Ok(Benutzername),\n"
+"        Fehler(e) => Fehler(e),\n"
+"    }\n"
+"}"
+
+#: src/error-handling/try-operator.md:41
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/try-operator.md:52
+#: src/error-handling/converting-error-types.md:70
+#, fuzzy
+msgid ""
+"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
+"* Use the `fs::write` call to test out the different scenarios: no file, "
+"empty file, file with username."
+msgstr ""
+"* Die Variable „username“ kann entweder „Ok(string)“ oder „Err(error)“ "
+"sein.\n"
+"* Verwenden Sie den `fs::write`-Aufruf, um die verschiedenen Szenarien zu "
+"testen: keine Datei, leere Datei, Datei mit Benutzername."
+
+#: src/error-handling/converting-error-types.md:1
+#, fuzzy
+msgid "# Converting Error Types"
+msgstr "# Konvertieren von Fehlertypen"
+
+#: src/error-handling/converting-error-types.md:3
+#, fuzzy
+msgid ""
+"The effective expansion of `?` is a little more complicated than previously "
+"indicated:"
+msgstr ""
+"Die effektive Erweiterung von „?“ ist etwas komplizierter als zuvor "
+"angedeutet:"
+
+#: src/error-handling/converting-error-types.md:5
+msgid ""
+"```rust,ignore\n"
+"expression?\n"
+"```"
+msgstr ""
+
+#: src/error-handling/converting-error-types.md:9
+#, fuzzy
+msgid "works the same as"
+msgstr "funktioniert genauso wie"
+
+#: src/error-handling/converting-error-types.md:11
+msgid ""
+"```rust,ignore\n"
+"match expression {\n"
+"    Ok(value) => value,\n"
+"    Err(err)  => return Err(From::from(err)),\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/converting-error-types.md:18
+#, fuzzy
+msgid ""
+"The `From::from` call here means we attempt to convert the error type to "
+"the\n"
+"type returned by the function:"
+msgstr ""
+"Der `From::from`-Aufruf hier bedeutet, dass wir versuchen, den Fehlertyp in "
+"den zu konvertieren\n"
+"Typ, der von der Funktion zurückgegeben wird:"
+
+#: src/error-handling/converting-error-types.md:21
+msgid ""
+"```rust,editable\n"
+"use std::error::Error;\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use std::fmt::{self, Display, Formatter};"
+msgstr ""
+
+#: src/error-handling/converting-error-types.md:27
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"enum ReadUsernameError {\n"
+"    IoError(io::Error),\n"
+"    EmptyUsername(String),\n"
+"}"
+msgstr ""
+"#[ableiten(Debuggen)]\n"
+"enum ReadUsernameError {\n"
+"    IoError(io::Fehler),\n"
+"    LeererBenutzername(String),\n"
+"}"
+
+#: src/error-handling/converting-error-types.md:33
+#, fuzzy
+msgid "impl Error for ReadUsernameError {}"
+msgstr "impl-Fehler für ReadUsernameError {}"
+
+#: src/error-handling/converting-error-types.md:35
+#, fuzzy
+msgid ""
+"impl Display for ReadUsernameError {\n"
+"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
+"        match self {\n"
+"            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
+"in {}\", filename),\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Anzeige für ReadUsernameError {\n"
+"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
+"        mit sich selbst übereinstimmen {\n"
+"            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Keinen "
+"Benutzernamen gefunden in {}\", filename),\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/error-handling/converting-error-types.md:44
+#, fuzzy
+msgid ""
+"impl From<io::Error> for ReadUsernameError {\n"
+"    fn from(err: io::Error) -> ReadUsernameError {\n"
+"        ReadUsernameError::IoError(err)\n"
+"    }\n"
+"}"
+msgstr ""
+"impl From<io::Error> für ReadUsernameError {\n"
+"    fn from(err: io::Error) -> ReadUsernameError {\n"
+"        ReadUsernameError::IoError(err)\n"
+"    }\n"
+"}"
+
+#: src/error-handling/converting-error-types.md:50
+#: src/error-handling/deriving-error-enums.md:19
+msgid ""
+"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
+"    }\n"
+"    Ok(username)\n"
+"}"
+msgstr ""
+
+#: src/error-handling/converting-error-types.md:59
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    let username = read_username(\"config.dat\");\n"
+"    println!(\"username or error: {username:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/converting-error-types.md:73
+#, fuzzy
+msgid ""
+"It is good practice for all error types to implement `std::error::Error`, "
+"which requires `Debug` and\n"
+"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
+"where possible, to make\n"
+"life easier for tests and consumers of your library. In this case we can't "
+"easily do so, because\n"
+"`io::Error` doesn't implement them."
+msgstr ""
+"Es ist eine gute Praxis für alle Fehlertypen, `std::error::Error` zu "
+"implementieren, was `Debug` und erfordert\n"
+"\"Anzeigen\". Es ist im Allgemeinen hilfreich für sie, `Clone` und `Eq` zu "
+"implementieren, wo es möglich ist, zu machen\n"
+"das Leben einfacher für Tests und Benutzer Ihrer Bibliothek. In diesem Fall "
+"können wir das nicht so einfach tun, weil\n"
+"`io::Error` implementiert sie nicht."
+
+#: src/error-handling/deriving-error-enums.md:1
+#, fuzzy
+msgid "# Deriving Error Enums"
+msgstr "# Fehleraufzählungen ableiten"
+
+#: src/error-handling/deriving-error-enums.md:3
+#, fuzzy
+msgid ""
+"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
+"an\n"
+"error enum like we did on the previous page:"
+msgstr ""
+"Die Kiste [thiserror](https://docs.rs/thiserror/) ist eine beliebte Methode "
+"zum Erstellen einer\n"
+"error enum wie auf der vorherigen Seite:"
+
+#: src/error-handling/deriving-error-enums.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use thiserror::Error;"
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:11
+#, fuzzy
+msgid ""
+"#[derive(Debug, Error)]\n"
+"enum ReadUsernameError {\n"
+"    #[error(\"Could not read: {0}\")]\n"
+"    IoError(#[from] io::Error),\n"
+"    #[error(\"Found no username in {0}\")]\n"
+"    EmptyUsername(String),\n"
+"}"
+msgstr ""
+"#[ableiten(Debug, Fehler)]\n"
+"enum ReadUsernameError {\n"
+"    #[error(\"Konnte nicht gelesen werden: {0}\")]\n"
+"    IoError(#[von] io::Fehler),\n"
+"    #[error(\"Keinen Benutzernamen in {0} gefunden\")]\n"
+"    LeererBenutzername(String),\n"
+"}"
+
+#: src/error-handling/deriving-error-enums.md:28
+#: src/error-handling/dynamic-errors.md:25
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/deriving-error-enums.md:39
+#, fuzzy
+msgid ""
+"`thiserror`'s derive macro automatically implements `std::error::Error`, and "
+"optionally `Display`\n"
+"(if the `#[error(...)]` attributes are provided) and `From` (if the "
+"`#[from]` attribute is added).\n"
+"It also works for structs."
+msgstr ""
+"Das Ableitungsmakro von `thiserror` implementiert automatisch "
+"`std::error::Error` und optional `Display`\n"
+"(wenn die `#[error(...)]`-Attribute bereitgestellt werden) und `From` (wenn "
+"das `#[from]`-Attribut hinzugefügt wird).\n"
+"Es funktioniert auch für Strukturen."
+
+#: src/error-handling/deriving-error-enums.md:43
+#, fuzzy
+msgid "It doesn't affect your public API, which makes it good for libraries."
+msgstr ""
+"Es wirkt sich nicht auf Ihre öffentliche API aus, was es gut für "
+"Bibliotheken macht."
+
+#: src/error-handling/dynamic-errors.md:1
+#, fuzzy
+msgid "# Dynamic Error Types"
+msgstr "# Dynamische Fehlertypen"
+
+#: src/error-handling/dynamic-errors.md:3
+#, fuzzy
+msgid ""
+"Sometimes we want to allow any type of error to be returned without writing "
+"our own enum covering\n"
+"all the different possibilities. `std::error::Error` makes this easy."
+msgstr ""
+"Manchmal möchten wir zulassen, dass jede Art von Fehler zurückgegeben wird, "
+"ohne unsere eigene Enum-Abdeckung zu schreiben\n"
+"all die verschiedenen Möglichkeiten. `std::error::Error` macht das einfach."
+
+#: src/error-handling/dynamic-errors.md:6
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::fs::{self, File};\n"
+"use std::io::Read;\n"
+"use thiserror::Error;\n"
+"use std::error::Error;"
+msgstr ""
+
+#: src/error-handling/dynamic-errors.md:12
+msgid ""
+"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
+"#[error(\"Found no username in {0}\")]\n"
+"struct EmptyUsernameError(String);"
+msgstr ""
+
+#: src/error-handling/dynamic-errors.md:16
+msgid ""
+"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    File::open(path)?.read_to_string(&mut username)?;\n"
+"    if username.is_empty() {\n"
+"        return Err(EmptyUsernameError(String::from(path)).into());\n"
+"    }\n"
+"    Ok(username)\n"
+"}"
+msgstr ""
+
+#: src/error-handling/dynamic-errors.md:36
+#, fuzzy
+msgid ""
+"This saves on code, but gives up the ability to cleanly handle different "
+"error cases differently in\n"
+"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
+"in the public API of a\n"
+"library, but it can be a good option in a program where you just want to "
+"display the error message\n"
+"somewhere."
+msgstr ""
+"Dies spart Code, gibt aber die Möglichkeit auf, verschiedene Fehlerfälle "
+"sauber unterschiedlich zu behandeln\n"
+"das Programm. Daher ist es im Allgemeinen keine gute Idee, `Box<dyn Error>` "
+"in der öffentlichen API von a zu verwenden\n"
+"Bibliothek, aber es kann eine gute Option in einem Programm sein, in dem Sie "
+"nur die Fehlermeldung anzeigen möchten\n"
+"irgendwo."
+
+#: src/error-handling/error-contexts.md:1
+#, fuzzy
+msgid "# Adding Context to Errors"
+msgstr "# Hinzufügen von Kontext zu Fehlern"
+
+#: src/error-handling/error-contexts.md:3
+#, fuzzy
+msgid ""
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
+"contextual information to your errors and allows you to have fewer\n"
+"custom error types:"
+msgstr ""
+"Die weit verbreitete Kiste [anyhow](https://docs.rs/anyhow/) kann Ihnen beim "
+"Hinzufügen helfen\n"
+"Kontextinformationen zu Ihren Fehlern und ermöglicht es Ihnen, weniger zu "
+"haben\n"
+"benutzerdefinierte Fehlertypen:"
+
+#: src/error-handling/error-contexts.md:7
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::{fs, io};\n"
+"use std::io::Read;\n"
+"use anyhow::{Context, Result, bail};"
+msgstr ""
+
+#: src/error-handling/error-contexts.md:12
+msgid ""
+"fn read_username(path: &str) -> Result<String> {\n"
+"    let mut username = String::with_capacity(100);\n"
+"    fs::File::open(path)\n"
+"        .context(format!(\"Failed to open {path}\"))?\n"
+"        .read_to_string(&mut username)\n"
+"        .context(\"Failed to read\")?;\n"
+"    if username.is_empty() {\n"
+"        bail!(\"Found no username in {path}\");\n"
+"    }\n"
+"    Ok(username)\n"
+"}"
+msgstr ""
+
+#: src/error-handling/error-contexts.md:24
+msgid ""
+"fn main() {\n"
+"    //fs::write(\"config.dat\", \"\").unwrap();\n"
+"    match read_username(\"config.dat\") {\n"
+"        Ok(username) => println!(\"Username: {username}\"),\n"
+"        Err(err)     => println!(\"Error: {err:?}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/error-handling/error-contexts.md:35
+#, fuzzy
+msgid ""
+"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
+"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not\n"
+"  a good choice for the public API of a library, but is widely used in "
+"applications.\n"
+"* Actual error type inside of it can be extracted for examination if "
+"necessary.\n"
+"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides\n"
+"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgstr ""
+"* `anyhow::Result<V>` ist ein Typ-Alias für `Result<V, anyhow::Error>`.\n"
+"* `anyhow::Error` ist im Wesentlichen ein Wrapper um `Box<dyn Error>`. Als "
+"solches ist es wieder im Allgemeinen nicht\n"
+"  eine gute Wahl für die öffentliche API einer Bibliothek, wird aber häufig "
+"in Anwendungen verwendet.\n"
+"* Der darin enthaltene tatsächliche Fehlertyp kann bei Bedarf zur "
+"Untersuchung extrahiert werden.\n"
+"* Die von `anyhow::Result<T>` bereitgestellte Funktionalität ist "
+"Go-Entwicklern möglicherweise vertraut, da sie bereitgestellt wird\n"
+"  ähnliche Nutzungsmuster und Ergonomie wie `(T, error)` von Go."
+
+#: src/testing.md:1
+#, fuzzy
+msgid "# Testing"
+msgstr "# Testen"
+
+#: src/testing.md:3
+#, fuzzy
+msgid "Rust and Cargo come with a simple unit test framework:"
+msgstr "Rust und Cargo verfügen über ein einfaches Unit-Test-Framework:"
+
+#: src/testing.md:5
+#, fuzzy
+msgid "* Unit tests are supported throughout your code."
+msgstr "* Komponententests werden im gesamten Code unterstützt."
+
+#: src/testing.md:7
+#, fuzzy
+msgid "* Integration tests are supported via the `tests/` directory."
+msgstr "* Integrationstests werden über das Verzeichnis „tests/“ unterstützt."
+
+#: src/testing/unit-tests.md:1
+#, fuzzy
+msgid "# Unit Tests"
+msgstr "# Einheitentests"
+
+#: src/testing/unit-tests.md:3
+#, fuzzy
+msgid "Mark unit tests with `#[test]`:"
+msgstr "Unit-Tests mit `#[test]` markieren:"
+
+#: src/testing/unit-tests.md:5
+msgid ""
+"```rust,editable\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/testing/unit-tests.md:13
+msgid ""
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}"
+msgstr ""
+
+#: src/testing/unit-tests.md:18
+msgid ""
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}"
+msgstr ""
+
+#: src/testing/unit-tests.md:23
+msgid ""
+"#[test]\n"
+"fn test_multiple_words() {\n"
+"    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/testing/unit-tests.md:29
+#, fuzzy
+msgid "Use `cargo test` to find and run the unit tests."
+msgstr ""
+"Verwenden Sie \"Cargo Test\", um die Komponententests zu finden und "
+"auszuführen."
+
+#: src/testing/test-modules.md:1
+#, fuzzy
+msgid "# Test Modules"
+msgstr "# Testmodule"
+
+#: src/testing/test-modules.md:3
+#, fuzzy
+msgid ""
+"Unit tests are often put in a nested module (run tests on the\n"
+"[Playground](https://play.rust-lang.org/)):"
+msgstr ""
+"Unit-Tests werden oft in ein verschachteltes Modul eingefügt (Tests auf der\n"
+"[Spielplatz](https://play.rust-lang.org/)):"
+
+#: src/testing/test-modules.md:6
+msgid ""
+"```rust,editable\n"
+"fn helper(a: &str, b: &str) -> String {\n"
+"    format!(\"{a} {b}\")\n"
+"}"
+msgstr ""
+
+#: src/testing/test-modules.md:11
+msgid ""
+"pub fn main() {\n"
+"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
+"}"
+msgstr ""
+
+#: src/testing/test-modules.md:19
+msgid ""
+"    #[test]\n"
+"    fn test_helper() {\n"
+"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/testing/test-modules.md:26
+#, fuzzy
+msgid ""
+"* This lets you unit test private helpers.\n"
+"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr ""
+"* Damit können Sie private Helfer testen.\n"
+"* Das Attribut `#[cfg(test)]` ist nur aktiv, wenn Sie `cargo test` ausführen."
+
+#: src/testing/doc-tests.md:1
+#, fuzzy
+msgid "# Documentation Tests"
+msgstr "# Dokumentationstests"
+
+#: src/testing/doc-tests.md:3
+#, fuzzy
+msgid "Rust has built-in support for documentation tests:"
+msgstr "Rust hat eine eingebaute Unterstützung für Dokumentationstests:"
+
+#: src/testing/doc-tests.md:5
+msgid ""
+"```rust\n"
+"/// Shortens a string to the given length.\n"
+"///\n"
+"/// ```\n"
+"/// use playground::shorten_string;\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 5), \"Hello\");\n"
+"/// assert_eq!(shorten_string(\"Hello World\", 20), \"Hello World\");\n"
+"/// ```\n"
+"pub fn shorten_string(s: &str, length: usize) -> &str {\n"
+"    &s[..std::cmp::min(length, s.len())]\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/testing/doc-tests.md:18
+#, fuzzy
+msgid ""
+"* Code blocks in `///` comments are automatically seen as Rust code.\n"
+"* The code will be compiled and executed as part of `cargo test`.\n"
+"* Test the above code on the [Rust "
+"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgstr ""
+"* Codeblöcke in `///`-Kommentaren werden automatisch als Rust-Code "
+"angesehen.\n"
+"* Der Code wird im Rahmen von „Cargo Test“ kompiliert und ausgeführt.\n"
+"* Testen Sie den obigen Code auf [Rust "
+"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+
+#: src/testing/integration-tests.md:1
+#, fuzzy
+msgid "# Integration Tests"
+msgstr "# Integrationstests"
+
+#: src/testing/integration-tests.md:3
+#, fuzzy
+msgid "If you want to test your library as a client, use an integration test."
+msgstr ""
+"Wenn Sie Ihre Bibliothek als Client testen möchten, verwenden Sie einen "
+"Integrationstest."
+
+#: src/testing/integration-tests.md:5
+#, fuzzy
+msgid "Create a `.rs` file under `tests/`:"
+msgstr "Erstellen Sie eine `.rs`-Datei unter `tests/`:"
+
+#: src/testing/integration-tests.md:7
+msgid "```rust,ignore\nuse my_library::init;"
+msgstr ""
+
+#: src/testing/integration-tests.md:10
+msgid ""
+"#[test]\n"
+"fn test_init() {\n"
+"    assert!(init().is_ok());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/testing/integration-tests.md:16
+#, fuzzy
+msgid "These tests only have access to the public API of your crate."
+msgstr "Diese Tests haben nur Zugriff auf die öffentliche API Ihrer Crate."
+
+#: src/unsafe.md:1
+#, fuzzy
+msgid "# Unsafe Rust"
+msgstr "# Unsicherer Rost"
+
+#: src/unsafe.md:3
+#, fuzzy
+msgid "The Rust language has two parts:"
+msgstr "Die Rust-Sprache besteht aus zwei Teilen:"
+
+#: src/unsafe.md:5
+#, fuzzy
+msgid ""
+"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
+"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"violated."
+msgstr ""
+"* **Safe Rust:** Speichersicher, kein undefiniertes Verhalten möglich.\n"
+"* **Unsicherer Rost:** kann undefiniertes Verhalten auslösen, wenn "
+"Vorbedingungen verletzt werden."
+
+#: src/unsafe.md:8
+#, fuzzy
+msgid ""
+"We will be seeing mostly safe Rust in this course, but it's important to "
+"know\n"
+"what Unsafe Rust is."
+msgstr ""
+"Wir werden in diesem Kurs hauptsächlich sicheres Rust sehen, aber es ist "
+"wichtig zu wissen\n"
+"was unsicherer Rost ist."
+
+#: src/unsafe.md:11
+#, fuzzy
+msgid ""
+"Unsafe code is usually small and isolated, and its correctness should be "
+"carefully\n"
+"documented. It is usually wrapped in a safe abstraction layer."
+msgstr ""
+"Unsicherer Code ist normalerweise klein und isoliert, und seine Korrektheit "
+"sollte sorgfältig geprüft werden\n"
+"dokumentiert. Es ist normalerweise in eine sichere Abstraktionsschicht "
+"eingeschlossen."
+
+#: src/unsafe.md:14
+#, fuzzy
+msgid "Unsafe Rust gives you access to five new capabilities:"
+msgstr "Unsafe Rust bietet Ihnen Zugriff auf fünf neue Funktionen:"
+
+#: src/unsafe.md:16
+#, fuzzy
+msgid ""
+"* Dereference raw pointers.\n"
+"* Access or modify mutable static variables.\n"
+"* Access `union` fields.\n"
+"* Call `unsafe` functions, including `extern` functions.\n"
+"* Implement `unsafe` traits."
+msgstr ""
+"* Rohzeiger dereferenzieren.\n"
+"* Greifen Sie auf veränderliche statische Variablen zu oder ändern Sie "
+"diese.\n"
+"* Greifen Sie auf `Union`-Felder zu.\n"
+"* „Unsichere“ Funktionen aufrufen, einschließlich „externer“ Funktionen.\n"
+"* Implementieren Sie \"unsichere\" Eigenschaften."
+
+#: src/unsafe.md:22
+#, fuzzy
+msgid ""
+"We will briefly cover unsafe capabilities next. For full details, please "
+"see\n"
+"[Chapter 19.1 in the Rust "
+"Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
+"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+msgstr ""
+"Als nächstes werden wir uns kurz mit unsicheren Fähigkeiten befassen. "
+"Ausführliche Informationen finden Sie unter\n"
+"[Kapitel 19.1 im "
+"Rust-Buch](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
+"und das [Rustonomicon] (https://doc.rust-lang.org/nomicon/)."
+
+#: src/unsafe.md:28
+#, fuzzy
+msgid ""
+"Unsafe Rust does not mean the code is incorrect. It means that developers "
+"have\n"
+"turned off the compiler safety features and have to write correct code by\n"
+"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"rules."
+msgstr ""
+"Unsicherer Rost bedeutet nicht, dass der Code falsch ist. Es bedeutet, dass "
+"Entwickler haben\n"
+"die Compiler-Sicherheitsfunktionen ausgeschaltet haben und korrekten Code "
+"schreiben müssen\n"
+"sich. Das bedeutet, dass der Compiler die Speichersicherheitsregeln von Rust "
+"nicht mehr erzwingt."
+
+#: src/unsafe/raw-pointers.md:1
+#, fuzzy
+msgid "# Dereferencing Raw Pointers"
+msgstr "# Rohzeiger dereferenzieren"
+
+#: src/unsafe/raw-pointers.md:3
+#, fuzzy
+msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
+msgstr ""
+"Das Erstellen von Zeigern ist sicher, aber das Dereferenzieren erfordert "
+"\"unsicher\":"
+
+#: src/unsafe/raw-pointers.md:5
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut num = 5;"
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:9
+msgid "    let r1 = &mut num as *mut i32;\n    let r2 = &num as *const i32;"
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:12
+msgid ""
+"    // Safe because r1 and r2 were obtained from references and so are "
+"guaranteed to be non-null and\n"
+"    // properly aligned, the objects underlying the references from which "
+"they were obtained are\n"
+"    // live throughout the whole unsafe block, and they are not accessed "
+"either through the\n"
+"    // references or concurrently through any other pointers.\n"
+"    unsafe {\n"
+"        println!(\"r1 is: {}\", *r1);\n"
+"        *r1 = 10;\n"
+"        println!(\"r2 is: {}\", *r2);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:26
+#, fuzzy
+msgid ""
+"It is good practice (and required by the Android Rust style guide) to write "
+"a comment for each\n"
+"`unsafe` block explaining how the code inside it satisfies the safety "
+"requirements of the unsafe\n"
+"operations it is doing."
+msgstr ""
+"Es ist eine gute Praxis (und vom Android Rust Styleguide vorgeschrieben), "
+"für jeden einen Kommentar zu schreiben\n"
+"\"unsicherer\" Block, der erklärt, wie der darin enthaltene Code die "
+"Sicherheitsanforderungen des unsicheren Codes erfüllt\n"
+"Operationen, die es tut."
+
+#: src/unsafe/raw-pointers.md:30
+#, fuzzy
+msgid ""
+"In the case of pointer dereferences, this means that the pointers must be\n"
+"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
+msgstr ""
+"Im Fall von Zeigerdereferenzen bedeutet dies, dass die Zeiger sein müssen\n"
+"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), also:"
+
+#: src/unsafe/raw-pointers.md:33
+#, fuzzy
+msgid ""
+" * The pointer must be non-null.\n"
+" * The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object).\n"
+" * The object must not have been deallocated.\n"
+" * There must not be concurrent accesses to the same location.\n"
+" * If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no\n"
+"   reference may be used to access the memory."
+msgstr ""
+" * Der Zeiger darf nicht null sein.\n"
+" * Der Zeiger muss _dereferenzierbar_ sein (innerhalb der Grenzen eines "
+"einzelnen zugewiesenen Objekts).\n"
+" * Das Objekt darf nicht freigegeben worden sein.\n"
+" * Es darf nicht gleichzeitig auf denselben Standort zugegriffen werden.\n"
+" * Wenn der Zeiger durch Casting einer Referenz erhalten wurde, muss das "
+"zugrunde liegende Objekt live sein und nein\n"
+"   Referenz kann verwendet werden, um auf den Speicher zuzugreifen."
+
+#: src/unsafe/raw-pointers.md:40
+#, fuzzy
+msgid "In most cases the pointer must also be properly aligned."
+msgstr "In den meisten Fällen muss auch der Zeiger richtig ausgerichtet werden."
+
+#: src/unsafe/mutable-static-variables.md:1
+#, fuzzy
+msgid "# Mutable Static Variables"
+msgstr "# Veränderliche statische Variablen"
+
+#: src/unsafe/mutable-static-variables.md:3
+#, fuzzy
+msgid "It is safe to read an immutable static variable:"
+msgstr "Es ist sicher, eine unveränderliche statische Variable zu lesen:"
+
+#: src/unsafe/mutable-static-variables.md:5
+msgid "```rust,editable\nstatic HELLO_WORLD: &str = \"Hello, world!\";"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:8
+msgid ""
+"fn main() {\n"
+"    println!(\"HELLO_WORLD: {}\", HELLO_WORLD);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:13
+#, fuzzy
+msgid ""
+"However, since data races can occur, it is unsafe to read and write mutable\n"
+"static variables:"
+msgstr ""
+"Da es jedoch zu Datenrennen kommen kann, ist es unsicher, änderbar zu lesen "
+"und zu schreiben\n"
+"statische Variablen:"
+
+#: src/unsafe/mutable-static-variables.md:16
+msgid "```rust,editable\nstatic mut COUNTER: u32 = 0;"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:19
+msgid ""
+"fn add_to_counter(inc: u32) {\n"
+"    unsafe { COUNTER += inc; }  // Potential data race!\n"
+"}"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:23
+msgid "fn main() {\n    add_to_counter(42);"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:26
+msgid ""
+"    unsafe { println!(\"COUNTER: {}\", COUNTER); }  // Potential data race!\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/mutable-static-variables.md:32
+#, fuzzy
+msgid ""
+"Using a mutable static is generally a bad idea, but there are some cases "
+"where it might make sense\n"
+"in low-level `no_std` code, such as implementing a heap allocator or working "
+"with some C APIs."
+msgstr ""
+"Die Verwendung eines änderbaren statischen Werts ist im Allgemeinen eine "
+"schlechte Idee, aber es gibt einige Fälle, in denen es sinnvoll sein könnte\n"
+"in `no_std`-Code auf niedriger Ebene, wie z. B. die Implementierung eines "
+"Heap-Allokators oder die Arbeit mit einigen C-APIs."
+
+#: src/unsafe/unions.md:1
+#, fuzzy
+msgid "# Unions"
+msgstr "# Gewerkschaften"
+
+#: src/unsafe/unions.md:3
+#, fuzzy
+msgid "Unions are like enums, but you need to track the active field yourself:"
+msgstr ""
+"Unions sind wie Aufzählungen, aber Sie müssen das aktive Feld selbst "
+"verfolgen:"
+
+#: src/unsafe/unions.md:5
+msgid ""
+"```rust,editable\n"
+"#[repr(C)]\n"
+"union MyUnion {\n"
+"    i: u8,\n"
+"    b: bool,\n"
+"}"
+msgstr ""
+
+#: src/unsafe/unions.md:12
+msgid ""
+"fn main() {\n"
+"    let u = MyUnion { i: 42 };\n"
+"    println!(\"int: {}\", unsafe { u.i });\n"
+"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/unions.md:21
+#, fuzzy
+msgid ""
+"Unions are very rarely needed in Rust as you can usually use an enum. They "
+"are occasionally needed\n"
+"for interacting with C library APIs."
+msgstr ""
+"Unions werden in Rust sehr selten benötigt, da Sie normalerweise eine "
+"Aufzählung verwenden können. Sie werden gelegentlich benötigt\n"
+"für die Interaktion mit C-Bibliotheks-APIs."
+
+#: src/unsafe/unions.md:24
+#, fuzzy
+msgid ""
+"If you just want to reinterpret bytes as a different type, you probably "
+"want\n"
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
+"or a safe\n"
+"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+msgstr ""
+"Wenn Sie Bytes nur als einen anderen Typ neu interpretieren möchten, möchten "
+"Sie dies wahrscheinlich tun\n"
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
+"oder einen Safe\n"
+"Wrapper wie die Kiste [`zerocopy`](https://crates.io/crates/zerocopy)."
+
+#: src/unsafe/calling-unsafe-functions.md:1
+#, fuzzy
+msgid "# Calling Unsafe Functions"
+msgstr "# Aufruf unsicherer Funktionen"
+
+#: src/unsafe/calling-unsafe-functions.md:3
+#, fuzzy
+msgid ""
+"A function or method can be marked `unsafe` if it has extra preconditions "
+"you\n"
+"must uphold to avoid undefined behaviour:"
+msgstr ""
+"Eine Funktion oder Methode kann als „unsicher“ gekennzeichnet werden, wenn "
+"sie zusätzliche Voraussetzungen für Sie hat\n"
+"muss eingehalten werden, um undefiniertes Verhalten zu vermeiden:"
+
+#: src/unsafe/calling-unsafe-functions.md:6
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let emojis = \"🗻∈🌏\";"
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:10
+msgid ""
+"    // Safe because the indices are in the correct order, within the bounds "
+"of\n"
+"    // the string slice, and lie on UTF-8 sequence boundaries.\n"
+"    unsafe {\n"
+"        println!(\"{}\", emojis.get_unchecked(0..4));\n"
+"        println!(\"{}\", emojis.get_unchecked(4..7));\n"
+"        println!(\"{}\", emojis.get_unchecked(7..11));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:1
+#, fuzzy
+msgid "# Writing Unsafe Functions"
+msgstr "# Unsichere Funktionen schreiben"
+
+#: src/unsafe/writing-unsafe-functions.md:3
+#, fuzzy
+msgid ""
+"You can mark your own functions as `unsafe` if they require particular "
+"conditions to avoid undefined\n"
+"behaviour."
+msgstr ""
+"Sie können Ihre eigenen Funktionen als \"unsicher\" markieren, wenn sie "
+"bestimmte Bedingungen erfordern, um undefined zu vermeiden\n"
+"Verhalten."
+
+#: src/unsafe/writing-unsafe-functions.md:6
+msgid ""
+"```rust,editable\n"
+"/// Swaps the values pointed to by the given pointers.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// The pointers must be valid and properly aligned.\n"
+"unsafe fn swap(a: *mut u8, b: *mut u8) {\n"
+"    let temp = *a;\n"
+"    *a = *b;\n"
+"    *b = temp;\n"
+"}"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:18
+msgid ""
+"fn main() {\n"
+"    let mut a = 42;\n"
+"    let mut b = 66;"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:22
+msgid ""
+"    // Safe because ...\n"
+"    unsafe {\n"
+"        swap(&mut a, &mut b);\n"
+"    }"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:27
+msgid ""
+"    println!(\"a = {}, b = {}\", a, b);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:33
+#, fuzzy
+msgid ""
+"We wouldn't actually use pointers for this because it can be done safely "
+"with references."
+msgstr ""
+"Wir würden dafür eigentlich keine Zeiger verwenden, da dies mit Referenzen "
+"sicher möglich ist."
+
+#: src/unsafe/writing-unsafe-functions.md:35
+#, fuzzy
+msgid ""
+"Note that unsafe code is allowed within an unsafe function without an "
+"`unsafe` block. We can\n"
+"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
+"what happens."
+msgstr ""
+"Beachten Sie, dass unsicherer Code innerhalb einer unsicheren Funktion ohne "
+"einen „unsicheren“ Block zulässig ist. Wir können\n"
+"verbieten Sie dies mit `#[deny(unsafe_op_in_unsafe_fn)]`. Versuchen Sie es "
+"hinzuzufügen und sehen Sie, was passiert."
+
+#: src/unsafe/extern-functions.md:1
+#, fuzzy
+msgid "# Calling External Code"
+msgstr "# Externer Code aufrufen"
+
+#: src/unsafe/extern-functions.md:3
+#, fuzzy
+msgid ""
+"Functions from other languages might violate the guarantees of Rust. "
+"Calling\n"
+"them is thus unsafe:"
+msgstr ""
+"Funktionen aus anderen Sprachen könnten die Garantien von Rust verletzen. "
+"Berufung\n"
+"sie ist somit unsicher:"
+
+#: src/unsafe/extern-functions.md:6
+msgid ""
+"```rust,editable\n"
+"extern \"C\" {\n"
+"    fn abs(input: i32) -> i32;\n"
+"}"
+msgstr ""
+
+#: src/unsafe/extern-functions.md:11
+msgid ""
+"fn main() {\n"
+"    unsafe {\n"
+"        // Undefined behavior if abs misbehaves.\n"
+"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/extern-functions.md:21
+#, fuzzy
+msgid ""
+"This is usually only a problem for extern functions which do things with "
+"pointers which might\n"
+"violate Rust's memory model, but in general any C function might have "
+"undefined behaviour under any\n"
+"arbitrary circumstances."
+msgstr ""
+"Dies ist normalerweise nur ein Problem für externe Funktionen, die "
+"möglicherweise Dinge mit Zeigern tun\n"
+"verletzen das Speichermodell von Rust, aber im Allgemeinen kann jede "
+"C-Funktion undefiniertes Verhalten unter jeder haben\n"
+"willkürliche Umstände."
+
+#: src/unsafe/extern-functions.md:25
+msgid ""
+"The `\"C\"` in this example is the ABI;\n"
+"[other ABIs are available "
+"too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
+msgstr ""
+
+#: src/unsafe/unsafe-traits.md:1
+#, fuzzy
+msgid "# Implementing Unsafe Traits"
+msgstr "# Unsichere Merkmale implementieren"
+
+#: src/unsafe/unsafe-traits.md:3
+#, fuzzy
+msgid ""
+"Like with functions, you can mark a trait as `unsafe` if the implementation "
+"must guarantee\n"
+"particular conditions to avoid undefined behaviour."
+msgstr ""
+"Wie bei Funktionen können Sie ein Merkmal als \"unsicher\" markieren, wenn "
+"die Implementierung dies gewährleisten muss\n"
+"besondere Bedingungen, um undefiniertes Verhalten zu vermeiden."
+
+#: src/unsafe/unsafe-traits.md:6
+#, fuzzy
+msgid ""
+"For example, the `zerocopy` crate has an unsafe trait that looks\n"
+"[something like "
+"this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+msgstr ""
+"Zum Beispiel hat die „Nullkopie“-Kiste eine unsichere Eigenschaft, die "
+"aussieht\n"
+"[etwas in der "
+"Art](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+
+#: src/unsafe/unsafe-traits.md:9
+msgid ""
+"```rust,editable\n"
+"use std::mem::size_of_val;\n"
+"use std::slice;"
+msgstr ""
+
+#: src/unsafe/unsafe-traits.md:13
+#, fuzzy
+msgid ""
+"/// ...\n"
+"/// # Safety\n"
+"/// The type must have a defined representation and no padding.\n"
+"pub unsafe trait AsBytes {\n"
+"    fn as_bytes(&self) -> &[u8] {\n"
+"        unsafe {\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"/// ...\n"
+"/// # Sicherheit\n"
+"/// Der Typ muss eine definierte Darstellung haben und darf nicht aufgefüllt "
+"werden.\n"
+"pub unsichere Eigenschaft AsBytes {\n"
+"    fn as_bytes(&self) -> &[u8] {\n"
+"        unsicher {\n"
+"            Slice::from_raw_parts(self als *const Self als *const u8, "
+"size_of_val(self))\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/unsafe/unsafe-traits.md:24
+msgid ""
+"// Safe because u32 has a defined representation and no padding.\n"
+"unsafe impl AsBytes for u32 {}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/unsafe-traits.md:30
+#, fuzzy
+msgid ""
+"There should be a `# Safety` section on the Rustdoc for the trait explaining "
+"the requirements for\n"
+"the trait to be safely implemented."
+msgstr ""
+"Es sollte einen Abschnitt „# Sicherheit“ im Rustdoc für das Merkmal geben, "
+"in dem die Anforderungen für erklärt werden\n"
+"die sicher zu implementierende Eigenschaft."
+
+#: src/unsafe/unsafe-traits.md:33
+#, fuzzy
+msgid ""
+"The actual safety section for `AsBytes` is rather longer and more "
+"complicated."
+msgstr ""
+"Der eigentliche Sicherheitsabschnitt für `AsBytes` ist etwas länger und "
+"komplizierter."
+
+#: src/unsafe/unsafe-traits.md:35
+#, fuzzy
+msgid "The built-in `Send` and `Sync` traits are unsafe."
+msgstr ""
+"Die eingebauten Eigenschaften „Senden“ und „Synchronisieren“ sind unsicher."
+
+#: src/exercises/day-3/afternoon.md:1
+#, fuzzy
+msgid "# Day 3: Afternoon Exercises"
+msgstr "# Tag 3: Nachmittagsübungen"
+
+#: src/exercises/day-3/afternoon.md:3
+#, fuzzy
+msgid "Let us build a safe wrapper for reading directory content!"
+msgstr ""
+"Lassen Sie uns einen sicheren Wrapper zum Lesen von Verzeichnisinhalten "
+"erstellen!"
+
+#: src/exercises/day-3/afternoon.md:7
+#, fuzzy
+msgid "After looking at the exercise, you can look at the [solution] provided."
+msgstr ""
+"Nachdem Sie sich die Übung angesehen haben, können Sie sich die "
+"bereitgestellte [Lösung] ansehen."
+
+#: src/exercises/day-3/afternoon.md:9
+#, fuzzy
+msgid "[solution]: solutions-afternoon.md"
+msgstr "[Lösung]: Lösungen-Nachmittag.md"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:1
+#, fuzzy
+msgid "# Safe FFI Wrapper"
+msgstr "# Sicherer FFI-Wrapper"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:3
+#, fuzzy
+msgid ""
+"Rust has great support for calling functions through a _foreign function\n"
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"functions you would use from C to read the filenames of a directory."
+msgstr ""
+"Rust bietet großartige Unterstützung für den Aufruf von Funktionen über eine "
+"_foreign-Funktion\n"
+"Schnittstelle_ (FFI). Wir werden dies verwenden, um einen sicheren Wrapper "
+"für die `libc` zu erstellen\n"
+"Funktionen, die Sie von C verwenden würden, um die Dateinamen eines "
+"Verzeichnisses zu lesen."
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:7
+#, fuzzy
+msgid "You will want to consult the manual pages:"
+msgstr "Sie werden die Handbuchseiten konsultieren wollen:"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:9
+#, fuzzy
+msgid ""
+"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
+"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
+"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr ""
+"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
+"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
+"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:13
+#, fuzzy
+msgid ""
+"You will also want to browse the [`std::ffi`] module, particular for "
+"[`CStr`]\n"
+"and [`CString`] types which are used to hold NUL-terminated strings coming "
+"from\n"
+"C. The [Nomicon] also has a very useful chapter about FFI."
+msgstr ""
+"Sie sollten auch das Modul [`std::ffi`] durchsuchen, insbesondere nach "
+"[`CStr`]\n"
+"und [`CString`]-Typen, die verwendet werden, um NUL-terminierte "
+"Zeichenfolgen zu halten, die von kommen\n"
+"C. Das [Nomicon] hat auch ein sehr nützliches Kapitel über FFI."
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:17
+#, fuzzy
+msgid ""
+"[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
+"[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
+"[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
+"[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
+msgstr ""
+"[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
+"[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
+"[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
+"[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:22
+#, fuzzy
+msgid ""
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"functions and methods:"
+msgstr ""
+"Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
+"füllen Sie die fehlenden aus\n"
+"Funktionen und Methoden:"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:29
+msgid ""
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:32
+#: src/exercises/day-3/solutions-afternoon.md:26
+msgid ""
+"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"    #[repr(C)]\n"
+"    pub struct DIR {\n"
+"        _data: [u8; 0],\n"
+"        _marker: core::marker::PhantomData<(*mut u8, "
+"core::marker::PhantomPinned)>,\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:39
+#: src/exercises/day-3/solutions-afternoon.md:33
+msgid ""
+"    // Layout as per readdir(3) and definitions in "
+"/usr/include/x86_64-linux-gnu.\n"
+"    #[repr(C)]\n"
+"    pub struct dirent {\n"
+"        pub d_ino: c_long,\n"
+"        pub d_off: c_ulong,\n"
+"        pub d_reclen: c_ushort,\n"
+"        pub d_type: c_char,\n"
+"        pub d_name: [c_char; 256],\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:49
+#: src/exercises/day-3/solutions-afternoon.md:43
+msgid ""
+"    extern \"C\" {\n"
+"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"        pub fn closedir(s: *mut DIR) -> c_int;\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:56
+#: src/exercises/day-3/solutions-afternoon.md:50
+msgid ""
+"use std::ffi::{CStr, CString, OsStr, OsString};\n"
+"use std::os::unix::ffi::OsStrExt;"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:59
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}"
+msgstr ""
+"#[ableiten(Debuggen)]\n"
+"struct DirectoryIterator {\n"
+"    Pfad: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:65
+#, fuzzy
+msgid ""
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
+"        // otherwise return Err with a message.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Ergebnis<DirectoryIterator, String> {\n"
+"        // Opendir aufrufen und einen Ok-Wert zurückgeben, wenn das "
+"funktioniert hat,\n"
+"        // andernfalls Err mit einer Nachricht zurückgeben.\n"
+"        nicht implementiert!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:73
+msgid ""
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:81
+#, fuzzy
+msgid ""
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        unimplemented!()\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Drop für DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Gegebenenfalls closedir aufrufen.\n"
+"        nicht implementiert!()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:88
+msgid ""
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/welcome-day-4.md:1
+#, fuzzy
+msgid "# Welcome to Day 4"
+msgstr "# Willkommen zu Tag 4"
+
+#: src/welcome-day-4.md:3
+#, fuzzy
+msgid "Today we will look at two main topics:"
+msgstr "Heute werden wir uns mit zwei Hauptthemen befassen:"
+
+#: src/welcome-day-4.md:5
+#, fuzzy
+msgid "* Concurrency: threads, channels, shared state, `Send` and `Sync`."
+msgstr ""
+"* Gleichzeitigkeit: Threads, Kanäle, gemeinsamer Status, „Senden“ und "
+"„Synchronisieren“."
+
+#: src/welcome-day-4.md:7
+#, fuzzy
+msgid ""
+"* Android: building binaries and libraries, using AIDL, logging, and\n"
+"  interoperability with C, C++, and Java."
+msgstr ""
+"* Android: Erstellung von Binärdateien und Bibliotheken, Verwendung von "
+"AIDL, Protokollierung und\n"
+"  Interoperabilität mit C, C++ und Java."
+
+#: src/welcome-day-4.md:10
+#, fuzzy
+msgid ""
+"> We will attempt to call Rust from one of your own projects today. So try "
+"to\n"
+"> find a little corner of your code base where we can move some lines of "
+"code to\n"
+"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that\n"
+"> parses some raw bytes would be ideal."
+msgstr ""
+"> Wir werden heute versuchen, Rust aus einem Ihrer eigenen Projekte "
+"anzurufen. Versuchen Sie es also\n"
+"> Finden Sie eine kleine Ecke Ihrer Codebasis, in die wir einige Codezeilen "
+"verschieben können\n"
+"> Rost. Je weniger Abhängigkeiten und \"exotische\" Typen, desto besser. "
+"Etwas das\n"
+"> parst einige rohe Bytes wäre ideal."
+
+#: src/concurrency.md:1
+#, fuzzy
+msgid "# Fearless Concurrency"
+msgstr "# Furchtlose Parallelität"
+
+#: src/concurrency.md:3
+#, fuzzy
+msgid ""
+"Rust has full support for concurrency using OS threads with mutexes and\n"
+"channels."
+msgstr ""
+"Rust bietet volle Unterstützung für Parallelität unter Verwendung von "
+"Betriebssystem-Threads mit Mutexes und\n"
+"Kanäle."
+
+#: src/concurrency.md:6
+#, fuzzy
+msgid ""
+"The Rust type system plays an important role in making many concurrency "
+"bugs\n"
+"compile time bugs. This is often referred to as _fearless concurrency_ since "
+"you\n"
+"can rely on the compiler to ensure correctness at runtime."
+msgstr ""
+"Das Rust-Typsystem spielt eine wichtige Rolle bei der Entstehung vieler "
+"Nebenläufigkeitsfehler\n"
+"Kompilierzeitfehler. Dies wird seit Ihnen oft als _furchtlose Parallelität_ "
+"bezeichnet\n"
+"kann sich auf den Compiler verlassen, um die Korrektheit zur Laufzeit "
+"sicherzustellen."
+
+#: src/concurrency/threads.md:1
+#, fuzzy
+msgid "# Threads"
+msgstr "# Threads"
+
+#: src/concurrency/threads.md:3
+#, fuzzy
+msgid "Rust threads work similarly to threads in other languages:"
+msgstr "Rust-Threads funktionieren ähnlich wie Threads in anderen Sprachen:"
+
+#: src/concurrency/threads.md:5
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+
+#: src/concurrency/threads.md:9
+msgid ""
+"fn main() {\n"
+"    thread::spawn(|| {\n"
+"        for i in 1..10 {\n"
+"            println!(\"Count in thread: {i}!\");\n"
+"            thread::sleep(Duration::from_millis(5));\n"
+"        }\n"
+"    });"
+msgstr ""
+
+#: src/concurrency/threads.md:17
+msgid ""
+"    for i in 1..5 {\n"
+"        println!(\"Main thread: {i}\");\n"
+"        thread::sleep(Duration::from_millis(5));\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/threads.md:24
+#, fuzzy
+msgid ""
+"* Threads are all daemon threads, the main thread does not wait for them.\n"
+"* Thread panics are independent of each other.\n"
+"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr ""
+"* Threads sind alle Daemon-Threads, der Haupt-Thread wartet nicht auf sie.\n"
+"* Thread-Panics sind voneinander unabhängig.\n"
+"  * Paniken können eine Nutzlast tragen, die mit `downcast_ref` entpackt "
+"werden kann."
+
+#: src/concurrency/threads.md:32
+#, fuzzy
+msgid ""
+"* Notice that the thread is stopped before it reaches 10 — the main thread "
+"is\n"
+"  not waiting."
+msgstr ""
+"* Beachten Sie, dass der Thread gestoppt wird, bevor er 10 erreicht – der "
+"Haupt-Thread ist es\n"
+"  nicht warten."
+
+#: src/concurrency/threads.md:35
+#, fuzzy
+msgid ""
+"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
+"for\n"
+"  the thread to finish."
+msgstr ""
+"* Verwenden Sie `let handle = thread::spawn(...)` und später "
+"`handle.join()`, um darauf zu warten\n"
+"  den Thread zu beenden."
+
+#: src/concurrency/threads.md:38
+#, fuzzy
+msgid "* Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+"* Lösen Sie eine Panik im Thread aus, beachten Sie, dass dies `main` nicht "
+"betrifft."
+
+#: src/concurrency/threads.md:40
+#, fuzzy
+msgid ""
+"* Use the `Result` return value from `handle.join()` to get access to the "
+"panic\n"
+"  payload. This is a good time to talk about [`Any`]."
+msgstr ""
+"* Verwenden Sie den `Result`-Rückgabewert von `handle.join()`, um Zugriff "
+"auf die Panik zu erhalten\n"
+"  Nutzlast. Dies ist ein guter Zeitpunkt, um über [`Any`] zu sprechen."
+
+#: src/concurrency/threads.md:43
+#, fuzzy
+msgid "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
+msgstr "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
+
+#: src/concurrency/scoped-threads.md:1
+#, fuzzy
+msgid "# Scoped Threads"
+msgstr "# Bereichsbezogene Threads"
+
+#: src/concurrency/scoped-threads.md:3
+#, fuzzy
+msgid "Normal threads cannot borrow from their environment:"
+msgstr "Normale Threads können nicht von ihrer Umgebung ausleihen:"
+
+#: src/concurrency/scoped-threads.md:5
+msgid "```rust,editable,compile_fail\nuse std::thread;"
+msgstr ""
+
+#: src/concurrency/scoped-threads.md:8 src/concurrency/scoped-threads.md:22
+msgid "fn main() {\n    let s = String::from(\"Hello\");"
+msgstr ""
+
+#: src/concurrency/scoped-threads.md:11
+msgid ""
+"    thread::spawn(|| {\n"
+"        println!(\"Length: {}\", s.len());\n"
+"    });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/scoped-threads.md:17
+#, fuzzy
+msgid "However, you can use a [scoped thread][1] for this:"
+msgstr "Sie können dafür jedoch einen [Scoped Thread][1] verwenden:"
+
+#: src/concurrency/scoped-threads.md:19
+msgid "```rust,editable\nuse std::thread;"
+msgstr ""
+
+#: src/concurrency/scoped-threads.md:25
+msgid ""
+"    thread::scope(|scope| {\n"
+"        scope.spawn(|| {\n"
+"            println!(\"Length: {}\", s.len());\n"
+"        });\n"
+"    });\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/scoped-threads.md:33
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
+msgstr "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
+
+#: src/concurrency/scoped-threads.md:35
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"* The reason for that is that when the `thread::scope` function completes, "
+"all the threads are guaranteed to be joined, so they can return borrowed "
+"data.\n"
+"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads.\n"
+"    \n"
+"</details>"
+msgstr ""
+"<Details>\n"
+"    \n"
+"* Der Grund dafür ist, dass nach Abschluss der `thread::scope`-Funktion "
+"garantiert alle Threads verbunden sind, sodass sie geliehene Daten "
+"zurückgeben können.\n"
+"* Es gelten die normalen Rust-Ausleihregeln: Sie können entweder "
+"veränderlich von einem Thread ausleihen oder unveränderlich von einer "
+"beliebigen Anzahl von Threads.\n"
+"    \n"
+"</Details>"
+
+#: src/concurrency/channels.md:1
+#, fuzzy
+msgid "# Channels"
+msgstr "# Kanäle"
+
+#: src/concurrency/channels.md:3
+#, fuzzy
+msgid ""
+"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
+"parts\n"
+"are connected via the channel, but you only see the end-points."
+msgstr ""
+"Rust-Kanäle bestehen aus zwei Teilen: einem `Sender<T>` und einem "
+"`Receiver<T>`. Die zwei Teile\n"
+"über den Kanal verbunden sind, aber Sie sehen nur die Endpunkte."
+
+#: src/concurrency/channels.md:6
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;"
+msgstr ""
+
+#: src/concurrency/channels.md:10 src/concurrency/channels/unbounded.md:10
+msgid "fn main() {\n    let (tx, rx) = mpsc::channel();"
+msgstr ""
+
+#: src/concurrency/channels.md:13
+msgid "    tx.send(10).unwrap();\n    tx.send(20).unwrap();"
+msgstr ""
+
+#: src/concurrency/channels.md:16
+msgid ""
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"    println!(\"Received: {:?}\", rx.recv());"
+msgstr ""
+
+#: src/concurrency/channels.md:19
+msgid ""
+"    let tx2 = tx.clone();\n"
+"    tx2.send(30).unwrap();\n"
+"    println!(\"Received: {:?}\", rx.recv());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/channels.md:27
+#, fuzzy
+msgid ""
+"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
+"`SyncSender` implement `Clone` (so\n"
+"  you can make multiple producers) but `Receiver` does not.\n"
+"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or\n"
+"  `Receiver` is dropped and the channel is closed."
+msgstr ""
+"* „mpsc“ steht für Multi-Producer, Single-Consumer. `Sender` und "
+"`SyncSender` implementieren `Clone` (also\n"
+"  Sie können mehrere Producer erstellen), aber 'Receiver' nicht.\n"
+"* `send()` und `recv()` geben `Result` zurück. Wenn sie `Err` zurückgeben, "
+"bedeutet dies das Gegenstück `Sender` bzw\n"
+"  „Receiver“ wird fallen gelassen und der Kanal wird geschlossen."
+
+#: src/concurrency/channels/unbounded.md:1
+#, fuzzy
+msgid "# Unbounded Channels"
+msgstr "# Unbegrenzte Kanäle"
+
+#: src/concurrency/channels/unbounded.md:3
+#, fuzzy
+msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
+msgstr ""
+"Einen unbegrenzten und asynchronen Kanal erhält man mit `mpsc::channel()`:"
+
+#: src/concurrency/channels/unbounded.md:5
+#: src/concurrency/channels/bounded.md:5
+msgid ""
+"```rust,editable\n"
+"use std::sync::mpsc;\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:13
+#: src/concurrency/channels/bounded.md:13
+msgid ""
+"    thread::spawn(move || {\n"
+"        let thread_id = thread::current().id();\n"
+"        for i in 1..10 {\n"
+"            tx.send(format!(\"Message {i}\")).unwrap();\n"
+"            println!(\"{thread_id:?}: sent Message {i}\");\n"
+"        }\n"
+"        println!(\"{thread_id:?}: done\");\n"
+"    });\n"
+"    thread::sleep(Duration::from_millis(100));"
+msgstr ""
+
+#: src/concurrency/channels/unbounded.md:23
+#: src/concurrency/channels/bounded.md:23
+msgid ""
+"    for msg in rx.iter() {\n"
+"        println!(\"Main: got {}\", msg);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:1
+#, fuzzy
+msgid "# Bounded Channels"
+msgstr "# Gebundene Kanäle"
+
+#: src/concurrency/channels/bounded.md:3
+#, fuzzy
+msgid "Bounded and synchronous channels make `send` block the current thread:"
+msgstr ""
+"Gebundene und synchrone Kanäle sorgen dafür, dass der aktuelle Thread durch "
+"„Senden“ blockiert wird:"
+
+#: src/concurrency/channels/bounded.md:10
+msgid "fn main() {\n    let (tx, rx) = mpsc::sync_channel(3);"
+msgstr ""
+
+#: src/concurrency/shared_state.md:1
+#, fuzzy
+msgid "# Shared State"
+msgstr "# Geteilter Zustand"
+
+#: src/concurrency/shared_state.md:3
+#, fuzzy
+msgid ""
+"Rust uses the type system to enforce synchronization of shared data. This "
+"is\n"
+"primarily done via two types:"
+msgstr ""
+"Rust verwendet das Typsystem, um die Synchronisierung gemeinsam genutzter "
+"Daten zu erzwingen. Das ist\n"
+"hauptsächlich über zwei Arten:"
+
+#: src/concurrency/shared_state.md:6
+#, fuzzy
+msgid ""
+"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
+"threads and\n"
+"  takes care to deallocate `T` when the last reference is dropped,\n"
+"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+msgstr ""
+"* [`Arc<T>`][1], Atomic Reference Counted `T`: handhabt die gemeinsame "
+"Nutzung zwischen Threads und\n"
+"  sorgt dafür, dass `T` freigegeben wird, wenn die letzte Referenz gelöscht "
+"wird,\n"
+"* [`Mutex<T>`][2]: sorgt für den sich gegenseitig ausschließenden Zugriff "
+"auf den `T`-Wert."
+
+#: src/concurrency/shared_state.md:10
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
+"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
+
+#: src/concurrency/shared_state/arc.md:1
+#, fuzzy
+msgid "# `Arc`"
+msgstr "# `Bogen`"
+
+#: src/concurrency/shared_state/arc.md:3
+#, fuzzy
+msgid "[`Arc<T>`][1] allows shared read-only access via its `clone` method:"
+msgstr ""
+"[`Arc<T>`][1] ermöglicht den gemeinsamen Nur-Lese-Zugriff über seine "
+"`clone`-Methode:"
+
+#: src/concurrency/shared_state/arc.md:5
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"use std::sync::Arc;"
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:9
+msgid ""
+"fn main() {\n"
+"    let v = Arc::new(vec![10, 20, 30]);\n"
+"    let mut handles = Vec::new();\n"
+"    for _ in 1..5 {\n"
+"        let v = v.clone();\n"
+"        handles.push(thread::spawn(move || {\n"
+"            let thread_id = thread::current().id();\n"
+"            println!(\"{thread_id:?}: {v:?}\");\n"
+"        }));\n"
+"    }"
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:20
+msgid ""
+"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:25
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+msgstr "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+
+#: src/concurrency/shared_state/arc.md:29
+#, fuzzy
+msgid ""
+"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
+"`Rc` that uses atomic\n"
+"  operations.\n"
+"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T`\n"
+"  implements them both.\n"
+"* `Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the\n"
+"  `T` is free.\n"
+"* Beware of reference cycles, `Arc` does not use a garbage collector to "
+"detect them.\n"
+"    * `std::sync::Weak` can help."
+msgstr ""
+"* `Arc` steht für \"Atomic Reference Counted\", eine Thread-sichere Version "
+"von `Rc`, die atomar verwendet\n"
+"  Operationen.\n"
+"* `Arc<T>` implementiert `Clone` unabhängig davon, ob `T` dies tut oder "
+"nicht. Es implementiert `Send` und `Sync` iff `T`\n"
+"  setzt sie beide um.\n"
+"* `Arc::clone()` hat die Kosten für atomare Operationen, die ausgeführt "
+"werden, aber danach die Verwendung der\n"
+"  „T“ ist frei.\n"
+"* Hüten Sie sich vor Referenzzyklen, `Arc` verwendet keinen Garbage "
+"Collector, um sie zu erkennen.\n"
+"    * `std::sync::Weak` kann helfen."
+
+#: src/concurrency/shared_state/mutex.md:1
+#, fuzzy
+msgid "# `Mutex`"
+msgstr "# `Mutex`"
+
+#: src/concurrency/shared_state/mutex.md:3
+#, fuzzy
+msgid ""
+"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
+"behind a read-only interface:"
+msgstr ""
+"[`Mutex<T>`][1] sorgt für gegenseitigen Ausschluss _und_ erlaubt "
+"veränderlichen Zugriff auf `T`\n"
+"hinter einer Nur-Lese-Schnittstelle:"
+
+#: src/concurrency/shared_state/mutex.md:6
+msgid "```rust,editable\nuse std::sync::Mutex;"
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:9
+msgid ""
+"fn main() {\n"
+"    let v: Mutex<Vec<i32>> = Mutex::new(vec![10, 20, 30]);\n"
+"    println!(\"v: {:?}\", v.lock().unwrap());"
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:13
+msgid ""
+"    {\n"
+"        let v: &Mutex<Vec<i32>> = &v;\n"
+"        let mut guard = v.lock().unwrap();\n"
+"        guard.push(40);\n"
+"    }"
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:19
+msgid ""
+"    println!(\"v: {:?}\", v.lock().unwrap());\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:23
+#, fuzzy
+msgid ""
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"implementation."
+msgstr ""
+"Beachten Sie, wie wir eine [`impl<T: Send> Sync for Mutex<T>`][2] Blanket "
+"haben\n"
+"Implementierung."
+
+#: src/concurrency/shared_state/mutex.md:26
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E\n"
+"[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
+"[2]: "
+"https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E\n"
+"[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+
+#: src/concurrency/shared_state/mutex.md:30
+#, fuzzy
+msgid ""
+"<details>\n"
+"    \n"
+"* `Mutex` in Rust looks like a collection with just one element - the "
+"protected data.\n"
+"    * It is not possible to forget to acquire the mutex before accessing the "
+"protected data.\n"
+"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the\n"
+"  `&mut T` doesn't outlive the lock being held.\n"
+"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
+"* A read-write lock counterpart - `RwLock`.\n"
+"* Why does `lock()` return a `Result`? \n"
+"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that\n"
+"      the data it protected might be in an inconsistent state. Calling "
+"`lock()` on a poisoned mutex\n"
+"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
+"to recover the data\n"
+"      regardless."
+msgstr ""
+"<Details>\n"
+"    \n"
+"* `Mutex` in Rust sieht aus wie eine Sammlung mit nur einem Element - den "
+"geschützten Daten.\n"
+"    * Es ist nicht möglich, das Abrufen des Mutex zu vergessen, bevor auf "
+"die geschützten Daten zugegriffen wird.\n"
+"* Sie können ein `&mut T` von einem `&Mutex<T>` erhalten, indem Sie die "
+"Sperre nehmen. Der `MutexGuard` sorgt dafür, dass die\n"
+"  `&mut T` überlebt die gehaltene Sperre nicht.\n"
+"* `Mutex<T>` implementiert sowohl `Send` als auch `Sync`, wenn `T` `Send` "
+"implementiert.\n"
+"* Ein Gegenstück zur Lese-Schreib-Sperre - `RwLock`.\n"
+"* Warum gibt `lock()` ein `Result` zurück?\n"
+"    * Wenn der Thread, der den `Mutex` enthielt, in Panik geriet, wird der "
+"`Mutex` \"vergiftet\", um dies zu signalisieren\n"
+"      Die geschützten Daten befinden sich möglicherweise in einem "
+"inkonsistenten Zustand. Aufruf von `lock()` auf einem vergifteten Mutex\n"
+"      schlägt mit einem [`PoisonError`] fehl. Sie können `into_inner()` für "
+"den Fehler aufrufen, um die Daten wiederherzustellen\n"
+"      trotzdem."
+
+#: src/concurrency/shared_state/mutex.md:44
+#, fuzzy
+msgid ""
+"[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html  "
+"\n"
+"    \n"
+"</details>"
+msgstr ""
+"[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html\n"
+"    \n"
+"</details>"
+
+#: src/concurrency/shared_state/example.md:3
+#, fuzzy
+msgid "Let us see `Arc` and `Mutex` in action:"
+msgstr "Sehen wir uns `Arc` und `Mutex` in Aktion an:"
+
+#: src/concurrency/shared_state/example.md:5
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"// use std::sync::{Arc, Mutex};"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:9
+msgid ""
+"fn main() {\n"
+"    let mut v = vec![10, 20, 30];\n"
+"    let handle = thread::spawn(|| {\n"
+"        v.push(10);\n"
+"    });\n"
+"    v.push(1000);"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:16
+msgid ""
+"    handle.join().unwrap();\n"
+"    println!(\"v: {v:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:23
+msgid ""
+"Possible solution:\n"
+"    \n"
+"```rust,editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:29
+msgid "fn main() {\n    let v = Arc::new(Mutex::new(vec![10, 20, 30]));"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:32
+msgid ""
+"    let v2 = v.clone();\n"
+"    let handle = thread::spawn(move || {\n"
+"        let mut v2 = v2.lock().unwrap();\n"
+"        v2.push(10);\n"
+"    });"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:38
+msgid ""
+"    {\n"
+"        let mut v = v.lock().unwrap();\n"
+"        v.push(1000);\n"
+"    }"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:43
+msgid "    handle.join().unwrap();"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:45
+msgid ""
+"    {\n"
+"        let v = v.lock().unwrap();\n"
+"        println!(\"v: {v:?}\");\n"
+"    }\n"
+"}\n"
+"```\n"
+"    \n"
+"Notable parts:"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:54
+#, fuzzy
+msgid ""
+"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal.\n"
+"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
+"state between threads.\n"
+"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature.\n"
+"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible.\n"
+"* We still need to acquire the `Mutex` to print our `Vec`."
+msgstr ""
+"* `v` ist sowohl in `Arc` als auch in `Mutex` eingeschlossen, weil ihre "
+"Anliegen orthogonal sind.\n"
+"  * Das Umhüllen eines `Mutex` in einen `Arc` ist ein gängiges Muster, um "
+"einen veränderlichen Zustand zwischen Threads zu teilen.\n"
+"* „v: Arc<_>“ muss als „v2“ geklont werden, bevor es in einen anderen Thread "
+"verschoben werden kann. Der Lambda-Signatur wurde der Hinweis „move“ "
+"hinzugefügt.\n"
+"* Blöcke werden eingeführt, um den Anwendungsbereich von `LockGuard` so weit "
+"wie möglich einzuschränken.\n"
+"* Wir müssen noch den `Mutex` erwerben, um unseren `Vec` zu drucken."
+
+#: src/concurrency/send-sync.md:1
+#, fuzzy
+msgid "# `Send` and `Sync`"
+msgstr "# `Senden` und `Synchronisieren`"
+
+#: src/concurrency/send-sync.md:3
+#, fuzzy
+msgid ""
+"How does Rust know to forbid shared access across thread? The answer is in "
+"two traits:"
+msgstr ""
+"Woher weiß Rust, dass es den gemeinsamen Zugriff über Threads verbieten "
+"soll? Die Antwort liegt in zwei Merkmalen:"
+
+#: src/concurrency/send-sync.md:5
+#, fuzzy
+msgid ""
+"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
+"thread\n"
+"  boundary.\n"
+"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
+"thread\n"
+"  boundary."
+msgstr ""
+"* [`Send`][1]: ein Typ `T` ist `Send`, wenn es sicher ist, ein `T` über "
+"einen Thread zu bewegen\n"
+"  Grenze.\n"
+"* [`Sync`][2]: ein Typ `T` ist `Sync`, wenn es sicher ist, ein `&T` über "
+"einen Thread zu verschieben\n"
+"  Grenze."
+
+#: src/concurrency/send-sync.md:10
+#, fuzzy
+msgid ""
+"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
+"derive them for your types\n"
+"as long as they only contain `Send` and `Sync` types. You can also implement "
+"them manually when you\n"
+"know it is valid."
+msgstr ""
+"„Senden“ und „Synchronisieren“ sind [unsichere Eigenschaften][3]. Der "
+"Compiler leitet sie automatisch für Ihre Typen ab\n"
+"solange sie nur die Typen `Send` und `Sync` enthalten. Sie können sie auch "
+"manuell implementieren, wenn Sie\n"
+"wissen, dass es gültig ist."
+
+#: src/concurrency/send-sync.md:14
+#, fuzzy
+msgid ""
+"[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
+"[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
+"[3]: ../unsafe/unsafe-traits.md"
+msgstr ""
+"[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
+"[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
+"[3]: ../unsafe/unsafe-traits.md"
+
+#: src/concurrency/send-sync.md:20
+#, fuzzy
+msgid ""
+"* One can think of these traits as markers that the type has certain "
+"thread-safety properties.\n"
+"* They can be used in the generic constraints as normal traits.\n"
+"  \n"
+"</details>"
+msgstr ""
+"* Man kann sich diese Eigenschaften als Markierungen dafür vorstellen, dass "
+"der Typ bestimmte Thread-Sicherheitseigenschaften hat.\n"
+"* Sie können in den generischen Einschränkungen als normale Merkmale "
+"verwendet werden.\n"
+"  \n"
+"</Details>"
+
+#: src/concurrency/send-sync/send.md:1
+#, fuzzy
+msgid "# `Send`"
+msgstr "# `Senden`"
+
+#: src/concurrency/send-sync/send.md:3
+#, fuzzy
+msgid ""
+"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
+"thread."
+msgstr ""
+"> Ein Typ `T` ist [`Send`][1], wenn es sicher ist, einen `T`-Wert in einen "
+"anderen Thread zu verschieben."
+
+#: src/concurrency/send-sync/send.md:5
+#, fuzzy
+msgid ""
+"The effect of moving ownership to another thread is that _destructors_ will "
+"run\n"
+"in that thread. So the question is when you can allocate a value in one "
+"thread\n"
+"and deallocate it in another."
+msgstr ""
+"Das Verschieben der Eigentümerschaft auf einen anderen Thread hat zur Folge, "
+"dass _destructors_ ausgeführt wird\n"
+"in diesem Thread. Die Frage ist also, wann Sie einen Wert in einem Thread "
+"zuweisen können\n"
+"und es in einem anderen freigeben."
+
+#: src/concurrency/send-sync/send.md:9
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
+msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
+
+#: src/concurrency/send-sync/sync.md:1
+#, fuzzy
+msgid "# `Sync`"
+msgstr "# `Synchronisieren`"
+
+#: src/concurrency/send-sync/sync.md:3
+#, fuzzy
+msgid ""
+"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
+"multiple\n"
+"> threads at the same time."
+msgstr ""
+"> Ein Typ `T` ist [`Sync`][1], wenn es sicher ist, von mehreren auf einen "
+"`T`-Wert zuzugreifen\n"
+"> Threads gleichzeitig."
+
+#: src/concurrency/send-sync/sync.md:6
+#, fuzzy
+msgid "More precisely, the definition is:"
+msgstr "Genauer gesagt lautet die Definition:"
+
+#: src/concurrency/send-sync/sync.md:8
+#, fuzzy
+msgid "> `T` is `Sync` if and only if `&T` is `Send`"
+msgstr "> `T` ist `Sync` genau dann, wenn `&T` `Send` ist"
+
+#: src/concurrency/send-sync/sync.md:10
+#, fuzzy
+msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
+msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
+
+#: src/concurrency/send-sync/sync.md:14
+#, fuzzy
+msgid ""
+"This statement is essentially a shorthand way of saying that if a type is "
+"thread-safe for shared use, it is also thread-safe to pass references of it "
+"across threads."
+msgstr ""
+"Diese Anweisung ist im Wesentlichen eine Kurzform dafür, dass ein Typ, der "
+"für die gemeinsame Verwendung Thread-sicher ist, auch Thread-sicher ist, "
+"Verweise auf ihn über Threads hinweg zu übergeben."
+
+#: src/concurrency/send-sync/sync.md:16
+#, fuzzy
+msgid ""
+"This is because if a type is Sync it means that it can be shared across "
+"multiple threads without the risk of data races or other synchronization "
+"issues, so it is safe to move it to another thread. A reference to the type "
+"is also safe to move to another thread, because the data it references can "
+"be accessed from any thread safely."
+msgstr ""
+"Denn wenn ein Typ Sync ist, bedeutet dies, dass er von mehreren Threads "
+"gemeinsam genutzt werden kann, ohne das Risiko von Datenrennen oder anderen "
+"Synchronisierungsproblemen, sodass es sicher ist, ihn in einen anderen "
+"Thread zu verschieben. Ein Verweis auf den Typ kann auch sicher in einen "
+"anderen Thread verschoben werden, da auf die Daten, auf die er verweist, von "
+"jedem Thread aus sicher zugegriffen werden kann."
+
+#: src/concurrency/send-sync/examples.md:1
+#, fuzzy
+msgid "# Examples"
+msgstr "# Beispiele"
+
+#: src/concurrency/send-sync/examples.md:3
+#, fuzzy
+msgid "## `Send + Sync`"
+msgstr "## `Senden + Synchronisieren`"
+
+#: src/concurrency/send-sync/examples.md:5
+#, fuzzy
+msgid "Most types you come across are `Send + Sync`:"
+msgstr "Die meisten Typen, auf die Sie stoßen, sind „Send + Sync“:"
+
+#: src/concurrency/send-sync/examples.md:7
+msgid ""
+"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
+"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
+"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
+"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
+"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
+"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:14
+#, fuzzy
+msgid ""
+"The generic types are typically `Send + Sync` when the type parameters are\n"
+"`Send + Sync`."
+msgstr ""
+"Die generischen Typen sind typischerweise `Send + Sync`, wenn es die "
+"Typparameter sind\n"
+"„Senden + Synchronisieren“."
+
+#: src/concurrency/send-sync/examples.md:17
+#, fuzzy
+msgid "## `Send + !Sync`"
+msgstr "## `Senden + !Sync`"
+
+#: src/concurrency/send-sync/examples.md:19
+#, fuzzy
+msgid ""
+"These types can be moved to other threads, but they're not thread-safe.\n"
+"Typically because of interior mutability:"
+msgstr ""
+"Diese Typen können in andere Threads verschoben werden, sind aber nicht "
+"Thread-sicher.\n"
+"Typischerweise wegen innerer Mutabilität:"
+
+#: src/concurrency/send-sync/examples.md:22
+#, fuzzy
+msgid ""
+"* `mpsc::Sender<T>`\n"
+"* `mpsc::Receiver<T>`\n"
+"* `Cell<T>`\n"
+"* `RefCell<T>`"
+msgstr ""
+"* `mpsc::Sender<T>`\n"
+"* `mpsc::Receiver<T>`\n"
+"* `Zelle<T>`\n"
+"* `RefCell<T>`"
+
+#: src/concurrency/send-sync/examples.md:27
+#, fuzzy
+msgid "## `!Send + Sync`"
+msgstr "## `!Senden + Synchronisieren`"
+
+#: src/concurrency/send-sync/examples.md:29
+#, fuzzy
+msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgstr ""
+"Diese Typen sind Thread-sicher, können aber nicht in einen anderen Thread "
+"verschoben werden:"
+
+#: src/concurrency/send-sync/examples.md:31
+#, fuzzy
+msgid ""
+"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
+"the\n"
+"  thread which created them."
+msgstr ""
+"* `MutexGuard<T>`: Verwendet Primitive auf Betriebssystemebene, die auf dem "
+"freigegeben werden müssen\n"
+"  Thread, der sie erstellt hat."
+
+#: src/concurrency/send-sync/examples.md:34
+#, fuzzy
+msgid "## `!Send + !Sync`"
+msgstr "## `!Senden + !Sync`"
+
+#: src/concurrency/send-sync/examples.md:36
+#, fuzzy
+msgid "These types are not thread-safe and cannot be moved to other threads:"
+msgstr ""
+"Diese Typen sind nicht Thread-sicher und können nicht in andere Threads "
+"verschoben werden:"
+
+#: src/concurrency/send-sync/examples.md:38
+#, fuzzy
+msgid ""
+"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
+"  non-atomic reference count.\n"
+"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
+"  concurrency considerations."
+msgstr ""
+"* `Rc<T>`: Jedes `Rc<T>` hat eine Referenz auf eine `RcBox<T>`, die eine "
+"enthält\n"
+"  nicht-atomarer Referenzzähler.\n"
+"* `*const T`, `*mut T`: Rust geht davon aus, dass Rohzeiger möglicherweise "
+"etwas Besonderes haben\n"
+"  Parallelitätsüberlegungen."
+
+#: src/exercises/day-4/morning.md:1 src/exercises/day-4/afternoon.md:1
+#, fuzzy
+msgid "# Exercises"
+msgstr "# Übungen"
+
+#: src/exercises/day-4/morning.md:3
+#, fuzzy
+msgid "Let us practice our new concurrency skills with"
+msgstr "Lassen Sie uns unsere neuen Nebenläufigkeitsfähigkeiten mit üben"
+
+#: src/exercises/day-4/morning.md:5
+#, fuzzy
+msgid "* Dining philosophers: a classic problem in concurrency."
+msgstr "* Speisephilosophen: ein klassisches Problem der Nebenläufigkeit."
+
+#: src/exercises/day-4/morning.md:7
+#, fuzzy
+msgid ""
+"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
+"  download dependencies and then check links in parallel."
+msgstr ""
+"* Multithreaded Link Checker: ein größeres Projekt, für das Sie Cargo "
+"verwenden werden\n"
+"  Abhängigkeiten herunterladen und dann parallel Links prüfen."
+
+#: src/exercises/day-4/dining-philosophers.md:1
+#, fuzzy
+msgid "# Dining Philosophers"
+msgstr "# Speisende Philosophen"
+
+#: src/exercises/day-4/dining-philosophers.md:3
+#, fuzzy
+msgid "The dining philosophers problem is a classic problem in concurrency:"
+msgstr ""
+"Das Dining-Philosophen-Problem ist ein klassisches Nebenläufigkeitsproblem:"
+
+#: src/exercises/day-4/dining-philosophers.md:5
+#, fuzzy
+msgid ""
+"> Five philosophers dine together at the same table. Each philosopher has "
+"their\n"
+"> own place at the table. There is a fork between each plate. The dish "
+"served is\n"
+"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
+"can\n"
+"> only alternately think and eat. Moreover, a philosopher can only eat "
+"their\n"
+"> spaghetti when they have both a left and right fork. Thus two forks will "
+"only\n"
+"> be available when their two nearest neighbors are thinking, not eating. "
+"After\n"
+"> an individual philosopher finishes eating, they will put down both forks."
+msgstr ""
+"> Fünf Philosophen speisen gemeinsam am selben Tisch. Jeder Philosoph hat "
+"seine\n"
+"> eigener Platz am Tisch. Zwischen jedem Teller befindet sich eine Gabel. "
+"Das servierte Gericht ist\n"
+"> eine Art Spaghetti, die mit zwei Gabeln gegessen werden muss. Jeder "
+"Philosoph kann\n"
+"> nur abwechselnd denken und essen. Außerdem kann ein Philosoph nur ihre "
+"essen\n"
+"> Spaghetti, wenn sie sowohl eine linke als auch eine rechte Gabel haben. "
+"Also zwei Gabeln werden nur\n"
+"> verfügbar sein, wenn ihre beiden nächsten Nachbarn nachdenken, nicht "
+"essen. Nach\n"
+"> ein einzelner Philosoph mit dem Essen fertig ist, legen sie beide Gabeln "
+"weg."
+
+#: src/exercises/day-4/dining-philosophers.md:13
+#, fuzzy
+msgid ""
+"You will need a local [Cargo installation](../../cargo/running-locally.md) "
+"for\n"
+"this exercise. Copy the code below to `src/main.rs` file, fill out the "
+"blanks,\n"
+"and test that `cargo run` does not deadlock:"
+msgstr ""
+"Dazu benötigen Sie eine lokale "
+"[Cargo-Installation](../../cargo/running-locally.md).\n"
+"diese Übung. Kopieren Sie den folgenden Code in die Datei `src/main.rs`, "
+"füllen Sie die Lücken aus,\n"
+"und teste, dass `cargo run` keinen Deadlock verursacht:"
+
+#: src/exercises/day-4/dining-philosophers.md:17
+msgid ""
+"```rust,compile_fail\n"
+"use std::sync::mpsc;\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:23
+#: src/exercises/day-4/solutions-morning.md:28
+msgid "struct Fork;"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:25
+#, fuzzy
+msgid ""
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // thoughts: ...\n"
+"}"
+msgstr ""
+"struct Philosoph {\n"
+"    Name: Zeichenfolge,\n"
+"    // left_fork: ...\n"
+"    // right_fork: ...\n"
+"    // Gedanken: ...\n"
+"}"
+
+#: src/exercises/day-4/dining-philosophers.md:32
+msgid ""
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:39
+msgid ""
+"    fn eat(&self) {\n"
+"        // Pick up forks...\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:46
+#: src/exercises/day-4/solutions-morning.md:60
+msgid ""
+"static PHILOSOPHERS: &[&str] =\n"
+"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:49
+#, fuzzy
+msgid "fn main() {\n    // Create forks"
+msgstr "fn Haupt() {\n    // Gabeln erstellen"
+
+#: src/exercises/day-4/dining-philosophers.md:52
+#, fuzzy
+msgid "    // Create philosophers"
+msgstr "    // Philosophen erstellen"
+
+#: src/exercises/day-4/dining-philosophers.md:54
+#, fuzzy
+msgid "    // Make them think and eat"
+msgstr "    // Lass sie denken und essen"
+
+#: src/exercises/day-4/dining-philosophers.md:56
+msgid ""
+"    // Output their thoughts\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:1
+#, fuzzy
+msgid "# Multi-threaded Link Checker"
+msgstr "# Multithreaded Link Checker"
+
+#: src/exercises/day-4/link-checker.md:3
+#, fuzzy
+msgid ""
+"Let us use our new knowledge to create a multi-threaded link checker. It "
+"should\n"
+"start at a webpage and check that links on the page are valid. It should\n"
+"recursively check other pages on the same domain and keep doing this until "
+"all\n"
+"pages have been validated."
+msgstr ""
+"Lassen Sie uns unser neues Wissen nutzen, um einen Multithread-Link-Checker "
+"zu erstellen. Es sollte\n"
+"Starten Sie auf einer Webseite und prüfen Sie, ob die Links auf der Seite "
+"gültig sind. Es sollte\n"
+"Überprüfen Sie rekursiv andere Seiten auf derselben Domain und tun Sie dies "
+"so lange, bis alle\n"
+"Seiten wurden validiert."
+
+#: src/exercises/day-4/link-checker.md:8
+#, fuzzy
+msgid ""
+"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
+"Cargo project and `reqwest` it as a dependency with:"
+msgstr ""
+"Dazu benötigen Sie einen HTTP-Client wie [`reqwest`][1]. Erstelle eine neue\n"
+"Frachtprojekt und `reqwest` es als Abhängigkeit mit:"
+
+#: src/exercises/day-4/link-checker.md:11
+msgid ""
+"```shell\n"
+"$ cargo new link-checker\n"
+"$ cd link-checker\n"
+"$ cargo add --features blocking,rustls-tls reqwest\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:17
+#, fuzzy
+msgid ""
+"> If `cargo add` fails with `error: no such subcommand`, then please edit "
+"the\n"
+"> `Cargo.toml` file by hand. Add the dependencies listed below."
+msgstr ""
+"> Wenn `cargo add` mit `error: no such subcommand` fehlschlägt, dann "
+"bearbeiten Sie bitte die\n"
+"> `Cargo.toml`-Datei von Hand. Fügen Sie die unten aufgeführten "
+"Abhängigkeiten hinzu."
+
+#: src/exercises/day-4/link-checker.md:20
+#, fuzzy
+msgid ""
+"You will also need a way to find links. We can use [`scraper`][2] for that:"
+msgstr ""
+"Sie benötigen auch eine Möglichkeit, Links zu finden. Dafür können wir "
+"[`scraper`][2] verwenden:"
+
+#: src/exercises/day-4/link-checker.md:22
+msgid ""
+"```shell\n"
+"$ cargo add scraper\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:26
+#, fuzzy
+msgid ""
+"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
+"for\n"
+"that:"
+msgstr ""
+"Schließlich brauchen wir eine Möglichkeit, mit Fehlern umzugehen. Wir "
+"verwenden [`thiserror`][3] für\n"
+"Das:"
+
+#: src/exercises/day-4/link-checker.md:29
+msgid ""
+"```shell\n"
+"$ cargo add thiserror\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:33
+#, fuzzy
+msgid ""
+"The `cargo add` calls will update the `Cargo.toml` file to look like this:"
+msgstr ""
+"Die `cargo add`-Aufrufe aktualisieren die `Cargo.toml`-Datei so, dass sie "
+"wie folgt aussieht:"
+
+#: src/exercises/day-4/link-checker.md:35
+msgid ""
+"```toml\n"
+"[dependencies]\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] "
+"}\n"
+"scraper = \"0.13.0\"\n"
+"thiserror = \"1.0.37\"\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:42
+#, fuzzy
+msgid ""
+"You can now download the start page. Try with a small site such as\n"
+"`https://www.google.org/`."
+msgstr ""
+"Sie können nun die Startseite herunterladen. Versuchen Sie es mit einer "
+"kleinen Website wie z\n"
+"`https://www.google.org/`."
+
+#: src/exercises/day-4/link-checker.md:45
+#, fuzzy
+msgid "Your `src/main.rs` file should look something like this:"
+msgstr "Ihre `src/main.rs`-Datei sollte in etwa so aussehen:"
+
+#: src/exercises/day-4/link-checker.md:47
+msgid ""
+"```rust,compile_fail\n"
+"use reqwest::blocking::{get, Response};\n"
+"use reqwest::Url;\n"
+"use scraper::{Html, Selector};\n"
+"use thiserror::Error;"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:53
+#, fuzzy
+msgid ""
+"#[derive(Error, Debug)]\n"
+"enum Error {\n"
+"    #[error(\"request error: {0}\")]\n"
+"    ReqwestError(#[from] reqwest::Error),\n"
+"}"
+msgstr ""
+"#[ableiten(Fehler, Debug)]\n"
+"Aufzählungsfehler {\n"
+"    #[error(\"Anforderungsfehler: {0}\")]\n"
+"    ReqwestError(#[from]reqwest::Error),\n"
+"}"
+
+#: src/exercises/day-4/link-checker.md:59
+msgid ""
+"fn extract_links(response: Response) -> Result<Vec<Url>, Error> {\n"
+"    let base_url = response.url().to_owned();\n"
+"    let document = response.text()?;\n"
+"    let html = Html::parse_document(&document);\n"
+"    let selector = Selector::parse(\"a\").unwrap();"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:65
+msgid ""
+"    let mut valid_urls = Vec::new();\n"
+"    for element in html.select(&selector) {\n"
+"        if let Some(href) = element.value().attr(\"href\") {\n"
+"            match base_url.join(href) {\n"
+"                Ok(url) => valid_urls.push(url),\n"
+"                Err(err) => {\n"
+"                    println!(\"On {base_url}: could not parse {href:?}: "
+"{err} (ignored)\",);\n"
+"                }\n"
+"            }\n"
+"        }\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:77
+#, fuzzy
+msgid "    Ok(valid_urls)\n}"
+msgstr "    Okay (valid_urls)\n}"
+
+#: src/exercises/day-4/link-checker.md:80
+msgid ""
+"fn main() {\n"
+"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
+"    let response = get(start_url).unwrap();\n"
+"    match extract_links(response) {\n"
+"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
+"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:90
+#, fuzzy
+msgid "Run the code in `src/main.rs` with"
+msgstr "Führen Sie den Code in `src/main.rs` mit aus"
+
+#: src/exercises/day-4/link-checker.md:92
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:96
+#, fuzzy
+msgid "## Tasks"
+msgstr "## Aufgaben"
+
+#: src/exercises/day-4/link-checker.md:98
+#, fuzzy
+msgid ""
+"* Use threads to check the links in parallel: send the URLs to be checked to "
+"a\n"
+"  channel and let a few threads check the URLs in parallel.\n"
+"* Extend this to recursively extract links from all pages on the\n"
+"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
+"you\n"
+"  don't end up being blocked by the site."
+msgstr ""
+"* Verwenden Sie Threads, um die Links parallel zu prüfen: Senden Sie die zu "
+"prüfenden URLs an a\n"
+"  Channel und lass ein paar Threads parallel die URLs prüfen.\n"
+"* Erweitern Sie dies, um Links von allen Seiten rekursiv zu extrahieren\n"
+"  `www.google.org`-Domain. Setzen Sie eine Obergrenze von 100 Seiten oder "
+"so, dass Sie\n"
+"  am Ende nicht von der Seite blockiert werden."
+
+#: src/exercises/day-4/link-checker.md:104
+#, fuzzy
+msgid ""
+"[1]: https://docs.rs/reqwest/\n"
+"[2]: https://docs.rs/scraper/\n"
+"[3]: https://docs.rs/thiserror/"
+msgstr ""
+"[1]: https://docs.rs/reqwest/\n"
+"[2]: https://docs.rs/scraper/\n"
+"[3]: https://docs.rs/thiserror/"
+
+#: src/android.md:1
+#, fuzzy
+msgid "# Android"
+msgstr "# Android"
+
+#: src/android.md:3
+#, fuzzy
+msgid ""
+"Rust is supported for native platform development on Android. This means "
+"that\n"
+"you can write new operating system services in Rust, as well as extending\n"
+"existing services."
+msgstr ""
+"Rust wird für die native Plattformentwicklung auf Android unterstützt. Das "
+"bedeutet, dass\n"
+"Sie können neue Betriebssystemdienste in Rust schreiben und erweitern\n"
+"bestehende Dienste."
+
+#: src/android/setup.md:1
+#, fuzzy
+msgid "# Setup"
+msgstr "# Aufstellen"
+
+#: src/android/setup.md:3
+#, fuzzy
+msgid ""
+"We will be using an Android Virtual Device to test our code. Make sure you "
+"have\n"
+"access to one or create a new one with:"
+msgstr ""
+"Wir werden ein Android Virtual Device verwenden, um unseren Code zu testen. "
+"Stell sicher dass du hast\n"
+"Greifen Sie auf eines zu oder erstellen Sie ein neues mit:"
+
+#: src/android/setup.md:6
+msgid ""
+"```shell\n"
+"$ source build/envsetup.sh\n"
+"$ lunch aosp_cf_x86_64_phone-userdebug\n"
+"$ acloud create\n"
+"```"
+msgstr ""
+
+#: src/android/setup.md:12
+#, fuzzy
+msgid ""
+"Please see the [Android Developer\n"
+"Codelab](https://source.android.com/docs/setup/start) for details."
+msgstr ""
+"Bitte lesen Sie die [Android Developer\n"
+"Codelab] (https://source.android.com/docs/setup/start) für Details."
+
+#: src/android/build-rules.md:1
+#, fuzzy
+msgid "# Build Rules"
+msgstr "# Bauregeln"
+
+#: src/android/build-rules.md:3
+#, fuzzy
+msgid "The Android build system (Soong) supports Rust via a number of modules:"
+msgstr ""
+"Das Android-Build-System (Soong) unterstützt Rust über eine Reihe von "
+"Modulen:"
+
+#: src/android/build-rules.md:5
+#, fuzzy
+msgid ""
+"| Module Type       | Description                                            "
+"                                            |\n"
+"|-------------------|----------------------------------------------------------------------------------------------------|\n"
+"| `rust_binary`     | Produces a Rust binary.                                "
+"                                            |\n"
+"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
+"`dylib` variants.                            |\n"
+"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
+"provides both static and shared variants.    |\n"
+"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
+"analogous to compiler plugins.                     |\n"
+"| `rust_test`       | Produces a Rust test binary that uses the standard "
+"Rust test harness.                              |\n"
+"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging `libfuzzer`.    "
+"                                            |\n"
+"| `rust_protobuf`   | Generates source and produces a Rust library that "
+"provides an interface for a particular protobuf. |\n"
+"| `rust_bindgen`    | Generates source and produces a Rust library "
+"containing Rust bindings to C libraries.              |"
+msgstr ""
+"| Modultyp | Beschreibung |\n"
+"|-------------------|------------------------ "
+"-------------------------------------------------- ---------------------|\n"
+"| `rust_binary` | Erzeugt eine Rust-Binärdatei. |\n"
+"| `rust_library` | Erzeugt eine Rust-Bibliothek und bietet sowohl `rlib`- "
+"als auch `dylib`-Varianten. |\n"
+"| `rust_ffi` | Erzeugt eine Rust-C-Bibliothek, die von `cc`-Modulen "
+"verwendet werden kann, und bietet sowohl statische als auch gemeinsam "
+"genutzte Varianten. |\n"
+"| `rust_proc_macro` | Erzeugt eine `proc-macro` Rust-Bibliothek. Diese sind "
+"analog zu Compiler-Plugins. |\n"
+"| `rust_test` | Erzeugt eine Rust-Test-Binärdatei, die die standardmäßige "
+"Rust-Testumgebung verwendet. |\n"
+"| `rust_fuzz` | Erzeugt eine Rust-Fuzz-Binärdatei, die `libfuzzer` nutzt. |\n"
+"| `rust_protobuf` | Generiert Quellcode und erstellt eine Rust-Bibliothek, "
+"die eine Schnittstelle für einen bestimmten Protobuf bereitstellt. |\n"
+"| `rust_bindgen` | Generiert Quellcode und erstellt eine Rust-Bibliothek, "
+"die Rust-Bindungen an C-Bibliotheken enthält. |"
+
+#: src/android/build-rules.md:16
+#, fuzzy
+msgid "We will look at `rust_binary` and `rust_library` next."
+msgstr "Als nächstes schauen wir uns `rust_binary` und `rust_library` an."
+
+#: src/android/build-rules/binary.md:1
+#, fuzzy
+msgid "# Rust Binaries"
+msgstr "# Rust-Binärdateien"
+
+#: src/android/build-rules/binary.md:3
+#, fuzzy
+msgid ""
+"Let us start with a simple application. At the root of an AOSP checkout, "
+"create\n"
+"the following files:"
+msgstr ""
+"Beginnen wir mit einer einfachen Anwendung. Erstellen Sie im "
+"Stammverzeichnis eines AOSP-Checkouts\n"
+"folgende Dateien:"
+
+#: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
+#, fuzzy
+msgid "_hello_rust/Android.bp_:"
+msgstr "_hello_rust/Android.bp_:"
+
+#: src/android/build-rules/binary.md:8
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust\",\n"
+"    crate_name: \"hello_rust\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/build-rules/binary.md:16 src/android/build-rules/library.md:34
+#, fuzzy
+msgid "_hello_rust/src/main.rs_:"
+msgstr "_hello_rust/src/main.rs_:"
+
+#: src/android/build-rules/binary.md:18
+msgid "```rust\n//! Rust demo."
+msgstr ""
+
+#: src/android/build-rules/binary.md:21
+msgid ""
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"Hello from Rust!\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/build-rules/binary.md:27
+#, fuzzy
+msgid "You can now build, push, and run the binary:"
+msgstr "Sie können die Binärdatei jetzt erstellen, pushen und ausführen:"
+
+#: src/android/build-rules/binary.md:29
+msgid ""
+"```shell\n"
+"$ m hello_rust\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust /data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust\n"
+"Hello from Rust!\n"
+"```"
+msgstr ""
+
+#: src/android/build-rules/library.md:1
+#, fuzzy
+msgid "# Rust Libraries"
+msgstr "# Rust-Bibliotheken"
+
+#: src/android/build-rules/library.md:3
+#, fuzzy
+msgid "You use `rust_library` to create a new Rust library for Android."
+msgstr ""
+"Sie verwenden `rust_library`, um eine neue Rust-Bibliothek für Android zu "
+"erstellen."
+
+#: src/android/build-rules/library.md:5
+#, fuzzy
+msgid "Here we declare a dependency on two libraries:"
+msgstr "Hier deklarieren wir eine Abhängigkeit von zwei Bibliotheken:"
+
+#: src/android/build-rules/library.md:7
+#, fuzzy
+msgid ""
+"* `libgreeting`, which we define below,\n"
+"* `libtextwrap`, which is a crate already vendored in\n"
+"  [`external/rust/crates/`][crates]."
+msgstr ""
+"* `libgreeting`, das wir unten definieren,\n"
+"* `libtextwrap`, das ist eine Kiste, in der bereits verkauft wird\n"
+"  [`extern/rust/crates/`][crates]."
+
+#: src/android/build-rules/library.md:11
+#, fuzzy
+msgid ""
+"[crates]: "
+"https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/"
+msgstr ""
+"[Kisten]: "
+"https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/"
+
+#: src/android/build-rules/library.md:15
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}"
+msgstr ""
+
+#: src/android/build-rules/library.md:27
+msgid ""
+"rust_library {\n"
+"    name: \"libgreetings\",\n"
+"    crate_name: \"greetings\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/build-rules/library.md:36
+msgid "```rust,ignore\n//! Rust demo."
+msgstr ""
+
+#: src/android/build-rules/library.md:39
+msgid "use greetings::greeting;\nuse textwrap::fill;"
+msgstr ""
+
+#: src/android/build-rules/library.md:42
+msgid ""
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/build-rules/library.md:48
+#, fuzzy
+msgid "_hello_rust/src/lib.rs_:"
+msgstr "_hello_rust/src/lib.rs_:"
+
+#: src/android/build-rules/library.md:50
+msgid "```rust,ignore\n//! Greeting library."
+msgstr ""
+
+#: src/android/build-rules/library.md:53
+msgid ""
+"/// Greet `name`.\n"
+"pub fn greeting(name: &str) -> String {\n"
+"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/build-rules/library.md:59
+#, fuzzy
+msgid "You build, push, and run the binary like before:"
+msgstr "Sie erstellen, pushen und führen die Binärdatei wie zuvor aus:"
+
+#: src/android/build-rules/library.md:61
+msgid ""
+"```shell\n"
+"$ m hello_rust_with_dep\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep "
+"/data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust_with_dep\n"
+"Hello Bob, it is very\n"
+"nice to meet you!\n"
+"```"
+msgstr ""
+
+#: src/android/aidl.md:1
+#, fuzzy
+msgid "# AIDL"
+msgstr "# AIDL"
+
+#: src/android/aidl.md:3
+#, fuzzy
+msgid ""
+"The [Android Interface Definition Language\n"
+"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
+"Rust:"
+msgstr ""
+"Die [Android Interface Definition Language\n"
+"(AIDL)](https://developer.android.com/guide/components/aidl) wird in Rust "
+"unterstützt:"
+
+#: src/android/aidl.md:6
+#, fuzzy
+msgid ""
+"* Rust code can call existing AIDL servers,\n"
+"* You can create new AIDL servers in Rust."
+msgstr ""
+"* Rust-Code kann bestehende AIDL-Server aufrufen,\n"
+"* Sie können neue AIDL-Server in Rust erstellen."
+
+#: src/android/aidl/interface.md:1
+#, fuzzy
+msgid "# AIDL Interfaces"
+msgstr "# AIDL-Schnittstellen"
+
+#: src/android/aidl/interface.md:3
+#, fuzzy
+msgid "You declare the API of your service using an AIDL interface:"
+msgstr "Sie deklarieren die API Ihres Dienstes über eine AIDL-Schnittstelle:"
+
+#: src/android/aidl/interface.md:5
+#, fuzzy
+msgid ""
+"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+msgstr ""
+"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+
+#: src/android/aidl/interface.md:7 src/android/aidl/changing.md:6
+msgid "```java\npackage com.example.birthdayservice;"
+msgstr ""
+
+#: src/android/aidl/interface.md:10
+msgid ""
+"/** Birthday service interface. */\n"
+"interface IBirthdayService {\n"
+"    /** Generate a Happy Birthday message. */\n"
+"    String wishHappyBirthday(String name, int years);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/interface.md:17
+#, fuzzy
+msgid "*birthday_service/aidl/Android.bp*:"
+msgstr "*birthday_service/aidl/Android.bp*:"
+
+#: src/android/aidl/interface.md:19
+msgid ""
+"```javascript\n"
+"aidl_interface {\n"
+"    name: \"com.example.birthdayservice\",\n"
+"    srcs: [\"com/example/birthdayservice/*.aidl\"],\n"
+"    unstable: true,\n"
+"    backend: {\n"
+"        rust: { // Rust is not enabled by default\n"
+"            enabled: true,\n"
+"        },\n"
+"    },\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/interface.md:32
+#, fuzzy
+msgid ""
+"Add `vendor_available: true` if your AIDL file is used by a binary in the "
+"vendor\n"
+"partition."
+msgstr ""
+"Fügen Sie „vendor_available: true“ hinzu, wenn Ihre AIDL-Datei von einer "
+"Binärdatei des Anbieters verwendet wird\n"
+"Partition."
+
+#: src/android/aidl/implementation.md:1
+#, fuzzy
+msgid "# Service Implementation"
+msgstr "# Dienstimplementierung"
+
+#: src/android/aidl/implementation.md:3
+#, fuzzy
+msgid "We can now implement the AIDL service:"
+msgstr "Wir können jetzt den AIDL-Dienst implementieren:"
+
+#: src/android/aidl/implementation.md:5
+#, fuzzy
+msgid "*birthday_service/src/lib.rs*:"
+msgstr "*birthday_service/src/lib.rs*:"
+
+#: src/android/aidl/implementation.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Implementation of the `IBirthdayService` AIDL interface.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+msgstr ""
+
+#: src/android/aidl/implementation.md:12
+msgid "/// The `IBirthdayService` implementation.\npub struct BirthdayService;"
+msgstr ""
+
+#: src/android/aidl/implementation.md:15
+#, fuzzy
+msgid "impl binder::Interface for BirthdayService {}"
+msgstr "impl binder::Interface für BirthdayService {}"
+
+#: src/android/aidl/implementation.md:17
+msgid ""
+"impl IBirthdayService for BirthdayService {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
+"binder::Result<String> {\n"
+"        Ok(format!(\n"
+"            \"Happy Birthday {name}, congratulations with the {years} "
+"years!\"\n"
+"        ))\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
+#: src/android/aidl/client.md:37
+#, fuzzy
+msgid "*birthday_service/Android.bp*:"
+msgstr "*birthday_service/Android.bp*:"
+
+#: src/android/aidl/implementation.md:28
+msgid ""
+"```javascript\n"
+"rust_library {\n"
+"    name: \"libbirthdayservice\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    crate_name: \"birthdayservice\",\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/server.md:1
+#, fuzzy
+msgid "# AIDL Server"
+msgstr "# AIDL-Server"
+
+#: src/android/aidl/server.md:3
+#, fuzzy
+msgid "Finally, we can create a server which exposes the service:"
+msgstr ""
+"Schließlich können wir einen Server erstellen, der den Dienst verfügbar "
+"macht:"
+
+#: src/android/aidl/server.md:5
+#, fuzzy
+msgid "*birthday_service/src/server.rs*:"
+msgstr "*birthday_service/src/server.rs*:"
+
+#: src/android/aidl/server.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use birthdayservice::BirthdayService;\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+msgstr ""
+
+#: src/android/aidl/server.md:13 src/android/aidl/client.md:12
+msgid "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";"
+msgstr ""
+
+#: src/android/aidl/server.md:15
+msgid ""
+"/// Entry point for birthday service.\n"
+"fn main() {\n"
+"    let birthday_service = BirthdayService;\n"
+"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
+"        birthday_service,\n"
+"        binder::BinderFeatures::default(),\n"
+"    );\n"
+"    binder::add_service(SERVICE_IDENTIFIER, "
+"birthday_service_binder.as_binder())\n"
+"        .expect(\"Failed to register service\");\n"
+"    binder::ProcessState::join_thread_pool()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/server.md:30
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_server\",\n"
+"    crate_name: \"birthday_server\",\n"
+"    srcs: [\"src/server.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"        \"libbirthdayservice\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/deploy.md:1
+#, fuzzy
+msgid "# Deploy"
+msgstr "# Einsetzen"
+
+#: src/android/aidl/deploy.md:3
+#, fuzzy
+msgid "We can now build, push, and start the service:"
+msgstr "Wir können den Dienst jetzt erstellen, pushen und starten:"
+
+#: src/android/aidl/deploy.md:5
+msgid ""
+"```shell\n"
+"$ m birthday_server\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/tmp\n"
+"$ adb shell /data/local/tmp/birthday_server\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/deploy.md:11
+#, fuzzy
+msgid "In another terminal, check that the service runs:"
+msgstr "Überprüfen Sie in einem anderen Terminal, ob der Dienst ausgeführt wird:"
+
+#: src/android/aidl/deploy.md:13
+msgid ""
+"```shell\n"
+"$ adb shell service check birthdayservice\n"
+"Service birthdayservice: found\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/deploy.md:18
+#, fuzzy
+msgid "You can also call the service with `service call`:"
+msgstr "Sie können den Service auch mit `Service Call` aufrufen:"
+
+#: src/android/aidl/deploy.md:20
+msgid ""
+"```shell\n"
+"$ $ adb shell service call birthdayservice 1 s16 Bob i32 24\n"
+"Result: Parcel(\n"
+"  0x00000000: 00000000 00000036 00610048 00700070 '....6...H.a.p.p.'\n"
+"  0x00000010: 00200079 00690042 00740072 00640068 'y. .B.i.r.t.h.d.'\n"
+"  0x00000020: 00790061 00420020 0062006f 0020002c 'a.y. .B.o.b.,. .'\n"
+"  0x00000030: 006f0063 0067006e 00610072 00750074 'c.o.n.g.r.a.t.u.'\n"
+"  0x00000040: 0061006c 00690074 006e006f 00200073 'l.a.t.i.o.n.s. .'\n"
+"  0x00000050: 00690077 00680074 00740020 00650068 'w.i.t.h. .t.h.e.'\n"
+"  0x00000060: 00320020 00200034 00650079 00720061 ' .2.4. .y.e.a.r.'\n"
+"  0x00000070: 00210073 00000000                   's.!.....        ')\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/client.md:1
+#, fuzzy
+msgid "# AIDL Client"
+msgstr "# AIDL-Client"
+
+#: src/android/aidl/client.md:3
+#, fuzzy
+msgid "Finally, we can create a Rust client for our new service."
+msgstr ""
+"Schließlich können wir einen Rust-Client für unseren neuen Dienst erstellen."
+
+#: src/android/aidl/client.md:5
+#, fuzzy
+msgid "*birthday_service/src/client.rs*:"
+msgstr "*birthday_service/src/client.rs*:"
+
+#: src/android/aidl/client.md:7
+msgid ""
+"```rust,ignore\n"
+"//! Birthday service.\n"
+"use "
+"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;"
+msgstr ""
+
+#: src/android/aidl/client.md:14
+#, fuzzy
+msgid ""
+"/// Connect to the BirthdayService.\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
+"binder::StatusCode> {\n"
+"    binder::get_interface(SERVICE_IDENTIFIER)\n"
+"}"
+msgstr ""
+"/// Mit dem Geburtstagsdienst verbinden.\n"
+"pub fn connect() -> Ergebnis<binder::Strong<dyn IBirthdayService>, "
+"binder::StatusCode> {\n"
+"    binder::get_interface(SERVICE_IDENTIFIER)\n"
+"}"
+
+#: src/android/aidl/client.md:19
+msgid ""
+"/// Call the birthday service.\n"
+"fn main() -> Result<(), binder::Status> {\n"
+"    let name = std::env::args()\n"
+"        .nth(1)\n"
+"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
+"    let years = std::env::args()\n"
+"        .nth(2)\n"
+"        .and_then(|arg| arg.parse::<i32>().ok())\n"
+"        .unwrap_or(42);"
+msgstr ""
+
+#: src/android/aidl/client.md:29
+msgid ""
+"    binder::ProcessState::start_thread_pool();\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
+"    let msg = service.wishHappyBirthday(&name, years)?;\n"
+"    println!(\"{msg}\");\n"
+"    Ok(())\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/client.md:39
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"birthday_client\",\n"
+"    crate_name: \"birthday_client\",\n"
+"    srcs: [\"src/client.rs\"],\n"
+"    rustlibs: [\n"
+"        \"com.example.birthdayservice-rust\",\n"
+"        \"libbinder_rs\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/client.md:52
+#, fuzzy
+msgid "Notice that the client does not depend on `libbirthdayservice`."
+msgstr "Beachten Sie, dass der Client nicht von `libbirthdayservice` abhängt."
+
+#: src/android/aidl/client.md:54
+#, fuzzy
+msgid "Build, push, and run the client on your device:"
+msgstr "Erstellen, pushen und führen Sie den Client auf Ihrem Gerät aus:"
+
+#: src/android/aidl/client.md:56
+msgid ""
+"```shell\n"
+"$ m birthday_client\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/tmp\n"
+"$ adb shell /data/local/tmp/birthday_client Charlie 60\n"
+"Happy Birthday Charlie, congratulations with the 60 years!\n"
+"```"
+msgstr ""
+
+#: src/android/aidl/changing.md:1
+#, fuzzy
+msgid "# Changing API"
+msgstr "# Ändern der API"
+
+#: src/android/aidl/changing.md:3
+#, fuzzy
+msgid ""
+"Let us extend the API with more functionality: we want to let clients "
+"specify a\n"
+"list of lines for the birthday card:"
+msgstr ""
+"Lassen Sie uns die API um mehr Funktionalität erweitern: Wir möchten, dass "
+"Kunden a angeben\n"
+"Liste der Zeilen für die Geburtstagskarte:"
+
+#: src/android/aidl/changing.md:9
+msgid ""
+"/** Birthday service interface. */\n"
+"interface IBirthdayService {\n"
+"    /** Generate a Happy Birthday message. */\n"
+"    String wishHappyBirthday(String name, int years, in String[] text);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/logging.md:1
+#, fuzzy
+msgid "# Logging"
+msgstr "# Protokollierung"
+
+#: src/android/logging.md:3
+#, fuzzy
+msgid ""
+"You should use the `log` crate to automatically log to `logcat` (on-device) "
+"or\n"
+"`stdout` (on-host):"
+msgstr ""
+"Sie sollten die `log`-Crate verwenden, um sich automatisch bei `logcat` (auf "
+"dem Gerät) anzumelden oder\n"
+"`stdout` (auf dem Host):"
+
+#: src/android/logging.md:6
+#, fuzzy
+msgid "_hello_rust_logs/Android.bp_:"
+msgstr "_hello_rust_logs/Android.bp_:"
+
+#: src/android/logging.md:8
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_logs\",\n"
+"    crate_name: \"hello_rust_logs\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"liblog_rust\",\n"
+"        \"liblogger\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"    host_supported: true,\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/logging.md:22
+#, fuzzy
+msgid "_hello_rust_logs/src/main.rs_:"
+msgstr "_hello_rust_logs/src/main.rs_:"
+
+#: src/android/logging.md:24
+msgid "```rust,ignore\n//! Rust logging demo."
+msgstr ""
+
+#: src/android/logging.md:27
+msgid "use log::{debug, error, info};"
+msgstr ""
+
+#: src/android/logging.md:29
+msgid ""
+"/// Logs a greeting.\n"
+"fn main() {\n"
+"    logger::init(\n"
+"        logger::Config::default()\n"
+"            .with_tag_on_device(\"rust\")\n"
+"            .with_min_level(log::Level::Trace),\n"
+"    );\n"
+"    debug!(\"Starting program.\");\n"
+"    info!(\"Things are going fine.\");\n"
+"    error!(\"Something went wrong!\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
+#: src/android/interoperability/with-c/rust.md:73
+#, fuzzy
+msgid "Build, push, and run the binary on your device:"
+msgstr "Erstellen, übertragen und führen Sie die Binärdatei auf Ihrem Gerät aus:"
+
+#: src/android/logging.md:44
+msgid ""
+"```shell\n"
+"$ m hello_rust_logs\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/tmp\n"
+"$ adb shell /data/local/tmp/hello_rust_logs\n"
+"```"
+msgstr ""
+
+#: src/android/logging.md:50
+#, fuzzy
+msgid "The logs show up in `adb logcat`:"
+msgstr "Die Protokolle werden in `adb logcat` angezeigt:"
+
+#: src/android/logging.md:52
+msgid ""
+"```shell\n"
+"$ adb logcat -s rust\n"
+"09-08 08:38:32.454  2420  2420 D rust: hello_rust_logs: Starting program.\n"
+"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going "
+"fine.\n"
+"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went "
+"wrong!\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability.md:1
+#, fuzzy
+msgid "# Interoperability"
+msgstr "# Interoperabilität"
+
+#: src/android/interoperability.md:3
+#, fuzzy
+msgid ""
+"Rust has excellent support for interoperability with other languages. This "
+"means\n"
+"that you can:"
+msgstr ""
+"Rust bietet eine hervorragende Unterstützung für die Interoperabilität mit "
+"anderen Sprachen. Das heisst\n"
+"dass du kannst:"
+
+#: src/android/interoperability.md:6
+#, fuzzy
+msgid ""
+"* Call Rust functions from other languages.\n"
+"* Call functions written in other languages from Rust."
+msgstr ""
+"* Rufen Sie Rust-Funktionen aus anderen Sprachen auf.\n"
+"* Rufen Sie in anderen Sprachen geschriebene Funktionen von Rust auf."
+
+#: src/android/interoperability.md:9
+#, fuzzy
+msgid ""
+"When you call functions in a foreign language we say that you're using a\n"
+"_foreign function interface_, also known as FFI."
+msgstr ""
+"Wenn Sie Funktionen in einer Fremdsprache aufrufen, sagen wir, dass Sie a "
+"verwenden\n"
+"_Fremdfunktionsschnittstelle_, auch bekannt als FFI."
+
+#: src/android/interoperability/with-c.md:1
+#, fuzzy
+msgid "# Interoperability with C"
+msgstr "# Interoperabilität mit C"
+
+#: src/android/interoperability/with-c.md:3
+#, fuzzy
+msgid ""
+"Rust has full support for linking object files with a C calling convention.\n"
+"Similarly, you can export Rust functions and call them from C."
+msgstr ""
+"Rust bietet volle Unterstützung für das Linken von Objektdateien mit einer "
+"C-Aufrufkonvention.\n"
+"Ebenso können Sie Rust-Funktionen exportieren und von C aus aufrufen."
+
+#: src/android/interoperability/with-c.md:6
+#, fuzzy
+msgid "You can do it by hand if you want:"
+msgstr "Sie können es von Hand tun, wenn Sie möchten:"
+
+#: src/android/interoperability/with-c.md:8
+msgid ""
+"```rust\n"
+"extern \"C\" {\n"
+"    fn abs(x: i32) -> i32;\n"
+"}"
+msgstr ""
+
+#: src/android/interoperability/with-c.md:13
+msgid ""
+"fn main() {\n"
+"    let x = -42;\n"
+"    let abs_x = unsafe { abs(x) };\n"
+"    println!(\"{x}, {abs_x}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c.md:20
+#, fuzzy
+msgid ""
+"We already saw this in the [Safe FFI Wrapper\n"
+"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+msgstr ""
+"Wir haben dies bereits im [Safe FFI Wrapper\n"
+"Übung](../../Übungen/Tag-3/safe-ffi-wrapper.md)."
+
+#: src/android/interoperability/with-c.md:23
+#, fuzzy
+msgid ""
+"> This assumes full knowledge of the target platform. Not recommended for\n"
+"> production."
+msgstr ""
+"> Dies setzt vollständige Kenntnisse der Zielplattform voraus. Nicht "
+"empfehlenswert für\n"
+"> Produktion."
+
+#: src/android/interoperability/with-c.md:26
+#, fuzzy
+msgid "We will look at better options next."
+msgstr "Wir werden uns als nächstes bessere Optionen ansehen."
+
+#: src/android/interoperability/with-c/bindgen.md:1
+#, fuzzy
+msgid "# Using Bindgen"
+msgstr "# Verwenden von Bindgen"
+
+#: src/android/interoperability/with-c/bindgen.md:3
+#, fuzzy
+msgid ""
+"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
+"tool\n"
+"can auto-generate bindings from a C header file."
+msgstr ""
+"Das Tool "
+"[bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html).\n"
+"kann Bindungen aus einer C-Header-Datei automatisch generieren."
+
+#: src/android/interoperability/with-c/bindgen.md:6
+#, fuzzy
+msgid "First create a small C library:"
+msgstr "Erstellen Sie zunächst eine kleine C-Bibliothek:"
+
+#: src/android/interoperability/with-c/bindgen.md:8
+#, fuzzy
+msgid "_interoperability/bindgen/libbirthday.h_:"
+msgstr "_interoperability/bindgen/libbirthday.h_:"
+
+#: src/android/interoperability/with-c/bindgen.md:10
+msgid ""
+"```c\n"
+"typedef struct card {\n"
+"  const char* name;\n"
+"  int years;\n"
+"} card;"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:16
+msgid "void print_card(const card* card);\n```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:19
+#, fuzzy
+msgid "_interoperability/bindgen/libbirthday.c_:"
+msgstr "_interoperability/bindgen/libbirthday.c_:"
+
+#: src/android/interoperability/with-c/bindgen.md:21
+msgid ""
+"```c\n"
+"#include <stdio.h>\n"
+"#include \"libbirthday.h\""
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:25
+msgid ""
+"void print_card(const card* card) {\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"  printf(\"| Happy Birthday %s!\\n"
+"\", card->name);\n"
+"  printf(\"| Congratulations with the %i years!\\n"
+"\", card->years);\n"
+"  printf(\"+--------------\\n"
+"\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:33
+#, fuzzy
+msgid "Add this to your `Android.bp` file:"
+msgstr "Fügen Sie dies zu Ihrer `Android.bp`-Datei hinzu:"
+
+#: src/android/interoperability/with-c/bindgen.md:35
+#: src/android/interoperability/with-c/bindgen.md:55
+#: src/android/interoperability/with-c/bindgen.md:69
+#: src/android/interoperability/with-c/bindgen.md:108
+#, fuzzy
+msgid "_interoperability/bindgen/Android.bp_:"
+msgstr "_interoperability/bindgen/Android.bp_:"
+
+#: src/android/interoperability/with-c/bindgen.md:37
+msgid ""
+"```javascript\n"
+"cc_library {\n"
+"    name: \"libbirthday\",\n"
+"    srcs: [\"libbirthday.c\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:44
+#, fuzzy
+msgid ""
+"Create a wrapper header file for the library (not strictly needed in this\n"
+"example):"
+msgstr ""
+"Erstellen Sie eine Wrapper-Header-Datei für die Bibliothek (in this\n"
+"Beispiel):"
+
+#: src/android/interoperability/with-c/bindgen.md:47
+#, fuzzy
+msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
+msgstr "_interoperability/bindgen/libbirthday_wrapper.h_:"
+
+#: src/android/interoperability/with-c/bindgen.md:49
+msgid ""
+"```c\n"
+"#include \"libbirthday.h\"\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:53
+#, fuzzy
+msgid "You can now auto-generate the bindings:"
+msgstr "Sie können die Bindungen jetzt automatisch generieren:"
+
+#: src/android/interoperability/with-c/bindgen.md:57
+msgid ""
+"```javascript\n"
+"rust_bindgen {\n"
+"    name: \"libbirthday_bindgen\",\n"
+"    crate_name: \"birthday_bindgen\",\n"
+"    wrapper_src: \"libbirthday_wrapper.h\",\n"
+"    source_stem: \"bindings\",\n"
+"    static_libs: [\"libbirthday\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:67
+#, fuzzy
+msgid "Finally, we can use the bindings in our Rust program:"
+msgstr "Schließlich können wir die Bindungen in unserem Rust-Programm verwenden:"
+
+#: src/android/interoperability/with-c/bindgen.md:71
+msgid ""
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"print_birthday_card\",\n"
+"    srcs: [\"main.rs\"],\n"
+"    rustlibs: [\"libbirthday_bindgen\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:79
+#, fuzzy
+msgid "_interoperability/bindgen/main.rs_:"
+msgstr "_interoperability/bindgen/main.rs_:"
+
+#: src/android/interoperability/with-c/bindgen.md:81
+msgid "```rust,compile_fail\n//! Bindgen demo."
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:84
+msgid "use birthday_bindgen::{card, print_card};"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:86
+msgid ""
+"fn main() {\n"
+"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
+"    let card = card {\n"
+"        name: name.as_ptr(),\n"
+"        years: 42,\n"
+"    };\n"
+"    unsafe {\n"
+"        print_card(&card as *const card);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:100
+msgid ""
+"```shell\n"
+"$ m print_birthday_card\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card "
+"/data/local/tmp\n"
+"$ adb shell /data/local/tmp/print_birthday_card\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:106
+#, fuzzy
+msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
+msgstr ""
+"Schließlich können wir automatisch generierte Tests ausführen, um "
+"sicherzustellen, dass die Bindungen funktionieren:"
+
+#: src/android/interoperability/with-c/bindgen.md:110
+msgid ""
+"```javascript\n"
+"rust_test {\n"
+"    name: \"libbirthday_bindgen_test\",\n"
+"    srcs: [\":libbirthday_bindgen\"],\n"
+"    crate_name: \"libbirthday_bindgen_test\",\n"
+"    test_suites: [\"general-tests\"],\n"
+"    auto_gen_config: true,\n"
+"    clippy_lints: \"none\", // Generated file, skip linting\n"
+"    lints: \"none\",\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/bindgen.md:122
+msgid ""
+"```shell\n"
+"$ atest libbirthday_bindgen_test\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:1
+#, fuzzy
+msgid "# Calling Rust"
+msgstr "# Rust anrufen"
+
+#: src/android/interoperability/with-c/rust.md:3
+#, fuzzy
+msgid "Exporting Rust functions and types to C is easy:"
+msgstr "Der Export von Rust-Funktionen und -Typen nach C ist einfach:"
+
+#: src/android/interoperability/with-c/rust.md:5
+#, fuzzy
+msgid "_interoperability/rust/libanalyze/analyze.rs_"
+msgstr "_interoperability/rust/libanalyze/analyze.rs_"
+
+#: src/android/interoperability/with-c/rust.md:7
+msgid ""
+"```rust,editable\n"
+"//! Rust FFI demo.\n"
+"#![deny(improper_ctypes_definitions)]"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:11
+msgid "use std::os::raw::c_int;"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:13
+msgid ""
+"/// Analyze the numbers.\n"
+"#[no_mangle]\n"
+"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
+"    if x < y {\n"
+"        println!(\"x ({x}) is smallest!\");\n"
+"    } else {\n"
+"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:24
+#, fuzzy
+msgid "_interoperability/rust/libanalyze/analyze.h_"
+msgstr "_interoperability/rust/libanalyze/analyze.h_"
+
+#: src/android/interoperability/with-c/rust.md:26
+msgid ""
+"```c\n"
+"#ifndef ANALYSE_H\n"
+"#define ANALYSE_H"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:30
+msgid ""
+"extern \"C\" {\n"
+"void analyze_numbers(int x, int y);\n"
+"}"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:34
+msgid "#endif\n```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:37
+#, fuzzy
+msgid "_interoperability/rust/libanalyze/Android.bp_"
+msgstr "_interoperability/rust/libanalyze/Android.bp_"
+
+#: src/android/interoperability/with-c/rust.md:39
+msgid ""
+"```javascript\n"
+"rust_ffi {\n"
+"    name: \"libanalyze_ffi\",\n"
+"    crate_name: \"analyze_ffi\",\n"
+"    srcs: [\"analyze.rs\"],\n"
+"    include_dirs: [\".\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:48
+#, fuzzy
+msgid "We can now call this from a C binary:"
+msgstr "Wir können dies jetzt aus einer C-Binärdatei aufrufen:"
+
+#: src/android/interoperability/with-c/rust.md:50
+#, fuzzy
+msgid "_interoperability/rust/analyze/main.c_"
+msgstr "_interoperability/rust/analyze/main.c_"
+
+#: src/android/interoperability/with-c/rust.md:52
+msgid "```c\n#include \"analyze.h\""
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:55
+msgid ""
+"int main() {\n"
+"  analyze_numbers(10, 20);\n"
+"  analyze_numbers(123, 123);\n"
+"  return 0;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:62
+#, fuzzy
+msgid "_interoperability/rust/analyze/Android.bp_"
+msgstr "_interoperability/rust/analyze/Android.bp_"
+
+#: src/android/interoperability/with-c/rust.md:64
+msgid ""
+"```javascript\n"
+"cc_binary {\n"
+"    name: \"analyze_numbers\",\n"
+"    srcs: [\"main.c\"],\n"
+"    static_libs: [\"libanalyze_ffi\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:75
+msgid ""
+"```shell\n"
+"$ m analyze_numbers\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/tmp\n"
+"$ adb shell /data/local/tmp/analyze_numbers\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:83
+#, fuzzy
+msgid ""
+"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
+"will just be the name of\n"
+"the function. You can also use `#[export_name = \"some_name\"]` to specify "
+"whatever name you want."
+msgstr ""
+"`#[no_mangle]` deaktiviert Rusts übliches Namensverstümmeln, so dass das "
+"exportierte Symbol nur der Name von ist\n"
+"die Funktion. Sie können auch `#[export_name = \"some_name\"]` verwenden, um "
+"einen beliebigen Namen anzugeben."
+
+#: src/android/interoperability/cpp.md:1
+#, fuzzy
+msgid "# With C++"
+msgstr "# Mit C++"
+
+#: src/android/interoperability/cpp.md:3
+#, fuzzy
+msgid ""
+"The [CXX crate][1] makes it possible to do safe interoperability between "
+"Rust\n"
+"and C++."
+msgstr ""
+"Die [CXX-Kiste][1] ermöglicht eine sichere Interoperabilität zwischen Rust\n"
+"und C++."
+
+#: src/android/interoperability/cpp.md:6
+#, fuzzy
+msgid "The overall approach looks like this:"
+msgstr "Der Gesamtansatz sieht wie folgt aus:"
+
+#: src/android/interoperability/cpp.md:8
+#, fuzzy
+msgid "<img src=\"cpp/overview.svg\">"
+msgstr "<img src=\"cpp/overview.svg\">"
+
+#: src/android/interoperability/cpp.md:10
+#, fuzzy
+msgid "See the [CXX tutorial][2] for an full example of using this."
+msgstr ""
+"Ein vollständiges Beispiel für die Verwendung finden Sie im [CXX-Tutorial] "
+"[2]."
+
+#: src/android/interoperability/cpp.md:12
+#, fuzzy
+msgid "[1]: https://cxx.rs/\n[2]: https://cxx.rs/tutorial.html"
+msgstr "[1]: https://cxx.rs/\n[2]: https://cxx.rs/tutorial.html"
+
+#: src/android/interoperability/java.md:1
+#, fuzzy
+msgid "# Interoperability with Java"
+msgstr "# Interoperabilität mit Java"
+
+#: src/android/interoperability/java.md:3
+#, fuzzy
+msgid ""
+"Java can load shared objects via [Java Native Interface\n"
+"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
+"crate](https://docs.rs/jni/) allows you to create a compatible library."
+msgstr ""
+"Java kann gemeinsame Objekte über [Java Native Interface\n"
+"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). Die [`jni`\n"
+"crate](https://docs.rs/jni/) ermöglicht es Ihnen, eine kompatible Bibliothek "
+"zu erstellen."
+
+#: src/android/interoperability/java.md:7
+#, fuzzy
+msgid "First, we create a Rust function to export to Java:"
+msgstr "Zuerst erstellen wir eine Rust-Funktion zum Exportieren nach Java:"
+
+#: src/android/interoperability/java.md:9
+#, fuzzy
+msgid "_interoperability/java/src/lib.rs_:"
+msgstr "_interoperability/java/src/lib.rs_:"
+
+#: src/android/interoperability/java.md:11
+msgid "```rust,compile_fail\n//! Rust <-> Java FFI demo."
+msgstr ""
+
+#: src/android/interoperability/java.md:14
+msgid ""
+"use jni::objects::{JClass, JString};\n"
+"use jni::sys::jstring;\n"
+"use jni::JNIEnv;"
+msgstr ""
+
+#: src/android/interoperability/java.md:18
+msgid ""
+"/// HelloWorld::hello method implementation.\n"
+"#[no_mangle]\n"
+"pub extern \"system\" fn Java_HelloWorld_hello(\n"
+"    env: JNIEnv,\n"
+"    _class: JClass,\n"
+"    name: JString,\n"
+") -> jstring {\n"
+"    let input: String = env.get_string(name).unwrap().into();\n"
+"    let greeting = format!(\"Hello, {input}!\");\n"
+"    let output = env.new_string(greeting).unwrap();\n"
+"    output.into_inner()\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:32
+#: src/android/interoperability/java.md:62
+#, fuzzy
+msgid "_interoperability/java/Android.bp_:"
+msgstr "_interoperability/java/Android.bp_:"
+
+#: src/android/interoperability/java.md:34
+msgid ""
+"```javascript\n"
+"rust_ffi_shared {\n"
+"    name: \"libhello_jni\",\n"
+"    crate_name: \"hello_jni\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    rustlibs: [\"libjni\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:43
+#, fuzzy
+msgid "Finally, we can call this function from Java:"
+msgstr "Schließlich können wir diese Funktion von Java aus aufrufen:"
+
+#: src/android/interoperability/java.md:45
+#, fuzzy
+msgid "_interoperability/java/HelloWorld.java_:"
+msgstr "_interoperability/java/HelloWorld.java_:"
+
+#: src/android/interoperability/java.md:47
+msgid ""
+"```java\n"
+"class HelloWorld {\n"
+"    private static native String hello(String name);"
+msgstr ""
+
+#: src/android/interoperability/java.md:51
+msgid ""
+"    static {\n"
+"        System.loadLibrary(\"hello_jni\");\n"
+"    }"
+msgstr ""
+
+#: src/android/interoperability/java.md:55
+msgid ""
+"    public static void main(String[] args) {\n"
+"        String output = HelloWorld.hello(\"Alice\");\n"
+"        System.out.println(output);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:64
+msgid ""
+"```javascript\n"
+"java_binary {\n"
+"    name: \"helloworld_jni\",\n"
+"    srcs: [\"HelloWorld.java\"],\n"
+"    main_class: \"HelloWorld\",\n"
+"    required: [\"libhello_jni\"],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/android/interoperability/java.md:73
+#, fuzzy
+msgid "Finally, you can build, sync, and run the binary:"
+msgstr ""
+"Schließlich können Sie die Binärdatei erstellen, synchronisieren und "
+"ausführen:"
+
+#: src/android/interoperability/java.md:75
+msgid ""
+"```shell\n"
+"$ m helloworld_jni\n"
+"$ adb sync  # requires adb root && adb remount\n"
+"$ adb shell /system/bin/helloworld_jni\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/afternoon.md:3
+#, fuzzy
+msgid ""
+"For the last exercise, we will look at one of the projects you work with. "
+"Let us\n"
+"group up and do this together. Some suggestions:"
+msgstr ""
+"Für die letzte Übung schauen wir uns eines der Projekte an, mit denen Sie "
+"arbeiten. Lassen Sie uns\n"
+"gruppiert euch und macht das gemeinsam. Einige Vorschläge:"
+
+#: src/exercises/day-4/afternoon.md:6
+#, fuzzy
+msgid "* Call your AIDL service with a client written in Rust."
+msgstr ""
+"* Rufen Sie Ihren AIDL-Service mit einem in Rust geschriebenen Client an."
+
+#: src/exercises/day-4/afternoon.md:8
+#, fuzzy
+msgid "* Move a function from your project to Rust and call it."
+msgstr ""
+"* Verschieben Sie eine Funktion aus Ihrem Projekt nach Rust und rufen Sie "
+"sie auf."
+
+#: src/exercises/day-4/afternoon.md:12
+#, fuzzy
+msgid ""
+"No solution is provided here since this is open-ended: it relies on someone "
+"in\n"
+"the class having a piece of code which you can turn in to Rust on the fly."
+msgstr ""
+"Hier wird keine Lösung bereitgestellt, da dies offen ist: Es hängt von "
+"jemandem ab\n"
+"Die Klasse hat einen Code, den Sie spontan an Rust übergeben können."
+
+#: src/thanks.md:1
+#, fuzzy
+msgid "# Thanks!"
+msgstr "# Danke!"
+
+#: src/thanks.md:3
+#, fuzzy
+msgid ""
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
+"it\n"
+"was useful."
+msgstr ""
+"_Vielen Dank, dass Sie Comprehensive Rust 🦀 genommen haben!_ Wir hoffen, "
+"dass es Ihnen gefallen hat und dass es\n"
+"war nützlich."
+
+#: src/thanks.md:6
+#, fuzzy
+msgid ""
+"We've had a lot of fun putting the course together. The course is not "
+"perfect,\n"
+"so if you spotted any mistakes or have ideas for improvements, please get "
+"in\n"
+"[contact with us on\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
+"love\n"
+"to hear from you."
+msgstr ""
+"Es hat uns viel Spaß gemacht, den Kurs zusammenzustellen. Der Kurs ist nicht "
+"perfekt,\n"
+"Wenn Sie also Fehler entdeckt haben oder Verbesserungsvorschläge haben, "
+"melden Sie sich bitte\n"
+"[Kontakt mit uns auf\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). Wir "
+"würden lieben\n"
+"von dir zu hören."
+
+#: src/other-resources.md:1
+#, fuzzy
+msgid "# Other Rust Resources"
+msgstr "# Andere Rostressourcen"
+
+#: src/other-resources.md:3
+#, fuzzy
+msgid ""
+"The Rust community has created a wealth of high-quality and free resources\n"
+"online."
+msgstr ""
+"Die Rust-Community hat eine Fülle hochwertiger und kostenloser Ressourcen "
+"geschaffen\n"
+"online."
+
+#: src/other-resources.md:6
+#, fuzzy
+msgid "## Official Documentation"
+msgstr "## Offizielle Dokumentation"
+
+#: src/other-resources.md:8
+#, fuzzy
+msgid "The Rust project hosts many resources. These cover Rust in general:"
+msgstr ""
+"Das Rust-Projekt beherbergt viele Ressourcen. Diese decken Rust im "
+"Allgemeinen ab:"
+
+#: src/other-resources.md:10
+#, fuzzy
+msgid ""
+"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
+"  canonical free book about Rust. Covers the language in detail and includes "
+"a\n"
+"  few projects for people to build.\n"
+"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust\n"
+"  syntax via a series of examples which showcase different constructs. "
+"Sometimes\n"
+"  includes small exercises where you are asked to expand on the code in the\n"
+"  examples.\n"
+"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
+"documentation of\n"
+"  the standard library for Rust.\n"
+"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book\n"
+"  which describes the Rust grammar and memory model."
+msgstr ""
+"* [Die Programmiersprache Rust](https://doc.rust-lang.org/book/): die\n"
+"  Kanonisches kostenloses Buch über Rust. Deckt die Sprache im Detail ab und "
+"enthält a\n"
+"  wenige Projekte für Menschen zu bauen.\n"
+"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): deckt den "
+"Rust ab\n"
+"  Syntax über eine Reihe von Beispielen, die verschiedene Konstrukte "
+"demonstrieren. Manchmal\n"
+"  enthält kleine Übungen, in denen Sie aufgefordert werden, den Code in der "
+"zu erweitern\n"
+"  Beispiele.\n"
+"* [Rust Standard Library](https://doc.rust-lang.org/std/): vollständige "
+"Dokumentation von\n"
+"  die Standardbibliothek für Rust.\n"
+"* [The Rust Reference](https://doc.rust-lang.org/reference/): ein "
+"unvollständiges Buch\n"
+"  das die Rust-Grammatik und das Speichermodell beschreibt."
+
+#: src/other-resources.md:22
+#, fuzzy
+msgid "More specialized guides hosted on the official Rust site:"
+msgstr ""
+"Weitere spezialisierte Guides, die auf der offiziellen Rust-Website gehostet "
+"werden:"
+
+#: src/other-resources.md:24
+#, fuzzy
+msgid ""
+"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
+"Rust,\n"
+"  including working with raw pointers and interfacing with other languages\n"
+"  (FFI).\n"
+"* [Asynchronous Programming in "
+"Rust](https://rust-lang.github.io/async-book/):\n"
+"  covers the new asynchronous programming model which was introduced after "
+"the\n"
+"  Rust Book was written.\n"
+"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an\n"
+"  introduction to using Rust on embedded devices without an operating system."
+msgstr ""
+"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): deckt unsicheres "
+"Rust ab,\n"
+"  einschließlich der Arbeit mit rohen Zeigern und der Anbindung an andere "
+"Sprachen\n"
+"  (FFI).\n"
+"* [Asynchrone Programmierung in "
+"Rust](https://rust-lang.github.io/async-book/):\n"
+"  deckt das neue asynchrone Programmiermodell ab, das nach dem eingeführt "
+"wurde\n"
+"  Rust Book wurde geschrieben.\n"
+"* [Das eingebettete Rust-Buch] "
+"(https://doc.rust-lang.org/stable/embedded-book/): an\n"
+"  Einführung in die Verwendung von Rust auf eingebetteten Geräten ohne "
+"Betriebssystem."
+
+#: src/other-resources.md:33
+#, fuzzy
+msgid "## Unofficial Learning Material"
+msgstr "## Inoffizielles Lernmaterial"
+
+#: src/other-resources.md:35
+#, fuzzy
+msgid "A small selection of other guides and tutorial for Rust:"
+msgstr "Eine kleine Auswahl an weiteren Guides und Tutorials für Rust:"
+
+#: src/other-resources.md:37
+#, fuzzy
+msgid ""
+"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
+"Rust\n"
+"  from the perspective of low-level C programmers.\n"
+"* [Rust for Embedded C\n"
+"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
+"from\n"
+"  the perspective of developers who write firmware in C.\n"
+"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
+"  covers the syntax of Rust using side-by-side comparisons with other "
+"languages\n"
+"  such as C, C++, Java, JavaScript, and Python.\n"
+"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
+"help\n"
+"  you learn Rust.\n"
+"* [Ferrous Teaching\n"
+"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
+"a\n"
+"  series of small presentations covering both basic and advanced part of "
+"the\n"
+"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
+"  covered.\n"
+"* [Beginner's Series to\n"
+"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
+"and\n"
+"  [Take your first steps with\n"
+"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
+"two\n"
+"  Rust guides aimed at new developers. The first is a set of 35 videos and "
+"the\n"
+"  second is a set of 11 modules which covers Rust syntax and basic "
+"constructs."
+msgstr ""
+"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): deckt "
+"Rust ab\n"
+"  aus der Perspektive von Low-Level-C-Programmierern.\n"
+"* [Rost für eingebettetes C\n"
+"  Programmierer] (https://docs.opentitan.org/doc/ug/rust_for_c/): deckt Rust "
+"ab\n"
+"  die Perspektive von Entwicklern, die Firmware in C schreiben.\n"
+"* [Rost für Profis](https://overexact.com/rust-for-professionals/):\n"
+"  deckt die Syntax von Rust durch Side-by-Side-Vergleiche mit anderen "
+"Sprachen ab\n"
+"  wie C, C++, Java, JavaScript und Python.\n"
+"* [Rust on Exercism](https://exercism.org/tracks/rust): Über 100 hilfreiche "
+"Übungen\n"
+"  Sie lernen Rost.\n"
+"* [Eisenlehre\n"
+"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
+"a\n"
+"  Reihe von kleinen Präsentationen, die sowohl den grundlegenden als auch "
+"den fortgeschrittenen Teil des\n"
+"  Rostige Sprache. Andere Themen wie WebAssembly und async/await sind "
+"ebenfalls enthalten\n"
+"  bedeckt.\n"
+"* [Anfängerserie bis\n"
+"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
+"und\n"
+"  [Machen Sie Ihre ersten Schritte mit\n"
+"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
+"zwei\n"
+"  Rust-Leitfäden für neue Entwickler. Die erste ist eine Reihe von 35 Videos "
+"und die\n"
+"  Das zweite ist ein Satz von 11 Modulen, der die Rust-Syntax und "
+"grundlegende Konstrukte abdeckt."
+
+#: src/other-resources.md:59
+#, fuzzy
+msgid ""
+"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
+"for\n"
+"even more Rust books."
+msgstr ""
+"Weitere Informationen finden Sie im [Little Book of Rust Books] "
+"(https://lborb.github.io/book/).\n"
+"noch mehr Rust-Bücher."
+
+#: src/credits.md:1
+#, fuzzy
+msgid "# Credits"
+msgstr "# Credits"
+
+#: src/credits.md:3
+#, fuzzy
+msgid ""
+"The material here builds on top of the many great sources of Rust "
+"documentation.\n"
+"See the page on [other resources](other-resources.md) for a full list of "
+"useful\n"
+"resources."
+msgstr ""
+"Das Material hier baut auf den vielen großartigen Quellen der "
+"Rust-Dokumentation auf.\n"
+"Auf der Seite [andere Ressourcen] (other-resources.md) finden Sie eine "
+"vollständige Liste nützlicher Ressourcen\n"
+"Ressourcen."
+
+#: src/credits.md:7
+#, fuzzy
+msgid ""
+"The material of Comprehensive Rust is licensed under the terms of the Apache "
+"2.0\n"
+"license, please see [`LICENSE`](../LICENSE) for details."
+msgstr ""
+"Das Material von Comprehensive Rust ist unter den Bedingungen von Apache 2.0 "
+"lizenziert\n"
+"Lizenz finden Sie unter [`LICENSE`](../LICENSE) für Einzelheiten."
+
+#: src/credits.md:10
+#, fuzzy
+msgid "## Rust by Example"
+msgstr "## Rost zum Beispiel"
+
+#: src/credits.md:12
+#, fuzzy
+msgid ""
+"Some examples and exercises have been copied and adapted from [Rust by\n"
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
+"`third_party/rust-by-example/` directory for details, including the license\n"
+"terms."
+msgstr ""
+"Einige Beispiele und Übungen wurden aus [Rust by\n"
+"Beispiel](https://doc.rust-lang.org/rust-by-example/). Bitte sehen Sie sich "
+"... an\n"
+"`third_party/rust-by-example/`-Verzeichnis für Details, einschließlich der "
+"Lizenz\n"
+"Bedingungen."
+
+#: src/credits.md:17
+#, fuzzy
+msgid "## Rust on Exercism"
+msgstr "## Rost auf Übung"
+
+#: src/credits.md:19
+#, fuzzy
+msgid ""
+"Some exercises have been copied and adapted from [Rust on\n"
+"Exercism](https://exercism.org/tracks/rust). Please see the\n"
+"`third_party/rust-on-exercism/` directory for details, including the "
+"license\n"
+"terms."
+msgstr ""
+"Einige Übungen wurden von [Rust on\n"
+"Übung] (https://exercism.org/tracks/rust). Bitte sehen Sie sich ... an\n"
+"`third_party/rust-on-exercism/`-Verzeichnis für Details, einschließlich der "
+"Lizenz\n"
+"Bedingungen."
+
+#: src/credits.md:24
+#, fuzzy
+msgid "## CXX"
+msgstr "##CXX"
+
+#: src/credits.md:26
+#, fuzzy
+msgid ""
+"The [Interoperability with C++](android/interoperability/cpp.md) section "
+"uses an\n"
+"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory\n"
+"for details, including the license terms."
+msgstr ""
+"Der Abschnitt [Interoperability with C++](android/interoperability/cpp.md) "
+"verwendet eine\n"
+"Bild von [CXX](https://cxx.rs/). Bitte sehen Sie sich das Verzeichnis "
+"`third_party/cxx/` an\n"
+"für Details, einschließlich der Lizenzbedingungen."
+
+#: src/exercises/solutions.md:1
+#, fuzzy
+msgid "# Solutions"
+msgstr "# Lösungen"
+
+#: src/exercises/solutions.md:3
+#, fuzzy
+msgid "You will find solutions to the exercises on the following pages."
+msgstr "Auf den folgenden Seiten finden Sie Lösungen zu den Aufgaben."
+
+#: src/exercises/solutions.md:5
+#, fuzzy
+msgid ""
+"Feel free to ask questions about the solutions [on\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
+"know\n"
+"if you have a different or better solution than what is presented here."
+msgstr ""
+"Fühlen Sie sich frei, Fragen zu den Lösungen zu stellen [on\n"
+"GitHub](https://github.com/google/comprehensive-rust/discussions). Lass uns "
+"wissen\n"
+"wenn Sie eine andere oder bessere Lösung als die hier vorgestellte haben."
+
+#: src/exercises/solutions.md:10
+#, fuzzy
+msgid ""
+"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
+"> comments you see in the solutions. They are there to make it possible to\n"
+"> re-use parts of the solutions as the exercises."
+msgstr ""
+"> **Hinweis:** Bitte ignorieren Sie `// ANCHOR: label` und `// ANCHOR_END: "
+"label`\n"
+"> Kommentare, die Sie in den Lösungen sehen. Sie sind da, um es zu "
+"ermöglichen\n"
+"> Teile der Lösungen als Aufgaben wiederverwenden."
+
+#: src/exercises/day-1/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 1 Morning Exercises"
+msgstr "# Tag 1 Morgengymnastik"
+
+#: src/exercises/day-1/solutions-morning.md:3
+#, fuzzy
+msgid "## Arrays and `for` Loops"
+msgstr "## Arrays und „for“-Schleifen"
+
+#: src/exercises/day-1/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](for-loops.md))"
+msgstr "([zurück zur Übung](for-loops.md))"
+
+#: src/exercises/day-1/solutions-morning.md:7
+#: src/exercises/day-1/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-morning.md:7
+#: src/exercises/day-2/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-afternoon.md:102
+#: src/exercises/day-3/solutions-morning.md:7
+#: src/exercises/day-3/solutions-afternoon.md:7
+#: src/exercises/day-4/solutions-morning.md:7
+msgid ""
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License."
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:22
+msgid ""
+"// ANCHOR: transpose\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    // ANCHOR_END: transpose\n"
+"    let mut result = [[0; 3]; 3];\n"
+"    for i in 0..3 {\n"
+"        for j in 0..3 {\n"
+"            result[j][i] = matrix[i][j];\n"
+"        }\n"
+"    }\n"
+"    return result;\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:34
+msgid ""
+"// ANCHOR: pretty_print\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    // ANCHOR_END: pretty_print\n"
+"    for row in matrix {\n"
+"        println!(\"{row:?}\");\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:42
+msgid ""
+"// ANCHOR: tests\n"
+"#[test]\n"
+"fn test_transpose() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], //\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"    let transposed = transpose(matrix);\n"
+"    assert_eq!(\n"
+"        transposed,\n"
+"        [\n"
+"            [101, 201, 301], //\n"
+"            [102, 202, 302],\n"
+"            [103, 203, 303],\n"
+"        ]\n"
+"    );\n"
+"}\n"
+"// ANCHOR_END: tests"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:62
+msgid ""
+"// ANCHOR: main\n"
+"fn main() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:73
+msgid ""
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
+"}\n"
+"```\n"
+"### Bonus question"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:80
+#, fuzzy
+msgid ""
+"It honestly doesn't work so well. It might seem that we could use a "
+"slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make "
+"our function handle any size of matrix. However, this quickly breaks down: "
+"the return type cannot be `&[&[i32]]` since it needs to own the data you "
+"return."
+msgstr ""
+"Es funktioniert ehrlich gesagt nicht so gut. Es scheint, als könnten wir ein "
+"Slice-of-Slices (`&[&[i32]]`) als Eingabetyp für die Transponierung "
+"verwenden und unsere Funktion so dazu bringen, jede Matrixgröße zu "
+"handhaben. Dies bricht jedoch schnell zusammen: Der Rückgabetyp kann nicht "
+"`&[&[i32]]` sein, da er die von Ihnen zurückgegebenen Daten besitzen muss."
+
+#: src/exercises/day-1/solutions-morning.md:82
+#, fuzzy
+msgid ""
+"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work "
+"very well either: it's hard to convert from `Vec<Vec<i32>>` to `&[&[i32]]` "
+"so now you cannot easily use `pretty_print` either."
+msgstr ""
+"Sie können versuchen, so etwas wie `Vec<Vec<i32>>` zu verwenden, aber das "
+"funktioniert auch nicht sehr gut: Es ist schwierig, `Vec<Vec<i32>>` in "
+"`&[&[i32]] umzuwandeln. ` also kannst du jetzt auch `pretty_print` nicht "
+"einfach verwenden."
+
+#: src/exercises/day-1/solutions-morning.md:84
+#, fuzzy
+msgid ""
+"In addition, the type itself would not enforce that the child slices are of "
+"the same length, so such variable could contain an invalid matrix."
+msgstr ""
+"Außerdem würde der Typ selbst nicht erzwingen, dass die untergeordneten "
+"Slices dieselbe Länge haben, sodass eine solche Variable eine ungültige "
+"Matrix enthalten könnte."
+
+#: src/exercises/day-1/solutions-afternoon.md:1
+#, fuzzy
+msgid "# Day 1 Afternoon Exercises"
+msgstr "# Tag 1 Nachmittagsübungen"
+
+#: src/exercises/day-1/solutions-afternoon.md:3
+#, fuzzy
+msgid "## Designing a Library"
+msgstr "## Entwerfen einer Bibliothek"
+
+#: src/exercises/day-1/solutions-afternoon.md:5
+#, fuzzy
+msgid "([back to exercise](book-library.md))"
+msgstr "([zurück zur Übung](book-library.md))"
+
+#: src/exercises/day-1/solutions-afternoon.md:22
+#, fuzzy
+msgid ""
+"// ANCHOR: setup\n"
+"struct Library {\n"
+"    books: Vec<Book>,\n"
+"}"
+msgstr ""
+"// ANKER: einrichten\n"
+"Struktur Bibliothek {\n"
+"    Bücher: Vec<Buch>,\n"
+"}"
+
+#: src/exercises/day-1/solutions-afternoon.md:42
+#, fuzzy
+msgid ""
+"// This makes it possible to print Book values with {}.\n"
+"impl std::fmt::Display for Book {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        write!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: setup"
+msgstr ""
+"// Dadurch ist es möglich, Buchwerte mit {} zu drucken.\n"
+"impl std::fmt::Anzeige für Buch {\n"
+"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
+"        schreibe!(f, \"{} ({})\", self.title, self.year)\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: Einrichtung"
+
+#: src/exercises/day-1/solutions-afternoon.md:50
+#, fuzzy
+msgid ""
+"// ANCHOR: Library_new\n"
+"impl Library {\n"
+"    fn new() -> Library {\n"
+"        // ANCHOR_END: Library_new\n"
+"        Library { books: Vec::new() }\n"
+"    }"
+msgstr ""
+"// ANKER: Bibliothek_neu\n"
+"impl-Bibliothek {\n"
+"    fn new() -> Bibliothek {\n"
+"        // ANCHOR_END: Bibliothek_neu\n"
+"        Bibliothek { Bücher: Vec::new() }\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:57
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_len\n"
+"    //fn len(self) -> usize {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_len\n"
+"    fn len(&self) -> usize {\n"
+"        self.books.len()\n"
+"    }"
+msgstr ""
+"    // ANKER: Library_len\n"
+"    //fn len(self) -> verwenden {\n"
+"    // nicht implementiert!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_len\n"
+"    fn len(&self) -> verwenden {\n"
+"        self.books.len()\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:66
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_is_empty\n"
+"    //fn is_empty(self) -> bool {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_is_empty\n"
+"    fn is_empty(&self) -> bool {\n"
+"        self.books.is_empty()\n"
+"    }"
+msgstr ""
+"    // ANKER: Bibliothek_ist_leer\n"
+"    //fn is_empty(self) -> bool {\n"
+"    // nicht implementiert!()\n"
+"    //}\n"
+"    // ANCHOR_END: Bibliothek_ist_leer\n"
+"    fn is_empty(&self) -> bool {\n"
+"        self.books.is_empty()\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:75
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_add_book\n"
+"    //fn add_book(self, book: Book) {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_add_book\n"
+"    fn add_book(&mut self, book: Book) {\n"
+"        self.books.push(book)\n"
+"    }"
+msgstr ""
+"    // ANKER: Library_add_book\n"
+"    //fn add_book(selbst, Buch: Buch) {\n"
+"    // nicht implementiert!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_add_book\n"
+"    fn add_book(&mut self, book: Buch) {\n"
+"        self.books.push(Buch)\n"
+"    }"
+
+#: src/exercises/day-1/solutions-afternoon.md:84
+msgid ""
+"    // ANCHOR: Library_print_books\n"
+"    //fn print_books(self) {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_print_books\n"
+"    fn print_books(&self) {\n"
+"        for book in &self.books {\n"
+"            println!(\"{}\", book);\n"
+"        }\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:95
+#, fuzzy
+msgid ""
+"    // ANCHOR: Library_oldest_book\n"
+"    //fn oldest_book(self) -> Option<&Book> {\n"
+"    //    unimplemented!()\n"
+"    //}\n"
+"    // ANCHOR_END: Library_oldest_book\n"
+"    fn oldest_book(&self) -> Option<&Book> {\n"
+"        self.books.iter().min_by_key(|book| book.year)\n"
+"    }\n"
+"}"
+msgstr ""
+"    // ANKER: Library_oldest_book\n"
+"    //fn ältestes_buch(selbst) -> Option<&Buch> {\n"
+"    // nicht implementiert!()\n"
+"    //}\n"
+"    // ANCHOR_END: Bibliothek_ältestes_Buch\n"
+"    fn ältestes_buch(&self) -> Option<&Buch> {\n"
+"        self.books.iter().min_by_key(|Buch| Buch.Jahr)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-1/solutions-afternoon.md:105
+msgid ""
+"// ANCHOR: main\n"
+"// This shows the desired behavior. Uncomment the code below and\n"
+"// implement the missing methods. You will need to update the\n"
+"// method signatures, including the \"self\" parameter! You may\n"
+"// also need to update the variable bindings within main.\n"
+"fn main() {\n"
+"    let library = Library::new();"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:113
+msgid ""
+"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
+"    //\n"
+"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    //\n"
+"    //library.print_books();\n"
+"    //\n"
+"    //match library.oldest_book() {\n"
+"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
+"    //    None => println!(\"My library is empty!\"),\n"
+"    //}\n"
+"    //\n"
+"    //println!(\"Our library has {} books\", library.len());\n"
+"}\n"
+"// ANCHOR_END: main"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:129
+msgid ""
+"#[test]\n"
+"fn test_library_len() {\n"
+"    let mut library = Library::new();\n"
+"    assert_eq!(library.len(), 0);\n"
+"    assert!(library.is_empty());"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:135
+msgid ""
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(library.len(), 2);\n"
+"    assert!(!library.is_empty());\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:141
+msgid ""
+"#[test]\n"
+"fn test_library_is_empty() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.is_empty());"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:146
+msgid ""
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert!(!library.is_empty());\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:150
+msgid ""
+"#[test]\n"
+"fn test_library_print_books() {\n"
+"    let mut library = Library::new();\n"
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    // We could try and capture stdout, but let us just call the\n"
+"    // method to start with.\n"
+"    library.print_books();\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:160
+msgid ""
+"#[test]\n"
+"fn test_library_oldest_book() {\n"
+"    let mut library = Library::new();\n"
+"    assert!(library.oldest_book().is_none());"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:165
+msgid ""
+"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Lord of the Rings\")\n"
+"    );"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:171
+msgid ""
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
+"    assert_eq!(\n"
+"        library.oldest_book().map(|b| b.title.as_str()),\n"
+"        Some(\"Alice's Adventures in Wonderland\")\n"
+"    );\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 2 Morning Exercises"
+msgstr "# Tag 2 Morgengymnastik"
+
+#: src/exercises/day-2/solutions-morning.md:3
+#, fuzzy
+msgid "## Points and Polygons"
+msgstr "## Punkte und Polygone"
+
+#: src/exercises/day-2/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](points-polygons.md))"
+msgstr "([zurück zur Übung](points-polygons.md))"
+
+#: src/exercises/day-2/solutions-morning.md:22
+#, fuzzy
+msgid ""
+"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
+"// ANCHOR: Point\n"
+"pub struct Point {\n"
+"    // ANCHOR_END: Point\n"
+"    x: i32,\n"
+"    y: i32,\n"
+"}"
+msgstr ""
+"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
+"// Ankerpunkt\n"
+"pub struct Punkt {\n"
+"    // ANCHOR_END: Punkt\n"
+"    x: i32,\n"
+"    y: i32,\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:30
+#, fuzzy
+msgid ""
+"// ANCHOR: Point-impl\n"
+"impl Point {\n"
+"    // ANCHOR_END: Point-impl\n"
+"    pub fn new(x: i32, y: i32) -> Point {\n"
+"        Point { x, y }\n"
+"    }"
+msgstr ""
+"// ANCHOR: Punkt-impl\n"
+"impl Punkt {\n"
+"    // ANCHOR_END: Punkt-impl\n"
+"    pub fn neu(x: i32, y: i32) -> Punkt {\n"
+"        Punkt { x, y }\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:37
+#, fuzzy
+msgid ""
+"    pub fn magnitude(self) -> f64 {\n"
+"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"    }"
+msgstr ""
+"    Pub fn Magnitude (selbst) -> f64 {\n"
+"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:41
+#, fuzzy
+msgid ""
+"    pub fn dist(self, other: Point) -> f64 {\n"
+"        (self - other).magnitude()\n"
+"    }\n"
+"}"
+msgstr ""
+"    pub fn dist(self, other: Point) -> f64 {\n"
+"        (selbst - andere).magnitude()\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:49
+#, fuzzy
+msgid ""
+"    fn add(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x + other.x,\n"
+"            y: self.y + other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn add(self, other: Self) -> Self::Output {\n"
+"        Selbst {\n"
+"            x: selbst.x + andere.x,\n"
+"            y: self.y + other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:57
+msgid "impl std::ops::Sub for Point {\n    type Output = Self;"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:60
+#, fuzzy
+msgid ""
+"    fn sub(self, other: Self) -> Self::Output {\n"
+"        Self {\n"
+"            x: self.x - other.x,\n"
+"            y: self.y - other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"    fn sub(self, other: Self) -> Self::Output {\n"
+"        Selbst {\n"
+"            x: self.x - other.x,\n"
+"            y: self.y - other.y,\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:68
+#, fuzzy
+msgid ""
+"// ANCHOR: Polygon\n"
+"pub struct Polygon {\n"
+"    // ANCHOR_END: Polygon\n"
+"    points: Vec<Point>,\n"
+"}"
+msgstr ""
+"// ANKER: Vieleck\n"
+"pub struct Polygon {\n"
+"    // ANCHOR_END: Vieleck\n"
+"    Punkte: Vec<Punkt>,\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:74
+#, fuzzy
+msgid ""
+"// ANCHOR: Polygon-impl\n"
+"impl Polygon {\n"
+"    // ANCHOR_END: Polygon-impl\n"
+"    pub fn new() -> Polygon {\n"
+"        Polygon { points: Vec::new() }\n"
+"    }"
+msgstr ""
+"// ANCHOR: Polygon-Impl\n"
+"impl Polygon {\n"
+"    // ANCHOR_END: Polygon-Impl\n"
+"    pub fn new() -> Polygon {\n"
+"        Vieleck { Punkte: Vec::new() }\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:81
+msgid ""
+"    pub fn add_point(&mut self, point: Point) {\n"
+"        self.points.push(point);\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:85
+#, fuzzy
+msgid ""
+"    pub fn left_most_point(&self) -> Option<Point> {\n"
+"        self.points.iter().min_by_key(|p| p.x).copied()\n"
+"    }"
+msgstr ""
+"    pub fn left_most_point(&self) -> Option<Punkt> {\n"
+"        self.points.iter().min_by_key(|p| p.x).kopiert()\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:89
+#, fuzzy
+msgid ""
+"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"        self.points.iter()\n"
+"    }"
+msgstr ""
+"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"        self.points.iter()\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:93
+msgid ""
+"    pub fn length(&self) -> f64 {\n"
+"        if self.points.is_empty() {\n"
+"            return 0.0;\n"
+"        }"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:98
+msgid ""
+"        let mut result = 0.0;\n"
+"        let mut last_point = self.points[0];\n"
+"        for point in &self.points[1..] {\n"
+"            result += last_point.dist(*point);\n"
+"            last_point = *point;\n"
+"        }\n"
+"        result += last_point.dist(self.points[0]);\n"
+"        result\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:109
+#, fuzzy
+msgid ""
+"// ANCHOR: Circle\n"
+"pub struct Circle {\n"
+"    // ANCHOR_END: Circle\n"
+"    center: Point,\n"
+"    radius: i32,\n"
+"}"
+msgstr ""
+"// ANKER: Kreis\n"
+"pub struct Kreis {\n"
+"    // ANCHOR_END: Kreis\n"
+"    Mittelpunkt,\n"
+"    Radius: i32,\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:116
+#, fuzzy
+msgid ""
+"// ANCHOR: Circle-impl\n"
+"impl Circle {\n"
+"    // ANCHOR_END: Circle-impl\n"
+"    pub fn new(center: Point, radius: i32) -> Circle {\n"
+"        Circle { center, radius }\n"
+"    }"
+msgstr ""
+"// ANCHOR: Kreis-Impl\n"
+"impl Kreis {\n"
+"    // ANCHOR_END: Kreis-Impl\n"
+"    pub fn neu (Zentrum: Punkt, Radius: i32) -> Kreis {\n"
+"        Kreis { Mittelpunkt, Radius }\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:123
+#, fuzzy
+msgid ""
+"    pub fn circumference(&self) -> f64 {\n"
+"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"    }"
+msgstr ""
+"    pub fn Umfang(&self) -> f64 {\n"
+"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"    }"
+
+#: src/exercises/day-2/solutions-morning.md:127
+#, fuzzy
+msgid ""
+"    pub fn dist(&self, other: &Self) -> f64 {\n"
+"        self.center.dist(other.center)\n"
+"    }\n"
+"}"
+msgstr ""
+"    pub fn dist(&selbst, andere: &selbst) -> f64 {\n"
+"        self.center.dist(anderes.center)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:132
+#, fuzzy
+msgid ""
+"// ANCHOR: Shape\n"
+"pub enum Shape {\n"
+"    Polygon(Polygon),\n"
+"    Circle(Circle),\n"
+"}\n"
+"// ANCHOR_END: Shape"
+msgstr ""
+"// ANKER: Form\n"
+"Pub-Aufzählung Form {\n"
+"    Vieleck(Vieleck),\n"
+"    Kreis (Kreis),\n"
+"}\n"
+"// ANCHOR_END: Form"
+
+#: src/exercises/day-2/solutions-morning.md:139
+#, fuzzy
+msgid ""
+"impl From<Polygon> for Shape {\n"
+"    fn from(poly: Polygon) -> Self {\n"
+"        Shape::Polygon(poly)\n"
+"    }\n"
+"}"
+msgstr ""
+"impl From<Polygon> für Form {\n"
+"    fn from(poly: Polygon) -> Self {\n"
+"        Form::Polygon (poly)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:145
+#, fuzzy
+msgid ""
+"impl From<Circle> for Shape {\n"
+"    fn from(circle: Circle) -> Self {\n"
+"        Shape::Circle(circle)\n"
+"    }\n"
+"}"
+msgstr ""
+"impl Von<Kreis> für Form {\n"
+"    fn from(Kreis: Kreis) -> Selbst {\n"
+"        Form :: Kreis (Kreis)\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:151
+#, fuzzy
+msgid ""
+"impl Shape {\n"
+"    pub fn perimeter(&self) -> f64 {\n"
+"        match self {\n"
+"            Shape::Polygon(poly) => poly.length(),\n"
+"            Shape::Circle(circle) => circle.circumference(),\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+"Impl-Form {\n"
+"    pub fn perimeter(&self) -> f64 {\n"
+"        mit sich selbst übereinstimmen {\n"
+"            Shape::Polygon(poly) => poly.length(),\n"
+"            Form::Kreis(Kreis) => Kreis.Umfang(),\n"
+"        }\n"
+"    }\n"
+"}"
+
+#: src/exercises/day-2/solutions-morning.md:160
+msgid ""
+"// ANCHOR: unit-tests\n"
+"#[cfg(test)]\n"
+"mod tests {\n"
+"    use super::*;"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:213
+msgid ""
+"    #[test]\n"
+"    fn test_shape_perimeters() {\n"
+"        let mut poly = Polygon::new();\n"
+"        poly.add_point(Point::new(12, 13));\n"
+"        poly.add_point(Point::new(17, 11));\n"
+"        poly.add_point(Point::new(16, 16));\n"
+"        let shapes = vec![\n"
+"            Shape::from(poly),\n"
+"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"        ];\n"
+"        let perimeters = shapes\n"
+"            .iter()\n"
+"            .map(Shape::perimeter)\n"
+"            .map(round_two_digits)\n"
+"            .collect::<Vec<_>>();\n"
+"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"    }\n"
+"}\n"
+"// ANCHOR_END: unit-tests"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:1
+#, fuzzy
+msgid "# Day 2 Afternoon Exercises"
+msgstr "# Tag 2 Nachmittagsübungen"
+
+#: src/exercises/day-2/solutions-afternoon.md:3
+#, fuzzy
+msgid "## Luhn Algorithm"
+msgstr "## Luhn-Algorithmus"
+
+#: src/exercises/day-2/solutions-afternoon.md:5
+#, fuzzy
+msgid "([back to exercise](luhn.md))"
+msgstr "([zurück zur Übung](luhn.md))"
+
+#: src/exercises/day-2/solutions-afternoon.md:22
+msgid ""
+"// ANCHOR: luhn\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    // ANCHOR_END: luhn\n"
+"    let mut digits_seen = 0;\n"
+"    let mut sum = 0;\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' "
+"').enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Some(d) => {\n"
+"                sum += if i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd / 10 + dd % 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                digits_seen += 1;\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:42
+msgid ""
+"    if digits_seen < 2 {\n"
+"        return false;\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:46
+#, fuzzy
+msgid "    sum % 10 == 0\n}"
+msgstr "    Summe % 10 == 0\n}"
+
+#: src/exercises/day-2/solutions-afternoon.md:49
+msgid ""
+"fn main() {\n"
+"    let cc_number = \"1234 5678 1234 5670\";\n"
+"    println!(\n"
+"        \"Is {} a valid credit card number? {}\",\n"
+"        cc_number,\n"
+"        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
+"    );\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:58
+msgid ""
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:89
+msgid ""
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"// ANCHOR_END: unit-tests\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:98
+#, fuzzy
+msgid "## Strings and Iterators"
+msgstr "## Strings und Iteratoren"
+
+#: src/exercises/day-2/solutions-afternoon.md:100
+#, fuzzy
+msgid "([back to exercise](strings-iterators.md))"
+msgstr "([zurück zur Übung](strings-iterators.md))"
+
+#: src/exercises/day-2/solutions-afternoon.md:117
+msgid ""
+"// ANCHOR: prefix_matches\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    // ANCHOR_END: prefix_matches\n"
+"    let prefixes = prefix.split('/');\n"
+"    let request_paths = request_path\n"
+"        .split('/')\n"
+"        .map(|p| Some(p))\n"
+"        .chain(std::iter::once(None));"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:126
+msgid ""
+"    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"        match request_path {\n"
+"            Some(request_path) => {\n"
+"                if (prefix != \"*\") && (prefix != request_path) {\n"
+"                    return false;\n"
+"                }\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:139
+msgid ""
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", "
+"\"/v1/publishers/abc/books\"));"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:166
+msgid ""
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
+"\"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"// ANCHOR_END: unit-tests\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 3 Morning Exercise"
+msgstr "# Tag 3 Morgengymnastik"
+
+#: src/exercises/day-3/solutions-morning.md:3
+#, fuzzy
+msgid "## A Simple GUI Library"
+msgstr "## Eine einfache GUI-Bibliothek"
+
+#: src/exercises/day-3/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](simple-gui.md))"
+msgstr "([zurück zur Übung](simple-gui.md))"
+
+#: src/exercises/day-3/solutions-morning.md:22
+msgid ""
+"// ANCHOR: setup\n"
+"pub trait Widget {\n"
+"    /// Natural width of `self`.\n"
+"    fn width(&self) -> usize;"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:82
+#, fuzzy
+msgid "// ANCHOR_END: setup"
+msgstr "// ANCHOR_END: Einrichtung"
+
+#: src/exercises/day-3/solutions-morning.md:84
+#, fuzzy
+msgid ""
+"// ANCHOR: Window-width\n"
+"impl Widget for Window {\n"
+"    fn width(&self) -> usize {\n"
+"        // ANCHOR_END: Window-width\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }"
+msgstr ""
+"// ANCHOR: Fensterbreite\n"
+"impl-Widget für Fenster {\n"
+"    fn width(&self) -> use {\n"
+"        // ANCHOR_END: Fensterbreite\n"
+"        std::cmp::max(\n"
+"            self.title.chars().count(),\n"
+"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
+"        )\n"
+"    }"
+
+#: src/exercises/day-3/solutions-morning.md:94
+msgid ""
+"    // ANCHOR: Window-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Window-draw_into\n"
+"        let mut inner = String::new();\n"
+"        for widget in &self.widgets {\n"
+"            widget.draw_into(&mut inner);\n"
+"        }"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:102
+msgid "        let window_width = self.width();"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:104
+msgid ""
+"        // TODO: after learning about error handling, you can change\n"
+"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
+"        // the ?-operator here instead of .unwrap().\n"
+"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"        writeln!(buffer, \"| {:^window_width$} |\", &self.title).unwrap();\n"
+"        writeln!(buffer, \"+={:=<window_width$}=+\", \"\").unwrap();\n"
+"        for line in inner.lines() {\n"
+"            writeln!(buffer, \"| {:window_width$} |\", line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:117
+#, fuzzy
+msgid ""
+"// ANCHOR: Button-width\n"
+"impl Widget for Button {\n"
+"    fn width(&self) -> usize {\n"
+"        // ANCHOR_END: Button-width\n"
+"        self.label.width() + 8 // add a bit of padding\n"
+"    }"
+msgstr ""
+"// ANCHOR: Button-Breite\n"
+"impl-Widget für Schaltfläche {\n"
+"    fn width(&self) -> use {\n"
+"        // ANCHOR_END: Button-Breite\n"
+"        self.label.width() + 8 // etwas Polsterung hinzufügen\n"
+"    }"
+
+#: src/exercises/day-3/solutions-morning.md:124
+msgid ""
+"    // ANCHOR: Button-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Button-draw_into\n"
+"        let width = self.width();\n"
+"        let mut label = String::new();\n"
+"        self.label.draw_into(&mut label);"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:131
+msgid ""
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"        for line in label.lines() {\n"
+"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
+"        }\n"
+"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:139
+#, fuzzy
+msgid ""
+"// ANCHOR: Label-width\n"
+"impl Widget for Label {\n"
+"    fn width(&self) -> usize {\n"
+"        // ANCHOR_END: Label-width\n"
+"        self.label\n"
+"            .lines()\n"
+"            .map(|line| line.chars().count())\n"
+"            .max()\n"
+"            .unwrap_or(0)\n"
+"    }"
+msgstr ""
+"// ANCHOR: Etikettenbreite\n"
+"impl-Widget für Label {\n"
+"    fn width(&self) -> use {\n"
+"        // ANCHOR_END: Etikettenbreite\n"
+"        self.label\n"
+"            .Linien()\n"
+"            .map(|line| line.chars().count())\n"
+"            .max()\n"
+"            .unwrap_or(0)\n"
+"    }"
+
+#: src/exercises/day-3/solutions-morning.md:150
+msgid ""
+"    // ANCHOR: Label-draw_into\n"
+"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"        // ANCHOR_END: Label-draw_into\n"
+"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/solutions-morning.md:157
+msgid ""
+"// ANCHOR: main\n"
+"fn main() {\n"
+"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\")));\n"
+"    window.add_widget(Box::new(Button::new(\n"
+"        \"Click me!\",\n"
+"        Box::new(|| println!(\"You clicked the button!\")),\n"
+"    )));\n"
+"    window.draw();\n"
+"}\n"
+"// ANCHOR_END: main\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:1
+#, fuzzy
+msgid "# Day 3 Afternoon Exercises"
+msgstr "# Tag 3 Nachmittagsübungen"
+
+#: src/exercises/day-3/solutions-afternoon.md:3
+#, fuzzy
+msgid "## Safe FFI Wrapper"
+msgstr "## Sicherer FFI-Wrapper"
+
+#: src/exercises/day-3/solutions-afternoon.md:5
+#, fuzzy
+msgid "([back to exercise](safe-ffi-wrapper.md))"
+msgstr "([zurück zur Übung](safe-ffi-wrapper.md))"
+
+#: src/exercises/day-3/solutions-afternoon.md:22
+msgid ""
+"// ANCHOR: ffi\n"
+"mod ffi {\n"
+"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:53
+#, fuzzy
+msgid ""
+"#[derive(Debug)]\n"
+"struct DirectoryIterator {\n"
+"    path: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"// ANCHOR_END: ffi"
+msgstr ""
+"#[ableiten(Debuggen)]\n"
+"struct DirectoryIterator {\n"
+"    Pfad: CString,\n"
+"    dir: *mut ffi::DIR,\n"
+"}\n"
+"// ANCHOR_END: ffi"
+
+#: src/exercises/day-3/solutions-afternoon.md:60
+msgid ""
+"// ANCHOR: DirectoryIterator\n"
+"impl DirectoryIterator {\n"
+"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
+"        // Call opendir and return a Ok value if that worked,\n"
+"        // otherwise return Err with a message.\n"
+"        // ANCHOR_END: DirectoryIterator\n"
+"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
+"{err}\"))?;\n"
+"        // SAFETY: path.as_ptr() cannot be NULL.\n"
+"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
+"        if dir.is_null() {\n"
+"            Err(format!(\"Could not open {:?}\", path))\n"
+"        } else {\n"
+"            Ok(DirectoryIterator { path, dir })\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:77
+msgid ""
+"// ANCHOR: Iterator\n"
+"impl Iterator for DirectoryIterator {\n"
+"    type Item = OsString;\n"
+"    fn next(&mut self) -> Option<OsString> {\n"
+"        // Keep calling readdir until we get a NULL pointer back.\n"
+"        // ANCHOR_END: Iterator\n"
+"        // SAFETY: self.dir is never NULL.\n"
+"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
+"        if dirent.is_null() {\n"
+"            // We have reached the end of the directory.\n"
+"            return None;\n"
+"        }\n"
+"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
+"        // terminated.\n"
+"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
+"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
+"        Some(os_str.to_owned())\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:97
+msgid ""
+"// ANCHOR: Drop\n"
+"impl Drop for DirectoryIterator {\n"
+"    fn drop(&mut self) {\n"
+"        // Call closedir as needed.\n"
+"        // ANCHOR_END: Drop\n"
+"        if !self.dir.is_null() {\n"
+"            // SAFETY: self.dir is not NULL.\n"
+"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
+"                panic!(\"Could not close {:?}\", self.path);\n"
+"            }\n"
+"        }\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:111
+msgid ""
+"// ANCHOR: main\n"
+"fn main() -> Result<(), String> {\n"
+"    let iter = DirectoryIterator::new(\".\")?;\n"
+"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
+"    Ok(())\n"
+"}\n"
+"// ANCHOR_END: main\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:1
+#, fuzzy
+msgid "# Day 4 Morning Exercise"
+msgstr "# Tag 4 Morgengymnastik"
+
+#: src/exercises/day-4/solutions-morning.md:3
+#, fuzzy
+msgid "## Dining Philosophers"
+msgstr "## Essende Philosophen"
+
+#: src/exercises/day-4/solutions-morning.md:5
+#, fuzzy
+msgid "([back to exercise](dining-philosophers.md))"
+msgstr "([zurück zur Übung](dining-philosophers.md))"
+
+#: src/exercises/day-4/solutions-morning.md:22
+msgid ""
+"// ANCHOR: Philosopher\n"
+"use std::sync::mpsc;\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"use std::time::Duration;"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:30
+#, fuzzy
+msgid ""
+"struct Philosopher {\n"
+"    name: String,\n"
+"    // ANCHOR_END: Philosopher\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    thoughts: mpsc::SyncSender<String>,\n"
+"}"
+msgstr ""
+"struct Philosoph {\n"
+"    Name: Zeichenfolge,\n"
+"    // ANCHOR_END: Philosoph\n"
+"    left_fork: Arc<Mutex<Fork>>,\n"
+"    right_fork: Arc<Mutex<Fork>>,\n"
+"    Gedanken: mpsc::SyncSender<String>,\n"
+"}"
+
+#: src/exercises/day-4/solutions-morning.md:38
+msgid ""
+"// ANCHOR: Philosopher-think\n"
+"impl Philosopher {\n"
+"    fn think(&self) {\n"
+"        self.thoughts\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
+"            .unwrap();\n"
+"    }\n"
+"    // ANCHOR_END: Philosopher-think"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:47
+msgid ""
+"    // ANCHOR: Philosopher-eat\n"
+"    fn eat(&self) {\n"
+"        // ANCHOR_END: Philosopher-eat\n"
+"        println!(\"{} is trying to eat\", &self.name);\n"
+"        let left = self.left_fork.lock().unwrap();\n"
+"        let right = self.right_fork.lock().unwrap();"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:54
+msgid ""
+"        // ANCHOR: Philosopher-eat-end\n"
+"        println!(\"{} is eating...\", &self.name);\n"
+"        thread::sleep(Duration::from_millis(10));\n"
+"    }\n"
+"}"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:63
+msgid ""
+"fn main() {\n"
+"    // ANCHOR_END: Philosopher-eat-end\n"
+"    let (tx, rx) = mpsc::sync_channel(10);"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:67
+msgid ""
+"    let forks = (0..PHILOSOPHERS.len())\n"
+"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
+"        .collect::<Vec<_>>();"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:71
+msgid ""
+"    for i in 0..forks.len() {\n"
+"        let tx = tx.clone();\n"
+"        let mut left_fork = forks[i].clone();\n"
+"        let mut right_fork = forks[(i + 1) % forks.len()].clone();"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:76
+msgid ""
+"        // To avoid a deadlock, we have to break the symmetry\n"
+"        // somewhere. This will swap the forks without deinitializing\n"
+"        // either of them.\n"
+"        if i == forks.len() - 1 {\n"
+"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"        }"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:83
+msgid ""
+"        let philosopher = Philosopher {\n"
+"            name: PHILOSOPHERS[i].to_string(),\n"
+"            thoughts: tx,\n"
+"            left_fork,\n"
+"            right_fork,\n"
+"        };"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:90
+msgid ""
+"        thread::spawn(move || {\n"
+"            for _ in 0..100 {\n"
+"                philosopher.eat();\n"
+"                philosopher.think();\n"
+"            }\n"
+"        });\n"
+"    }"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:98
+msgid ""
+"    drop(tx);\n"
+"    for thought in rx {\n"
+"        println!(\"{}\", thought);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""


### PR DESCRIPTION
Initial commit for the German translation, based on the auto-translation 
provided by @mgeisler. 

Some small fixes so far:
* Links to course parts (rendered on the left) are reviewed and corrected.
* Introduction is reviewed and corrected.

Terminology aims to follow the translation of the Rust programming book 
(https://rust-lang-de.github.io/rustbook-de/). Deviations from this are not 
intentional and should be corrected in future commits. 

I tested that the translation renders correctly using `mdbook`.