### PR TITLE
Tweak speaker note about move closures and FnOnce

### DIFF
--- a/src/traits/closures.md
+++ b/src/traits/closures.md
@@ -13,26 +13,49 @@ fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {
 
 fn main() {
     let add_3 = |x| x + 3;
-    let mul_5 = |x| x * 5;
-
     println!("add_3: {}", apply_with_log(add_3, 10));
-    println!("mul_5: {}", apply_with_log(mul_5, 20));
+    println!("add_3: {}", apply_with_log(add_3, 20));
+
+    let mut v = Vec::new();
+    let mut accumulate = |x: i32| {
+        v.push(x);
+        v.iter().sum::<i32>()
+    };
+    println!("accumulate: {}", apply_with_log(&mut accumulate, 4));
+    println!("accumulate: {}", apply_with_log(&mut accumulate, 5));
+
+    let multiply_sum = |x| x * v.into_iter().sum::<i32>();
+    println!("multiply_sum: {}", apply_with_log(multiply_sum, 3));
 }
 ```
 
 <details>
 
-If you have an `FnOnce`, you may only call it once. It might consume captured values.
+An `Fn` neither consumes nor mutates captured values, or perhaps captures nothing at all, so it can
+be called multiple times concurrently.
 
 An `FnMut` might mutate captured values, so you can call it multiple times but not concurrently.
 
-An `Fn` neither consumes nor mutates captured values, or perhaps captures nothing at all, so it can
-be called multiple times concurrently.
+If you have an `FnOnce`, you may only call it once. It might consume captured values.
 
 `FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. I.e. you can use an
 `FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever an `FnMut` or `FnOnce`
 is called for.
 
-Both `move` and non-`move` closures might only implement `FnOnce`.
+The compiler infers some other traits for closures. For example, `add_3` is `Copy` and
+`multiply_sum` is `Clone`.
+
+By default, closures will capture by reference if they can. The `move` keyword makes them capture
+by value.
+```rust,editable
+fn make_greeter(prefix: String) -> impl Fn(&str) {
+    return move |name| println!("{} {}", prefix, name)
+}
+
+fn main() {
+    let hi = make_greeter("Hi".to_string());
+    hi("there");
+}
+```
 
 </details>

--- a/src/traits/closures.md
+++ b/src/traits/closures.md
@@ -31,19 +31,21 @@ fn main() {
 
 <details>
 
-An `Fn` neither consumes nor mutates captured values, or perhaps captures nothing at all, so it can
-be called multiple times concurrently.
+An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or perhaps captures
+nothing at all. It can be called multiple times concurrently.
 
-An `FnMut` might mutate captured values, so you can call it multiple times but not concurrently.
+An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it multiple times,
+but not concurrently.
 
-If you have an `FnOnce`, you may only call it once. It might consume captured values.
+If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It might consume
+captured values.
 
 `FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. I.e. you can use an
 `FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever an `FnMut` or `FnOnce`
 is called for.
 
-The compiler infers some other traits for closures. For example, `add_3` is `Copy` and
-`multiply_sum` is `Clone`.
+The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. `multiply_sum`),
+depending on what the closure captures.
 
 By default, closures will capture by reference if they can. The `move` keyword makes them capture
 by value.

--- a/src/traits/closures.md
+++ b/src/traits/closures.md
@@ -33,6 +33,6 @@ be called multiple times concurrently.
 `FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever an `FnMut` or `FnOnce`
 is called for.
 
-`move` closures only implement `FnOnce`.
+Both `move` and non-`move` closures might only implement `FnOnce`.
 
 </details>


### PR DESCRIPTION
Fixes #651. I was going to just delete the note, but the disconnect is interesting. The current draft highlights it.

Example of a `move` closure implementing `Fn`
```rust
let x = String::new();
let x_len = move || x.len();
x_len();
x_len(); // OK
```

Example of a non-`move` closure which implements only `FnOnce`
```rust
let x = String::new();
let just_drop = || drop(x); // implicitly captures by value
just_drop();
just_drop(); // error
x.len(); // error
```
