### PR TITLE
Move closures to the top level

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -144,7 +144,7 @@
   - [Drop](traits/drop.md)
   - [Default](traits/default.md)
   - [Operators: Add, Mul, ...](traits/operators.md)
-    - [Closures](traits/closures.md)
+  - [Closures: Fn, FnMut, FnOnce](traits/closures.md)
 - [Exercises](exercises/day-3/morning.md)
   - [A Simple GUI Library](exercises/day-3/simple-gui.md)
 


### PR DESCRIPTION
I've gone looking for where we discuss closures, and without this change they do not appear in the TOC until you twirl down "Operators", which is a weird place for them.

Also, I looked at the list of "Important Traits" and, sure, I can get through those before lunch.  But these traits take quite a while to understand!