### PR TITLE
Memory Management: Rework Scope-based Cons

### DIFF
--- a/src/memory-management/comparison.md
+++ b/src/memory-management/comparison.md
@@ -27,7 +27,8 @@ Here is a rough comparison of the memory management techniques.
   * Garbage collection pauses.
   * Destructor delays.
 * Scope-based like C++:
-  * Complex, opt-in by programmer.
+  * Circular references can lead to memory leaks
+  * Complex, opt-in by programmer (on C++).
   * Potential for use-after-free.
 * Compiler-enforced and scope-based like Rust:
   * Some upfront complexity.

--- a/src/memory-management/comparison.md
+++ b/src/memory-management/comparison.md
@@ -27,9 +27,9 @@ Here is a rough comparison of the memory management techniques.
   * Garbage collection pauses.
   * Destructor delays.
 * Scope-based like C++:
-  * Circular references can lead to memory leaks
   * Complex, opt-in by programmer (on C++).
-  * Potential for use-after-free.
+  * Circular references can lead to memory leaks
+  * Potential runtime overhead
 * Compiler-enforced and scope-based like Rust:
   * Some upfront complexity.
   * Can reject valid programs.


### PR DESCRIPTION
Trying to also capture Swift's ARC, I'm not sure if it's really scope-based but it's very close(?)

BTW: I have no idea how use-after-free can happen here?