### PR TITLE
remove $ from code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,29 +40,29 @@ The course is built using a few tools:
 First clone the repository:
 
 ```shell
-$ git clone https://github.com/google/comprehensive-rust/
-$ cd comprehensive-rust
+git clone https://github.com/google/comprehensive-rust/
+cd comprehensive-rust
 ```
 
 Then install these tools with:
 
 ```shell
-$ cargo install mdbook
-$ cargo install mdbook-svgbob
-$ cargo install mdbook-i18n-helpers
-$ cargo install --path mdbook-exerciser
+cargo install mdbook
+cargo install mdbook-svgbob
+cargo install mdbook-i18n-helpers
+cargo install --path mdbook-exerciser
 ```
 
 Run
 
 ```shell
-$ mdbook test
+mdbook test
 ```
 
 to test all included Rust snippets. Run
 
 ```shell
-$ mdbook serve
+mdbook serve
 ```
 
 to start a web server with the course. You'll find the content on


### PR DESCRIPTION
This helps with copying code/scripts from the readme on GitHub:

![image](https://github.com/google/comprehensive-rust/assets/715417/b5cc6686-9461-4ebd-a5bc-5074ed1ed16d)

