### PR TITLE
Reuse Rust cache across different jobs

### DIFF
--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -7,3 +7,6 @@ runs:
   steps:
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: "v0"
+        shared-key: "rust"


### PR DESCRIPTION
By default, the rust-cache action will derive a cache key from the GitHub action job. That is, our `translations` job uses a different cache from our `i18n-helpers` job.

This is not useful in our case since all our jobs install roughly the same set of binaries: `mdbook`, `mdbook-svgbob`, `i18n-helpers`. We should therefore use a single cache for all of these jobs.

If we’re wrong, we pay with an increase in compilation time: regardless of what we cache, Cargo will install the right thing when asked.