### PR TITLE
Add information about async cancellation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -290,6 +290,7 @@
   - [Blocking the Executor](async/pitfalls/blocking-executor.md)
   - [Pin](async/pitfalls/pin.md)
   - [Async Traits](async/pitfalls/async-traits.md)
+  - [Cancellation](async/pitfalls/cancellation.md)
 - [Exercises](exercises/concurrency/afternoon.md)
   - [Dining Philosophers](exercises/concurrency/dining-philosophers-async.md)
   - [Broadcast Chat Application](exercises/concurrency/chat-app.md)

--- a/src/async/control-flow/select.md
+++ b/src/async/control-flow/select.md
@@ -74,4 +74,7 @@ async fn main() {
   pass `&mut future` instead of the future itself, but this can lead to
   issues, further discussed in the pinning slide.
 
+* Unmatched branches are dropped, which cancels their futures (unless a reference
+  was used).
+
 </details>

--- a/src/async/control-flow/select.md
+++ b/src/async/control-flow/select.md
@@ -69,12 +69,10 @@ async fn main() {
 * Try adding a deadline to the race, demonstrating selecting different sorts of
   futures.
 
-* Note that `select!` moves the values it is given. It is easiest to use
-  when every execution of `select!` creates new futures. An alternative is to
-  pass `&mut future` instead of the future itself, but this can lead to
-  issues, further discussed in the pinning slide.
+* Note that `select!` drops unmatched branches, which cancels their futures.
+  It is easiest to use when every execution of `select!` creates new futures.
 
-* Unmatched branches are dropped, which cancels their futures (unless a reference
-  was used).
+    * An alternative is to pass `&mut future` instead of the future itself, but
+      this can lead to issues, further discussed in the pinning slide.
 
 </details>

--- a/src/async/pitfalls.md
+++ b/src/async/pitfalls.md
@@ -5,3 +5,4 @@ Async / await provides convenient and efficient abstraction for concurrent async
 - [Blocking the Executor](pitfalls/blocking-executor.md)
 - [Pin](pitfalls/pin.md)
 - [Async Traits](pitfall/async-traits.md)
+- [Cancellation](pitfalls/cancellation.md)

--- a/src/async/pitfalls/cancellation.md
+++ b/src/async/pitfalls/cancellation.md
@@ -73,10 +73,8 @@ async fn main() -> std::io::Result<()> {
 * The compiler doesn't help with cancellation-safety. You need to read API
   documentation and consider what state your `async fn` holds.
 
-* Cancellation can be compared to panics and the `?` operator
-
-    * Unlike `panic` and `?`, cancellation is part of normal control flow
-      (vs error-handling).
+* Unlike `panic` and `?`, cancellation is part of normal control flow
+  (vs error-handling).
 
 * The example loses parts of the string.
 

--- a/src/async/pitfalls/cancellation.md
+++ b/src/async/pitfalls/cancellation.md
@@ -1,0 +1,91 @@
+# Cancellation
+
+Dropping a future implies it can never be polled again. This is called *cancellation*.
+It can occur at any `await` point. Care is needed with stateful resources.
+
+```rust,editable,compile_fail
+use std::time::Duration;
+use tokio::io::{DuplexStream, AsyncWriteExt, BufReader, AsyncBufReadExt};
+use tokio::time;
+
+// A producer which slowly writes bytes
+async fn producer(mut stream: DuplexStream) -> std::io::Result<()> {
+    let data = b"hello\nworld\n";
+    for chunk in data.chunks(2) {
+        stream.write_all(chunk).await?;
+        time::sleep(Duration::from_millis(10)).await;
+    }
+    Ok(())
+}
+
+// A consumer which is waiting for one of several events
+async fn consumer(stream: DuplexStream) -> std::io::Result<()> {
+    let mut reader = BufReader::new(stream);
+    let mut buf = String::new();
+    let mut interval = time::interval(Duration::from_millis(5));
+    loop {
+        tokio::select! { 
+            res = reader.read_line(&mut buf) => match res? {
+                0 => return Ok(()),
+                _ => {
+                    print!("{}", buf);
+                    buf.clear()
+                }
+            },
+            _ = interval.tick() => {
+                println!("tick!");
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let (a, b) = tokio::io::duplex(10);
+    let h1 = tokio::spawn(producer(a));
+    let h2 = tokio::spawn(consumer(b));
+    h1.await.unwrap().unwrap();
+    h2.await.unwrap().unwrap();
+}
+```
+
+<details>
+
+* [`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line)
+  isn't cancellation safe. It reads data, but only guarantees that it appears in `buf` once there's a newline.
+
+    * `interval` sometimes ticks before a full line is received and `select!`
+      drops the `read_line` future.
+
+    * Use `AsyncBufReadExt::lines` to convert the reader into a stream of lines,
+      which has a cancellation-safe `next_line` method.
+
+        ```rust,compile_fail
+        let mut lines = BufReader::new(stream).lines();
+        loop {
+            select! {
+                res = lines.next_line() => match res? {
+                    None => return Ok(()),
+                    Some(l) => {
+                        println!("{}", l);
+                    }
+                },
+              ..
+            }
+        }
+        ```
+
+* [`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick)
+  is cancellation safe because it keeps track of whether a tick has been 'delivered'.
+
+* Graceful shutdown, i.e. stopping based on some signal, is sometimes an
+  alternative to cancellation.
+
+    * For example, a task receiving messages from an mpsc channel might
+      do some cleanup when it detects that all senders have been dropped.
+    
+    * [tokio-util](https://docs.rs/tokio-util/latest/tokio_util/) inculdes a
+      [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html)
+      for explicitly signaling when tasks should shut down.
+
+</details>

--- a/src/async/pitfalls/cancellation.md
+++ b/src/async/pitfalls/cancellation.md
@@ -1,91 +1,116 @@
 # Cancellation
 
-Dropping a future implies it can never be polled again. This is called *cancellation*.
-It can occur at any `await` point. Care is needed with stateful resources.
+Dropping a future implies it can never be polled again. This is called *cancellation*
+and it can occur at any `await` point. Care is needed to ensure the system works
+correctly even when futures are cancelled. For example, it shouldn't deadlock or
+lose data.
 
 ```rust,editable,compile_fail
+use std::io::{self, ErrorKind};
 use std::time::Duration;
-use tokio::io::{DuplexStream, AsyncWriteExt, BufReader, AsyncBufReadExt};
-use tokio::time;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 
-// A producer which slowly writes bytes
-async fn producer(mut stream: DuplexStream) -> std::io::Result<()> {
-    let data = b"hello\nworld\n";
-    for chunk in data.chunks(2) {
-        stream.write_all(chunk).await?;
-        time::sleep(Duration::from_millis(10)).await;
+struct LinesReader {
+    stream: DuplexStream,
+}
+
+impl LinesReader {
+    fn new(stream: DuplexStream) -> Self {
+        Self { stream }
+    }
+
+    async fn next(&mut self) -> io::Result<Option<String>> {
+        let mut buf = Vec::new();
+        loop {
+            buf.push(0);
+            let last = buf.len() - 1;
+            if self.stream.read(&mut buf[last..]).await? == 0 {
+                // Assume file ends with newline
+                return Ok(None)
+            }
+            if buf[last] == b'\n' {
+                break;
+            }
+        }
+        let s = String::from_utf8(buf)
+            .map_err(|_| io::Error::new(ErrorKind::InvalidData, "not UTF-8"))?;
+        Ok(Some(s))
+    }
+}
+
+async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::Result<()> {
+    for b in source.bytes() {
+        dest.write_u8(b).await?;
+        tokio::time::sleep(Duration::from_millis(10)).await
     }
     Ok(())
 }
 
-// A consumer which is waiting for one of several events
-async fn consumer(stream: DuplexStream) -> std::io::Result<()> {
-    let mut reader = BufReader::new(stream);
-    let mut buf = String::new();
-    let mut interval = time::interval(Duration::from_millis(5));
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let (client, server) = tokio::io::duplex(5);
+    let handle = tokio::spawn(slow_copy("hi\nthere\n".to_owned(), client));
+
+    let mut lines = LinesReader::new(server);
+    let mut interval = tokio::time::interval(Duration::from_millis(60));
     loop {
-        tokio::select! { 
-            res = reader.read_line(&mut buf) => match res? {
-                0 => return Ok(()),
-                _ => {
-                    print!("{}", buf);
-                    buf.clear()
-                }
+        tokio::select! {
+            _ = interval.tick() => println!("tick!"),
+            line = lines.next() => if let Some(l) = line? {
+                print!("{}", l)
+            } else {
+                break
             },
-            _ = interval.tick() => {
-                println!("tick!");
-            }
         }
     }
-}
-
-#[tokio::main]
-async fn main() {
-    let (a, b) = tokio::io::duplex(10);
-    let h1 = tokio::spawn(producer(a));
-    let h2 = tokio::spawn(consumer(b));
-    h1.await.unwrap().unwrap();
-    h2.await.unwrap().unwrap();
+    handle.await.unwrap()?;
+    Ok(())
 }
 ```
 
 <details>
 
-* [`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line)
-  isn't cancellation safe. It reads data, but only guarantees that it appears in `buf` once there's a newline.
+* The compiler doesn't help with cancellation-safety. You need to read API
+  documentation and consider what state your `async fn` holds.
 
-    * `interval` sometimes ticks before a full line is received and `select!`
-      drops the `read_line` future.
+* Cancellation can be compared to panics and the `?` operator
 
-    * Use `AsyncBufReadExt::lines` to convert the reader into a stream of lines,
-      which has a cancellation-safe `next_line` method.
+    * Unlike `panic` and `?`, cancellation is part of normal control flow
+      (vs error-handling).
 
+* The example loses parts of the string.
+
+    * Whenever the `tick()` branch finishes first, `next()` and its `buf` are dropped.
+
+    * `LinesReader` can be made cancellation-safe by makeing `buf` part of the struct:
         ```rust,compile_fail
-        let mut lines = BufReader::new(stream).lines();
-        loop {
-            select! {
-                res = lines.next_line() => match res? {
-                    None => return Ok(()),
-                    Some(l) => {
-                        println!("{}", l);
-                    }
-                },
-              ..
+        struct LinesReader {
+            stream: DuplexStream,
+            buf: Vec<u8>,
+        }
+
+        impl LinesReader {
+            fn new(stream: DuplexStream) -> Self {
+                Self { stream, buf: Vec::new() }
+            }
+            async fn next(&mut self) -> io::Result<Option<String>> {
+                // replace buf with self.buf
+                // ...
+                let raw = std::mem::take(&mut self.buf);
+                let s = String::from_utf8(raw)
+                // ...
             }
         }
         ```
 
 * [`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick)
-  is cancellation safe because it keeps track of whether a tick has been 'delivered'.
+  is cancellation-safe because it keeps track of whether a tick has been 'delivered'.
 
-* Graceful shutdown, i.e. stopping based on some signal, is sometimes an
-  alternative to cancellation.
+* [`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read)
+  is cancellation-safe because it either returns or doesn't read data.
 
-    * For example, a task receiving messages from an mpsc channel might
-      do some cleanup when it detects that all senders have been dropped.
-    
-    * [tokio-util](https://docs.rs/tokio-util/latest/tokio_util/) inculdes a
-      [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html)
-      for explicitly signaling when tasks should shut down.
+* [`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line)
+  is similar to the example and *isn't* cancellation-safe. See its documentation
+  for details and alternatives.
 
 </details>


### PR DESCRIPTION
This adds a couple bits about cancellation in the context of async Rust:
* a speaker note on the `select!` slide
* a separate slide (in "Pitfalls") about cancellation

I mostly think it's worth saying something on the `select!` slide because it's a common(?) mistake. I added a whole slide to provide more context and an example, but I'm not sure this problem is common enough to warrant it. I also wasn't sure how much to say about graceful shutdown... it's related, but tangential.

@djmitche @rbehjati might have thoughts?