### PR TITLE
da: Translate most small messages

### DIFF
--- a/po/da.po
+++ b/po/da.po
@@ -675,22 +675,20 @@ msgid "With Java"
 msgstr ""
 
 #: src/SUMMARY.md:207
-#, fuzzy
 msgid "Bare Metal: Morning"
-msgstr "Dag 1: Formiddag"
+msgstr "Rå jern: Formiddag"
 
 #: src/SUMMARY.md:212
 msgid "no_std"
-msgstr ""
+msgstr "no_std"
 
 #: src/SUMMARY.md:213
-#, fuzzy
 msgid "A Minimal Example"
-msgstr "Et little eksempel"
+msgstr "Et minimalt eksempel"
 
 #: src/SUMMARY.md:214
 msgid "alloc"
-msgstr ""
+msgstr "alloc"
 
 #: src/SUMMARY.md:215
 msgid "Microcontrollers"
@@ -698,11 +696,11 @@ msgstr ""
 
 #: src/SUMMARY.md:216
 msgid "Raw MMIO"
-msgstr ""
+msgstr "Rå MMIO"
 
 #: src/SUMMARY.md:217
 msgid "PACs"
-msgstr ""
+msgstr "PAC'er"
 
 #: src/SUMMARY.md:218
 msgid "HAL Crates"
@@ -718,29 +716,27 @@ msgstr ""
 
 #: src/SUMMARY.md:221
 msgid "embedded-hal"
-msgstr ""
+msgstr "embedded-hal"
 
 #: src/SUMMARY.md:222
 msgid "probe-rs, cargo-embed"
-msgstr ""
+msgstr "probe-rs, cargo-embed"
 
 #: src/SUMMARY.md:223
 msgid "Debugging"
-msgstr ""
+msgstr "Debugning"
 
 #: src/SUMMARY.md:224 src/SUMMARY.md:242
 msgid "Other Projects"
-msgstr ""
+msgstr "Andre projekter"
 
 #: src/SUMMARY.md:226
-#, fuzzy
 msgid "Compass"
-msgstr "Sammenligning"
+msgstr "Kompas"
 
 #: src/SUMMARY.md:228
-#, fuzzy
 msgid "Bare Metal: Afternoon"
-msgstr "Dag 1: Eftermiddag"
+msgstr "Rå jern: Eftermiddag"
 
 #: src/SUMMARY.md:230
 msgid "Application Processors"
@@ -752,7 +748,7 @@ msgstr ""
 
 #: src/SUMMARY.md:232
 msgid "MMIO"
-msgstr ""
+msgstr "MMIO"
 
 #: src/SUMMARY.md:233
 msgid "Let's Write a UART Driver"
@@ -768,7 +764,7 @@ msgstr ""
 
 #: src/SUMMARY.md:236
 msgid "Bitflags"
-msgstr ""
+msgstr "Bitflag"
 
 #: src/SUMMARY.md:237
 msgid "Multiple Registers"
@@ -776,12 +772,11 @@ msgstr ""
 
 #: src/SUMMARY.md:238
 msgid "Driver"
-msgstr ""
+msgstr "Driver"
 
 #: src/SUMMARY.md:239 src/SUMMARY.md:241
-#, fuzzy
 msgid "Using It"
-msgstr "Brug af Cargo"
+msgstr "Anvendelse"
 
 #: src/SUMMARY.md:243
 msgid "Useful Crates"
@@ -789,27 +784,27 @@ msgstr ""
 
 #: src/SUMMARY.md:244
 msgid "zerocopy"
-msgstr ""
+msgstr "zerocopy"
 
 #: src/SUMMARY.md:245
 msgid "aarch64-paging"
-msgstr ""
+msgstr "aarch64-paging"
 
 #: src/SUMMARY.md:246
 msgid "buddy_system_allocator"
-msgstr ""
+msgstr "buddy_system_allocator"
 
 #: src/SUMMARY.md:247
 msgid "tinyvec"
-msgstr ""
+msgstr "tinyvec"
 
 #: src/SUMMARY.md:248
 msgid "spin"
-msgstr ""
+msgstr "spin"
 
 #: src/SUMMARY.md:250
 msgid "vmbase"
-msgstr ""
+msgstr "vmbase"
 
 #: src/SUMMARY.md:252
 msgid "RTC Driver"
@@ -821,7 +816,7 @@ msgstr ""
 
 #: src/SUMMARY.md:260
 msgid "Threads"
-msgstr ""
+msgstr "Tråde"
 
 #: src/SUMMARY.md:261
 msgid "Scoped Threads"
@@ -829,43 +824,43 @@ msgstr ""
 
 #: src/SUMMARY.md:262
 msgid "Channels"
-msgstr ""
+msgstr "Kanaler"
 
 #: src/SUMMARY.md:263
 msgid "Unbounded Channels"
-msgstr ""
+msgstr "Ubegrænsede kanaler"
 
 #: src/SUMMARY.md:264
 msgid "Bounded Channels"
-msgstr ""
+msgstr "Begrænsede kanaler"
 
 #: src/SUMMARY.md:265
 msgid "Send and Sync"
-msgstr ""
+msgstr "Send og Sync"
 
 #: src/SUMMARY.md:265
 msgid "Send"
-msgstr ""
+msgstr "Send"
 
 #: src/SUMMARY.md:265
 msgid "Sync"
-msgstr ""
+msgstr "Sync"
 
 #: src/SUMMARY.md:268
 msgid "Examples"
-msgstr ""
+msgstr "Eksempler"
 
 #: src/SUMMARY.md:269
 msgid "Shared State"
-msgstr ""
+msgstr "Delt tilstand"
 
 #: src/SUMMARY.md:270
 msgid "Arc"
