### PR TITLE
Fix inconsistent code in unbounded.md

### DIFF
--- a/src/concurrency/channels/unbounded.md
+++ b/src/concurrency/channels/unbounded.md
@@ -21,7 +21,7 @@ fn main() {
     thread::sleep(Duration::from_millis(100));
 
     for msg in rx.iter() {
-        println!("Main: got {}", msg);
+        println!("Main: got {msg}");
     }
 }
 ```


### PR DESCRIPTION
Fix inconsistency between concurrency `unbounded.md` and `bounded.md` by using implicitly named arguments for both.