### PR TITLE
Fixing a typo in a "details" close tag

### DIFF
--- a/src/basic-syntax/functions-interlude.md
+++ b/src/basic-syntax/functions-interlude.md
@@ -27,5 +27,5 @@ fn main() {
 * When using generics, the standard library's `Into<T>` can provide a kind of limited
   polymorphism on argument types. We will see more details in a later section.
 
-</defails>
+</details>
 


### PR DESCRIPTION
Currently, when we click for a printable version (also a single page version of the book), the contents stop before Morning 1 exercises, on the topic "function overloading". The rest of the content go inside the details of this page. There is a typo on this page on the details tag closing.