### PR TITLE
Remove `renderers` from `links` and `index` preprocessors

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -11,12 +11,8 @@ edition = "2021"
 [build]
 extra-watch-dirs = ["po"]
 
-[preprocessor.links]
-
 [preprocessor.gettext]
 after = ["links"]
-
-[preprocessor.index]
 
 [preprocessor.svgbob]
 renderers = ["html"]

--- a/book.toml
+++ b/book.toml
@@ -14,11 +14,13 @@ extra-watch-dirs = ["po"]
 [preprocessor.links]
 
 [preprocessor.gettext]
+after = ["links"]
 
 [preprocessor.index]
 
 [preprocessor.svgbob]
 renderers = ["html"]
+after = ["gettext"]
 class = "bob"
 
 # Enable this preprocessor to overlay a large red rectangle on the

--- a/book.toml
+++ b/book.toml
@@ -12,12 +12,10 @@ edition = "2021"
 extra-watch-dirs = ["po"]
 
 [preprocessor.links]
-renderers = ["html"]
 
 [preprocessor.gettext]
 
 [preprocessor.index]
-renderers = ["html"]
 
 [preprocessor.svgbob]
 renderers = ["html"]


### PR DESCRIPTION
These two preprocessors are default preprocessors and controlled by `build.use_default_preprocessors` not by `renders`.