### PR TITLE
Run `cargo fmt` in presubmit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Test code snippets
         run: mdbook test
 
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Format Rust code
+        run: cargo fmt --all -- --check
+
   cargo:
     runs-on: ubuntu-latest
     steps:

--- a/i18n-helpers/src/bin/mdbook-gettext.rs
+++ b/i18n-helpers/src/bin/mdbook-gettext.rs
@@ -21,7 +21,7 @@
 //! is found under `po` directory based on the `book.language`.
 //! For example, `book.langauge` is set to `ko`, then `po/ko.po` is used.
 //! You can set `preprocessor.gettext.po-dir` to specify where to find PO
-//! files. If the PO file is not found, you'll get the untranslated book. 
+//! files. If the PO file is not found, you'll get the untranslated book.
 //!
 //! See `TRANSLATIONS.md` in the repository root for more information.
 

--- a/i18n-helpers/src/bin/mdbook-xgettext.rs
+++ b/i18n-helpers/src/bin/mdbook-xgettext.rs
@@ -91,8 +91,7 @@ fn create_catalog(ctx: &RenderContext) -> anyhow::Result<Catalog> {
                 Some(path) => ctx.config.book.src.join(path),
                 None => continue,
             };
-            for msg in i18n_helpers::extract_msgs(&chapter.content)
-            {
+            for msg in i18n_helpers::extract_msgs(&chapter.content) {
                 let source = format!("{}:{}", path.display(), msg.line_number());
                 add_message(&mut catalog, msg.text(&chapter.content), &source);
             }


### PR DESCRIPTION
I ran `cargo fmt` once to format the existing code, and added a presubmit workflow to check it automatically in future.