### PR TITLE
Disambiguate b in main_improved.rs

### DIFF
--- a/src/bare-metal/aps/examples/src/main_improved.rs
+++ b/src/bare-metal/aps/examples/src/main_improved.rs
@@ -38,9 +38,9 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
     writeln!(uart, "main({x0:#x}, {x1:#x}, {x2:#x}, {x3:#x})").unwrap();
 
     loop {
-        if let Some(b) = uart.read_byte() {
-            uart.write_byte(b);
-            match b {
+        if let Some(byte) = uart.read_byte() {
+            uart.write_byte(byte);
+            match byte {
                 b'\r' => {
                     uart.write_byte(b'\n');
                 }


### PR DESCRIPTION
When reading lines 43/44/47, I wonder how the b from line 43 can be matched against a b in line 44 and also again in 47. Without the syntax highlighting in the HTML code viewer, it is difficult to read the byte-string prefix as something different from the captured local b variable. I propose to rename the b variable to byte.