### PR TITLE
Remove unnecessary jobs names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
         run: mdbook test
 
   format:
-    name: Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,7 +50,6 @@ jobs:
         run: cargo test
 
   bare-metal:
-    name: Build bare-metal Rust examples
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
They are inconsistent with the rest of the jobs and they overflow the horizontal space in the GitHub UI.