### PR TITLE
Remove extraneous trailing parenthesis

### DIFF
--- a/src/modules/visibility.md
+++ b/src/modules/visibility.md
@@ -40,7 +40,7 @@ fn main() {
 
 Additionally, there are advanced `pub(...)` specifiers to restrict the scope of public visibility.
 
-* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)).
+* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).
 * Configuring `pub(crate)` visibility is a common pattern.
 * Less commonly, you can give visibility to a specific path.
 * In any case, visibility must be granted to an ancestor module (and all of its descendants).


### PR DESCRIPTION
The text currently looks like this:
> See the Rust Reference).

And should look like this:
> See the Rust Reference.

Closes #452