### PR TITLE
Add example where breaking UTF-8 encoding leads to a crash.

### DIFF
--- a/src/unsafe/calling-unsafe-functions.md
+++ b/src/unsafe/calling-unsafe-functions.md
@@ -10,9 +10,19 @@ fn main() {
     // Safe because the indices are in the correct order, within the bounds of
     // the string slice, and lie on UTF-8 sequence boundaries.
     unsafe {
-        println!("{}", emojis.get_unchecked(0..4));
-        println!("{}", emojis.get_unchecked(4..7));
-        println!("{}", emojis.get_unchecked(7..11));
+        println!("emoji: {}", emojis.get_unchecked(0..4));
+        println!("emoji: {}", emojis.get_unchecked(4..7));
+        println!("emoji: {}", emojis.get_unchecked(7..11));
     }
+
+    println!("char count: {}", count_chars(unsafe { emojis.get_unchecked(0..7) }));
+
+    // Not upholding the UTF-8 encoding requirement breaks memory safety!
+    // println!("emoji: {}", unsafe { emojis.get_unchecked(0..3) });
+    // println!("char count: {}", count_chars(unsafe { emojis.get_unchecked(0..3) }));
+}
+
+fn count_chars(s: &str) -> usize {
+    s.chars().map(|_| 1).sum()
 }
 ```


### PR DESCRIPTION
On the current version of the playground, trying to print the invalid string just prints garbage:

```
emoji: ���
```

...but more interestingly calling the more complex function `count_chars()` on it leads to the following crash (illegal instruction):

```
timeout: the monitored command dumped core
/playground/tools/entrypoint.sh: line 11:     8 Illegal instruction     timeout --signal=KILL ${timeout} "$@"
```