### PR TITLE
Update while-let-expressions.md

### DIFF
--- a/src/control-flow/while-let-expressions.md
+++ b/src/control-flow/while-let-expressions.md
@@ -14,7 +14,7 @@ fn main() {
 }
 ```
 
-Here the iterator returned by `v.iter()` will return a `Option<i32>` on every
+Here the iterator returned by `v.into_iter()` will return a `Option<i32>` on every
 call to `next()`. It returns `Some(x)` until it is done, after which it will
 return `None`. The `while let` lets us keep iterating through all items.
 


### PR DESCRIPTION
Update code snippet description to use `v.into_iter()` instead of `v.iter()` since the former is what's actually used in the code snippet.