### PR TITLE
Add kuanhungchen to CODEOWNERS of zh-Hant

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@ po/ko.po @jiyongp @jooyunghan
 po/pt-BR.po @rastringer @hugojacob
 po/zh-Hans.po @suetfei @wnghl
 po/pl.po @jkotur @pawelpaa
-po/zh-Hant.po @victorhsieh @hueich
+po/zh-Hant.po @victorhsieh @hueich @kuanhungchen


### PR DESCRIPTION
Add @kuanhungchen to CODEOWNERS of zh-Hant to work on reviewing traditional Chinese translation.