### PR TITLE
Static variables don't need unsafe

### DIFF
--- a/src/basic-syntax/static-and-const.md
+++ b/src/basic-syntax/static-and-const.md
@@ -41,9 +41,8 @@ fn main() {
 As noted in the [Rust RFC Book][1], these are not inlined upon use and have an actual associated memory location.  This is useful for unsafe and embedded code, and the variable lives through the entirety of the program execution.
 When a globally-scoped value does not have a reason to need object identity, `const` is generally preferred.
 
-
+Because `static` variables are accessible from any thread, they need to be guarded, for example by a [`Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html), or accessed using `unsafe` code.
 We will look at [mutating static data](../unsafe/mutable-static-variables.md) in the chapter on Unsafe Rust.
-Because `static` variables are accessible from any thread, mutable static variables require manual, unsafe, synchronization of accesses.
 
 <details>
 


### PR DESCRIPTION
Thix fixes a slight inaccuracy introduced in #912