### PR TITLE
Fix slices immutable example

### DIFF
--- a/src/basic-syntax/slices.md
+++ b/src/basic-syntax/slices.md
@@ -4,7 +4,7 @@ A slice gives you a view into a larger collection:
 
 ```rust,editable
 fn main() {
-    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];
+    let mut a: [i32; 6] = [10, 20, 30, 40, 50, 60];
     println!("a: {a:?}");
 
     let s: &[i32] = &a[2..4];


### PR DESCRIPTION
The question "What happens if you modify `a[3]`?", aims to teach the reader that we cannot mutate the array after creating a slice. However, the array is immutable regardless.
Running the edited example:

```rust
fn main() {
    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];
    println!("a: {a:?}");

    let s: &[i32] = &a[2..4];
    a[3] = 0;
    println!("s: {s:?}");
}
```

will return the following output:

```
   Compiling playground v0.0.1 (/playground)
error[E0594]: cannot assign to `a[_]`, as `a` is not declared as mutable
 --> src/main.rs:6:5
  |
6 |     a[3] = 0;
  |     ^^^^^^^^ cannot assign
  |
help: consider changing this to be mutable
  |
2 |     let mut a: [i32; 6] = [10, 20, 30, 40, 50, 60];
  |         +++

error[E0506]: cannot assign to `a[_]` because it is borrowed
 --> src/main.rs:6:5
  |
5 |     let s: &[i32] = &a[2..4];
  |                      - `a[_]` is borrowed here
6 |     a[3] = 0;
  |     ^^^^^^^^ `a[_]` is assigned to here but it was already borrowed
7 |     println!("s: {s:?}");
  |                   - borrow later used here

Some errors have detailed explanations: E0506, E0594.
For more information about an error, try `rustc --explain E0506`.
error: could not compile `playground` due to 2 previous errors
```

While the error explains both issues (assignment to an immutable value and assignment to a borrowed value), I think it would be better to make the array mutable to better understand the limitation.