### PR TITLE
Update for-loops.md to remove misleading sentence

### DIFF
--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -85,7 +85,7 @@ preview of issues of ownership that will come later in the afternoon.
 Without the `&`...
 * The loop would have been one that consumes the array.  This is a
   change [introduced in the 2021
-  Edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)
+  Edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html).
 * An implicit array copy would have occured.  Since `i32` is a copy type, then
   `[i32; 3]` is also a copy type.
 

--- a/src/exercises/day-1/for-loops.md
+++ b/src/exercises/day-1/for-loops.md
@@ -85,9 +85,8 @@ preview of issues of ownership that will come later in the afternoon.
 Without the `&`...
 * The loop would have been one that consumes the array.  This is a
   change [introduced in the 2021
-  Edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html), and ...
-* since the array is also accessed in the second loop, an implicit
-  array copy would have occured; since `i32` is a copy type, then
+  Edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)
+* An implicit array copy would have occured.  Since `i32` is a copy type, then
   `[i32; 3]` is also a copy type.
 
 </details>


### PR DESCRIPTION
Drops the comment about usage in the other loop.  It's not related to the focus on copy semantics, and so we want to eliminate that possible confusion.