### PR TITLE
'Stack Memory' slide isn't really showing stack memory

### DIFF
--- a/src/memory-management/stack.md
+++ b/src/memory-management/stack.md
@@ -1,7 +1,7 @@
-# Stack Memory
+# Stack and Heap Example
 
-Creating a `String` puts fixed-sized data on the stack and dynamically sized
-data on the heap:
+Creating a `String` puts fixed-sized metadata on the stack and dynamically sized
+data, the actual string, on the heap:
 
 ```rust,editable
 fn main() {
@@ -40,7 +40,7 @@ fn main() {
         // String provides no guarantees about its layout, so this could lead to
         // undefined behavior.
         unsafe {
-            let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);
+            let (ptr, capacity, len): (usize, usize, usize) = std::mem::transmute(s1);
             println!("ptr = {ptr:#x}, len = {len}, capacity = {capacity}");
         }
     }


### PR DESCRIPTION
The current "Stack Memory" slide talks about a data structure that mainly lives on the heap.
This PR aims to make this slide more generic, so it fits in the story.
It also fixes a bug in the unsafe code below.

An alternative idea for the future would be to show off a true stack value, like a `[0_u8; 1024]` here