### PR TITLE
Clarify that each philosopher should think/eat 100 times

### DIFF
--- a/src/exercises/concurrency/dining-philosophers.md
+++ b/src/exercises/concurrency/dining-philosophers.md
@@ -32,7 +32,7 @@ blanks, and test that `cargo run` does not deadlock:
 
     // Create philosophers
 
-    // Make them think and eat
+    // Make each of them think and eat 100 times
 
     // Output their thoughts
 }


### PR DESCRIPTION
Folks who have hazy memories of the philosopher dining problem may interpret the original instructions as "make each philosopher think and eat once". This interpretation loses a critical detail, because the resulting code is highly unlikely to deadlock in practice, even without breaking the symmetry.