### PR TITLE
zh-TW: translation for src/control-flow/break-continue.md

### DIFF
--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -6268,7 +6268,7 @@ msgstr ""
 
 #: src/control-flow/break-continue.md:1
 msgid "# `break` and `continue`"
-msgstr ""
+msgstr "# `break` and `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
@@ -6278,6 +6278,10 @@ msgid ""
 "the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
 "expressions/loop-expr.html#continue-expressions)."
 msgstr ""
+"- 如果你想提早跳出迴圈，可以使用 [`break`]((https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions))，\n"
+"- 如果你想立即進入下一次迭代，可以使用 [`continue`](https://doc.rust-lang."
+"org/reference/expressions/loop-expr.html#continue-expressions)。"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
@@ -6285,6 +6289,8 @@ msgid ""
 "used\n"
 "to break out of nested loops:"
 msgstr ""
+"`continue` 以及 `break` 都可以選擇性地接收一個迴圈標籤，用來跳出巢狀迴圈中的"
+"某一層："
 
 #: src/control-flow/break-continue.md:10
 msgid ""
@@ -6310,7 +6316,7 @@ msgstr ""
 #: src/control-flow/break-continue.md:28
 msgid ""
 "In this case we break the outer loop after 3 iterations of the inner loop."
-msgstr ""
+msgstr "在這個範例中，內層迴圈經過三次迭代後，我們使用 `break` 跳出外層迴圈。"
 
 #: src/std.md:1
 msgid "# Standard Library"

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -6268,7 +6268,7 @@ msgstr ""
 
 #: src/control-flow/break-continue.md:1
 msgid "# `break` and `continue`"
-msgstr "# `break` and `continue`"
+msgstr "# `break` 和 `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""


### PR DESCRIPTION
I couldn't find a good translation for "break" and "continue", so I just followed Korean version for not translating them.

Part of #684.