### PR TITLE
Add dining philosophers as an async exercise

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -290,7 +290,9 @@
   - [Blocking the Executor](async/pitfalls/blocking-executor.md)
   - [Pin](async/pitfalls/pin.md)
   - [Async Traits](async/pitfalls/async-traits.md)
-- [Exercises](exercises/concurrency/elevator.md)
+- [Exercises](exercises/concurrency/afternoon.md)
+  - [Dining Philosophers](exercises/concurrency/dining-philosophers-async.md)
+  - [Elevator Operations](exercises/concurrency/elevator.md)
 
 
 # Final Words
@@ -316,3 +318,4 @@
   - [Bare Metal Rust Morning](exercises/bare-metal/solutions-morning.md)
   - [Bare Metal Rust Afternoon](exercises/bare-metal/solutions-afternoon.md)
   - [Concurrency Morning](exercises/concurrency/solutions-morning.md)
+  - [Concurrency Afternoon](exercises/concurrency/solutions-afternoon.md)

--- a/src/exercises/concurrency/afternoon.md
+++ b/src/exercises/concurrency/afternoon.md
@@ -3,7 +3,7 @@
 To practice your Async Rust skills, we have again two exercises for you:
 
 * Dining philosophers: we already saw this problem in the morning. This time
-  you are going to solve it with Async Rust.
+  you are going to implement it with Async Rust.
 
 * The Elevator Problem: this is a larger project that allows you experiment
   with more advanced Async Rust features and some of its pitfalls!

--- a/src/exercises/concurrency/afternoon.md
+++ b/src/exercises/concurrency/afternoon.md
@@ -1,0 +1,17 @@
+# Exercises
+
+To practice your Async Rust skills, we have again two exercises for you:
+
+* Dining philosophers: we already saw this problem in the morning. This time
+  you are going to solve it with Async Rust.
+
+* The Elevator Problem: this is a larger project that allows you experiment
+  with more advanced Async Rust features and some of its pitfalls!
+
+<details>
+
+After looking at the exercises, you can look at the [solutions] provided.
+
+[solutions]: solutions-afternoon.md
+
+</details>

