### PR TITLE
Minor fixes for Day 3 Morning

### DIFF
--- a/src/generics/impl-trait.md
+++ b/src/generics/impl-trait.md
@@ -16,7 +16,6 @@ fn main() {
 }
 ```
 
-* `impl Trait` cannot be used with the `::<>` turbo fish syntax.
 * `impl Trait` allows you to work with types which you cannot name.
 
 <details>
@@ -24,9 +23,16 @@ fn main() {
 The meaning of `impl Trait` is a bit different in the different positions.
 
 * For a parameter, `impl Trait` is like an anonymous generic parameter with a trait bound.
+
 * For a return type, it means that the return type is some concrete type that implements the trait,
   without naming the type. This can be useful when you don't want to expose the concrete type in a
   public API.
+
+  Inference is hard in return position. A function returning `impl Foo` picks
+  the concrete type it returns, without writing it out in the source. A function
+  returning a generic type like `collect<B>() -> B` can return any type
+  satisfying `B`, and the caller may need to choose one, such as with `let x:
+  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`.
 
 This example is great, because it uses `impl Display` twice. It helps to explain that
 nothing here enforces that it is _the same_ `impl Display` type. If we used a single 
@@ -34,5 +40,5 @@ nothing here enforces that it is _the same_ `impl Display` type. If we used a si
 It would not work for this particular function, as the type we expect as input is likely not
 what `format!` returns. If we wanted to do the same via `: Display` syntax, we'd need two
 independent generic parameters.
-    
+
 </details>

--- a/src/traits.md
+++ b/src/traits.md
@@ -3,51 +3,45 @@
 Rust lets you abstract over types with traits. They're similar to interfaces:
 
 ```rust,editable
-trait Greet {
-    fn say_hello(&self);
+trait Pet {
+    fn name(&self) -> String;
 }
 
 struct Dog {
     name: String,
 }
 
-struct Cat;  // No name, cats won't respond to it anyway.
+struct Cat;
 
-impl Greet for Dog {
-    fn say_hello(&self) {
-        println!("Wuf, my name is {}!", self.name);
+impl Pet for Dog {
+    fn name(&self) -> String {
+        self.name.clone()
     }
 }
 
-impl Greet for Cat {
-    fn say_hello(&self) {
-        println!("Miau!");
+impl Pet for Cat {
+    fn name(&self) -> String {
+        String::from("The cat") // No name, cats won't respond to it anyway.
     }
+}
+
+fn greet(pet: &impl Pet) {
+    println!("Who's a cutie? {} is!", pet.name());
 }
 
 fn main() {
-    let pets: Vec<Box<dyn Greet>> = vec![
-        Box::new(Dog { name: String::from("Fido") }),
-        Box::new(Cat),
-    ];
-    for pet in pets {
-        pet.say_hello();
-    }
+    let fido = Dog { name: "Fido".into() };
+    greet(&fido);
+
+    let captain_floof = Cat;
+    greet(&captain_floof);
 }
 ```
 
 <details>
 
-* Types that implement a given trait may be of different sizes. This makes it impossible to have things like `Vec<Greet>` in the example above.
-* `dyn Greet` is a way to tell the compiler about a dynamically sized type that implements `Greet`.
-* In the example, `pets` holds Fat Pointers to objects that implement `Greet`. The Fat Pointer consists of two components, a pointer to the actual object and a pointer to the virtual method table for the `Greet` implementation of that particular object.
-* Compare these outputs in the above example:
-     ```rust,ignore
-         println!("{} {}", std::mem::size_of::<Dog>(), std::mem::size_of::<Cat>());
-         println!("{} {}", std::mem::size_of::<&Dog>(), std::mem::size_of::<&Cat>());
-         println!("{}", std::mem::size_of::<&dyn Greet>());
-         println!("{}", std::mem::size_of::<Box<dyn Greet>>());
-     ```
-* Default methods are covered in a subsequent chapter.
+* Later sections will get into more detail on generic functions like `greet`.
+  For now, students only need to know that `greet` will operate on a reference
+  to anything that implements `Pet`.
 
 </details>

--- a/src/traits.md
+++ b/src/traits.md
@@ -38,7 +38,6 @@ fn main() {
 
 <details>
 
-* Traits may specify pre-implemented (default) methods and methods that users are required to implement themselves. Methods with default implementations can rely on required methods.
 * Types that implement a given trait may be of different sizes. This makes it impossible to have things like `Vec<Greet>` in the example above.
 * `dyn Greet` is a way to tell the compiler about a dynamically sized type that implements `Greet`.
 * In the example, `pets` holds Fat Pointers to objects that implement `Greet`. The Fat Pointer consists of two components, a pointer to the actual object and a pointer to the virtual method table for the `Greet` implementation of that particular object.
@@ -49,5 +48,6 @@ fn main() {
          println!("{}", std::mem::size_of::<&dyn Greet>());
          println!("{}", std::mem::size_of::<Box<dyn Greet>>());
      ```
+* Default methods are covered in a subsequent chapter.
 
 </details>

--- a/src/traits/iterator.md
+++ b/src/traits/iterator.md
@@ -29,13 +29,16 @@ fn main() {
 
 <details>
 
-* `IntoIterator` is the trait that makes for loops work. It is implemented by collection types such as
-  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also implement it.
 * The `Iterator` trait implements many common functional programming operations over collections 
   (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can find all the documentation
   about them. In Rust these functions should produce the code as efficient as equivalent imperative
   implementations.
     
+* `IntoIterator` is the trait that makes for loops work. It is implemented by collection types such as
+  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also implement it. This is why
+  you can iterate over a vector with `for i in some_vec { .. }` but
+  `some_vec.next()` doesn't exist.
+
 </details>
 
 [1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html


### PR DESCRIPTION
Some fixes that came up in reading the day-3 morning session. Mostly, this simplifies the initial "Traits" chapter in deference to later descriptions of some of the more interesting features. It also fixes up the speaker notes for "Iterator" to mostly talk about the iterator trait and _then_ touch on `IntoIterator`.