### PR TITLE
Use hyphen rather than underscore for gic-version

### DIFF
--- a/src/exercises/bare-metal/rtc/Makefile
+++ b/src/exercises/bare-metal/rtc/Makefile
@@ -31,7 +31,7 @@ rtc.bin: build
 	$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@
 
 qemu: rtc.bin
-	qemu-system-aarch64 -machine virt,gic_version=3 -cpu max -serial mon:stdio -display none -kernel $< -s
+	qemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio -display none -kernel $< -s
 
 clean:
 	cargo clean


### PR DESCRIPTION
Older versions of QEMU seem to only accept a hyphen, while new versions accept either.