### PR TITLE
Clarify that trait bounds give access to methods and add example of impl Trait.

### DIFF
--- a/src/generics/trait-bounds.md
+++ b/src/generics/trait-bounds.md
@@ -1,11 +1,19 @@
 # Trait Bounds
 
-When working with generics, you often want to limit the types. You can do this
-with `T: Trait` or `impl Trait`:
+When working with generics, you often want to require the types to implement
+some trait, so that you can call this trait's methods.
+
+You can do this with `T: Trait` or `impl Trait`:
 
 ```rust,editable
 fn duplicate<T: Clone>(a: T) -> (T, T) {
     (a.clone(), a.clone())
+}
+
+// Syntactic sugar for:
+//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {
+fn add_42_millions(x: impl Into<i32>) -> i32 {
+    x.into() + 42_000_000
 }
 
 // struct NotClonable;
@@ -14,6 +22,11 @@ fn main() {
     let foo = String::from("foo");
     let pair = duplicate(foo);
     println!("{pair:?}");
+
+    let many = add_42_millions(42_i8);
+    println!("{many}");
+    let many_more = add_42_millions(10_000_000);
+    println!("{many_more}");
 }
 ```
 


### PR DESCRIPTION
1. IMO it's clearer to think as trait bounds as **giving access** to methods, rather than restricting the types - i.e. if we don't specify any bounds, we cannot do anything with the types.
2. Since `impl Trait` is mentioned, it would be useful to show a case where it applies (doesn't apply to the `duplicate` method).