### PR TITLE
Remove `.md` redirects from book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -45,11 +45,8 @@ line-numbers = true
 [output.html.redirect]
 # Redirects in the form of "old-path" = "new-path", where the new path
 # is relative to the old path.
-"android.md" = "android.html"
 "async/concurrency/channels.html" = "../channels.html"
 "async/pitfall/async-traits.html" = "../pitfalls/async-traits.html"
-"bare-metal.md" = "bare-metal.html"
-"concurrency.md" = "concurrency.html"
 "control-flow/while-let-expression.html" = "while-let-expressions.html"
 "exercises/day-1/soluções-tarde.html" = "solutions-afternoon.html"
 "exercises/day-2/soluções-tarde.html" = "solutions-afternoon.html"


### PR DESCRIPTION
Those redirects don't actually work: they are not given a `Content-Type` by GitHub and so the browser doesn't threat them as HTML and won't follow any redirect.