### PR TITLE
Exclude `book/` directory from auto-formatting

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -17,6 +17,7 @@
     "**/*.toml"
   ],
   "excludes": [
+    "/book/",
     "/src/",
     "/third_party/",
     "target/"


### PR DESCRIPTION
The directory contains generated files and should be ignored when reformatting.