### PR TITLE
Update default-methods.md

### DIFF
--- a/src/traits/default-methods.md
+++ b/src/traits/default-methods.md
@@ -33,13 +33,18 @@ fn main() {
   implement themselves. Methods with default implementations can rely on required methods.
 
 * Move method `not_equal` to a new trait `NotEqual`.
-
-* Make `NotEqual` a super trait for `Equal`.
     ```rust,editable,compile_fail
-    trait NotEqual: Equals {
+    trait NotEqual {
         fn not_equal(&self, other: &Self) -> bool {
             !self.equal(other)
         }
+    }
+    ```
+
+* Make `NotEqual` a super trait for `Equal`.
+    ```rust,editable,compile_fail
+    trait Equals: NotEqual {
+        fn equal(&self, other: &Self) -> bool;
     }
     ```
 


### PR DESCRIPTION
This commit updates the example code to make NotEqual a super trait for Equals. The example code implements "trait NotEqual: Equals", which makes Equals a super trait for NotEqual.