### PR TITLE
Clarification in Trait Objects.

### DIFF
--- a/src/generics/trait-objects.md
+++ b/src/generics/trait-objects.md
@@ -66,7 +66,7 @@ Memory layout after allocating `xs`:
                                   '- - - - - - - - - - - - - - - - - - - - - - - -'
 ```
 
-Similarly, you need a trait object if you want to return different values
+Similarly, you need a trait object if you want to return different types
 implementing a trait:
 
 ```rust,editable


### PR DESCRIPTION
The sentence mentioned returning different *values*, which is perfectly fine in normal functions (if these values have the same type). What matters here is that the function aims to return values of heterogeneous *types*.