-msgstr ""
+msgstr "Arc"
 
 #: src/SUMMARY.md:271
 msgid "Mutex"
-msgstr ""
+msgstr "Mutex"
 
 #: src/SUMMARY.md:274 src/SUMMARY.md:294
 msgid "Dining Philosophers"
@@ -873,7 +868,7 @@ msgstr ""
 
 #: src/SUMMARY.md:275
 msgid "Multi-threaded Link Checker"
-msgstr ""
+msgstr "Flertrådet linktjekker"
 
 #: src/SUMMARY.md:277
 #, fuzzy
@@ -886,7 +881,7 @@ msgstr ""
 
 #: src/SUMMARY.md:280
 msgid "async/await"
-msgstr ""
+msgstr "async/await"
 
 #: src/SUMMARY.md:281
 msgid "Futures"
@@ -899,7 +894,7 @@ msgstr "Garantier under programudføring"
 
 #: src/SUMMARY.md:283
 msgid "Tokio"
-msgstr ""
+msgstr "Tokio"
 
 #: src/SUMMARY.md:284
 msgid "Tasks"
@@ -907,15 +902,15 @@ msgstr ""
 
 #: src/SUMMARY.md:285
 msgid "Async Channels"
-msgstr ""
+msgstr "Asynkrone kanaler"
 
 #: src/SUMMARY.md:287
 msgid "Join"
-msgstr ""
+msgstr "Join"
 
 #: src/SUMMARY.md:288
 msgid "Select"
-msgstr ""
+msgstr "Select"
 
 #: src/SUMMARY.md:289
 msgid "Pitfalls"
@@ -927,7 +922,7 @@ msgstr ""
 
 #: src/SUMMARY.md:291
 msgid "Pin"
-msgstr ""
+msgstr "Pin"
 
 #: src/SUMMARY.md:292
 msgid "Async Traits"
@@ -943,11 +938,11 @@ msgstr ""
 
 #: src/SUMMARY.md:302
 msgid "Thanks!"
-msgstr ""
+msgstr "Tak!"
 
 #: src/SUMMARY.md:303
 msgid "Other Resources"
-msgstr ""
+msgstr "Andre resourcer"
 
 #: src/SUMMARY.md:304
 msgid "Credits"
@@ -955,7 +950,7 @@ msgstr ""
 
 #: src/SUMMARY.md:307
 msgid "Solutions"
-msgstr ""
+msgstr "Løsninger"
 
 #: src/SUMMARY.md:312
 msgid "Day 1 Morning"
@@ -1048,7 +1043,6 @@ msgid ""
 msgstr ""
 
 #: src/welcome.md:7
-#, fuzzy
 msgid ""
 "This is a three day Rust course developed by the Android team. The course "
 "covers\n"
@@ -1057,7 +1051,7 @@ msgid ""
 "and error handling. It also includes Android-specific content on the last "
 "day."
 msgstr ""
-"Dette er et fire dages Rust-kursus udviklet af Android-teamet. Kurset\n"
+"Dette er et tre dages Rust-kursus udviklet af Android-teamet. Kurset\n"
 "dækker hele spektret af Rust, fra grundlæggende syntaks til avancerede\n"
 "emner som generiske og fejlhåndtering. Det inkluderer også\n"
 "Android-specifikt indhold på den sidste dag."
@@ -1129,7 +1123,7 @@ msgstr ""
 
 #: src/welcome.md:41
 msgid "## Assumptions"
-msgstr ""
+msgstr "## Antagelser"
 
 #: src/welcome.md:43
 msgid ""
@@ -1242,7 +1236,7 @@ msgstr ""
 #: src/exercises/concurrency/afternoon.md:11
 #: src/exercises/concurrency/dining-philosophers-async.md:75
 msgid "<details>"
-msgstr ""
+msgstr "<details>"
 
 #: src/welcome.md:52
 msgid ""
@@ -1349,7 +1343,7 @@ msgstr ""
 #: src/exercises/concurrency/afternoon.md:17
 #: src/exercises/concurrency/dining-philosophers-async.md:79
 msgid "</details>"
-msgstr ""
+msgstr "</details>"
 
 #: src/running-the-course.md:1
 msgid "# Running the Course"
@@ -2549,6 +2543,8 @@ msgid ""
 "<details>\n"
 "Key points:"
 msgstr ""
+" <details>\n"
+"Nøglepunkter:"
 
 #: src/basic-syntax/references.md:24
 msgid ""
@@ -2925,7 +2921,7 @@ msgstr ""
 
 #: src/exercises/day-1/morning.md:1
 msgid "# Day 1: Morning Exercises"
-msgstr ""
+msgstr "# Dag 1: morgenøvelser"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
@@ -3894,7 +3890,6 @@ msgid "After move to `s2`:"
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:32
-#, fuzzy
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -3919,15 +3914,22 @@ msgid ""
 msgstr ""
 "```bob\n"
 " Stak                              Bunke\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.\n"
-":                           :     :                               :\n"
-":    s1                     :     :                               :\n"
-":   +-----------+-------+   :     :   +----+----+----+----+----+  :\n"
-":   | ptr       |   o---+---+-----+-->| H  | a  | l  | l  | o  |  :\n"
-":   | len       |     5 |   :     :   +----+----+----+----+----+  :\n"
-":   | capacity  |     5 |   :     :                               :\n"
-":   +-----------+-------+   :     :                               :\n"
-":                           :     `- - - - - - - - - - - - - - - -'\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - -.\n"
+":                           :     :                           :\n"
+":    s1 \"(utilgængelig)\"    :     :                           :\n"
+":   +-----------+-------+   :     :   +----+----+----+----+   :\n"
+":   | ptr       |   o---+---+--+--+-->| R  | u  | s  | t  |   :\n"
+":   | len       |     4 |   :  |  :   +----+----+----+----+   :\n"
+":   | capacity  |     4 |   :  |  :                           :\n"
+":   +-----------+-------+   :  |  :                           :\n"
+":                           :  |  `- - - - - - - - - - - - - -'\n"
+":    s2                     :  |\n"
+":   +-----------+-------+   :  |\n"
+":   | ptr       |   o---+---+--'\n"
+":   | len       |     4 |   :\n"
+":   | capacity  |     4 |   :\n"
+":   +-----------+-------+   :\n"
+":                           :\n"
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
@@ -3980,7 +3982,6 @@ msgid "After copy-assignment:"
 msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:32
