### PR TITLE
Corrected spelling in bounded.md

### DIFF
--- a/src/concurrency/channels/bounded.md
+++ b/src/concurrency/channels/bounded.md
@@ -28,7 +28,7 @@ fn main() {
 
 <details>
     
-* Calling `send` will block the currnet thread until there is space in the channel for the new message. The thread can be blocked indefinitely if there is nobody who reads from the channel.
+* Calling `send` will block the current thread until there is space in the channel for the new message. The thread can be blocked indefinitely if there is nobody who reads from the channel.
 * A call to `send` will abort with an error (that is why it returns `Result`) if the channel is closed. A channel is closed when the receiver is dropped.
 * A bounded channel with a size of zero is called a "rendezvous channel". Every send will block the current thread until another thread calls `read`.
     


### PR DESCRIPTION
"the currnet thread" to "the current thread"

I have signed the Contributor License Agreement.