### PR TITLE
Adding link checker solution to concurrency morning solutions

### DIFF
--- a/src/exercises/concurrency/solutions-morning.md
+++ b/src/exercises/concurrency/solutions-morning.md
@@ -8,3 +8,10 @@
 {{#include dining-philosophers.rs}}
 ```
 
+## Multi-threaded Link Checker
+
+([back to exercise](link-checker.md))
+
+```rust
+{{#include link-checker.rs}}
+```


### PR DESCRIPTION
The solution for the multi-threaded link checker was missing from the solution file,
adding the missing bit.