-#, fuzzy
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -4005,15 +4006,22 @@ msgid ""
 msgstr ""
 "```bob\n"
 " Stak                              Bunke\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.\n"
-":                           :     :                               :\n"
-":    s1                     :     :                               :\n"
-":   +-----------+-------+   :     :   +----+----+----+----+----+  :\n"
-":   | ptr       |   o---+---+-----+-->| H  | a  | l  | l  | o  |  :\n"
-":   | len       |     5 |   :     :   +----+----+----+----+----+  :\n"
-":   | capacity  |     5 |   :     :                               :\n"
-":   +-----------+-------+   :     :                               :\n"
-":                           :     `- - - - - - - - - - - - - - - -'\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - -.\n"
+":                           :     :                       :\n"
+":    s1                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+--+--+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     :                       :\n"
+":    s2                     :     :                       :\n"
+":   +-----------+-------+   :     :   +----+----+----+    :\n"
+":   | ptr       |   o---+---+-----+-->| C  | p  | p  |    :\n"
+":   | len       |     3 |   :     :   +----+----+----+    :\n"
+":   | capacity  |     3 |   :     :                       :\n"
+":   +-----------+-------+   :     :                       :\n"
+":                           :     `- - - - - - - - - - - -'\n"
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
@@ -4554,7 +4562,7 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:8
 msgid "## `Iterator`"
-msgstr ""
+msgstr "## `Iterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 msgid ""
@@ -4616,7 +4624,7 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
 msgid "## `IntoIterator`"
-msgstr ""
+msgstr "## `IntoIterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 msgid ""
@@ -4675,7 +4683,7 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
 msgid "## `for` Loops"
-msgstr ""
+msgstr "## `for`-løkker"
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 msgid ""
@@ -4785,6 +4793,8 @@ msgid ""
 "<details>\n"
 "Key Points: "
 msgstr ""
+"<details>\n"
+"Nøglepunkter: "
 
 #: src/structs.md:32
 msgid ""
@@ -5671,7 +5681,7 @@ msgstr ""
 
 #: src/exercises/day-2/morning.md:1
 msgid "# Day 2: Morning Exercises"
-msgstr ""
+msgstr "# Dag 2: morgenøvelser"
 
 #: src/exercises/day-2/morning.md:3
 msgid "We will look at implementing methods in two contexts:"
@@ -6736,7 +6746,6 @@ msgid ""
 msgstr ""
 
 #: src/std/box-recursive.md:18
-#, fuzzy
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
@@ -6758,17 +6767,16 @@ msgid ""
 "```"
 msgstr ""
 "```bob\n"
-" Stak                              Bunke\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.\n"
-":                           :     :                               :\n"
-":    s1                     :     :                               :\n"
-":   +-----------+-------+   :     :   +----+----+----+----+----+  :\n"
-":   | ptr       |   o---+---+-----+-->| H  | a  | l  | l  | o  |  :\n"
-":   | len       |     5 |   :     :   +----+----+----+----+----+  :\n"
-":   | capacity  |     5 |   :     :                               :\n"
-":   +-----------+-------+   :     :                               :\n"
-":                           :     `- - - - - - - - - - - - - - - -'\n"
-"`- - - - - - - - - - - - - -'\n"
+" Stak                            Bunke\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+":                         :     :                                               :\n"
+":    list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
+":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // |   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
+":                         :     :                                               :\n"
+":                         :     :                                               :\n"
+"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
 "```"
 
 #: src/std/box-recursive.md:33
@@ -6800,7 +6808,6 @@ msgid ""
 msgstr ""
 
 #: src/std/box-niche.md:19
-#, fuzzy
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
@@ -6822,17 +6829,16 @@ msgid ""
 "```"
 msgstr ""
 "```bob\n"
-" Stak                              Bunke\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.\n"
-":                           :     :                               :\n"
-":    s1                     :     :                               :\n"
-":   +-----------+-------+   :     :   +----+----+----+----+----+  :\n"
-":   | ptr       |   o---+---+-----+-->| H  | a  | l  | l  | o  |  :\n"
-":   | len       |     5 |   :     :   +----+----+----+----+----+  :\n"
-":   | capacity  |     5 |   :     :                               :\n"
-":   +-----------+-------+   :     :                               :\n"
-":                           :     `- - - - - - - - - - - - - - - -'\n"
-"`- - - - - - - - - - - - - -'\n"
+" Stak                            Bunke\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+":                         :     :                                             :\n"
+":    list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |             :\n"
+":   +----+----+           :     :    +----+----+    +----+------+             :\n"
+":                         :     :                                             :\n"
+":                         :     :                                             :\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - -'\n"
 "```"
 
 #: src/std/rc.md:1
@@ -7596,7 +7602,6 @@ msgid "Memory layout after allocating `pets`:"
 msgstr ""
 
 #: src/traits/trait-objects.md:42
-#, fuzzy
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
@@ -7649,16 +7654,30 @@ msgid ""
 msgstr ""
 "```bob\n"
 " Stak                              Bunke\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - -.\n"
