### PR TITLE
Point students to the git repo containing exercise code

### DIFF
--- a/src/exercises/bare-metal/compass.md
+++ b/src/exercises/bare-metal/compass.md
@@ -20,8 +20,9 @@ Hints:
   [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.5.pdf) if you want, but
   it shouldn't be necessary for this exercise.
 
-Download the [exercise template](../../comprehensive-rust-exercises.zip) and look in the `compass`
-directory for the following files.
+Find the following files either in `compass/` in the [exercise
+template](../../comprehensive-rust-exercises.zip) or in
+[`src/exercises/bare-metal/compass`](https://github.com/google/comprehensive-rust/tree/main/src/exercises/bare-metal/compass).
 
 `src/main.rs`:
 

--- a/src/exercises/bare-metal/rtc.md
+++ b/src/exercises/bare-metal/rtc.md
@@ -12,9 +12,9 @@ should write a driver for it.
    - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.
    - Once the interrupt is enabled, you can put the core to sleep via `arm_gic::wfi()`, which will cause the core to sleep until it receives an interrupt.
    
-
-Download the [exercise template](../../comprehensive-rust-exercises.zip) and look in the `rtc`
-directory for the following files.
+Find the following files either in `rtc/` in the [exercise
+template](../../comprehensive-rust-exercises.zip) or in
+[`src/exercises/bare-metal/compass`](https://github.com/google/comprehensive-rust/tree/main/src/exercises/bare-metal/rtc).
 
 `src/main.rs`:
 

--- a/src/exercises/concurrency/elevator.md
+++ b/src/exercises/concurrency/elevator.md
@@ -11,8 +11,9 @@ by sending and receiving messages.
 
 ## Getting Started
 
-Download the [exercise template](../../comprehensive-rust-exercises.zip) and look in the `elevator`
-directory for the following files.
+Find the following files either in `elevator/` in the [exercise
+template](../../comprehensive-rust-exercises.zip) or in
+[`src/exercises/bare-metal/compass`](https://github.com/google/comprehensive-rust/tree/main/src/exercises/concurrency/elevator).
 
 `src/main.rs`:
 


### PR DESCRIPTION
One of the students in my session mentioned that a Git repo containing the exercise code would be more useful to them than a ZIP file. This seems pretty easy to provide!

/cc @rbehjati in case of conflicts with other changes to the concurrency exercise.