### PR TITLE
Update `polib` dependency to version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "linereader"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d921fea6860357575519aca014c6e22470585accdd543b370c404a8a72d0dd1d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,9 +1457,12 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polib"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17009af1604eef4137497a743594fbe8f37e52f004cb5d8f7cf5130dc74a5644"
+checksum = "6b393b155cf9be86249cba1b56cc81be0e6212c66d94ac0d76d37a1761f3bb1b"
+dependencies = [
+ "linereader",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.68"
 mdbook = "0.4.25"
-polib = "0.1.0"
+polib = "0.2.0"
 pulldown-cmark = { version = "0.9.2", default-features = false }
 semver = "1.0.16"
 serde_json = "1.0.91"

--- a/i18n-helpers/src/bin/mdbook-xgettext.rs
+++ b/i18n-helpers/src/bin/mdbook-xgettext.rs
@@ -26,42 +26,40 @@ use mdbook::renderer::RenderContext;
 use mdbook::BookItem;
 use polib::catalog::Catalog;
 use polib::message::Message;
+use polib::metadata::CatalogMetadata;
 use std::{fs, io};
 
 fn add_message(catalog: &mut Catalog, msgid: &str, source: &str) {
-    let sources = match catalog.find_message(msgid) {
-        Some(msg) => format!("{}\n{}", msg.source, source),
+    let sources = match catalog.find_message(None, msgid, None) {
+        Some(msg) => format!("{}\n{}", msg.source(), source),
         None => String::from(source),
     };
-    let message = Message::new_singular("", &sources, "", "", msgid, "");
-
-    // Carefully update the existing message or add a new one. It's an
-    // error to create a catalog with duplicate msgids.
-    match catalog.find_message_index(msgid) {
-        Some(&idx) => catalog.update_message_by_index(idx, message).unwrap(),
-        None => catalog.add_message(message),
-    }
+    let message = Message::build_singular()
+        .with_source(sources)
+        .with_msgid(String::from(msgid))
+        .done();
+    catalog.append_or_update(message);
 }
 
 fn create_catalog(ctx: &RenderContext) -> anyhow::Result<Catalog> {
-    let mut catalog = Catalog::new();
+    let mut metadata = CatalogMetadata::new();
     if let Some(title) = &ctx.config.book.title {
-        catalog.metadata.project_id_version = String::from(title);
+        metadata.project_id_version = String::from(title);
     }
     if let Some(lang) = &ctx.config.book.language {
-        catalog.metadata.language = String::from(lang);
+        metadata.language = String::from(lang);
     }
-    catalog.metadata.mime_version = String::from("1.0");
-    catalog.metadata.content_type = String::from("text/plain; charset=UTF-8");
-    catalog.metadata.content_transfer_encoding = String::from("8bit");
-
-    let summary_path = ctx.config.book.src.join("SUMMARY.md");
-    let summary = std::fs::read_to_string(ctx.root.join(&summary_path))?;
+    metadata.mime_version = String::from("1.0");
+    metadata.content_type = String::from("text/plain; charset=UTF-8");
+    metadata.content_transfer_encoding = String::from("8bit");
+    let mut catalog = Catalog::new(metadata);
 
     // First, add all chapter names and part titles from SUMMARY.md.
     // The book items are in order of the summary, so we can assign
     // correct line numbers for duplicate lines by tracking the index
     // of our last search.
+    let summary_path = ctx.config.book.src.join("SUMMARY.md");
+    let summary = std::fs::read_to_string(ctx.root.join(&summary_path))?;
     let mut last_idx = 0;
     for item in ctx.book.iter() {
         let line = match item {
@@ -114,10 +112,6 @@ fn main() -> anyhow::Result<()> {
     fs::create_dir_all(&ctx.destination)
         .with_context(|| format!("Could not create {}", ctx.destination.display()))?;
     let output_path = ctx.destination.join(path);
-    if output_path.exists() {
-        fs::remove_file(&output_path)
-            .with_context(|| format!("Removing {}", output_path.display()))?
-    }
     let catalog = create_catalog(&ctx).context("Extracting messages")?;
     polib::po_file::write(&catalog, &output_path)
         .with_context(|| format!("Writing messages to {}", output_path.display()))?;


### PR DESCRIPTION
The API changed a little from version 0.1.0.

The new release includes https://github.com/BrettDong/polib/pull/1, which means we can simplify the code that writes a new PO file.