### PR TITLE
Fix broken link to trait objects

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -54,6 +54,7 @@ editable = true
 "generics/closures.html" = "../traits/closures.html"
 "generics/impl-trait.html" = "../traits/impl-trait.html"
 "generics/trait-bounds.html" = "../traits/trait-bounds.html"
+"generics/trait-objects.html" = "../traits/trait-objects.html"
 "running-the-course/day-4.html" = "course-structure.html"
 "structure.html" = "running-the-course/course-structure.html"
 "unsafe/unsafe-functions.html" = "calling-unsafe-functions.html"


### PR DESCRIPTION
I'm seeing 404 hits on the old URLs — the file was renamed in #503 and has been indexed before that. The redirects should help direct search engines to the new home.