### PR TITLE
Direct users to "smccc" crate rather than "psci"

### DIFF
--- a/src/bare-metal/aps/inline-assembly.md
+++ b/src/bare-metal/aps/inline-assembly.md
@@ -7,7 +7,7 @@ to make an <abbr title="hypervisor call">HVC</abbr> to tell the firmware to powe
 {{#include examples/src/main_psci.rs:main}}
 ```
 
-(If you actually want to do this, use the [`psci`][1] crate which has wrappers for all these functions.)
+(If you actually want to do this, use the [`smccc`][1] crate which has wrappers for all these functions.)
 
 <details>
 
@@ -28,4 +28,4 @@ to make an <abbr title="hypervisor call">HVC</abbr> to tell the firmware to powe
 
 </details>
 
-[1]: https://crates.io/crates/psci
+[1]: https://crates.io/crates/smccc


### PR DESCRIPTION
psci's docs.rs page redirects users to `smccc` instead as the crate has been renamed.