### PR TITLE
Remove silenced warnings in for-loops exercise

### DIFF
--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -49,7 +49,7 @@ Hard-code both functions to operate on 3 × 3 matrices.
 Copy the code below to <https://play.rust-lang.org/> and implement the
 functions:
 
-```rust,should_panic
+```rust
 //fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {
 //    unimplemented!()
 //}

--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -50,16 +50,28 @@ Copy the code below to <https://play.rust-lang.org/> and implement the
 functions:
 
 ```rust,should_panic
+//fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {
+//    unimplemented!()
+//}
 
-{{#include for-loops.rs:transpose}}
-    unimplemented!()
+//fn pretty_print(matrix: &[[i32; 3]; 3]) {
+//    unimplemented!()
+//}
+
+fn main() {
+    let matrix = [
+        [101, 102, 103], // <-- the comment makes rustfmt add a newline
+        [201, 202, 203],
+        [301, 302, 303],
+    ];
+
+    println!("matrix: {matrix:?}" );
+    //pretty_print(&matrix);
+
+    //let transposed = transpose(matrix);
+    //println!("transposed:");
+    //pretty_print(&transposed);
 }
-
-{{#include for-loops.rs:pretty_print}}
-    unimplemented!()
-}
-
-{{#include for-loops.rs:main}}
 ```
 
 ## Bonus Question

--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -49,29 +49,18 @@ Hard-code both functions to operate on 3 × 3 matrices.
 Copy the code below to <https://play.rust-lang.org/> and implement the
 functions:
 
-```rust
-//fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {
-//    unimplemented!()
-//}
-
-//fn pretty_print(matrix: &[[i32; 3]; 3]) {
-//    unimplemented!()
-//}
-
-fn main() {
-    let matrix = [
-        [101, 102, 103], // <-- the comment makes rustfmt add a newline
-        [201, 202, 203],
-        [301, 302, 303],
-    ];
-
-    println!("matrix: {matrix:?}" );
-    //pretty_print(&matrix);
-
-    //let transposed = transpose(matrix);
-    //println!("transposed:");
-    //pretty_print(&transposed);
+```rust, should_panic
+{{#include for-loops.rs:transpose}}
+    println!("Use matrix {matrix}");
+    unimplemented!()
 }
+
+{{#include for-loops.rs:pretty_print}}
+    println!("Use matrix {matrix}");
+    unimplemented!()
+}
+
+{{#include for-loops.rs:main}}
 ```
 
 ## Bonus Question

--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -50,8 +50,6 @@ Copy the code below to <https://play.rust-lang.org/> and implement the
 functions:
 
 ```rust,should_panic
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
 
 {{#include for-loops.rs:transpose}}
     unimplemented!()

--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -51,12 +51,12 @@ functions:
 
 ```rust, should_panic
 {{#include for-loops.rs:transpose}}
-    println!("Use matrix {matrix}");
+    println!("Use matrix {:?}", matrix);
     unimplemented!()
 }
 
 {{#include for-loops.rs:pretty_print}}
-    println!("Use matrix {matrix}");
+    println!("Use matrix {:?}", matrix);
     unimplemented!()
 }
 


### PR DESCRIPTION
This code had variables in the function arguments that were not being used (yet). 
To address that, in this PR I commented out the functions. This changes allow us to remove the line to silence warnings for unused variables #71.

Alternatively, we could keep the functions commented in and use their arguments in a print statement. As seen in #392.