### PR TITLE
Use `.po` file as target for edit link on translations

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -158,9 +158,16 @@
                         </a>
                         {{/if}}
                         {{#if git_repository_edit_url}}
+                        {{#if (eq language "en")}}
                         <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit">
                             <i id="git-edit-button" class="fa fa-edit"></i>
                         </a>
+                        {{else}}
+                        <a href="https://github.com/google/comprehensive-rust/edit/main/po/{{language}}.po"
+                           title="Suggest an edit to the translation" aria-label="Suggest an edit to the translation">
+                            <i id="git-edit-button" class="fa fa-edit"></i>
+                        </a>
+                        {{/if}}
                         {{/if}}
 
                     </div>


### PR DESCRIPTION
This is not ideal because of the size of the `.po` files, but I hope it's more useful than sending people to the English language Markdown file.

Fixes #383.