### PR TITLE
Display line numbers for code examples

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -40,6 +40,7 @@ level = 0
 
 [output.html.playground]
 editable = true
+line-numbers = true
 
 [output.html.redirect]
 # Redirects in the form of "old-path" = "new-path", where the new path


### PR DESCRIPTION
This makes it easier to refer to a specific line of code while teaching or collaborating on a code snippet.