### PR TITLE
Update CODEOWNERS after `pt-BR.po` rename

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 po/da.po @mgeisler
 po/de.po @ronaldfw
 po/ko.po @jiyongp @jooyunghan
-po/pt_BR.po @rastringer @hugojacob
+po/pt-BR.po @rastringer @hugojacob


### PR DESCRIPTION
The file was renamed in #381 but I forgot to update the path here.