### PR TITLE
zh-TW: Translate test-modules.md and doc-tests.md

### DIFF
--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -552,7 +552,7 @@ msgstr "測試模組"
 
 #: src/SUMMARY.md:166
 msgid "Documentation Tests"
-msgstr ""
+msgstr "文件測試"
 
 #: src/SUMMARY.md:167
 msgid "Integration Tests"
@@ -9069,11 +9069,11 @@ msgstr ""
 
 #: src/testing/doc-tests.md:1
 msgid "# Documentation Tests"
-msgstr ""
+msgstr "# 文件測試"
 
 #: src/testing/doc-tests.md:3
 msgid "Rust has built-in support for documentation tests:"
-msgstr ""
+msgstr "Rust 內建支援文件測試 (documentation tests)："
 
 #: src/testing/doc-tests.md:5
 msgid ""
@@ -9098,6 +9098,12 @@ msgid ""
 "* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
+"* 在 `///` 註解中的程式碼區塊將自動被視為 Rust 程式碼。\n"
+"* `cargo test` 會編譯並執行此程式碼。\n"
+"* 在 [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) 中"
+"測試上面的程式碼。"
+
 
 #: src/testing/integration-tests.md:1
 msgid "# Integration Tests"

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -548,7 +548,7 @@ msgstr "單元測試"
 
 #: src/SUMMARY.md:165
 msgid "Test Modules"
-msgstr ""
+msgstr "測試模組"
 
 #: src/SUMMARY.md:166
 msgid "Documentation Tests"
@@ -9026,13 +9026,15 @@ msgstr "用 `cargo test` 尋找並執行單元測試。"
 
 #: src/testing/test-modules.md:1
 msgid "# Test Modules"
-msgstr ""
+msgstr "# 測試模組"
 
 #: src/testing/test-modules.md:3
 msgid ""
 "Unit tests are often put in a nested module (run tests on the\n"
 "[Playground](https://play.rust-lang.org/)):"
 msgstr ""
+"測試常常被放在巢狀模組中 (在 [Playground](https://play.rust-lang.org/) 中"
+"執行以下測試）："
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -9062,6 +9064,8 @@ msgid ""
 "* This lets you unit test private helpers.\n"
 "* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
+"* 藉此你可以對私有輔助函式作單元測試。\n"
+"* `#[cfg(test)]` 屬性只有在執行 `cargo test` 時才有效。"
 
 #: src/testing/doc-tests.md:1
 msgid "# Documentation Tests"


### PR DESCRIPTION
private -> 私有 is from https://rust-lang.tw/book-tw/ch07-02-defining-modules-to-control-scope-and-privacy.html#:~:text=Asparagus%20%E4%BE%86%E6%89%BE%E5%88%B0%E3%80%82-,%E7%A7%81%E6%9C%89,-vs%20%E5%85%AC%E9%96%8B%EF%BC%9A%E6%A8%A1%E7%B5%84