### PR TITLE
Adds a comment for an iterator based implementation for Polygon::length

### DIFF
--- a/src/exercises/day-2/points-polygons.rs
+++ b/src/exercises/day-2/points-polygons.rs
@@ -96,6 +96,12 @@ impl Polygon {
         }
         result += last_point.dist(self.points[0]);
         result
+        // Alternatively, Iterator::zip() lets us iterate over the points as pairs
+        // but we need to pair each point with the next one, and the last point
+        // with the first point. The zip() iterator is finished as soon as one of 
+        // the source iterators is finished, a neat trick is to combine Iterator::cycle
+        // with Iterator::skip to create the second iterator for the zip and using map 
+        // and sum to calculate the total length.
     }
 }
 


### PR DESCRIPTION
Outlines an alternative implementation for Polygon::length.  This exercise is aimed at novice users and we want to keep the implementation simple. For users familiar with iterator concepts this comment points to an alternative.