### PR TITLE
Use explicit `Arc::clone` instead of calling `.clone()` method

### DIFF
--- a/src/concurrency/shared_state/arc.md
+++ b/src/concurrency/shared_state/arc.md
@@ -1,6 +1,6 @@
 # `Arc`
 
-[`Arc<T>`][1] allows shared read-only access via its `clone` method:
+[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:
 
 ```rust,editable
 use std::thread;
@@ -10,7 +10,7 @@ fn main() {
     let v = Arc::new(vec![10, 20, 30]);
     let mut handles = Vec::new();
     for _ in 1..5 {
-        let v = v.clone();
+        let v = Arc::clone(&v);
         handles.push(thread::spawn(move || {
             let thread_id = thread::current().id();
             println!("{thread_id:?}: {v:?}");

--- a/src/concurrency/shared_state/example.md
+++ b/src/concurrency/shared_state/example.md
@@ -7,7 +7,7 @@ use std::thread;
 // use std::sync::{Arc, Mutex};
 
 fn main() {
-    let mut v = vec![10, 20, 30];
+    let v = vec![10, 20, 30];
     let handle = thread::spawn(|| {
         v.push(10);
     });
@@ -29,7 +29,7 @@ use std::thread;
 fn main() {
     let v = Arc::new(Mutex::new(vec![10, 20, 30]));
 
-    let v2 = v.clone();
+    let v2 = Arc::clone(&v);
     let handle = thread::spawn(move || {
         let mut v2 = v2.lock().unwrap();
         v2.push(10);

--- a/src/std/rc.md
+++ b/src/std/rc.md
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 fn main() {
     let mut a = Rc::new(10);
-    let mut b = a.clone();
+    let mut b = Rc::clone(&a);
 
     println!("a: {a}");
     println!("b: {b}");
@@ -28,13 +28,13 @@ fn main() {
 
 <details>
 
-* `Rc`'s Count ensures that its contained value is valid for as long as there are references.
+* `Rc`'s count ensures that its contained value is valid for as long as there are references.
 * Like C++'s `std::shared_ptr`.
-* `clone` is cheap: it creates a pointer to the same allocation and increases the reference count. Does not make a deep clone and can generally be ignored when looking for performance issues in code.
+* `Rc::clone` is cheap: it creates a pointer to the same allocation and increases the reference count. Does not make a deep clone and can generally be ignored when looking for performance issues in code.
 * `make_mut` actually clones the inner value if necessary ("clone-on-write") and returns a mutable reference.
 * Use `Rc::strong_count` to check the reference count.
 * Compare the different datatypes mentioned. `Box` enables (im)mutable borrows that are enforced at compile time. `RefCell` enables (im)mutable borrows that are enforced at run time and will panic if it fails at runtime.
-* You can `downgrade()` a `Rc` into a *weakly reference-counted* object to
+* `Rc::downgrade` gives you a *weakly reference-counted* object to
   create cycles that will be dropped properly (likely in combination with
   `RefCell`).
 


### PR DESCRIPTION
This is to highlight that the clones are cheap: they run custom logic in the reference counted type, they don’t do a deep clone.