### PR TITLE
Rephrase when `send` blocks

### DIFF
--- a/src/concurrency/channels/bounded.md
+++ b/src/concurrency/channels/bounded.md
@@ -30,5 +30,6 @@ fn main() {
     
 * Calling `send` will block the currnet thread until there is space in the channel for the new message. The thread can be blocked indefinitely if there is nobody who reads from the channel.
 * A call to `send` will abort with an error (that is why it returns `Result`) if the channel is closed. A channel is closed when the receiver is dropped.
+* A bounded channel with a size of zero is called a "rendezvous channel". Every send will block the current thread until another thread calls `read`.
     
 </details>

--- a/src/concurrency/channels/bounded.md
+++ b/src/concurrency/channels/bounded.md
@@ -1,6 +1,6 @@
 # Bounded Channels
 
-Bounded and synchronous channels make `send` block the current thread:
+With bounded (synchronous) channels, `send` can block the current thread:
 
 ```rust,editable
 use std::sync::mpsc;
@@ -25,3 +25,10 @@ fn main() {
     }
 }
 ```
+
+<details>
+    
+* Calling `send` will block the currnet thread until there is space in the channel for the new message. The thread can be blocked indefinitely if there is nobody who reads from the channel.
+* A call to `send` will abort with an error (that is why it returns `Result`) if the channel is closed. A channel is closed when the receiver is dropped.
+    
+</details>


### PR DESCRIPTION
From a discussion with @hueich: https://github.com/google/comprehensive-rust/pull/786#discussion_r1224850499.