### PR TITLE
ja: Chapter 0

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2023-05-30 19:59+0900\n"
+"PO-Revision-Date: 2023-05-30 20:20+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
 "Language: ja\n"
@@ -1014,6 +1014,11 @@ msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?"
 "style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
 msgstr ""
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/"
+"build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build."
+"yml?query=branch%3Amain)\n"
+"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?"
+"style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
 
 #: src/welcome.md:4
 msgid "GitHub contributors"
@@ -1026,6 +1031,10 @@ msgid ""
 "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
 "(https://github.com/google/comprehensive-rust/stargazers)"
 msgstr ""
+"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?"
+"style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)\n"
+"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
+"(https://github.com/google/comprehensive-rust/stargazers)"
 
 #: src/welcome.md:5
 msgid "GitHub stars"
@@ -1036,6 +1045,8 @@ msgid ""
 "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
 "(https://github.com/google/comprehensive-rust/stargazers)"
 msgstr ""
+"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
+"(https://github.com/google/comprehensive-rust/stargazers)"
 
 #: src/welcome.md:7
 msgid ""
@@ -1043,12 +1054,17 @@ msgid ""
 "the full spectrum of Rust, from basic syntax to advanced topics like generics\n"
 "and error handling. It also includes Android-specific content on the last day."
 msgstr ""
+"この資料は、GoogleのAndroidチームによって開発された3日間のRust講座です。本講座では、基本構文から"
+"ジェネリクスやエラー処理など、幅広い内容をカバーします。また、最終日にはAndroid専用の内容も含まれて"
+"います。"
 
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know anything\n"
 "about Rust and hope to:"
 msgstr ""
+"本講座の目的は、Rustを教える事です。Rustに関する前提知識は不要としており、次の目標を設定していま"
+"す："
 
 #: src/welcome.md:14
 msgid ""
@@ -1056,12 +1072,15 @@ msgid ""
 "* Enable you to modify existing programs and write new programs in Rust.\n"
 "* Show you common Rust idioms."
 msgstr ""
+"* Rustの基本構文と言語についての理解を深める。\n"
+"* 既存のプログラムを修正したり、新規プログラムをRustで書けるようにする。\n"
+"* 一般的なRustのイディオムを紹介する。"
 
 #: src/welcome.md:18
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, you're\n"
 "invited to dive into one or more spezialized topics:"
-msgstr ""
+msgstr "最初の3日間は、Rustの基礎を学びます。その後、より専門的なトピックに進む事ができます："
 
 #: src/welcome.md:21
 msgid ""
@@ -1075,16 +1094,25 @@ msgid ""
 "  mutextes) and async/await concurrency (cooperative multitasking using\n"
 "  futures)."
 msgstr ""
+"* [Android](android.md)： Androidオープンソースプラットフォーム（AOSP）でRustを使用するための半日講"
+"座。C、C++、およびJavaとの相互運用性も含まれます。\n"
+"* [Bare-metal](bare-metal.md)： ベアメタル（組み込み）開発でRustを使用するための1日講座。マイクロコ"
+"ントローラとアプリケーションプロセッサの両方が対象となります。\n"
+"* [Concurrency](concurrency.md)： Rustの並行性についての1日講座。並行性（スレッドとミューテックスを"
+"用いたプリエンプティブなスケジューリング）と、async/awaitを使用した並行性（futuresを用いた協調的マ"
+"ルチタスク）がカバーされます。"
 
 #: src/welcome.md:32
 msgid "## Non-Goals"
-msgstr ""
+msgstr "## 本講座の対象外"
 
 #: src/welcome.md:34
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few days.\n"
 "Some non-goals of this course are:"
 msgstr ""
+"Rustは非常に汎用性の高い言語であり、数日で全てを網羅する事はできません。本講座の目標として設定され"
+"ていないものには、以下のようなものがあります："
 
 #: src/welcome.md:37
 msgid ""
@@ -1092,10 +1120,13 @@ msgid ""
 "  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
 "  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
+"* マクロ（macro）の開発。マクロの詳細については、[Rust Book 日本語版 Ch. 19.5](https://doc.rust-jp."
+"rs/book-ja/ch19-06-macros.html)と[Rust by Example 日本語版 Ch.17](http://doc.rust-jp.rs/rust-by-"
+"example-ja/macros.html)を参照してください。"
 
 #: src/welcome.md:41
 msgid "## Assumptions"
-msgstr ""
+msgstr "## 前提知識"
 
 #: src/welcome.md:43
 msgid ""
