### PR TITLE
Rename confusing 'Double Free'

### DIFF
--- a/src/ownership/double-free-modern-cpp.md
+++ b/src/ownership/double-free-modern-cpp.md
@@ -1,4 +1,4 @@
-# Double Frees in Modern C++
+# Extra Work in Modern C++ 
 
 Modern C++ solves this differently:
 


### PR DESCRIPTION
Doble Free is commonly known as a vulnerability name, and also, this C++ also needs to allocate twice and copy.

Edit: 1000th PR 🎉