### PR TITLE
Mention symlinks on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ versions of the course, run `MDBOOK_BOOK__LANGUAGE=xx mdbook build -d book/xx`
 where `xx` is the ISO 639 language code (e.g. `da` for the Danish translation).
 [TRANSLATIONS.md](TRANSLATIONS.md) contains further instructions.
 
-> **Note**·On·Windows,·you·need·to·enable·symlinks
+> **Note** On Windows, you need to enable symlinks
 > (`git config --global core.symlinks true`) and Developer Mode.
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ versions of the course, run `MDBOOK_BOOK__LANGUAGE=xx mdbook build -d book/xx`
 where `xx` is the ISO 639 language code (e.g. `da` for the Danish translation).
 [TRANSLATIONS.md](TRANSLATIONS.md) contains further instructions.
 
+> **Note**
+> On Windows, you need to enable symlinks
+> (`git config --global core.symlinks true`) and Developer Mode.
+
 ## Contact
 
 For questions or comments, please contact

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ versions of the course, run `MDBOOK_BOOK__LANGUAGE=xx mdbook build -d book/xx`
 where `xx` is the ISO 639 language code (e.g. `da` for the Danish translation).
 [TRANSLATIONS.md](TRANSLATIONS.md) contains further instructions.
 
-> **Note**
-> On Windows, you need to enable symlinks
+> **Note**·On·Windows,·you·need·to·enable·symlinks
 > (`git config --global core.symlinks true`) and Developer Mode.
 
 ## Contact


### PR DESCRIPTION
This adds a small note about symlinks to the README, motivated by #733. I can imagine placing it earlier in the page (this should be done before running `mdbook`). However, it felt overly prominent to me. I don't feel strongly tho.

Also, this use the [GitHub note syntax](https://github.com/orgs/community/discussions/16925). It can be previewed on [my branch](https://github.com/mauvealerts/comprehensive-rust/tree/symlink-note#building)