--- a/src/exercises/concurrency/dining-philosophers-async.md
+++ b/src/exercises/concurrency/dining-philosophers-async.md
@@ -48,4 +48,10 @@ tokio = {version = "1.26.0", features = ["sync", "time", "macros", "rt-multi-thr
 ```
 
 Also note that this time you have to use the `Mutex` and the `mpsc` module
-provided by the `tokio` crate.
+form the `tokio` crate.
+
+<details>
+
+* Can you make your implementation single-threaded? 
+
+</details>

--- a/src/exercises/concurrency/dining-philosophers-async.md
+++ b/src/exercises/concurrency/dining-philosophers-async.md
@@ -11,46 +11,17 @@ that `cargo run` does not deadlock:
 <!-- File src/main.rs -->
 
 ```rust,compile_fail
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
-use tokio::time;
-use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::Mutex;
-
-
-struct Fork;
-
-/// We've already learnt that to avoid a deadlock, we have to break the
-/// symmetry. So here we call the forks the first_fork and the second_fork.
-/// The left fork is not necessarily the first fork.
-struct Philosopher {
-    name: String,
-    first_fork: ...,
-    second_fork: ...,
-    thoughts: ...,
+{{#include dining-philosophers-async.rs:Philosopher}}
+    // left_fork: ...
+    // right_fork: ...
+    // thoughts: ...
 }
 
-impl Philosopher {
-    async fn think(&self) {
-        self.thoughts
-            .send(format!("Eureka! {} has a new idea!", &self.name)).await
-            .unwrap();
-    }
+{{#include dining-philosophers-async.rs:Philosopher-think}}
 
-    async fn eat(&self) {
-        // Pick up forks...
-
-        println!("{} is eating...", &self.name);
-        time::sleep(time::Duration::from_millis(10)).await;
-    }
-}
-
-static PHILOSOPHERS: &[&str] =
-    &["Socrates", "Plato", "Aristotle", "Thales", "Pythagoras"];
-
-#[tokio::main]
-async fn main() {
+{{#include dining-philosophers-async.rs:Philosopher-eat}}
+{{#include dining-philosophers-async.rs:Philosopher-eat-body}}
+{{#include dining-philosophers-async.rs:Philosopher-eat-end}}
     // Create forks
 
     // Create philosophers
@@ -59,7 +30,6 @@ async fn main() {
 
     // Output their thoughts
 }
-
 ```
 
 Since this time you are using Async Rust, you'll need a `tokio` dependency.

--- a/src/exercises/concurrency/dining-philosophers-async.md
+++ b/src/exercises/concurrency/dining-philosophers-async.md
@@ -1,0 +1,81 @@
+# Dining Philosophers - Async
+
+See [dining philosophers](dining-philosophers.md) for a description of the
+problem.
+
+As before, you will need a local
+[Cargo installation](../../cargo/running-locally.md) for this exercise. Copy
+the code below to a file called `src/main.rs`, fill out the blanks, and test
+that `cargo run` does not deadlock:
+
+<!-- File src/main.rs -->
+
+```rust,compile_fail
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tokio::time;
+use tokio::sync::mpsc::{self, Sender};
+use tokio::sync::Mutex;
+
+
+struct Fork;
+
+/// We've already learnt that to avoid a deadlock, we have to break the
+/// symmetry. So here we call the forks the first_fork and the second_fork.
+/// The left fork is not necessarily the first fork.
+struct Philosopher {
+    name: String,
+    first_fork: ...,
+    second_fork: ...,
+    thoughts: ...,
+}
+
+impl Philosopher {
+    async fn think(&self) {
+        self.thoughts
+            .send(format!("Eureka! {} has a new idea!", &self.name)).await
+            .unwrap();
+    }
+
+    async fn eat(&self) {
+        // Pick up forks...
+
+        println!("{} is eating...", &self.name);
+        time::sleep(time::Duration::from_millis(10)).await;
+    }
+}
+
+static PHILOSOPHERS: &[&str] =
+    &["Socrates", "Plato", "Aristotle", "Thales", "Pythagoras"];
+
+#[tokio::main]
+async fn main() {
+    // Create forks
+
+    // Create philosophers
+
+    // Make them think and eat
+
+    // Output their thoughts
+}
+
+```
+
+Since this time you are using Async Rust, you'll need a `tokio` dependency.
+You can use the following `Cargo.toml`:
+
+<!-- File Cargo.toml -->
+
+```toml
+[package]
+name = "dining-philosophers-async-dine"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = {version = "1.26.0", features = ["sync", "time", "macros", "rt-multi-thread"]}
+```
+
+Also note that this time you have to use the `Mutex` and the `mpsc` module
+provided by the `tokio` crate.

--- a/src/exercises/concurrency/dining-philosophers-async.rs
+++ b/src/exercises/concurrency/dining-philosophers-async.rs
@@ -1,0 +1,99 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc};
+use std::thread;
+use std::time::Duration;
+use tokio::time;
+use tokio::sync::mpsc::{self, Sender};
+use tokio::sync::Mutex;
+
+
+struct Fork;
+
+/// We've already learnt that to avoid a deadlock, we have to break the
+/// symmetry. So here we call the forks the first_fork and the second_fork.
+/// The left fork is not necessarily the first fork.
+struct Philosopher {
+    name: String,
+    first_fork: Arc<Mutex<Fork>>,
+    second_fork: Arc<Mutex<Fork>>,
+    thoughts: Sender<String>,
+}
+
+impl Philosopher {
+    async fn think(&self) {
+        self.thoughts
+            .send(format!("Eureka! {} has a new idea!", &self.name)).await
+            .unwrap();
+    }
+
+    async fn eat(&self) {
+        // Pick up forks...
+        let _first_lock = self.first_fork.lock().await;
+        // Add a delay before picking the second fork to allow the execution
+        // to transfer to another task
+        time::sleep(time::Duration::from_millis(1)).await;
+        let _second_lock = self.second_fork.lock().await;
+
+        println!("{} is eating...", &self.name);
+        time::sleep(time::Duration::from_millis(5)).await;
+
+        // The locks are dropped here
+    }
+}
+
+static PHILOSOPHERS: &[&str] =
+    &["Socrates", "Plato", "Aristotle", "Thales", "Pythagoras"];
+
+#[tokio::main]
+async fn main() {
+    // Create forks
+    let mut forks = vec![];
+    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::new(Fork))));
+
+    // Create philosophers
+    let (philosophers, mut rx) = {
+        let mut philosophers = vec![];
+        let (tx, rx) = mpsc::channel(10);
+        for (i, name) in PHILOSOPHERS.iter().enumerate() {
+            let left_fork = forks[i].clone();
+            let right_fork = forks[(i + 1) % PHILOSOPHERS.len()].clone();
+            philosophers.push(Philosopher {
+                name: name.to_string(),
+                first_fork: if i % 2 == 0 { left_fork.clone() } else { right_fork.clone() },
+                second_fork: if i % 2 == 0 { right_fork.clone() } else { left_fork.clone() },
+                thoughts: tx.clone(),
+            });
+        }
+        (philosophers, rx)
+        // tx is dropped here, so we don't need to explicitly drop it later
+    };
+
+    // Make them think and eat
+    for phil in philosophers {
+        tokio::spawn(async move {
+            for _ in 0..100 {
+                phil.think().await;
+                phil.eat().await;
+            }
+        });
+
+    }
+
+    // Output their thoughts
+    while let Some(thought) = rx.recv().await {
+        println!("Here is a thought: {thought}");
+    }
+}

--- a/src/exercises/concurrency/solutions-afternoon.md
+++ b/src/exercises/concurrency/solutions-afternoon.md
@@ -4,7 +4,7 @@
 
 ([back to exercise](dining-philosophers-async.md))
 
-```rust
+```rust,compile_fail
 {{#include dining-philosophers-async.rs}}
 ```
 

--- a/src/exercises/concurrency/solutions-afternoon.md
+++ b/src/exercises/concurrency/solutions-afternoon.md
@@ -1,0 +1,10 @@
+# Concurrency Afternoon Exercise
+
+## Dining Philosophers - Async
+
+([back to exercise](dining-philosophers-async.md))
+
+```rust
+{{#include dining-philosophers-async.rs}}
+```
+


### PR DESCRIPTION
This PR adds Dining Philosophers as an async exercise. 
Since we already have a description of the dining philosophers problem, this PR mostly 
- Adds template for async dining philosophers, with a few brief notes about the use of `tokio`,
- Adds the async solution for dining philosophers,
- Updates the structure to show that now we have two Async Rust exercises.

@djmitche I did not remove the elevator exercise. I think we can keep it for now, until we find a simpler replacement for it. Do we have a complete solution for it anywhere? If so, we could add a link to it in the solution section.

@mgeisler I've added a redirect rule for the link I change, but I am not sure if it is right. Can you please check that?
- Update: Removed the redirect, as one of the CI steps seemed to fail because of it.
