### PR TITLE
Remove silenced warnings in string-iterators exercise

### DIFF
--- a/src/exercises/day-2/strings-iterators.md
+++ b/src/exercises/day-2/strings-iterators.md
@@ -10,10 +10,8 @@ pass. Try avoiding allocating a `Vec` for your intermediate results:
 
 
 ```rust
-// TODO: remove this when you're done with your implementation.
-#![allow(unused_variables, dead_code)]
-
-{{#include strings-iterators.rs:prefix_matches}}
+pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {
+    println!("Use parameters {prefix} and {request_path}");
     unimplemented!()
 }
 

--- a/src/exercises/day-2/strings-iterators.md
+++ b/src/exercises/day-2/strings-iterators.md
@@ -10,7 +10,10 @@ pass. Try avoiding allocating a `Vec` for your intermediate results:
 
 
 ```rust
-{{#include strings-iterators.rs:prefix_matches_unimplemented}}
+{{#include strings-iterators.rs:prefix_matches}}
+    println!("Use parameters {prefix} and {request_path}");
+    unimplemented!()
+}
 
 {{#include strings-iterators.rs:unit-tests}}
 ```

--- a/src/exercises/day-2/strings-iterators.md
+++ b/src/exercises/day-2/strings-iterators.md
@@ -10,6 +10,7 @@ pass. Try avoiding allocating a `Vec` for your intermediate results:
 
 
 ```rust
+{{#include strings-iterators.rs:prefix_matches}}
 pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {
     println!("Use parameters {prefix} and {request_path}");
     unimplemented!()

--- a/src/exercises/day-2/strings-iterators.md
+++ b/src/exercises/day-2/strings-iterators.md
@@ -10,11 +10,7 @@ pass. Try avoiding allocating a `Vec` for your intermediate results:
 
 
 ```rust
-{{#include strings-iterators.rs:prefix_matches}}
-pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {
-    println!("Use parameters {prefix} and {request_path}");
-    unimplemented!()
-}
+{{#include strings-iterators.rs:prefix_matches_unimplemented}}
 
 {{#include strings-iterators.rs:unit-tests}}
 ```

--- a/src/exercises/day-2/strings-iterators.rs
+++ b/src/exercises/day-2/strings-iterators.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//ANCHOR: prefix_matches_unimplemented
+pub fn prefix_matches_unimplemented(prefix: &str, request_path: &str) -> bool {
+    println!("Use parameters {prefix} and {request_path}");
+    unimplemented!()
+}
 // ANCHOR: prefix_matches
 pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {
     // ANCHOR_END: prefix_matches

--- a/src/exercises/day-2/strings-iterators.rs
+++ b/src/exercises/day-2/strings-iterators.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//ANCHOR: prefix_matches_unimplemented
-pub fn prefix_matches_unimplemented(prefix: &str, request_path: &str) -> bool {
-    println!("Use parameters {prefix} and {request_path}");
-    unimplemented!()
-}
 // ANCHOR: prefix_matches
 pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {
     // ANCHOR_END: prefix_matches


### PR DESCRIPTION
This code had variables in the function arguments that were not being used (yet). 
To address that, in this PR I use the function arguments in a print statement. This changes allow us to remove the line to silence warnings for unused variables #71.

Alternatively, we could comment out the functions. As seen in #389.