### PR TITLE
Add a bit about 'use'

### DIFF
--- a/src/modules/filesystem.md
+++ b/src/modules/filesystem.md
@@ -28,11 +28,15 @@ These document the item that contains them -- in this case, a module.
 //! This module implements the garden, including a highly performant germination
 //! implementation.
 
-/// Sow the given seed packets.
-fn sow(seeds: Vec<SeedPacket>) { todo!() }
+// Re-export types from this module.
+pub use seeds::SeedPacket;
+pub use garden::Garden;
 
-// Harvest the produce in the garden that is ready.
-fn harvest(garden: &mut Garden) { todo!() }
+/// Sow the given seed packets.
+pub fn sow(seeds: Vec<SeedPacket>) { todo!() }
+
+/// Harvest the produce in the garden that is ready.
+pub fn harvest(garden: &mut Garden) { todo!() }
 ```
 
 <details>

--- a/src/modules/paths.md
+++ b/src/modules/paths.md
@@ -9,3 +9,11 @@ Paths are resolved as follows:
 2. As an absolute path:
    * `crate::foo` refers to `foo` in the root of the current crate,
    * `bar::foo` refers to `foo` in the `bar` crate.
+
+A module can bring symbols from another module into scope with `use`.
+You will typically see something like this at the top of each module:
+
+```rust,editable
+use std::collection::HashSet;
+use serde_json::json;
+```

--- a/src/modules/paths.md
+++ b/src/modules/paths.md
@@ -14,6 +14,6 @@ A module can bring symbols from another module into scope with `use`.
 You will typically see something like this at the top of each module:
 
 ```rust,editable
-use std::collection::HashSet;
-use serde_json::json;
+use std::collections::HashSet;
+use std::mem::transmute;
 ```


### PR DESCRIPTION
I didn't want to make a whole new slide, so I split this across the "paths" page (which introduces `::`, so kind of makes sense) and "Filesystem Hierarchy" (where re-exporting starts to seem more useful).