### PR TITLE
Rename zh-Hant.po to zh-TW.po and add CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@ po/pt-BR.po @rastringer @hugojacob
 po/tr.po @duyguisler
 po/zh-Hans.po @suetfei @wnghl @anlunx @kongy @noahdragon
 po/pl.po @jkotur @pawelpaa
-po/zh-Hant.po @edong @hueich @kuanhungchen @victorhsieh
+po/zh-TW.po @edong @hueich @kuanhungchen @victorhsieh @mingyc

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -4,11 +4,11 @@ msgstr ""
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2023-06-01 22:43+0800\n"
 "Last-Translator: Hank Chen <kuanhungchen@google.com>\n"
-"Language-Team: Chinese (Traditional) <zh-l10n@lists.linux.org.tw>\n"
+"Language-Team: Traditional Chinese (Taiwan) <zh-l10n@lists.linux.org.tw>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh-Hant\n"
+"Language: zh-TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: src/SUMMARY.md:3


### PR DESCRIPTION
- Add myself as the code reviewer for zh-TW, as I am already listed in [the sheet](https://docs.google.com/spreadsheets/d/1bVSJEUGkI9gcqmmA4va4y-I7LzgQUqNwnZYJsQNMBGE/edit#gid=0) for zh-Hant translation
- As mentioned in https://github.com/google/comprehensive-rust/issues/684#issuecomment-1571700135, Traditional Chinese are used differently in HK and TW. The intention for zh-Hant.go was to cover zh-TW.