### PR TITLE
`svgbob` should run after `gettext`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -20,6 +20,7 @@ renderers = ["html"]
 
 [preprocessor.svgbob]
 renderers = ["html"]
+after = ["gettext"]
 class = "bob"
 
 # Enable this preprocessor to overlay a large red rectangle on the


### PR DESCRIPTION
svgbob translates `_text_` into `*text*`, which makes gettext fail to translate paragraphs with `_text_`.