### PR TITLE
Make User pub to avoid unused code warnings when running tests

### DIFF
--- a/third_party/rust-on-exercism/health-statistics.rs
+++ b/third_party/rust-on-exercism/health-statistics.rs
@@ -1,4 +1,4 @@
-struct User {
+pub struct User {
     name: String,
     age: u32,
     weight: f32,


### PR DESCRIPTION
When the tests are run without this on Playground, it gives a bunch of warnings about unused methods on `User`, because they are not part of the public API of the library. Making `User` public avoids most of them, and seems like a reasonable approach for people to take.