### PR TITLE
Don't allocate in success case

### DIFF
--- a/src/error-handling/error-contexts.md
+++ b/src/error-handling/error-contexts.md
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, bail};
 fn read_username(path: &str) -> Result<String> {
     let mut username = String::with_capacity(100);
     fs::File::open(path)
-        .context(format!("Failed to open {path}"))?
+        .with_context(|| format!("Failed to open {path}"))?
         .read_to_string(&mut username)
         .context("Failed to read")?;
     if username.is_empty() {


### PR DESCRIPTION
`format!` was being called (and allocating a string) even in the success case.