### PR TITLE
zh-CN: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -11,29 +11,29 @@ msgstr ""
 "Language: zh-Hans\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr ""
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
-msgstr ""
+msgstr "授课"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
-msgstr ""
+msgstr "课程结构"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "键盘快捷键"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
-msgstr ""
+msgstr "翻译"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
-msgstr ""
+msgstr "使用 Cargo"
 
 #: src/SUMMARY.md:9
 msgid "Rust Ecosystem"
@@ -56,55 +56,55 @@ msgstr "第一天：早上"
 msgid "Welcome"
 msgstr "欢迎"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "什么是 Rust？"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
-msgstr ""
+msgstr "Hello World!"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "简短示例"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "为什么选择 Rust？"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "编译期保障"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "运行时保障"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "现代特性"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "基本语法"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "标量类型"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "复合类型"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "引用"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "悬垂引用"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "切片"
 
@@ -112,15 +112,16 @@ msgstr "切片"
 msgid "String vs str"
 msgstr ""
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "函数"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
-msgstr ""
+msgstr "Rustdoc"
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "方法"
 
@@ -131,10 +132,14 @@ msgstr "重载"
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
 #: src/SUMMARY.md:251 src/SUMMARY.md:273 src/SUMMARY.md:293
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
+#: src/exercises/concurrency/morning.md:1
+#: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "习题"
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "隐式类型转换"
 
@@ -146,11 +151,11 @@ msgstr "数组与 for 循环"
 msgid "Day 1: Afternoon"
 msgstr "第 1 天：下午"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "变量"
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "类型推导"
 
@@ -158,29 +163,29 @@ msgstr "类型推导"
 msgid "static & const"
 msgstr ""
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
-msgstr ""
+msgstr "作用域和隐藏 (Shadowing)"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
-msgstr ""
+msgstr "内存管理"
 
 #: src/SUMMARY.md:48
 msgid "Stack vs Heap"
 msgstr ""
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
-msgstr ""
+msgstr "栈内存"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
-msgstr ""
+msgstr "手动内存管理"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
-msgstr ""
+msgstr "基于作用域的内存管理"
 
 #: src/SUMMARY.md:52
 msgid "Garbage Collection"
@@ -190,59 +195,60 @@ msgstr ""
 msgid "Rust Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
-msgstr ""
+msgstr "比较"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
-msgstr ""
+msgstr "所有权"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
-msgstr ""
+msgstr "移动语义"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
-msgstr ""
+msgstr "Rust 中移动的字符串"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
-msgstr ""
+msgstr "现代 C++ 中的双重释放"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
-msgstr ""
+msgstr "函数调用中的移动"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
-msgstr ""
+msgstr "复制和克隆"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
-msgstr ""
+msgstr "借用"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
-msgstr ""
+msgstr "共享和唯一的借用"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
-msgstr ""
+msgstr "生命周期"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
-msgstr ""
+msgstr "函数调用中的生命周期"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
-msgstr ""
+msgstr "数据结构中的生命周期"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr ""
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr ""
 
@@ -250,63 +256,64 @@ msgstr ""
 msgid "Day 2: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
-msgstr ""
+msgstr "结构体"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
-msgstr ""
+msgstr "元组结构体"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
-msgstr ""
+msgstr "字段简写语法"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
-msgstr ""
+msgstr "枚举"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
-msgstr ""
+msgstr "变体载荷"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
-msgstr ""
+msgstr "枚举大小"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr ""
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:272
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
-msgstr ""
+msgstr "示例"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "模式匹配"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr ""
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr ""
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "解构数组"
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr ""
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "健康统计"
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr ""
 
@@ -314,13 +321,13 @@ msgstr ""
 msgid "Day 2: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:96 src/SUMMARY.md:286
+#: src/SUMMARY.md:96 src/SUMMARY.md:286 src/control-flow.md:1
 msgid "Control Flow"
-msgstr ""
+msgstr "控制流"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
-msgstr ""
+msgstr "块"
 
 #: src/SUMMARY.md:98
 msgid "if expressions"
@@ -354,17 +361,17 @@ msgstr ""
 msgid "break & continue"
 msgstr ""
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
-msgstr ""
+msgstr "标准库"
 
 #: src/SUMMARY.md:107
 msgid "Option and Result"
 msgstr ""
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
-msgstr ""
+msgstr "String"
 
 #: src/SUMMARY.md:109
 msgid "Vec"
@@ -382,35 +389,37 @@ msgstr ""
 msgid "Recursive Data Types"
 msgstr ""
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
-msgstr ""
+msgstr "小众优化"
 
 #: src/SUMMARY.md:114
 msgid "Rc"
 msgstr ""
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr ""
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr ""
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr ""
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr ""
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr ""
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:97
 msgid "Strings and Iterators"
 msgstr ""
 
@@ -418,57 +427,57 @@ msgstr ""
 msgid "Day 3: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/generics.md:1
 msgid "Generics"
-msgstr ""
+msgstr "泛型"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/generics/data-types.md:1
 msgid "Generic Data Types"
-msgstr ""
+msgstr "通用数据类型"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/generics/methods.md:1
 msgid "Generic Methods"
-msgstr ""
+msgstr "泛型方法"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/generics/monomorphization.md:1
 msgid "Monomorphization"
-msgstr ""
+msgstr "单态化"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits.md:1
 msgid "Traits"
-msgstr ""
+msgstr "特征"
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/trait-objects.md:1
 msgid "Trait Objects"
-msgstr ""
+msgstr "特征（Trait）对象"
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
-msgstr ""
+msgstr "派生特征"
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md:136 src/traits/default-methods.md:1
 msgid "Default Methods"
-msgstr ""
+msgstr "默认方法"
 
-#: src/SUMMARY.md:137
+#: src/SUMMARY.md:137 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
-msgstr ""
+msgstr "特征边界"
 
 #: src/SUMMARY.md:138
 msgid "impl Trait"
 msgstr ""
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/traits/important-traits.md:1
 msgid "Important Traits"
-msgstr ""
+msgstr "重要特征"
 
 #: src/SUMMARY.md:140
 msgid "Iterator"
 msgstr ""
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/traits/from-iterator.md:1
 msgid "FromIterator"
-msgstr ""
+msgstr "FromIterator"
 
 #: src/SUMMARY.md:142
 msgid "From and Into"
@@ -494,7 +503,8 @@ msgstr ""
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr ""
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr ""
 
@@ -502,13 +512,13 @@ msgstr ""
 msgid "Day 3: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
-msgstr ""
+msgstr "错误处理"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
-msgstr ""
+msgstr "Panics"
 
 #: src/SUMMARY.md:155
 msgid "Catching Stack Unwinding"
@@ -522,93 +532,96 @@ msgstr ""
 msgid "Propagating Errors with ?"
 msgstr ""
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
-msgstr ""
+msgstr "转换错误类型"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
-msgstr ""
+msgstr "派生错误枚举"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
-msgstr ""
+msgstr "动态错误类型"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
-msgstr ""
+msgstr "为错误添加背景信息"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
-msgstr ""
+msgstr "测试"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
-msgstr ""
+msgstr "单元测试"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
-msgstr ""
+msgstr "测试模块"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
-msgstr ""
+msgstr "文档测试"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
-msgstr ""
+msgstr "集成测试"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr ""
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
-msgstr ""
+msgstr "不安全 Rust"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
-msgstr ""
+msgstr "解引用裸指针"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
-msgstr ""
+msgstr "可变的静态变量"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
-msgstr ""
+msgstr "联合体"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
-msgstr ""
+msgstr "调用 Unsafe 函数"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
-msgstr ""
+msgstr "编写 Unsafe 函数"
 
 #: src/SUMMARY.md:175
 msgid "Extern Functions"
 msgstr ""
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
-msgstr ""
+msgstr "实现 Unsafe Trait"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr ""
 
 #: src/SUMMARY.md:181 src/SUMMARY.md:249
+#: src/running-the-course/course-structure.md:16 src/bare-metal/android.md:1
 msgid "Android"
-msgstr ""
+msgstr "Android"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/android/setup.md:1
 msgid "Setup"
-msgstr ""
+msgstr "设置"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/android/build-rules.md:1
 msgid "Build Rules"
-msgstr ""
+msgstr "构建规则"
 
 #: src/SUMMARY.md:188
 msgid "Binary"
@@ -618,7 +631,7 @@ msgstr ""
 msgid "Library"
 msgstr ""
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/android/aidl.md:1
 msgid "AIDL"
 msgstr ""
 
@@ -634,23 +647,24 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:194 src/android/aidl/deploy.md:1
 msgid "Deploy"
-msgstr ""
+msgstr "部署"
 
 #: src/SUMMARY.md:195
 msgid "Client"
 msgstr ""
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:196 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr ""
 
-#: src/SUMMARY.md:197 src/SUMMARY.md:240
+#: src/SUMMARY.md:197 src/SUMMARY.md:240 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr ""
 
@@ -666,7 +680,7 @@ msgstr ""
 msgid "Calling Rust from C"
 msgstr ""
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr ""
 
@@ -690,11 +704,11 @@ msgstr ""
 msgid "alloc"
 msgstr ""
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr ""
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr ""
 
@@ -722,7 +736,7 @@ msgstr ""
 msgid "probe-rs, cargo-embed"
 msgstr ""
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr ""
 
@@ -730,7 +744,8 @@ msgstr ""
 msgid "Other Projects"
 msgstr ""
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:226 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr ""
 
@@ -762,7 +777,7 @@ msgstr ""
 msgid "A Better UART Driver"
 msgstr ""
 
-#: src/SUMMARY.md:236
+#: src/SUMMARY.md:236 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr ""
 
@@ -770,7 +785,7 @@ msgstr ""
 msgid "Multiple Registers"
 msgstr ""
 
-#: src/SUMMARY.md:238
+#: src/SUMMARY.md:238 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr ""
 
@@ -802,7 +817,7 @@ msgstr ""
 msgid "spin"
 msgstr ""
 
-#: src/SUMMARY.md:250
+#: src/SUMMARY.md:250 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr ""
 
@@ -814,25 +829,25 @@ msgstr ""
 msgid "Concurrency: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:260
+#: src/SUMMARY.md:260 src/concurrency/threads.md:1
 msgid "Threads"
-msgstr ""
+msgstr "线程"
 
-#: src/SUMMARY.md:261
+#: src/SUMMARY.md:261 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
-msgstr ""
+msgstr "范围线程"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:262 src/concurrency/channels.md:1
 msgid "Channels"
-msgstr ""
+msgstr "通道"
 
-#: src/SUMMARY.md:263
+#: src/SUMMARY.md:263 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
-msgstr ""
+msgstr "无界通道"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
-msgstr ""
+msgstr "有界通道"
 
 #: src/SUMMARY.md:265
 msgid "Send and Sync"
@@ -846,13 +861,13 @@ msgstr ""
 msgid "Sync"
 msgstr ""
 
-#: src/SUMMARY.md:268
+#: src/SUMMARY.md:268 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
-msgstr ""
+msgstr "示例"
 
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md:269 src/concurrency/shared_state.md:1
 msgid "Shared State"
-msgstr ""
+msgstr "共享状态"
 
 #: src/SUMMARY.md:270
 msgid "Arc"
@@ -863,10 +878,12 @@ msgid "Mutex"
 msgstr ""
 
 #: src/SUMMARY.md:274 src/SUMMARY.md:294
+#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr ""
 
-#: src/SUMMARY.md:275
+#: src/SUMMARY.md:275 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr ""
 
@@ -882,31 +899,32 @@ msgstr ""
 msgid "async/await"
 msgstr ""
 
-#: src/SUMMARY.md:281
+#: src/SUMMARY.md:281 src/async/futures.md:1
 msgid "Futures"
 msgstr ""
 
-#: src/SUMMARY.md:282
+#: src/SUMMARY.md:282 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr ""
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md:283 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr ""
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/exercises/concurrency/link-checker.md:106
+#: src/exercises/concurrency/chat-app.md:140 src/async/tasks.md:1
 msgid "Tasks"
 msgstr ""
 
-#: src/SUMMARY.md:285
+#: src/SUMMARY.md:285 src/async/channels.md:1
 msgid "Async Channels"
 msgstr ""
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:287 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:288
+#: src/SUMMARY.md:288 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
@@ -918,15 +936,16 @@ msgstr ""
 msgid "Blocking the Executor"
 msgstr ""
 
-#: src/SUMMARY.md:291
+#: src/SUMMARY.md:291 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr ""
 
-#: src/SUMMARY.md:292
+#: src/SUMMARY.md:292 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr ""
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md:295 src/exercises/concurrency/chat-app.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:113
 msgid "Broadcast Chat Application"
 msgstr ""
 
@@ -934,7 +953,7 @@ msgstr ""
 msgid "Final Words"
 msgstr ""
 
-#: src/SUMMARY.md:302
+#: src/SUMMARY.md:302 src/thanks.md:1
 msgid "Thanks!"
 msgstr ""
 
@@ -942,11 +961,11 @@ msgstr ""
 msgid "Other Resources"
 msgstr ""
 
-#: src/SUMMARY.md:304
+#: src/SUMMARY.md:304 src/credits.md:1
 msgid "Credits"
-msgstr ""
+msgstr "鸣谢"
 
-#: src/SUMMARY.md:307
+#: src/SUMMARY.md:307 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr ""
 
@@ -978,7 +997,7 @@ msgstr ""
 msgid "Bare Metal Rust Morning"
 msgstr ""
 
-#: src/SUMMARY.md:319
+#: src/SUMMARY.md:319 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr ""
 
@@ -988,10 +1007,6 @@ msgstr ""
 
 #: src/SUMMARY.md:321
 msgid "Concurrency Afternoon"
-msgstr ""
-
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
 msgstr ""
 
 #: src/welcome.md:3
@@ -1009,8 +1024,8 @@ msgstr ""
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 msgstr ""
@@ -1023,10 +1038,9 @@ msgstr ""
 msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
 #: src/welcome.md:5
@@ -1043,310 +1057,106 @@ msgstr ""
 #: src/welcome.md:7
 msgid ""
 "This is a three day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
+msgstr ""
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr ""
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
 msgstr ""
 
 #: src/welcome.md:18
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, "
-"you're\n"
-"invited to dive into one or more specialized topics:"
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
 
 #: src/welcome.md:21
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android "
-"platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a full day class on using Rust for bare-"
-"metal\n"
-"  (embedded) development. Both microcontrollers and application processors "
-"are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a full day class on concurrency in Rust. "
-"We\n"
-"  cover both classical concurrency (preemptively scheduling using threads "
-"and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
+msgstr ""
+
+#: src/welcome.md:23
+msgid ""
+"[Bare-metal](bare-metal.md): a full day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+
+#: src/welcome.md:26
+msgid ""
+"[Concurrency](concurrency.md): a full day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
 msgstr ""
 
 #: src/welcome.md:32
-msgid "## Non-Goals"
+msgid "Non-Goals"
 msgstr ""
 
 #: src/welcome.md:34
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 
 #: src/welcome.md:37
 msgid ""
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
 
 #: src/welcome.md:41
-msgid "## Assumptions"
+msgid "Assumptions"
 msgstr ""
 
 #: src/welcome.md:43
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/scalar-types.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/references.md:21
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/methods.md:32 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:100
-#: src/structs.md:29 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums.md:31
-#: src/enums/variant-payloads.md:33 src/enums/sizes.md:27 src/methods.md:28
-#: src/methods/receiver.md:22 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:21
-#: src/control-flow/while-let-expressions.md:24
-#: src/control-flow/for-expressions.md:23
-#: src/control-flow/loop-expressions.md:25
-#: src/control-flow/match-expressions.md:26 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:42 src/exercises/day-2/afternoon.md:5
-#: src/generics/data-types.md:19 src/generics/methods.md:23
-#: src/traits/trait-objects.md:70 src/traits/default-methods.md:30
-#: src/traits/trait-bounds.md:33 src/traits/impl-trait.md:21
-#: src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/drop.md:32 src/traits/default.md:38
-#: src/traits/operators.md:24 src/traits/closures.md:23
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:46
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:25 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:5
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/android/morning.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:37 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart.md:53 src/bare-metal/aps/uart/traits.md:22
-#: src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:49 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:44
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/scoped-threads.md:35 src/concurrency/channels.md:25
-#: src/concurrency/send-sync.md:18 src/concurrency/send-sync/send.md:11
-#: src/concurrency/send-sync/sync.md:12 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21
-#: src/exercises/concurrency/morning.md:10 src/async/async-await.md:23
-#: src/async/futures.md:30 src/async/runtimes.md:18
-#: src/async/runtimes/tokio.md:31 src/async/tasks.md:51
-#: src/async/channels.md:33 src/async/control-flow/join.md:34
-#: src/async/control-flow/select.md:59
-#: src/async/pitfalls/blocking-executor.md:27 src/async/pitfalls/pin.md:66
-#: src/exercises/concurrency/afternoon.md:11
-#: src/exercises/concurrency/dining-philosophers-async.md:75
-msgid "<details>"
-msgstr "<details>"
-
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
-#: src/why-rust/modern.md:66 src/basic-syntax/scalar-types.md:43
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:29
-#: src/basic-syntax/slices.md:36 src/basic-syntax/string-slices.md:44
-#: src/basic-syntax/functions.md:41 src/basic-syntax/rustdoc.md:33
-#: src/basic-syntax/methods.md:45 src/basic-syntax/functions-interlude.md:30
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:104
-#: src/structs.md:42 src/structs/tuple-structs.md:43
-#: src/structs/field-shorthand.md:72 src/enums.md:41
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:28 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:29
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:46
-#: src/control-flow/if-expressions.md:37
-#: src/control-flow/if-let-expressions.md:41
-#: src/control-flow/while-let-expressions.md:29
-#: src/control-flow/for-expressions.md:30
-#: src/control-flow/loop-expressions.md:32
-#: src/control-flow/match-expressions.md:33 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:42 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:71 src/exercises/day-2/afternoon.md:11
-#: src/generics/data-types.md:25 src/generics/methods.md:31
-#: src/traits/trait-objects.md:83 src/traits/default-methods.md:60
-#: src/traits/trait-bounds.md:50 src/traits/impl-trait.md:44
-#: src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/drop.md:42 src/traits/default.md:47
-#: src/traits/operators.md:38 src/traits/closures.md:38
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:53
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:43 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:11
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/android/morning.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:49
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/inline-assembly.md:58 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:55 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:49
-#: src/bare-metal/useful-crates/zerocopy.md:53
-#: src/bare-metal/useful-crates/aarch64-paging.md:33
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
-#: src/bare-metal/useful-crates/tinyvec.md:26
-#: src/bare-metal/useful-crates/spin.md:30 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/scoped-threads.md:40 src/concurrency/channels.md:32
-#: src/concurrency/send-sync.md:23 src/concurrency/send-sync/send.md:16
-#: src/concurrency/send-sync/sync.md:18 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56
-#: src/exercises/concurrency/morning.md:16 src/async/async-await.md:48
-#: src/async/futures.md:45 src/async/runtimes.md:29
-#: src/async/runtimes/tokio.md:49 src/async/tasks.md:64
-#: src/async/channels.md:49 src/async/control-flow/join.md:50
-#: src/async/control-flow/select.md:77
-#: src/async/pitfalls/blocking-executor.md:50 src/async/pitfalls/pin.md:112
-#: src/async/pitfalls/async-traits.md:63
-#: src/exercises/concurrency/afternoon.md:17
-#: src/exercises/concurrency/dining-philosophers-async.md:79
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# 授课"
-
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> 本页面适用于课程教师。"
+msgid "This page is for the course instructor."
+msgstr "本页面适用于课程教师。"
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
-msgstr ""
-"以下是有关 Google 内部授课方式的一些背景信息。"
+"course internally at Google."
+msgstr "以下是有关 Google 内部授课方式的一些背景信息。"
 
 #: src/running-the-course.md:8
 msgid "Before you run the course, you will want to:"
@@ -1354,233 +1164,193 @@ msgstr "在授课之前，你需要完成以下事项："
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   to help highlight the key points (please help us by contributing more "
-"speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes "
-"in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). "
-"This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Decide on the dates. Since the course takes at least three full days, we "
-"recommend that you\n"
-"   schedule the days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-25 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself "
-"and for the\n"
-"   students: you will all need to be able to sit and work with your "
-"laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, "
-"so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups.\n"
-"   We typically spend 30-45 minutes on exercises in the morning and in the "
-"afternoon (including time to review the solutions).\n"
-"   Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. 熟悉课程资料。我们添加了演讲者备注，"
-"借此强调要点（请帮个忙，多多贡献演讲者备注！）。"
-"演示幻灯片时，你应确保在弹出式窗口中"
-"打开演讲者备注（点击对应的链接，在“演讲者备注”旁边有一个小箭头）。这样，"
-"你就可以确保屏幕整洁有序，更好地向全班学员展示课程内容。\n"
-"\n"
-"1. 确定培训日期。由于本课程至少需要三天的时间，因此我们建议你"
-"安排两周以上的时间。课程学员曾表示，"
-"在每堂课之间留一段间隔会很有帮助，因为这有利于他们"
-"吸收我们所提供的所有信息。\n"
-"\n"
-"1. 找一间足以容纳全体线下学员的大教室。我们建议你"
-"将课程人数控制在 15-25 人之间。这样，人数足够少，"
-"不仅便于学员提问问题，配备的一位教师也有"
-"时间答疑解惑。确保教室备有供你和"
-"学生使用的“课桌”：你们都需要能够坐下来并操作各自的笔记本电脑。"
-"特别是身为教师，你现场要进行大量编码，所以讲台对你"
-"来说用处不大。\n"
-"\n"
-"1. 在开课当天，请提前一点到教室，设置好教学设备"
-"。我们建议你直接在"
-"笔记本电脑上运行 `mdbook serve` 来演示课程内容（请参阅[安装说明][3]）。这样可"
-"以确保你在切换页面时没有延迟，演示效果更好。"
-"当你或课程学员发现拼写错误时，"
-"你也可以使用笔记本电脑及时更正。"
-"\n"
-"1. 让学员采取小组形式或独立解题。"
-"通常，我们会在上午和下午各安排 30-45 分钟的练习时间"
-"（包括查看解决方案的时间）。请务必"
-"询问学员是否遇到困难，或是否需要任何帮助。如果你看到"
-"多位学员遇到同样的问题，请在班级集体进行讲解，"
-"并提供相应的解决方案，例如告诉大家在标准库的什么位置"
-"可以找到相关信息。"
+"熟悉课程资料。我们添加了演讲者备注，借此强调要点（请帮个忙，多多贡献演讲者备"
+"注！）。演示幻灯片时，你应确保在弹出式窗口中打开演讲者备注（点击对应的链接，"
+"在“演讲者备注”旁边有一个小箭头）。这样，你就可以确保屏幕整洁有序，更好地向全"
+"班学员展示课程内容。"
+
+#: src/running-the-course.md:16
+msgid ""
+"Decide on the dates. Since the course takes at least three full days, we "
+"recommend that you schedule the days over two weeks. Course participants "
+"have said that they find it helpful to have a gap in the course since it "
+"helps them process all the information we give them."
+msgstr ""
+"确定培训日期。由于本课程至少需要三天的时间，因此我们建议你安排两周以上的时"
+"间。课程学员曾表示，在每堂课之间留一段间隔会很有帮助，因为这有利于他们吸收我"
+"们所提供的所有信息。"
+
+#: src/running-the-course.md:21
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-25 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"找一间足以容纳全体线下学员的大教室。我们建议你将课程人数控制在 15-25 人之间。"
+"这样，人数足够少，不仅便于学员提问问题，配备的一位教师也有时间答疑解惑。确保"
+"教室备有供你和学生使用的“课桌”：你们都需要能够坐下来并操作各自的笔记本电脑。"
+"特别是身为教师，你现场要进行大量编码，所以讲台对你来说用处不大。"
+
+#: src/running-the-course.md:29
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"在开课当天，请提前一点到教室，设置好教学设备。我们建议你直接在笔记本电脑上运"
+"行 `mdbook serve` 来演示课程内容（请参阅[安装说明](https://github.com/google/"
+"comprehensive-rust#building)）。这样可以确保你在切换页面时没有延迟，演示效果"
+"更好。当你或课程学员发现拼写错误时，你也可以使用笔记本电脑及时更正。"
+
+#: src/running-the-course.md:35
+msgid ""
+"Let people solve the exercises by themselves or in small groups. We "
+"typically spend 30-45 minutes on exercises in the morning and in the "
+"afternoon (including time to review the solutions). Make sure to ask people "
+"if they're stuck or if there is anything you can help with. When you see "
+"that several people have the same problem, call it out to the class and "
+"offer a solution, e.g., by showing people where to find the relevant "
+"information in the standard library."
+msgstr ""
+"让学员采取小组形式或独立解题。通常，我们会在上午和下午各安排 30-45 分钟的练习"
+"时间（包括查看解决方案的时间）。请务必询问学员是否遇到困难，或是否需要任何帮"
+"助。如果你看到多位学员遇到同样的问题，请在班级集体进行讲解，并提供相应的解决"
+"方案，例如告诉大家在标准库的什么位置可以找到相关信息。"
 
 #: src/running-the-course.md:43
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
-msgstr ""
-"今天的分享就是这些，祝你授课顺利！希望你和我们一样，"
-"乐在其中！"
+"for you as it has been for us!"
+msgstr "今天的分享就是这些，祝你授课顺利！希望你和我们一样，乐在其中！"
 
 #: src/running-the-course.md:46
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"欢迎你课后[提供反馈][1]，帮助我们不断改进"
-"课程。我们非常期待了解哪些方面做得不错，哪些方面还需要"
-"改进。同时非常欢迎学生们[向我们发送反馈][2]！"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# 课程结构"
+"欢迎你课后[提供反馈](https://github.com/google/comprehensive-rust/"
+"discussions/86)，帮助我们不断改进课程。我们非常期待了解哪些方面做得不错，哪些"
+"方面还需要改进。同时非常欢迎学生们[向我们发送反馈](https://github.com/google/"
+"comprehensive-rust/discussions/100)！"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "本课程节奏紧凑，涵盖内容广泛："
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust."
-msgstr ""
-"* 第 1 天：Rust 的基础知识、所有权和借用检查器。\n"
-"* 第 2 天：复合数据类型、模式匹配和标准库。\n"
-"* 第 3 天：trait 和泛型、错误处理、测试和不安全 Rust。"
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "第 1 天：Rust 的基础知识、所有权和借用检查器。"
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
+msgstr "第 2 天：复合数据类型、模式匹配和标准库。"
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr "第 3 天：trait 和泛型、错误处理、测试和不安全 Rust。"
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
-msgstr "## 深入探究"
+msgid "Deep Dives"
+msgstr "深入探究"
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
-msgstr ""
-"除了为期 3 天的“Rust 基础知识”课程外，我们还推出了一些"
-"专题课程："
-
-#: src/running-the-course/course-structure.md:16
-msgid "### Android"
-msgstr "### Android"
+msgstr "除了为期 3 天的“Rust 基础知识”课程外，我们还推出了一些专题课程："
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
 "The [Android Deep Dive](../android.md) is a half-day course on using Rust "
-"for\n"
-"Android platform development. This includes interoperability with C, C++, "
-"and\n"
-"Java."
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
-"“[深入探究 Android](../android.md)”课程为期半天，旨在介绍如何使用 Rust 进行\n"
-"Android 平台开发。其中包括与 C、C++ 和 Java 的"
-"互操作性。"
+"“[深入探究 Android](../android.md)”课程为期半天，旨在介绍如何使用 Rust 进行 "
+"Android 平台开发。其中包括与 C、C++ 和 Java 的互操作性。"
 
 #: src/running-the-course/course-structure.md:22
 msgid ""
-"You will need an [AOSP checkout][1]. Make a checkout of the [course\n"
-"repository][2] on the same machine and move the `src/android/` directory "
-"into\n"
-"the root of your AOSP checkout. This will ensure that the Android build "
-"system\n"
-"sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"你将需要[签出 AOSP][1]。在同一机器上签出[课程库][2]，\n"
-"然后将 `src/android/` 目录移至"
-"所签出的 AOSP 的根目录。这将确保 Android 构建系统"
-"能检测到 `src/android/` 中的 `Android.bp` 文件。"
+"你将需要[签出 AOSP](https://source.android.com/docs/setup/download/"
+"downloading)。在同一机器上签出[课程库](https://github.com/google/"
+"comprehensive-rust)， 然后将 `src/android/` 目录移至所签出的 AOSP 的根目录。"
+"这将确保 Android 构建系统能检测到 `src/android/` 中的 `Android.bp` 文件。"
 
 #: src/running-the-course/course-structure.md:27
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
-"all\n"
-"Android examples using `src/android/build_all.sh`. Read the script to see "
-"the\n"
-"commands it runs and make sure they work when you run them by hand."
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"确保 `adb sync` 适用于你的模拟器或实际设备，\n"
-"并使用 `src/android/build_all.sh` 预构建所有 Android 示例。请阅读脚本，\n"
-"查看它所运行的命令，并确保这些命令能在你手动运行时正确执行。"
+"确保 `adb sync` 适用于你的模拟器或实际设备， 并使用 `src/android/build_all."
+"sh` 预构建所有 Android 示例。请阅读脚本， 查看它所运行的命令，并确保这些命令"
+"能在你手动运行时正确执行。"
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
-msgstr "### 裸机"
+msgid "Bare-Metal"
+msgstr "裸机"
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
 "The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
-"for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
-"“[深入探究裸机](../bare-metal.md)”课程为期一天，旨在介绍如何使用 Rust 进行"
-"裸机（嵌入式）开发。其中涵盖了微控制器和应用\n"
-"处理器。"
+"“[深入探究裸机](../bare-metal.md)”课程为期一天，旨在介绍如何使用 Rust 进行裸"
+"机（嵌入式）开发。其中涵盖了微控制器和应用 处理器。"
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
-"对于微控制器部分，你需要提前购买\n"
-"[BBC micro:bit](https://microbit.org/) 第 2 版开发板。每个人"
-"都需要安装多个软件包，\n"
-"具体如[欢迎页面](../bare-metal.md)中所述。"
+"对于微控制器部分，你需要提前购买 [BBC micro:bit](https://microbit.org/) 第 2 "
+"版开发板。每个人都需要安装多个软件包， 具体如[欢迎页面](../bare-metal.md)中所"
+"述。"
 
 #: src/running-the-course/course-structure.md:45
-msgid "### Concurrency"
-msgstr "### 并发"
+msgid "Concurrency"
+msgstr "并发"
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
 "The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
-"classical\n"
-"as well as `async`/`await` concurrency."
+"classical as well as `async`/`await` concurrency."
 msgstr ""
-"“[深入探究并发](../concurrency.md)”课程为期一天，旨在介绍传统并发"
-"和 `async`/`await` 并发。"
+"“[深入探究并发](../concurrency.md)”课程为期一天，旨在介绍传统并发和 `async`/"
+"`await` 并发。"
 
 #: src/running-the-course/course-structure.md:50
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
-"to\n"
-"go. You can then copy/paste the examples into `src/main.rs` to experiment "
-"with\n"
-"them:"
+"to go. You can then copy/paste the examples into `src/main.rs` to experiment "
+"with them:"
 msgstr ""
-"你需要设置一个新 crate，下载所需的依赖项，\n"
-"做好课前准备。然后，你可以将示例复制/粘贴到 `src/main.rs` 中，\n"
-"以便对以下代码进行实验："
+"你需要设置一个新 crate，下载所需的依赖项， 做好课前准备。然后，你可以将示例复"
+"制/粘贴到 `src/main.rs` 中， 以便对以下代码进行实验："
 
 #: src/running-the-course/course-structure.md:54
 msgid ""
@@ -1599,56 +1369,74 @@ msgstr ""
 "```"
 
 #: src/running-the-course/course-structure.md:61
-msgid "## Format"
-msgstr "## 课程形式"
+msgid "Format"
+msgstr "课程形式"
 
 #: src/running-the-course/course-structure.md:63
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
-msgstr ""
-"本课程的互动性非常强，\n"
-"建议你以问题驱动探索 Rust！"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# 键盘快捷键"
+msgstr "本课程的互动性非常强， 建议你以问题驱动探索 Rust！"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "mdBook 中有一些实用键盘快捷键："
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>向左箭头</kbd>：转到上一页。\n"
-"* <kbd>向右箭头</kbd>：转到下一页。\n"
-"* <kbd>Ctrl + Enter</kbd>：执行具有焦点的代码示例。\n"
-"* <kbd>s</kbd>：激活搜索栏。"
+msgid "Arrow-Left"
+msgstr "向左箭头"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# 翻译"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr "：转到上一页。"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "向右箭头"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr "：转到下一页。"
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr "：执行具有焦点的代码示例。"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr "：激活搜索栏。"
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
-msgstr ""
-"一批优秀的志愿者已将本课程"
-"翻译成其他语言："
+msgstr "一批优秀的志愿者已将本课程翻译成其他语言："
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"\\[Brazilian Portuguese\\]\\[pt-BR\\] by \\[@rastringer\\] and "
+"\\[@hugojacob\\]."
 msgstr ""
-"* [巴西葡萄牙语][pt-BR]：[@rastringer] 和 [@hugojacob]。\n"
-"* [韩语][ko]：[@keispace]、[@jiyongp] 和 [@jooyunghan]。"
+"[巴西葡萄牙语](https://google.github.io/comprehensive-rust/pt-BR/)："
+"[@rastringer](https://github.com/rastringer) 和 [@hugojacob](https://github."
+"com/hugojacob)。"
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"\\[Korean\\]\\[ko\\] by \\[@keispace\\], \\[@jiyongp\\] and "
+"\\[@jooyunghan\\]."
+msgstr ""
+"[韩语](https://google.github.io/comprehensive-rust/ko/)：[@keispace](https://"
+"github.com/keispace)、[@jiyongp](https://github.com/jiyongp) 和 [@jooyunghan]"
+"(https://github.com/jooyunghan)。"
 
 #: src/running-the-course/translations.md:9
 msgid ""
@@ -1657,49 +1445,41 @@ msgstr "使用右上角的语言选择器切换语言。"
 
 #: src/running-the-course/translations.md:20
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see \\[our instructions\\] for "
+"how to get going. Translations are coordinated on the \\[issue tracker\\]."
 msgstr ""
-"如果你想参与其中，请参阅[我们的说明]，\n"
-"了解如何开始翻译。翻译工作将通过[问题跟踪器]进行协调。"
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# 使用 Cargo"
+"如果你想参与其中，请参阅\\[我们的说明\\]， 了解如何开始翻译。翻译工作将通过"
+"\\[问题跟踪器\\]进行协调。"
 
 #: src/cargo.md:3
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
 "开始了解 Rust 后，你很快就会遇到 [Cargo](https://doc.rust-lang.org/cargo/)，"
-"这是 Rust 生态系统中\n"
-"用于构建和运行 Rust 应用的标准工具。在这里，我们希望\n"
-"简要介绍一下什么是 Cargo，它如何融入更广泛的生态系统，\n"
-"以及我们如何在本培训中合理利用 Cargo。"
+"这是 Rust 生态系统中 用于构建和运行 Rust 应用的标准工具。在这里，我们希望 简"
+"要介绍一下什么是 Cargo，它如何融入更广泛的生态系统， 以及我们如何在本培训中合"
+"理利用 Cargo。"
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## 安装"
+msgid "Installation"
+msgstr "安装"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup（推荐）"
+msgid "Rustup (Recommended)"
+msgstr "Rustup（推荐）"
 
 #: src/cargo.md:12
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
-"你可以按照说明，使用由 Rust 基金会维护的 [rustup][3] 工具安装 cargo 和 rust "
-"编译器，以及其他标准的生态系统工具。"
+"你可以按照说明，使用由 Rust 基金会维护的 [rustup](https://rust-analyzer."
+"github.io/) 工具安装 cargo 和 rust 编译器，以及其他标准的生态系统工具。"
 
 #: src/cargo.md:14
 msgid ""
@@ -1711,20 +1491,20 @@ msgstr ""
 "具链、设置交叉编译等。"
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### 软件包管理系统"
+msgid "Package Managers"
+msgstr "软件包管理系统"
 
 #: src/cargo.md:18
-msgid "#### Debian"
-msgstr "#### Debian"
+msgid "Debian"
+msgstr "Debian"
 
 #: src/cargo.md:20
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
 "在 Debian/Ubuntu 上，你可以通过以下方式安装 Cargo、Rust 源代码和 [Rust 格式设"
-"置工具][6]："
+"置工具](https://github.com/rust-lang/rustfmt)："
 
 #: src/cargo.md:22
 msgid ""
@@ -1738,27 +1518,29 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"这将允许 [rust-analyzer][1] 跳到定义。我们建议使用\n"
-"[VS Code][2] 来编写代码（也可使用任何兼容 LSP 的编辑器）。"
+"这将允许 \\[rust-analyzer\\]\\[1\\] 跳到定义。我们建议使用 [VS Code](https://"
+"code.visualstudio.com/) 来编写代码（也可使用任何兼容 LSP 的编辑器）。"
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"有些人还喜欢使用 [JetBrains][4] IDE 系列自行分析，但会根据自身情况加以权衡。"
-"如果你想使用这些工具，可以安装 [Rust 插件][5]。请注意，自 2023 年 1 月起，调"
-"试仅适用于 CLion 版本的 JetBrains IDEA 套件。"
+"有些人还喜欢使用 [JetBrains](https://www.jetbrains.com/clion/) IDE 系列自行分"
+"析，但会根据自身情况加以权衡。如果你想使用这些工具，可以安装 [Rust 插件]"
+"(https://www.jetbrains.com/rust/)。请注意，自 2023 年 1 月起，调试仅适用于 "
+"CLion 版本的 JetBrains IDEA 套件。"
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# Rust 生态系统"
+msgid "The Rust Ecosystem"
+msgstr "Rust 生态系统"
 
 #: src/cargo/rust-ecosystem.md:3
 msgid ""
@@ -1767,37 +1549,32 @@ msgstr "Rust 生态系统由许多工具组成，其中的主要工具包括："
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
+msgstr "`rustc`：Rust 编译器，可将 `.rs` 文件转换为二进制文件和其他 中间格式。"
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
 msgstr ""
-"* `rustc`：Rust 编译器，可将 `.rs` 文件转换为二进制文件和其他\n"
-"中间格式。\n"
-"\n"
-"* `cargo`：Rust 依赖项管理器和构建工具。Cargo 知道如何\n"
-"下载托管在 <https://crates.io> 上的依赖项，并在构建项目时将它们\n"
-"传递给 `rustc`。Cargo 还附带一个内置的\n"
-"测试运行程序，用于执行单元测试。\n"
-"\n"
-"* `rustup`：Rust 工具链安装程序和更新程序。发布新版本 Rust 时，此工具用于\n"
-"安装并更新 `rustc` 和 `cargo`。\n"
-"此外，`rustup` 还可以下载标准\n"
-"库的文档。你可以同时安装多个版本的 Rust，并且 `rustup`\n"
-"可让你根据需要在这些版本之间切换。"
+"`cargo`：Rust 依赖项管理器和构建工具。Cargo 知道如何 下载托管在 <https://"
+"crates.io> 上的依赖项，并在构建项目时将它们 传递给 `rustc`。Cargo 还附带一个"
+"内置的 测试运行程序，用于执行单元测试。"
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
+"`rustup`：Rust 工具链安装程序和更新程序。发布新版本 Rust 时，此工具用于 安装"
+"并更新 `rustc` 和 `cargo`。 此外，`rustup` 还可以下载标准 库的文档。你可以同"
+"时安装多个版本的 Rust，并且 `rustup` 可让你根据需要在这些版本之间切换。"
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1812,103 +1589,126 @@ msgstr "关键点："
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust 有一个快速发布时间表，每六周就会发布一次\n"
-"新版本。新版本保持与\n"
-"旧版本的向后兼容性，还添加了新功能。\n"
-"\n"
-"* 共有三个发布阶段：“稳定版”“Beta 版”和“夜间版”。\n"
-"\n"
-"* 我们会在“夜间版”上测试新功能，每六周将“Beta 版”升级为\n"
-"“稳定版”。\n"
-"\n"
-"* Rust 也有三个[版本]：当前版本是 Rust 2021。之前的\n"
-"版本是 Rust 2015 和 Rust 2018。\n"
-"\n"
-"  * 这些版本支持对语言进行向后不兼容的\n"
-"更改。\n"
-"\n"
-"  * 为防止破坏代码，你可以自行选择版本：\n"
-"通过 `Cargo.toml` 文件为 crate 选择合适的版本。\n"
-"\n"
-"  * 为免分割生态系统，Rust 编译器可以混合使用\n"
-"为不同版本编写的代码。\n"
-"\n"
-"  * 提及不通过 `cargo` 而直接使用编译器的情况相当少见（大多数用户从不这样"
-"做）。\n"
-"\n"
-"  * 值得注意的是，Cargo 本身就是一个功能强大且全面的工具。它能够实现许多高级"
-"功能，包括但不限于：\n"
-"      * 项目/软件包结构\n"
-"      * [工作区]\n"
-"      * 开发依赖项和运行时依赖项管理/缓存\n"
-"      * [构建脚本]\n"
-"      * [全局安装] ]\n"
-"      * 它还可以使用子命令插件（例如 [cargo clippy]）进行扩展。\n"
-"  * 如需了解详情，请参阅[ Cargo 官方图书]"
+"Rust 有一个快速发布时间表，每六周就会发布一次 新版本。新版本保持与 旧版本的向"
+"后兼容性，还添加了新功能。"
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "共有三个发布阶段：“稳定版”“Beta 版”和“夜间版”。"
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr "我们会在“夜间版”上测试新功能，每六周将“Beta 版”升级为 “稳定版”。"
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"Rust 也有三个\\[版本\\]：当前版本是 Rust 2021。之前的 版本是 Rust 2015 和 "
+"Rust 2018。"
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "这些版本支持对语言进行向后不兼容的 更改。"
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"为防止破坏代码，你可以自行选择版本： 通过 `Cargo.toml` 文件为 crate 选择合适"
+"的版本。"
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr "为免分割生态系统，Rust 编译器可以混合使用 为不同版本编写的代码。"
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+"提及不通过 `cargo` 而直接使用编译器的情况相当少见（大多数用户从不这样做）。"
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+"值得注意的是，Cargo 本身就是一个功能强大且全面的工具。它能够实现许多高级功"
+"能，包括但不限于："
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "项目/软件包结构"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr "\\[工作区\\]"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr "开发依赖项和运行时依赖项管理/缓存"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr "\\[构建脚本\\]"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr "\\[全局安装\\] \\]"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"它还可以使用子命令插件（例如 [cargo clippy](https://github.com/rust-lang/"
+"rust-clippy)）进行扩展。"
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr "如需了解详情，请参阅\\[ Cargo 官方图书\\]"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr " # 本培训中的代码示例"
+msgid "Code Samples in This Training"
+msgstr "本培训中的代码示例"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
-"在本培训中，我们将主要通过示例\n"
-"探索 Rust 语言，这些示例可通过浏览器执行。这能大大简化设置过程，\n"
-"并确保所有人都能获得一致的体验。"
+"在本培训中，我们将主要通过示例 探索 Rust 语言，这些示例可通过浏览器执行。这能"
+"大大简化设置过程， 并确保所有人都能获得一致的体验。"
 
 #: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
-"我们仍然建议你安装 Cargo：它有助于你更轻松地完成\n"
-"练习。在最后一天，我们要做一个更大的练习，\n"
-"向你展示如何使用依赖项，因此你需要安装 Cargo。"
+"我们仍然建议你安装 Cargo：它有助于你更轻松地完成 练习。在最后一天，我们要做一"
+"个更大的练习， 向你展示如何使用依赖项，因此你需要安装 Cargo。"
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -1929,57 +1729,54 @@ msgstr ""
 "```"
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
-msgstr ""
-"当文本框为\n"
-"焦点时，你可以使用 <kbd>Ctrl + Enter</kbd> 来执行代码。"
+msgid "You can use "
+msgstr "当文本框为 焦点时，你可以使用 "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr " 来执行代码。"
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
-"大多数代码示例都可修改（如上图所示）。少数代码示例\n"
-"可能会因各种原因而不可修改："
+"大多数代码示例都可修改（如上图所示）。少数代码示例 可能会因各种原因而不可修"
+"改："
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* 嵌入式 Playground 无法执行单元测试。将代码复制并粘贴\n"
-"到实际 Playground 中，以演示单元测试。\n"
-"\n"
-"* 嵌入式 Playground 会在你离开页面后立即\n"
-"丢失其状态！正因如此，学员应\n"
-"使用本地安装的 Rust 或通过\n"
-"Playground 解题。"
+"嵌入式 Playground 无法执行单元测试。将代码复制并粘贴 到实际 Playground 中，以"
+"演示单元测试。"
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"嵌入式 Playground 会在你离开页面后立即 丢失其状态！正因如此，学员应 使用本地"
+"安装的 Rust 或通过 Playground 解题。"
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# 使用 Cargo 在本地运行代码"
+msgid "Running Code Locally with Cargo"
+msgstr "使用 Cargo 在本地运行代码"
 
 #: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
-"如果你想在自己的系统上对代码进行实验，\n"
-"则需要先安装 Rust。为此，请按照 [Rust 图书中的\n"
-"说明][1]操作。这应会为你提供一个有效的 `rustc` 和 `cargo`。在撰写\n"
-"本文时，最新的 Rust 稳定版具有以下版本号："
+"如果你想在自己的系统上对代码进行实验， 则需要先安装 Rust。为此，请按照 [Rust "
+"图书中的 说明](https://doc.rust-lang.org/book/ch01-01-installation.html)操"
+"作。这应会为你提供一个有效的 `rustc` 和 `cargo`。在撰写 本文时，最新的 Rust "
+"稳定版具有以下版本号："
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -1999,155 +1796,160 @@ msgstr ""
 
 #: src/cargo/running-locally.md:15
 msgid ""
-"With this in place, follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this in place, follow these steps to build a Rust binary from one of "
+"the examples in this training:"
 msgstr ""
-"了解这些信息后，请按照以下步骤从本培训中的\n"
-"一个示例中构建 Rust 二进制文件："
+"了解这些信息后，请按照以下步骤从本培训中的 一个示例中构建 Rust 二进制文件："
 
 #: src/cargo/running-locally.md:18
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr "在你要复制的示例上点击“复制到剪贴板”按钮。"
+
+#: src/cargo/running-locally.md:20
 msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in `target/"
-"debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr "使用 `cargo new exercise` 为你的代码新建一个 `exercise/` 目录："
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
 msgstr ""
-"1. 在你要复制的示例上点击“复制到剪贴板”按钮。\n"
-"\n"
-"2. 使用 `cargo new exercise` 为你的代码新建一个 `exercise/` 目录：\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. 导航至 `exercise/` 并使用 `cargo run` 构建并运行你的二进制文件：\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. 将 `src/main.rs` 中的样板代码替换为你自己的代码。例如，\n"
-"使用上一页中的示例，将 `src/main.rs` 改为：\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. 使用 `cargo run` 构建并运行你更新后的二进制文件：\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. 使用 `cargo check` 快速检查项目是否存在错误；使用 `cargo build`\n"
-"只进行编译，而不运行。你可以在 `target/debug/`\n"
-"中找到常规调试 build 的输出。使用 `cargo build --release` 在 `target/release/"
-"` 中生成经过优化的\n"
-"发布 build。\n"
-"\n"
-"7. 你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你\n"
-"运行 `cargo` 命令时，系统会自动为你下载和编译缺失\n"
-"的依赖项。"
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr "导航至 `exercise/` 并使用 `cargo run` 构建并运行你的二进制文件："
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+"将 `src/main.rs` 中的样板代码替换为你自己的代码。例如， 使用上一页中的示例，"
+"将 `src/main.rs` 改为："
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr "使用 `cargo run` 构建并运行你更新后的二进制文件："
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+"使用 `cargo check` 快速检查项目是否存在错误；使用 `cargo build` 只进行编译，"
+"而不运行。你可以在 `target/debug/` 中找到常规调试 build 的输出。使用 `cargo "
+"build --release` 在 `target/release/` 中生成经过优化的 发布 build。"
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
+msgstr ""
+"你可以通过修改 `Cargo.toml` 为项目添加依赖项。当你 运行 `cargo` 命令时，系统"
+"会自动为你下载和编译缺失 的依赖项。"
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
-"尽量鼓励全班学员安装 Cargo 并使用\n"
-"本地编辑器。这能为他们营造常规\n"
-"开发环境，让工作变得更加轻松。"
+"尽量鼓励全班学员安装 Cargo 并使用 本地编辑器。这能为他们营造常规 开发环境，让"
+"工作变得更加轻松。"
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# 欢迎来到第一天"
+msgid "Welcome to Day 1"
+msgstr "欢迎来到第一天"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr "现在是学习 Comprehensive Rust 的第一天。今天我们会涉及很多内容："
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* Rust 基本语法：变量，标量（scalar）和复合（compound）类型，枚举（enum），结构体（struct），引用，"
-"函数和方法。\n"
-"\n"
-"* 内存管理：栈与堆，手动内存管理，基于作用域的内存管理，以及垃圾回收。\n"
-"\n"
-"* 所有权：移动（move）的语义，复制（copy）和克隆（clone），借用（borrow），以及生命周期。"
+"Rust 基本语法：变量，标量（scalar）和复合（compound）类型，枚举（enum），结构"
+"体（struct），引用，函数和方法。"
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr "内存管理：栈与堆，手动内存管理，基于作用域的内存管理，以及垃圾回收。"
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"所有权：移动（move）的语义，复制（copy）和克隆（clone），借用（borrow），以及"
+"生命周期。"
 
 #: src/welcome-day-1.md:16
 msgid "Please remind the students that:"
@@ -2155,133 +1957,158 @@ msgstr "请提醒学生："
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i."
-"e.,\n"
-"    keep the related to how Rust does things vs some other language. It can "
-"be\n"
-"    hard to find the right balance, but err on the side of allowing "
-"discussions\n"
-"    since they engage people much more than one-way communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
+msgstr "他们可以随时提问，不需要留到最后。"
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr "这个课程本应该是互动的，我们鼓励大家积极讨论。"
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the related to how Rust does things vs some other language. It can be "
+"hard to find the right balance, but err on the side of allowing discussions "
+"since they engage people much more than one-way communication."
 msgstr ""
-"* 他们可以随时提问，不需要留到最后。\n"
-"* 这个课程本应该是互动的，我们鼓励大家积极讨论。\n"
-"  * 作为讲师，你应该尽量保证讨论话题的相关性，例如，讨论围绕Rust是如何做某些事情，而不是其他的语言"
-"如何如何。\n"
-"    这个平衡点不容易找到，但是尽量倾向于允许 \n"
-"    讨论，因为讨论比起单方面的灌输更有利于让大家投入。\n"
-"*  有些问题会导致我们提前谈到后面的内容\n"
-"   * 这完全没有问题! 重复是学习的一个重要方法。请记得\n"
-"   这些幻灯片只是一个辅助，你可以选择性地跳过。"
+"作为讲师，你应该尽量保证讨论话题的相关性，例如，讨论围绕Rust是如何做某些事"
+"情，而不是其他的语言如何如何。 这个平衡点不容易找到，但是尽量倾向于允许  讨"
+"论，因为讨论比起单方面的灌输更有利于让大家投入。"
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr "有些问题会导致我们提前谈到后面的内容"
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"这完全没有问题! 重复是学习的一个重要方法。请记得 这些幻灯片只是一个辅助，你可"
+"以选择性地跳过。"
 
 #: src/welcome-day-1.md:29
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
-"第一天的主要目标是要谈到著名的 borrow checker，其他方面点到为止。Rust 处理内存的方式是其主要特点，这"
-"点我们应该尽早展示给学生。"
+"第一天的主要目标是要谈到著名的 borrow checker，其他方面点到为止。Rust 处理内"
+"存的方式是其主要特点，这点我们应该尽早展示给学生。"
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
-"如果你是在教室里教授此课程，不妨在这里介绍一下时间安排。 这边建议是把每天分成两部分（跟着幻灯片来）："
+"如果你是在教室里教授此课程，不妨在这里介绍一下时间安排。 这边建议是把每天分成"
+"两部分（跟着幻灯片来）："
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* 早上：9:00 到 12:00，\n"
-"* 下午：13:00 到 16:00。"
+msgid "Morning: 9:00 to 12:00,"
+msgstr "早上：9:00 到 12:00，"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "下午：13:00 到 16:00。"
 
 #: src/welcome-day-1.md:39
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
-msgstr "当然你也可以看情况调整时间。但是请务必记得提供休息时间。我们建议每个小时休息一次！"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# 什么是 Rust ？"
+"breaks, we recommend a break every hour!"
+msgstr ""
+"当然你也可以看情况调整时间。但是请务必记得提供休息时间。我们建议每个小时休息"
+"一次！"
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
-"Rust 是一种新的编程语言，它的[1.0 版本于 2015 年发布][1]："
+"Rust 是一种新的编程语言，它的[1.0 版本于 2015 年发布](https://blog.rust-lang."
+"org/2015/05/15/Rust-1.0.html)："
 
 #: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "Rust 是一种静态编译语言，其功能定位与 C++ 相似"
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` 使用 LLVM 作为它的后端。"
+
+#: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"* Rust 是一种静态编译语言，其功能定位与 C++ 相似\n"
-"  * `rustc` 使用 LLVM 作为它的后端。\n"
-"* Rust 支持多种[平台和架构](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust 被广泛用于各种设备中：\n"
-"  * 固件和引导程序，\n"
-"  * 智能显示器，\n"
-"  * 手机，\n"
-"  * 桌面，\n"
-"  * 服务器。"
+"Rust 支持多种[平台和架构](https://doc.rust-lang.org/nightly/rustc/platform-"
+"support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, ..."
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rust 被广泛用于各种设备中："
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "固件和引导程序，"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "智能显示器，"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "手机，"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "桌面，"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "服务器。"
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust 和 C++ 适用于类似的场景："
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* 极高的灵活性。\n"
-"* 高度的控制能力。\n"
-"* 能够在资源极度有限的设备（如手机）上运行。\n"
-"* 没有运行时和垃圾收集。\n"
-"* 关注程序可靠性和安全性，而不会牺牲任何性能。"
+msgid "High flexibility."
+msgstr "极高的灵活性。"
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr "# Hello World!"
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "高度的控制能力。"
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr "能够在资源极度有限的设备（如手机）上运行。"
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "没有运行时和垃圾收集。"
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr "关注程序可靠性和安全性，而不会牺牲任何性能。"
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
-msgstr ""
-"让我们进入最简单的 Rust 程序，一个经典的 Hello World 程序："
+msgstr "让我们进入最简单的 Rust 程序，一个经典的 Hello World 程序："
 
 #: src/hello-world.md:6
 msgid ""
@@ -2297,61 +2124,70 @@ msgstr ""
 "}\n"
 "```"
 
-
 #: src/hello-world.md:12
 msgid "What you see:"
 msgstr "你看到的："
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
-msgstr ""
-"* 函数以 `fn` 开头。\n"
-"* 像 C 和 C++ 一样，块由花括号分隔。\n"
-"* `main` 函数是程序的入口。\n"
-"* Rust 有卫生宏 (hygienic macros)，`println!` 就是一个例子。\n"
-"* Rust 字符串是 UTF-8 编码的，可以包含任何 Unicode 字符。"
+msgid "Functions are introduced with `fn`."
+msgstr "函数以 `fn` 开头。"
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "像 C 和 C++ 一样，块由花括号分隔。"
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "`main` 函数是程序的入口。"
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr "Rust 有卫生宏 (hygienic macros)，`println!` 就是一个例子。"
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr "Rust 字符串是 UTF-8 编码的，可以包含任何 Unicode 字符。"
 
 #: src/hello-world.md:22
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
-msgstr "这张幻灯片试图让学生们熟悉 Rust 代码。在接下来的四天里，他们会看到很多 Rust 代码, 所以我们从一些熟悉的东西开始。"
-
+msgstr ""
+"这张幻灯片试图让学生们熟悉 Rust 代码。在接下来的四天里，他们会看到很多 Rust "
+"代码, 所以我们从一些熟悉的东西开始。"
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude."
-"md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/"
-"hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rust 非常像 C/C++/Java 等其他传统语言。它是指令式语言（而非函数式），而且除非绝对必要，它不会尝试重新发明新的概念。\n"
-"* Rust 是一种现代编程语言，它完全支持 Unicode 等特性。\n"
-"* 在需要处理可变数量的参数的情况下，Rust 使用宏（没有函数[重载](basic-syntax/functions-interlude.md)）。\n"
-"* 宏是“卫生的”意味着它们不会意外地捕获它们所在作用域中的标识符。Rust 的宏实际上只是[部分卫生](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)。"
+"Rust 非常像 C/C++/Java 等其他传统语言。它是指令式语言（而非函数式），而且除非"
+"绝对必要，它不会尝试重新发明新的概念。"
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# 简短示例"
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "Rust 是一种现代编程语言，它完全支持 Unicode 等特性。"
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"在需要处理可变数量的参数的情况下，Rust 使用宏（没有函数[重载](basic-syntax/"
+"functions-interlude.md)）。"
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
+msgstr ""
+"宏是“卫生的”意味着它们不会意外地捕获它们所在作用域中的标识符。Rust 的宏实际上"
+"只是[部分卫生](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)。"
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2394,381 +2230,458 @@ msgstr ""
 #: src/hello-world/small-example.md:23
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
-"这段代码实现了 Collatz 猜想：猜想认为该循环总是会结束，但该猜想还没有被证明。可以编辑代码来尝试不同的输入。"
+"这段代码实现了 Collatz 猜想：猜想认为该循环总是会结束，但该猜想还没有被证明。"
+"可以编辑代码来尝试不同的输入。"
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::"
-"fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library."
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* 说明所有变量的类型都是静态的。尝试删除 `i32` 来触发类型推断。尝试使用 `i8` 来触发运行时整数溢出。\n"
-"\n"
-"* 将 `let mut x` 改为 `let x`，讨论出现的编译错误。\n"
-"\n"
-"* 展示 `print!` 在参数与格式字符串不匹配时产生的编译错误。\n"
-"\n"
-"* 展示如何使用 `{}` 作为占位符，来输出比单个变量更复杂的表达式。\n"
-"\n"
-"* 向学生展示标准库，展示如何搜索 `std::"
-"fmt`，其中包含用于格式化字符串的微型语言规则。要点是让学生熟悉在标准库中搜索的过程。"
+"说明所有变量的类型都是静态的。尝试删除 `i32` 来触发类型推断。尝试使用 `i8` 来"
+"触发运行时整数溢出。"
 
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# 为什么选择 Rust？"
+#: src/hello-world/small-example.md:32
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "将 `let mut x` 改为 `let x`，讨论出现的编译错误。"
+
+#: src/hello-world/small-example.md:34
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr "展示 `print!` 在参数与格式字符串不匹配时产生的编译错误。"
+
+#: src/hello-world/small-example.md:37
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr "展示如何使用 `{}` 作为占位符，来输出比单个变量更复杂的表达式。"
+
+#: src/hello-world/small-example.md:40
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"向学生展示标准库，展示如何搜索 `std::fmt`，其中包含用于格式化字符串的微型语言"
+"规则。要点是让学生熟悉在标准库中搜索的过程。"
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Rust 有一些独特的卖点："
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* 编译期内存安全。\n"
-"* 没有运行时未定义行为。\n"
-"* 现代的编程语言特性。"
+msgid "Compile time memory safety."
+msgstr "编译期内存安全。"
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "没有运行时未定义行为。"
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "现代的编程语言特性。"
 
 #: src/why-rust.md:11
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
-msgstr ""
-"应该问问学生们都使用过哪些语言。根据答案侧重讲解 Rust 的不同特性："
+"Depending on the answer you can highlight different features of Rust:"
+msgstr "应该问问学生们都使用过哪些语言。根据答案侧重讲解 Rust 的不同特性："
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* 使用过 C 或 C++：Rust 利用\"借用检查\"消除了一类 _运行时错误_ 。你可以达到堪比 C 和 C++\n"
-"的性能，而没有内存不安全的问题。并且你还可以得到些现代的语言构造，比如模式匹配和内置依赖管理。\n"
-"\n"
-"* 使用过 Java, Go, Python, JavaScript...：你可以得到和这些语言相同的内存安全特性，并拥有"
-"类似的使用高级语言的感受。同时你可以得到类似 C 和 C++ 的高速且可预测的执行性能（无垃圾回收机制）"
-"，以及在需要时对底层硬件的访问。"
+"使用过 C 或 C++：Rust 利用\"借用检查\"消除了一类 _运行时错误_ 。你可以达到堪"
+"比 C 和 C++ 的性能，而没有内存不安全的问题。并且你还可以得到些现代的语言构"
+"造，比如模式匹配和内置依赖管理。"
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# 编译期保障"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"使用过 Java, Go, Python, JavaScript...：你可以得到和这些语言相同的内存安全特"
+"性，并拥有类似的使用高级语言的感受。同时你可以得到类似 C 和 C++ 的高速且可预"
+"测的执行性能（无垃圾回收机制），以及在需要时对底层硬件的访问。"
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "编译期静态内存管理："
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* 不存在未初始化的变量。\n"
-"* 不存在内存泄漏（_通常情况下_，见注释）。\n"
-"* 不存在“双重释放”。\n"
-"* 不存在“释放后使用”。\n"
-"* 不存在 `NULL` 指针。\n"
-"* 不存在被遗忘的互斥锁。\n"
-"* 不存在线程之间的数据竞争。\n"
-"* 不存在迭代器失效。"
+msgid "No uninitialized variables."
+msgstr "不存在未初始化的变量。"
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "不存在内存泄漏（_通常情况下_，见注释）。"
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "不存在“双重释放”。"
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "不存在“释放后使用”。"
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "不存在 `NULL` 指针。"
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "不存在被遗忘的互斥锁。"
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "不存在线程之间的数据竞争。"
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "不存在迭代器失效。"
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
-msgstr ""
-"在（安全的）Rust 中也有可能产生内存泄漏。例如："
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
+msgstr "在（安全的）Rust 中也有可能产生内存泄漏。例如："
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can for use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can for use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* 可以使用 [`Box::leak`] 来泄漏一个指针。该方法可以用于得到在运行时决定大小和初始化的静态变量\n"
-"* 可以使用 [`std::mem::forget`] 来让编译器“忘记”一个值（即其析构函数不会被执行）。\n"
-"* 可以使用 `Rc` 或 `Arc` 意外创建一个循环引用（[reference cycle]）。\n"
-"* 实际上，有人认为无限填充一个集合也是一种内存泄漏，Rust 对此没有保护。"
+"可以使用 [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) 来泄漏一个指针。该方法可以用于得到在运行时决定大小和初始化"
+"的静态变量"
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"可以使用 [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) 来让编译器“忘记”一个值（即其析构函数不会被执行）。"
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"可以使用 `Rc` 或 `Arc` 意外创建一个循环引用（[reference cycle](https://doc."
+"rust-lang.org/book/ch15-06-reference-cycles.html)）。"
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr "实际上，有人认为无限填充一个集合也是一种内存泄漏，Rust 对此没有保护。"
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
-msgstr ""
-"就本课程而言，“不存在内存泄漏”应理解为“几乎没有 *意外* 内存泄漏”。"
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# 运行时保障"
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
+msgstr "就本课程而言，“不存在内存泄漏”应理解为“几乎没有 _意外_ 内存泄漏”。"
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "Rust 没有运行时未定义行为："
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
-msgstr ""
-"* 数组访问有边界检查。\n"
-"* 整数溢出的行为有明确定义。"
+msgid "Array access is bounds checked."
+msgstr "数组访问有边界检查。"
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
+msgstr "整数溢出的行为有明确定义。"
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* 整数溢出的行为由编译时的标志指定。可以选择 panic（一种受控的程序崩溃）或使用“绕回（wrap-around）”语义。"
-"默认情况下，使用调试模式编译（`cargo build`）的行为为 panic，"
-"使用发布模式编译（`cargo build --release`）的行为为“绕回”。\n"
-"\n"
-"* 边界检查不能使用编译标志禁用，也不能直接通过 `unsafe` 关键字禁用。然而，\n"
-"`unsafe` 允许你调用 `slice::get_unchecked` 等不做边界检查的函数。"
+"整数溢出的行为由编译时的标志指定。可以选择 panic（一种受控的程序崩溃）或使"
+"用“绕回（wrap-around）”语义。默认情况下，使用调试模式编译（`cargo build`）的"
+"行为为 panic，使用发布模式编译（`cargo build --release`）的行为为“绕回”。"
 
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# 现代特性"
+#: src/why-rust/runtime.md:17
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"边界检查不能使用编译标志禁用，也不能直接通过 `unsafe` 关键字禁用。然而， "
+"`unsafe` 允许你调用 `slice::get_unchecked` 等不做边界检查的函数。"
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
 msgstr "Rust 建立于过去 40 年来所获得的经验之上。"
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## 语言特性"
+msgid "Language Features"
+msgstr "语言特性"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* 枚举和模式匹配。\n"
-"* 泛型。\n"
-"* 无额外开销外部函数接口（FFI）。\n"
-"* 零成本抽象。"
+msgid "Enums and pattern matching."
+msgstr "枚举和模式匹配。"
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "泛型。"
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "无额外开销外部函数接口（FFI）。"
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "零成本抽象。"
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
-msgstr "## 工具"
+msgid "Tooling"
+msgstr "工具"
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* 强大的编译器错误提示。\n"
-"* 内置依赖管理器。\n"
-"* 对测试的内置支持。\n"
-"* 优秀的语言服务协议（Language Server Protocol）支持。"
+msgid "Great compiler errors."
+msgstr "强大的编译器错误提示。"
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "内置依赖管理器。"
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "对测试的内置支持。"
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "优秀的语言服务协议（Language Server Protocol）支持。"
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* 与 C++ 类似的零成本抽象，意味着你不需要为高级程序语言的结构“付出”更多的内存和 CPU。"
-"例如使用 `for` 循环与使用 `.iter().fold()` 结构应该会生成大致相同的底层指令。\n"
-"\n"
-"* 值得一提的是，Rust 的枚举是“代数数据类型”（也叫“和类型”）。它使得类型系统可以表示\n"
-"  `Option<T>` 和 `Result<T, E>` 等结构。\n"
-"\n"
-"* 提醒学生去阅读编译错误 --- 许多开发者已经习惯去忽略冗长的编译器输出。Rust 编译器会比其它编译器更健谈。"
-"它通常会提供 _可操作的_ 反馈，可以直接复制粘贴到代码中。\n"
-"\n"
-"* 相比 Java, Python 和 Go 等语言，Rust 标准库较为精简。Rust 并没有内置一些你可能认为标准和必要的功能：\n"
-"\n"
-"  * 随机数生成器，可以使用 [rand] 替代。\n"
-"  * SSL 和 TLS 支持，可以使用 [rusttls] 替代。\n"
-"  * JSON 支持，可以使用 [serde_json] 替代。\n"
-"\n"
-"  Rust 这么做的原因是标准库中的功能是无法去除的，因此该功能必须非常稳定。"
-"对于以上例子，Rust 社区仍在寻找最佳解决方案 --- 甚至对一些情况可能没有单一的“最佳解决方案”。\n"
-"\n"
-"  Rust 内置了一个包管理器 Cargo，使得下载和编译第三方 crate 变得简单。这也导致标准库可以更加精简。\n"
-"\n"
-"  发现高质量的第三方 crate 也许是一个问题。\n"
-"  <https://lib.rs/> 等网站对此问题有所帮助。它能帮你比较 crate 的健康指标，以找到一个高质量并受信任的 crate。\n"
-"  \n"
-"* [rust-analyzer] 是一个受到广泛支持的 LSP 实现，被主流的 IDE 和文本编辑器所使用。"
+"与 C++ 类似的零成本抽象，意味着你不需要为高级程序语言的结构“付出”更多的内存"
+"和 CPU。例如使用 `for` 循环与使用 `.iter().fold()` 结构应该会生成大致相同的底"
+"层指令。"
 
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
-msgstr "# 基本语法"
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+"值得一提的是，Rust 的枚举是“代数数据类型”（也叫“和类型”）。它使得类型系统可以"
+"表示 `Option<T>` 和 `Result<T, E>` 等结构。"
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"提醒学生去阅读编译错误 --- 许多开发者已经习惯去忽略冗长的编译器输出。Rust 编"
+"译器会比其它编译器更健谈。它通常会提供 _可操作的_ 反馈，可以直接复制粘贴到代"
+"码中。"
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+"相比 Java, Python 和 Go 等语言，Rust 标准库较为精简。Rust 并没有内置一些你可"
+"能认为标准和必要的功能："
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr "随机数生成器，可以使用 [rand](https://docs.rs/rand/) 替代。"
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr "SSL 和 TLS 支持，可以使用 [rusttls](https://docs.rs/rustls/) 替代。"
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr "JSON 支持，可以使用 [serde_json](https://docs.rs/serde_json/) 替代。"
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+"Rust 这么做的原因是标准库中的功能是无法去除的，因此该功能必须非常稳定。对于以"
+"上例子，Rust 社区仍在寻找最佳解决方案 --- 甚至对一些情况可能没有单一的“最佳解"
+"决方案”。"
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+"Rust 内置了一个包管理器 Cargo，使得下载和编译第三方 crate 变得简单。这也导致"
+"标准库可以更加精简。"
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+"发现高质量的第三方 crate 也许是一个问题。 <https://lib.rs/> 等网站对此问题有"
+"所帮助。它能帮你比较 crate 的健康指标，以找到一个高质量并受信任的 crate。"
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/) 是一个受到广泛支持的 LSP 实"
+"现，被主流的 IDE 和文本编辑器所使用。"
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr "Rust 的许多语法与 C, C++ 和 Java 的语法相似"
 
 #: src/basic-syntax.md:5
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/"
-"* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
-msgstr ""
-"* 代码块和作用域都是由花括号来界定的。\n"
-"* 行内注释以 `//` 起始，块注释使用 `/"
-"* ...\n"
-"  */` 来界定。\n"
-"* `if` 和 `while` 等关键词作用与以上语言一致。\n"
-"* 变量赋值使用 `=`，值之间比较使用 `==`。"
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "代码块和作用域都是由花括号来界定的。"
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
-msgstr "# 标量类型"
-
-#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax.md:6
 msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | "
-"`\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
-msgstr ""
-"|                        | 类型                                     | "
-"字面量                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| 有符号整数              | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| 无符号整数              | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| 浮点数                 | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| 字符串                 | `&str`                                     | "
-"`\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode 标量类型       | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| 布尔值                 | `bool`                                     | "
-"`true`, `false`               |"
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
+msgstr "行内注释以 `//` 起始，块注释使用 `/* ... */` 来界定。"
+
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "`if` 和 `while` 等关键词作用与以上语言一致。"
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr "变量赋值使用 `=`，值之间比较使用 `==`。"
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Types"
+msgstr "类型"
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr "字面量"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr "有符号整数"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr "无符号整数"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr "浮点数"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr "字符串"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr "`\"foo\"`, `\"two\\nlines\"`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr "Unicode 标量类型"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr "`char`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Booleans"
+msgstr "布尔值"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`bool`"
+msgstr "`bool`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`true`, `false`"
+msgstr "`true`, `false`"
 
 #: src/basic-syntax/scalar-types.md:12
 msgid "The types have widths as follows:"
 msgstr "各类型占用的空间为："
 
 #: src/basic-syntax/scalar-types.md:14
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
-msgstr "* `iN`, `uN` 和 `fN` 占用 _N_ 位，\n"
-"* `isize` 和 `usize` 占用一个指针大小的空间，\n"
-"* `char` 占用 32 位空间，\n"
-"* `bool` 占用 8 位空间。"
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN` 和 `fN` 占用 _N_ 位，"
+
+#: src/basic-syntax/scalar-types.md:15
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` 和 `usize` 占用一个指针大小的空间，"
+
+#: src/basic-syntax/scalar-types.md:16
+msgid "`char` is 32 bit wide,"
+msgstr "`char` 占用 32 位空间，"
+
+#: src/basic-syntax/scalar-types.md:17
+msgid "`bool` is 8 bit wide."
+msgstr "`bool` 占用 8 位空间。"
 
 #: src/basic-syntax/scalar-types.md:21
 msgid "There are a few syntaxes which are not shown above:"
@@ -2776,69 +2689,72 @@ msgstr "上表中还有一些未提及的语法："
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
-"- 原始字符串可在创建 `&str` 时禁用转义："
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`。可以在外层引号两侧添加相同数量的 `#`，以在字符串中嵌入双引号：\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- 字节串可以用于直接创建 `&[u8]` 类型的值：\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"原始字符串可在创建 `&str` 时禁用转义：`r\"\\n\" == \"\\\\n\"`。可以在外层引号"
+"两侧添加相同数量的 `#`，以在字符串中嵌入双引号："
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr "# 复合类型"
-
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:27
 msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
 msgstr ""
-"|        | 类型                         | 字面量                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| 数组（Arrays） | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| 元组（Tuples） | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr "字节串可以用于直接创建 `&[u8]` 类型的值："
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr "数组（Arrays）"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr "`[T; N]`"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr "`[20, 30, 40]`, `[0; 3]`"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr "元组（Tuples）"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
 
 #: src/basic-syntax/compound-types.md:8
 msgid "Array assignment and access:"
@@ -2876,80 +2792,72 @@ msgstr "数组："
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
-"compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
 msgstr ""
-"* 数组中的元素具有相同的类型 `T`，数组的长度为 `N`，`N` 是一个编译期常量。\n"
-"  需要注意的是数组的长度是它*类型的一部分*, 这意味着 "
-"`[u8; 3]` 和\n"
-"  `[u8; 4]` 在 Rust 中被认为是不同的类型。\n"
-"\n"
-"* 我们可以使用字面量来为数组赋值。\n"
-"\n"
-"* 在主函数中，打印（print）语句使用 `?` 格式请求调试实现。\n"
-"  使用参数 `{}` 打印默认输出，`{:?}` 表示以调试格式输出。 "
-"我们也可以不在格式化字符串后面指定变量值，直接使用 `{a}` 和 `{a:?}` 进行输出。"
-"\n"
-"* 添加 `#`, 比如 `{a:#?}`, 会输出“美观打印（pretty printing）” 格式, 这种格式可能会更加易读。"
+"数组中的元素具有相同的类型 `T`，数组的长度为 `N`，`N` 是一个编译期常量。 需要"
+"注意的是数组的长度是它_类型的一部分_, 这意味着 `[u8; 3]` 和 `[u8; 4]` 在 "
+"Rust 中被认为是不同的类型。"
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr "我们可以使用字面量来为数组赋值。"
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+"在主函数中，打印（print）语句使用 `?` 格式请求调试实现。 使用参数 `{}` 打印默"
+"认输出，`{:?}` 表示以调试格式输出。 我们也可以不在格式化字符串后面指定变量"
+"值，直接使用 `{a}` 和 `{a:?}` 进行输出。"
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
+msgstr ""
+"添加 `#`, 比如 `{a:#?}`, 会输出“美观打印（pretty printing）” 格式, 这种格式可"
+"能会更加易读。"
 
 #: src/basic-syntax/compound-types.md:47
 msgid "Tuples:"
 msgstr "元组："
 
 #: src/basic-syntax/compound-types.md:49
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
-msgstr ""
-"* 和数组一样，元组也具有固定的长度。\n"
-"\n"
-"* 元组将不同类型的值组成一个复合类型。\n"
-"\n"
-"* 元组中的字段可以通过英文句号加上值的下标进行访问"
-"比如：`t.0`, `t.1`。\n"
-"\n"
-"* 空元组 `()` 也被称作 “单元（unit）类型”. 它既是一个"
-"类型，\n"
-"  也是这种类型的唯一值——也就是说它的类型和它的"
-"  值都被表示为 `()`。它通常用于表示，比如，一个"
-"  函数或表达式没有返回值，我们会在后续的幻灯片种见到这种用法。"
-"  \n"
-"    * 你可以将其理解为你可能在其他编程语言中比较熟悉的 \n"
-"      `void` 类型"
+msgid "Like arrays, tuples have a fixed length."
+msgstr "和数组一样，元组也具有固定的长度。"
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
-msgstr "# 引用"
+#: src/basic-syntax/compound-types.md:51
+msgid "Tuples group together values of different types into a compound type."
+msgstr "元组将不同类型的值组成一个复合类型。"
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr "元组中的字段可以通过英文句号加上值的下标进行访问比如：`t.0`, `t.1`。"
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+"空元组 `()` 也被称作 “单元（unit）类型”. 它既是一个类型， 也是这种类型的唯一"
+"值——也就是说它的类型和它的  值都被表示为 `()`。它通常用于表示，比如，一个  函"
+"数或表达式没有返回值，我们会在后续的幻灯片种见到这种用法。"
+
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr "你可以将其理解为你可能在其他编程语言中比较熟悉的  `void` 类型"
 
 #: src/basic-syntax/references.md:3
 msgid "Like C++, Rust has references:"
@@ -2973,32 +2881,37 @@ msgstr "一些注意事项："
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* 就像 C 与 C++ 中的指针一样，对引用 `ref_x` 进行赋值时，我们必须对其解引用。\n"
-"* Rust 有时会进行自动解引用。比如调用方法 `ref_x.count_ones()` 时，ref_x 会被解引用。\n"
-"* 如果引用值被声明为 `mut`（可变引用），那么这个引用值可以在它的生命周期内被绑定为不同的值。"
+"就像 C 与 C++ 中的指针一样，对引用 `ref_x` 进行赋值时，我们必须对其解引用。"
+
+#: src/basic-syntax/references.md:17
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+"Rust 有时会进行自动解引用。比如调用方法 `ref_x.count_ones()` 时，ref_x 会被解"
+"引用。"
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"如果引用值被声明为 `mut`（可变引用），那么这个引用值可以在它的生命周期内被绑"
+"定为不同的值。"
 
 #: src/basic-syntax/references.md:25
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"* 注意 `let mut ref_x: &i32` 与 `let ref_x: &mut i32` "
-"之间的区别。第一条语句声明了一个可变引用，所以我们可以修改这个引用所绑定的值；第二条语句声明了一个指向可变变量的引用。"
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
-msgstr "# 悬垂引用（Dangling References）"
+"注意 `let mut ref_x: &i32` 与 `let ref_x: &mut i32` 之间的区别。第一条语句声"
+"明了一个可变引用，所以我们可以修改这个引用所绑定的值；第二条语句声明了一个指"
+"向可变变量的引用。"
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -3029,19 +2942,18 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
-msgstr ""
-"* 一个引用被认为是“借用（borrow）”了它指向的值。\n"
-"* Rust 会跟踪所有引用的生命周期，以确保这些值的存活时间足够长。\n"
-"* 我们会在讲到所有权（ownership）时详细讨论借用（borrow）。"
+msgid "A reference is said to \"borrow\" the value it refers to."
+msgstr "一个引用被认为是“借用（borrow）”了它指向的值。"
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
-msgstr "# 切片"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr "Rust 会跟踪所有引用的生命周期，以确保这些值的存活时间足够长。"
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr "我们会在讲到所有权（ownership）时详细讨论借用（borrow）。"
 
 #: src/basic-syntax/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
@@ -3061,51 +2973,74 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
-msgstr ""
-"* 切片从被切片的类型中借用 (borrow) 数据。\n"
-"* 请思考：如果我们改变 `a[3]`，将会产生怎样的后果？"
+msgid "Slices borrow data from the sliced type."
+msgstr "切片从被切片的类型中借用 (borrow) 数据。"
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "请思考：如果我们改变 `a[3]`，将会产生怎样的后果？"
 
 #: src/basic-syntax/slices.md:20
+#, fuzzy
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr "创建切片时，我们借用了 `a` ，并在方括号中标明了起始和结尾下标。"
+
+#: src/basic-syntax/slices.md:22
+#, fuzzy
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use "
-"`&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
-"(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"identical."
 msgstr ""
-"* 创建切片时，我们借用了 `a` ，并在方括号中标明了起始和结尾下标。\n"
-"* 如果切片的起始下标为 0， Rust 语法允许我们省略起始下标。比如说 `&a[0..a.len()]` 与 `&a[..a.len()]` 是等价的。\n"
-"* 结尾下标也可以用相同方式省略。比如说 `&a[2..a.len()]` 和 `&a[2..]` 是等价的。\n"
-"* 因此，我们可以用 `&a[..]` 来创建包含整个数组的切片。\n"
-"* 切片会从另外一个对象中借用数据。在这个例子中， `a` 必须在其切片存活时保持存活（处于作用域中）。\n"
-"* 关于修改 `a[3]` 的问题可能会引发精彩的讨论。正确答案是：为了保证内存安全，在创建切片后，我们不能通过 `a` 来修改数据。不过我们可以通过 "
-"`a` 或者 `s` 来读取数据。我们将会在“借用”章节着重介绍这个内容。"
+"如果切片的起始下标为 0， Rust 语法允许我们省略起始下标。比如说 `&a[0..a."
+"len()]` 与 `&a[..a.len()]` 是等价的。"
+
+#: src/basic-syntax/slices.md:24
+#, fuzzy
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"结尾下标也可以用相同方式省略。比如说 `&a[2..a.len()]` 和 `&a[2..]` 是等价的。"
+
+#: src/basic-syntax/slices.md:26
+#, fuzzy
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr "因此，我们可以用 `&a[..]` 来创建包含整个数组的切片。"
+
+#: src/basic-syntax/slices.md:28
+#, fuzzy
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+"切片会从另外一个对象中借用数据。在这个例子中， `a` 必须在其切片存活时保持存活"
+"（处于作用域中）。"
+
+#: src/basic-syntax/slices.md:30
+#, fuzzy
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"关于修改 `a[3]` 的问题可能会引发精彩的讨论。正确答案是：为了保证内存安全，在"
+"创建切片后，我们不能通过 `a` 来修改数据。不过我们可以通过 `a` 或者 `s` 来读取"
+"数据。我们将会在“借用”章节着重介绍这个内容。"
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
+msgid "`String` vs `str`"
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:3
@@ -3135,70 +3070,73 @@ msgid "Rust terminology:"
 msgstr "Rust 术语："
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* `&str` 是一个指向字符串片段的不可变引用。\n"
-"* `String` 是一个可变字符串缓冲区。"
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str` 是一个指向字符串片段的不可变引用。"
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String` 是一个可变字符串缓冲区。"
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::"
-"string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* `&str` 引入了一个字符串切片，它是一个指向保存在内存块中的 UTF-8 编码字符串数据的不可变引用。"
-"   字符串字面量（`”Hello”`）会保存在程序的二进制文件中。\n"
-"\n"
-"* Rust 的 `String` 类型是一个字节 vector 的封装。和 `Vec<T>` 一样，它是拥有所有权的。\n"
-"   \n"
-"* 和其他类型一样，`String::from()` 会从字符串字面量创建一个字符串；`String::new()` 会创建一个新的空字符串，"
-"   之后可以使用 `push()` 和 `push_str()` 方法向其中添加字符串数据。\n"
-"\n"
-"* `format!()` 宏可以方便地动态生成拥有所有权的字符串。它接受和 `println!()` 相同的格式规范。\n"
-"   \n"
-"* 你可以通过 `&` 和可选的范围选择从 `String` 中借用 `&str` 切片。\n"
-"   \n"
-"* 对于 C++ 程序员：可以把 `&str` 当作 C++ 中的 `const char*`，但是它总是指向内存中的一个有效字符串。"
-"   Rust 的 `String` 大致相当于 C++ 中 `std::string` （主要区别：它只能包含 UTF-8 编码的字节，"
-"   并且永远不会使用小字符串优化（small-string optimization））。\n"
-"    "
+"`&str` 引入了一个字符串切片，它是一个指向保存在内存块中的 UTF-8 编码字符串数"
+"据的不可变引用。   字符串字面量（`”Hello”`）会保存在程序的二进制文件中。"
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
-msgstr "# 函数（Functions）"
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+"Rust 的 `String` 类型是一个字节 vector 的封装。和 `Vec<T>` 一样，它是拥有所有"
+"权的。"
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"和其他类型一样，`String::from()` 会从字符串字面量创建一个字符串；`String::"
+"new()` 会创建一个新的空字符串，   之后可以使用 `push()` 和 `push_str()` 方法"
+"向其中添加字符串数据。"
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+"`format!()` 宏可以方便地动态生成拥有所有权的字符串。它接受和 `println!()` 相"
+"同的格式规范。"
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr "你可以通过 `&` 和可选的范围选择从 `String` 中借用 `&str` 切片。"
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"对于 C++ 程序员：可以把 `&str` 当作 C++ 中的 `const char*`，但是它总是指向内"
+"存中的一个有效字符串。   Rust 的 `String` 大致相当于 C++ 中 `std::string` "
+"（主要区别：它只能包含 UTF-8 编码的字节，   并且永远不会使用小字符串优化"
+"（small-string optimization））。"
 
 #: src/basic-syntax/functions.md:3
 msgid ""
 "A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
 "Fizz_buzz) interview question:"
 msgstr ""
-"一个 Rust 版本的著名 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 面试题："
+"一个 Rust 版本的著名 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 面试"
+"题："
 
 #: src/basic-syntax/functions.md:5
 msgid ""
@@ -3233,32 +3171,45 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
+msgstr ""
+"我们在 `main` 中引用了下面编写的一个函数。不需要提前声明或添加头文件。 "
+
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr "类型跟随在声明的参数后（与某些编程语言相反），然后是返回类型。"
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+"函数体（或任何块）中的最后一个表达式将成为返回值。只需省略表达式末尾的 `;` 即"
+"可。"
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+"有些函数没有返回值，会返回“单元类型（unit type）”`()`。如果省略了`-> ()`的返"
+"回类型，编译器将会自动推断。"
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
 "`=n`, which causes it to include the upper bound."
 msgstr ""
-"* 我们在 `main` 中引用了下面编写的一个函数。不需要提前声明或添加头文件。 \n"
-"* 类型跟随在声明的参数后（与某些编程语言相反），然后是返回类型。\n"
-"* 函数体（或任何块）中的最后一个表达式将成为返回值。只需省略表达式末尾的 `;` 即可。\n"
-"* 有些函数没有返回值，会返回“单元类型（unit type）”`()`。如果省略了`-> ()`的返回类型，编译器将会自动推断。\n"
-"* `print_fizzbuzz_to()`函数中`for`循环的范围表达式（range expression）包含`=n`，这会导致它包括上限。"
-
-#: src/basic-syntax/rustdoc.md:1
-msgid "# Rustdoc"
-msgstr "# Rustdoc"
+"`print_fizzbuzz_to()`函数中`for`循环的范围表达式（range expression）包含"
+"`=n`，这会导致它包括上限。"
 
 #: src/basic-syntax/rustdoc.md:3
 msgid ""
 "All language items in Rust can be documented using special `///` syntax."
-msgstr ""
-"Rust 中的所有语言元素都可以通过特殊的 `///` 语法进行文档化。"
+msgstr "Rust 中的所有语言元素都可以通过特殊的 `///` 语法进行文档化。"
 
 #: src/basic-syntax/rustdoc.md:5
 msgid ""
@@ -3290,41 +3241,42 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
-"文档的内容会被当做 Markdown 处理。所有已发布 Rust 库 crate 都会自动被[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 工具在 [`docs.rs`](https://docs.rs)存档。 "
-"按照这种方式来为 API 中的所有公开项编写文档是 Rust 中惯用的做法。"
+"文档的内容会被当做 Markdown 处理。所有已发布 Rust 库 crate 都会自动被"
+"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 工具在 "
+"[`docs.rs`](https://docs.rs)存档。 按照这种方式来为 API 中的所有公开项编写文"
+"档是 Rust 中惯用的做法。"
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
-"* 向学生展示在 [`docs.rs/rand`](https://docs.rs/rand) 中为 `rand` crate 生成的文档。\n"
-"* 本课程的幻灯片中不包含 rustdoc，这是为了节省空间，但是在实际的代码中，应当编写相关的程序文档。\n"
-"* 内部文档注释将在稍后（在讲解模块的页面）讨论，这里无需进行说明。"
+"向学生展示在 [`docs.rs/rand`](https://docs.rs/rand) 中为 `rand` crate 生成的"
+"文档。"
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
-msgstr "# 方法"
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+"本课程的幻灯片中不包含 rustdoc，这是为了节省空间，但是在实际的代码中，应当编"
+"写相关的程序文档。"
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr "内部文档注释将在稍后（在讲解模块的页面）讨论，这里无需进行说明。"
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
-"method is\n"
-"an instance of the type it is associated with:"
+"method is an instance of the type it is associated with:"
 msgstr ""
 "方法是与某种类型关联的函数。方法的 `self` 参数是与其关联类型的一个实例："
 
@@ -3357,58 +3309,67 @@ msgstr ""
 
 #: src/basic-syntax/methods.md:30
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
-msgstr ""
-"我们将在今天的练习和明天的课程中更深入地学习方法相关的概念。"
+msgstr "我们将在今天的练习和明天的课程中更深入地学习方法相关的概念。"
 
 #: src/basic-syntax/methods.md:34
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
+msgstr "新增一个 `Rectangle::new` 构造函数并在 `main` 函数中调用它:"
+
+#: src/basic-syntax/methods.md:36
 msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
 msgstr ""
-"- 新增一个 `Rectangle::new` 构造函数并在 `main` 函数中调用它:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- 新增一个 `Rectangle::new_square(width: u32)` 构造函数来说明构造函数可以接受任意参数。"
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
+msgstr ""
+"新增一个 `Rectangle::new_square(width: u32)` 构造函数来说明构造函数可以接受任"
+"意参数。"
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
-msgstr "# 函数重载"
+msgid "Function Overloading"
+msgstr "函数重载"
 
 #: src/basic-syntax/functions-interlude.md:3
 msgid "Overloading is not supported:"
-msgstr "# 不支持重载："
+msgstr "不支持重载："
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* 每一个函数都只有一种实现：\n"
-"  * 始终接受固定个数的形参。\n"
-"  * 始终接受一组形参类型。\n"
-"* 不支持提供默认值：\n"
-"  * 实参的数量在所有调用的地方都是一样的。\n"
-"  * 有时可以用宏（Macro）作为替代。"
+msgid "Each function has a single implementation:"
+msgstr "每一个函数都只有一种实现："
 
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "始终接受固定个数的形参。"
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "始终接受一组形参类型。"
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "不支持提供默认值："
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr "实参的数量在所有调用的地方都是一样的。"
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "有时可以用宏（Macro）作为替代。"
 
 #: src/basic-syntax/functions-interlude.md:12
 msgid "However, function parameters can be generic:"
@@ -3440,31 +3401,28 @@ msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
-"* 标准库中的 `Into<T>` 通过泛型参数提供了一种具有"
-"有限多态性的参数类型。详见之后的章节。"
+"标准库中的 `Into<T>` 通过泛型参数提供了一种具有有限多态性的参数类型。详见之后"
+"的章节。"
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
-msgstr "# 第一天上午习题"
+msgid "Day 1: Morning Exercises"
+msgstr "第一天上午习题"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
 msgstr "在这些习题中，我们将探索 Rust 的两个部分："
 
 #: src/exercises/day-1/morning.md:5
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
-msgstr ""
-"* 类型之间的隐式转换。\n"
-"\n"
-"* 数组和 `for` 循环。"
+msgid "Implicit conversions between types."
+msgstr "类型之间的隐式转换。"
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
+msgstr "数组和 `for` 循环。"
 
 #: src/exercises/day-1/morning.md:11
 msgid "A few things to consider while solving the exercises:"
@@ -3472,21 +3430,20 @@ msgstr "在解题时要考虑几件事："
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* 最好使用本地安装的 Rust，以实现在编辑器中自动补全。关于安装 Rust 的细节，请参见 [使用 Cargo] 页面。\n"
-"\n"
-"* 也可以使用 Rust Playground 作为替代。"
+"最好使用本地安装的 Rust，以实现在编辑器中自动补全。关于安装 Rust 的细节，请参"
+"见 \\[使用 Cargo\\] 页面。"
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
+msgstr "也可以使用 Rust Playground 作为替代。"
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
 "页面内嵌的代码片段是不可编辑的：因为离开页面后内嵌代码片段中的修改会丢失。"
@@ -3498,21 +3455,18 @@ msgstr ""
 #: src/exercises/concurrency/morning.md:12
 #: src/exercises/concurrency/afternoon.md:13
 msgid ""
-"After looking at the exercises, you can look at the [solutions] provided."
-msgstr ""
-"读完习题后，可以阅读本书提供的 [题解]。"
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
-msgstr "# 隐式类型转换"
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
+msgstr "读完习题后，可以阅读本书提供的 \\[题解\\]。"
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
-"[与 C++ 不同][3]，Rust 不会自动进行 _隐式类型转换_。例如，下面的程序中不存在隐式类型转换："
+"[与 C++ 不同](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)，Rust 不会自动进行 _隐式类型转换_。例如，下面的程序中不"
+"存在隐式类型转换："
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
@@ -3544,65 +3498,65 @@ msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Rust 的整数类型都实现了 [`From<T>`][1] 和 [`Into<T>`][2]\n"
-"trait，使得我们可以在它们之间进行转换。`From<T>` trait 包含 "
-"`from()`\n"
-"方法，`Into<T>` trait 包含 `into()` 方法。"
-"类型通过实现这些 trait 来表达它将被如何转换为另一个类型。"
+"Rust 的整数类型都实现了 [`From<T>`](https://doc.rust-lang.org/std/convert/"
+"trait.From.html) 和 [`Into<T>`](https://doc.rust-lang.org/std/convert/trait."
+"Into.html) trait，使得我们可以在它们之间进行转换。`From<T>` trait 包含 "
+"`from()` 方法，`Into<T>` trait 包含 `into()` 方法。类型通过实现这些 trait 来"
+"表达它将被如何转换为另一个类型。"
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
-"标准库中包含 `From<i8> for i16` 的实现，即我们可以通过调用 `i16::from(x)` 来将 `i8`\n"
-"类型的变量 `x` 转换为 `i16`。或者也可以简单地使用 `x.into()`，因为 `From<i8> for i16`\n"
-"的实现会自动创建 `Into<i16> for i8` 的实现。"
+"标准库中包含 `From<i8> for i16` 的实现，即我们可以通过调用 `i16::from(x)` 来"
+"将 `i8` 类型的变量 `x` 转换为 `i16`。或者也可以简单地使用 `x.into()`，因为 "
+"`From<i8> for i16` 的实现会自动创建 `Into<i16> for i8` 的实现。"
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
-"这同样也适用于自定义类型的 `From` 实现，只需实现 `From` 就可以自动得到对应的 `Into` 实现。"
+"这同样也适用于自定义类型的 `From` 实现，只需实现 `From` 就可以自动得到对应的 "
+"`Into` 实现。"
 
 #: src/exercises/day-1/implicit-conversions.md:33
+msgid "Execute the above program and look at the compiler error."
+msgstr "执行上述程序，并查看对应的编译错误。"
+
+#: src/exercises/day-1/implicit-conversions.md:35
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr "修改代码，使用 `into()` 进行类型转换。"
+
+#: src/exercises/day-1/implicit-conversions.md:37
 msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
-"1. 执行上述程序，并查看对应的编译错误。\n"
-"\n"
-"2. 修改代码，使用 `into()` 进行类型转换。\n"
-"\n"
-"3. 修改 `x` 和 `y` 的类型（例如 `f32`, `bool`,\n"
-"   `i128` 等）来了解哪些类型之间可以相互转换。尝试将较小的类型转换为较大的类型和将较大的类型转换为较小的类型。阅读\n"
-"   [标准库文档][1] 来了解对于你所尝试的两个类型 `From<T>` 是否已被实现。"
+"修改 `x` 和 `y` 的类型（例如 `f32`, `bool`, `i128` 等）来了解哪些类型之间可以"
+"相互转换。尝试将较小的类型转换为较大的类型和将较大的类型转换为较小的类型。阅"
+"读 [标准库文档](https://doc.rust-lang.org/std/convert/trait.From.html) 来了解"
+"对于你所尝试的两个类型 `From<T>` 是否已被实现。"
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
-msgstr "# 数组与 `for` 循环"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "数组与 `for` 循环"
 
 #: src/exercises/day-1/for-loops.md:3
 msgid "We saw that an array can be declared like this:"
@@ -3622,8 +3576,7 @@ msgstr ""
 msgid ""
 "You can print such an array by asking for its debug representation with `{:?}"
 "`:"
-msgstr ""
-"你可以使用 `{:?}` 来打印这种数组的调试格式："
+msgstr "你可以使用 `{:?}` 来打印这种数组的调试格式："
 
 #: src/exercises/day-1/for-loops.md:11
 msgid ""
@@ -3643,10 +3596,9 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
-msgstr ""
-"在 Rust 中，可以使用 `for` 关键词遍历数组和区间等元素："
+msgstr "在 Rust 中，可以使用 `for` 关键词遍历数组和区间等元素："
 
 #: src/exercises/day-1/for-loops.md:21
 msgid ""
@@ -3687,12 +3639,11 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
-"使用以上知识，写一个用易读的格式输出矩阵的 `pretty_print` 函数，以及一个对矩阵进行转置（将行和列互换）的\n"
-"`transpose` 函数："
+"使用以上知识，写一个用易读的格式输出矩阵的 `pretty_print` 函数，以及一个对矩"
+"阵进行转置（将行和列互换）的 `transpose` 函数："
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3714,10 +3665,9 @@ msgstr "硬编码这两个函数，让它们处理 3 × 3 的矩阵。"
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
-msgstr ""
-"将下面的代码复制到 <https://play.rust-lang.org/> 并实现上述函数："
+msgstr "将下面的代码复制到 <https://play.rust-lang.org/> 并实现上述函数："
 
 #: src/exercises/day-1/for-loops.md:52
 msgid ""
@@ -3778,45 +3728,39 @@ msgstr ""
 "```"
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
-msgstr "## 附加题"
+msgid "Bonus Question"
+msgstr "附加题"
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"是否可以使用 `&[i32]` 切片而不是硬编码的 3 × 3 矩阵作为函数的参数和返回类型？例如使用\n"
-"`&[&[i32]]` 表示一个二维的切片的切片。为什么这样做是可行或不可行的？"
+"是否可以使用 `&[i32]` 切片而不是硬编码的 3 × 3 矩阵作为函数的参数和返回类型？"
+"例如使用 `&[&[i32]]` 表示一个二维的切片的切片。为什么这样做是可行或不可行的？"
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
-"参考 [`ndarray` crate](https://docs.rs/ndarray/) 以了解该功能满足生产环境质量的实现。"
+"参考 [`ndarray` crate](https://docs.rs/ndarray/) 以了解该功能满足生产环境质量"
+"的实现。"
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"题目解答和附加题的答案在\n"
-"[题解](solutions-morning.md#arrays-and-for-loops) 章节中。"
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
-msgstr "# 变量"
+"题目解答和附加题的答案在 [题解](solutions-morning.md#arrays-and-for-loops) 章"
+"节中。"
 
 #: src/basic-syntax/variables.md:3
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
-msgstr ""
-"Rust 通过静态类型实现了类型安全。变量绑定默认是不可变的："
+"by default:"
+msgstr "Rust 通过静态类型实现了类型安全。变量绑定默认是不可变的："
 
 #: src/basic-syntax/variables.md:6
 msgid ""
@@ -3840,18 +3784,18 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
+msgstr ""
+"由于类型推导，`i32` 可以省略。随着课程推进，我们会越来越少地看到类型声明。"
+
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
 "function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
-"* 由于类型推导，`i32` 可以省略。随着课程推进，我们会越来越少地看到类型声明。\n"
-"* 需要注意的是由于 `println!` 是一个宏，尽管使用了一个 `println!(\"x: {}\", x)` 这样"
-"形如函数的语法，`x` 也不会被移动。"
-
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
-msgstr "# 类型推导"
+"需要注意的是由于 `println!` 是一个宏，尽管使用了一个 `println!(\"x: {}\", "
+"x)` 这样形如函数的语法，`x` 也不会被移动。"
 
 #: src/basic-syntax/type-inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
@@ -3901,20 +3845,19 @@ msgstr ""
 msgid ""
 "This slide demonstrates how the Rust compiler infers types based on "
 "constraints given by variable declarations and usages."
-msgstr ""
-"这张幻灯片演示了 Rust 编译器是如何根据变量声明和用法来推导其类型的。"
+msgstr "这张幻灯片演示了 Rust 编译器是如何根据变量声明和用法来推导其类型的。"
 
 #: src/basic-syntax/type-inference.md:28
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
-"需要重点强调的是这样声明的变量并非像那种动态类型语言中可以持有任何数据的“任何类型”。"
-"这种声明所生成的机器码与明确类型声明完全相同。"
-"编译器进行类型推导能够让我们编写更简略的代码。"
+"需要重点强调的是这样声明的变量并非像那种动态类型语言中可以持有任何数据的“任何"
+"类型”。这种声明所生成的机器码与明确类型声明完全相同。编译器进行类型推导能够让"
+"我们编写更简略的代码。"
 
 #: src/basic-syntax/type-inference.md:32
 #, fuzzy
@@ -3923,7 +3866,8 @@ msgid ""
 "container without the code ever explicitly specifying the contained type, "
 "using `_` as a placeholder:"
 msgstr ""
-"下面的代码通过使用 `_` 占位符来告诉编译器无需明确指定其类型就可以将对应数据拷贝到该容器： "
+"下面的代码通过使用 `_` 占位符来告诉编译器无需明确指定其类型就可以将对应数据拷"
+"贝到该容器： "
 
 #: src/basic-syntax/type-inference.md:34
 msgid ""
@@ -3958,20 +3902,20 @@ msgid ""
 "rust-lang.org/std/iter/trait.FromIterator.html) implements."
 msgstr ""
 "[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
-"html#method.collect) 依赖 [`HashSet`](https://doc."
-"rust-lang.org/std/iter/trait.FromIterator.html) 实现的 `FromIterator`。"
+"html#method.collect) 依赖 [`HashSet`](https://doc.rust-lang.org/std/iter/"
+"trait.FromIterator.html) 实现的 `FromIterator`。"
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
-msgstr "# 静态 (Static) 变量和常数 (Constant) 变量"
+msgid "Static and Constant Variables"
+msgstr "静态 (Static) 变量和常数 (Constant) 变量"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid "Global state is managed with static and constant variables."
 msgstr "全局的状态是由静态变量和常数变量来管理的。"
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
-msgstr "## `const`"
+msgid "`const`"
+msgstr "`const`"
 
 #: src/basic-syntax/static-and-const.md:7
 msgid "You can declare compile-time constants:"
@@ -4018,12 +3962,16 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According to the [Rust RFC Book][1] these are inlined upon use."
-msgstr "根据 [Rust RFC Book][1] 这些变量在使用时是内联 (inlined) 的。"
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
+msgstr ""
+"根据 [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html) 这些变量在使用时是内联 (inlined) 的。"
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
-msgstr "## `static`"
+msgid "`static`"
+msgstr "`static`"
 
 #: src/basic-syntax/static-and-const.md:31
 msgid "You can also declare static variables:"
@@ -4049,47 +3997,44 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:41
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
-"正如 [Rust RFC Book][1] 中所述，这些变量在使用时并不是内联的，"
-"而且还具有实际相关联的内存位置。这对于不安全的嵌入式代码是有用的，"
-"并且这些变量存在于整个程序的执行过程之中。"
+"正如 [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html) 中所述，这些变量在使用时并不是内联的，而且还具有实际相关联的内存位置。"
+"这对于不安全的嵌入式代码是有用的，并且这些变量存在于整个程序的执行过程之中。"
 
 #: src/basic-syntax/static-and-const.md:44
 msgid ""
 "We will look at mutating static data in the [chapter on Unsafe Rust](../"
 "unsafe.md)."
-msgstr ""
-"我们会在[关于不安全的Rust的章节](../unsafe.md)中研究改变静态数据。"
+msgstr "我们会在[关于不安全的Rust的章节](../unsafe.md)中研究改变静态数据。"
 
 #: src/basic-syntax/static-and-const.md:48
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
-msgstr ""
-"* 值得一提的是，`const` 在语义上与C++的 `constexpr` 类似。\n"
-"* 另一方面，`static` 远远更类似于C++中的 `const` 或可改变的全局变量。\n"
-"* 虽然需要使用在运行中求值的常量的情况并不是很常见，但是它是有帮助的，"
-"而且比使用静态变量更安全。"
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
+msgstr "值得一提的是，`const` 在语义上与C++的 `constexpr` 类似。"
 
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
-msgstr "# 作用域和隐藏 (Shadowing) "
+#: src/basic-syntax/static-and-const.md:49
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr "另一方面，`static` 远远更类似于C++中的 `const` 或可改变的全局变量。"
+
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+"虽然需要使用在运行中求值的常量的情况并不是很常见，但是它是有帮助的，而且比使"
+"用静态变量更安全。"
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
-msgstr ""
-"你可以隐藏变量，位于外部作用域的变量和\n"
-"相同作用域的变量都可以："
+"the same scope:"
+msgstr "你可以隐藏变量，位于外部作用域的变量和 相同作用域的变量都可以："
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
@@ -4129,22 +4074,32 @@ msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"定义: 隐藏和变更 (mutation) 不同，因为在隐藏之后，两个变量都会同时存在于内存"
+"的不同位置中。在同一个名字下的两个变量都是可以被使用的，但是你在代码的哪里使"
+"用会最终决定你使用哪一个变量。"
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr "一个隐藏变量可以具有不同的类型。"
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr "隐藏起初看起来会有些晦涩，但是它很便于存 `.unwrap()` 之后的得到的值。"
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
-"* 定义: 隐藏和变更 (mutation) 不同，因为在隐藏之后，两个变量都会同时存在于内存的不同位置中。"
-"在同一个名字下的两个变量都是可以被使用的，但是你在代码的哪里使用会最终决定你使用哪一个变量。\n"
-"* 一个隐藏变量可以具有不同的类型。\n"
-"* 隐藏起初看起来会有些晦涩，但是它很便于存 `.unwrap()` 之后的得到的值。\n"
-"* 以下代码说明了为什么在作用域内隐藏一个不可变的变量时，即使是在变量类型没有改变的情况下，"
-"编译器也不能简单地重复利用之前的内存位置。"
+"以下代码说明了为什么在作用域内隐藏一个不可变的变量时，即使是在变量类型没有改"
+"变的情况下，编译器也不能简单地重复利用之前的内存位置。"
 
 #: src/basic-syntax/scopes-shadowing.md:30
 msgid ""
@@ -4166,22 +4121,19 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr "# 内存管理"
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr "传统上，语言分为两大类："
 
 #: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr "通过手动内存管理实现完全控制：C、C++、Pascal…"
+
+#: src/memory-management.md:6
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
-msgstr ""
-"* 通过手动内存管理实现完全控制：C、C++、Pascal…\n"
-"* 运行时通过自动内存管理实现完全安全：Java、Python、Go、Haskell…"
+msgstr "运行时通过自动内存管理实现完全安全：Java、Python、Go、Haskell…"
 
 #: src/memory-management.md:8
 msgid "Rust offers a new mix:"
@@ -4189,11 +4141,9 @@ msgstr "Rust 提供了一个全新的组合："
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
-msgstr ""
-"> 通过编译时强制执行正确的内存"
-">管理来实现完全控制与安全。"
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
+msgstr "通过编译时强制执行正确的内存>管理来实现完全控制与安全。"
 
 #: src/memory-management.md:13
 msgid "It does this with an explicit ownership concept."
@@ -4204,45 +4154,51 @@ msgid "First, let's refresh how memory management works."
 msgstr "首先，我们回顾一下内存管理的工作原理。"
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
-msgstr "# 栈与堆"
+msgid "The Stack vs The Heap"
+msgstr "栈与堆"
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* 栈：局部变量的连续内存区域。\n"
-"  * 值在编译时具有已知的固定大小。\n"
-"  * 速度极快：只需移动一个栈指针。\n"
-"  * 易于管理：遵循函数调用规则。\n"
-"  * 优秀的内存局部性。\n"
-"\n"
-"* 堆：函数调用之外的值的存储。\n"
-"  * 值具有动态大小，具体大小需在运行时确定。\n"
-"  * 比栈稍慢：需要向系统申请空间。\n"
-"  * 不保证内存局部性。"
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "栈：局部变量的连续内存区域。"
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
-msgstr "# 栈内存"
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr "值在编译时具有已知的固定大小。"
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr "速度极快：只需移动一个栈指针。"
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr "易于管理：遵循函数调用规则。"
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr "优秀的内存局部性。"
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr "堆：函数调用之外的值的存储。"
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr "值具有动态大小，具体大小需在运行时确定。"
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "比栈稍慢：需要向系统申请空间。"
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr "不保证内存局部性。"
 
 #: src/memory-management/stack.md:3
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
-"创建 `String` 时将固定大小的数据存储在栈上，\n"
-"并将动态大小的数据存储在堆上："
+"创建 `String` 时将固定大小的数据存储在栈上， 并将动态大小的数据存储在堆上："
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -4290,62 +4246,65 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
-"* 指出 `String` 底层由 `Vec` 实现，因此它具有容量和长度，如果值可变，则可以通过在堆上重新分配存储空间进行增长。\n"
-"\n"
-"* 如果学员提出相关问题，你可以提及我们不仅能使用[系统分配器]在堆上分配底层内"
-"存，还能使用 [Allocator API] 实现自定义分配器\n"
-"\n"
-"* 我们可以使用 `unsafe` 代码检查内存布局。不过，你应该指出，这种做法不安全！\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"指出 `String` 底层由 `Vec` 实现，因此它具有容量和长度，如果值可变，则可以通过"
+"在堆上重新分配存储空间进行增长。"
 
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
-msgstr "# 手动内存管理"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+"如果学员提出相关问题，你可以提及我们不仅能使用\\[系统分配器\\]在堆上分配底层"
+"内存，还能使用 [Allocator API](https://doc.rust-lang.org/std/alloc/index."
+"html) 实现自定义分配器"
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+"我们可以使用 `unsafe` 代码检查内存布局。不过，你应该指出，这种做法不安全！"
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
 
 #: src/memory-management/manual.md:3
 msgid "You allocate and deallocate heap memory yourself."
@@ -4358,8 +4317,8 @@ msgid ""
 msgstr "稍有不慎，这可能会导致崩溃、bug、安全漏洞和内存泄漏。"
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
-msgstr "## C++ 示例"
+msgid "C Example"
+msgstr "C++ 示例"
 
 #: src/memory-management/manual.md:9
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
@@ -4390,15 +4349,10 @@ msgstr ""
 #: src/memory-management/manual.md:21
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
-"如果函数在 `malloc` 和 `free` 之间提前返回，则会导致内存泄漏：\n"
-"指针丢失，而我们无法释放对应的内存。"
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
-msgstr "# 基于作用域的内存管理"
+"如果函数在 `malloc` 和 `free` 之间提前返回，则会导致内存泄漏： 指针丢失，而我"
+"们无法释放对应的内存。"
 
 #: src/memory-management/scope-based.md:3
 msgid ""
@@ -4407,27 +4361,24 @@ msgstr "构造函数和析构函数让你可以钩入对象的生命周期。"
 
 #: src/memory-management/scope-based.md:5
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
-"通过将指针封装在对象中，你可以在该对象\n"
-"被销毁时释放内存。编译器可保证这一点的实现，即使"
-"引发了异常也不例外。"
+"通过将指针封装在对象中，你可以在该对象 被销毁时释放内存。编译器可保证这一点的"
+"实现，即使引发了异常也不例外。"
 
 #: src/memory-management/scope-based.md:9
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr ""
-"这通常称为“资源获取即初始化 (resource acquisition is initialization, RAII)”，\n"
-"并为你提供智能指针。"
+"这通常称为“资源获取即初始化 (resource acquisition is initialization, "
+"RAII)”， 并为你提供智能指针。"
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
-msgstr "## C++ 示例"
+msgid "C++ Example"
+msgstr "C++ 示例"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -4445,15 +4396,17 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:20
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
-msgstr ""
-"* `std::unique_ptr` 对象在栈上分配内存，并指向"
-"在堆上分配的内存。\n"
-"* 在 `say_hello` 结束时，`std::unique_ptr` 析构函数将运行。\n"
-"* 析构函数释放它所指向的 `Person` 对象。"
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
+msgstr "`std::unique_ptr` 对象在栈上分配内存，并指向在堆上分配的内存。"
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr "在 `say_hello` 结束时，`std::unique_ptr` 析构函数将运行。"
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
+msgstr "析构函数释放它所指向的 `Person` 对象。"
 
 #: src/memory-management/scope-based.md:25
 msgid ""
@@ -4473,30 +4426,28 @@ msgstr ""
 "```"
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
-msgstr "# 自动内存管理"
+msgid "Automatic Memory Management"
+msgstr "自动内存管理"
 
 #: src/memory-management/garbage-collection.md:3
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
-msgstr ""
-"自动内存管理是手动和基于作用域的内存管理\n"
-"的替代方案："
+"memory management:"
+msgstr "自动内存管理是手动和基于作用域的内存管理 的替代方案："
 
 #: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "程序员从不显式分配或取消分配内存。"
+
+#: src/memory-management/garbage-collection.md:7
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
-msgstr ""
-"* 程序员从不显式分配或取消分配内存。\n"
-"* 垃圾回收器找到未使用的内存，并为程序员将其取消分配。"
+msgstr "垃圾回收器找到未使用的内存，并为程序员将其取消分配。"
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
-msgstr "## Java 示例"
+msgid "Java Example"
+msgstr "Java 示例"
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
@@ -4517,29 +4468,36 @@ msgstr ""
 "```"
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
-msgstr "# Rust 中的内存管理"
+msgid "Memory Management in Rust"
+msgstr "Rust 中的内存管理"
 
 #: src/memory-management/rust.md:3
 msgid "Memory management in Rust is a mix:"
 msgstr "Rust 中的内存管理是一种混合模式："
 
 #: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "像 Java 一样安全又正确，但没有垃圾回收器。"
+
+#: src/memory-management/rust.md:6
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+"根据你选择的抽象（或抽象组合），可以是单个唯一指针，也可以是引用计数，或原子"
+"引用计数。"
+
+#: src/memory-management/rust.md:7
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr "像 C++ 一样基于作用域，但编译器会强制完全遵循规则。"
+
+#: src/memory-management/rust.md:8
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
-"* 像 Java 一样安全又正确，但没有垃圾回收器。\n"
-"* 根据你选择的抽象（或抽象组合），可以是单个唯一指针，也可以是引用计数，或原"
-"子引用计数。\n"
-"* 像 C++ 一样基于作用域，但编译器会强制完全遵循规则。\n"
-"* Rust 用户可以根据具体情况选择合适的抽象，有些甚至没有像 C 那样的运行时开"
-"销。"
+"Rust 用户可以根据具体情况选择合适的抽象，有些甚至没有像 C 那样的运行时开销。"
 
 #: src/memory-management/rust.md:10
 msgid "It achieves this by modeling _ownership_ explicitly."
@@ -4547,106 +4505,125 @@ msgstr "它通过对“所有权”进行显式建模来实现这一点。"
 
 #: src/memory-management/rust.md:14
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* 如果此时被问及如何操作，你可以提及在 Rust 中，这通常由 RAII 封装容器类型"
-"（例如 [Box]、[Vec]、[Rc] 或 [Arc]）处理。这些类型通过各种方式封装了所有权和"
-"内存分配，并防止了 C 中潜在错误的发生。\n"
-"\n"
-"* 你可能会被问及析构函数，此处 [Drop] trait 是 Rust 等效项。"
+"如果此时被问及如何操作，你可以提及在 Rust 中，这通常由 RAII 封装容器类型（例"
+"如 [Box](https://doc.rust-lang.org/std/boxed/struct.Box.html)、[Vec](https://"
+"doc.rust-lang.org/std/vec/struct.Vec.html)、[Rc](https://doc.rust-lang.org/"
+"std/rc/struct.Rc.html) 或 [Arc](https://doc.rust-lang.org/std/sync/struct."
+"Arc.html)）处理。这些类型通过各种方式封装了所有权和内存分配，并防止了 C 中潜"
+"在错误的发生。"
 
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
-msgstr "# 比较"
+#: src/memory-management/rust.md:16
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
+msgstr ""
+"你可能会被问及析构函数，此处 [Drop](https://doc.rust-lang.org/std/ops/trait."
+"Drop.html) trait 是 Rust 等效项。"
 
 #: src/memory-management/comparison.md:3
 msgid "Here is a rough comparison of the memory management techniques."
 msgstr "下面是对内存管理技术的粗略比较。"
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## 不同内存管理技术的优点"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "不同内存管理技术的优点"
 
-#: src/memory-management/comparison.md:7
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* 手动（如 C）：\n"
-"  * 无运行时开销。\n"
-"* 自动（如 Java）：\n"
-"  * 完全自动。\n"
-"  * 安全且正确。\n"
-"* 基于作用域（如 C++）：\n"
-"  * 部分自动。\n"
-"  * 无运行时开销。\n"
-"* 由编译器强制执行、基于作用域（如 Rust）：\n"
-"  * 由编译器强制执行。\n"
-"  * 无运行时开销。\n"
-"  * 安全且正确。"
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
+msgid "Manual like C:"
+msgstr "手动（如 C）："
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+msgid "No runtime overhead."
+msgstr "无运行时开销。"
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+msgid "Automatic like Java:"
+msgstr "自动（如 Java）："
+
+#: src/memory-management/comparison.md:10
+msgid "Fully automatic."
+msgstr "完全自动。"
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+msgid "Safe and correct."
+msgstr "安全且正确。"
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+msgid "Scope-based like C++:"
+msgstr "基于作用域（如 C++）："
+
+#: src/memory-management/comparison.md:13
+msgid "Partially automatic."
+msgstr "部分自动。"
+
+#: src/memory-management/comparison.md:15
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "由编译器强制执行、基于作用域（如 Rust）："
+
+#: src/memory-management/comparison.md:16
+msgid "Enforced by compiler."
+msgstr "由编译器强制执行。"
 
 #: src/memory-management/comparison.md:20
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## 不同内存管理技术的缺点"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "不同内存管理技术的缺点"
 
-#: src/memory-management/comparison.md:22
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* 手动（如 C）：\n"
-"  * 释放后使用。\n"
-"  * 双重释放。\n"
-"  * 内存泄漏。\n"
-"* 自动（如 Java）：\n"
-"  * 垃圾回收暂停。\n"
-"  * 析构函数延迟。\n"
-"* 基于作用域（如 C++）：\n"
-"  * 复杂，由程序员自选。\n"
-"  * 有望释放后使用。\n"
-"* 由编译器强制执行、基于作用域（如 Rust）：\n"
-"  * 前期有些复杂。\n"
-"  * 可能拒绝有效的程序。"
+#: src/memory-management/comparison.md:23
+msgid "Use-after-free."
+msgstr "释放后使用。"
 
-#: src/ownership.md:1
-msgid "# Ownership"
-msgstr "# 所有权"
+#: src/memory-management/comparison.md:24
+msgid "Double-frees."
+msgstr "双重释放。"
+
+#: src/memory-management/comparison.md:25
+msgid "Memory leaks."
+msgstr "内存泄漏。"
+
+#: src/memory-management/comparison.md:27
+msgid "Garbage collection pauses."
+msgstr "垃圾回收暂停。"
+
+#: src/memory-management/comparison.md:28
+msgid "Destructor delays."
+msgstr "析构函数延迟。"
+
+#: src/memory-management/comparison.md:30
+msgid "Complex, opt-in by programmer."
+msgstr "复杂，由程序员自选。"
+
+#: src/memory-management/comparison.md:31
+msgid "Potential for use-after-free."
+msgstr "有望释放后使用。"
+
+#: src/memory-management/comparison.md:32
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "由编译器强制执行、基于作用域（如 Rust）："
+
+#: src/memory-management/comparison.md:33
+msgid "Some upfront complexity."
+msgstr "前期有些复杂。"
+
+#: src/memory-management/comparison.md:34
+msgid "Can reject valid programs."
+msgstr "可能拒绝有效的程序。"
 
 #: src/ownership.md:3
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
-msgstr ""
-"所有变量绑定都有一个有效的“作用域”，使用\n"
-"超出其作用域的变量是错误的："
+"to use a variable outside its scope:"
+msgstr "所有变量绑定都有一个有效的“作用域”，使用 超出其作用域的变量是错误的："
 
 #: src/ownership.md:6
 msgid ""
@@ -4676,17 +4653,16 @@ msgstr ""
 
 #: src/ownership.md:18
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
-msgstr ""
-"* 作用域结束时，变量会“被丢弃”，数据会被释放。\n"
-"* 析构函数可在此运行以释放资源。\n"
-"* 指出变量“拥有”值。"
+"At the end of the scope, the variable is _dropped_ and the data is freed."
+msgstr "作用域结束时，变量会“被丢弃”，数据会被释放。"
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
-msgstr "# 移动语义"
+#: src/ownership.md:19
+msgid "A destructor can run here to free up resources."
+msgstr "析构函数可在此运行以释放资源。"
+
+#: src/ownership.md:20
+msgid "We say that the variable _owns_ the value."
+msgstr "指出变量“拥有”值。"
 
 #: src/ownership/move-semantics.md:3
 msgid "An assignment will transfer ownership between variables:"
@@ -4713,34 +4689,36 @@ msgstr ""
 "```"
 
 #: src/ownership/move-semantics.md:14
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
-msgstr ""
-"* 将 `s1` 赋值给 `s2`，即转移了所有权。\n"
-"* 数据从 `s1`“移出”，且 `s1` 不再可供访问。\n"
-"* 当 `s1` 离开作用域时，什么都不会发生：它没有所有权。\n"
-"* 当 `s2` 离开作用域时，字符串数据被释放。\n"
-"* 变量绑定在任一时刻有且“只有”一个值。"
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "将 `s1` 赋值给 `s2`，即转移了所有权。"
+
+#: src/ownership/move-semantics.md:15
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr "数据从 `s1`“移出”，且 `s1` 不再可供访问。"
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr "当 `s1` 离开作用域时，什么都不会发生：它没有所有权。"
+
+#: src/ownership/move-semantics.md:17
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr "当 `s2` 离开作用域时，字符串数据被释放。"
+
+#: src/ownership/move-semantics.md:18
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr "变量绑定在任一时刻有且“只有”一个值。"
 
 #: src/ownership/move-semantics.md:22
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* 指出这与 C++ 中的默认值相反。除非你使用 `std::move`（并已定义 move 构造函"
-"数！），否则 C++ 中的默认值是按值复制的。\n"
-"\n"
-"* 在 Rust 中，克隆是显式的（通过使用 `clone`）。"
+"指出这与 C++ 中的默认值相反。除非你使用 `std::move`（并已定义 move 构造函"
+"数！），否则 C++ 中的默认值是按值复制的。"
 
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
-msgstr "# Rust 中移动的字符串"
+#: src/ownership/move-semantics.md:24
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "在 Rust 中，克隆是显式的（通过使用 `clone`）。"
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4759,12 +4737,12 @@ msgstr ""
 "```"
 
 #: src/ownership/moved-strings-rust.md:10
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
-msgstr ""
-"* `s1` 中的堆数据会被 `s2` 重复使用。\n"
-"* 当 `s1` 离开作用域时，什么都不会发生（它已被移出）。"
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "`s1` 中的堆数据会被 `s2` 重复使用。"
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgstr "当 `s1` 离开作用域时，什么都不会发生（它已被移出）。"
 
 #: src/ownership/moved-strings-rust.md:13
 msgid "Before move to `s2`:"
@@ -4850,10 +4828,6 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr "# 现代 C++ 中的双重释放"
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr "现代 C++ 以不同的方式解决此问题："
@@ -4872,12 +4846,12 @@ msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
-msgstr ""
-"* `s1` 中的堆数据被复制，`s2` 获得自己的独立副本。\n"
-"* 当 `s1` 和 `s2` 离开作用域时，它们会各自释放自己的内存。"
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+msgstr "`s1` 中的堆数据被复制，`s2` 获得自己的独立副本。"
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr "当 `s1` 和 `s2` 离开作用域时，它们会各自释放自己的内存。"
 
 #: src/ownership/double-free-modern-cpp.md:13
 msgid "Before copy-assignment:"
@@ -4961,17 +4935,11 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/moves-function-calls.md:1
-msgid "# Moves in Function Calls"
-msgstr "# 函数调用中的移动"
-
 #: src/ownership/moves-function-calls.md:3
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
-msgstr ""
-"你将值传递给函数时，该值会被赋给函数\n"
-"参数。这就转移了所有权："
+msgstr "你将值传递给函数时，该值会被赋给函数 参数。这就转移了所有权："
 
 #: src/ownership/moves-function-calls.md:6
 msgid ""
@@ -5001,30 +4969,39 @@ msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* 首次调用 `say_hello` 时，`main` 便放弃了 `name` 的所有权。此后，`main` 中不"
-"能再使用 `name`。\n"
-"* 在 `say_hello` 函数结束时，系统会释放为 `name` 分配的堆内存。\n"
-"* 如果 `main` 将 `name` 作为引用 (`&name`) 传递过去，且 `say_hello` 接受作为"
-"参数的引用，则可保留所有权。\n"
-"* 此外，`main` 也可以在首次调用时传递 `name` 的克隆 (`name.clone()`)。\n"
-"* 相较于 C++，Rust 通过将移动语义设为默认值，并强制程序员进行显式克隆，更难以"
-"无意中创建副本。"
+"首次调用 `say_hello` 时，`main` 便放弃了 `name` 的所有权。此后，`main` 中不能"
+"再使用 `name`。"
 
-#: src/ownership/copy-clone.md:1
-msgid "# Copying and Cloning"
-msgstr "# 复制和克隆"
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr "在 `say_hello` 函数结束时，系统会释放为 `name` 分配的堆内存。"
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"如果 `main` 将 `name` 作为引用 (`&name`) 传递过去，且 `say_hello` 接受作为参"
+"数的引用，则可保留所有权。"
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr "此外，`main` 也可以在首次调用时传递 `name` 的克隆 (`name.clone()`)。"
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"相较于 C++，Rust 通过将移动语义设为默认值，并强制程序员进行显式克隆，更难以无"
+"意中创建副本。"
 
 #: src/ownership/copy-clone.md:3
 msgid ""
@@ -5086,12 +5063,12 @@ msgstr ""
 "```"
 
 #: src/ownership/copy-clone.md:30
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
-msgstr ""
-"* 赋值之后，`p1` 和 `p2` 都拥有自己的数据。\n"
-"* 我们还可以使用 `p1.clone()` 显式复制数据。"
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr "赋值之后，`p1` 和 `p2` 都拥有自己的数据。"
+
+#: src/ownership/copy-clone.md:31
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr "我们还可以使用 `p1.clone()` 显式复制数据。"
 
 #: src/ownership/copy-clone.md:35
 msgid "Copying and cloning are not the same thing:"
@@ -5099,18 +5076,24 @@ msgstr "复制和克隆是两码事："
 
 #: src/ownership/copy-clone.md:37
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C+"
-"+).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
-msgstr ""
-"* 复制是指内存区域的按位复制，不适用于任意对象。\n"
-"* 复制不允许自定义逻辑（不同于 C++ 中的复制构造函数）。\n"
-"* 克隆是一种更通用的操作，也允许通过实现 `Clone` trait 来自定义行为。\n"
-"* 复制不适用于实现 `Drop` trait 的类型。"
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
+msgstr "复制是指内存区域的按位复制，不适用于任意对象。"
+
+#: src/ownership/copy-clone.md:38
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr "复制不允许自定义逻辑（不同于 C++ 中的复制构造函数）。"
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr "克隆是一种更通用的操作，也允许通过实现 `Clone` trait 来自定义行为。"
+
+#: src/ownership/copy-clone.md:40
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr "复制不适用于实现 `Drop` trait 的类型。"
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 msgid "In the above example, try the following:"
@@ -5118,40 +5101,37 @@ msgstr "在上述示例中，请尝试以下操作："
 
 #: src/ownership/copy-clone.md:44
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* 在 `struct Point` 中添加 `String` 字段。由于 `String` 不属于 `Copy` 类型，"
-"因此无法编译。\n"
-"* 从 `derive` 属性中移除 `Copy`。现在，编译器错误位于 `p1`的 `println!` "
-"中。\n"
-"* 指出如果你改为克隆 `p1`，则可按预期运行。"
+"在 `struct Point` 中添加 `String` 字段。由于 `String` 不属于 `Copy` 类型，因"
+"此无法编译。"
+
+#: src/ownership/copy-clone.md:45
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"从 `derive` 属性中移除 `Copy`。现在，编译器错误位于 `p1`的 `println!` 中。"
+
+#: src/ownership/copy-clone.md:46
+msgid "Show that it works if you clone `p1` instead."
+msgstr "指出如果你改为克隆 `p1`，则可按预期运行。"
 
 #: src/ownership/copy-clone.md:48
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated."
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
-"如果学员问起 `derive`，只需说这是一种\n"
-"在编译时生成 Rust 代码的方法。在这种情况下，系统会生成 `Copy` 和 `Clone` "
-"trait 的默认实现。"
-
-#: src/ownership/borrowing.md:1
-msgid "# Borrowing"
-msgstr "# 借用"
+"如果学员问起 `derive`，只需说这是一种 在编译时生成 Rust 代码的方法。在这种情"
+"况下，系统会生成 `Copy` 和 `Clone` trait 的默认实现。"
 
 #: src/ownership/borrowing.md:3
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
-msgstr ""
-"调用函数时，你可以让\n"
-"函数“借用”值，而不是转移所有权："
+msgstr "调用函数时，你可以让 函数“借用”值，而不是转移所有权："
 
 #: src/ownership/borrowing.md:6
 msgid ""
@@ -5188,12 +5168,12 @@ msgstr ""
 "```"
 
 #: src/ownership/borrowing.md:22
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
-msgstr ""
-"* `add` 函数“借用”两个点并返回一个新点。\n"
-"* 调用方会保留输入的所有权。"
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr "`add` 函数“借用”两个点并返回一个新点。"
+
+#: src/ownership/borrowing.md:23
+msgid "The caller retains ownership of the inputs."
+msgstr "调用方会保留输入的所有权。"
 
 #: src/ownership/borrowing.md:27
 msgid "Notes on stack returns:"
@@ -5201,78 +5181,82 @@ msgstr "关于栈返回的说明："
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can "
+"Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while they stay the same when changing to the "
-"\"RELEASE\" setting:\n"
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
+msgstr ""
+"证明从 `add` 返回的开销很低，因为编译器可以消除复制操作。更改上述代码以输出栈"
+"地址，并在 [Playground](https://play.rust-lang.org/) 上运行它。在“调试”优化级"
+"别中，地址应发生变化，而在改成“发布”设置时保持不变："
+
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
 "\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
 "\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
 "\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification "
-"because constructors can have side effects. In Rust, this is not an issue at "
-"all. If RVO did not happen, Rust will always performs a simple and efficient "
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr "Rust 编译器能够执行返回值优化 (RVO)。"
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always performs a simple and efficient "
 "`memcpy` copy."
 msgstr ""
-"* 证明从 `add` 返回的开销很低，因为编译器可以消除复制操作。更改上述代码以输出"
-"栈地址，并在 [Playground] 上运行它。在“调试”优化级别中，地址应发生变化，而在"
-"改成“发布”设置时保持不变：\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"*  Rust 编译器能够执行返回值优化 (RVO)。\n"
-"* 在 C++ 中，必须在语言规范中定义复制省略，因为构造函数可能会有附带效应。在 "
+"在 C++ 中，必须在语言规范中定义复制省略，因为构造函数可能会有附带效应。在 "
 "Rust 中，这完全不是问题。如果 RVO 未发生，Rust 将始终执行简单且高效的 "
 "`memcpy` 复制。"
-
-#: src/ownership/shared-unique-borrows.md:1
-msgid "# Shared and Unique Borrows"
-msgstr "# 共享和唯一的借用"
 
 #: src/ownership/shared-unique-borrows.md:3
 msgid "Rust puts constraints on the ways you can borrow values:"
 msgstr "Rust 限制了借用值的方式："
 
 #: src/ownership/shared-unique-borrows.md:5
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* 在任何给定时间，你都可以有一个或多个 `&T` 值，或者\n"
-"* 你可以有且只有一个 `&mut T` 值。"
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "在任何给定时间，你都可以有一个或多个 `&T` 值，或者"
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
+msgstr "你可以有且只有一个 `&mut T` 值。"
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
@@ -5308,49 +5292,64 @@ msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:25
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+"上述代码无法编译，因为 `a` 同时作为可变值（通过 `c`）和不可变值（通过 `b`）被"
+"借用。"
+
+#: src/ownership/shared-unique-borrows.md:26
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"将`b` 的 `println!` 语句移到引入 `c` 的作用域之前，这段代码就可以编译。"
+
+#: src/ownership/shared-unique-borrows.md:27
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"* 上述代码无法编译，因为 `a` 同时作为可变值（通过 `c`）和不可变值（通过 `b`）"
-"被借用。\n"
-"* 将`b` 的 `println!` 语句移到引入 `c` 的作用域之前，这段代码就可以编译。\n"
-"* 这样更改后，编译器会发现 `b` 只在通过 `c` 对 `a` 进行新可变借用之前使用过。"
-"这是借用检查器的一个功能，名为“非词法作用域生命周期”。"
-
-#: src/ownership/lifetimes.md:1
-msgid "# Lifetimes"
-msgstr "# 生命周期"
+"这样更改后，编译器会发现 `b` 只在通过 `c` 对 `a` 进行新可变借用之前使用过。这"
+"是借用检查器的一个功能，名为“非词法作用域生命周期”。"
 
 #: src/ownership/lifetimes.md:3
 msgid "A borrowed value has a _lifetime_:"
 msgstr "借用的值是有“生命周期”的："
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully "
-"specified,\n"
-"  but Rust allows these to be elidied in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
-msgstr ""
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
+msgstr "生命周期可以是隐式的：add(p1: &Point, p2: &Point) -> Point\\`。"
 
-#: src/ownership/lifetimes-function-calls.md:1
-msgid "# Lifetimes in Function Calls"
-msgstr "# 函数调用中的生命周期"
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr "生命周期也可以是显式的：`&'a Point`、`&'document str`。"
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr "将 `&'a Point` 读取为“借用的 `Point，至少 在 `a\\` 生命周期内有效。"
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr "生命周期始终由编译器推断出来：你不能自行 分配生命周期。"
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr "生命周期注释会创建约束条件；编译器会验证 是否存在有效的解决方案。"
+
+#: src/ownership/lifetimes.md:13
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows these to be elidied in most cases with [a few simple rules]"
+"(https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:3
 msgid ""
@@ -5393,60 +5392,99 @@ msgstr ""
 "```"
 
 #: src/ownership/lifetimes-function-calls.md:21
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`'a` 是一个泛型形参，由编译器推断出来。"
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr "以 `'` 和 `'a` 开头的生命周期是典型的默认名称。"
+
+#: src/ownership/lifetimes-function-calls.md:25
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
-msgstr ""
-"* `'a` 是一个泛型形参，由编译器推断出来。\n"
-"* 以 `'` 和 `'a` 开头的生命周期是典型的默认名称。\n"
-"* 将 `&'a Point` 读取为“借用的 `Point，至少\n"
-"在 `a` 生命周期内有效。\n"
-"  * 当参数在不同的作用域时，“至少”部分至关重要。"
+"The _at least_ part is important when parameters are in different scopes."
+msgstr "当参数在不同的作用域时，“至少”部分至关重要。"
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:1
-msgid "# Lifetimes in Data Structures"
-msgstr "# 数据结构中的生命周期"
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+
+#: src/ownership/lifetimes-function-calls.md:50
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr "请注意：由于 `p3` 的生命周期比 `p2` 长，因此无法编译。"
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+"重置工作区，然后将函数签名更改为 `fn left_most<'a, 'b>(p1: &'a Point, p2: "
+"&'a Point) -> &'b Point`。这不会被编译，因为 `'a` 和 `'b` 生命周期之间的关系"
+"不明确。"
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr "另一种解释方式："
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr "对两个值的两个引用被一个函数借用，该函数返回 另一个引用。"
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr "它必须是来自这两个输入中的一个（或来自一个全局变量）。"
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
 msgid ""
@@ -5495,33 +5533,47 @@ msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data "
+"In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This "
-"can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one "
-"lifetime annotation. This can be necessary if there is a need to describe "
-"lifetime relationships between the references themselves, in addition to the "
-"lifetime of the struct itself. Those are very advanced use cases."
+"`Highlight` that uses that data."
 msgstr ""
-"* 在上述示例中，`Highlight` 注释会强制包含 `&str` 的底层数据的生命周期至少与"
-"使用该数据的任何 `Highlight` 实例一样长。\n"
-"* 如果 `text` 在 `fox`（或 `dog`）的生命周期结束前被消耗，借用检查器将抛出一"
-"个错误。\n"
-"* 借用数据的类型会迫使用户保留原始数据。这对于创建轻量级视图很有用，但通常会"
-"使它们更难使用。\n"
-"* 如有可能，让数据结构直接拥有自己的数据。\n"
-"* 一些包含多个引用的结构可以有多个生命周期注释。除了结构体本身的生命周期之"
-"外，如果需要描述引用之间的生命周期关系，则可能需要这样做。这些都是非常高级的"
-"用例。"
+"在上述示例中，`Highlight` 注释会强制包含 `&str` 的底层数据的生命周期至少与使"
+"用该数据的任何 `Highlight` 实例一样长。"
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"如果 `text` 在 `fox`（或 `dog`）的生命周期结束前被消耗，借用检查器将抛出一个"
+"错误。"
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"借用数据的类型会迫使用户保留原始数据。这对于创建轻量级视图很有用，但通常会使"
+"它们更难使用。"
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr "如有可能，让数据结构直接拥有自己的数据。"
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"一些包含多个引用的结构可以有多个生命周期注释。除了结构体本身的生命周期之外，"
+"如果需要描述引用之间的生命周期关系，则可能需要这样做。这些都是非常高级的用"
+"例。"
 
 #: src/exercises/day-1/afternoon.md:1
-msgid "# Day 1: Afternoon Exercises"
+msgid "Day 1: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:3
@@ -5529,21 +5581,17 @@ msgid "We will look at two things:"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:5
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
+msgid "A small book library,"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:1
-msgid "# Designing a Library"
+#: src/exercises/day-1/afternoon.md:7
+msgid "Iterators and ownership (hard)."
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:3
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:6
@@ -5563,8 +5611,8 @@ msgstr ""
 
 #: src/exercises/day-1/book-library.md:18
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:21
@@ -5655,27 +5703,21 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-msgid "# Iterators and Ownership"
-msgstr ""
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
-msgid "## `Iterator`"
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
+msgid "`Iterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
@@ -5731,12 +5773,12 @@ msgid "Why is this type used?"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
-msgid "## `IntoIterator`"
+msgid "`IntoIterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
@@ -5755,19 +5797,21 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:62
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 
@@ -5790,15 +5834,14 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
-msgid "## `for` Loops"
+msgid "`for` Loops"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
@@ -5825,58 +5868,47 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:105
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 
 #: src/welcome-day-2.md:1
-msgid "# Welcome to Day 2"
-msgstr "# 欢迎来到第二天"
+msgid "Welcome to Day 2"
+msgstr "欢迎来到第二天"
 
 #: src/welcome-day-2.md:3
 msgid "Now that we have seen a fair amount of Rust, we will continue with:"
 msgstr "现在我们已经了解了相当多的Rust，接下来我们将学习："
 
 #: src/welcome-day-2.md:5
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
-msgstr ""
-"* 结构体（struct）, 枚举（enum）, 方法（method）。\n"
-"\n"
-"* 模式匹配: 解构枚举, 结构体和数组（array）。\n"
-"\n"
-"* 控制流的构造: `if`, `if let`, `while`, `while let`, `break`, "
-"和\n"
-"  `continue`。\n"
-"\n"
-"* 标准库: `字符串（String）`, `选项（Option）` 和 `结果（Result）`, `动态数组（Vec）`, `散列表（HashMap）`, "
-"`引用计数（Rc）`\n"
-"  和 `共享引用计数（Arc）`。\n"
-"\n"
-"* 模块: 可见性, 路径和文件系统的层次结构。"
+msgid "Structs, enums, methods."
+msgstr "结构体（struct）, 枚举（enum）, 方法（method）。"
 
-#: src/structs.md:1
-msgid "# Structs"
-msgstr "# 结构体"
+#: src/welcome-day-2.md:7
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr "模式匹配: 解构枚举, 结构体和数组（array）。"
+
+#: src/welcome-day-2.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+"控制流的构造: `if`, `if let`, `while`, `while let`, `break`, 和 `continue`。"
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+"标准库: `字符串（String）`, `选项（Option）` 和 `结果（Result）`, `动态数组"
+"（Vec）`, `散列表（HashMap）`, `引用计数（Rc）` 和 `共享引用计数（Arc）`。"
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr "模块: 可见性, 路径和文件系统的层次结构。"
 
 #: src/structs.md:3
 msgid "Like C and C++, Rust has support for custom structs:"
@@ -5916,27 +5948,48 @@ msgid "Key Points:"
 msgstr "关键点："
 
 #: src/structs.md:33
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
 msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
-
-#: src/structs/tuple-structs.md:1
-msgid "# Tuple Structs"
-msgstr "# 元组结构体"
 
 #: src/structs/tuple-structs.md:3
 msgid "If the field names are unimportant, you can use a tuple struct:"
@@ -5982,26 +6035,44 @@ msgstr ""
 
 #: src/structs/tuple-structs.md:37
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). "
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
+"如需对基元类型中的值的额外信息进行编码，使用 newtype 是一种非常好的方式，例"
+"如："
 
-#: src/structs/field-shorthand.md:1
-msgid "# Field Shorthand Syntax"
-msgstr "# 字段简写语法"
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr "数字会以某些单位来衡量：上方示例中为 `Newtons`。"
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"值在创建时已通过一些验证，因此您不再需要在每次使用时都再次验证它："
+"`PhoneNumber(String)` 或 `OddNumber(u32)`。"
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+"展示如何通过访问 newtype 中的单个字段，将 `f64` 值添加到 `Newtons` 类型。"
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr "Rust 通常不喜欢不明确的内容，例如自动解封或将布尔值用作整数。"
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics). "
+msgstr ""
 
 #: src/structs/field-shorthand.md:3
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr "如果您已有名称正确的变量，则可以使用简写形式创建结构体："
 
@@ -6029,66 +6100,80 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use "
-"the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-msgid "# Enums"
-msgstr "# 枚举"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
 
 #: src/enums.md:3
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
-msgstr ""
-"`enum` 关键字允许创建具有几个\n"
-"不同变体的类型："
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
+msgstr "`enum` 关键字允许创建具有几个 不同变体的类型："
 
 #: src/enums.md:6
 msgid ""
@@ -6119,40 +6204,49 @@ msgid ""
 msgstr ""
 
 #: src/enums.md:36
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr "枚举允许你从一种类型下收集一组值"
+
+#: src/enums.md:37
 msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+"本页提供了一个枚举类型 `CoinFlip`，其中包含 `Heads` 和`Tail`两个变体。在使用"
+"变体时，你可能会注意到命名空间。"
+
+#: src/enums.md:38
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr "这可能是比较结构体和枚举的好时机："
+
+#: src/enums.md:39
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"在这两者中，你可以获得一个不含字段的简单版本（单位结构体），或一个包含不同类"
+"型字段的版本（变体载荷）。"
+
+#: src/enums.md:40
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr "在这两者中，关联的函数都在 `impl` 块中定义。"
+
+#: src/enums.md:41
+msgid ""
+"You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
 msgstr ""
-"* 枚举允许你从一种类型下收集一组值\n"
-"* 本页提供了一个枚举类型 `CoinFlip`，其中包含 `Heads` 和`Tail`两个变体。在使"
-"用变体时，你可能会注意到命名空间。\n"
-"* 这可能是比较结构体和枚举的好时机：\n"
-"  * 在这两者中，你可以获得一个不含字段的简单版本（单位结构体），或一个包含不"
-"同类型字段的版本（变体载荷）。\n"
-"  * 在这两者中，关联的函数都在 `impl` 块中定义。\n"
-"  * 你甚至可以使用单独的结构体实现枚举的不同变体，但这样一来，如果它们都已在"
-"枚举中定义，类型与之前也不一样。"
-
-#: src/enums/variant-payloads.md:1
-msgid "# Variant Payloads"
-msgstr "# 变体载荷"
+"你甚至可以使用单独的结构体实现枚举的不同变体，但这样一来，如果它们都已在枚举"
+"中定义，类型与之前也不一样。"
 
 #: src/enums/variant-payloads.md:3
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
-"你可以定义更丰富的枚举，其中变体会携带数据。然后，你可以使用\n"
-"`match` 语句从每个变体中提取数据："
+"你可以定义更丰富的枚举，其中变体会携带数据。然后，你可以使用 `match` 语句从每"
+"个变体中提取数据："
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -6212,46 +6306,65 @@ msgstr ""
 
 #: src/enums/variant-payloads.md:35
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There "
-"is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example.  \n"
-"  "
+"after the `=>`."
 msgstr ""
-"* 枚举变体中的值只有在被模式匹配后，才可访问。模式将引用绑定到 `=>` 之后"
-"的“match 分支”中的字段。\n"
-"  * 表达式会从上到下与模式匹配。没有像 C 或 C++ 中那样的跳转。\n"
-"  * 匹配表达式拥有一个值。值是 match 分支中被执行的最后一个表达式。\n"
-"  * 从顶部开始，查找与该值匹配的模式，然后沿箭头运行代码。一旦找到匹配，我们"
-"便会停止。\n"
-"* 展示搜索不详尽时会发生的情况。请注意 Rust 编译器的优势，即确认所有情况何时"
-"都得到了处理。\n"
-"* `match` 会检查 `enum` 中的隐藏的判别字段。\n"
-"* 可以通过调用 `std::mem::discriminant()` 来检索判别\n"
-"  * 这很有用，例如如果为结构体实现 `PartialEq`，比较字段值不会影响等式。\n"
-"* `WebEvent::Click { ... }` 与含顶层 `struct Click { ... }` 的 `WebEvent::"
-"Click(Click)` 不完全相同。例如，内嵌版本无法实现 trait。\n"
-"  "
+"枚举变体中的值只有在被模式匹配后，才可访问。模式将引用绑定到 `=>` 之后"
+"的“match 分支”中的字段。"
 
-#: src/enums/sizes.md:1
-msgid "# Enum Sizes"
-msgstr "# 枚举大小"
+#: src/enums/variant-payloads.md:36
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr "表达式会从上到下与模式匹配。没有像 C 或 C++ 中那样的跳转。"
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr "匹配表达式拥有一个值。值是 match 分支中被执行的最后一个表达式。"
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+"从顶部开始，查找与该值匹配的模式，然后沿箭头运行代码。一旦找到匹配，我们便会"
+"停止。"
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+"展示搜索不详尽时会发生的情况。请注意 Rust 编译器的优势，即确认所有情况何时都"
+"得到了处理。"
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr "`match` 会检查 `enum` 中的隐藏的判别字段。"
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr "可以通过调用 `std::mem::discriminant()` 来检索判别"
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr "这很有用，例如如果为结构体实现 `PartialEq`，比较字段值不会影响等式。"
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
+"`WebEvent::Click { ... }` 与含顶层 `struct Click { ... }` 的 `WebEvent::"
+"Click(Click)` 不完全相同。例如，内嵌版本无法实现 trait。"
 
 #: src/enums/sizes.md:3
 msgid ""
@@ -6303,293 +6416,320 @@ msgstr ""
 
 #: src/enums/sizes.md:25
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 msgstr ""
-"* 请参阅 [Rust 引用](https://doc.rust-lang.org/reference/type-layout.html)。"
+"请参阅 [Rust 引用](https://doc.rust-lang.org/reference/type-layout.html)。"
 
 #: src/enums/sizes.md:31
+#, fuzzy
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr "在内部，Rust 使用字段（判别）来跟踪枚举变体。"
+
+#: src/enums/sizes.md:33
+#, fuzzy
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr "你可以根据需要控制判别（例如，与 C 的兼容性）："
+
+#: src/enums/sizes.md:35
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with "
-"C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
-"\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits "
-"2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche "
-"optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit "
-"machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge use unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* "
-"look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees "
-"regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
-"$bit_type>($e));\n"
-"         };\n"
-"     }\n"
-"\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"\n"
-"     More complex example if you want to discuss what happens when we chain "
-"more than 256 `Option`s together.\n"
-"\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
-"$bit_type>($e));\n"
-"         };\n"
-"     }\n"
-"\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
-"signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
-"\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
-"Some(Some(Some(Some(false)))));\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
 msgstr ""
-" * 在内部，Rust 使用字段（判别）来跟踪枚举变体。\n"
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * 你可以根据需要控制判别（例如，与 C 的兼容性）：\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+
+#: src/enums/sizes.md:50
+#, fuzzy
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+"如果不使用 `repr`，判别类型会占用 2 个字节，因为 10001 是一个 2 个字节的数"
+"值。"
+
+#: src/enums/sizes.md:54
+#, fuzzy
+msgid "Try out other types such as"
+msgstr "试试其他类型，例如："
+
+#: src/enums/sizes.md:56
+#, fuzzy
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr "`dbg_size!(bool)`：大小占用 1 个字节，对齐占用 1 个字节；"
+
+#: src/enums/sizes.md:57
+#, fuzzy
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+"`dbg_size!(Option<bool>)`：大小占用 1 个字节，对齐占用 1 个字节（小众优化，请"
+"参阅下文）；"
+
+#: src/enums/sizes.md:58
+#, fuzzy
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+"`dbg_size!(&i32)`：大小占用 8 个字节，对齐占用 8 个字节（在 64 位设备上）；"
+
+#: src/enums/sizes.md:59
+#, fuzzy
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+"`dbg_size!(Option<&i32>)`：大小占用 8 个字节，对齐占用 8 个字节（Null 指针优"
+"化，请参阅下文）。"
+
+#: src/enums/sizes.md:61
+#, fuzzy
+msgid ""
+"Niche optimization: Rust will merge use unused bit patterns for the enum "
+"discriminant."
+msgstr "小众优化：Rust 将对枚举判别合并使用 未使用的位模式。"
+
+#: src/enums/sizes.md:64
+#, fuzzy
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+"Null 指针优化：对于[某些 类型](https://doc.rust-lang.org/std/option/"
+"#representation)，Rust 保证 `size_of::<T>()` 等效于 `size_of::"
+"<Option<T>>()`。"
+
+#: src/enums/sizes.md:68
+#, fuzzy
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+"如果你想展示位表示方式在实践中“可能”会是什么样子，请参考示例代码。 请务必注"
+"意，编译器对此表示法不提供任何保证，因此这是完全不安全的。"
+
+#: src/enums/sizes.md:71
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    如果不使用 `repr`，判别类型会占用 2 个字节，因为 10001 是一个 2\n"
-"个字节的数值。\n"
-"\n"
-"\n"
-" * 试试其他类型，例如：\n"
-" \n"
-"     * `dbg_size!(bool)`：大小占用 1 个字节，对齐占用 1 个字节；\n"
-"     * `dbg_size!(Option<bool>)`：大小占用 1 个字节，对齐占用 1 个字节（小众"
-"优化，请参阅下文）；\n"
-"     * `dbg_size!(&i32)`：大小占用 8 个字节，对齐占用 8 个字节（在 64 位设备"
-"上）；\n"
-"     * `dbg_size!(Option<&i32>)`：大小占用 8 个字节，对齐占用 8 个字节（Null "
-"指针优化，请参阅下文）。\n"
-"\n"
-" * 小众优化：Rust 将对枚举判别合并使用\n"
-"未使用的位模式。\n"
-"\n"
-" * Null 指针优化：对于[某些\n"
-"类型](https://doc.rust-lang.org/std/option/#representation)，Rust 保证\n"
-"`size_of::<T>()` 等效于 `size_of::<Option<T>>()`。\n"
-"\n"
-" 如果你想展示位表示方式在实践中“可能”会是什么样子，请参考示例代码。\n"
-"     请务必注意，编译器对此表示法不提供任何保证，因此这是完全不安全的。\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```\n"
+" ```rust,editable\n"
+" use std::mem::transmute;\n"
 "\n"
-"     如果你想讨论当我们把 256 个以上的 `Option` 串联在一起时会发生什么，可以"
-"用更复杂的示例。\n"
-"\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+" macro_rules! dbg_bits {\n"
+"     ($e:expr, $bit_type:ty) => {\n"
+"         println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"     };\n"
+" }\n"
 "\n"
-"     // 用于封装 2^n Some() 中的值的宏，其中 n 的 \"@\" 符号的个数。\n"
-"     // 增加递归限制需要评估这个宏。\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
+" fn main() {\n"
+"     // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"     // representation of types.\n"
+"     unsafe {\n"
+"         println!(\"Bitwise representation of bool\");\n"
+"         dbg_bits!(false, u8);\n"
+"         dbg_bits!(true, u8);\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
+"         println!(\"Bitwise representation of Option<bool>\");\n"
+"         dbg_bits!(None::<bool>, u8);\n"
+"         dbg_bits!(Some(false), u8);\n"
+"         dbg_bits!(Some(true), u8);\n"
+"\n"
+"         println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"         dbg_bits!(Some(Some(false)), u8);\n"
+"         dbg_bits!(Some(Some(true)), u8);\n"
+"         dbg_bits!(Some(None::<bool>), u8);\n"
+"         dbg_bits!(None::<Option<bool>>, u8);\n"
+"\n"
+"         println!(\"Bitwise representation of Option<&i32>\");\n"
+"         dbg_bits!(None::<&i32>, usize);\n"
+"         dbg_bits!(Some(&0i32), usize);\n"
+"     }\n"
+" }\n"
+" ```\n"
+"\n"
+" 如果你想讨论当我们把 256 个以上的 `Option` 串联在一起时会发生什么，可以用更"
+"复杂的示例。\n"
+"\n"
+" ```rust,editable\n"
+" #![recursion_limit = \"1000\"]\n"
+"\n"
+" use std::mem::transmute;\n"
+" \n"
+" macro_rules! dbg_bits {\n"
+"     ($e:expr, $bit_type:ty) => {\n"
+"         println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"     };\n"
+" }\n"
+"\n"
+" // 用于封装 2^n Some() 中的值的宏，其中 n 的 \"@\" 符号的个数。\n"
+" // 增加递归限制需要评估这个宏。\n"
+" macro_rules! many_options {\n"
+"     ($value:expr) => { Some($value) };\n"
+"     ($value:expr, @) => {\n"
+"         Some(Some($value))\n"
+"     };\n"
+"     ($value:expr, @ $($more:tt)+) => {\n"
+"         many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"     };\n"
+" }\n"
+"\n"
+" fn main() {\n"
+"     // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"     // representation of types.\n"
+"     unsafe {\n"
+"         assert_eq!(many_options!(false), Some(false));\n"
+"         assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"         assert_eq!(many_options!(false, @@), "
 "Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"         println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"         dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"         dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"         println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"         dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"         dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
+"         println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"         dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"         dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"         dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
 "     }\n"
-"     ```"
+" }\n"
+" ```\n"
+"```"
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
+"\n"
+"use std::mem::transmute;\n"
+"\n"
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"    };\n"
+"}\n"
+"\n"
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"signs.\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
+"Some(Some(Some(Some(false)))));\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/methods.md:3
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
 
 #: src/methods.md:6
@@ -6618,77 +6758,104 @@ msgid ""
 msgstr ""
 
 #: src/methods.md:31
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
 
-#: src/methods/receiver.md:1
-msgid "# Method Receiver"
+#: src/methods.md:32
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+
+#: src/methods.md:33
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+
+#: src/methods.md:34
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr ""
+
+#: src/methods.md:35
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+
+#: src/methods.md:36
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+
+#: src/methods.md:37
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+
+#: src/methods.md:38
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+
+#: src/methods.md:39
+msgid "We describe the distinction between method receivers next."
 msgstr ""
 
 #: src/methods/receiver.md:3
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
 
 #: src/methods/receiver.md:6
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted. Complete ownership does not automatically mean mutability.\n"
-"* `mut self`: same as above, but the method can mutate the object. \n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:8
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:10
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+
+#: src/methods/receiver.md:14
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+
+#: src/methods/receiver.md:15
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
 msgstr ""
 
 #: src/methods/receiver.md:18
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
 
 #: src/methods/receiver.md:24
 msgid ""
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it."
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "# Example"
-msgstr "# 示例"
 
 #: src/methods/example.md:3
 msgid ""
@@ -6737,30 +6904,41 @@ msgid ""
 msgstr ""
 
 #: src/methods/example.md:47
-msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
-"functions are called the same way in the main body. Rust enables automatic "
-"referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
-"over. We describe vectors in more detail in the afternoon. "
+msgid "All four methods here use a different method receiver."
 msgstr ""
 
-#: src/pattern-matching.md:1
-msgid "# Pattern Matching"
-msgstr "# 模式匹配"
+#: src/methods/example.md:48
+msgid ""
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+
+#: src/methods/example.md:49
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+
+#: src/methods/example.md:50
+msgid ""
+"Note that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+
+#: src/methods/example.md:51
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
+msgstr ""
 
 #: src/pattern-matching.md:3
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
-msgstr "使用关键词 `match` 对一个值进行模式匹配。进行匹配时，会从上至下依次进行比较，并选定第一个匹配成功的结果。"
+"The comparisons are done from top to bottom and the first match wins."
+msgstr ""
+"使用关键词 `match` 对一个值进行模式匹配。进行匹配时，会从上至下依次进行比较，"
+"并选定第一个匹配成功的结果。"
 
 #: src/pattern-matching.md:6
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
@@ -6787,38 +6965,58 @@ msgid "The `_` pattern is a wildcard pattern which matches any value."
 msgstr "模式 `_` 是外卡 (wildcard) 模式。它可以匹配任何值。"
 
 #: src/pattern-matching.md:26
+#, fuzzy
 msgid ""
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
-"* 你可以解释一些用于表达模式的特殊字符的用法\n"
-"  *`|` 表示或 (or)\n"
-"  *`..` 可以展开为任意一个或多个值\n"
-"  *`1..=5` 代表了一个闭区间范围\n"
-"* 解释模式匹配中的绑定的原理可能会很有帮助。比如可以用一个变量替代外卡，或者去除 `q` 外面的引号。\n"
-"* 你可以展示如何匹配一个引用。\n"
-"* 现在是一个讲解不可反驳 (irrefutable) 模式的好时机。因为这个术语可能会出现在错误信息中。"
+"你可以解释一些用于表达模式的特殊字符的用法 \\*`|` 表示或 (or) \\*`..` 可以展"
+"开为任意一个或多个值 \\*`1..=5` 代表了一个闭区间范围"
 
-#: src/pattern-matching/destructuring-enums.md:1
-msgid "# Destructuring Enums"
+#: src/pattern-matching.md:27
+#, fuzzy
+msgid "`|` as an `or`"
+msgstr ""
+"解释模式匹配中的绑定的原理可能会很有帮助。比如可以用一个变量替代外卡，或者去"
+"除 `q` 外面的引号。"
+
+#: src/pattern-matching.md:28
+#, fuzzy
+msgid "`..` can expand as much as it needs to be"
+msgstr "你可以展示如何匹配一个引用。"
+
+#: src/pattern-matching.md:29
+#, fuzzy
+msgid "`1..=5` represents an inclusive range"
+msgstr ""
+"现在是一个讲解不可反驳 (irrefutable) 模式的好时机。因为这个术语可能会出现在错"
+"误信息中。"
+
+#: src/pattern-matching.md:30
+msgid "`_` is a wild card"
+msgstr ""
+
+#: src/pattern-matching.md:31
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+
+#: src/pattern-matching.md:32
+msgid "You can demonstrate matching on a reference."
+msgstr ""
+
+#: src/pattern-matching.md:33
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:3
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:6
@@ -6849,24 +7047,22 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:36
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:1
-msgid "# Destructuring Structs"
+#: src/pattern-matching/destructuring-enums.md:37
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:3
@@ -6895,25 +7091,24 @@ msgid ""
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard "
-"to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that "
-"it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-msgid "# Destructuring Arrays"
-msgstr "# 解构数组"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:25
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
+msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
 msgid ""
 "You can destructure arrays, tuples, and slices by matching on their elements:"
-msgstr ""
-"你可以通过元素匹配来解构数组、元组和切片："
+msgstr "你可以通过元素匹配来解构数组、元组和切片："
 
 #: src/pattern-matching/destructuring-arrays.md:5
 msgid ""
@@ -6933,69 +7128,68 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were "
-"ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of "
-"elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
-msgstr ""
-"* 对未知长度的切片进行解构也可以使用固定长度的模式。\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were "
-"ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* 使用 `_` 创建一个新的模式来代表一个元素。\n"
-"* 向数组中添加更多的值。\n"
-"* 指出 `..` 是如何扩展以适应不同数量的元素的。 \n"
-"* 展示使用模式 `[.., b]` 和 `[a@..,b]` 来匹配切片的尾部。"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
+msgstr "对未知长度的切片进行解构也可以使用固定长度的模式。"
 
-#: src/pattern-matching/match-guards.md:1
-msgid "# Match Guards"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr "使用 `_` 创建一个新的模式来代表一个元素。"
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr "向数组中添加更多的值。"
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr "指出 `..` 是如何扩展以适应不同数量的元素的。 "
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr "展示使用模式 `[.., b]` 和 `[a@..,b]` 来匹配切片的尾部。"
 
 #: src/pattern-matching/match-guards.md:3
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:6
@@ -7017,65 +7211,67 @@ msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:24
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`."
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:26
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:27
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
 msgstr ""
 
 #: src/exercises/day-2/morning.md:1
-msgid "# Day 2: Morning Exercises"
-msgstr "# 第二天上午习题"
+msgid "Day 2: Morning Exercises"
+msgstr "第二天上午习题"
 
 #: src/exercises/day-2/morning.md:3
 msgid "We will look at implementing methods in two contexts:"
 msgstr "我们将考虑以下两种场景："
 
 #: src/exercises/day-2/morning.md:5
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
-msgstr ""
-"* 实现一个简单的结构体中的方法，用于追踪健康统计数据。\n"
-"\n"
-"* 实现多个结构体和枚举中的方法，用于绘图库。"
+msgid "Simple struct which tracks health statistics."
+msgstr "实现一个简单的结构体中的方法，用于追踪健康统计数据。"
 
-#: src/exercises/day-2/health-statistics.md:1
-msgid "# Health Statistics"
-msgstr "# 健康统计"
+#: src/exercises/day-2/morning.md:7
+msgid "Multiple structs and enums for a drawing library."
+msgstr "实现多个结构体和枚举中的方法，用于绘图库。"
 
 #: src/exercises/day-2/health-statistics.md:3
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
-"你正在实现一个健康监控系统。作为其中的一部分，你需要对用户的健康统计数据进行追踪。"
+"你正在实现一个健康监控系统。作为其中的一部分，你需要对用户的健康统计数据进行"
+"追踪。"
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
-"`User` 结构体的定义和 `impl` 块中一些函数的框架已经给出。你的目标是实现在 `impl` 块中定义的 `User` `struct` 的方法。"
+"`User` 结构体的定义和 `impl` 块中一些函数的框架已经给出。你的目标是实现在 "
+"`impl` 块中定义的 `User` `struct` 的方法。"
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
-msgstr ""
-"将以下代码复制到 <https://play.rust-lang.org/>，并填充缺失的方法："
+msgstr "将以下代码复制到 <https://play.rust-lang.org/>，并填充缺失的方法："
 
 #: src/exercises/day-2/health-statistics.md:13
 msgid ""
@@ -7192,16 +7388,14 @@ msgstr ""
 "```"
 
 #: src/exercises/day-2/points-polygons.md:1
-msgid "# Polygon Struct"
+msgid "Polygon Struct"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:3
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:7
@@ -7318,9 +7512,8 @@ msgstr ""
 #: src/exercises/day-2/points-polygons.md:117
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:120
@@ -7329,42 +7522,32 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:122
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
 
-#: src/control-flow.md:1
-msgid "# Control Flow"
-msgstr "# 控制流"
+#: src/exercises/day-2/points-polygons.md:123
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
 
 #: src/control-flow.md:3
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
-"正如我们所知，`if` 是 Rust 中的一个表达式。它用于有条件地\n"
-"评估两个块中的一个，但这些块可以有一个值，\n"
-"然后成为 `if` 表达式的值。其他控制流表达式在 Rust 中也有类似\n"
-"的运作方式。"
-
-#: src/control-flow/blocks.md:1
-msgid "# Blocks"
-msgstr "# 块"
+"正如我们所知，`if` 是 Rust 中的一个表达式。它用于有条件地 评估两个块中的一"
+"个，但这些块可以有一个值， 然后成为 `if` 表达式的值。其他控制流表达式在 Rust "
+"中也有类似 的运作方式。"
 
 #: src/control-flow/blocks.md:3
 msgid ""
 "A block in Rust has a value and a type: the value is the last expression of "
-"the\n"
-"block:"
-msgstr ""
-"Rust 中的块包含值和类型：值是\n"
-"块的最后一个表达式："
+"the block:"
+msgstr "Rust 中的块包含值和类型：值是 块的最后一个表达式："
 
 #: src/control-flow/blocks.md:6
 msgid ""
@@ -7408,11 +7591,9 @@ msgstr ""
 
 #: src/control-flow/blocks.md:25
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
-msgstr ""
-"同样的规则也适用于函数：函数主体的值\n"
-"是返回值："
+msgstr "同样的规则也适用于函数：函数主体的值 是返回值："
 
 #: src/control-flow/blocks.md:28
 msgid ""
@@ -7444,33 +7625,29 @@ msgstr "不过，如果最后一个表达式以 `;` 结尾，那么生成的值�
 
 #: src/control-flow/blocks.md:43
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr "这张幻灯片的重点是说明在 Rust 中，块有类型和值。"
+
+#: src/control-flow/blocks.md:44
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
-"* 这张幻灯片的重点是说明在 Rust 中，块有类型和值。\n"
-"* 你可以通过更改块的最后一行，来展示块值的变化情况。例如，添加/移除分号或使"
-"用 `return`。\n"
-"   "
+"你可以通过更改块的最后一行，来展示块值的变化情况。例如，添加/移除分号或使用 "
+"`return`。"
 
 #: src/control-flow/if-expressions.md:1
-msgid "# `if` expressions"
-msgstr "# `if` 表达式"
+msgid "`if` expressions"
+msgstr "`if` 表达式"
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
-"[`if`\n"
-"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"的用法与其他语言中的 `if` 语句完全一样。"
+"[`if` 表达式](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-expressions) 的用法与其他语言中的 `if` 语句完全一样。"
 
 #: src/control-flow/if-expressions.md:7
 msgid ""
@@ -7498,11 +7675,11 @@ msgstr ""
 
 #: src/control-flow/if-expressions.md:18
 msgid ""
-"In addition, you can use `if` as an expression. The last expression of each\n"
+"In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
-"此外，你还可以将 `if` 用作一个表达式。每个块的最后一个表达式\n"
-"将成为 `if` 表达式的值："
+"此外，你还可以将 `if` 用作一个表达式。每个块的最后一个表达式 将成为 `if` 表达"
+"式的值："
 
 #: src/control-flow/if-expressions.md:22
 msgid ""
@@ -7538,21 +7715,17 @@ msgstr ""
 "类型。考虑在第二个示例中将 `;` 添加到 `x / 2` 的后面，看看会出现什么情况。"
 
 #: src/control-flow/if-let-expressions.md:1
-msgid "# `if let` expressions"
-msgstr "# `if let` 表达式"
+msgid "`if let` expressions"
+msgstr "`if let` 表达式"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
-"[`if let`\n"
-"表达式](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-"
-"expressions)\n"
-"能让你根据某个值是否与模式相匹配来执行不同的代码："
+"[`if let` 表达式](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-let-expressions) 能让你根据某个值是否与模式相匹配来执行不同的代码："
 
 #: src/control-flow/if-let-expressions.md:7
 msgid ""
@@ -7583,71 +7756,79 @@ msgstr ""
 #: src/control-flow/match-expressions.md:23
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
-"如需详细了解 Rust 中\n"
-"的模式，请参阅[模式匹配](../pattern-matching.md)。"
+"如需详细了解 Rust 中 的模式，请参阅[模式匹配](../pattern-matching.md)。"
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is "
-"interesting. In contrast, `match` requires all branches to be covered.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
+msgstr ""
+"`if let` 可能比 `match` 更简洁，例如，当只关注一种情况时。相比之下，`match` "
+"要求覆盖所有分支。"
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr "使用 `Option` 时，常见的做法是处理 `Some` 值。"
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr "与 `match` 不同的是，`if let` 不支持模式匹配的 guard 子句。"
+
+#: src/control-flow/if-let-expressions.md:26
+msgid ""
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) construct allows to do a destructuring "
 "assignment, or if it fails, have a non-returning block branch (panic/return/"
-"break/continue):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"break/continue):"
 msgstr ""
-"* `if let` 可能比 `match` 更简洁，例如，当只关注一种情况时。相比之下，"
-"`match` 要求覆盖所有分支。\n"
-"* 使用 `Option` 时，常见的做法是处理 `Some` 值。\n"
-"* 与 `match` 不同的是，`if let` 不支持模式匹配的 guard 子句。\n"
-"* 自 1.65 版以来，类似的 [let-else](https://doc.rust-lang.org/rust-by-"
-"example/flow_control/let_else.html) 结构允许执行解构赋值，或者如果不满足条"
-"件，则有一个非返回块分支 (panic/return/break/continue)：\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"自 1.65 版以来，类似的 [let-else](https://doc.rust-lang.org/rust-by-example/"
+"flow_control/let_else.html) 结构允许执行解构赋值，或者如果不满足条件，则有一"
+"个非返回块分支 (panic/return/break/continue)："
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 
 #: src/control-flow/while-expressions.md:1
-msgid "# `while` loops"
-msgstr "# `while` 循环"
+msgid "`while` loops"
+msgstr "`while` 循环"
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 "[`while` 关键字](https://doc.rust-lang.org/reference/expressions/loop-expr."
-"html#predicate-loops)\n"
-" 的工作方式与其他语言非常相似："
+"html#predicate-loops) 的工作方式与其他语言非常相似："
 
 #: src/control-flow/while-expressions.md:6
 msgid ""
@@ -7680,18 +7861,18 @@ msgstr ""
 "```"
 
 #: src/control-flow/while-let-expressions.md:1
-msgid "# `while let` loops"
-msgstr "# `while let` 循环"
+msgid "`while let` loops"
+msgstr "`while let` 循环"
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variant which repeatedly tests a value against a pattern:"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
 "与 `if let` 一样，[`with let`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#predicate-pattern-loops)\n"
-"变体会针对一个模式重复测试一个值："
+"expressions/loop-expr.html#predicate-pattern-loops) 变体会针对一个模式重复测"
+"试一个值："
 
 #: src/control-flow/while-let-expressions.md:6
 msgid ""
@@ -7720,43 +7901,42 @@ msgstr ""
 #: src/control-flow/while-let-expressions.md:17
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
-"在这里，每次\n"
-"调用 `next()` 时，`v.iter()` 返回的迭代器都会返回一个 `Option<i32>`。它将一直"
-"返回 `Some(x)`，直到完成。\n"
-" 之后它将返回 `None`。`while let`能让我们持续迭代所有项。"
+"在这里，每次 调用 `next()` 时，`v.iter()` 返回的迭代器都会返回一个 "
+"`Option<i32>`。它将一直返回 `Some(x)`，直到完成。 之后它将返回 `None`。"
+"`while let`能让我们持续迭代所有项。"
 
 #: src/control-flow/while-let-expressions.md:26
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
+msgstr "指出只要值与模式匹配，`while let` 循环就会一直进行下去。"
+
+#: src/control-flow/while-let-expressions.md:27
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
 "statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
-"* 指出只要值与模式匹配，`while let` 循环就会一直进行下去。\n"
-"* 你可以使用 if 语句将 `while let` 循环重写为无限循环，当 `iter.next()` 没有"
-"值可以解封时中断。`while let` 为上述情况提供了语法糖。\n"
-"    "
+"你可以使用 if 语句将 `while let` 循环重写为无限循环，当 `iter.next()` 没有值"
+"可以解封时中断。`while let` 为上述情况提供了语法糖。"
 
 #: src/control-flow/for-expressions.md:1
-msgid "# `for` loops"
-msgstr "# `for` 循环"
+msgid "`for` loops"
+msgstr "`for` 循环"
 
 #: src/control-flow/for-expressions.md:3
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely\n"
-"related to the [`while let` loop](while-let-expression.md). It will\n"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expression.md). It will "
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
-"[`for` 循环](https://doc.rust-lang.org/std/keyword.for.html)\n"
-"与 [`when let` 循环](when-let-expression.md)密切相关。它会\n"
-" 自动对表达式调用 `into_iter()`，然后对其进行迭代："
+"[`for` 循环](https://doc.rust-lang.org/std/keyword.for.html) 与 [`when let` "
+"循环](when-let-expression.md)密切相关。它会 自动对表达式调用 `into_iter()`，"
+"然后对其进行迭代："
 
 #: src/control-flow/for-expressions.md:7
 msgid ""
@@ -7793,33 +7973,38 @@ msgid "You can use `break` and `continue` here as usual."
 msgstr "你可以在此照常使用 `break` 和 `continue`。"
 
 #: src/control-flow/for-expressions.md:25
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr "在这种情况下，索引迭代在 Rust 中并不是一个特殊的语法。"
+
+#: src/control-flow/for-expressions.md:26
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "`(0..10)` 是实现 `Iterator` trait 的范围。"
+
+#: src/control-flow/for-expressions.md:27
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr "`step_by` 是返回另一个 `Iterator` 的方法，用于逐一跳过所有其他元素。"
+
+#: src/control-flow/for-expressions.md:28
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
-"* 在这种情况下，索引迭代在 Rust 中并不是一个特殊的语法。\n"
-"* `(0..10)` 是实现 `Iterator` trait 的范围。\n"
-"* `step_by` 是返回另一个 `Iterator` 的方法，用于逐一跳过所有其他元素。\n"
-"* 修改矢量中的元素并说明编译器错误。将矢量 `v` 改为可变，并将 for 循环改为 "
+"修改矢量中的元素并说明编译器错误。将矢量 `v` 改为可变，并将 for 循环改为 "
 "`for x in v.iter_mut()`。"
 
 #: src/control-flow/loop-expressions.md:1
-msgid "# `loop` expressions"
-msgstr "# `loop` 表达式"
+msgid "`loop` expressions"
+msgstr "`loop` 表达式"
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
 "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 "最后是用于创建无限循环的 [`loop` 关键字](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"。"
+"expressions/loop-expr.html#infinite-loops) 。"
 
 #: src/control-flow/loop-expressions.md:6
 msgid "Here you must either `break` or `return` to stop the loop:"
@@ -7862,34 +8047,31 @@ msgstr ""
 "```"
 
 #: src/control-flow/loop-expressions.md:27
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr "用一个值（例如 `break 8`）来中断 `loop` 并将其输出。"
+
+#: src/control-flow/loop-expressions.md:28
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-"
-"trivial\n"
-"  value. This is because it's guaranteed to be entered at least once "
-"(unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
-"* 用一个值（例如 `break 8`）来中断 `loop` 并将其输出。\n"
-"* 请注意，`loop` 是唯一返回有意义的值的循环结构。\n"
-"  这是因为它保证至少被输入一次（与 `while` 和 `for` 循环不同）。"
+"请注意，`loop` 是唯一返回有意义的值的循环结构。 这是因为它保证至少被输入一次"
+"（与 `while` 和 `for` 循环不同）。"
 
 #: src/control-flow/match-expressions.md:1
-msgid "# `match` expressions"
-msgstr "# `match` 表达式"
+msgid "`match` expressions"
+msgstr "`match` 表达式"
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
 "The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
-"expr.html)\n"
-"is used to match a value against one or more patterns. In that sense, it "
-"works\n"
-"like a series of `if let` expressions:"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
 "[`match` 关键字](https://doc.rust-lang.org/reference/expressions/match-expr."
-"html)\n"
-"用于将一个值与一个或多个模式进行匹配。从这个意义上讲，它的工作方式\n"
-"类似于一系列的 `if let` 表达式："
+"html) 用于将一个值与一个或多个模式进行匹配。从这个意义上讲，它的工作方式 类似"
+"于一系列的 `if let` 表达式："
 
 #: src/control-flow/match-expressions.md:7
 msgid ""
@@ -7921,57 +8103,66 @@ msgstr ""
 
 #: src/control-flow/match-expressions.md:20
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
-"与 `if let` 类似，每个匹配分支必须有相同的类型。该类型是块的最后一个\n"
-"表达式（如有）。在上例中，类型是 `()`。"
+"与 `if let` 类似，每个匹配分支必须有相同的类型。该类型是块的最后一个 表达式"
+"（如有）。在上例中，类型是 `()`。"
 
 #: src/control-flow/match-expressions.md:28
+msgid "Save the match expression to a variable and print it out."
+msgstr "将 match 表达式保存到一个变量中并输出结果。"
+
+#: src/control-flow/match-expressions.md:29
+msgid "Remove `.as_deref()` and explain the error."
+msgstr "移除 `.as_deref()` 并说明错误。"
+
+#: src/control-flow/match-expressions.md:30
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
 msgstr ""
-"* 将 match 表达式保存到一个变量中并输出结果。\n"
-"* 移除 `.as_deref()` 并说明错误。\n"
-"    * `std::env::args().next()` 会返回  `Option<String>`，但无法与 `String` "
-"进行匹配。\n"
-"    * `as_deref()` 会将 `Option<T>` 转换为 `Option<&T::Target>`。在我们的示例"
-"中，这会将 `Option<String>` 转换为 `Option<&str>`。\n"
-"    * 现在，我们可以使用模式匹配来匹配 `Option` 中的 `&str`。"
+"`std::env::args().next()` 会返回  `Option<String>`，但无法与 `String` 进行匹"
+"配。"
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+"`as_deref()` 会将 `Option<T>` 转换为 `Option<&T::Target>`。在我们的示例中，这"
+"会将 `Option<String>` 转换为 `Option<&str>`。"
+
+#: src/control-flow/match-expressions.md:32
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
+msgstr "现在，我们可以使用模式匹配来匹配 `Option` 中的 `&str`。"
 
 #: src/control-flow/break-continue.md:1
-msgid "# `break` and `continue`"
-msgstr "# `break` 和 `continue`"
+msgid "`break` and `continue`"
+msgstr "`break` 和 `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
 msgstr ""
-"- 如果你想提前退出循环，请使用 [`break`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#break-expressions)，\n"
-"- 如果需要立即启动\n"
-"下一次迭代，请使用 [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)。"
+"如果你想提前退出循环，请使用 [`break`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#break-expressions)，"
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+msgstr ""
+"如果需要立即启动 下一次迭代，请使用 [`continue`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#continue-expressions)。"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
-"used\n"
-"to break out of nested loops:"
-msgstr ""
-"`continue` 和 `break` 都可以选择接受一个标签参数，用来\n"
-"终止嵌套循环："
+"used to break out of nested loops:"
+msgstr "`continue` 和 `break` 都可以选择接受一个标签参数，用来 终止嵌套循环："
 
 #: src/control-flow/break-continue.md:10
 msgid ""
@@ -8016,21 +8207,14 @@ msgid ""
 "In this case we break the outer loop after 3 iterations of the inner loop."
 msgstr "在本示例中，我们会在内循环 3 次迭代后终止外循环。"
 
-#: src/std.md:1
-msgid "# Standard Library"
-msgstr "# 标准库"
-
 #: src/std.md:3
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
-"Rust 附带一个标准库，此库有助于建立一个供 Rust 库和程序\n"
-"使用的常用类型集。这样一来，两个库便可顺畅地搭配运作，\n"
-"因为它们使用相同的 `String` 类型。"
+"Rust 附带一个标准库，此库有助于建立一个供 Rust 库和程序 使用的常用类型集。这"
+"样一来，两个库便可顺畅地搭配运作， 因为它们使用相同的 `String` 类型。"
 
 #: src/std.md:7
 msgid "The common vocabulary types include:"
@@ -8038,56 +8222,64 @@ msgstr "常见的词汇类型包括："
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
-"data."
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
 msgstr ""
-"* [`Option` 和 `Result`](std/option-result.md) 类型：用于可选值和\n"
-"[错误处理](error-handling.md)。\n"
-"\n"
-"* [`String`](std/string.md)：用于自有数据的默认字符串类型。\n"
-"\n"
-"* [`Vec`](std/vec.md)：标准的可扩展矢量。\n"
-"\n"
-"* [`HashMap`](std/hashmap.md)：采用可配置哈希算法的哈希映射\n"
-"类型。\n"
-"\n"
-"* [`Box`](std/box.md)：适用于堆分配数据的自有指针。\n"
-"\n"
-"* [`Rc`](std/rc.md)：适用于堆分配数据的共享引用计数指针。"
+"[`Option` 和 `Result`](std/option-result.md) 类型：用于可选值和 [错误处理]"
+"(error-handling.md)。"
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr "[`String`](std/string.md)：用于自有数据的默认字符串类型。"
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr "[`Vec`](std/vec.md)：标准的可扩展矢量。"
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr "[`HashMap`](std/hashmap.md)：采用可配置哈希算法的哈希映射 类型。"
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr "[`Box`](std/box.md)：适用于堆分配数据的自有指针。"
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
+msgstr "[`Rc`](std/rc.md)：适用于堆分配数据的共享引用计数指针。"
 
 #: src/std.md:25
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
+msgstr "Rust 实际上含有多个层级的标准库，分别是 `core`、`alloc` 和 `std`。"
+
+#: src/std.md:26
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
 msgstr ""
-"  * Rust 实际上含有多个层级的标准库，分别是 `core`、`alloc` 和 `std`。\n"
-"  * `core` 包括最基本的类型与函数，这些类型与函数不依赖于 `libc`、分配器\n"
-"或是否存在操作系统。\n"
-"  * `alloc` 包括需要全局堆分配器的类型，例如 `Vec`、`Box` 和 `Arc`。\n"
-"  * 嵌入式 Rust 应用通常只使用 `core`，偶尔会使用 `alloc`。"
+"`core` 包括最基本的类型与函数，这些类型与函数不依赖于 `libc`、分配器 或是否存"
+"在操作系统。"
+
+#: src/std.md:28
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr "`alloc` 包括需要全局堆分配器的类型，例如 `Vec`、`Box` 和 `Arc`。"
+
+#: src/std.md:29
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr "嵌入式 Rust 应用通常只使用 `core`，偶尔会使用 `alloc`。"
 
 #: src/std/option-result.md:1
-msgid "# `Option` and `Result`"
-msgstr "# `Option` 和 `Result`"
+msgid "`Option` and `Result`"
+msgstr "`Option` 和 `Result`"
 
 #: src/std/option-result.md:3
 msgid "The types represent optional data:"
@@ -8108,31 +8300,40 @@ msgid ""
 msgstr ""
 
 #: src/std/option-result.md:18
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
-msgstr ""
-"* `Option` 和 `Result` 的使用范围很广，不局限于标准库。\n"
-"* 相较于 `&T`，`Option<&T>` 的空间开销为零。\n"
-"* `Result` 是用于实现错误处理的标准类型，我们将在第 3 天的课程中介绍。\n"
-"* `binary_search` 会返回 `Result<usize, usize>`。\n"
-"  * 如果找到该元素，`Result::Ok` 会保留该元素所在位置的索引。\n"
-"  * 如果没有找到该元素，`Result::Err` 会包含应插入这类元素的索引。"
+msgid "`Option` and `Result` are widely used not just in the standard library."
+msgstr "`Option` 和 `Result` 的使用范围很广，不局限于标准库。"
 
-#: src/std/string.md:1
-msgid "# String"
-msgstr "# String"
+#: src/std/option-result.md:19
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "相较于 `&T`，`Option<&T>` 的空间开销为零。"
+
+#: src/std/option-result.md:20
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr "`Result` 是用于实现错误处理的标准类型，我们将在第 3 天的课程中介绍。"
+
+#: src/std/option-result.md:21
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "`binary_search` 会返回 `Result<usize, usize>`。"
+
+#: src/std/option-result.md:22
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr "如果找到该元素，`Result::Ok` 会保留该元素所在位置的索引。"
+
+#: src/std/option-result.md:23
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr "如果没有找到该元素，`Result::Err` 会包含应插入这类元素的索引。"
 
 #: src/std/string.md:3
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
-msgstr "[`String`][1] 是标准堆分配的可扩容 UTF-8 字符串缓冲区："
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
+msgstr ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) 是标准堆"
+"分配的可扩容 UTF-8 字符串缓冲区："
 
 #: src/std/string.md:5
 msgid ""
@@ -8156,47 +8357,90 @@ msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` 会实现 [`Deref<Target = str>`][2]，这意味着您可以\n"
-"对 `String` 调用所有 `str` 方法。"
+"`String` 会实现 [`Deref<Target = str>`](https://doc.rust-lang.org/std/string/"
+"struct.String.html#deref-methods-str)，这意味着您可以 对 `String` 调用所有 "
+"`str` 方法。"
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to index a `String`:\n"
-"    * To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-"
-"bound, out-of-bounds.\n"
-"    * To a substring by using `s3[0..4]`, where that slice is on character "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
 #: src/std/vec.md:1
-msgid "# `Vec`"
-msgstr "# `Vec`"
+msgid "`Vec`"
+msgstr "`Vec`"
 
 #: src/std/vec.md:3
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
-msgstr "[`Vec`][1] 是标准的可调整大小堆分配缓冲区："
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
+msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 是标准的可调整大小"
+"堆分配缓冲区："
 
 #: src/std/vec.md:5
 msgid ""
@@ -8227,38 +8471,50 @@ msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
-"`Vec` 会实现 [`Deref<Target = [T]>`][2]，这意味着您可以对 `Vec`\n"
-"调用 slice 方法。"
+"`Vec` 会实现 [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D)，这意味着您可以对 `Vec` 调用 slice 方"
+"法。"
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
-msgid "# `HashMap`"
-msgstr "# `HashMap`"
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
+msgid "`HashMap`"
+msgstr "`HashMap`"
 
 #: src/std/hashmap.md:3
 msgid "Standard hash map with protection against HashDoS attacks:"
@@ -8304,48 +8560,80 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
-msgid "# `Box`"
-msgstr "# `Box`"
+msgid "`Box`"
+msgstr "`Box`"
 
 #: src/std/box.md:3
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "[`Box`][1] 是指向堆上数据的自有指针："
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 是指向堆上数据的"
+"自有指针："
 
 #: src/std/box.md:5
 msgid ""
@@ -8376,36 +8664,49 @@ msgstr ""
 #: src/std/box.md:26
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 "`Box<T>` 会实现 `Deref<Target = T>`，这意味着您可以[直接在 `Box<T>` 上通过 "
-"`T`\n"
-"调用相应方法][2]。"
+"`T` 调用相应方法](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-"
+"deref-coercion)。"
 
 #: src/std/box.md:34
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
 msgstr ""
-"* 在 C++ 中，`Box` 与 `std::unique_ptr` 类似，除了它一定会不为 null 以外。\n"
-"* 在上面的示例中，因为有 `Deref`，您甚至可以在 `println!` 语句中省略 `*`。\n"
-"* 在以下情况下，`Box` 可能会很实用：\n"
-"   * 在编译时间遇到无法知晓大小的类型，但 Rust 编译器需要知道确切大小。\n"
-"   * 想要转让大量数据的所有权。为避免在堆栈上复制大量数据，请改为将数据存储"
-"在 `Box` 中的堆上，以便仅移动指针。"
+"在 C++ 中，`Box` 与 `std::unique_ptr` 类似，除了它一定会不为 null 以外。"
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+"在上面的示例中，因为有 `Deref`，您甚至可以在 `println!` 语句中省略 `*`。"
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr "在以下情况下，`Box` 可能会很实用："
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr "在编译时间遇到无法知晓大小的类型，但 Rust 编译器需要知道确切大小。"
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr ""
+"想要转让大量数据的所有权。为避免在堆栈上复制大量数据，请改为将数据存储在 "
+"`Box` 中的堆上，以便仅移动指针。"
 
 #: src/std/box-recursive.md:1
-msgid "# Box with Recursive Data Structures"
-msgstr "# 包含递归数据结构的 Box"
+msgid "Box with Recursive Data Structures"
+msgstr "包含递归数据结构的 Box"
 
 #: src/std/box-recursive.md:3
 msgid ""
@@ -8453,43 +8754,38 @@ msgstr ""
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly "
-"into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it "
-"would look infinite.\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
-"* 如果这里未使用 `Box`，且我们曾尝试将一个 `List` 直接嵌入 `List`，\n"
-"编译器就不会计算内存中结构体的固定大小，结构体看起来会像是无限大。\n"
-"\n"
-"* `Box` 大小与一般指针相同，并且只会指向堆中的下一个 `List` 元素，\n"
-"因此可以解决这个问题。\n"
-"\n"
-"* 将 `Box` 从 List 定义中移除后，画面上会显示编译器错误。如果您看"
-"到“Recursive with indirection”错误消息，这是在提示您使用 Box 或其他类型的引"
-"用，而不是直接储存值。\n"
-"    "
+"如果这里未使用 `Box`，且我们曾尝试将一个 `List` 直接嵌入 `List`， 编译器就不"
+"会计算内存中结构体的固定大小，结构体看起来会像是无限大。"
 
-#: src/std/box-niche.md:1
-msgid "# Niche Optimization"
-msgstr "# 小众优化"
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+"`Box` 大小与一般指针相同，并且只会指向堆中的下一个 `List` 元素， 因此可以解决"
+"这个问题。"
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
+"将 `Box` 从 List 定义中移除后，画面上会显示编译器错误。如果您看到“Recursive "
+"with indirection”错误消息，这是在提示您使用 Box 或其他类型的引用，而不是直接"
+"储存值。"
 
 #: src/std/box-niche.md:16
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
-"`Box` 不得为空，因此指针始终有效且非 `null`。这样，\n"
-"编译器就可以优化内存布局："
+"`Box` 不得为空，因此指针始终有效且非 `null`。这样， 编译器就可以优化内存布"
+"局："
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -8514,17 +8810,17 @@ msgid ""
 msgstr ""
 
 #: src/std/rc.md:1
-msgid "# `Rc`"
-msgstr "# `Rc`"
+msgid "`Rc`"
+msgstr "`Rc`"
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`][1] 是引用计数的共享指针。如果您需要从多个位置\n"
-"引用相同的数据，请使用此指针："
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) 是引用计数的共享指"
+"针。如果您需要从多个位置 引用相同的数据，请使用此指针："
 
 #: src/std/rc.md:6
 msgid ""
@@ -8543,52 +8839,76 @@ msgstr ""
 
 #: src/std/rc.md:18
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
 msgstr ""
-"* 如果您需要在 `Rc` 内修改数据，则需将数据封装入\n"
-"[`Cell` 或 `RefCell`][2] 等类型中。\n"
-"* 如果您在多线程情境中，请参阅 [`Arc`][3]。\n"
-"* 您可以将共享指针*降级*为 [`Weak`][4] 指针，\n"
-"以便创建之后会被舍弃的循环引用。"
+"如果您需要在 `Rc` 内修改数据，则需将数据封装入 [`Cell` 或 `RefCell`](../"
+"concurrency/shared_state/arc.md) 等类型中。"
+
+#: src/std/rc.md:20
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+"如果您在多线程情境中，请参阅 [`Arc`](https://doc.rust-lang.org/std/sync/"
+"struct.Mutex.html)。"
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
+"您可以将共享指针_降级_为 [`Weak`](https://doc.rust-lang.org/std/rc/struct."
+"Weak.html) 指针， 以便创建之后会被舍弃的循环引用。"
 
 #: src/std/rc.md:31
 msgid ""
-"* `Rc`'s count ensures that its contained value is valid for as long as "
-"there are references.\n"
-"* Like C++'s `std::shared_ptr`.\n"
-"* `Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr "`Rc` 的计数可确保只要有引用，内含的值就会保持有效。"
+
+#: src/std/rc.md:32
+msgid "Like C++'s `std::shared_ptr`."
+msgstr "类似 C++ 的 `std::shared_ptr`。"
+
+#: src/std/rc.md:33
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-"
-"write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable "
-"borrows that are enforced at compile time. `RefCell` enables (im)mutable "
-"borrows that are enforced at run time and will panic if it fails at "
-"runtime.\n"
-"* `Rc::downgrade` gives you a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"be ignored when looking for performance issues in code."
 msgstr ""
-"* `Rc` 的计数可确保只要有引用，内含的值就会保持有效。\n"
-"* 类似 C++ 的 `std::shared_ptr`。\n"
-"* `Rc::clone` 的成本很低：这个做法会创建指向相同分配的指针，并增加引用计数，"
-"而不会产生深层的克隆，排查代码性能问题时通常可以忽略。\n"
-"* `make_mut` 实际上会在必要时克隆内部值（“clone-on-write”），并返回可变的引"
-"用。\n"
-"* 使用 `Rc::strong_count` 可查看引用计数。\n"
-"* 比较提及的不同数据类型。`Box` 可启用在编译时强制执行的可变/不可变借用。"
+"`Rc::clone` 的成本很低：这个做法会创建指向相同分配的指针，并增加引用计数，而"
+"不会产生深层的克隆，排查代码性能问题时通常可以忽略。"
+
+#: src/std/rc.md:34
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+"`make_mut` 实际上会在必要时克隆内部值（“clone-on-write”），并返回可变的引用。"
+
+#: src/std/rc.md:35
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr "使用 `Rc::strong_count` 可查看引用计数。"
+
+#: src/std/rc.md:36
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+"比较提及的不同数据类型。`Box` 可启用在编译时强制执行的可变/不可变借用。"
 "`RefCell` 可启用在运行时强制执行的可变/不可变借用，如果在运行时失败，将产生恐"
-"慌。\n"
-"* `Rc::downgrade` 会向您提供 *弱引用计数* 对象，\n"
-"以便创建之后会被适当舍弃的周期（可能会与\n"
-"`RefCell` 组合）。"
+"慌。"
+
+#: src/std/rc.md:37
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
+msgstr ""
+"`Rc::downgrade` 会向您提供 _弱引用计数_ 对象， 以便创建之后会被适当舍弃的周期"
+"（可能会与 `RefCell` 组合）。"
 
 #: src/std/rc.md:41
 msgid ""
@@ -8619,10 +8939,6 @@ msgid ""
 "    println!(\"graph: {root:#?}\");\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/modules.md:1
-msgid "# Modules"
 msgstr ""
 
 #: src/modules.md:3
@@ -8657,15 +8973,18 @@ msgstr ""
 
 #: src/modules.md:28
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/visibility.md:1
-msgid "# Visibility"
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
 #: src/modules/visibility.md:3
@@ -8673,12 +8992,17 @@ msgid "Modules are a privacy boundary:"
 msgstr ""
 
 #: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr ""
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr ""
+
+#: src/modules/visibility.md:7
 msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
 msgstr ""
 
 #: src/modules/visibility.md:10
@@ -8712,7 +9036,7 @@ msgid ""
 msgstr ""
 
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
+msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
 #: src/modules/visibility.md:41
@@ -8723,16 +9047,22 @@ msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
-"its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/paths.md:1
-msgid "# Paths"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
 msgstr ""
 
 #: src/modules/paths.md:3
@@ -8740,20 +9070,33 @@ msgid "Paths are resolved as follows:"
 msgstr ""
 
 #: src/modules/paths.md:5
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgid "As a relative path:"
+msgstr ""
+
+#: src/modules/paths.md:6
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+
+#: src/modules/paths.md:7
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr ""
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
 #: src/modules/paths.md:13
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
 
 #: src/modules/paths.md:16
@@ -8762,10 +9105,6 @@ msgid ""
 "use std::collections::HashSet;\n"
 "use std::mem::transmute;\n"
 "```"
-msgstr ""
-
-#: src/modules/filesystem.md:1
-msgid "# Filesystem Hierarchy"
 msgstr ""
 
 #: src/modules/filesystem.md:3
@@ -8784,9 +9123,11 @@ msgid "The `garden` module content is found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:11
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:12
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:14
@@ -8794,9 +9135,11 @@ msgid "Similarly, a `garden::vegetables` module can be found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:16
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:17
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:19
@@ -8804,16 +9147,18 @@ msgid "The `crate` root is in:"
 msgstr ""
 
 #: src/modules/filesystem.md:21
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:22
+msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
 #: src/modules/filesystem.md:24
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
-"comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 
 #: src/modules/filesystem.md:27
@@ -8837,79 +9182,93 @@ msgstr ""
 
 #: src/modules/filesystem.md:44
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:47
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:57
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:60
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:63
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:68
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
-msgid "# Day 2: Afternoon Exercises"
-msgstr "# 第二天下午习题"
+msgid "Day 2: Afternoon Exercises"
+msgstr "第二天下午习题"
 
 #: src/exercises/day-2/afternoon.md:3
 msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr "今天下午的习题将重点关注字符串（string）和迭代器（iterator）。"
 
-#: src/exercises/day-2/luhn.md:1
-msgid "# Luhn Algorithm"
-msgstr ""
-
 #: src/exercises/day-2/luhn.md:3
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:19
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 
@@ -8965,23 +9324,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-msgid "# Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/strings-iterators.md:3
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:8
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
@@ -9035,7 +9388,7 @@ msgid ""
 msgstr ""
 
 #: src/welcome-day-3.md:1
-msgid "# Welcome to Day 3"
+msgid "Welcome to Day 3"
 msgstr ""
 
 #: src/welcome-day-3.md:3
@@ -9044,36 +9397,36 @@ msgstr ""
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
 
-#: src/generics.md:1
-msgid "# Generics"
-msgstr "# 泛型"
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
 
 #: src/generics.md:3
 msgid ""
 "Rust support generics, which lets you abstract an algorithm (such as "
-"sorting)\n"
-"over the types used in the algorithm."
+"sorting) over the types used in the algorithm."
 msgstr ""
 "Rust 支持泛型，允许您根据算法（例如排序）中使用的类型对算法进行抽象化处理。"
-
-#: src/generics/data-types.md:1
-msgid "# Generic Data Types"
-msgstr "# 通用数据类型"
 
 #: src/generics/data-types.md:3
 msgid "You can use generics to abstract over the concrete field type:"
@@ -9097,15 +9450,12 @@ msgid ""
 msgstr ""
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
 msgstr ""
 
-#: src/generics/methods.md:1
-msgid "# Generic Methods"
-msgstr "# 泛型方法"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
+msgstr ""
 
 #: src/generics/methods.md:3
 msgid "You can declare a generic type on your `impl` block:"
@@ -9134,25 +9484,32 @@ msgstr ""
 
 #: src/generics/methods.md:25
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
-"* *问：*为什么 `T` 在 `impl<T> Point<T> {}` 中指定了两次？这不是多余的吗？\n"
-"    * 这是因为它是泛型类型的泛型实现部分。它们是独立的泛型内容。\n"
-"    * 这意味着这些方法是针对所有 `T` 定义的。\n"
-"    * 可以编写 `impl Point<u32> { .. }`。\n"
-"      * `Point` 依然是一个泛型，并且您可以使用 `Point<f64>`，但此块中的方法将仅"
-"适用于 `Point<u32>`。"
+"\\*问：\\*为什么 `T` 在 `impl<T> Point<T> {}` 中指定了两次？这不是多余的吗？"
 
-#: src/generics/monomorphization.md:1
-msgid "# Monomorphization"
-msgstr "# 单态化"
+#: src/generics/methods.md:26
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr "这是因为它是泛型类型的泛型实现部分。它们是独立的泛型内容。"
+
+#: src/generics/methods.md:27
+msgid "It means these methods are defined for any `T`."
+msgstr "这意味着这些方法是针对所有 `T` 定义的。"
+
+#: src/generics/methods.md:28
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "可以编写 `impl Point<u32> { .. }`。"
+
+#: src/generics/methods.md:29
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"`Point` 依然是一个泛型，并且您可以使用 `Point<f64>`，但此块中的方法将仅适用"
+"于 `Point<u32>`。"
 
 #: src/generics/monomorphization.md:3
 msgid "Generic code is turned into non-generic code based on the call sites:"
@@ -9195,15 +9552,10 @@ msgstr ""
 #: src/generics/monomorphization.md:31
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 "这是零成本的抽象化处理：您得到的结果不会受到影响，也就是说，与在没有进行抽象"
 "化处理的情况下，对数据结构进行手动编码时的结果一样。"
-
-#: src/traits.md:1
-msgid "# Traits"
-msgstr "# 特征"
 
 #: src/traits.md:3
 msgid ""
@@ -9249,10 +9601,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/trait-objects.md:1
-msgid "# Trait Objects"
-msgstr "# 特征（Trait）对象"
 
 #: src/traits/trait-objects.md:3
 msgid ""
@@ -9356,28 +9704,39 @@ msgstr ""
 
 #: src/traits/trait-objects.md:72
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Pet>` in the example above.\n"
-"* `dyn Pet` is a way to tell the compiler about a dynamically sized type "
-"that implements `Pet`.\n"
-"* In the example, `pets` holds *fat pointers* to objects that implement "
-"`Pet`. The fat pointer consists of two components, a pointer to the actual "
-"object and a pointer to the virtual method table for the `Pet` "
-"implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"     ```"
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Pet>` in the example above."
 msgstr ""
 
-#: src/traits/deriving-traits.md:1
-msgid "# Deriving Traits"
-msgstr "# 派生特征"
+#: src/traits/trait-objects.md:73
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/traits/trait-objects.md:74
+msgid ""
+"In the example, `pets` holds _fat pointers_ to objects that implement `Pet`. "
+"The fat pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Pet` implementation of "
+"that particular object."
+msgstr ""
+
+#: src/traits/trait-objects.md:75
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits/trait-objects.md:76
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
+msgstr ""
 
 #: src/traits/deriving-traits.md:3
 msgid "You can let the compiler derive a number of traits:"
@@ -9401,10 +9760,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/default-methods.md:1
-msgid "# Default Methods"
-msgstr "# 默认方法"
 
 #: src/traits/default-methods.md:3
 msgid "Traits can implement behavior in terms of other trait methods:"
@@ -9440,51 +9795,61 @@ msgstr ""
 
 #: src/traits/default-methods.md:32
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to\n"
-"  implement themselves. Methods with default implementations can rely on "
-"required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `NotEqual` a super trait for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `NotEqual` as a "
-"super trait for `Equal`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
 
-#: src/traits/trait-bounds.md:1
-msgid "# Trait Bounds"
-msgstr "# 特征边界"
+#: src/traits/default-methods.md:35
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr ""
+
+#: src/traits/default-methods.md:37
+msgid "Make `NotEqual` a super trait for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:38
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:46
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `NotEqual` as a super "
+"trait for `Equal`."
+msgstr ""
 
 #: src/traits/trait-bounds.md:3
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
-"使用泛型时，您通常会想要利用类型来实现某些特性，\n"
-"这样才能调用此特征的方法。"
+"使用泛型时，您通常会想要利用类型来实现某些特性， 这样才能调用此特征的方法。"
 
 #: src/traits/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
@@ -9543,30 +9908,29 @@ msgstr ""
 "```"
 
 #: src/traits/trait-bounds.md:46
+msgid "It declutters the function signature if you have many parameters."
+msgstr "它会在您有多个形参的情况下整理函数签名。"
+
+#: src/traits/trait-bounds.md:47
+msgid "It has additional features making it more powerful."
+msgstr "它具有额外功能，因此也更强大。"
+
+#: src/traits/trait-bounds.md:48
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":"
-"\" can be arbitrary, like `Option<T>`.\n"
-"    "
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
-"* 它会在您有多个形参的情况下整理函数签名。\n"
-"* 它具有额外功能，因此也更强大。\n"
-"    * 如果有人提问，便阐明额外功能是指“:”左侧的类别可为任意值，例如 "
-"`Option<T>`。\n"
-"    "
+"如果有人提问，便阐明额外功能是指“:”左侧的类别可为任意值，例如 `Option<T>`。"
 
 #: src/traits/impl-trait.md:1
-msgid "# `impl Trait`"
-msgstr "# `impl Trait`"
+msgid "`impl Trait`"
+msgstr "`impl Trait`"
 
 #: src/traits/impl-trait.md:3
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
-msgstr ""
-"与特征边界类似，`impl Trait` 语法可以在函数实参\n"
-"和返回值中使用："
+msgstr "与特征边界类似，`impl Trait` 语法可以在函数实参 和返回值中使用："
 
 #: src/traits/impl-trait.md:6
 msgid ""
@@ -9585,8 +9949,8 @@ msgid ""
 msgstr ""
 
 #: src/traits/impl-trait.md:19
-msgid "* `impl Trait` allows you to work with types which you cannot name."
-msgstr "* `impl Trait` 让您可使用无法命名的类型。"
+msgid "`impl Trait` allows you to work with types which you cannot name."
+msgstr "`impl Trait` 让您可使用无法命名的类型。"
 
 #: src/traits/impl-trait.md:23
 msgid ""
@@ -9595,61 +9959,48 @@ msgstr "`impl Trait` 的意义因使用位置而略有不同。"
 
 #: src/traits/impl-trait.md:25
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` "
-"picks\n"
-"  the concrete type it returns, without writing it out in the source. A "
-"function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let "
-"x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
+msgstr "对形参来说，`impl Trait` 就像是具有特征边界的匿名泛型形参。"
+
+#: src/traits/impl-trait.md:27
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
 msgstr ""
-"* 对形参来说，`impl Trait` 就像是具有特征边界的匿名泛型形参。\n"
-"\n"
-"* 对返回值类型来说，它则意味着返回值类型就是实现该特征的某具体类型，\n"
-"无需为该类型命名。如果您不想在公共 API 中公开该具体类型，便可\n"
-"使用此方法。\n"
-"\n"
-"在返回位置处进行推断有一定难度。会返回 `impl Foo` 的函数会挑选\n"
-"自身返回的具体类型，而不必在来源中写出此信息。会返回\n"
-"泛型类型（例如 `collect<B>() -> B`）的函数则可返回符合 `B`\n"
-"的任何类型，而调用方可能需要选择一个类型，例如使用 `let x:\n"
-"  Vec<_> = foo.collect()` 或使用以下 Turbofish：`foo.collect::<Vec<_>>()`。"
+"对返回值类型来说，它则意味着返回值类型就是实现该特征的某具体类型， 无需为该类"
+"型命名。如果您不想在公共 API 中公开该具体类型，便可 使用此方法。"
+
+#: src/traits/impl-trait.md:31
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
+msgstr ""
+"在返回位置处进行推断有一定难度。会返回 `impl Foo` 的函数会挑选 自身返回的具体"
+"类型，而不必在来源中写出此信息。会返回 泛型类型（例如 `collect<B>() -> B`）的"
+"函数则可返回符合 `B` 的任何类型，而调用方可能需要选择一个类型，例如使用 `let "
+"x: Vec<_> = foo.collect()` 或使用以下 Turbofish：`foo.collect::<Vec<_>>()`。"
 
 #: src/traits/impl-trait.md:37
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters."
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
-"这是一个非常棒的示例，因为它使用了两次 `impl Display`。这有助于说明\n"
-"此处没有任何项目会强制使用相同的 `impl Display` 类型。如果我们使用单个\n"
-"`T: Display`，它会强制限制输入 `T` 和返回 `T` 均为同一类型。\n"
-"这并不适用于这个特定函数，因为我们预期作为输入的类型可能\n"
-"不会是 `format!` 返回的值。如果我们希望通过 `: Display` 语法执行相同的操作，"
-"则需要两个\n"
-"独立的泛型形参。"
-
-#: src/traits/important-traits.md:1
-msgid "# Important Traits"
-msgstr "# 重要特征"
+"这是一个非常棒的示例，因为它使用了两次 `impl Display`。这有助于说明 此处没有"
+"任何项目会强制使用相同的 `impl Display` 类型。如果我们使用单个 `T: Display`，"
+"它会强制限制输入 `T` 和返回 `T` 均为同一类型。 这并不适用于这个特定函数，因为"
+"我们预期作为输入的类型可能 不会是 `format!` 返回的值。如果我们希望通过 `: "
+"Display` 语法执行相同的操作，则需要两个 独立的泛型形参。"
 
 #: src/traits/important-traits.md:3
 msgid ""
@@ -9659,27 +10010,67 @@ msgstr "现在，我们来看看 Rust 标准库的一些最常见的特征："
 
 #: src/traits/important-traits.md:5
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
 msgstr ""
-"* [`Iterator`][1] 和 [`IntoIterator`][2] 用于 `for` 循环中，\n"
-"* [`From`][3] 和 [`Into`][4] 用于转换值，\n"
-"* [`Read`][5] 和 [`Write`][6] 用于实现 IO。\n"
-"* [`Add`][7]、[`Mul`][8] 等用于实现运算符重载，\n"
-"* [`Drop`][9] 用于定义析构函数。\n"
-"* [`Default`][10] 用于构建相应类型的默认实例。"
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) 和 "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"用于 `for` 循环中，"
+
+#: src/traits/important-traits.md:6
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) 用于转换值，"
+
+#: src/traits/important-traits.md:7
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) 用于实现 IO。"
+
+#: src/traits/important-traits.md:8
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html)、[`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html) 等用于实现运算符重载，"
+
+#: src/traits/important-traits.md:9
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 用于定义析构函"
+"数。"
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 用于构"
+"建相应类型的默认实例。"
 
 #: src/traits/iterator.md:1
-msgid "# Iterators"
-msgstr "# 迭代器"
+msgid "Iterators"
+msgstr "迭代器"
 
 #: src/traits/iterator.md:3
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
-msgstr "您可以自行实现 [`Iterator`][1] 特征："
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
+msgstr ""
+"您可以自行实现 [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) 特征："
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -9711,40 +10102,37 @@ msgstr ""
 
 #: src/traits/iterator.md:32
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
-"* `Iterator` 特征会对集合实现许多常见的函数程序操作，\n"
-"例如 `map``filter`和`reduce` 等。您可以通过此特征找到有关它们的所有\n"
-"文档。在 Rust 中，这些函数应生成代码，且生成的代码应与等效命令式实现一样\n"
-"高效。\n"
-"    \n"
-"* `IntoIterator` 是迫使 for 循环运作的特征。此特征由集合类型\n"
-"（例如 `Vec<T>`）和相关引用（例如 `&Vec<T>` 和 `&[T]`）而实现。此外，范围也会"
-"实现这项特征。因此，\n"
-"您可以使用 `for i in some_vec { .. }` 来遍历某矢量，但\n"
-"`some_vec.next()` 不存在。"
+"`Iterator` 特征会对集合实现许多常见的函数程序操作， 例如 `` map``filter ``和"
+"`reduce` 等。您可以通过此特征找到有关它们的所有 文档。在 Rust 中，这些函数应"
+"生成代码，且生成的代码应与等效命令式实现一样 高效。"
 
-#: src/traits/from-iterator.md:1
-msgid "# FromIterator"
-msgstr "# FromIterator"
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
+"`IntoIterator` 是迫使 for 循环运作的特征。此特征由集合类型 （例如 `Vec<T>`）"
+"和相关引用（例如 `&Vec<T>` 和 `&[T]`）而实现。此外，范围也会实现这项特征。因"
+"此， 您可以使用 `for i in some_vec { .. }` 来遍历某矢量，但 `some_vec."
+"next()` 不存在。"
 
 #: src/traits/from-iterator.md:3
 msgid ""
-"[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
-msgstr "[`FromIterator`][1] 让您可通过 [`Iterator`][2] 构建一个集合。"
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
+msgstr ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"让您可通过 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator."
+"html) 构建一个集合。"
 
 #: src/traits/from-iterator.md:5
 msgid ""
@@ -9761,34 +10149,33 @@ msgstr ""
 
 #: src/traits/from-iterator.md:17
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"`Iterator` 会实现\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` 会实现 `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 
 #: src/traits/from-iterator.md:23
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
-"还有一些实现，让您可执行一些很酷的操作，比如\n"
-"将 `Iterator<Item = Result<V, E>>` 转换成 `Result<Vec<V>, E>`。"
+"还有一些实现，让您可执行一些很酷的操作，比如 将 `Iterator<Item = Result<V, "
+"E>>` 转换成 `Result<Vec<V>, E>`。"
 
 #: src/traits/from-into.md:1
-msgid "# `From` and `Into`"
-msgstr "# `From` 和 `Into`"
+msgid "`From` and `Into`"
+msgstr "`From` 和 `Into`"
 
 #: src/traits/from-into.md:3
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
-msgstr "类型会实现 [`From`][1] 和 [`Into`][2] 以加快类型转换："
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
+msgstr ""
+"类型会实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) "
+"和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 以加快类型"
+"转换："
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -9805,8 +10192,12 @@ msgstr ""
 
 #: src/traits/from-into.md:15
 msgid ""
-"[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
-msgstr "实现 [`From`][1] 后，系统会自动实现 [`Into`][2]："
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
+msgstr ""
+"实现 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 后，系统"
+"会自动实现 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)："
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -9823,28 +10214,34 @@ msgstr ""
 
 #: src/traits/from-into.md:29
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
+msgstr "这就是为什么通常只需实现 `From`，因为您的类型也会实现 `Into`。"
+
+#: src/traits/from-into.md:30
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
 msgstr ""
-"* 这就是为什么通常只需实现 `From`，因为您的类型也会实现 `Into`。\n"
-"* 若要声明某个函数实参输入类型（例如“任何可转换成 `String` 的类型”），规则便"
-"会相反，此时应使用 `Into`。\n"
-"您的函数会接受可实现 `From` 的类型，以及那些仅实现 `Into` 的类型。\n"
-"    "
+"若要声明某个函数实参输入类型（例如“任何可转换成 `String` 的类型”），规则便会"
+"相反，此时应使用 `Into`。 您的函数会接受可实现 `From` 的类型，以及那些仅实现 "
+"`Into` 的类型。"
 
 #: src/traits/read-write.md:1
-msgid "# `Read` and `Write`"
-msgstr "# `Read` 和 `Write`"
+msgid "`Read` and `Write`"
+msgstr "`Read` 和 `Write`"
 
 #: src/traits/read-write.md:3
 msgid ""
-"Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
-msgstr "您可以使用 [`Read`][1] 和 [`BufRead`][2] 对 `u8` 来源进行抽象化处理："
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr ""
+"您可以使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 对 `u8` 来源"
+"进行抽象化处理："
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -9868,8 +10265,12 @@ msgid ""
 msgstr ""
 
 #: src/traits/read-write.md:23
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
-msgstr "您同样可使用 [`Write`][3] 对 `u8` 接收器进行抽象化处理："
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
+msgstr ""
+"您同样可使用 [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 对 "
+"`u8` 接收器进行抽象化处理："
 
 #: src/traits/read-write.md:25
 msgid ""
@@ -9892,14 +10293,16 @@ msgid ""
 msgstr ""
 
 #: src/traits/drop.md:1
-msgid "# The `Drop` Trait"
-msgstr "# `Drop` 特征"
+msgid "The `Drop` Trait"
+msgstr "`Drop` 特征"
 
 #: src/traits/drop.md:3
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
-msgstr "用于实现 [`Drop`][1] 的值可以指定在超出范围时运行的代码："
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
+msgstr ""
+"用于实现 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 的值可以"
+"指定在超出范围时运行的代码："
 
 #: src/traits/drop.md:5
 msgid ""
@@ -9936,26 +10339,29 @@ msgid "Discussion points:"
 msgstr "讨论点："
 
 #: src/traits/drop.md:36
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "为什么 `Drop::drop` 不使用 `self`？"
+
+#: src/traits/drop.md:37
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
-"* 为什么 `Drop::drop` 不使用 `self`？\n"
-"    * 简答：如果这样的话，系统会在代码块结尾\n"
-"调用 `std::mem::drop`，进而引发再一次调用 `Drop::drop`，并引发堆栈\n"
-"溢出！\n"
-"* 尝试用 `a.drop()` 替换 `drop(a)`。"
+"简答：如果这样的话，系统会在代码块结尾 调用 `std::mem::drop`，进而引发再一次"
+"调用 `Drop::drop`，并引发堆栈 溢出！"
+
+#: src/traits/drop.md:40
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "尝试用 `a.drop()` 替换 `drop(a)`。"
 
 #: src/traits/default.md:1
-msgid "# The `Default` Trait"
-msgstr "# `Default` 特征"
+msgid "The `Default` Trait"
+msgstr "`Default` 特征"
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait provides a default implementation of a trait."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"provides a default implementation of a trait."
 msgstr ""
 
 #: src/traits/default.md:5
@@ -9996,31 +10402,47 @@ msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e."
-"g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
-"provides convenience methods that use it."
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr "系统可以直接实现它，也可以通过 `#[derive(Default)]` 派生出它。"
+
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr "派生的实现会生成一个实例，其中字段全都设为其默认值。"
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr "这意味着，该结构体中的所有类型也都必须实现 `Default`。"
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
 msgstr ""
-"  * 系统可以直接实现它，也可以通过 `#[derive(Default)]` 派生出它。\n"
-"  * 派生的实现会生成一个实例，其中字段全都设为其默认值。\n"
-"    * 这意味着，该结构体中的所有类型也都必须实现 `Default`。\n"
-"  * 标准的 Rust 类型通常会以合理的值（例如 `0``\"\"` 等）实现 `Default`。\n"
-"  * 部分结构体副本可与默认值完美搭配运作。\n"
-"  * Rust 标准库了解类型可能会实现 `Default`，因此提供了便利的使用方式。"
+"标准的 Rust 类型通常会以合理的值（例如 `` 0``\"\" `` 等）实现 `Default`。"
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr "部分结构体副本可与默认值完美搭配运作。"
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
+"provides convenience methods that use it."
+msgstr "Rust 标准库了解类型可能会实现 `Default`，因此提供了便利的使用方式。"
 
 #: src/traits/operators.md:1
-msgid "# `Add`, `Mul`, ..."
-msgstr "# `Add``Mul`…"
+msgid "`Add`, `Mul`, ..."
+msgstr "`` Add``Mul ``…"
 
 #: src/traits/operators.md:3
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
-msgstr "运算符重载是通过 [`std::ops`][1] 中的特征实现的："
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
+msgstr ""
+"运算符重载是通过 [`std::ops`](https://doc.rust-lang.org/std/ops/index.html) "
+"中的特征实现的："
 
 #: src/traits/operators.md:5
 msgid ""
@@ -10046,37 +10468,43 @@ msgstr ""
 
 #: src/traits/operators.md:28
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter?\n"
-"    * Short answer: Type parameters are controlled by the caller, but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
+msgstr "您可以针对 `&Point` 实现 `Add`。此做法在哪些情况下可派上用场？"
+
+#: src/traits/operators.md:29
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"回答：`Add:add` 会耗用 `self`。如果您的运算符重载对象 （即类型 `T`）不是 "
+"`Copy`，建议您也为 `&T` 重载运算符。这可避免调用点上存在不必要的 克隆任务。"
+
+#: src/traits/operators.md:33
+msgid "Why is `Output` an associated type? Could it be made a type parameter?"
+msgstr ""
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Type parameters are controlled by the caller, but associated "
+"types (like `Output`) are controlled by the implementor of a trait."
 msgstr ""
 
 #: src/traits/closures.md:1
-msgid "# Closures"
-msgstr "# 闭包"
+msgid "Closures"
+msgstr "闭包"
 
 #: src/traits/closures.md:3
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
-"闭包或 lambda 表达式具有无法命名的类型。不过，它们会\n"
-"实现特殊的 [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)，\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和\n"
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) 特征："
+"闭包或 lambda 表达式具有无法命名的类型。不过，它们会 实现特殊的 [`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html)， [`FnMut`](https://doc."
+"rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://doc.rust-lang."
+"org/std/ops/trait.FnOnce.html) 特征："
 
 #: src/traits/closures.md:8
 msgid ""
@@ -10111,127 +10539,106 @@ msgstr ""
 #: src/traits/closures.md:29
 msgid ""
 "An `Fn` neither consumes nor mutates captured values, or perhaps captures "
-"nothing at all, so it can\n"
-"be called multiple times concurrently."
+"nothing at all, so it can be called multiple times concurrently."
 msgstr ""
 
 #: src/traits/closures.md:43
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 "`FnMut` 是 `FnOnce` 的子类型。`Fn` 是 `FnMut` 和 `FnOnce` 的子类型。也就是"
-"说，您可以在任何\n"
-"需要调用 `FnOnce` 的地方使用 `FnMut`，还可在任何需要调用 `FnMut` 或 `FnOnce` "
-"的地方\n"
-"使用 `Fn`。"
+"说，您可以在任何 需要调用 `FnOnce` 的地方使用 `FnMut`，还可在任何需要调用 "
+"`FnMut` 或 `FnOnce` 的地方 使用 `Fn`。"
 
 #: src/traits/closures.md:36
 msgid "`move` closures only implement `FnOnce`."
 msgstr ""
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait produces a default value for a type."
-msgstr "[`Default`][1] 特征会为类型生成默认值。"
-
-#: src/traits/operators.md:28
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter of "
-"the method?\n"
-"    * Short answer: Function type parameters are controlled by the caller, "
-"but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait.\n"
-"* You could implement `Add` for two different types, e.g.\n"
-"  `impl Add<(i32, i32)> for Point` would add a tuple to a `Point`."
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
 msgstr ""
-"* 您可以针对 `&Point` 实现 `Add`。此做法在哪些情况下可派上用场？\n"
-"    * 回答：`Add:add` 会耗用 `self`。如果您的运算符重载对象\n"
-"（即类型 `T`）不是 `Copy`，建议您也为 `&T`\n"
-"重载运算符。这可避免调用点上存在不必要的\n"
-"克隆任务。\n"
-"* 为什么 `Output` 是关联类型？可将它用作该方法的类型形参吗？\n"
-"    * 简答：函数类型形参是由调用方控管，但\n"
-"`Output` 这类关联类型则由特征实现人员\n"
-"控管。\n"
-"* 您可以针对两种不同类型实现 `Add`，例如，\n"
-"`impl Add<(i32, i32)> for Point` 会向 `Point` 中添加元组。"
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 特征会"
+"为类型生成默认值。"
+
+#: src/traits/operators.md:33
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr "为什么 `Output` 是关联类型？可将它用作该方法的类型形参吗？"
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementor of a "
+"trait."
+msgstr ""
+"简答：函数类型形参是由调用方控管，但 `Output` 这类关联类型则由特征实现人员 控"
+"管。"
+
+#: src/traits/operators.md:37
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
+msgstr ""
+"您可以针对两种不同类型实现 `Add`，例如， `impl Add<(i32, i32)> for Point` 会"
+"向 `Point` 中添加元组。"
 
 #: src/traits/closures.md:34
 msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
-"perhaps captures\n"
-"nothing at all. It can be called multiple times concurrently."
+"perhaps captures nothing at all. It can be called multiple times "
+"concurrently."
 msgstr ""
-"`Fn`（例如 `add_3`）既不会耗用也不会修改捕获的值，或许\n"
-"也不会捕获任何值。它可被并发调用多次。"
+"`Fn`（例如 `add_3`）既不会耗用也不会修改捕获的值，或许 也不会捕获任何值。它可"
+"被并发调用多次。"
 
 #: src/traits/closures.md:37
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
-"multiple times,\n"
-"but not concurrently."
+"multiple times, but not concurrently."
 msgstr ""
-"`FnMut`（例如 `accumulate`）可能会改变捕获的值。您可以多次调用它，\n"
-"但不能并发调用它。"
+"`FnMut`（例如 `accumulate`）可能会改变捕获的值。您可以多次调用它， 但不能并发"
+"调用它。"
 
 #: src/traits/closures.md:40
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
-"might consume\n"
-"captured values."
+"might consume captured values."
 msgstr ""
-"如果您使用 `FnOnce`（例如 `multiply_sum`），或许只能调用它一次。它可能会耗"
-"用\n"
+"如果您使用 `FnOnce`（例如 `multiply_sum`），或许只能调用它一次。它可能会耗用 "
 "所捕获的值。"
 
 #: src/traits/closures.md:47
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
-"`multiply_sum`),\n"
-"depending on what the closure captures."
+"`multiply_sum`), depending on what the closure captures."
 msgstr ""
-"编译器也会推断 `Copy`（例如针对 `add_3`）和 `Clone`（例如 "
-"`multiply_sum`），\n"
+"编译器也会推断 `Copy`（例如针对 `add_3`）和 `Clone`（例如 `multiply_sum`）， "
 "具体取决于闭包捕获的数据。"
 
 #: src/traits/closures.md:50
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
-"keyword makes them capture\n"
-"by value."
+"keyword makes them capture by value."
 msgstr ""
 "默认情况下，闭包会依据引用来捕获数据（如果可以的话）。`move` 关键字则可让闭包"
-"依据值\n"
-"来捕获数据。"
+"依据值 来捕获数据。"
 
 #: src/exercises/day-3/morning.md:1
-msgid "# Day 3: Morning Exercises"
+msgid "Day 3: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:3
 msgid "We will design a classical GUI library traits and trait objects."
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:1
-msgid "# A Simple GUI Library"
-msgstr ""
-
 #: src/exercises/day-3/simple-gui.md:3
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 
@@ -10240,11 +10647,17 @@ msgid "We will have a number of widgets in our library:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:8
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:9
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:11
+msgid "`Label`: has a `label`."
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:13
@@ -10253,7 +10666,7 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:15
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
@@ -10392,11 +10805,10 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:142
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:147
@@ -10430,25 +10842,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-msgid "# Error Handling"
-msgstr "# 错误处理"
-
 #: src/error-handling.md:3
 msgid "Error handling in Rust is done using explicit control flow:"
 msgstr "Rust 中的错误处理是使用显式控制流来进行的："
 
 #: src/error-handling.md:5
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
-msgstr ""
-"* 包含错误的函数会在返回类型中列出相关信息。\n"
-"* 此规则没有例外。"
+msgid "Functions that can have errors list this in their return type,"
+msgstr "包含错误的函数会在返回类型中列出相关信息。"
 
-#: src/error-handling/panics.md:1
-msgid "# Panics"
-msgstr "# Panics"
+#: src/error-handling.md:6
+msgid "There are no exceptions."
+msgstr "此规则没有例外。"
 
 #: src/error-handling/panics.md:3
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
@@ -10465,18 +10869,21 @@ msgid ""
 msgstr ""
 
 #: src/error-handling/panics.md:12
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "Panic 用于指示不可恢复的意外错误。"
+
+#: src/error-handling/panics.md:13
+msgid "Panics are symptoms of bugs in the program."
+msgstr "Panic反映了程序中的 bug 问题。"
+
+#: src/error-handling/panics.md:14
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
-msgstr ""
-"* Panic 用于指示不可恢复的意外错误。\n"
-"  * Panic反映了程序中的 bug 问题。\n"
-"* 如果崩溃不可接受，请使用不会触发 panic 的 API（例如 `Vec::get`）。"
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+msgstr "如果崩溃不可接受，请使用不会触发 panic 的 API（例如 `Vec::get`）。"
 
 #: src/error-handling/panic-unwind.md:1
-msgid "# Catching the Stack Unwinding"
-msgstr "# 捕获堆栈展开"
+msgid "Catching the Stack Unwinding"
+msgstr "捕获堆栈展开"
 
 #: src/error-handling/panic-unwind.md:3
 msgid ""
@@ -10503,26 +10910,26 @@ msgstr ""
 
 #: src/error-handling/panic-unwind.md:21
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* 如果服务器需要持续运行（即使是在请求发生崩溃的情况下），\n"
-"  此方法十分有用。\n"
-"* 如果您在 `Cargo.toml` 中设置了 `panic = 'abort'`，此方法不会生效。"
+"如果服务器需要持续运行（即使是在请求发生崩溃的情况下）， 此方法十分有用。"
+
+#: src/error-handling/panic-unwind.md:23
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr "如果您在 `Cargo.toml` 中设置了 `panic = 'abort'`，此方法不会生效。"
 
 #: src/error-handling/result.md:1
-msgid "# Structured Error Handling with `Result`"
-msgstr "# 使用 `Result` 进行结构化错误处理"
+msgid "Structured Error Handling with `Result`"
+msgstr "使用 `Result` 进行结构化错误处理"
 
 #: src/error-handling/result.md:3
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
-"在前面，我们看到了 `Result` 枚举。在遇到正常操作产生的预期错误时，\n"
-"我们常会用到此方法："
+"在前面，我们看到了 `Result` 枚举。在遇到正常操作产生的预期错误时， 我们常会用"
+"到此方法："
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10548,38 +10955,33 @@ msgstr ""
 
 #: src/error-handling/result.md:27
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
 msgstr ""
-"  * 与 `Option` 方法相同，成功值位于 `Result` 方法内部，\n"
-"    开发者必须显示提取成功值。因此，建议进行错误检查。在绝不应出现错误的情况"
-"下，\n"
-"    可以调用 `unwrap()` 或 `expect()` 方法，这也是一种开发者意向信号。\n"
-"  * 我们建议阅读 `Result` 文档。虽然课程中不会涉及该文档，但是有必要提到"
-"它。\n"
-"    该文档中包含许多便捷的方法和函数，对于函数式编程很有帮助。\n"
-"    "
+"与 `Option` 方法相同，成功值位于 `Result` 方法内部， 开发者必须显示提取成功"
+"值。因此，建议进行错误检查。在绝不应出现错误的情况下， 可以调用 `unwrap()` "
+"或 `expect()` 方法，这也是一种开发者意向信号。"
+
+#: src/error-handling/result.md:30
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr ""
+"我们建议阅读 `Result` 文档。虽然课程中不会涉及该文档，但是有必要提到它。 该文"
+"档中包含许多便捷的方法和函数，对于函数式编程很有帮助。"
 
 #: src/error-handling/try-operator.md:1
-msgid "# Propagating Errors with `?`"
-msgstr "# 使用 `?` 传播错误"
+msgid "Propagating Errors with `?`"
+msgstr "使用 `?` 传播错误"
 
 #: src/error-handling/try-operator.md:3
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
-msgstr ""
-"try 操作符 `?` 用于将错误返回给调用方。它能把常用命令"
+"turn the common"
+msgstr "try 操作符 `?` 用于将错误返回给调用方。它能把常用命令"
 
 #: src/error-handling/try-operator.md:6
 msgid ""
@@ -10645,19 +11047,17 @@ msgstr ""
 
 #: src/error-handling/try-operator.md:50
 #: src/error-handling/converting-error-types-example.md:52
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
-msgstr ""
-"* `username` 变量可以是 `Ok(string)` 或 `Err(error)`。\n"
-"* 可以使用 `fs::write` 调用来测试不同的场景：没有文件、空文件、包含用户名的文"
-"件。"
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr "`username` 变量可以是 `Ok(string)` 或 `Err(error)`。"
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-msgid "# Converting Error Types"
-msgstr "# 转换错误类型"
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
+"可以使用 `fs::write` 调用来测试不同的场景：没有文件、空文件、包含用户名的文"
+"件。"
 
 #: src/error-handling/converting-error-types.md:3
 msgid ""
@@ -10697,12 +11097,10 @@ msgstr ""
 
 #: src/error-handling/converting-error-types.md:18
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
-"此处的 `From::from` 调用表示，我们尝试将错误类型转换为\n"
-"函数返回的类型："
+"此处的 `From::from` 调用表示，我们尝试将错误类型转换为 函数返回的类型："
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -10756,31 +11154,23 @@ msgstr ""
 #: src/error-handling/converting-error-types-example.md:55
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
 msgstr ""
 "对所有错误类型实现 `std::error::Error` 是一种很好的做法，而这需要结合使用 "
-"`Debug` 和 `Display` 方法。\n"
-"通常，在可能的情况下实现 `Clone` 和 `Eq` 也十分有益，\n"
-"可以让库的测试和使用变得更加简单。在本例中，我们无法轻松做到这一点，\n"
-"因为 `io::Error` 不能实现这些方法。"
-
-#: src/error-handling/deriving-error-enums.md:1
-msgid "# Deriving Error Enums"
-msgstr "# 派生错误枚举"
+"`Debug` 和 `Display` 方法。 通常，在可能的情况下实现 `Clone` 和 `Eq` 也十分有"
+"益， 可以让库的测试和使用变得更加简单。在本例中，我们无法轻松做到这一点， 因"
+"为 `io::Error` 不能实现这些方法。"
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
-"[thiserror](https://docs.rs/thiserror/) crate 是创建错误枚举的常用方法，\n"
-"就像前一页中提供的示例一样："
+"[thiserror](https://docs.rs/thiserror/) crate 是创建错误枚举的常用方法， 就像"
+"前一页中提供的示例一样："
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -10819,33 +11209,25 @@ msgstr ""
 #: src/error-handling/deriving-error-enums.md:39
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 "`thiserror` 的派生宏会自动实现 `std::error::Error`，并且可以选择性地实现 "
-"`Display`\n"
-"（如果提供了 `#[error(...)]` 属性）和 `From`（如果添加了 `#[from]` 属性）。\n"
-"此规则也适用于结构体。"
+"`Display` （如果提供了 `#[error(...)]` 属性）和 `From`（如果添加了 `#[from]` "
+"属性）。 此规则也适用于结构体。"
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr "但是，此规则不会影响公共 API，对于库而言，这非常理想。"
 
-#: src/error-handling/dynamic-errors.md:1
-msgid "# Dynamic Error Types"
-msgstr "# 动态错误类型"
-
 #: src/error-handling/dynamic-errors.md:3
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 "有时，我们需要允许返回任意类型的错误，但又不想自己手动编写枚举来涵盖所有不同"
-"的可能性。\n"
-"`std::error::Error` 可以让我们轻松做到这一点。"
+"的可能性。 `std::error::Error` 可以让我们轻松做到这一点。"
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -10881,32 +11263,24 @@ msgstr ""
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
 "虽然这可以省却编写代码的麻烦，但也会导致我们无法在程序中以不同的方式正常处理"
-"不同的\n"
-"错误情况。因此，在库的公共 API 中使用 `Box<dyn Error>` 通常不是一个好主意。\n"
-"但是对于您只需要在某处显示错误消息的程序来说，这不失为一个\n"
-"很好的选择。"
-
-#: src/error-handling/error-contexts.md:1
-msgid "# Adding Context to Errors"
-msgstr "# 为错误添加背景信息"
+"不同的 错误情况。因此，在库的公共 API 中使用 `Box<dyn Error>` 通常不是一个好"
+"主意。 但是对于您只需要在某处显示错误消息的程序来说，这不失为一个 很好的选"
+"择。"
 
 #: src/error-handling/error-contexts.md:3
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
-"广泛使用的 [anyhow](https://docs.rs/anyhow/) crate 可以帮助我们为错误添加\n"
-"背景信息，并减少自定义错误类型的\n"
-"数量。"
+"广泛使用的 [anyhow](https://docs.rs/anyhow/) crate 可以帮助我们为错误添加 背"
+"景信息，并减少自定义错误类型的 数量。"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -10938,47 +11312,50 @@ msgid ""
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
-msgstr ""
-"* “anyhow::Result<V>”是“Result<V, anyhow::Error>”的类型别名。\n"
-"* “anyhow::Error”本质上是“Box<dyn Error>”的封装容器。因此，就像前面提到的那"
-"样，在库的公共 API 中\n"
-"  使用它通常不是一个好主意。但是它广泛用于应用中。\n"
-"* 如果需要，可以提取其内部的实际错误类型进行检查。\n"
-"* Go 开发者可能会十分熟悉 `anyhow::Result<T>` 提供的功能，\n"
-"  因为它的使用模式和工效学设计与 Go 的 `(T, error)` 方法十分相似。"
+#, fuzzy
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
+msgstr "“anyhow::Result"
 
-#: src/testing.md:1
-msgid "# Testing"
-msgstr "# 测试"
+#: src/error-handling/error-contexts.md:36
+#, fuzzy
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr "”是“Result\\<V, anyhow::Error>”的类型别名。"
+
+#: src/error-handling/error-contexts.md:38
+#, fuzzy
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr "“anyhow::Error”本质上是“Box"
+
+#: src/error-handling/error-contexts.md:39
+#, fuzzy
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"”的封装容器。因此，就像前面提到的那样，在库的公共 API 中 使用它通常不是一个好"
+"主意。但是它广泛用于应用中。\n"
+"\n"
+"如果需要，可以提取其内部的实际错误类型进行检查。\n"
+"\n"
+"Go 开发者可能会十分熟悉 `anyhow::Result<T>` 提供的功能， 因为它的使用模式和工"
+"效学设计与 Go 的 `(T, error)` 方法十分相似。"
 
 #: src/testing.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr "Rust 和 Cargo 随附了一个简单的单元测试框架："
 
 #: src/testing.md:5
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
-msgstr ""
-"* 单元测试在您的整个代码中都受支持。\n"
-"\n"
-"* 您可以通过 `tests/` 目录来支持集成测试。"
+msgid "Unit tests are supported throughout your code."
+msgstr "单元测试在您的整个代码中都受支持。"
 
-#: src/testing/unit-tests.md:1
-msgid "# Unit Tests"
-msgstr "# 单元测试"
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr "您可以通过 `tests/` 目录来支持集成测试。"
 
 #: src/testing/unit-tests.md:3
 msgid "Mark unit tests with `#[test]`:"
@@ -11015,14 +11392,10 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr "使用 `cargo test` 查找并运行单元测试。"
 
-#: src/testing/test-modules.md:1
-msgid "# Test Modules"
-msgstr "# 测试模块"
-
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 "单元测试通常会放在嵌套模块中（在 [Playground](https://play.rust-lang.org/) 上"
 "运行测试）："
@@ -11051,16 +11424,12 @@ msgid ""
 msgstr ""
 
 #: src/testing/test-modules.md:26
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
-msgstr ""
-"* 这样一来，您可以对专用帮助程序进行单元测试。\n"
-"* 仅当您运行 `cargo test` 时，`#[cfg(test)]` 属性才有效。"
+msgid "This lets you unit test private helpers."
+msgstr "这样一来，您可以对专用帮助程序进行单元测试。"
 
-#: src/testing/doc-tests.md:1
-msgid "# Documentation Tests"
-msgstr "# 文档测试"
+#: src/testing/test-modules.md:27
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr "仅当您运行 `cargo test` 时，`#[cfg(test)]` 属性才有效。"
 
 #: src/testing/doc-tests.md:3
 msgid "Rust has built-in support for documentation tests:"
@@ -11083,21 +11452,21 @@ msgid ""
 msgstr ""
 
 #: src/testing/doc-tests.md:18
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr "`///` 注释中的代码块会自动被视为 Rust 代码。"
+
+#: src/testing/doc-tests.md:19
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "代码会作为 `cargo test` 的一部分进行编译和执行。"
+
+#: src/testing/doc-tests.md:20
 msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"* `///` 注释中的代码块会自动被视为 Rust 代码。\n"
-"* 代码会作为 `cargo test` 的一部分进行编译和执行。\n"
-"* 在 [Rust Playground](https://play.rust-lang.org/?"
+"在 [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
 "上测试上述代码。"
-
-#: src/testing/integration-tests.md:1
-msgid "# Integration Tests"
-msgstr "# 集成测试"
 
 #: src/testing/integration-tests.md:3
 msgid "If you want to test your library as a client, use an integration test."
@@ -11124,8 +11493,8 @@ msgid "These tests only have access to the public API of your crate."
 msgstr "这些测试只能使用您的 crate 的公共 API。"
 
 #: src/testing/useful-crates.md:1
-msgid "## Useful crates for writing tests"
-msgstr "## 用于编写测试的实用 crate"
+msgid "Useful crates for writing tests"
+msgstr "用于编写测试的实用 crate"
 
 #: src/testing/useful-crates.md:3
 msgid "Rust comes with only basic support for writing tests."
@@ -11137,98 +11506,94 @@ msgstr "下面列出了我们建议在编写测试时使用的一些其他 crate
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
-"tests."
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
 msgstr ""
-"* [googletest](https://docs.rs/googletest)：遵从 GoogleTest for C++ 传统的综"
-"合测试断言库。\n"
-"* [proptest](https://docs.rs/proptest)：基于属性的测试，适用于 Rust。\n"
-"* [rstest](https://docs.rs/rstest)：支持固件和参数化测试。"
+"[googletest](https://docs.rs/googletest)：遵从 GoogleTest for C++ 传统的综合"
+"测试断言库。"
 
-#: src/unsafe.md:1
-msgid "# Unsafe Rust"
-msgstr "# 不安全 Rust"
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr "[proptest](https://docs.rs/proptest)：基于属性的测试，适用于 Rust。"
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
+msgstr "[rstest](https://docs.rs/rstest)：支持固件和参数化测试。"
 
 #: src/unsafe.md:3
 msgid "The Rust language has two parts:"
 msgstr "Rust 语言包含两个部分："
 
 #: src/unsafe.md:5
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr "\\*\\*安全 Rust：\\*\\*内存安全，没有潜在的未定义行为。"
+
+#: src/unsafe.md:6
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
-msgstr ""
-"* **安全 Rust：**内存安全，没有潜在的未定义行为。\n"
-"* **不安全 Rust：**如果违反了前提条件，可能会触发未定义的行为。"
+msgstr "\\*\\*不安全 Rust：\\*\\*如果违反了前提条件，可能会触发未定义的行为。"
 
 #: src/unsafe.md:8
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr ""
-"本课程中出现的大多为“安全 Rust”，但是了解“不安全 Rust”的定义\n"
-"非常重要。"
+"本课程中出现的大多为“安全 Rust”，但是了解“不安全 Rust”的定义 非常重要。"
 
 #: src/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
-"不安全的代码通常内容很少而且与其他代码隔离，\n"
-"其正确性也应得到仔细记录。这类代码通常封装在安全的抽象层中。"
+"不安全的代码通常内容很少而且与其他代码隔离， 其正确性也应得到仔细记录。这类代"
+"码通常封装在安全的抽象层中。"
 
 #: src/unsafe.md:14
 msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr "不安全 Rust 提供了五种新功能："
 
 #: src/unsafe.md:16
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
-msgstr ""
-"* 解引用原始指针。\n"
-"* 访问或修改可变的静态变量。\n"
-"* 访问 `union` 字段。\n"
-"* 调用 `unsafe` 函数，包括 `extern` 函数。\n"
-"* 实现 `unsafe` trait。"
+msgid "Dereference raw pointers."
+msgstr "解引用原始指针。"
+
+#: src/unsafe.md:17
+msgid "Access or modify mutable static variables."
+msgstr "访问或修改可变的静态变量。"
+
+#: src/unsafe.md:18
+msgid "Access `union` fields."
+msgstr "访问 `union` 字段。"
+
+#: src/unsafe.md:19
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr "调用 `unsafe` 函数，包括 `extern` 函数。"
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
+msgstr "实现 `unsafe` trait。"
 
 #: src/unsafe.md:22
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
+"We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
-"下面，我们将简要介绍这些不安全功能。如需了解完整详情，请参阅\n"
-"[《Rust 手册》第 19.1 章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust."
-"html)\n"
-"和 [Rustonomicon](https://doc.rust-lang.org/nomicon/)。"
+"下面，我们将简要介绍这些不安全功能。如需了解完整详情，请参阅 [《Rust 手册》"
+"第 19.1 章](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) 和 "
+"[Rustonomicon](https://doc.rust-lang.org/nomicon/)。"
 
 #: src/unsafe.md:28
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
-"不安全 Rust 并不意味着代码不正确，而是这意味着开发者已停用\n"
-"编译器的安全功能，必须自行编写正确的\n"
-"代码。也就是说，编译器不再强制执行 Rust 的内存安全规则。"
-
-#: src/unsafe/raw-pointers.md:1
-msgid "# Dereferencing Raw Pointers"
-msgstr "# 解引用裸指针"
+"不安全 Rust 并不意味着代码不正确，而是这意味着开发者已停用 编译器的安全功能，"
+"必须自行编写正确的 代码。也就是说，编译器不再强制执行 Rust 的内存安全规则。"
 
 #: src/unsafe/raw-pointers.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
@@ -11261,49 +11626,49 @@ msgstr ""
 #: src/unsafe/raw-pointers.md:27
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 "我们建议（而且 Android Rust 样式指南要求）为每个 `unsafe` 代码块编写一条注"
-"释，\n"
-"说明该代码块中的代码如何满足其所执行的不安全操作的\n"
-"安全要求。"
+"释， 说明该代码块中的代码如何满足其所执行的不安全操作的 安全要求。"
 
 #: src/unsafe/raw-pointers.md:31
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
-"对于指针解除引用，这意味着指针必须为\n"
-"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety)，即："
+"对于指针解除引用，这意味着指针必须为 [_valid_](https://doc.rust-lang.org/std/"
+"ptr/index.html#safety)，即："
 
 #: src/unsafe/raw-pointers.md:34
+msgid "The pointer must be non-null."
+msgstr "指针必须为非 null。"
+
+#: src/unsafe/raw-pointers.md:35
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
+msgstr "指针必须是 _dereferenceable_（在单个已分配对象的边界内）。"
+
+#: src/unsafe/raw-pointers.md:36
+msgid "The object must not have been deallocated."
+msgstr "对象不得已取消分配。"
+
+#: src/unsafe/raw-pointers.md:37
+msgid "There must not be concurrent accesses to the same location."
+msgstr "不得并发访问相同位置。"
+
+#: src/unsafe/raw-pointers.md:38
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
 msgstr ""
-" * 指针必须为非 null。\n"
-" * 指针必须是 _dereferenceable_（在单个已分配对象的边界内）。\n"
-" * 对象不得已取消分配。\n"
-" * 不得并发访问相同位置。\n"
-" * 如果通过转换引用类型来获取指针，则底层对象必须处于活跃状态，\n"
-"而且不得使用任何引用来访问内存。"
+"如果通过转换引用类型来获取指针，则底层对象必须处于活跃状态， 而且不得使用任何"
+"引用来访问内存。"
 
 #: src/unsafe/raw-pointers.md:41
 msgid "In most cases the pointer must also be properly aligned."
 msgstr "在大多数情况下，指针还必须正确对齐。"
-
-#: src/unsafe/mutable-static-variables.md:1
-msgid "# Mutable Static Variables"
-msgstr "# 可变的静态变量"
 
 #: src/unsafe/mutable-static-variables.md:3
 msgid "It is safe to read an immutable static variable:"
@@ -11322,11 +11687,9 @@ msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
-msgstr ""
-"但是，读取和写入可变的静态变量是不安全的，因为这可能会\n"
-"造成数据争用："
+msgstr "但是，读取和写入可变的静态变量是不安全的，因为这可能会 造成数据争用："
 
 #: src/unsafe/mutable-static-variables.md:16
 msgid ""
@@ -11348,17 +11711,11 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:32
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 "通常，我们不建议使用可变的静态变量，但在某些情况下，在低层级 `no_std` 代码中"
-"可能需要这样做，\n"
-"例如实现堆分配器或使用某些 C API。"
-
-#: src/unsafe/unions.md:1
-msgid "# Unions"
-msgstr "# 联合体"
+"可能需要这样做， 例如实现堆分配器或使用某些 C API。"
 
 #: src/unsafe/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
@@ -11384,37 +11741,28 @@ msgstr ""
 #: src/unsafe/unions.md:21
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
-"在 Rust 中很少需要用到联合体，因为您通常可以使用枚举。联合体只是偶尔用于\n"
-"与 C 库 API 进行交互。"
+"在 Rust 中很少需要用到联合体，因为您通常可以使用枚举。联合体只是偶尔用于 与 "
+"C 库 API 进行交互。"
 
 #: src/unsafe/unions.md:24
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
+"If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
-"如果您只是想将字节重新解释为其他类型，则可能需要使用\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) 或\n"
-"安全的封装容器，例如 [`zerocopy`](https://crates.io/crates/zerocopy) crate。"
-
-#: src/unsafe/calling-unsafe-functions.md:1
-msgid "# Calling Unsafe Functions"
-msgstr "# 调用 Unsafe 函数"
+"如果您只是想将字节重新解释为其他类型，则可能需要使用 [`std::mem::transmute`]"
+"(https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) 或 安全的封装容"
+"器，例如 [`zerocopy`](https://crates.io/crates/zerocopy) crate。"
 
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
-"如果函数或方法具有额外的前提条件，您必须遵守这些前提条件来避免未定义的行"
-"为，\n"
+"如果函数或方法具有额外的前提条件，您必须遵守这些前提条件来避免未定义的行为， "
 "则可以将该函数或方法标记为 `unsafe`："
 
 #: src/unsafe/calling-unsafe-functions.md:6
@@ -11447,18 +11795,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-msgid "# Writing Unsafe Functions"
-msgstr "# 编写 Unsafe 函数"
-
 #: src/unsafe/writing-unsafe-functions.md:3
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
-"如果您自己编写的函数需要满足特定条件以避免未定义的行为，\n"
-"您可以将这些函数标记为 `unsafe`。"
+"如果您自己编写的函数需要满足特定条件以避免未定义的行为， 您可以将这些函数标记"
+"为 `unsafe`。"
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -11497,27 +11840,23 @@ msgstr "实际上，我们不会这样使用指针，因为使用引用可以安
 #: src/unsafe/writing-unsafe-functions.md:35
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 "请注意，在不安全函数中，可以在没有 `unsafe` 代码块的情况下使用不安全代码。我"
-"们可以\n"
-"使用 `#[deny(unsafe_op_in_unsafe_fn)]` 来禁止此行为。请尝试添加该命令，看看会"
-"出现什么情况。"
+"们可以 使用 `#[deny(unsafe_op_in_unsafe_fn)]` 来禁止此行为。请尝试添加该命"
+"令，看看会出现什么情况。"
 
 #: src/unsafe/extern-functions.md:1
-msgid "# Calling External Code"
-msgstr "# 调用外部代码"
+msgid "Calling External Code"
+msgstr "调用外部代码"
 
 #: src/unsafe/extern-functions.md:3
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
-"基于其他语言的函数可能会违反 Rust 的保证。因此，\n"
-"调用这类函数是不安全的："
+"基于其他语言的函数可能会违反 Rust 的保证。因此， 调用这类函数是不安全的："
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
@@ -11538,43 +11877,33 @@ msgstr ""
 #: src/unsafe/extern-functions.md:21
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
-"这个问题通常仅存在于使用指针执行违反 Rust 内存模型的操作的外部函数中。\n"
-"但一般而言，任何 C 函数都有可能在任意情况下出现未定义行为。"
+"这个问题通常仅存在于使用指针执行违反 Rust 内存模型的操作的外部函数中。 但一般"
+"而言，任何 C 函数都有可能在任意情况下出现未定义行为。"
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/"
-"external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-msgid "# Implementing Unsafe Traits"
-msgstr "# 实现 Unsafe Trait"
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
-"与函数一样，如果您在实现某个 trait 时必须保证特定条件来避免未定义的行为，\n"
-"您也可以将该 trait 标记为 `unsafe`。"
+"与函数一样，如果您在实现某个 trait 时必须保证特定条件来避免未定义的行为， 您"
+"也可以将该 trait 标记为 `unsafe`。"
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
-"例如，`zerocopy` crate 包含一个不安全的 trait，\n"
-"[大致内容是这样的](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html)："
+"例如，`zerocopy` crate 包含一个不安全的 trait， [大致内容是这样的](https://"
+"docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html)："
 
 #: src/unsafe/unsafe-traits.md:9
 msgid ""
@@ -11602,11 +11931,10 @@ msgstr ""
 #: src/unsafe/unsafe-traits.md:30
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
-"在 Rustdoc 中有关 trait 的章节下，有一个标题为 `# 安全` 的部分介绍了\n"
-"安全实现 trait 的要求。"
+"在 Rustdoc 中有关 trait 的章节下，有一个标题为 `# 安全` 的部分介绍了 安全实"
+"现 trait 的要求。"
 
 #: src/unsafe/unsafe-traits.md:33
 msgid ""
@@ -11619,7 +11947,7 @@ msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr "内置的 `Send` 和 `Sync` trait 都是不安全的。"
 
 #: src/exercises/day-3/afternoon.md:1
-msgid "# Day 3: Afternoon Exercises"
+msgid "Day 3: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:3
@@ -11627,17 +11955,15 @@ msgid "Let us build a safe wrapper for reading directory content!"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:7
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-msgid "# Safe FFI Wrapper"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 
@@ -11646,30 +11972,72 @@ msgid "You will want to consult the manual pages:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module. There you find a "
-"number of\n"
-"string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Encoding"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Use"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"| Types                      | Encoding       | "
-"Use                            |\n"
-"|----------------------------|----------------|--------------------------------|\n"
-"| [`str`] and [`String`]     | UTF-8          | Text processing in "
-"Rust        |\n"
-"| [`CStr`] and [`CString`]   | NUL-terminated | Communicating with C "
-"functions |\n"
-"| [`OsStr`] and [`OsString`] | OS-specific    | Communicating with the "
-"OS      |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "UTF-8"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "Text processing in Rust"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "NUL-terminated"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "Communicating with C functions"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "OS-specific"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "Communicating with the OS"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
@@ -11678,30 +12046,47 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:24
 msgid ""
-"- `&str` to `CString`: you need to allocate space for a trailing `\\0` "
-"character,\n"
-"- `CString` to `*const i8`: you need a pointer to call C functions,\n"
-"- `*const i8` to `&CStr`: you need something which can find the trailing "
-"`\\0` character,\n"
-"- `&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknow data\",\n"
-"- `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
-"html)\n"
-"  to create it,\n"
-"- `&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able "
-"to return it and call\n"
-"  `readdir` again."
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
-msgid "The [Nomicon] also has a very useful chapter about FFI."
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
@@ -11796,39 +12181,36 @@ msgid ""
 msgstr ""
 
 #: src/android.md:1
-msgid "# Welcome to Rust in Android"
-msgstr "# 欢迎来到Android 中的Rust"
+msgid "Welcome to Rust in Android"
+msgstr "欢迎来到Android 中的Rust"
 
 #: src/android.md:3
 msgid ""
-"Rust is supported for native platform development on Android. This means that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
-msgstr "Rust 支持Android 的原生平台开发。这意味着您可以在Rust 中编写新的操作系统服务，以及扩展现有服务。"
+"Rust is supported for native platform development on Android. This means "
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
+msgstr ""
+"Rust 支持Android 的原生平台开发。这意味着您可以在Rust 中编写新的操作系统服"
+"务，以及扩展现有服务。"
 
 #: src/android.md:7
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try to\n"
-"> find a little corner of your code base where we can move some lines of code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something that\n"
-"> parses some raw bytes would be ideal."
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
-"> 今天我们会尝试在你自己的项目中调用Rust。\n"
-"> 所以试着在你的代码中找一小段来改成Rust。\n"
-"> 代码中越少依赖(dependencies)，越少“独特”的类型，越好。比如\n"
-"> 一段解析原始字符的代码就很理想。"
-
-#: src/android/setup.md:1
-msgid "# Setup"
-msgstr "# 设置"
+"今天我们会尝试在你自己的项目中调用Rust。 所以试着在你的代码中找一小段来改成"
+"Rust。 代码中越少依赖(dependencies)，越少“独特”的类型，越好。比如 一段解析原"
+"始字符的代码就很理想。"
 
 #: src/android/setup.md:3
 msgid ""
-"We will be using an Android Virtual Device to test our code. Make sure you have\n"
-"access to one or create a new one with:"
+"We will be using an Android Virtual Device to test our code. Make sure you "
+"have access to one or create a new one with:"
 msgstr ""
-"我们将会使用Android 虚拟设备（Android Virtual Device）来测试我们的代码。\n"
-"确保你有权限访问一个，或者用以下命令创建一个新的："
+"我们将会使用Android 虚拟设备（Android Virtual Device）来测试我们的代码。 确保"
+"你有权限访问一个，或者用以下命令创建一个新的："
 
 #: src/android/setup.md:6
 msgid ""
@@ -11846,57 +12228,124 @@ msgstr ""
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
-msgstr "更多细节请参考 [Android Developer Codelab](https://source.android.com/docs/setup/start)."
-
-#: src/android/build-rules.md:1
-msgid "# Build Rules"
-msgstr "# 构建规则"
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
+msgstr ""
+"更多细节请参考 [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start)."
 
 #: src/android/build-rules.md:3
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr "Android 构建系统（Soong）通过一系列模块来支持Rust："
 
 #: src/android/build-rules.md:5
-msgid ""
-"| Module Type       | Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust binary. |\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and `dylib` variants. |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and provides both static and shared variants.|\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are analogous to compiler plugins. |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard Rust test harness. |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging `libfuzzer`. |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library containing Rust bindings to C libraries.              "
-"|"
+#, fuzzy
+msgid "Module Type"
 msgstr ""
-"| 模块类型      | 描述                                                                                        |\n"
-"|—————————|——————————————————————————————————————————————————|\n"
-"| `rust_binary`     | Rust 二进制文件。                                                                           |\n"
-"| `rust_library`    | 生成Rust 库，并且提供 `rlib` 和 `dylib` 变体。                       |\n"
-"| `rust_ffi`        | 生成可由 cc 模块使用的 Rust C 库，并提供静态和共享变体。    |\n"
-"| `rust_proc_macro` | 生成 proc-macro Rust 库。 这些宏与编译器插件类似。                     |\n"
-"| `rust_test`       | 生成使用标准 Rust 自动化测试框架的 Rust 测试二进制文件。                             |\n"
-"| `rust_fuzz`       | 生成使用 libfuzzer 的 Rust 模糊测试二进制文件。                                         |\n"
-"| `rust_protobuf`   | 生成源代码，并生成为特定 protobuf 提供接口的 Rust 库。|\n"
-"| `rust_bindgen`    | 生成源代码，并生成包含与 C 库的 Rust 绑定的 Rust 库。｜"
+"\\| 模块类型      | 描"
+"述                                                                                        "
+"| \\|—————————|——————————————————————————————————————————————————| \\| "
+"`rust_binary`     | Rust 二进制文"
+"件。                                                                           "
+"| \\| `rust_library`    | 生成Rust 库，并且提供 `rlib` 和 `dylib` 变"
+"体。                       | \\| `rust_ffi`        | 生成可由 cc 模块使用的 "
+"Rust C 库，并提供静态和共享变体。    | \\| `rust_proc_macro` | 生成 proc-"
+"macro Rust 库。 这些宏与编译器插件类似。                     | \\| "
+"`rust_test`       | 生成使用标准 Rust 自动化测试框架的 Rust 测试二进制文"
+"件。                             | \\| `rust_fuzz`       | 生成使用 "
+"libfuzzer 的 Rust 模糊测试二进制文"
+"件。                                         | \\| `rust_protobuf`   | 生成源"
+"代码，并生成为特定 protobuf 提供接口的 Rust 库。| \\| `rust_bindgen`    | 生"
+"成源代码，并生成包含与 C 库的 Rust 绑定的 Rust 库。｜"
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr ""
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr ""
+
+#: src/android/build-rules.md:9
+msgid ""
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr ""
 
 #: src/android/build-rules.md:16
 msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr "下面我们来看看`rust_binary` 和 `rust_library`。"
 
 #: src/android/build-rules/binary.md:1
-msgid "# Rust Binaries"
-msgstr "# Rust 二进制文件"
+msgid "Rust Binaries"
+msgstr "Rust 二进制文件"
 
 #: src/android/build-rules/binary.md:3
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr "让我们从一个简单的应用程序开始。在 AOSP 签出的根目录下，创建以下文件："
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
@@ -11966,8 +12415,8 @@ msgstr ""
 "```"
 
 #: src/android/build-rules/library.md:1
-msgid "# Rust Libraries"
-msgstr "# Rust 库"
+msgid "Rust Libraries"
+msgstr "Rust 库"
 
 #: src/android/build-rules/library.md:3
 msgid "You use `rust_library` to create a new Rust library for Android."
@@ -11978,15 +12427,18 @@ msgid "Here we declare a dependency on two libraries:"
 msgstr "在这里，我们声明了对两个库的依赖："
 
 #: src/android/build-rules/library.md:7
+msgid "`libgreeting`, which we define below,"
+msgstr "`libgreeting`, 我们在下面进行了定义，"
+
+#: src/android/build-rules/library.md:8
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"* `libgreeting`, 我们在下面进行了定义，\n"
-"* `libtextwrap`, 一个已经在\n"
-" [`external/rust/crates/`][crates]\n"
-"中提供的 crate。"
+"`libtextwrap`, 一个已经在 [`external/rust/crates/`](https://cs.android.com/"
+"android/platform/superproject/+/master:external/rust/crates/) 中提供的 "
+"crate。"
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -12102,26 +12554,23 @@ msgstr ""
 "nice to meet you!\n"
 "```"
 
-#: src/android/aidl.md:1
-msgid "# AIDL"
-msgstr ""
-
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
 #: src/android/aidl.md:6
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr ""
+
+#: src/android/aidl.md:7
+msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
 #: src/android/aidl/interface.md:1
-msgid "# AIDL Interfaces"
-msgstr "# AIDL 接口"
+msgid "AIDL Interfaces"
+msgstr "AIDL 接口"
 
 #: src/android/aidl/interface.md:3
 msgid "You declare the API of your service using an AIDL interface:"
@@ -12129,9 +12578,9 @@ msgstr "您可以使用 AIDL 接口声明您的服务的 API："
 
 #: src/android/aidl/interface.md:5
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 
 #: src/android/aidl/interface.md:7
 msgid ""
@@ -12156,8 +12605,8 @@ msgstr ""
 "```"
 
 #: src/android/aidl/interface.md:17
-msgid "*birthday_service/aidl/Android.bp*:"
-msgstr "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_birthday_service/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md:19
 msgid ""
@@ -12190,14 +12639,13 @@ msgstr ""
 #: src/android/aidl/interface.md:32
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 "如果供应商分区中的二进制文件使用了您的 AIDL 文件，请添加 `vendor_available: "
 "true`。"
 
 #: src/android/aidl/implementation.md:1
-msgid "# Service Implementation"
+msgid "Service Implementation"
 msgstr ""
 
 #: src/android/aidl/implementation.md:3
@@ -12205,7 +12653,7 @@ msgid "We can now implement the AIDL service:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:5
-msgid "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:7
@@ -12235,7 +12683,7 @@ msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
-msgid "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:28
@@ -12254,16 +12702,16 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/server.md:1
-msgid "# AIDL Server"
-msgstr "# AIDL 服务器"
+msgid "AIDL Server"
+msgstr "AIDL 服务器"
 
 #: src/android/aidl/server.md:3
 msgid "Finally, we can create a server which exposes the service:"
 msgstr "最后，我们可以创建一个暴露服务的服务器："
 
 #: src/android/aidl/server.md:5
-msgid "*birthday_service/src/server.rs*:"
-msgstr "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_birthday_service/src/server.rs_:"
 
 #: src/android/aidl/server.md:7
 msgid ""
@@ -12343,10 +12791,6 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/android/aidl/deploy.md:1
-msgid "# Deploy"
-msgstr "# 部署"
-
 #: src/android/aidl/deploy.md:3
 msgid "We can now build, push, and start the service:"
 msgstr "我们现在可以构建、推送和启动服务："
@@ -12414,7 +12858,7 @@ msgstr ""
 "```"
 
 #: src/android/aidl/client.md:1
-msgid "# AIDL Client"
+msgid "AIDL Client"
 msgstr ""
 
 #: src/android/aidl/client.md:3
@@ -12422,7 +12866,7 @@ msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
 #: src/android/aidl/client.md:5
-msgid "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
 #: src/android/aidl/client.md:7
@@ -12495,15 +12939,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-msgid "# Changing API"
-msgstr ""
-
 #: src/android/aidl/changing.md:3
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr ""
 
 #: src/android/aidl/changing.md:6
@@ -12519,15 +12958,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-msgid "# Logging"
-msgstr ""
-
 #: src/android/logging.md:3
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
 
 #: src/android/logging.md:6
@@ -12606,36 +13040,33 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-msgid "# Interoperability"
-msgstr ""
-
 #: src/android/interoperability.md:3
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 
 #: src/android/interoperability.md:6
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
+msgid "Call Rust functions from other languages."
+msgstr ""
+
+#: src/android/interoperability.md:7
+msgid "Call functions written in other languages from Rust."
 msgstr ""
 
 #: src/android/interoperability.md:9
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:1
-msgid "# Interoperability with C"
+msgid "Interoperability with C"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:3
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
@@ -12660,14 +13091,14 @@ msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:23
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:26
@@ -12675,14 +13106,13 @@ msgid "We will look at better options next."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:1
-msgid "# Using Bindgen"
+msgid "Using Bindgen"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:3
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:6
@@ -12747,7 +13177,7 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
@@ -12855,7 +13285,7 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
-msgid "# Calling Rust"
+msgid "Calling Rust"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:3
@@ -12968,43 +13398,35 @@ msgstr ""
 #: src/android/interoperability/with-c/rust.md:83
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
-msgstr ""
-
-#: src/android/interoperability/cpp.md:1
-msgid "# With C++"
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:3
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:8
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr ""
-
 #: src/android/interoperability/cpp.md:10
-msgid "See the [CXX tutorial][2] for an full example of using this."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
 
 #: src/android/interoperability/java.md:1
-msgid "# Interoperability with Java"
+msgid "Interoperability with Java"
 msgstr ""
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 
 #: src/android/interoperability/java.md:7
@@ -13107,70 +13529,66 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
-#: src/exercises/concurrency/morning.md:1
-#: src/exercises/concurrency/afternoon.md:1
-msgid "# Exercises"
-msgstr ""
-
 #: src/exercises/android/morning.md:3
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
-"and\n"
-"try to integrate some Rust into it. Some suggestions:"
+"and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 
 #: src/exercises/android/morning.md:6
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr ""
+
+#: src/exercises/android/morning.md:8
+msgid "Move a function from your project to Rust and call it."
 msgstr ""
 
 #: src/exercises/android/morning.md:12
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
 #: src/bare-metal.md:1
-msgid "# Welcome to Bare Metal Rust"
+msgid "Welcome to Bare Metal Rust"
 msgstr ""
 
 #: src/bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/bare-metal.md:7
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 
 #: src/bare-metal.md:10
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr ""
+
+#: src/bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr ""
+
+#: src/bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr ""
+
+#: src/bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
 #: src/bare-metal.md:15
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 
@@ -13224,27 +13642,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/no_std.md:1
-msgid "# `no_std`"
-msgstr ""
-
-#: src/bare-metal/no_std.md:3
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -13252,72 +13657,100 @@ msgstr ""
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:19
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-
 #: src/bare-metal/no_std.md:24
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
+msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
-msgid ""
-"</td>\n"
-"<td>"
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr ""
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:38
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:45
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:56
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:62
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr ""
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
 #: src/bare-metal/minimal.md:1
-msgid "# A minimal `no_std` program"
+msgid "A minimal `no_std` program"
 msgstr ""
 
 #: src/bare-metal/minimal.md:3
@@ -13336,29 +13769,34 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-msgid "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -13398,25 +13836,32 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-msgid "# Microcontrollers"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
@@ -13452,21 +13897,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:1
-msgid "# Raw MMIO"
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:6
@@ -13536,8 +13978,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:66
@@ -13555,16 +13997,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
-msgid "# Peripheral Access Crates"
+msgid "Peripheral Access Crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -13612,19 +14052,31 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:61
@@ -13635,16 +14087,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
-msgid "# HAL crates"
+msgid "HAL crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -13682,11 +14133,13 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:45
@@ -13697,7 +14150,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
-msgid "# Board support crates"
+msgid "Board support crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:3
@@ -13732,13 +14185,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:28
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:36
@@ -13749,7 +14207,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
-msgid "# The type state pattern"
+msgid "The type state pattern"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:3
@@ -13787,118 +14245,177 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "# `embedded-hal`"
+msgid "`embedded-hal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
+msgid "GPIO"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid " server"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
 msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:1
-msgid "# Debugging"
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/debugging.md:3
@@ -13957,39 +14474,86 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
-msgid "# Other projects"
+msgid "Other projects"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "[RTIC](https://rtic.rs/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
 
@@ -13999,15 +14563,11 @@ msgid ""
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:1
-msgid "# Compass"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
-"serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:6
@@ -14016,45 +14576,50 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C "
-"bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:11
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:12
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:13
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:17
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:19
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `compass`\n"
-"directory for the following files."
+"look in the `compass` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 msgid "`src/main.rs`:"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
-#: src/exercises/concurrency/dining-philosophers.md:17
-#: src/exercises/concurrency/link-checker.md:55
-#: src/exercises/concurrency/dining-philosophers-async.md:11
-msgid "<!-- File src/main.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:30
@@ -14098,14 +14663,6 @@ msgstr ""
 msgid "`Cargo.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:66 src/exercises/bare-metal/rtc.md:387
-#: src/exercises/concurrency/dining-philosophers.md:63
-#: src/exercises/concurrency/link-checker.md:35
-#: src/exercises/concurrency/dining-philosophers-async.md:60
-#: src/exercises/concurrency/chat-app.md:17
-msgid "<!-- File Cargo.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
 "```toml\n"
@@ -14130,10 +14687,6 @@ msgstr ""
 msgid "`Embed.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:87
-msgid "<!-- File Embed.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
 "```toml\n"
@@ -14150,10 +14703,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
 msgid "`.cargo/config.toml` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
-msgid "<!-- File .cargo/config.toml -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:104
@@ -14195,39 +14744,47 @@ msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
 #: src/bare-metal/aps.md:1
-msgid "# Application processors"
+msgid "Application processors"
 msgstr ""
 
 #: src/bare-metal/aps.md:3
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
+msgstr ""
+
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
-msgid "# Inline assembly"
+msgid "Inline assembly"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid " to tell the firmware to power off the system:"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:6
@@ -14268,74 +14825,99 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the [`smccc`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
-"it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are "
-"conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the "
-"standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–"
-"`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do "
-"anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:51
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:56
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
-msgid "# Volatile memory access for MMIO"
+msgid "Volatile memory access for MMIO"
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:9
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:1
-msgid "# Let's write a UART driver"
+msgid "Let's write a UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -14395,31 +14977,30 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is "
-"because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i."
-"e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else "
-"aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume "
-"the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but "
-"`write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls "
-"`write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving "
-"the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:66
-msgid "</detais>"
+#: src/bare-metal/aps/uart.md:60
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:63
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:1
-msgid "# More traits"
+msgid "More traits"
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:3
@@ -14450,51 +15031,188 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with "
-"our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:25
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
-msgid "# A better UART driver"
+msgid "A better UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
+msgid "Offset"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:26
-msgid "- There are also some ID registers which have been omitted for brevity."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-msgid "# Bitflags"
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
@@ -14538,13 +15256,12 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
-"with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:1
-msgid "# Multiple registers"
+msgid "Multiple registers"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:3
@@ -14591,17 +15308,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust "
-"representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-msgid "# Driver"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -14675,21 +15386,19 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
-"fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
-msgid "# Using it"
+msgid "Using it"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
-"and echo incoming\n"
-"bytes."
+"and echo incoming bytes."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:6
@@ -14741,18 +15450,21 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
 msgid ""
-"* As in the [inline assembly](../inline-assembly.md) example, this `main` "
-"function is called from our\n"
-"  entry point code in `entry.S`. See the speaker notes there for details.\n"
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/"
-"examples`."
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:53
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -14803,7 +15515,7 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
@@ -14855,29 +15567,53 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:47
 msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
-msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling, page tables\n"
-"   * Not all very well written, so beware.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
-msgid "# Useful crates"
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:7
+msgid ""
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:9
+msgid "Not all very well written, so beware."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:11
+msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
@@ -14887,14 +15623,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "# `zerocopy`"
+msgid "`zerocopy`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
@@ -14937,34 +15673,44 @@ msgstr ""
 #: src/bare-metal/useful-crates/zerocopy.md:40
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "# `aarch64-paging`"
+msgid "`aarch64-paging`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
@@ -14992,27 +15738,37 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real "
-"hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -15035,26 +15791,27 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+msgid "PCI BARs always have alignment equal to their size."
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "# `tinyvec`"
+msgid "`tinyvec`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
@@ -15075,29 +15832,30 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:23
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
-"initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine "
-"inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:1
-msgid "# `spin`"
+msgid "`spin`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:7
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:9
@@ -15116,28 +15874,33 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/android.md:1
-msgid "# Android"
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/android.md:3
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
 #: src/bare-metal/android.md:7
@@ -15182,16 +15945,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-msgid "# vmbase"
-msgstr ""
-
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -15212,11 +15971,14 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:21
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md:3
@@ -15224,40 +15986,51 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:1
-msgid "# RTC driver"
+#: src/exercises/bare-metal/solutions-afternoon.md:3
+msgid "RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. "
-"For this exercise, you\n"
-"should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:6
 msgid ""
-"1. Use it to print the current time to the serial console. You can use the "
-"[`chrono`][2] crate for\n"
-"   date/time formatting.\n"
-"2. Use the match register and raw interrupt status to busy-wait until a "
-"given time, e.g. 3 seconds\n"
-"   in the future. (Call [`core::hint::spin_loop`][3] inside the loop.)\n"
-"3. _Extension if you have time:_ Enable and handle the interrupt generated "
-"by the RTC match. You can\n"
-"   use the driver provided in the [`arm-gic`][4] crate to configure the Arm "
-"Generic Interrupt Controller.\n"
-"   - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.\n"
-"   - Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt.\n"
-"   "
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:8
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:10
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:12
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:13
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `rtc`\n"
-"directory for the following files."
+"look in the `rtc` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:23
@@ -15322,10 +16095,6 @@ msgstr ""
 msgid ""
 "`src/exceptions.rs` (you should only need to change this for the 3rd part of "
 "the exercise):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:77
-msgid "<!-- File src/exceptions.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:79
@@ -15406,10 +16175,6 @@ msgstr ""
 msgid "`src/logger.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:151
-msgid "<!-- File src/logger.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:153
 msgid ""
 "```rust,compile_fail\n"
@@ -15473,10 +16238,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "`src/pl011.rs` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:212
-msgid "<!-- File src/pl011.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:214
@@ -15686,10 +16447,6 @@ msgstr ""
 msgid "`build.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:412
-msgid "<!-- File build.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:414
 msgid ""
 "```rust,compile_fail\n"
@@ -15727,10 +16484,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
 msgid "`entry.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:448
-msgid "<!-- File entry.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:450
@@ -15897,10 +16650,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:595
 msgid "`exceptions.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:597
-msgid "<!-- File exceptions.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:599
@@ -16101,10 +16850,6 @@ msgstr ""
 msgid "`idmap.S` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:782
-msgid "<!-- File idmap.S -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
 "```armasm\n"
@@ -16156,10 +16901,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:829
 msgid "`image.ld` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:831
-msgid "<!-- File image.ld -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:833
@@ -16277,10 +17018,6 @@ msgstr ""
 msgid "`Makefile` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:942
-msgid "<!-- File Makefile -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:944
 msgid ""
 "```makefile\n"
@@ -16340,31 +17077,23 @@ msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
 #: src/concurrency.md:1
-msgid "# Welcome to Concurrency in Rust"
-msgstr "# 欢迎了解 Rust 中的并发"
+msgid "Welcome to Concurrency in Rust"
+msgstr "欢迎了解 Rust 中的并发"
 
 #: src/concurrency.md:3
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
-msgstr ""
-"Rust 完全支持使用带有互斥锁和通道的操作系统线程进行并发。"
+msgstr "Rust 完全支持使用带有互斥锁和通道的操作系统线程进行并发。"
 
 #: src/concurrency.md:6
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
-"Rust 类型系统能帮助我们把许多并发bug转换为编译期bug\n"
-"发挥着重要作用。这通常称为“无畏并发”，因为你可以依靠编译器来确保\n"
-"运行时的正确性。"
-
-#: src/concurrency/threads.md:1
-msgid "# Threads"
-msgstr "# 线程"
+"Rust 类型系统能帮助我们把许多并发bug转换为编译期bug 发挥着重要作用。这通常称"
+"为“无畏并发”，因为你可以依靠编译器来确保 运行时的正确性。"
 
 #: src/concurrency/threads.md:3
 msgid "Rust threads work similarly to threads in other languages:"
@@ -16411,45 +17140,43 @@ msgstr ""
 "```"
 
 #: src/concurrency/threads.md:24
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
-msgstr ""
-"* 线程均为守护程序线程，主线程不会等待这些线程。\n"
-"* 线程紧急警报 (panic) 是彼此独立的。\n"
-"* 紧急警报可以携带载荷，并可以使用 `downcast_ref` 对载荷进行解压缩。"
+msgid "Threads are all daemon threads, the main thread does not wait for them."
+msgstr "线程均为守护程序线程，主线程不会等待这些线程。"
+
+#: src/concurrency/threads.md:25
+msgid "Thread panics are independent of each other."
+msgstr "线程紧急警报 (panic) 是彼此独立的。"
+
+#: src/concurrency/threads.md:26
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr "紧急警报可以携带载荷，并可以使用 `downcast_ref` 对载荷进行解压缩。"
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
-msgstr ""
-"* 请注意，线程在达到 10 之前就停止了，而主线程并\n"
-"没有等待。\n"
-"\n"
-"* 使用 `let handle = thread::spawn(...)` 和后面的 `handle.join()` 等待\n"
-"线程完成。\n"
-"\n"
-"* 在线程中触发紧急警报，并注意这为何不会影响到 `main`。\n"
-"\n"
-"* 使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报\n"
-"载荷的访问权限。现在有必要介绍一下 [`Any`] 了。"
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
+msgstr "请注意，线程在达到 10 之前就停止了，而主线程并 没有等待。"
 
-#: src/concurrency/scoped-threads.md:1
-msgid "# Scoped Threads"
-msgstr "# 范围线程"
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+"使用 `let handle = thread::spawn(...)` 和后面的 `handle.join()` 等待 线程完"
+"成。"
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr "在线程中触发紧急警报，并注意这为何不会影响到 `main`。"
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
+"使用 `handle.join()` 的 `Result` 返回值来获取对紧急警报 载荷的访问权限。现在"
+"有必要介绍一下 [`Any`](https://doc.rust-lang.org/std/any/index.html) 了。"
 
 #: src/concurrency/scoped-threads.md:3
 msgid "Normal threads cannot borrow from their environment:"
@@ -16482,8 +17209,12 @@ msgstr ""
 "```"
 
 #: src/concurrency/scoped-threads.md:17
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "不过，你可以使用[范围线程][1]来实现此目的："
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"不过，你可以使用[范围线程](https://doc.rust-lang.org/std/thread/fn.scope."
+"html)来实现此目的："
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -16517,31 +17248,27 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:37
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"* 其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使"
-"得线程能够返回借用的数据。\n"
-"* 此时须遵守常规 Rust 借用规则：你可以通过一个线程以可变的方式借用，也可以通"
-"过任意数量的线程以不可变的方式借用。\n"
-"    "
+"其原因在于，在 `thread::scope` 函数完成后，可保证所有线程都已联结在一起，使得"
+"线程能够返回借用的数据。"
 
-#: src/concurrency/channels.md:1
-msgid "# Channels"
-msgstr "# 通道"
+#: src/concurrency/scoped-threads.md:38
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"此时须遵守常规 Rust 借用规则：你可以通过一个线程以可变的方式借用，也可以通过"
+"任意数量的线程以不可变的方式借用。"
 
 #: src/concurrency/channels.md:3
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
-"Rust 通道（Channel）包含两个部分：`Sender<T>` 和 `Receiver<T>`。这两个部分\n"
-"通过通道进行连接，但你只能看到端点。"
+"Rust 通道（Channel）包含两个部分：`Sender<T>` 和 `Receiver<T>`。这两个部分 通"
+"过通道进行连接，但你只能看到端点。"
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -16585,23 +17312,20 @@ msgstr ""
 
 #: src/concurrency/channels.md:27
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* `mpsc` 代表多个生产方，单个使用方。`Sender` 和 `SyncSender` 会实现 `Clone`"
-"（因此，\n"
-"你可以设置多个生产方），但 `Receiver` 不会实现。\n"
-"* `send()` 和 `recv()` 会返回 `Result`。如果它们返回 `Err`，则表示对应的 "
-"`Sender` 或 `Receiver`\n"
-"已被丢弃，且通道已关闭。"
+"`mpsc` 代表多个生产方，单个使用方。`Sender` 和 `SyncSender` 会实现 `Clone`"
+"（因此， 你可以设置多个生产方），但 `Receiver` 不会实现。"
 
-#: src/concurrency/channels/unbounded.md:1
-msgid "# Unbounded Channels"
-msgstr "# 无界通道"
+#: src/concurrency/channels.md:29
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()` 和 `recv()` 会返回 `Result`。如果它们返回 `Err`，则表示对应的 "
+"`Sender` 或 `Receiver` 已被丢弃，且通道已关闭。"
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
@@ -16656,10 +17380,6 @@ msgstr ""
 "    }\n"
 "}\n"
 "```"
-
-#: src/concurrency/channels/bounded.md:1
-msgid "# Bounded Channels"
-msgstr "# 有界通道"
 
 #: src/concurrency/channels/bounded.md:3
 msgid "Bounded and synchronous channels make `send` block the current thread:"
@@ -16716,8 +17436,8 @@ msgstr ""
 "```"
 
 #: src/concurrency/send-sync.md:1
-msgid "# `Send` and `Sync`"
-msgstr "# `Send` 和 `Sync`"
+msgid "`Send` and `Sync`"
+msgstr "`Send` 和 `Sync`"
 
 #: src/concurrency/send-sync.md:3
 msgid ""
@@ -16727,93 +17447,87 @@ msgstr "Rust 如何知道要禁止跨线程共享访问？答案在于 Rust 的�
 
 #: src/concurrency/send-sync.md:5
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [`Send`][1]：如果跨线程边界移动 `T` 是安全的，则类型 `T`\n"
-"为 `Send`。\n"
-"* [`Sync`][2]：如果跨线程边界移动 `&T` 是安全的，则类型 `T`\n"
-"为 `Sync`。"
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)：如果跨线程边"
+"界移动 `T` 是安全的，则类型 `T` 为 `Send`。"
+
+#: src/concurrency/send-sync.md:7
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)：如果跨线程边"
+"界移动 `&T` 是安全的，则类型 `T` 为 `Sync`。"
 
 #: src/concurrency/send-sync.md:10
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
-"`Send` 和 `Sync` 均为[不安全特征][3]。只要类型仅包含 `Send` 和 `Sync` 类型，"
-"编译器就会自动为类型派生\n"
-"这两种特征。你也可以手动实现它们（如果你确定这样\n"
-"有效的话）。"
+"`Send` 和 `Sync` 均为[不安全特征](../unsafe/unsafe-traits.md)。只要类型仅包"
+"含 `Send` 和 `Sync` 类型，编译器就会自动为类型派生 这两种特征。你也可以手动实"
+"现它们（如果你确定这样 有效的话）。"
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-"
-"safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
-msgstr ""
-"* 不妨将这些特征视为类型包含某些线程安全属性的标记。\n"
-"* 它们可以在泛型约束中作为常规特征使用。\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
+msgstr "不妨将这些特征视为类型包含某些线程安全属性的标记。"
+
+#: src/concurrency/send-sync.md:21
+msgid "They can be used in the generic constraints as normal traits."
+msgstr "它们可以在泛型约束中作为常规特征使用。"
 
 #: src/concurrency/send-sync/send.md:1
-msgid "# `Send`"
-msgstr "# `Send`"
+msgid "`Send`"
+msgstr "`Send`"
 
 #: src/concurrency/send-sync/send.md:3
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
-msgstr "> 如果将 `T` 值移动到另一个线程是安全的，则类型 `T` 为 [`Send`][1]。"
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
+msgstr ""
+"如果将 `T` 值移动到另一个线程是安全的，则类型 `T` 为 [`Send`](https://doc."
+"rust-lang.org/std/marker/trait.Send.html)。"
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
-"将所有权转移到另一个线程的影响是，“析构函数”将在相应线程中\n"
-"运行。因此，问题在于你何时可以在一个线程中分配某个值，然后在\n"
-"另一个线程中取消分配该值。"
+"将所有权转移到另一个线程的影响是，“析构函数”将在相应线程中 运行。因此，问题在"
+"于你何时可以在一个线程中分配某个值，然后在 另一个线程中取消分配该值。"
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
-"a\n"
-"single thread."
-msgstr ""
-"例如，与 SQLite 库的连接只能通过\n"
-"单个线程访问。"
+"a single thread."
+msgstr "例如，与 SQLite 库的连接只能通过 单个线程访问。"
 
 #: src/concurrency/send-sync/sync.md:1
-msgid "# `Sync`"
-msgstr "# `Sync`"
+msgid "`Sync`"
+msgstr "`Sync`"
 
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"> 如果同时从多个线程访问 `T` 值是安全的，则类型 `T`\n"
-">为 [`Sync`][1]。"
+"如果同时从多个线程访问 `T` 值是安全的，则类型 `T` 为 [`Sync`](https://doc."
+"rust-lang.org/std/marker/trait.Sync.html)。"
 
 #: src/concurrency/send-sync/sync.md:6
 msgid "More precisely, the definition is:"
 msgstr "更准确地说，定义是："
 
 #: src/concurrency/send-sync/sync.md:8
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
-msgstr "> 当且仅当 `&T` 为 `Send` 时，`T` 为 `Sync`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
+msgstr "当且仅当 `&T` 为 `Send` 时，`T` 为 `Sync`"
 
 #: src/concurrency/send-sync/sync.md:14
 msgid ""
@@ -16836,69 +17550,75 @@ msgstr ""
 "用或其他同步问题的风险，因此将其移动到另一个线程是安全的。对该类型的引用同样"
 "可以安全地移动到另一个线程，因为它引用的数据可以从任何线程安全地访问。"
 
-#: src/concurrency/send-sync/examples.md:1
-msgid "# Examples"
-msgstr "# 示例"
-
 #: src/concurrency/send-sync/examples.md:3
-msgid "## `Send + Sync`"
-msgstr "## `Send + Sync`"
+msgid "`Send + Sync`"
+msgstr "`Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:5
 msgid "Most types you come across are `Send + Sync`:"
 msgstr "你遇到的类型大都属于 `Send + Sync`："
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
-msgstr ""
-"* `i8`、`f32`、`bool`、`char`、`&str`…\n"
-"* `(T1, T2)`、`[T; N]`、`&[T]`、`struct { x: T }`…\n"
-"* `String`、`Option<T>`、`Vec<T>`、`Box<T>`…\n"
-"* `Arc<T>`：明确通过原子引用计数实现线程安全。\n"
-"* `Mutex<T>`：明确通过内部锁定实现线程安全。\n"
-"* `AtomicBool`、`AtomicU8`…：使用特殊的原子指令。"
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr "`i8`、`f32`、`bool`、`char`、`&str`…"
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr "`(T1, T2)`、`[T; N]`、`&[T]`、`struct { x: T }`…"
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr "`String`、`Option<T>`、`Vec<T>`、`Box<T>`…"
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr "`Arc<T>`：明确通过原子引用计数实现线程安全。"
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr "`Mutex<T>`：明确通过内部锁定实现线程安全。"
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgstr "`AtomicBool`、`AtomicU8`…：使用特殊的原子指令。"
 
 #: src/concurrency/send-sync/examples.md:14
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
-msgstr ""
-"当类型参数为 `Send + Sync` 时，泛型类型通常\n"
-"为 `Send + Sync`。"
+msgstr "当类型参数为 `Send + Sync` 时，泛型类型通常 为 `Send + Sync`。"
 
 #: src/concurrency/send-sync/examples.md:17
-msgid "## `Send + !Sync`"
-msgstr "## `Send + !Sync`"
+msgid "`Send + !Sync`"
+msgstr "`Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:19
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
-"这些类型可以移动到其他线程，但它们不是线程安全的。\n"
-"这通常是由内部可变性造成的："
+"这些类型可以移动到其他线程，但它们不是线程安全的。 这通常是由内部可变性造成"
+"的："
 
 #: src/concurrency/send-sync/examples.md:22
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Sender<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Receiver<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+msgid "`Cell<T>`"
+msgstr "`Cell<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+msgid "`RefCell<T>`"
+msgstr "`RefCell<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
-msgid "## `!Send + Sync`"
-msgstr "## `!Send + Sync`"
+msgid "`!Send + Sync`"
+msgstr "`!Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:29
 msgid ""
@@ -16907,16 +17627,15 @@ msgstr "这些类型是线程安全的，但它们不能移动到另一个线程
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
-"* `MutexGuard<T>`：使用操作系统级别的原语（必须在创建这些原语的线程上\n"
-"取消分配）。"
+"`MutexGuard<T>`：使用操作系统级别的原语（必须在创建这些原语的线程上 取消分"
+"配）。"
 
 #: src/concurrency/send-sync/examples.md:34
-msgid "## `!Send + !Sync`"
-msgstr "## `!Send + !Sync`"
+msgid "`!Send + !Sync`"
+msgstr "`!Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:36
 msgid "These types are not thread-safe and cannot be moved to other threads:"
@@ -16924,47 +17643,52 @@ msgstr "这些类型不是线程安全的，不能移动到其他线程："
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
-"* `Rc<T>`：每个 `Rc<T>` 都具有对 `RcBox<T>` 的引用，其中包含\n"
-"非原子引用计数。\n"
-"* `*const T`、`*mut T`：Rust 会假定原始指针可能\n"
-"在并发方面有特殊的注意事项。"
+"`Rc<T>`：每个 `Rc<T>` 都具有对 `RcBox<T>` 的引用，其中包含 非原子引用计数。"
 
-#: src/concurrency/shared_state.md:1
-msgid "# Shared State"
-msgstr "# 共享状态"
+#: src/concurrency/send-sync/examples.md:40
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr ""
+"`*const T`、`*mut T`：Rust 会假定原始指针可能 在并发方面有特殊的注意事项。"
 
 #: src/concurrency/shared_state.md:3
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
-msgstr ""
-"Rust 使用类型系统来强制同步共享数据。这主要\n"
-"通过两种类型实现："
+msgstr "Rust 使用类型系统来强制同步共享数据。这主要 通过两种类型实现："
 
 #: src/concurrency/shared_state.md:6
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1]，对 `T` 进行原子计数：用于处理线程之间的共享，并负责\n"
-"在最后一个引用被丢弃时取消分配 `T`。\n"
-"* [`Mutex<T>`][2]：确保对 `T` 值的互斥访问。"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)，对 `T` 进行原"
+"子计数：用于处理线程之间的共享，并负责 在最后一个引用被丢弃时取消分配 `T`。"
+
+#: src/concurrency/shared_state.md:8
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)：确保对 "
+"`T` 值的互斥访问。"
 
 #: src/concurrency/shared_state/arc.md:1
-msgid "# `Arc`"
-msgstr "# `Arc`"
+msgid "`Arc`"
+msgstr "`Arc`"
 
 #: src/concurrency/shared_state/arc.md:3
-msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
-msgstr "[`Arc<T>`][1] 允许通过 `Arc::clone` 实现共享只读权限："
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
+msgstr ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) 允许通过 "
+"`Arc::clone` 实现共享只读权限："
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -17010,40 +17734,48 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
+msgstr "`Arc` 代表“原子引用计数”，它是使用原子操作的 `Rc` 的 线程安全版本。"
+
+#: src/concurrency/shared_state/arc.md:31
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
 msgstr ""
-"* `Arc` 代表“原子引用计数”，它是使用原子操作的 `Rc` 的\n"
-"线程安全版本。\n"
-"* 无论 `T` 是否实现 `Clone`，`Arc<T>` 都会实现 `Clone`。如果 `T` 实现了 "
-"`Send` 和 `Sync`，`Arc<T>` 便会\n"
-"实现二者。\n"
-"* `Arc::clone()` 在执行原子操作方面有开销，但在此之后，`T` 便可\n"
-"随意使用，而没有任何开销。\n"
-"* 请警惕引用循环，`Arc` 不会使用垃圾回收器检测引用循环。\n"
-"* `std::sync::Weak` 对此有所帮助。"
+"无论 `T` 是否实现 `Clone`，`Arc<T>` 都会实现 `Clone`。如果 `T` 实现了 `Send` "
+"和 `Sync`，`Arc<T>` 便会 实现二者。"
+
+#: src/concurrency/shared_state/arc.md:33
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"`Arc::clone()` 在执行原子操作方面有开销，但在此之后，`T` 便可 随意使用，而没"
+"有任何开销。"
+
+#: src/concurrency/shared_state/arc.md:35
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr "请警惕引用循环，`Arc` 不会使用垃圾回收器检测引用循环。"
+
+#: src/concurrency/shared_state/arc.md:36
+msgid "`std::sync::Weak` can help."
+msgstr "`std::sync::Weak` 对此有所帮助。"
 
 #: src/concurrency/shared_state/mutex.md:1
-msgid "# `Mutex`"
-msgstr "# `互斥器 (Mutex)`"
+msgid "`Mutex`"
+msgstr "`互斥器 (Mutex)`"
 
 #: src/concurrency/shared_state/mutex.md:3
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
-"[`Mutex<T>`][1] 能够确保互斥，并允许对只读接口\n"
-"后面的 `T` 进行可变访问："
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) 能够确保互"
+"斥，并允许对只读接口 后面的 `T` 进行可变访问："
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -17081,46 +17813,58 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
-"请注意我们如何设置 [`impl<T: Send> Sync for Mutex<T>`][2] 通用\n"
-"实现。"
+"请注意我们如何设置 [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-lang."
+"org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) 通用 实现。"
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
 msgstr ""
-"* Rust 中的互斥器看起来就像只包含一个元素的集合，其中的元素就是受保护的数"
-"据。\n"
-"* 在访问受保护的数据之前不可能忘记获取互斥量。\n"
-"* 你可以通过获取锁，从 `&Mutex<T>` 中获取 `&mut T`。`MutexGuard` 能够确保 "
-"`&mut T`\n"
-"存在的时间不会比持有锁的时间更长。\n"
-"* 如果 `T` 实现了 `Send`，`Mutex<T>` 便会实现 `Send` 和 `Sync`。\n"
-"* 读写锁版本 - `RwLock`。\n"
-"* 为什么 `lock()` 会返回 `Result`？\n"
-"* 如果持有 `Mutex` 的线程发生panic，`Mutex` 便会“中毒”并发出信号，\n"
-"表明其所保护的数据可能处于不一致状态。对中毒的互斥量调用 `lock()` 将会失"
-"败，\n"
-"并将显示 [`PoisonError`]。无论如何，你可以对该错误调用 `into_inner()` 来\n"
-"恢复数据。"
+"Rust 中的互斥器看起来就像只包含一个元素的集合，其中的元素就是受保护的数据。"
+
+#: src/concurrency/shared_state/mutex.md:32
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr "在访问受保护的数据之前不可能忘记获取互斥量。"
+
+#: src/concurrency/shared_state/mutex.md:33
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+"你可以通过获取锁，从 `&Mutex<T>` 中获取 `&mut T`。`MutexGuard` 能够确保 "
+"`&mut T` 存在的时间不会比持有锁的时间更长。"
+
+#: src/concurrency/shared_state/mutex.md:35
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr "如果 `T` 实现了 `Send`，`Mutex<T>` 便会实现 `Send` 和 `Sync`。"
+
+#: src/concurrency/shared_state/mutex.md:36
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "读写锁版本 - `RwLock`。"
+
+#: src/concurrency/shared_state/mutex.md:37
+msgid "Why does `lock()` return a `Result`? "
+msgstr "为什么 `lock()` 会返回 `Result`？"
+
+#: src/concurrency/shared_state/mutex.md:38
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"如果持有 `Mutex` 的线程发生panic，`Mutex` 便会“中毒”并发出信号， 表明其所保护"
+"的数据可能处于不一致状态。对中毒的互斥量调用 `lock()` 将会失败， 并将显示 "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html)。"
+"无论如何，你可以对该错误调用 `into_inner()` 来 恢复数据。"
 
 #: src/concurrency/shared_state/example.md:3
 msgid "Let us see `Arc` and `Mutex` in action:"
@@ -17220,35 +17964,42 @@ msgstr "值得注意的部分："
 
 #: src/concurrency/shared_state/example.md:51
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
-"possible."
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr "`Arc` 和 `Mutex` 中都封装了 `v`，因为它们的关注点是正交的。"
+
+#: src/concurrency/shared_state/example.md:52
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr "将 `Mutex` 封装在 `Arc` 中是一种在线程之间共享可变状态的常见模式。"
+
+#: src/concurrency/shared_state/example.md:53
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
 msgstr ""
-"* `Arc` 和 `Mutex` 中都封装了 `v`，因为它们的关注点是正交的。\n"
-"* 将 `Mutex` 封装在 `Arc` 中是一种在线程之间共享可变状态的常见模式。\n"
-"* `v: Arc<_>` 必须先克隆为 `v2`，然后才能移动到另一个线程中。请注意，lambda "
-"签名中添加了 `move`。\n"
-"* 我们引入了块，以尽可能缩小 `LockGuard` 的作用域。"
+"`v: Arc<_>` 必须先克隆为 `v2`，然后才能移动到另一个线程中。请注意，lambda 签"
+"名中添加了 `move`。"
+
+#: src/concurrency/shared_state/example.md:54
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible."
+msgstr "我们引入了块，以尽可能缩小 `LockGuard` 的作用域。"
 
 #: src/exercises/concurrency/morning.md:3
 msgid "Let us practice our new concurrency skills with"
 msgstr ""
 
 #: src/exercises/concurrency/morning.md:5
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
+msgid "Dining philosophers: a classic problem in concurrency."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md:1
-msgid "# Dining Philosophers"
+#: src/exercises/concurrency/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:3
@@ -17257,28 +18008,21 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:5
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:13
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to a file called `src/main.rs`, fill out "
-"the\n"
-"blanks, and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:19
@@ -17340,24 +18084,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:1
-msgid "# Multi-threaded Link Checker"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:3
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:11
@@ -17371,14 +18109,14 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:17
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:20
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:22
@@ -17390,9 +18128,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:29
@@ -17426,8 +18163,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:50
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:53
@@ -17492,76 +18229,66 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:106
-#: src/exercises/concurrency/chat-app.md:140
-msgid "## Tasks"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:108
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:110
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
 
 #: src/async.md:1
-msgid "# Async Rust"
+msgid "Async Rust"
 msgstr ""
 
 #: src/async.md:3
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
-"concurrently by\n"
-"executing each task until it would block, then switching to another task "
-"that is\n"
-"ready to make progress. The model allows running a larger number of tasks on "
-"a\n"
-"limited number of threads. This is because the per-task overhead is "
-"typically\n"
-"very low and operating systems provide primitives for efficiently "
-"identifying\n"
-"I/O that is able to proceed."
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 
 #: src/async.md:10
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
-"that\n"
-"may be completed in the future. Futures are \"polled\" until they signal "
-"that\n"
-"they are complete."
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
 
 #: src/async.md:14
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 
 #: src/async.md:17
-msgid "## Comparisons"
+msgid "Comparisons"
 msgstr ""
 
 #: src/async.md:19
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type "
-"is\n"
-"   callback-based, and not polled. Async Python programs require a "
-"\"loop\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The "
-"language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
+msgstr ""
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
 msgstr ""
 
 #: src/async/async-await.md:1
-msgid "# `async`/`await`"
+msgid "`async`/`await`"
 msgstr ""
 
 #: src/async/async-await.md:3
@@ -17593,58 +18320,62 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no "
-"long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the "
-"compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current "
-"thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. "
-"Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
-"* 请注意，这只是一个简单的示例，用于展示语法。其中没有长时间运行的操作或任何真正的并发！\n"
-"\n"
-"* 异步调用的返回类型是什么？\n"
-"  * 在 `main` 中使用 `let future: () = async_main(10);` 来查看类型。\n"
-"\n"
-"* \"async\" 关键字是语法糖。编译器会将返回类型替换为 future。\n"
-"\n"
-"* 你不能将 `main` 声明为异步函数，除非在编译器中加入额外的指令来告诉它如何使用返回的 future。\n"
-"\n"
-"* 你需要一个执行器来运行异步代码。`block_on`会阻塞当前线程，直到提供的future完成为止。 \n"
-"\n"
-"* `.await` 会异步地等待另一个操作的完成。与 `block_on` 不同，`.await` 不会阻塞当前线程。\n"
-"\n"
-"* `.await` 只能在 `async` 函数（或块，这些稍后会介绍）中使用。 "
+"请注意，这只是一个简单的示例，用于展示语法。其中没有长时间运行的操作或任何真"
+"正的并发！"
 
-#: src/async/futures.md:1
-msgid "# Futures"
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr "异步调用的返回类型是什么？"
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr "在 `main` 中使用 `let future: () = async_main(10);` 来查看类型。"
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr "\"async\" 关键字是语法糖。编译器会将返回类型替换为 future。"
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
 msgstr ""
+"你不能将 `main` 声明为异步函数，除非在编译器中加入额外的指令来告诉它如何使用"
+"返回的 future。"
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+"你需要一个执行器来运行异步代码。`block_on`会阻塞当前线程，直到提供的future完"
+"成为止。 "
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+"`.await` 会异步地等待另一个操作的完成。与 `block_on` 不同，`.await` 不会阻塞"
+"当前线程。"
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr "`.await` 只能在 `async` 函数（或块，这些稍后会介绍）中使用。 "
 
 #: src/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not "
-"be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
 #: src/async/futures.md:8
@@ -17669,86 +18400,86 @@ msgstr ""
 #: src/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
-"uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` "
-"returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
 
 #: src/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
-"to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers "
-"into\n"
-"    that future remain valid. This is required to allow references to "
-"remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/runtimes.md:1
-msgid "# Runtimes"
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
 msgstr ""
 
 #: src/async/runtimes.md:3
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust "
-"does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
 #: src/async/runtimes.md:7
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem "
-"of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and "
-"includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
+msgstr ""
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
 msgstr ""
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 
 #: src/async/runtimes.md:20
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most "
-"interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/"
-"O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are "
-"never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
 
-#: src/async/runtimes/tokio.md:1
-msgid "# Tokio"
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:4
@@ -17756,10 +18487,15 @@ msgid "Tokio provides: "
 msgstr ""
 
 #: src/async/runtimes/tokio.md:6
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:10
@@ -17787,12 +18523,15 @@ msgid ""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:39
@@ -17801,35 +18540,32 @@ msgstr ""
 
 #: src/async/runtimes/tokio.md:41
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to "
-"wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
 
-#: src/async/tasks.md:1
-msgid "# Tasks"
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
 msgstr ""
 
 #: src/async/tasks.md:3
 msgid ""
-"Runtimes have the concept of a \"task\", similar to a thread but much\n"
-"less resource-intensive."
+"Runtimes have the concept of a \"task\", similar to a thread but much less "
+"resource-intensive."
 msgstr ""
 
 #: src/async/tasks.md:6
 msgid ""
 "A task has a single top-level future which the executor polls to make "
-"progress.\n"
-"That future may have one or more nested futures that its `poll` method "
-"polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible "
-"by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
 
 #: src/async/tasks.md:11
@@ -17883,20 +18619,21 @@ msgstr ""
 
 #: src/async/tasks.md:55
 msgid ""
-"* Ask students to visualize what the state of the example server would be "
-"with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling "
-"using `?`."
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/async/channels.md:1
-msgid "# Async Channels"
+#: src/async/tasks.md:58
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+
+#: src/async/tasks.md:62
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
+"using `?`."
 msgstr ""
 
 #: src/async/channels.md:3
@@ -17938,49 +18675,56 @@ msgid ""
 msgstr ""
 
 #: src/async/channels.md:35
+msgid "Change the channel size to `3` and see how it affects the execution."
+msgstr ""
+
+#: src/async/channels.md:37
 msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be "
-"convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to "
-"combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
 msgstr ""
 
 #: src/async/control-flow.md:1
-msgid "# Futures Control Flow"
+msgid "Futures Control Flow"
 msgstr ""
 
 #: src/async/control-flow.md:3
 msgid ""
 "Futures can be combined together to produce concurrent compute flow graphs. "
-"We\n"
-"have already seen tasks, that function as independent threads of execution."
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
 
 #: src/async/control-flow.md:6
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
 msgstr ""
 
-#: src/async/control-flow/join.md:1
-msgid "# Join"
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
 msgstr ""
 
 #: src/async/control-flow/join.md:3
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
@@ -18016,43 +18760,39 @@ msgstr ""
 
 #: src/async/control-flow/join.md:38
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` "
-"but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this "
-"would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all "
-"requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but "
-"demonstrates `join!`."
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/select.md:1
-msgid "# Select"
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
+"demonstrates `join!`."
 msgstr ""
 
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
 msgid ""
 "This is usually a macro, similar to match, with each arm of the form "
-"`pattern =\n"
-"future => statement`. When the future is ready, the statement is executed "
-"with the\n"
-"variable bound to the future's result."
+"`pattern = future => statement`. When the future is ready, the statement is "
+"executed with the variable bound to the future's result."
 msgstr ""
 
 #: src/async/control-flow/select.md:12
@@ -18107,29 +18847,34 @@ msgstr ""
 
 #: src/async/control-flow/select.md:61
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick "
-"whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are "
-"supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts "
-"of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` moves the values it is given. It is easiest to use\n"
-"  when every execution of `select!` creates new futures. An alternative is "
-"to\n"
-"  pass `&mut future` instead of the future itself, but this can lead to\n"
-"  issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
+msgstr ""
+
+#: src/async/control-flow/select.md:66
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+
+#: src/async/control-flow/select.md:69
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:72
+msgid ""
+"Note that `select!` moves the values it is given. It is easiest to use when "
+"every execution of `select!` creates new futures. An alternative is to pass "
+"`&mut future` instead of the future itself, but this can lead to issues, "
+"further discussed in the pinning slide."
 msgstr ""
 
 #: src/async/pitfalls.md:1
-msgid "# Pitfalls of async/await"
+msgid "Pitfalls of async/await"
 msgstr ""
 
 #: src/async/pitfalls.md:3
@@ -18141,22 +18886,27 @@ msgid ""
 msgstr ""
 
 #: src/async/pitfalls.md:5
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfall/async-traits.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfall/async-traits.md)"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:1
-msgid "# Blocking the executor"
+msgid "Blocking the executor"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:3
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other "
-"tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:7
@@ -18184,58 +18934,57 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its "
-"result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an "
-"actual\n"
-"  thread and transforms its handle into a future without blocking the "
-"executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and "
-"most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, "
-"where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
-"situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause "
-"another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:1
-msgid "# Pin"
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
 "When you await a future, all local variables (that would ordinarily be "
-"stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. "
-"If your\n"
-"future has pointers to data on the stack, those pointers might get "
-"invalidated.\n"
-"This is unsafe."
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:8
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to "
-"don't\n"
+"Therefore, you must guarantee that the addresses your future points to don't "
 "change. That is why we need to `pin` futures. Using the same future "
-"repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:12
@@ -18297,60 +19046,78 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your "
-"time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!"
-"(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the "
-"`loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to "
-"the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on "
-"every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, "
-"but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that "
-"will send to a `oneshot` channel every 100ms."
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:1
-msgid "# Async Traits"
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:3
@@ -18413,26 +19180,25 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:49
-msgid "<details>  "
-msgstr ""
-
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations "
-"to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of "
-"time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:3
@@ -18442,32 +19208,32 @@ msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
-"* Dining philosophers: we already saw this problem in the morning. This "
-"time\n"
-"  you are going to implement it with Async Rust.\n"
-"\n"
-"* A Broadcast Chat Application: this is a larger project that allows you\n"
-"  experiment with more advanced Async Rust features."
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr ""
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
-msgid "# Dining Philosophers - Async"
+#: src/exercises/concurrency/solutions-afternoon.md:3
+msgid "Dining Philosophers - Async"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the\n"
+"See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 msgid ""
-"As before, you will need a local\n"
-"[Cargo installation](../../cargo/running-locally.md) for this exercise. "
-"Copy\n"
-"the code below to a file called `src/main.rs`, fill out the blanks, and "
-"test\n"
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
@@ -18520,7 +19286,7 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
 msgid ""
-"Since this time you are using Async Rust, you'll need a `tokio` dependency.\n"
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
@@ -18540,33 +19306,29 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:72
 msgid ""
-"Also note that this time you have to use the `Mutex` and the `mpsc` module\n"
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "* Can you make your implementation single-threaded? "
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:1
-msgid "# Broadcast Chat Application"
+msgid "Can you make your implementation single-threaded? "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
 msgid ""
-"In this exercise, we want to use our new knowledge to implement a broadcast\n"
+"In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
-"publish\n"
-"their messages. The client reads user messages from the standard input, and\n"
-"sends them to the server. The chat server broadcasts each message that it\n"
-"receives to all the clients."
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel][1] on the server, and\n"
-"[`tokio_websockets`][2] for the communication between the client and the\n"
-"server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:13
@@ -18594,57 +19356,69 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:32
-msgid "## The required APIs"
+msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
-"You are going to need the following functions from `tokio` and\n"
-"[`tokio_websockets`][2]. Spend a few minutes to familiarize yourself with "
-"the\n"
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
 "API. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
-"- [WebsocketStream::next()][3]: for asynchronously reading messages from a\n"
-"  Websocket Stream.\n"
-"- [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously\n"
-"  sending messages on a Websocket Stream.\n"
-"- [BufReader::read_line()][5]: for asynchronously reading user messages\n"
-"  from the standard input.\n"
-"- [Sender::subscribe()][6]: for subscribing to a broadcast channel."
+"[WebsocketStream::next()](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/proto/struct.WebsocketStream.html#method.next): for "
+"asynchronously reading messages from a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:41
+msgid ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
-msgid "## Two binaries"
+msgid "Two binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one\n"
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client,\n"
-"and one for the server. You could potentially make them two separate Cargo\n"
-"projects, but we are going to put them in a single Cargo project with two\n"
-"binaries. For this to work, the client and the server code should go under\n"
-"`src/bin` (see the [documentation][7]). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and\n"
-"`src/bin/client.rs`, respectively. Your task is to complete these files as\n"
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:59
 #: src/exercises/concurrency/solutions-afternoon.md:117
 msgid "`src/bin/server.rs`:"
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:61
-msgid "<!-- File src/bin/server.rs -->"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:63
@@ -18694,10 +19468,6 @@ msgstr ""
 msgid "`src/bin/client.rs`:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:104
-msgid "<!-- File src/bin/client.rs -->"
-msgstr ""
-
 #: src/exercises/concurrency/chat-app.md:106
 msgid ""
 "```rust,compile_fail\n"
@@ -18724,7 +19494,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:127
-msgid "## Running the binaries"
+msgid "Running the binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:128
@@ -18750,58 +19520,60 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:142
-msgid ""
-"* Implement the `handle_connection` function in `src/bin/server.rs`.\n"
-"  * Hint: Use `tokio::select!` for concurrently performing two tasks in a\n"
-"    continuous loop. One task receives messages from the client and "
-"broadcasts\n"
-"    them. The other sends messages received by the server to the client.\n"
-"* Complete the main function in `src/bin/client.rs`.\n"
-"  * Hint: As before, use `tokio::select!` in a continuous loop for "
-"concurrently\n"
-"    performing two tasks: (1) reading user messages from standard input and\n"
-"    sending them to the server, and (2) receiving messages from the server, "
-"and\n"
-"    displaying them for the user.\n"
-"* Optional: Once you are done, change the code to broadcast messages to all\n"
-"  clients, but the sender of the message."
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/thanks.md:1
-msgid "# Thanks!"
+#: src/exercises/concurrency/chat-app.md:143
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:147
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:151
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
 msgstr ""
 
 #: src/thanks.md:3
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
-"that it\n"
-"was useful."
+"that it was useful."
 msgstr ""
 
 #: src/thanks.md:6
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 
 #: src/other-resources.md:1
-msgid "# Other Rust Resources"
+msgid "Other Rust Resources"
 msgstr ""
 
 #: src/other-resources.md:3
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 
 #: src/other-resources.md:6
-msgid "## Official Documentation"
+msgid "Official Documentation"
 msgstr ""
 
 #: src/other-resources.md:8
@@ -18810,22 +19582,29 @@ msgstr ""
 
 #: src/other-resources.md:10
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
+msgstr ""
+
+#: src/other-resources.md:13
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+
+#: src/other-resources.md:17
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+
+#: src/other-resources.md:19
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
 msgstr ""
 
 #: src/other-resources.md:22
@@ -18834,22 +19613,27 @@ msgstr ""
 
 #: src/other-resources.md:24
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
+msgstr ""
+
+#: src/other-resources.md:27
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+
+#: src/other-resources.md:30
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
 msgstr ""
 
 #: src/other-resources.md:33
-msgid "## Unofficial Learning Material"
+msgid "Unofficial Learning Material"
 msgstr ""
 
 #: src/other-resources.md:35
@@ -18858,130 +19642,118 @@ msgstr ""
 
 #: src/other-resources.md:37
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
+msgstr ""
+
+#: src/other-resources.md:39
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+
+#: src/other-resources.md:42
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+
+#: src/other-resources.md:45
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+
+#: src/other-resources.md:47
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+
+#: src/other-resources.md:52
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
 msgstr ""
 
 #: src/other-resources.md:63
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
+"for even more Rust books."
 msgstr ""
-
-#: src/credits.md:1
-msgid "# Credits"
-msgstr "# 鸣谢"
 
 #: src/credits.md:3
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
-"本课中的资料以众多优秀的 Rust 文档资源为基础。\n"
-"如需查看实用资源的完整列表，\n"
+"本课中的资料以众多优秀的 Rust 文档资源为基础。 如需查看实用资源的完整列表， "
 "请参阅关于[其他资源](other-resources.md)的页面。"
 
 #: src/credits.md:7
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
 msgstr ""
-"我们根据 Apache 2.0 许可条款\n"
-"授权你使用“全面了解 Rust”(Comprehensive Rust) 的资料。如需了解详情，请参阅[`"
-"许可`](../LICENSE)。"
+"我们根据 Apache 2.0 许可条款 授权你使用“全面了解 Rust”(Comprehensive Rust) 的"
+"资料。如需了解详情，请参阅[`许可`](../LICENSE)。"
 
 #: src/credits.md:10
-msgid "## Rust by Example"
-msgstr "## Rust by Example"
+msgid "Rust by Example"
+msgstr "Rust by Example"
 
 #: src/credits.md:12
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
-"部分示例和练习复制并\n"
-"改编自[Rust by Example](https://doc.rust-lang.org/rust-by-example/)。如需了解"
-"详情（包括许可\n"
-"条款），请参阅\n"
-"`third_party/rust-by-example/` 目录。"
+"部分示例和练习复制并 改编自[Rust by Example](https://doc.rust-lang.org/rust-"
+"by-example/)。如需了解详情（包括许可 条款），请参阅 `third_party/rust-by-"
+"example/` 目录。"
 
 #: src/credits.md:17
-msgid "## Rust on Exercism"
-msgstr "## Rust on Exercism"
+msgid "Rust on Exercism"
+msgstr "Rust on Exercism"
 
 #: src/credits.md:19
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"部分练习复制并\n"
-"改编自 [Rust on Exercism](https://exercism.org/tracks/rust)。如需了解详情（包"
-"括许可\n"
-"条款），请参阅\n"
-"`third_party/rust-on-exercism/` 目录。"
+"部分练习复制并 改编自 [Rust on Exercism](https://exercism.org/tracks/rust)。"
+"如需了解详情（包括许可 条款），请参阅 `third_party/rust-on-exercism/` 目录。"
 
 #: src/credits.md:24
-msgid "## CXX"
-msgstr "## CXX"
+msgid "CXX"
+msgstr "CXX"
 
 #: src/credits.md:26
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
-"“[与 C++ 的互操作性](android/interoperability/cpp.md)”部分引用了一张\n"
-"来自 [CXX](https://cxx.rs/) 的图片。如需了解详情（包括许可条款），\n"
-"请参阅 `third_party/cxx/` 目录。"
-
-#: src/exercises/solutions.md:1
-msgid "# Solutions"
-msgstr ""
+"“[与 C++ 的互操作性](android/interoperability/cpp.md)”部分引用了一张 来自 "
+"[CXX](https://cxx.rs/) 的图片。如需了解详情（包括许可条款）， 请参阅 "
+"`third_party/cxx/` 目录。"
 
 #: src/exercises/solutions.md:3
 msgid "You will find solutions to the exercises on the following pages."
@@ -18989,25 +19761,20 @@ msgstr ""
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
 
 #: src/exercises/solutions.md:10
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:1
-msgid "# Day 1 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:3
-msgid "## Arrays and `for` Loops"
+msgid "Day 1 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:5
@@ -19090,7 +19857,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
-msgid "### Bonus question"
+msgid "Bonus question"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:80
@@ -19111,7 +19878,8 @@ msgstr ""
 #: src/exercises/day-1/solutions-morning.md:84
 msgid ""
 "Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:86
@@ -19151,11 +19919,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
-msgid "# Day 1 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-msgid "## Designing a Library"
+msgid "Day 1 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:5
@@ -19358,11 +20122,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
-msgid "# Day 2 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:3
-msgid "## Points and Polygons"
+msgid "Day 2 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:5
@@ -19602,11 +20362,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
-msgid "# Day 2 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-msgid "## Luhn Algorithm"
+msgid "Day 2 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:5
@@ -19707,10 +20463,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:97
-msgid "## Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/solutions-afternoon.md:99
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
@@ -19798,11 +20550,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
-msgid "# Day 3 Morning Exercise"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:3
-msgid "## A Simple GUI Library"
+msgid "Day 3 Morning Exercise"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:5
@@ -19982,11 +20730,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
-msgid "# Day 3 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-msgid "## Safe FFI Wrapper"
+msgid "Day 3 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:5
@@ -20169,11 +20913,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-msgid "## Compass"
+msgid "Bare Metal Rust Morning Exercise"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:5
@@ -20345,14 +21085,6 @@ msgid ""
 "    max(min_value, min(value, max_value))\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "# Bare Metal Rust Afternoon"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-msgid "## RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -20649,11 +21381,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
-msgid "# Concurrency Morning Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:3
-msgid "## Dining Philosophers"
+msgid "Concurrency Morning Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:5
@@ -20761,11 +21489,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
-msgid "# Concurrency Afternoon Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:3
-msgid "## Dining Philosophers - Async"
+msgid "Concurrency Afternoon Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:5
@@ -20884,10 +21608,6 @@ msgid ""
 "    }\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:113
-msgid "## Broadcast Chat Application"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:115
@@ -21043,202 +21763,89 @@ msgid ""
 msgstr ""
 
 #: src/running-the-course/translations.md:11
-msgid "## Incomplete Translations"
-msgstr "## 未完成的翻译"
+msgid "Incomplete Translations"
+msgstr "未完成的翻译"
 
 #: src/running-the-course/translations.md:13
 msgid ""
-"There is a large number of in-progress translations. We link to the most\n"
+"There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
-msgstr ""
-"多数语言版本仍在翻译中。我们会提供"
-"最近更新的翻译的链接："
+msgstr "多数语言版本仍在翻译中。我们会提供最近更新的翻译的链接："
 
-#: src/running-the-course/translations.md:16
+#: src/running-the-course/translations.md:16 src/enums.md:6
+#, fuzzy
+msgid "\\[French\\]\\[fr\\] by \\[@KookaS\\] and \\[@vcaen\\]."
+msgstr "\\[法语\\]\\[fr\\]：\\[@KookaS\\] 和 \\[@vcaen\\]。"
+
+#: src/running-the-course/translations.md:17 src/enums.md:7
+#, fuzzy
+msgid "\\[German\\]\\[de\\] by \\[@Throvn\\] and \\[@ronaldfw\\]."
+msgstr "\\[德语\\]\\[de\\]：\\[@Throvn\\] 和 \\[@ronaldfw\\]。"
+
+#: src/running-the-course/translations.md:18 src/enums.md:8
+#, fuzzy
 msgid ""
-"* [French][fr] by [@KookaS] and [@vcaen].\n"
-"* [German][de] by [@Throvn] and [@ronaldfw].\n"
-"* [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105]."
+"\\[Japanese\\]\\[ja\\] by \\[@CoinEZ-JPN\\] and \\[@momotaro1105\\]."
+"\\```rust,editable fn generate_random_number() -> i32 { // Implementation "
+"based on https://xkcd.com/221/ 4  // Chosen by fair dice roll. Guaranteed to "
+"be random. }"
+msgstr "\\[日语\\]\\[ja\\]：\\[@CoinEZ-JPN\\] 和 \\[@momotaro1105\\]。"
+
+#: src/running-the-course/translations.md:24 src/enums.md:14
+msgid "\\#\\[derive(Debug)\\] enum CoinFlip { Heads, Tails, }"
 msgstr ""
-"* [法语][fr]：[@KookaS] 和 [@vcaen]。\n"
-"* [德语][de]：[@Throvn] 和 [@ronaldfw]。\n"
-"* [日语][ja]：[@CoinEZ-JPN] 和 [@momotaro1105]。"
-#: src/enums.md:6
+
+#: src/running-the-course/translations.md:30 src/enums.md:20
 msgid ""
-"```rust,editable\n"
-"fn generate_random_number() -> i32 {\n"
-"    // Implementation based on https://xkcd.com/221/\n"
-"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"enum CoinFlip {\n"
-"    Heads,\n"
-"    Tails,\n"
-"}\n"
-"\n"
-"fn flip_coin() -> CoinFlip {\n"
-"    let random_number = generate_random_number();\n"
-"    if random_number % 2 == 0 {\n"
-"        return CoinFlip::Heads;\n"
-"    } else {\n"
-"        return CoinFlip::Tails;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    println!(\"You got: {:?}\", flip_coin());\n"
-"}\n"
+"fn flip_coin() -> CoinFlip { let random_number = generate_random_number(); "
+"if random_number % 2 == 0 { return CoinFlip::Heads; } else { return "
+"CoinFlip::Tails; } }"
+msgstr ""
+
+#: src/running-the-course/translations.md:39 src/enums.md:29
+msgid "fn main() { println!(\"You got: {:?}\", flip_coin()); }"
+msgstr ""
+
+#: src/running-the-course/translations.md:42 src/enums.md:32
+msgid ""
+"```\n"
 "```"
-
 msgstr ""
-"```rust,editable\n"
-"fn generate_random_number() -> i32 {\n"
-"    // Implementation based on https://xkcd.com/221/\n"
-"    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
-"}\n"
-"\n"
-"#[derive(Debug)]\n"
-"enum CoinFlip {\n"
-"    Heads,\n"
-"    Tails,\n"
-"}\n"
-"\n"
-"fn flip_coin() -> CoinFlip {\n"
-"    let random_number = generate_random_number();\n"
-"    if random_number % 2 == 0 {\n"
-"        return CoinFlip::Heads;\n"
-"    } else {\n"
-"        return CoinFlip::Tails;\n"
-"    }\n"
-"}\n"
-"\n"
-"fn main() {\n"
-"    println!(\"You got: {:?}\", flip_coin());\n"
-"}\n"
-"```"
 
-#: src/ownership/lifetimes.md:5
+#: src/ownership/lifetimes.md:13
 msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully "
-"specified,\n"
-"  but Rust allows these to be elided in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows these to be elided in most cases with [a few simple rules]"
+"(https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
 msgstr ""
-"* 生命周期可以是隐式的：add(p1: &Point, p2: &Point) -> Point`。\n"
-"* 生命周期也可以是显式的：`&'a Point`、`&'document str`。\n"
-"* 将 `&'a Point` 读取为“一个借用的 `Point`，至少在\n"
-"生命周期 `a` 内有效”。\n"
-"* 生命周期始终由编译器推断出来：你不能自行\n"
-"分配生命周期。\n"
-"  * 生命周期注释会创建约束条件；编译器会验证\n"
-"是否存在有效的解决方案。\n"
-"* 必须完全指定函数参数和返回值的生命周期，\n"
-"但 Rust 允许在大多数情况下通过[一些简单的\n"
-"规则](https://doc.rust-lang.org/nomicon/lifetime-elision.html）来省略此操作。"
+"必须完全指定函数参数和返回值的生命周期， 但 Rust 允许在大多数情况下通过\\[一"
+"些简单的 规则\\](https://doc.rust-lang.org/nomicon/lifetime-elision.html）来"
+"省略此操作。"
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
-msgstr ""
-"* 将 `p2` 和 `p3` 的声明移至新作用域 (`{ ... }`)，以产生以下代码：\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-" 请注意：由于 `p3` 的生命周期比 `p2` 长，因此无法编译。\n"
-"\n"
-"* 重置工作区，然后将函数签名更改为 `fn left_most<'a, 'b>(p1: &'a Point, p2: "
-"&'a Point) -> &'b Point`。这不会被编译，因为 `'a` 和 `'b` 生命周期之间的关系"
-"不明确。\n"
-"* 另一种解释方式：\n"
-"  * 对两个值的两个引用被一个函数借用，该函数返回\n"
-"另一个引用。\n"
-"  * 它必须是来自这两个输入中的一个（或来自一个全局变量）。\n"
-"  * 是哪一个呢？编译器需要知道这一点，因此在调用点，返回的引用\n"
-"的使用时间不会超过引用的来源中的变量。"
+"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
+"resulting in the following code:"
+msgstr "将 `p2` 和 `p3` 的声明移至新作用域 (`{ ... }`)，以产生以下代码："
 
-#: src/structs/tuple-structs.md:37
+#: src/ownership/lifetimes-function-calls.md:57
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics).\n"
-"* The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"Which one is it? The compiler needs to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
+"是哪一个呢？编译器需要知道这一点，因此在调用点，返回的引用 的使用时间不会超过"
+"引用的来源中的变量。"
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics)."
+msgstr "运算符过载在第 3 天（泛型）讨论。"
+
+#: src/structs/tuple-structs.md:43
+msgid ""
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
 "wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
-"* 如需对基元类型中的值的额外信息进行编码，使用 newtype 是一种非常好的方式，例"
-"如：\n"
-"  * 数字会以某些单位来衡量：上方示例中为 `Newtons`。\n"
-"  * 值在创建时已通过一些验证，因此您不再需要在每次使用时都再次验证它："
-"`PhoneNumber(String)` 或 `OddNumber(u32)`。\n"
-"* 展示如何通过访问 newtype 中的单个字段，将 `f64` 值添加到 `Newtons` 类型。\n"
-"  *  Rust 通常不喜欢不明确的内容，例如自动解封或将布尔值用作整数。\n"
-"  *  运算符过载在第 3 天（泛型）讨论。\n"
-"* 此示例巧妙地引用了[火星气候探测者号](https://zh.wikipedia.org/wiki/"
+"此示例巧妙地引用了[火星气候探测者号](https://zh.wikipedia.org/wiki/"
 "%E7%81%AB%E6%98%9F%E6%B0%A3%E5%80%99%E6%8E%A2%E6%B8%AC%E8%80%85%E8%99%9F) 的"
 "失败事故。"


### PR DESCRIPTION
Before, po/zh-CN.po had these statistics:

    693 translated messages, 90 fuzzy translations, 998 untranslated messages.

Afterwards, the statistics for po/zh-CN.po is:

    1079 translated messages, 121 fuzzy translations, 1267 untranslated messages.

The number of translated messages changed from 39% to 44%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.