-":                           :     :                               :\n"
-":    s1                     :     :                               :\n"
-":   +-----------+-------+   :     :   +----+----+----+----+----+  :\n"
-":   | ptr       |   o---+---+-----+-->| H  | a  | l  | l  | o  |  :\n"
-":   | len       |     5 |   :     :   +----+----+----+----+----+  :\n"
-":   | capacity  |     5 |   :     :                               :\n"
-":   +-----------+-------+   :     :                               :\n"
-":                           :     `- - - - - - - - - - - - - - - -'\n"
-"`- - - - - - - - - - - - - -'\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+":                           :     :                                             :\n"
+":    pets                   :     :                                             :\n"
+":   +-----------+-------+   :     :   +-----+-----+                             :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o |                             :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-+                             :\n"
+":   | capacity  |     2 |   :     :     | |   | |   +---------------+           :\n"
+":   +-----------+-------+   :     :     | |   | '-->| name: \"Fido\"  |           :\n"
+":                           :     :     | |   |     +---------------+           :\n"
+"`- - - - - - - - - - - - - -'     :     | |   |                                 :\n"
+"                                  :     | |   |     +----------------------+    :\n"
+"                                  :     | |   '---->| \"<Dog as Pet>::name\" |    :\n"
+"                                  :     | |         +----------------------+    :\n"
+"                                  :     | |                                     :\n"
+"                                  :     | |   +-+                               :\n"
+"                                  :     | '-->|\\|                               :\n"
+"                                  :     |     +-+                               :\n"
+"                                  :     |                                       :\n"
+"                                  :     |     +----------------------+          :\n"
+"                                  :     '---->| \"<Cat as Pet>::name\" |          :\n"
+"                                  :           +----------------------+          :\n"
+"                                  :                                             :\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - - -'\n"
+"\n"
 "```"
 
 #: src/traits/trait-objects.md:72
@@ -8340,7 +8359,7 @@ msgstr ""
 
 #: src/exercises/day-3/morning.md:1
 msgid "# Day 3: Morning Exercises"
-msgstr ""
+msgstr "# Dag 3: Morgenøvelser"
 
 #: src/exercises/day-3/morning.md:3
 msgid "We will design a classical GUI library traits and trait objects."
@@ -10952,9 +10971,8 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal.md:1
-#, fuzzy
 msgid "# Welcome to Bare Metal Rust"
-msgstr "# Velkommen til Comprehensive Rust 🦀"
+msgstr "# Velkommen til Rust på det rå jern"
 
 #: src/bare-metal.md:3
 msgid ""
@@ -11007,6 +11025,13 @@ msgid ""
 "cargo install cargo-binutils cargo-embed\n"
 "```"
 msgstr ""
+"```bash\n"
+"sudo apt install gcc-aarch64-linux-gnu gdb-multiarch libudev-dev picocom pkg-config qemu-system-arm\n"
+"rustup update\n"
+"rustup target add aarch64-unknown-none thumbv7em-none-eabihf\n"
+"rustup component add llvm-tools-preview\n"
+"cargo install cargo-binutils cargo-embed\n"
+"```"
 
 #: src/bare-metal.md:30
 msgid ""
@@ -11022,10 +11047,15 @@ msgid ""
 "sudo udevadm control --reload-rules\n"
 "```"
 msgstr ""
+"```bash\n"
+"echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0d28\", MODE=\"0664\", GROUP=\"plugdev\"' |\\\n"
+"  sudo tee /etc/udev/rules.d/50-microbit.rules\n"
+"sudo udevadm control --reload-rules\n"
+"```"
 
 #: src/bare-metal.md:38
 msgid "On MacOS:"
-msgstr ""
+msgstr "På MacOS:"
 
 #: src/bare-metal.md:40
 msgid ""
@@ -11039,10 +11069,19 @@ msgid ""
 "cargo install cargo-binutils cargo-embed\n"
 "```"
 msgstr ""
+"```bash\n"
+"xcode-select --install\n"
+"brew install gdb picocom qemu\n"
+"brew install --cask gcc-aarch64-embedded\n"
+"rustup update\n"
+"rustup target add aarch64-unknown-none thumbv7em-none-eabihf\n"
+"rustup component add llvm-tools-preview\n"
+"cargo install cargo-binutils cargo-embed\n"
+"```"
 
 #: src/bare-metal/no_std.md:1
 msgid "# `no_std`"
-msgstr ""
+msgstr "# `no_std`"
 
 #: src/bare-metal/no_std.md:3
 msgid ""
@@ -11050,24 +11089,29 @@ msgid ""
 "<tr>\n"
 "<th>"
 msgstr ""
+"<table>\n"
+"<tr>\n"
+"<th>"
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
-msgstr ""
+msgstr "`core`"
 
 #: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
 msgid ""
 "</th>\n"
 "<th>"
 msgstr ""
+"</th>\n"
+"<th>"
 
 #: src/bare-metal/no_std.md:12
 msgid "`alloc`"
-msgstr ""
+msgstr "`alloc`"
 
 #: src/bare-metal/no_std.md:17
 msgid "`std`"
-msgstr ""
+msgstr "`std`"
 
 #: src/bare-metal/no_std.md:19
 msgid ""
@@ -11126,6 +11170,11 @@ msgid ""
 "\n"
 "<details>"
 msgstr ""
+"</td>\n"
+"</tr>\n"
+"</table>\n"
+"\n"
+"<details>"
 
 #: src/bare-metal/no_std.md:62
 msgid ""
@@ -11817,9 +11866,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:1
-#, fuzzy
 msgid "# Compass"
-msgstr "Sammenligning"
+msgstr "# Kompas"
 
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
@@ -11867,7 +11915,7 @@ msgstr ""
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 #: src/exercises/concurrency/elevator.md:17
 msgid "`src/main.rs`:"
