### PR TITLE
Move Poedit instructions into new section

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -13,7 +13,7 @@ directory. The `.po` files are small text-based translation databases.
 > such as [Poedit](https://poedit.net/). There are also several online editors
 > available. This will ensure that the file is encoded correctly.
 
-> **Important** If you are planning to use [Poedit](https://poedit.net/) as
+> **Important:** If you are planning to use [Poedit](https://poedit.net/) as
 > suggested above, make sure to follow the additional configuration
 > steps](#Additional-Configuration-Steps-for-Poedit) below to ensure the `.po`
 > file is correctly formatted.
@@ -98,7 +98,7 @@ Next, please update the file `.github/labeler.yml` to include the new language:
 + - po/xx.po
 ```
 
-### Updating an Existing Translation
+### Refreshing an Existing Translation
 
 As the English text changes, translations gradually become outdated. To update
 the `po/xx.po` file with new messages, first extract the English text into a
@@ -118,14 +118,23 @@ remove the fuzzy marker.
 > the two since it often creates a very large diff, which is hard or impossible
 > to review.
 
-## Additional Configuration Steps for Poedit
+### Editing a Translation
+
+You should install a PO editor to edit the `.po` file for your language. The
+files are simple text files, but it helps to use a dedicated editor since it
+will take care of escaping things like `"` correctly.
+
+There are many PO editors available. [Poedit](https://poedit.net/) is a popular
+cross-platform choice, but you can also find several online editors.
+
+#### Additional Configuration for Poedit
 
 If you are using [Poedit](https://poedit.net/) to work with your `.po` file, you
 will need to change a few things from their default configuration:
 
 1. Open the **Settings** dialog
    1. On Windows, go to **File / Settings**
-   1. On MacOS, select **Settings** from the **Poedit** menu item)
+   1. On MacOS, select **Settings** from the **Poedit** menu item
 1. Go to the **Advanced** tab
 1. On **Line endings**, select the option **Unix (recommended)**
 1. Check the **Wrap at** box, and **79** on the textbox


### PR DESCRIPTION
We did not actually have a section with instructions for how to edit a translation. Instead, this information was kind of implicitly there.