### PR TITLE
Move the xkcd credit to a footnote

### DIFF
--- a/src/enums.md
+++ b/src/enums.md
@@ -5,8 +5,7 @@ different variants:
 
 ```rust,editable
 fn generate_random_number() -> i32 {
-    // Implementation based on https://xkcd.com/221/
-    4  // Chosen by fair dice roll. Guaranteed to be random.
+    4  // Chosen by fair dice roll. Guaranteed to be random. [1]
 }
 
 #[derive(Debug)]
@@ -27,6 +26,8 @@ fn flip_coin() -> CoinFlip {
 fn main() {
     println!("You got: {:?}", flip_coin());
 }
+
+// [1] See https://xkcd.com/221/
 ```
 
 <details>


### PR DESCRIPTION
Since this is a joke, delivery is important, and putting the credit in the middle of the joke kind of ruins that delivery. Hopefully this duly credits Munroe while still preserving the humor!

/cc @TPReal who suggested the credit initially in #748.