### PR TITLE
Remove confusing text in variables.md

### DIFF
--- a/src/basic-syntax/variables.md
+++ b/src/basic-syntax/variables.md
@@ -15,6 +15,5 @@ fn main() {
 <details>
 
 * Due to type inference the `i32` is optional. We will gradually show the types less and less as the course progresses.
-* Note that since `println!` is a macro, `x` is not moved, even using the function like syntax of `println!("x: {}", x)`
 
 </details>


### PR DESCRIPTION
We have not yet talked about copy/move here, so the notes were confusing.

Fixes #519.