### PR TITLE
zh-TW: fix style in src/testing.md

### DIFF
--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -8961,7 +8961,7 @@ msgstr "# 測試"
 
 #: src/testing.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
-msgstr "Rust 和 Cargo 提供了一個簡單的單元測試 (unit test) 框架: "
+msgstr "Rust 和 Cargo 提供了一個簡單的單元測試 (unit test) 框架："
 
 #: src/testing.md:5
 msgid ""


### PR DESCRIPTION
According to the localization guide, colons, in documentation, should be 全形.