### PR TITLE
Move `thread::spawn` to separate function

### DIFF
--- a/src/concurrency/scoped-threads.md
+++ b/src/concurrency/scoped-threads.md
@@ -5,12 +5,15 @@ Normal threads cannot borrow from their environment:
 ```rust,editable,compile_fail
 use std::thread;
 
-fn main() {
+fn foo() {
     let s = String::from("Hello");
-
     thread::spawn(|| {
         println!("Length: {}", s.len());
     });
+}
+
+fn main() {
+    foo();
 }
 ```
 


### PR DESCRIPTION
This might make it clearer why the thread cannot borrow from the string.

@djmitche, do you think this is worth the extra vertical space?