### PR TITLE
Ensure code blocks are editable

### DIFF
--- a/src/error-handling/panic-unwind.md
+++ b/src/error-handling/panic-unwind.md
@@ -2,7 +2,7 @@
 
 By default, a panic will cause the stack to unwind. The unwinding can be caught:
 
-```rust
+```rust,editable
 use std::panic;
 
 let result = panic::catch_unwind(|| {

--- a/src/error-handling/result.md
+++ b/src/error-handling/result.md
@@ -3,7 +3,7 @@
 We have already seen the `Result` enum. This is used pervasively when errors are
 expected as part of normal operation:
 
-```rust
+```rust,editable
 use std::fs::File;
 use std::io::Read;
 

--- a/src/hello-world.md
+++ b/src/hello-world.md
@@ -3,7 +3,7 @@
 Let us jump into the simplest possible Rust program, a classic Hello World
 program:
 
-```rust
+```rust,editable
 fn main() {
     println!("Hello 🌍!");
 }

--- a/src/testing/unit-tests.md
+++ b/src/testing/unit-tests.md
@@ -2,7 +2,7 @@
 
 Mark unit tests with `#[test]`:
 
-```rust,ignore
+```rust,editable,ignore
 fn first_word(text: &str) -> &str {
     match text.find(' ') {
         Some(idx) => &text[..idx],


### PR DESCRIPTION
We should default to making code blocks editable: this ensures consistent syntax highlighting (see #343) and it allows the instructor to freely edit anything they want.

This doesn't convert all code blocks, only the ones I noticed while teaching the class.