-msgstr ""
+msgstr "`src/main.rs`:"
 
 #: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
 #: src/exercises/concurrency/dining-philosophers.md:17
@@ -11875,7 +11923,7 @@ msgstr ""
 #: src/exercises/concurrency/dining-philosophers-async.md:11
 #: src/exercises/concurrency/elevator.md:19
 msgid "<!-- File src/main.rs -->"
-msgstr ""
+msgstr "<!-- File src/main.rs -->"
 
 #: src/exercises/bare-metal/compass.md:30
 msgid ""
@@ -11925,7 +11973,7 @@ msgstr ""
 #: src/exercises/concurrency/dining-philosophers-async.md:60
 #: src/exercises/concurrency/elevator.md:367
 msgid "<!-- File Cargo.toml -->"
-msgstr ""
+msgstr "<!-- File Cargo.toml -->"
 
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
@@ -11953,7 +12001,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:87
 msgid "<!-- File Embed.toml -->"
-msgstr ""
+msgstr "<!-- File Embed.toml -->"
 
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
@@ -11975,7 +12023,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
 msgid "<!-- File .cargo/config.toml -->"
-msgstr ""
+msgstr "<!-- File .cargo/config.toml -->"
 
 #: src/exercises/bare-metal/compass.md:104
 msgid ""
@@ -13229,7 +13277,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:151
 msgid "<!-- File src/logger.rs -->"
-msgstr ""
+msgstr "<!-- File src/logger.rs -->"
 
 #: src/exercises/bare-metal/rtc.md:153
 msgid ""
@@ -13298,7 +13346,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:212
 msgid "<!-- File src/pl011.rs -->"
-msgstr ""
+msgstr "<!-- File src/pl011.rs -->"
 
 #: src/exercises/bare-metal/rtc.md:214
 msgid ""
@@ -13509,10 +13557,9 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:412
 msgid "<!-- File build.rs -->"
-msgstr ""
+msgstr "<!-- File build.rs -->"
 
 #: src/exercises/bare-metal/rtc.md:414
-#, fuzzy
 msgid ""
 "```rust,compile_fail\n"
 "// Copyright 2023 Google LLC\n"
@@ -13546,8 +13593,8 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-"```rust\n"
-"// Copyright 2022 Google LLC\n"
+"```rust,compile_fail\n"
+"// Copyright 2023 Google LLC\n"
 "//\n"
 "// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
 "// you may not use this file except in compliance with the License.\n"
@@ -13559,7 +13606,24 @@ msgstr ""
 "// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
 "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
 "// See the License for the specific language governing permissions and\n"
-"// limitations under the License."
+"// limitations under the License.\n"
+"\n"
+"use cc::Build;\n"
+"use std::env;\n"
+"\n"
+"fn main() {\n"
+"    #[cfg(target_os = \"linux\")]\n"
+"    env::set_var(\"CROSS_COMPILE\", \"aarch64-linux-gnu\");\n"
+"    #[cfg(not(target_os = \"linux\"))]\n"
+"    env::set_var(\"CROSS_COMPILE\", \"aarch64-none-elf\");\n"
+"\n"
+"    Build::new()\n"
+"        .file(\"entry.S\")\n"
+"        .file(\"exceptions.S\")\n"
+"        .file(\"idmap.S\")\n"
+"        .compile(\"empty\")\n"
+"}\n"
+"```"
 
 #: src/exercises/bare-metal/rtc.md:446
 msgid "`entry.S` (you shouldn't need to change this):"
@@ -13567,7 +13631,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:448
 msgid "<!-- File entry.S -->"
-msgstr ""
+msgstr "<!-- File entry.S -->"
 
 #: src/exercises/bare-metal/rtc.md:450
 msgid ""
@@ -13737,7 +13801,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:597
 msgid "<!-- File exceptions.S -->"
-msgstr ""
+msgstr "<!-- File exceptions.S -->"
 
 #: src/exercises/bare-metal/rtc.md:599
 msgid ""
@@ -13939,7 +14003,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:782
 msgid "<!-- File idmap.S -->"
-msgstr ""
+msgstr "<!-- File idmap.S -->"
 
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
@@ -13996,7 +14060,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:831
 msgid "<!-- File image.ld -->"
-msgstr ""
+msgstr "<!-- File image.ld -->"
 
 #: src/exercises/bare-metal/rtc.md:833
 msgid ""
@@ -14115,10 +14179,9 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:942
 msgid "<!-- File Makefile -->"
-msgstr ""
+msgstr "<!-- File Makefile -->"
 
 #: src/exercises/bare-metal/rtc.md:944
-#, fuzzy
 msgid ""
 "```makefile\n"
 "# Copyright 2023 Google LLC\n"
@@ -14162,20 +14225,46 @@ msgid ""
 "\trm -f *.bin\n"
 "```"
 msgstr ""
