### PR TITLE
Make chat-client reads cancellation safe

### DIFF
--- a/src/exercises/concurrency/chat-app.md
+++ b/src/exercises/concurrency/chat-app.md
@@ -29,7 +29,7 @@ API.
   Websocket Stream.
 - [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously
   sending messages on a Websocket Stream.
-- [BufReader::read_line()][5]: for asynchronously reading user messages
+- [Lines::next_line()][5]: for asynchronously reading user messages
   from the standard input.
 - [Sender::subscribe()][6]: for subscribing to a broadcast channel.
 
@@ -104,6 +104,6 @@ $ cargo run --bin client
 [2]: https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/
 [3]: https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/proto/struct.WebsocketStream.html#method.next
 [4]: https://docs.rs/futures-util/0.3.28/futures_util/sink/trait.SinkExt.html#method.send
-[5]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line
+[5]: https://docs.rs/tokio/latest/tokio/io/struct.Lines.html#method.next_line
 [6]: https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.subscribe
 [7]: https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries


### PR DESCRIPTION
`AsyncBufReadExt::read_line()` isn't cancellation safe. In practice, this doesn't matter much because we expect the client to be run from a terminal, which buffers by lines anyway. Since using the cancellation-safe approach is so simple, it seems worth fixing.

Related: This is a pretty common mistake, particularly with `select!`. I'm debating between adding (possibly in a separate PR):
* a speaker note on the `select!` slide
* a separate slide (in "Pitfalls") about cancellation (e.g. could mention explicit signaling)

@djmitche @rbehjati thoughts? (n.b. I'm OOO, back on June 6)