### PR TITLE
Open GitHub edit links in new tabs

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -207,12 +207,14 @@
                         {{/if}}
                         {{#if git_repository_edit_url}}
                         {{#if (eq language "en")}}
-                        <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit">
+                        <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit"
+                           target="_blank">
                             <i id="git-edit-button" class="fa fa-edit"></i>
                         </a>
                         {{else}}
                         <a href="https://github.com/google/comprehensive-rust/edit/main/po/{{language}}.po"
-                           title="Suggest an edit to the translation" aria-label="Suggest an edit to the translation">
+                           title="Suggest an edit to the translation" aria-label="Suggest an edit to the translation"
+                           target="_blank">
                             <i id="git-edit-button" class="fa fa-edit"></i>
                         </a>
                         {{/if}}


### PR DESCRIPTION
I find this nicer since you don't lose your location in the book then.