### PR TITLE
Add missing newlines around `<details>`

### DIFF
--- a/src/basic-syntax/references.md
+++ b/src/basic-syntax/references.md
@@ -19,6 +19,7 @@ Some notes:
 * References that are declared as `mut` can be bound to different values over their lifetime.
 
 <details>
+
 Key points:
 
 * Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x:

--- a/src/structs.md
+++ b/src/structs.md
@@ -27,7 +27,8 @@ fn main() {
 ```
 
 <details>
-Key Points: 
+
+Key Points:
 
 * Structs work like in C or C++.
   * Like in C++, and unlike in C, no typedef is needed to define a type.


### PR DESCRIPTION
The newlines makes the text more uniform when extracted into the POT file (spotted while doing #646).