### PR TITLE
Add redirect for old async/concurrency/ directory

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -44,6 +44,7 @@ editable = true
 [output.html.redirect]
 # Redirects in the form of "old-path" = "new-path", where the new path
 # is relative to the old path.
+"async/concurrency/channels.html" = "../channels.html"
 "exercises/day-4/afternoon.html" = "../android/morning.html"
 "exercises/day-4/android.html" = "../android/morning.html"
 "exercises/day-4/dining-philosophers.html" = "../concurrency/dining-philosophers.html"


### PR DESCRIPTION
It seems we had a link to async/concurrency/channels.html for a brief period. This got indexed and now show up as 404 errors in my reports.