-"```rust\n"
-"// Copyright 2022 Google LLC\n"
-"//\n"
-"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
-"// you may not use this file except in compliance with the License.\n"
-"// You may obtain a copy of the License at\n"
-"//\n"
-"//      http://www.apache.org/licenses/LICENSE-2.0\n"
-"//\n"
-"// Unless required by applicable law or agreed to in writing, software\n"
-"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-"// See the License for the specific language governing permissions and\n"
-"// limitations under the License."
+"```makefile\n"
+"# Copyright 2023 Google LLC\n"
+"#\n"
+"# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"# you may not use this file except in compliance with the License.\n"
+"# You may obtain a copy of the License at\n"
+"#\n"
+"#      http://www.apache.org/licenses/LICENSE-2.0\n"
+"#\n"
+"# Unless required by applicable law or agreed to in writing, software\n"
+"# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"# See the License for the specific language governing permissions and\n"
+"# limitations under the License.\n"
+"\n"
+"UNAME := $(shell uname -s)\n"
+"ifeq ($(UNAME),Linux)\n"
+"\tTARGET = aarch64-linux-gnu\n"
+"else\n"
+"\tTARGET = aarch64-none-elf\n"
+"endif\n"
+"OBJCOPY = $(TARGET)-objcopy\n"
+"\n"
+".PHONY: build qemu_minimal qemu qemu_logger\n"
+"\n"
+"all: rtc.bin\n"
+"\n"
+"build:\n"
+"\tcargo build\n"
+"\n"
+"rtc.bin: build\n"
+"\t$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@\n"
+"\n"
+"qemu: rtc.bin\n"
+"\tqemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio -display none -kernel $< -s\n"
+"\n"
+"clean:\n"
+"\tcargo clean\n"
+"\trm -f *.bin\n"
+"```"
 
 #: src/exercises/bare-metal/rtc.md:989
 msgid ""
@@ -14320,7 +14409,7 @@ msgstr ""
 
 #: src/concurrency/channels.md:1
 msgid "# Channels"
-msgstr ""
+msgstr "# Kanaler"
 
 #: src/concurrency/channels.md:3
 msgid ""
@@ -14363,7 +14452,7 @@ msgstr ""
 
 #: src/concurrency/channels/unbounded.md:1
 msgid "# Unbounded Channels"
-msgstr ""
+msgstr "# Ubegrænsede kanaler"
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
@@ -14398,7 +14487,7 @@ msgstr ""
 
 #: src/concurrency/channels/bounded.md:1
 msgid "# Bounded Channels"
-msgstr ""
+msgstr "# Begrænsede kanaler"
 
 #: src/concurrency/channels/bounded.md:3
 msgid "Bounded and synchronous channels make `send` block the current thread:"
@@ -14433,7 +14522,7 @@ msgstr ""
 
 #: src/concurrency/send-sync.md:1
 msgid "# `Send` and `Sync`"
-msgstr ""
+msgstr "# `Send` og `Sync`"
 
 #: src/concurrency/send-sync.md:3
 msgid ""
@@ -14470,7 +14559,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/send.md:1
 msgid "# `Send`"
-msgstr ""
+msgstr "# `Send`"
 
 #: src/concurrency/send-sync/send.md:3
 msgid ""
@@ -14496,7 +14585,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/sync.md:1
 msgid "# `Sync`"
-msgstr ""
+msgstr "# `Sync`"
 
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
@@ -14531,11 +14620,11 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:1
 msgid "# Examples"
-msgstr ""
+msgstr "# Eksempler"
 
 #: src/concurrency/send-sync/examples.md:3
 msgid "## `Send + Sync`"
-msgstr ""
+msgstr "## `Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:5
 msgid "Most types you come across are `Send + Sync`:"
@@ -14559,7 +14648,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:17
 msgid "## `Send + !Sync`"
-msgstr ""
+msgstr "## `Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:19
 msgid ""
@@ -14577,7 +14666,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:27
 msgid "## `!Send + Sync`"
-msgstr ""
+msgstr "## `!Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:29
 msgid ""
@@ -14593,7 +14682,7 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:34
 msgid "## `!Send + !Sync`"
-msgstr ""
+msgstr "## `!Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:36
 msgid "These types are not thread-safe and cannot be moved to other threads:"
@@ -14609,7 +14698,7 @@ msgstr ""
 
 #: src/concurrency/shared_state.md:1
 msgid "# Shared State"
-msgstr ""
+msgstr "# Delt tilstand"
 
 #: src/concurrency/shared_state.md:3
 msgid ""
@@ -14628,7 +14717,7 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md:1
 msgid "# `Arc`"
-msgstr ""
+msgstr "# `Arc`"
 
 #: src/concurrency/shared_state/arc.md:3
 msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
@@ -14675,7 +14764,7 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:1
 msgid "# `Mutex`"
-msgstr ""
+msgstr "# `Mutex`"
 
 #: src/concurrency/shared_state/mutex.md:3
 msgid ""
@@ -14906,7 +14995,7 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:1
 msgid "# Multi-threaded Link Checker"
-msgstr ""
+msgstr "# Flertrådet linktjekker"
 
 #: src/exercises/concurrency/link-checker.md:3
 msgid ""
@@ -15058,7 +15147,7 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:106
 msgid "## Tasks"
-msgstr ""
+msgstr "## Opgaver"
 
 #: src/exercises/concurrency/link-checker.md:108
 msgid ""
@@ -15106,9 +15195,8 @@ msgid ""
 msgstr ""
 
 #: src/async.md:17
-#, fuzzy
 msgid "## Comparisons"
-msgstr "Sammenligning"
+msgstr "## Sammenligninger"
 
 #: src/async.md:19
 msgid ""
@@ -15126,7 +15214,7 @@ msgstr ""
 
 #: src/async/async-await.md:1
 msgid "# `async`/`await`"
-msgstr ""
+msgstr "# `async`/`await`"
 
 #: src/async/async-await.md:3
 msgid ""
@@ -15299,7 +15387,7 @@ msgstr ""
 
 #: src/async/runtimes/tokio.md:1
 msgid "# Tokio"
-msgstr ""
+msgstr "# Tokio"
 
 #: src/async/runtimes/tokio.md:4
 msgid "Tokio provides: "
@@ -15363,7 +15451,7 @@ msgstr ""
 
 #: src/async/tasks.md:1
 msgid "# Tasks"
-msgstr ""
+msgstr "# Tasks (opgaver)"
 
 #: src/async/tasks.md:3
 msgid ""
@@ -15525,7 +15613,7 @@ msgstr ""
 
 #: src/async/control-flow/join.md:1
 msgid "# Join"
