### PR TITLE
CODEOWNERS: initial check-in

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Brazilian portuguese reviewers
+po/pt_BR.po @rastringer @hugojacob


### PR DESCRIPTION
That's the initial check-in of the CODEOWNERS file.

By reading through the [CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), it's not clear to me whether a default assignee (e.g `* <someone>`) is needed, though.