### PR TITLE
Add Mutex information to Rc slide

### DIFF
--- a/src/std/rc.md
+++ b/src/std/rc.md
@@ -17,14 +17,15 @@ fn main() {
 
 * If you need to mutate the data inside an `Rc`, you will need to wrap the data in
   a type such as [`Cell` or `RefCell`][2].
-* See [`Arc`][3] if you are in a multi-threaded context.
-* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create cycles
+* See [`Arc`][3] and [`Mutex`][4] if you are in a multi-threaded context.
+* You can *downgrade* a shared pointer into a [`Weak`][5] pointer to create cycles
   that will get dropped.
 
 [1]: https://doc.rust-lang.org/std/rc/struct.Rc.html
 [2]: https://doc.rust-lang.org/std/cell/index.html
 [3]: ../concurrency/shared_state/arc.md
-[4]: https://doc.rust-lang.org/std/rc/struct.Weak.html
+[4]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
+[5]: https://doc.rust-lang.org/std/rc/struct.Weak.html
 
 <details>
 


### PR DESCRIPTION
`RefCell` usually needs to be replaced with `Mutex` if `Rc` is replaced with `Arc`