@@ -1103,12 +1134,16 @@ msgid ""
 "typed language and we will sometimes make comparisons with C and C++ to better\n"
 "explain or contrast the Rust approach."
 msgstr ""
+"本講座では、既にプログラミングの知識がある事を前提としています。Rustは静的型付け言語であり、Rustの"
+"アプローチをより分かりやすく説明するために、時折CやC++との比較を行います。"
 
 #: src/welcome.md:47
 msgid ""
 "If you know how to program in a dynamically typed language such as Python or\n"
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
+"もし受講者の知識がPythonやJavaScriptなどの動的型付け言語に限定されている場合でも、本講座の受講は可"
+"能です。"
 
 #: src/welcome.md:50 src/cargo/rust-ecosystem.md:19 src/cargo/code-samples.md:22
 #: src/cargo/running-locally.md:68 src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
@@ -1188,6 +1223,8 @@ msgid ""
 "information to the slides. This could be key points which the instructor should\n"
 "cover as well as answers to typical questions which come up in class."
 msgstr ""
+"これはスピーカーノートの一例です。これを使用してスライドを捕捉します。講師がカバーすべき要点や、授"
+"業でよく出る質問への回答などが含まれます。"
 
 #: src/welcome.md:56 src/cargo/rust-ecosystem.md:67 src/cargo/code-samples.md:35
 #: src/cargo/running-locally.md:74 src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2023-05-26 17:58+0900\n"
+"PO-Revision-Date: 2023-05-30 19:59+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
 "Language: ja\n"
@@ -249,7 +249,7 @@ msgstr "イテレータと所有権"
 
 #: src/SUMMARY.md:71
 msgid "Day 2: Morning"
-msgstr "Day 2；AM"
+msgstr "Day 2： AM"
 
 #: src/SUMMARY.md:76
 msgid "Structs"
@@ -313,7 +313,7 @@ msgstr "ポイントとポリゴン"
 
 #: src/SUMMARY.md:94
 msgid "Day 2: Afternoon"
-msgstr "Day 2：PM"
+msgstr "Day 2： PM"
 
 #: src/SUMMARY.md:96 src/SUMMARY.md:286
 msgid "Control Flow"
@@ -417,7 +417,7 @@ msgstr "文字列とイテレータ"
 
 #: src/SUMMARY.md:124
 msgid "Day 3: Morning"
-msgstr "Day 3：AM"
+msgstr "Day 3： AM"
 
 #: src/SUMMARY.md:129
 msgid "Generics"
@@ -501,7 +501,7 @@ msgstr "GUIライブラリ"
 
 #: src/SUMMARY.md:151
 msgid "Day 3: Afternoon"
-msgstr "Day 3：PM"
+msgstr "Day 3： PM"
 
 #: src/SUMMARY.md:153
 msgid "Error Handling"
@@ -677,7 +677,7 @@ msgstr "Java"
 
 #: src/SUMMARY.md:207
 msgid "Bare Metal: Morning"
-msgstr "ベアメタル：AM"
+msgstr "ベアメタル： AM"
 
 #: src/SUMMARY.md:212
 msgid "no_std"
@@ -737,7 +737,7 @@ msgstr "コンパス"
 
 #: src/SUMMARY.md:228
 msgid "Bare Metal: Afternoon"
-msgstr "ベアメタル：PM"
+msgstr "ベアメタル： PM"
 
 #: src/SUMMARY.md:230
 msgid "Application Processors"
@@ -813,7 +813,7 @@ msgstr "RTC（リアルタイムクロック）ドライバ"
 
 #: src/SUMMARY.md:255
 msgid "Concurrency: Morning"
-msgstr "並行性：AM"
+msgstr "並行性： AM"
 
 #: src/SUMMARY.md:260
 msgid "Threads"
@@ -873,7 +873,7 @@ msgstr "マルチスレッド・リンクチェッカー"
 
 #: src/SUMMARY.md:277
 msgid "Concurrency: Afternoon"
-msgstr "並行性：PM"
+msgstr "並行性： PM"
 
 #: src/SUMMARY.md:279
 msgid "Async Basics"


### PR DESCRIPTION
- `mdbook serve` does NOT reflect translations in the following areas in both localhost and prod
![Screenshot 2023-05-30 at 20 27 23](https://github.com/google/comprehensive-rust/assets/132030351/84d9c7e5-7195-4384-96af-4539fc9ef742)
- same behavior as above observed in prod for Brazilian and Korean
- minor edits to table of contents for consistency in first commit

Part of #652.