### PR TITLE
Expand "iff" to "if and only if"

### DIFF
--- a/src/concurrency/shared_state/arc.md
+++ b/src/concurrency/shared_state/arc.md
@@ -28,8 +28,8 @@ fn main() {
 
 * `Arc` stands for "Atomic Reference Counted", a thread safe version of `Rc` that uses atomic
   operations.
-* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` and `Sync` iff
-  (if and only if) `T` implements them both.
+* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` and `Sync` if
+  and only if `T` implements them both.
 * `Arc::clone()` has the cost of atomic operations that get executed, but after that the use of the
   `T` is free.
 * Beware of reference cycles, `Arc` does not use a garbage collector to detect them.

--- a/src/concurrency/shared_state/arc.md
+++ b/src/concurrency/shared_state/arc.md
@@ -28,8 +28,8 @@ fn main() {
 
 * `Arc` stands for "Atomic Reference Counted", a thread safe version of `Rc` that uses atomic
   operations.
-* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` and `Sync` iff `T`
-  implements them both.
+* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` and `Sync` iff
+  (if and only if) `T` implements them both.
 * `Arc::clone()` has the cost of atomic operations that get executed, but after that the use of the
   `T` is free.
 * Beware of reference cycles, `Arc` does not use a garbage collector to detect them.


### PR DESCRIPTION
There has been a few PRs which wanted to change "iff" to "if". Expanding it should help, but we might also consider using less heavy math jargon.