### PR TITLE
Remove silence warnings in exercises

### DIFF
--- a/po/da.po
+++ b/po/da.po
@@ -7339,7 +7339,7 @@ msgstr ""
 #: src/exercises/day-3/simple-gui.md:18
 #: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
-"```rust,should_panic\n"
+"```rust,should_panic"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:22

--- a/po/da.po
+++ b/po/da.po
@@ -2659,8 +2659,6 @@ msgstr ""
 #: src/exercises/day-2/health-statistics.md:13
 msgid ""
 "```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:56
@@ -5125,8 +5123,6 @@ msgstr ""
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
 "```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:11
@@ -7344,8 +7340,6 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
 "```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:22

--- a/po/da.po
+++ b/po/da.po
@@ -7340,8 +7340,6 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
 "```rust,should_panic\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:22

--- a/po/da.po
+++ b/po/da.po
@@ -5123,8 +5123,6 @@ msgstr ""
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
 "```rust\n"
-"// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:11

--- a/po/da.po
+++ b/po/da.po
@@ -5123,6 +5123,8 @@ msgstr ""
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
 "```rust\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:11
@@ -7340,6 +7342,8 @@ msgstr ""
 #: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
 "```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_imports, unused_variables, dead_code)]"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:22

--- a/src/exercises/day-1/book-library.md
+++ b/src/exercises/day-1/book-library.md
@@ -18,8 +18,6 @@ Use this to create a library application. Copy the code below to
 <https://play.rust-lang.org/> and update the types to make it compile:
 
 ```rust,should_panic
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
 
 {{#include book-library.rs:setup}}
 

--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -50,14 +50,14 @@ Copy the code below to <https://play.rust-lang.org/> and implement the
 functions:
 
 ```rust,should_panic
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
 
 {{#include for-loops.rs:transpose}}
+    println!("Use matrix {:?}", matrix);
     unimplemented!()
 }
 
 {{#include for-loops.rs:pretty_print}}
+    println!("Use matrix {:?}", matrix);
     unimplemented!()
 }
 

--- a/src/exercises/day-2/health-statistics.md
+++ b/src/exercises/day-2/health-statistics.md
@@ -6,8 +6,6 @@ Copy the code below to <https://play.rust-lang.org/> and fill in the missing
 methods:
 
 ```rust,should_panic
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
 
 {{#include ../../../third_party/rust-on-exercism/health-statistics.rs}}
 

--- a/src/exercises/day-2/luhn.md
+++ b/src/exercises/day-2/luhn.md
@@ -21,9 +21,6 @@ function:
 
 
 ```rust
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
-
 {{#include luhn.rs:luhn}}
     unimplemented!()
 }

--- a/src/exercises/day-2/luhn.md
+++ b/src/exercises/day-2/luhn.md
@@ -22,7 +22,6 @@ function:
 
 ```rust
 {{#include luhn.rs:luhn}}
-pub fn luhn(cc_number: &str) -> bool {
     println!("{cc_number}");
     unimplemented!()
 }

--- a/src/exercises/day-2/luhn.md
+++ b/src/exercises/day-2/luhn.md
@@ -21,6 +21,7 @@ function:
 
 
 ```rust
+{{#include luhn.rs:luhn}}
 pub fn luhn(cc_number: &str) -> bool {
     println!("{cc_number}");
     unimplemented!()

--- a/src/exercises/day-2/luhn.md
+++ b/src/exercises/day-2/luhn.md
@@ -21,7 +21,8 @@ function:
 
 
 ```rust
-{{#include luhn.rs:luhn}}
+pub fn luhn(cc_number: &str) -> bool {
+    println!("{cc_number}");
     unimplemented!()
 }
 

--- a/src/exercises/day-2/points-polygons.md
+++ b/src/exercises/day-2/points-polygons.md
@@ -5,8 +5,6 @@ to <https://play.rust-lang.org/> and fill in the missing methods to make the
 tests pass:
 
 ```rust
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
 
 {{#include points-polygons.rs:Point}}
     // add fields

--- a/src/exercises/day-2/strings-iterators.md
+++ b/src/exercises/day-2/strings-iterators.md
@@ -11,9 +11,10 @@ pass. Try avoiding allocating a `Vec` for your intermediate results:
 
 ```rust
 // TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
+
 
 {{#include strings-iterators.rs:prefix_matches}}
+    println!("Use parameters {prefix} and {request_path}");
     unimplemented!()
 }
 

--- a/src/exercises/day-2/strings-iterators.md
+++ b/src/exercises/day-2/strings-iterators.md
@@ -10,8 +10,6 @@ pass. Try avoiding allocating a `Vec` for your intermediate results:
 
 
 ```rust
-// TODO: remove this when you're done with your implementation.
-
 
 {{#include strings-iterators.rs:prefix_matches}}
     println!("Use parameters {prefix} and {request_path}");

--- a/src/exercises/day-3/safe-ffi-wrapper.md
+++ b/src/exercises/day-3/safe-ffi-wrapper.md
@@ -23,25 +23,23 @@ Copy the code below to <https://play.rust-lang.org/> and fill in the missing
 functions and methods:
 
 ```rust,should_panic
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_imports)]
 
 {{#include safe-ffi-wrapper.rs:ffi}}
 
 {{#include safe-ffi-wrapper.rs:DirectoryIterator}}
-        print!("The path", self.path)
+        print!("The path {:?}", path);
         unimplemented!()
     }
 }
 
 {{#include safe-ffi-wrapper.rs:Iterator}}
-        print!("The path", self.path)
+        print!("The path {:?}", self.path);
         unimplemented!()
     }
 }
 
 {{#include safe-ffi-wrapper.rs:Drop}}
-        print!("The path", self.path)
+        print!("The path {:?}", self.path);
         unimplemented!()
     }
 }

--- a/src/exercises/day-3/safe-ffi-wrapper.md
+++ b/src/exercises/day-3/safe-ffi-wrapper.md
@@ -24,21 +24,24 @@ functions and methods:
 
 ```rust,should_panic
 // TODO: remove this when you're done with your implementation.
-#![allow(unused_imports, unused_variables, dead_code)]
+#![allow(unused_imports)]
 
 {{#include safe-ffi-wrapper.rs:ffi}}
 
 {{#include safe-ffi-wrapper.rs:DirectoryIterator}}
+        print!("The path", self.path)
         unimplemented!()
     }
 }
 
 {{#include safe-ffi-wrapper.rs:Iterator}}
+        print!("The path", self.path)
         unimplemented!()
     }
 }
 
 {{#include safe-ffi-wrapper.rs:Drop}}
+        print!("The path", self.path)
         unimplemented!()
     }
 }

--- a/src/exercises/day-3/simple-gui.md
+++ b/src/exercises/day-3/simple-gui.md
@@ -16,8 +16,6 @@ Copy the code below to <https://play.rust-lang.org/>, fill in the missing
 `draw_into` methods so that you implement the `Widget` trait:
 
 ```rust,should_panic
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_imports, unused_variables, dead_code)]
 
 {{#include simple-gui.rs:setup}}
 

--- a/third_party/rust-on-exercism/health-statistics.rs
+++ b/third_party/rust-on-exercism/health-statistics.rs
@@ -6,26 +6,32 @@ struct User {
 
 impl User {
     pub fn new(name: String, age: u32, weight: f32) -> Self {
+        println!("Use name {:?} age {:?} and weight{:?}", name, age, weight);
         unimplemented!()
     }
 
     pub fn name(&self) -> &str {
+        println!("Use name {:?}", self.name);
         unimplemented!()
     }
 
     pub fn age(&self) -> u32 {
+        println!("Use name {:?}", self.name);
         unimplemented!()
     }
 
     pub fn weight(&self) -> f32 {
+        println!("Use name {:?}", self.name);
         unimplemented!()
     }
 
     pub fn set_age(&mut self, new_age: u32) {
+        println!("Use name {:?} and new age {:?}", self.name, new_age);
         unimplemented!()
     }
 
     pub fn set_weight(&mut self, new_weight: f32) {
+        println!("Use name {:?} and new age {:?}", self.name, new_weight);
         unimplemented!()
     }
 }


### PR DESCRIPTION
This code had variables in the function arguments that were not being used (yet).
To address that, in this PR I use the function arguments in a print statement. This changes allow us to remove the line to silence warnings for unused variables https://github.com/google/comprehensive-rust/issues/71.

Alternatively, we could comment out the functions. As seen in #389.