### PR TITLE
zh-CN: fix display error in hello-world.md

### DIFF
--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -54,7 +54,7 @@ msgstr ""
 #: src/SUMMARY.md:18 src/SUMMARY.md:75 src/SUMMARY.md:128 src/SUMMARY.md:185
 #: src/SUMMARY.md:211 src/SUMMARY.md:259
 msgid "Welcome"
-msgstr ""
+msgstr "欢迎"
 
 #: src/SUMMARY.md:19
 msgid "What is Rust?"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: src/SUMMARY.md:33
 msgid "Functions"
-msgstr ""
+msgstr "函数"
 
 #: src/SUMMARY.md:34
 msgid "Rustdoc"
@@ -122,11 +122,11 @@ msgstr ""
 
 #: src/SUMMARY.md:35 src/SUMMARY.md:82
 msgid "Methods"
-msgstr ""
+msgstr "方法"
 
 #: src/SUMMARY.md:36
 msgid "Overloading"
-msgstr ""
+msgstr "重载"
 
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
@@ -2056,10 +2056,10 @@ msgid ""
 "* Rust has hygienic macros, `println!` is an example of this.\n"
 "* Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
-"* 函数以 `fn` 开头。\n" 
-"* 像 C 和 C++ 一样，块由花括号分隔。\n" 
-"* main 函数是程序的入口。\n" 
-"* Rust 有卫生宏 (hygienic macros)，`println!` 就是一个例子。\n" 
+"* 函数以 `fn` 开头。\n"
+"* 像 C 和 C++ 一样，块由花括号分隔。\n"
+"* `main` 函数是程序的入口。\n"
+"* Rust 有卫生宏 (hygienic macros)，`println!` 就是一个例子。\n"
 "* Rust 字符串是 UTF-8 编码的，可以包含任何 Unicode 字符。"
 
 #: src/hello-world.md:22
@@ -2990,7 +2990,7 @@ msgstr ""
 
 #: src/basic-syntax/methods.md:1 src/methods.md:1
 msgid "# Methods"
-msgstr ""
+msgstr "# 方法"
 
 #: src/basic-syntax/methods.md:3
 msgid ""
@@ -2998,6 +2998,7 @@ msgid ""
 "method is\n"
 "an instance of the type it is associated with:"
 msgstr ""
+"方法是与某种类型关联的函数。方法的 `self` 参数是与其关联类型的一个实例："
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3031,6 +3032,7 @@ msgid ""
 "* We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
+"我们将在今天的练习和明天的课程中更深入地学习方法相关的概念。"
 
 #: src/basic-syntax/methods.md:34
 msgid ""
@@ -3045,6 +3047,15 @@ msgid ""
 "- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
 "  constructors can take arbitrary parameters."
 msgstr ""
+"- 新增一个 `Rectangle::new` 构造器并在 `main` 函数中调用它:\n"
+"\n"
+"    ```rust,editable,compile_fail\n"
+"    fn new(width: u32, height: u32) -> Rectangle {\n"
+"        Rectangle { width, height }\n"
+"    }\n"
+"    ```\n"
+"\n"
+"- 新增一个 `Rectangle::new_square(width: u32)` 构造器来说明构造器可以接受任意参数。"
 
 #: src/basic-syntax/functions-interlude.md:1
 msgid "# Function Overloading"


### PR DESCRIPTION
#324 
Space after the right quotation mark will make the book display like this:
<img width="944" alt="image" src="https://github.com/google/comprehensive-rust/assets/42133316/56739f7b-cf74-42cf-b0f4-9b239b8db6ea">
