### PR TITLE
Add kongy to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@ po/it.po @detro @nicomazz @bznein
 po/ja.po @keiichiw @chikoski
 po/ko.po @jiyongp @jooyunghan
 po/pt-BR.po @rastringer @hugojacob
-po/zh-Hans.po @suetfei @wnghl
+po/zh-Hans.po @suetfei @wnghl @kongy
 po/pl.po @jkotur @pawelpaa
 po/zh-Hant.po @victorhsieh @hueich @kuanhungchen


### PR DESCRIPTION
I work on the Android LLVM Team and contributed to Rust on Android.