### PR TITLE
Fix language selector on unpublished languages

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -172,7 +172,9 @@
                               langList.style.display = langList.style.display == "block" ? "none" : "block";
                           });
                           let selectedLang = document.getElementById("{{ language }}");
-                          selectedLang.parentNode.classList.add("theme-selected");
+                          if (selectedLang) {
+                              selectedLang.parentNode.classList.add("theme-selected");
+                          }
 
                           // The path to the root, taking the current
                           // language into account.


### PR DESCRIPTION
The Danish translation is not yet linked in the language selector since it is very incomplete. This means that `selectedLang` is `null` in this case and thus we should not call any methods on it.