### PR TITLE
Missing word in welcome day speaker notes

### DIFF
--- a/src/welcome-day-1.md
+++ b/src/welcome-day-1.md
@@ -18,9 +18,9 @@ Please remind the students that:
 * They should ask questions when they get them, don't save them to the end.
 * The class is meant to be interactive and discussions are very much encouraged!
   * As an instructor, you should try to keep the discussions relevant, i.e.,
-    keep the related to how Rust does things vs some other language. It can be
-    hard to find the right balance, but err on the side of allowing discussions
-    since they engage people much more than one-way communication.
+    keep the discussions related to how Rust does things vs some other language. 
+    It can be hard to find the right balance, but err on the side of allowing 
+    discussions since they engage people much more than one-way communication.
 * The questions will likely mean that we talk about things ahead of the slides.
   * This is perfectly okay! Repetition is an important part of learning. Remember
     that the slides are just a support and you are free to skip them as you


### PR DESCRIPTION
The current version of the speaker notes for `Welcome to Day 1` mentions `As an instructor, you should try to keep the discussions relevant, i.e., keep the related to how Rust does things vs some other language`. I find that the word `discussions` is missing before the word `related`, the change for which I am putting in this merge request.

Alongwith that, I also made sure that the line lengths remain consistent when adding the word `discussions` in the `md` file, and thus the next few lines are also adjusted accordingly. 