### PR TITLE
Add badges to README and welcome page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Comprehensive Rust 🦀
 
+[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml)
+[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)
+[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)
+
 This repository has the source code for Comprehensive Rust 🦀, a four day Rust
 course developed by the Android team. The course covers all aspects of Rust,
 from basic syntax to generics and error handling. It also includes

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -1,5 +1,9 @@
 # Welcome to Comprehensive Rust 🦀
 
+[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml)
+[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)
+[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)
+
 This is a four day Rust course developed by the Android team. The course covers
 the full spectrum of Rust, from basic syntax to advanced topics like generics
 and error handling. It also includes Android-specific content on the last day.


### PR DESCRIPTION
These badges showcase the build status (to reassure people that we test the code) as well as the number of GitHub contributors and stars (to encourage people to contribute).