### PR TITLE
Mentioned the XKCD source of the joke in enums.md

### DIFF
--- a/src/enums.md
+++ b/src/enums.md
@@ -6,6 +6,7 @@ different variants:
 ```rust,editable
 fn generate_random_number() -> i32 {
     4  // Chosen by fair dice roll. Guaranteed to be random.
+    // (Source: https://xkcd.com/221/)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
XKCD is under CC BY-NC 2.5 licence, so it is fair to at least link to the source when reusing a joke.