### PR TITLE
Add futures page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -232,9 +232,8 @@
 - [Async](async.md)
   - [async/await](async/async-await.md)
   - [Async Blocks](async/async-blocks.md)
-  - Futures
-  - Executors
-  - Polling
+  - [Futures](async/futures.md)
+  - Executors and Polling
   - Pin
   - Channels
   - Select

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -233,10 +233,6 @@
   - [async/await](async/async-await.md)
   - [Async Blocks](async/async-blocks.md)
   - [Futures](async/futures.md)
-  - Executors and Polling
-  - Pin
-  - Channels
-  - Select
 - [Exercises](exercises/day-4/async.md)
 
 # Final Words

--- a/src/async/async-await.md
+++ b/src/async/async-await.md
@@ -5,8 +5,8 @@ At a high level, async Rust code looks very much like "normal" sequential code:
 ```rust,editable
 use tokio::time;
 
-async fn count_to(i: i32) {
-    for i in 1..10 {
+async fn count_to(count: i32) {
+    for i in 1..=count {
         println!("Count in task: {i}!");
         time::sleep(time::Duration::from_millis(5)).await;
     }

--- a/src/async/async-await.md
+++ b/src/async/async-await.md
@@ -2,7 +2,7 @@
 
 At a high level, async Rust code looks very much like "normal" sequential code:
 
-```rust,editable
+```rust,editable,compile_fail
 use tokio::time;
 
 async fn count_to(count: i32) {

--- a/src/async/async-blocks.md
+++ b/src/async/async-blocks.md
@@ -3,7 +3,7 @@
 Similar to closures, a snippet of async code can be included inline in another
 function with an async block:
 
-```rust, editable
+```rust,editable,compile_fail
 use tokio::{time, task};
 
 #[tokio::main]

--- a/src/async/futures.md
+++ b/src/async/futures.md
@@ -41,7 +41,7 @@ pub enum Poll<T> {
 
 An async function returns an `impl Future`, and an async block evaluates to an
 `impl Future`. It's also possible (but uncommon) to implement `Future` for your
-own types. For example, the `JoinHandle` returns from `tokio::spawn` implements
+own types. For example, the `JoinHandle` returned from `tokio::spawn` implements
 `Future` to allow joining to it.
 
 The `.await` keyword, applied to a Future, causes the current async function or

--- a/src/async/futures.md
+++ b/src/async/futures.md
@@ -2,7 +2,7 @@
 
 What is the type of an async operation?
 
-```rust, editable
+```rust,editable,compile_fail
 use tokio::time;
 
 async fn count_to(count: i32) -> i32 {

--- a/src/async/futures.md
+++ b/src/async/futures.md
@@ -1,11 +1,33 @@
 # Futures
 
+What is the type of an async operation?
+
+```rust, editable
+use tokio::time;
+
+async fn count_to(count: i32) -> i32 {
+    for i in 1..=count {
+        println!("Count in task: {i}!");
+        time::sleep(time::Duration::from_millis(5)).await;
+    }
+    count
+}
+
+#[tokio::main]
+async fn main() {
+    let _: () = count_to(13);
+}
+```
+
 [Future](https://doc.rust-lang.org/nightly/src/core/future/future.rs.html#37)
 is a trait, implemented by objects that represent an operation that may not be
 complete yet. A future can be polled, and `poll` returns either
 `Poll::Ready(result)` or `Poll::Pending`.
 
 ```rust
+use std::pin::Pin;
+use std::task::Context;
+
 pub trait Future {
     type Output;
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
@@ -22,30 +44,29 @@ An async function returns an `impl Future`, and an async block evaluates to an
 own types. For example, the `JoinHandle` returns from `tokio::spawn` implements
 `Future` to allow joining to it.
 
-```rust,editable
-async fn fetch_token() -> String {
-	todo!()
-}
-
-async fn api_request() {
-	let _token_fut: () = fetch_token();
-	todo!()
-}
-```
-
 The `.await` keyword, applied to a Future, causes the current async function or
 block to pause until that Future is ready, and then evaluates to its output.
 
+An important difference from other languages is that a Future is inert: it does
+not do anything until it is polled.
+
 <details>
 
-* These types are conceptually quite simple, and implemented as such in
-  `std::task`.
+* Run the example and look at the error message. `_: () = ..` is a common
+  technique for getting the type of an expression. Try adding a `.await` in
+  `main`.
 
-* We will get to `Pin` and `Context` shortly, so don't get into any depth on
-  those items yet.
+* The `Future` and `Poll` types are conceptually quite simple, and implemented as
+  such in `std::task`.
 
-* The second code sample shows a technique for finding the type of a value,
-  from the error message.  Try adding `.await` after `fetch_token()` to see
-  the error message change.
+* We will not get to `Pin` and `Context`, as we will focus on writing async
+  code, rather than building new async primitives. Briefly:
+
+  * `Context` allows a Future to schedule itself to be polled again when an
+    event occurs.
+
+  * `Pin` ensures that the Future isn't moved in memory, so that pointers into
+    that future remain valid. This is required to allow references to remain
+    valid after an `.await`.
 
 </details>

--- a/src/async/futures.md
+++ b/src/async/futures.md
@@ -1,0 +1,51 @@
+# Futures
+
+[Future](https://doc.rust-lang.org/nightly/src/core/future/future.rs.html#37)
+is a trait, implemented by objects that represent an operation that may not be
+complete yet. A future can be polled, and `poll` returns either
+`Poll::Ready(result)` or `Poll::Pending`.
+
+```rust
+pub trait Future {
+    type Output;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
+}
+
+pub enum Poll<T> {
+    Ready(T),
+    Pending,
+}
+```
+
+An async function returns an `impl Future`, and an async block evaluates to an
+`impl Future`. It's also possible (but uncommon) to implement `Future` for your
+own types. For example, the `JoinHandle` returns from `tokio::spawn` implements
+`Future` to allow joining to it.
+
+```rust,editable
+async fn fetch_token() -> String {
+	todo!()
+}
+
+async fn api_request() {
+	let _token_fut: () = fetch_token();
+	todo!()
+}
+```
+
+The `.await` keyword, applied to a Future, causes the current async function or
+block to pause until that Future is ready, and then evaluates to its output.
+
+<details>
+
+* These types are conceptually quite simple, and implemented as such in
+  `std::task`.
+
+* We will get to `Pin` and `Context` shortly, so don't get into any depth on
+  those items yet.
+
+* The second code sample shows a technique for finding the type of a value,
+  from the error message.  Try adding `.await` after `fetch_token()` to see
+  the error message change.
+
+</details>


### PR DESCRIPTION
This adds a page about futures, showing how `async` and `await` interact with them.