-msgstr ""
+msgstr "# Join"
 
 #: src/async/control-flow/join.md:3
 msgid ""
@@ -15585,7 +15673,7 @@ msgstr ""
 
 #: src/async/control-flow/select.md:1
 msgid "# Select"
-msgstr ""
+msgstr "# Select"
 
 #: src/async/control-flow/select.md:3
 msgid ""
@@ -15680,7 +15768,7 @@ msgstr ""
 
 #: src/async/pitfalls.md:1
 msgid "# Pitfalls of async/await"
-msgstr ""
+msgstr "# Faldgruber ved async/await"
 
 #: src/async/pitfalls.md:3
 msgid ""
@@ -15766,7 +15854,7 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:1
 msgid "# Pin"
-msgstr ""
+msgstr "# Pin"
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
@@ -15965,7 +16053,7 @@ msgstr ""
 
 #: src/async/pitfalls/async-traits.md:49
 msgid "<details>  "
-msgstr ""
+msgstr "<details>  "
 
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
@@ -16123,7 +16211,7 @@ msgstr ""
 
 #: src/exercises/concurrency/elevator.md:12
 msgid "## Getting Started"
-msgstr ""
+msgstr "## Kom godt igang"
 
 #: src/exercises/concurrency/elevator.md:14
 msgid ""
@@ -16168,7 +16256,7 @@ msgstr ""
 
 #: src/exercises/concurrency/elevator.md:49
 msgid "<!-- File src/building.rs -->"
-msgstr ""
+msgstr "<!-- File src/building.rs -->"
 
 #: src/exercises/concurrency/elevator.md:51
 msgid ""
@@ -16429,7 +16517,7 @@ msgstr ""
 
 #: src/exercises/concurrency/elevator.md:290
 msgid "<!-- File src/driver.rs -->"
-msgstr ""
+msgstr "<!-- File src/driver.rs -->"
 
 #: src/exercises/concurrency/elevator.md:292
 msgid ""
@@ -16479,7 +16567,7 @@ msgstr ""
 
 #: src/exercises/concurrency/elevator.md:332
 msgid "<!-- File src/controller.rs -->"
-msgstr ""
+msgstr "<!-- File src/controller.rs -->"
 
 #: src/exercises/concurrency/elevator.md:334
 msgid ""
@@ -16535,9 +16623,8 @@ msgid "Use `cargo run` to run the elevator simulation."
 msgstr ""
 
 #: src/exercises/concurrency/elevator.md:383
-#, fuzzy
 msgid "## Exercises"
-msgstr "Øvelser"
+msgstr "## Øvelser"
 
 #: src/exercises/concurrency/elevator.md:385
 msgid ""
@@ -16593,7 +16680,7 @@ msgstr ""
 
 #: src/thanks.md:1
 msgid "# Thanks!"
-msgstr ""
+msgstr "# Tak!"
 
 #: src/thanks.md:3
 msgid ""
@@ -16601,6 +16688,8 @@ msgid ""
 "that it\n"
 "was useful."
 msgstr ""
+"_Tak for at tage Comprehensive Rust 🦀!_ Vi håber du har nydt det og\n"
+"at det har været hjælpsomt."
 
 #: src/thanks.md:6
 msgid ""
@@ -16616,7 +16705,7 @@ msgstr ""
 
 #: src/other-resources.md:1
 msgid "# Other Rust Resources"
-msgstr ""
+msgstr "# Andre Rust-resourcer"
 
 #: src/other-resources.md:3
 msgid ""
@@ -16626,7 +16715,7 @@ msgstr ""
 
 #: src/other-resources.md:6
 msgid "## Official Documentation"
-msgstr ""
+msgstr "## Officiel dokumentation"
 
 #: src/other-resources.md:8
 msgid "The Rust project hosts many resources. These cover Rust in general:"
@@ -16748,7 +16837,7 @@ msgstr ""
 
 #: src/credits.md:10
 msgid "## Rust by Example"
-msgstr ""
+msgstr "## Rust by Example"
 
 #: src/credits.md:12
 msgid ""
@@ -16760,7 +16849,7 @@ msgstr ""
 
 #: src/credits.md:17
 msgid "## Rust on Exercism"
-msgstr ""
+msgstr "## Rust på Exercism"
 
 #: src/credits.md:19
 msgid ""
@@ -16773,7 +16862,7 @@ msgstr ""
 
 #: src/credits.md:24
 msgid "## CXX"
-msgstr ""
+msgstr "## CXX"
 
 #: src/credits.md:26
 msgid ""
@@ -16786,11 +16875,11 @@ msgstr ""
 
 #: src/exercises/solutions.md:1
 msgid "# Solutions"
-msgstr ""
+msgstr "# Løsninger"
 
 #: src/exercises/solutions.md:3
 msgid "You will find solutions to the exercises on the following pages."
-msgstr ""
+msgstr "Du til finde løsningerne til opgaverne på de næste sider."
 
 #: src/exercises/solutions.md:5
 msgid ""
@@ -16809,7 +16898,7 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:1
 msgid "# Day 1 Morning Exercises"
-msgstr ""
+msgstr "# Dag 1 morgenøvelser"
 
 #: src/exercises/day-1/solutions-morning.md:3
 msgid "## Arrays and `for` Loops"
@@ -16817,7 +16906,7 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:5
 msgid "([back to exercise](for-loops.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](for-loops.md))"
 
 #: src/exercises/day-1/solutions-morning.md:7
 msgid ""
@@ -16896,7 +16985,7 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
 msgid "### Bonus question"
-msgstr ""
+msgstr "### Bonusspørgsmål"
 
 #: src/exercises/day-1/solutions-morning.md:80
 msgid ""
@@ -16961,11 +17050,11 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:3
 msgid "## Designing a Library"
