### PR TITLE
ko: Fix the link back to the English translation

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -1238,7 +1238,7 @@ msgid ""
 "* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
 "* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
 msgstr ""
-"* [영어][en]\n"
+"* [영어](https://google.github.io/comprehensive-rust/)\n"
 "* [브라질 포르투갈어][pt-BR] ([@rastringer], [@hugojacob]).\n"
 "* [한국어][ko] ([@keispace], [@jiyongp], [@jooyunghan])"
 


### PR DESCRIPTION
This will fix the [missing link](https://google.github.io/comprehensive-rust/ko/running-the-course/translations.html):

![image](https://github.com/google/comprehensive-rust/assets/89623/c18da01b-40de-4a75-98dd-ed6a466ca4fb)
