### PR TITLE
Use `Arc::clone` instead of `.clone()`

### DIFF
--- a/src/exercises/concurrency/dining-philosophers.rs
+++ b/src/exercises/concurrency/dining-philosophers.rs
@@ -62,8 +62,8 @@ fn main() {
 
     for i in 0..forks.len() {
         let tx = tx.clone();
-        let mut left_fork = forks[i].clone();
-        let mut right_fork = forks[(i + 1) % forks.len()].clone();
+        let mut left_fork = Arc::clone(&forks[i]);
+        let mut right_fork = Arc::clone(&forks[(i + 1) % forks.len()]);
 
         // To avoid a deadlock, we have to break the symmetry
         // somewhere. This will swap the forks without deinitializing


### PR DESCRIPTION
The fully qualified syntax is recommended for `Arc` which implements all methods as associated methods.