### PR TITLE
Fix title of 'Runtimes'

### DIFF
--- a/src/async/runtimes.md
+++ b/src/async/runtimes.md
@@ -1,4 +1,4 @@
-# Runtimes and Tasks
+# Runtimes
 
 A *runtime* provides support for performing operations asynchronously (a
 *reactor*) and is responsible for executing futures (an *executor*). Rust does not have a


### PR DESCRIPTION
I think this got missed when refactoring. The title is already correct in SUMMARY.md.