### PR TITLE
Cleanup control flow slides

### DIFF
--- a/src/control-flow/break-continue.md
+++ b/src/control-flow/break-continue.md
@@ -1,8 +1,11 @@
 # `break` and `continue`
 
-If you want to exit a loop early, use `break`, if you want to immediately start
-the next iteration use `continue`. Both `continue` and `break` can optionally
-take a label argument which is used to break out of nested loops:
+- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions),
+- If you want to immediately start
+the next iteration use [`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions).
+
+Both `continue` and `break` can optionally take a label argument which is used
+to break out of nested loops:
 
 ```rust,editable
 fn main() {

--- a/src/control-flow/for-expressions.md
+++ b/src/control-flow/for-expressions.md
@@ -1,6 +1,7 @@
-# `for` expressions
+# `for` loops
 
-The `for` expression is closely related to the `while let` expression. It will
+The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely
+related to the [`while let` loop](while-let-expression.md). It will
 automatically call `into_iter()` on the expression and then iterate over it:
 
 ```rust,editable

--- a/src/control-flow/if-expressions.md
+++ b/src/control-flow/if-expressions.md
@@ -1,6 +1,8 @@
 # `if` expressions
 
-You use `if` very similarly to how you would in other languages:
+You use [`if`
+expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions)
+exactly like `if` statements in other languages:
 
 ```rust,editable
 fn main() {
@@ -13,7 +15,9 @@ fn main() {
 }
 ```
 
-In addition, you can use it as an expression. This does the same as above:
+In addition, you can use `if` as an expression. The last expression of each
+block becomes the value of the `if` expression:
+
 
 ```rust,editable
 fn main() {

--- a/src/control-flow/if-let-expressions.md
+++ b/src/control-flow/if-let-expressions.md
@@ -1,6 +1,8 @@
 # `if let` expressions
 
-If you want to match a value against a pattern, you can use `if let`:
+The [`if let`
+expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions)
+lets you execute different code depending on whether a value matches a pattern:
 
 ```rust,editable
 fn main() {

--- a/src/control-flow/loop-expressions.md
+++ b/src/control-flow/loop-expressions.md
@@ -1,7 +1,9 @@
 # `loop` expressions
 
-Finally, there is a `loop` keyword which creates an endless loop. Here you must
-either `break` or `return` to stop the loop:
+Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops)
+which creates an endless loop.
+
+Here you must either `break` or `return` to stop the loop:
 
 ```rust,editable
 fn main() {
@@ -23,5 +25,8 @@ fn main() {
 <details>
     
 * Break the `loop` with a value (e.g. `break 8`) and print it out.
+* Note that `loop` is the only looping construct which returns a non-trivial
+  value. This is because it's guaranteed to be entered at least once (unline
+  `while` and `for` loops).
 
 </details>

--- a/src/control-flow/loop-expressions.md
+++ b/src/control-flow/loop-expressions.md
@@ -26,7 +26,7 @@ fn main() {
     
 * Break the `loop` with a value (e.g. `break 8`) and print it out.
 * Note that `loop` is the only looping construct which returns a non-trivial
-  value. This is because it's guaranteed to be entered at least once (unline
+  value. This is because it's guaranteed to be entered at least once (unlike
   `while` and `for` loops).
 
 </details>

--- a/src/control-flow/match-expressions.md
+++ b/src/control-flow/match-expressions.md
@@ -1,7 +1,8 @@
 # `match` expressions
 
-The `match` keyword is used to match a value against one or more patterns. In
-that sense, it works like a series of `if let` expressions:
+The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-expr.html)
+is used to match a value against one or more patterns. In that sense, it works
+like a series of `if let` expressions:
 
 ```rust,editable
 fn main() {

--- a/src/control-flow/while-expressions.md
+++ b/src/control-flow/while-expressions.md
@@ -1,6 +1,7 @@
-# `while` expressions
+# `while` loops
 
-The `while` keyword works very similar to other languages:
+The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops)
+works very similar to other languages:
 
 ```rust,editable
 fn main() {

--- a/src/control-flow/while-let-expressions.md
+++ b/src/control-flow/while-let-expressions.md
@@ -1,7 +1,7 @@
-# `while let` expressions
+# `while let` loops
 
-Like with `if`, there is a `while let` variant which repeatedly tests a value
-against a pattern:
+Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops)
+variant which repeatedly tests a value against a pattern:
 
 ```rust,editable
 fn main() {
@@ -20,7 +20,6 @@ return `None`. The `while let` lets us keep iterating through all items.
 
 See [pattern matching](../pattern-matching.md) for more details on patterns in
 Rust.
-
 
 <details>
 


### PR DESCRIPTION
This avoids calling all the looping constructs “expressions” since they all (except for `loop`) return trivial values.