### PR TITLE
Update default-methods.md

### DIFF
--- a/src/traits/default-methods.md
+++ b/src/traits/default-methods.md
@@ -34,7 +34,7 @@ fn main() {
 
 * Move method `not_equal` to a new trait `NotEqual`.
 
-* Make `NotEqual` a super trait for `Equal`.
+* Make `Equals` a super trait for `NotEqual`.
     ```rust,editable,compile_fail
     trait NotEqual: Equals {
         fn not_equal(&self, other: &Self) -> bool {

--- a/src/traits/default-methods.md
+++ b/src/traits/default-methods.md
@@ -55,6 +55,6 @@ fn main() {
         }
     }
     ```
-  * With the blanket implementation, you no longer need `NotEqual` as a super trait for `Equal`.
+  * With the blanket implementation, you no longer need `Equals` as a super trait for `NotEqual`.
     
 </details>


### PR DESCRIPTION
This commit resolves two issues.

a) typo: Equal -> Equals
b) update details to comply w/ example source code