### PR TITLE
Add `pkg-config` to list of packages

### DIFF
--- a/src/welcome-bare-metal.md
+++ b/src/welcome-bare-metal.md
@@ -20,7 +20,7 @@ an on-board SWD debugger.
 To get started, install some tools we'll need later. On gLinux or Debian:
 
 ```bash
-sudo apt install gcc-aarch64-linux-gnu gdb-multiarch libudev-dev picocom qemu-system-arm
+sudo apt install gcc-aarch64-linux-gnu gdb-multiarch libudev-dev picocom pkg-config qemu-system-arm
 rustup update
 rustup target add aarch64-unknown-none thumbv7em-none-eabihf
 rustup component add llvm-tools-preview


### PR DESCRIPTION
`pkg-config` is also required for `cargo install` to work.