### PR TITLE
Enable `imports_granularity` for `rustfmt`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Format Rust code
+      - name: Install nightly rustfmt
+        run: |
+          rustup default nightly
+          rustup component add rustfmt
+
+      - name: Check Rust formatting
         run: cargo fmt --all -- --check
 
   cargo:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-# imports_granularity = "module"
+imports_granularity = "module"  # Please use nightly for this setting.
 max_width = 90


### PR DESCRIPTION
This requires us to run a [nightly Rust for our formatting check][1]. Other users will see a warning when invoking `rustfmt`:

  Warning: can't set `imports_granularity = Module`, unstable features
  are only available in nightly channel.

This should be harmless overall and help us ensure better consistency in our import formatting.

[1]: https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#imports_granularity