### PR TITLE
Remove explicit typing in Mutex example

### DIFF
--- a/src/concurrency/shared_state/mutex.md
+++ b/src/concurrency/shared_state/mutex.md
@@ -7,11 +7,10 @@ behind a read-only interface:
 use std::sync::Mutex;
 
 fn main() {
-    let v: Mutex<Vec<i32>> = Mutex::new(vec![10, 20, 30]);
+    let v = Mutex::new(vec![10, 20, 30]);
     println!("v: {:?}", v.lock().unwrap());
 
     {
-        let v: &Mutex<Vec<i32>> = &v;
         let mut guard = v.lock().unwrap();
         guard.push(40);
     }


### PR DESCRIPTION
Example contained unnecessary explicit type info for the vector in Mutex v. Rust will magically do the needful conversions for us. Code looks cleaner/simpler without the explicit typing.