### PR TITLE
Move to more legible types

### DIFF
--- a/src/basic-syntax/scalar-types.md
+++ b/src/basic-syntax/scalar-types.md
@@ -40,4 +40,7 @@ There are a few syntaxes which are not shown above:
   }
   ```
 
+- All underscores in numbers can be left out, they are for legibility only.
+  So `1_000` can be written as `1000` (or `10_00`), and `123_i64` can be written as `123i64`.
+
 </details>

--- a/src/basic-syntax/scalar-types.md
+++ b/src/basic-syntax/scalar-types.md
@@ -1,13 +1,13 @@
 # Scalar Types
 
-|                        | Types                                      | Literals                      |
-|------------------------|--------------------------------------------|-------------------------------|
-| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, `1_000`, `123i64` |
-| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, `123`, `10u16`           |
-| Floating point numbers | `f32`, `f64`                               | `3.14`, `-10.0e20`, `2f32`    |
-| Strings                | `&str`                                     | `"foo"`, `"two\nlines"`       |
-| Unicode scalar values  | `char`                                     | `'a'`, `'α'`, `'∞'`           |
-| Booleans               | `bool`                                     | `true`, `false`               |
+|                        | Types                                      | Literals                       |
+|------------------------|--------------------------------------------|--------------------------------|
+| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, `1_000`, `123_i64` |
+| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, `123`, `10_u16`           |
+| Floating point numbers | `f32`, `f64`                               | `3.14`, `-10.0e20`, `2_f32`    |
+| Strings                | `&str`                                     | `"foo"`, `"two\nlines"`        |
+| Unicode scalar values  | `char`                                     | `'a'`, `'α'`, `'∞'`            |
+| Booleans               | `bool`                                     | `true`, `false`                |
 
 The types have widths as follows:
 


### PR DESCRIPTION
There is some Clippy lint (cannot find it right now) that suggests this change, and I think it's reasonable.
`321i32` vs `321_i32` - I got a clear favorite.