### PR TITLE
fix links for IntoIterator for Vec

### DIFF
--- a/src/exercises/day-1/iterators-and-ownership.md
+++ b/src/exercises/day-1/iterators-and-ownership.md
@@ -104,7 +104,7 @@ What is the type of `word` in each loop?
 
 Experiment with the code above and then consult the documentation for [`impl
 IntoIterator for
-&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)
+&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E)
 and [`impl IntoIterator for
-Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)
+Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT,+A%3E)
 to check your answers.


### PR DESCRIPTION
I imagine the format of these links are a little unstable (they were changed in3f4ae0606d6e18065dcb13d426f4b11e2a43370d by @imichael2e2 too), but these work now.