### PR TITLE
Use non-generic default

### DIFF
--- a/src/structs/field-shorthand.md
+++ b/src/structs/field-shorthand.md
@@ -56,11 +56,11 @@ fn main() {
      }
      fn create_default() {
          let tmp = Person {
-             ..Default::default()
+             ..Person::default()
          };
          let tmp = Person {
              name: "Sam".to_string(),
-             ..Default::default()
+             ..Person::default()
          };
      }
      ```


### PR DESCRIPTION
This is what clippy (albeit pedantic) suggests (see https://rust-lang.github.io/rust-clippy/master/index.html#/default_trait_access ) and it feels less redundant to me.