### PR TITLE
Wrap comments at 80 columns

### DIFF
--- a/src/unsafe/raw-pointers.md
+++ b/src/unsafe/raw-pointers.md
@@ -9,9 +9,10 @@ fn main() {
     let r1 = &mut num as *mut i32;
     let r2 = r1 as *const i32;
 
-    // Safe because r1 and r2 were obtained from references and so are guaranteed to be non-null and
-    // properly aligned, the objects underlying the references from which they were obtained are
-    // live throughout the whole unsafe block, and they are not accessed either through the
+    // Safe because r1 and r2 were obtained from references and so are
+    // guaranteed to be non-null and properly aligned, the objects underlying
+    // the references from which they were obtained are live throughout the
+    // whole unsafe block, and they are not accessed either through the
     // references or concurrently through any other pointers.
     unsafe {
         println!("r1 is: {}", *r1);


### PR DESCRIPTION
When teaching the class, I notice that these comments (which are wrapped at 100 columns) cause a horizontal scrollbar which makes them hard to read at a glance.

Here I wrapped them at 80 columns, which fits on the screen and which avoids overly long lines.