### PR TITLE
Remove statement that data is moved when assigning

### DIFF
--- a/src/ownership/move-semantics.md
+++ b/src/ownership/move-semantics.md
@@ -20,7 +20,7 @@ fn main() {
 
 * Mention that this is the opposite of the defaults in C++, which copies by value unless you use `std::move` (and the move constructor is defined!).
 
-* It is only the ownership that moves. Whether the resulting machine code copies any data around is a matter of optimization, and such copies are aggressively optimized away.
+* It is only the ownership that moves. Whether any machine code is generated to manipulate the data itself is a matter of optimization, and such copies are aggressively optimized away.
 
 * Simple values (such as integers) can be marked `Copy` (see later slides).
 

--- a/src/ownership/move-semantics.md
+++ b/src/ownership/move-semantics.md
@@ -1,6 +1,6 @@
 # Move Semantics
 
-An assignment will transfer ownership between variables:
+An assignment will transfer _ownership_ between variables:
 
 ```rust,editable
 fn main() {
@@ -12,7 +12,6 @@ fn main() {
 ```
 
 * The assignment of `s1` to `s2` transfers ownership.
-* The data was _moved_ from `s1` and `s1` is no longer accessible.
 * When `s1` goes out of scope, nothing happens: it has no ownership.
 * When `s2` goes out of scope, the string data is freed.
 * There is always _exactly_ one variable binding which owns a value.
@@ -20,6 +19,10 @@ fn main() {
 <details>
 
 * Mention that this is the opposite of the defaults in C++, which copies by value unless you use `std::move` (and the move constructor is defined!).
+
+* Data is not moved when you do `s2 = s1`, it is only the ownership that moves.
+
+* Simple values (such as integers) can be marked `Copy` (see later slides).
 
 * In Rust, clones are explicit (by using `clone`).
 

--- a/src/ownership/move-semantics.md
+++ b/src/ownership/move-semantics.md
@@ -12,7 +12,7 @@ fn main() {
 ```
 
 * The assignment of `s1` to `s2` transfers ownership.
-* When `s1` goes out of scope, nothing happens: it has no ownership.
+* When `s1` goes out of scope, nothing happens: it does not own anything.
 * When `s2` goes out of scope, the string data is freed.
 * There is always _exactly_ one variable binding which owns a value.
 
@@ -20,7 +20,7 @@ fn main() {
 
 * Mention that this is the opposite of the defaults in C++, which copies by value unless you use `std::move` (and the move constructor is defined!).
 
-* Data is not moved when you do `s2 = s1`, it is only the ownership that moves.
+* It is only the ownership that moves. Whether the resulting machine code copies any data around is a matter of optimization, and such copies are aggressively optimized away.
 
 * Simple values (such as integers) can be marked `Copy` (see later slides).
 


### PR DESCRIPTION
The distinction between non-`Copy` and `Copy` types is tricky to explain. One problem is that people often focus on _moving_ vs _copying_ when both variable types always copy data.

This PR removes the statement about moving data (since that is wrong on its own).