### PR TITLE
Fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ course developed by the Android team. The course covers all aspects of Rust,
 from basic syntax to generics and error handling. It also includes deep dives on
 [Android], [bare-metal], and [concurrency].
 
-[Android]: https://google.github.io/comprehensive-rust/android.md
-[bare-metal]: https://google.github.io/comprehensive-rust/bare-metal.md
-[concurrency]: https://google.github.io/comprehensive-rust/concurrency.md
+[Android]: https://google.github.io/comprehensive-rust/android.html
+[bare-metal]: https://google.github.io/comprehensive-rust/bare-metal.html
+[concurrency]: https://google.github.io/comprehensive-rust/concurrency.html
 
 Read the course at **https://google.github.io/comprehensive-rust/**.
 


### PR DESCRIPTION
Links inside the course are automatically turned into `.html` by mdbook, but this is a regular README and so we need proper links.