### PR TITLE
Use smccc crate rather than psci in examples and exercise.

### DIFF
--- a/src/bare-metal/aps/examples/Cargo.lock
+++ b/src/bare-metal/aps/examples/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "bitflags",
  "cc",
  "log",
- "psci",
+ "smccc",
  "spin",
 ]
 
@@ -57,16 +57,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "psci"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3374e3ae47f134467227a48be93b929e5d304efcd25ce5d176006403ca1d9bab"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "smccc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617d17f088ec733e5a6b86da6ce4cce1414e6e856d6061c16dda51cceae6f68c"
 
 [[package]]
 name = "spin"

--- a/src/bare-metal/aps/examples/Cargo.toml
+++ b/src/bare-metal/aps/examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 bitflags = "2.0.0"
 log = "0.4.17"
-psci = "0.1.1"
+smccc = "0.1.1"
 spin = "0.9.8"
 
 [build-dependencies]

--- a/src/bare-metal/aps/examples/src/exceptions.rs
+++ b/src/bare-metal/aps/examples/src/exceptions.rs
@@ -13,52 +13,53 @@
 // limitations under the License.
 
 use log::error;
-use psci::system_off;
+use smccc::psci::system_off;
+use smccc::Hvc;
 
 #[no_mangle]
 extern "C" fn sync_exception_current(_elr: u64, _spsr: u64) {
     error!("sync_exception_current");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn irq_current(_elr: u64, _spsr: u64) {
     error!("irq_current");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn fiq_current(_elr: u64, _spsr: u64) {
     error!("fiq_current");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn serr_current(_elr: u64, _spsr: u64) {
     error!("serr_current");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn sync_lower(_elr: u64, _spsr: u64) {
     error!("sync_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn irq_lower(_elr: u64, _spsr: u64) {
     error!("irq_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn fiq_lower(_elr: u64, _spsr: u64) {
     error!("fiq_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn serr_lower(_elr: u64, _spsr: u64) {
     error!("serr_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }

--- a/src/bare-metal/aps/examples/src/main_improved.rs
+++ b/src/bare-metal/aps/examples/src/main_improved.rs
@@ -23,7 +23,8 @@ use crate::pl011::Uart;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use log::error;
-use psci::system_off;
+use smccc::psci::system_off;
+use smccc::Hvc;
 
 /// Base address of the primary PL011 UART.
 const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;
@@ -50,13 +51,13 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
     }
 
     writeln!(uart, "Bye!").unwrap();
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 // ANCHOR_END: main
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     error!("{info}");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
     loop {}
 }

--- a/src/bare-metal/aps/examples/src/main_logger.rs
+++ b/src/bare-metal/aps/examples/src/main_logger.rs
@@ -23,7 +23,8 @@ mod pl011;
 use crate::pl011::Uart;
 use core::panic::PanicInfo;
 use log::{error, info, LevelFilter};
-use psci::system_off;
+use smccc::psci::system_off;
+use smccc::Hvc;
 
 /// Base address of the primary PL011 UART.
 const PL011_BASE_ADDRESS: *mut u32 = 0x900_0000 as _;
@@ -39,13 +40,13 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
 
     assert_eq!(x1, 42);
 
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     error!("{info}");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
     loop {}
 }
 // ANCHOR_END: main

--- a/src/bare-metal/aps/examples/src/main_minimal.rs
+++ b/src/bare-metal/aps/examples/src/main_minimal.rs
@@ -23,7 +23,8 @@ use crate::pl011_minimal::Uart;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use log::error;
-use psci::system_off;
+use smccc::psci::system_off;
+use smccc::Hvc;
 
 /// Base address of the primary PL011 UART.
 const PL011_BASE_ADDRESS: *mut u8 = 0x900_0000 as _;
@@ -36,13 +37,13 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
 
     writeln!(uart, "main({:#x}, {:#x}, {:#x}, {:#x})", x0, x1, x2, x3).unwrap();
 
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 // ANCHOR_END: main
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     error!("{}", info);
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
     loop {}
 }

--- a/src/exercises/bare-metal/rtc/Cargo.toml
+++ b/src/exercises/bare-metal/rtc/Cargo.toml
@@ -11,7 +11,7 @@ arm-gic = "0.1.0"
 bitflags = "2.0.0"
 chrono = { version = "0.4.24", default-features = false }
 log = "0.4.17"
-psci = "0.1.1"
+smccc = "0.1.1"
 spin = "0.9.8"
 
 [build-dependencies]

--- a/src/exercises/bare-metal/rtc/src/exceptions.rs
+++ b/src/exercises/bare-metal/rtc/src/exceptions.rs
@@ -14,12 +14,13 @@
 
 use arm_gic::gicv3::GicV3;
 use log::{error, info, trace};
-use psci::system_off;
+use smccc::psci::system_off;
+use smccc::Hvc;
 
 #[no_mangle]
 extern "C" fn sync_exception_current(_elr: u64, _spsr: u64) {
     error!("sync_exception_current");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
@@ -32,35 +33,35 @@ extern "C" fn irq_current(_elr: u64, _spsr: u64) {
 #[no_mangle]
 extern "C" fn fiq_current(_elr: u64, _spsr: u64) {
     error!("fiq_current");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn serr_current(_elr: u64, _spsr: u64) {
     error!("serr_current");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn sync_lower(_elr: u64, _spsr: u64) {
     error!("sync_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn irq_lower(_elr: u64, _spsr: u64) {
     error!("irq_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn fiq_lower(_elr: u64, _spsr: u64) {
     error!("fiq_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[no_mangle]
 extern "C" fn serr_lower(_elr: u64, _spsr: u64) {
     error!("serr_lower");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }

--- a/src/exercises/bare-metal/rtc/src/main.rs
+++ b/src/exercises/bare-metal/rtc/src/main.rs
@@ -32,7 +32,8 @@ use crate::pl011::Uart;
 use arm_gic::gicv3::GicV3;
 use core::panic::PanicInfo;
 use log::{error, info, trace, LevelFilter};
-use psci::system_off;
+use smccc::psci::system_off;
+use smccc::Hvc;
 
 /// Base addresses of the GICv3.
 const GICD_BASE_ADDRESS: *mut u64 = 0x800_0000 as _;
@@ -124,13 +125,13 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
     info!("Finished waiting");
 
     // ANCHOR: main_end
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
 }
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     error!("{info}");
-    system_off().unwrap();
+    system_off::<Hvc>().unwrap();
     loop {}
 }
 // ANCHOR_END: main_end


### PR DESCRIPTION
It was renamed.

This is a follow-up to #578.