### PR TITLE
Revert "`std::mem::drop` is in the prelude"

### DIFF
--- a/src/traits/drop.md
+++ b/src/traits/drop.md
@@ -34,7 +34,7 @@ fn main() {
 Discussion points:
 
 * Why doesn't `Drop::drop` take `self`?
-    * Short-answer: If it did, `drop` would be called at the end of
+    * Short-answer: If it did, `std::mem::drop` would be called at the end of
         the block, resulting in another call to `Drop::drop`, and a stack
         overflow!
 * Try replacing `drop(a)` with `a.drop()`.


### PR DESCRIPTION
Reverts google/comprehensive-rust#1027

We discussed it and it seems nicer to spell out the full function name in the text.