-msgstr ""
+msgstr "## Design af et bibliotek"
 
 #: src/exercises/day-1/solutions-afternoon.md:5
 msgid "([back to exercise](book-library.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](book-library.md))"
 
 #: src/exercises/day-1/solutions-afternoon.md:7
 msgid ""
@@ -17164,15 +17253,15 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
 msgid "# Day 2 Morning Exercises"
-msgstr ""
+msgstr "# Dag 2 morgenøvelser"
 
 #: src/exercises/day-2/solutions-morning.md:3
 msgid "## Points and Polygons"
-msgstr ""
+msgstr "## Punkter og polygoner"
 
 #: src/exercises/day-2/solutions-morning.md:5
 msgid "([back to exercise](points-polygons.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](points-polygons.md))"
 
 #: src/exercises/day-2/solutions-morning.md:7
 msgid ""
@@ -17412,11 +17501,11 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:3
 msgid "## Luhn Algorithm"
-msgstr ""
+msgstr "## Luhn-algorithmen"
 
 #: src/exercises/day-2/solutions-afternoon.md:5
 msgid "([back to exercise](luhn.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](luhn.md))"
 
 #: src/exercises/day-2/solutions-afternoon.md:7
 msgid ""
@@ -17511,14 +17600,103 @@ msgid ""
 "// ANCHOR_END: unit-tests\n"
 "```"
 msgstr ""
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"// ANCHOR: luhn\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    // ANCHOR_END: luhn\n"
+"    let mut digits_seen = 0;\n"
+"    let mut sum = 0;\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ').enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Some(d) => {\n"
+"                sum += if i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd / 10 + dd % 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                digits_seen += 1;\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    if digits_seen < 2 {\n"
+"        return false;\n"
+"    }\n"
+"\n"
+"    sum % 10 == 0\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let cc_number = \"1234 5678 1234 5670\";\n"
+"    println!(\n"
+"        \"Is {cc_number} a valid credit card number? {}\",\n"
+"        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
+"    );\n"
+"}\n"
+"\n"
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_invalid_cc_number() {\n"
+"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
+"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
+"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"}\n"
+"// ANCHOR_END: unit-tests\n"
+"```"
 
 #: src/exercises/day-2/solutions-afternoon.md:97
 msgid "## Strings and Iterators"
-msgstr ""
+msgstr "## Strenge og iteratorer"
 
 #: src/exercises/day-2/solutions-afternoon.md:99
 msgid "([back to exercise](strings-iterators.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](strings-iterators.md))"
 
 #: src/exercises/day-2/solutions-afternoon.md:101
 msgid ""
@@ -17601,10 +17779,84 @@ msgid ""
 "fn main() {}\n"
 "```"
 msgstr ""
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"// ANCHOR: prefix_matches\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    // ANCHOR_END: prefix_matches\n"
+"    let prefixes = prefix.split('/');\n"
+"    let request_paths = request_path\n"
+"        .split('/')\n"
+"        .map(|p| Some(p))\n"
+"        .chain(std::iter::once(None));\n"
+"\n"
+"    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"        match request_path {\n"
+"            Some(request_path) => {\n"
+"                if (prefix != \"*\") && (prefix != request_path) {\n"
+"                    return false;\n"
+"                }\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"}\n"
+"\n"
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"// ANCHOR_END: unit-tests\n"
+"\n"
+"fn main() {}\n"
+"```"
 
 #: src/exercises/day-3/solutions-morning.md:1
 msgid "# Day 3 Morning Exercise"
-msgstr ""
+msgstr "# Dag 3 morgenøvelser"
 
 #: src/exercises/day-3/solutions-morning.md:3
 msgid "## A Simple GUI Library"
@@ -17612,7 +17864,7 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:5
 msgid "([back to exercise](simple-gui.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](simple-gui.md))"
 
 #: src/exercises/day-3/solutions-morning.md:7
 msgid ""
@@ -17796,7 +18048,7 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:5
 msgid "([back to exercise](safe-ffi-wrapper.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](safe-ffi-wrapper.md))"
 
 #: src/exercises/day-3/solutions-afternoon.md:7
 msgid ""
@@ -17975,16 +18227,15 @@ msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
 msgid "# Bare Metal Rust Morning Exercise"
-msgstr ""
+msgstr "# Rå jern morgenøvelser"
 
 #: src/exercises/bare-metal/solutions-morning.md:3
-#, fuzzy
 msgid "## Compass"
-msgstr "Sammenligning"
+msgstr "## Kompas"
 
 #: src/exercises/bare-metal/solutions-morning.md:5
 msgid "([back to exercise](compass.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](compass.md))"
 
 #: src/exercises/bare-metal/solutions-morning.md:7
 msgid ""
@@ -18163,11 +18414,11 @@ msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
 msgid "([back to exercise](rtc.md))"
-msgstr ""
+msgstr "([tilbage til øvelsen](rtc.md))"
 
 #: src/exercises/bare-metal/solutions-afternoon.md:7
 msgid "`main.rs`:"
-msgstr ""
+msgstr "`main.rs`:"
 
 #: src/exercises/bare-metal/solutions-afternoon.md:9
 msgid ""
@@ -18318,7 +18569,7 @@ msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:149
 msgid "`pl031.rs`:"
-msgstr ""
+msgstr "`pl031.rs`:"
 
 #: src/exercises/bare-metal/solutions-afternoon.md:151
 msgid ""


### PR DESCRIPTION
This copies a bunch of untranslatable page titles (such as crate names) to the translation. I also translated a lot of small and fuzzy entries. We should now be at 200 translated entries.

```
% msgfmt -o /dev/null --statistics po/da.po
200 translated messages, 3 fuzzy translations, 1530 untranslated messages.
```