### PR TITLE
Fix references within options returned from Args

### DIFF
--- a/src/control-flow/match-expressions.md
+++ b/src/control-flow/match-expressions.md
@@ -23,10 +23,10 @@ See [pattern matching](../pattern-matching.md) for more details on patterns in
 Rust.
 
 <details>
-    
+
 * Save the match expression to a variable and print it out.
 * Remove `.as_deref()` and explain the error.
-    * `std::env::args().next()` returns an `Option<&String>`, but we cannot match against `String`.
-    * `as_deref()` transforms an `Option<T>` to `Option<T::Target>`. In our case, this turns `Option<&String>` into `Option<&str>`.
+    * `std::env::args().next()` returns an `Option<String>`, but we cannot match against `String`.
+    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, this turns `Option<String>` into `Option<&str>`.
     * We can now use pattern matching to match against the `&str` inside `Option`.
 </details>


### PR DESCRIPTION
The speaker notes for 18.8 Match Expressions says that std::env::args().next() returns Option<&String>, but actually it returns Option. See https://doc.rust-lang.org/stable/std/env/struct.Args.html#method.next

"as_deref() transforms an Option to Option<T::Target>" is wrong too. as_deref transforms an Option to Option<&T::Target>, so then in this case an Option is turned into an Option<&str>.

This fixes #426