### PR TITLE
Remove ineffective LICENSE link

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -72,7 +72,6 @@ line-numbers = true
 "unsafe/unsafe-functions.html" = "calling-unsafe-functions.html"
 "welcome-bare-metal.html" = "bare-metal.html"
 "welcome-day-4.html" = "concurrency.html"
-"LICENSE" = "https://github.com/google/comprehensive-rust/blob/main/LICENSE"
 
 [output.exerciser]
 output-directory = "comprehensive-rust-exercises"


### PR DESCRIPTION
Just like the Markdown files in #846, we cannot generate a redirect for the LICENSE file this way. The broken link was fixed in #813, so we should be fine here.