### PR TITLE
Publish the in-progress Italian translation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   # Update the language picker in index.hbs to link new languages.
-  LANGUAGES: da pt-BR ko
+  LANGUAGES: da it pt-BR ko
 
 jobs:
   publish:


### PR DESCRIPTION
This makes the translation available on the official site. It's not linked yet, but having it available there should make it easier to review the state.