### PR TITLE
Fix broken module example

### DIFF
--- a/src/modules/filesystem.md
+++ b/src/modules/filesystem.md
@@ -62,7 +62,7 @@ pub fn harvest(garden: &mut Garden) { todo!() }
 
   ```rust,ignore
   #[path = "some/path.rs"]
-  mod some_module { }
+  mod some_module;
   ```
 
   This is useful, for example, if you would like to place tests for a module in a file named


### PR DESCRIPTION
The module is external, so it should not have curly braces.