### PR TITLE
Fix link to LICENSE in credits.md

### DIFF
--- a/src/credits.md
+++ b/src/credits.md
@@ -5,7 +5,9 @@ See the page on [other resources](other-resources.md) for a full list of useful
 resources.
 
 The material of Comprehensive Rust is licensed under the terms of the Apache 2.0
-license, please see [`LICENSE`](../LICENSE) for details.
+license, please see
+[`LICENSE`](https://github.com/google/comprehensive-rust/blob/main/LICENSE) for
+details.
 
 ## Rust by Example
 


### PR DESCRIPTION
The link worked fine when GitHub was rendering it — it rewrites the relative path correctly. However, when viewed as the output of `mdbook`, the link pointed to nowhere.