### PR TITLE
Remove silenced warnings in book-library exercise

### DIFF
--- a/src/exercises/day-1/book-library.md
+++ b/src/exercises/day-1/book-library.md
@@ -18,8 +18,6 @@ Use this to create a library application. Copy the code below to
 <https://play.rust-lang.org/> and update the types to make it compile:
 
 ```rust,should_panic
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
 
 {{#include book-library.rs:setup}}
 

--- a/src/exercises/day-1/book-library.rs
+++ b/src/exercises/day-1/book-library.rs
@@ -118,8 +118,8 @@ fn main() {
     //}
     //
     //println!("Our library has {} books", library.len());
-    for b in library.books {
-        println!("{b}");
+    for book in library.books {
+        println!("{book}");
     }
 }
 // ANCHOR_END: main

--- a/src/exercises/day-1/book-library.rs
+++ b/src/exercises/day-1/book-library.rs
@@ -104,8 +104,10 @@ fn main() {
     let library = Library::new();
 
     //println!("Our library is empty: {}", library.is_empty());
-    //
-    //library.add_book(Book::new("Lord of the Rings", 1954));
+
+    let favorite_book = Book::new("Lord of the Rings", 1954);
+    println!("Our favorite book {favorite_book} should go in the library");
+    //library.add_book(favorite_book);
     //library.add_book(Book::new("Alice's Adventures in Wonderland", 1865));
     //
     //library.print_books();
@@ -116,6 +118,9 @@ fn main() {
     //}
     //
     //println!("Our library has {} books", library.len());
+    for b in library.books {
+        println!("{b}");
+    }
 }
 // ANCHOR_END: main
 


### PR DESCRIPTION
In book-library.rs we create instances of the structs (library books) so that the struct fields are not unused. These changes allow us to remove the line to silence warnings for unused variables https://github.com/google/comprehensive-rust/issues/71.