### PR TITLE
Simplify JNI function names via the `jni_fn` crate

### DIFF
--- a/src/android/interoperability/java.md
+++ b/src/android/interoperability/java.md
@@ -4,6 +4,8 @@ Java can load shared objects via [Java Native Interface
 (JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`
 crate](https://docs.rs/jni/) allows you to create a compatible library.
 
+The [`jni_fn` crate](https://docs.rs/jni_fn/) provides a macro for easier JNI function name generation. 
+
 First, we create a Rust function to export to Java:
 
 _interoperability/java/src/lib.rs_:

--- a/src/android/interoperability/java/src/lib.rs
+++ b/src/android/interoperability/java/src/lib.rs
@@ -18,10 +18,11 @@
 use jni::objects::{JClass, JString};
 use jni::sys::jstring;
 use jni::JNIEnv;
+use jni_fn::jni_fn;
 
 /// HelloWorld::hello method implementation.
-#[no_mangle]
-pub extern "system" fn Java_HelloWorld_hello(
+#[jni_fn("HelloWorld")]
+pub fn hello(
     env: JNIEnv,
     _class: JClass,
     name: JString,


### PR DESCRIPTION
Just a small idea, to improve the readability and simplicity of the JNI function names.

The `jni_fn` crate (https://docs.rs/jni_fn/) provides a macro, which allows generating the mangled version JNI is expecting (including package and class name).

Please let me know what you think. Further improvement ideas welcome :)