### PR TITLE
Clarify Default trait and operators

### DIFF
--- a/src/traits/default.md
+++ b/src/traits/default.md
@@ -1,6 +1,6 @@
 # The `Default` Trait
 
-[`Default`][1] trait provides a default implementation of a trait.
+[`Default`][1] trait produces a default value for a type.
 
 ```rust,editable
 #[derive(Debug, Default)]

--- a/src/traits/operators.md
+++ b/src/traits/operators.md
@@ -34,6 +34,8 @@ Discussion points:
     * Short answer: Function type parameters are controlled by the caller, but
         associated types (like `Output`) are controlled by the implementor of a
         trait.
+* You could implement `Add` for two different types, e.g.
+  `impl Add<(i32, i32)> for Point` would add a tuple to a `Point`.
 
 </details>
 

--- a/src/traits/operators.md
+++ b/src/traits/operators.md
@@ -30,8 +30,8 @@ Discussion points:
         overloading the operator is not `Copy`, you should consider overloading
         the operator for `&T` as well. This avoids unnecessary cloning on the
         call site.
-* Why is `Output` an associated type? Could it be made a type parameter?
-    * Short answer: Type parameters are controlled by the caller, but
+* Why is `Output` an associated type? Could it be made a type parameter of the method?
+    * Short answer: Function type parameters are controlled by the caller, but
         associated types (like `Output`) are controlled by the implementor of a
         trait.
 


### PR DESCRIPTION
The description of `Default` sounded (to me) like it was referring to derive macros or something. I don't feel strongly about the verb (provides vs produces), but I think 'produces' suggests creating a value (which is usually the case).

I feel less strongly about the proposed changes to the 'operators' slide...
* the existing bullet point just needed clarification during the class
* implementing operators for different types might be too niche to bother with