### PR TITLE
zh-TW: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -5,35 +5,35 @@ msgstr ""
 "PO-Revision-Date: 2023-06-02 14:43+0800\n"
 "Last-Translator: Hank Chen <kuanhungchen@google.com>\n"
 "Language-Team: Traditional Chinese (Taiwan) <zh-l10n@lists.linux.org.tw>\n"
-"Language: zh-TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: zh-TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr ""
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
-msgstr ""
+msgstr "講授課程"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
-msgstr ""
+msgstr "課程架構"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "鍵盤快速鍵"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
-msgstr ""
+msgstr "翻譯"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
-msgstr ""
+msgstr "使用 Cargo"
 
 #: src/SUMMARY.md:9
 msgid "Rust Ecosystem"
@@ -56,55 +56,55 @@ msgstr ""
 msgid "Welcome"
 msgstr ""
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr ""
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr ""
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr ""
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr ""
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr ""
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr ""
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr ""
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr ""
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr ""
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr ""
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr ""
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr ""
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr ""
 
@@ -112,15 +112,16 @@ msgstr ""
 msgid "String vs str"
 msgstr ""
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr ""
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr ""
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr ""
 
@@ -131,10 +132,14 @@ msgstr ""
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
 #: src/SUMMARY.md:251 src/SUMMARY.md:273 src/SUMMARY.md:293
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
+#: src/exercises/concurrency/morning.md:1
+#: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr ""
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr ""
 
@@ -146,11 +151,11 @@ msgstr ""
 msgid "Day 1: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr ""
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr ""
 
@@ -158,29 +163,29 @@ msgstr ""
 msgid "static & const"
 msgstr ""
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr ""
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
-msgstr ""
+msgstr "記憶體管理"
 
 #: src/SUMMARY.md:48
 msgid "Stack vs Heap"
 msgstr ""
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
-msgstr ""
+msgstr "堆疊記憶體"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
-msgstr ""
+msgstr "手動記憶體管理"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
-msgstr ""
+msgstr "作用域式記憶體管理"
 
 #: src/SUMMARY.md:52
 msgid "Garbage Collection"
@@ -190,59 +195,60 @@ msgstr ""
 msgid "Rust Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
-msgstr ""
+msgstr "比較"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
-msgstr ""
+msgstr "所有權"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
-msgstr ""
+msgstr "移動語意"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
-msgstr ""
+msgstr "Rust 中移動的字串"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
-msgstr ""
+msgstr "現代 C++ 中的雙重釋放"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
-msgstr ""
+msgstr "函式呼叫中的移動"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
-msgstr ""
+msgstr "複製和克隆"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
-msgstr ""
+msgstr "借用"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
-msgstr ""
+msgstr "共用借用和專屬借用"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
-msgstr ""
+msgstr "生命週期"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
-msgstr ""
+msgstr "函式呼叫中的生命週期"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
-msgstr ""
+msgstr "資料結構中的生命週期"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr ""
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr ""
 
@@ -250,63 +256,64 @@ msgstr ""
 msgid "Day 2: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
-msgstr ""
+msgstr "結構體"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
-msgstr ""
+msgstr "元組結構體"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
-msgstr ""
+msgstr "欄位簡寫語法"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
-msgstr ""
+msgstr "列舉"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
-msgstr ""
+msgstr "變體負載"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
-msgstr ""
+msgstr "列舉大小"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr ""
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:272
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
-msgstr ""
+msgstr "範例"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr ""
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr ""
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr ""
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr ""
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr ""
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr ""
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr ""
 
@@ -314,13 +321,13 @@ msgstr ""
 msgid "Day 2: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:96 src/SUMMARY.md:286
+#: src/SUMMARY.md:96 src/SUMMARY.md:286 src/control-flow.md:1
 msgid "Control Flow"
-msgstr ""
+msgstr "控制流程"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
-msgstr ""
+msgstr "區塊"
 
 #: src/SUMMARY.md:98
 msgid "if expressions"
@@ -354,17 +361,17 @@ msgstr ""
 msgid "break & continue"
 msgstr ""
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
-msgstr ""
+msgstr "標準函式庫"
 
 #: src/SUMMARY.md:107
 msgid "Option and Result"
 msgstr ""
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
-msgstr ""
+msgstr "String"
 
 #: src/SUMMARY.md:109
 msgid "Vec"
@@ -382,35 +389,37 @@ msgstr ""
 msgid "Recursive Data Types"
 msgstr ""
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
-msgstr ""
+msgstr "區位最佳化"
 
 #: src/SUMMARY.md:114
 msgid "Rc"
 msgstr ""
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr ""
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr ""
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr ""
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr ""
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr ""
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:97
 msgid "Strings and Iterators"
 msgstr ""
 
@@ -418,57 +427,57 @@ msgstr ""
 msgid "Day 3: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/generics.md:1
 msgid "Generics"
-msgstr ""
+msgstr "泛型"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/generics/data-types.md:1
 msgid "Generic Data Types"
-msgstr ""
+msgstr "泛型資料型別"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/generics/methods.md:1
 msgid "Generic Methods"
-msgstr ""
+msgstr "泛型方法"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/generics/monomorphization.md:1
 msgid "Monomorphization"
-msgstr ""
+msgstr "單型化"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits.md:1
 msgid "Traits"
-msgstr ""
+msgstr "特徵"
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/trait-objects.md:1
 msgid "Trait Objects"
-msgstr ""
+msgstr "特徵物件"
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
-msgstr ""
+msgstr "衍生特徵"
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md:136 src/traits/default-methods.md:1
 msgid "Default Methods"
-msgstr ""
+msgstr "預設方法"
 
-#: src/SUMMARY.md:137
+#: src/SUMMARY.md:137 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
-msgstr ""
+msgstr "特徵界限"
 
 #: src/SUMMARY.md:138
 msgid "impl Trait"
 msgstr ""
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/traits/important-traits.md:1
 msgid "Important Traits"
-msgstr ""
+msgstr "重要特徵"
 
 #: src/SUMMARY.md:140
 msgid "Iterator"
 msgstr ""
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/traits/from-iterator.md:1
 msgid "FromIterator"
-msgstr ""
+msgstr "FromIterator"
 
 #: src/SUMMARY.md:142
 msgid "From and Into"
@@ -494,7 +503,8 @@ msgstr ""
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr ""
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr ""
 
@@ -502,13 +512,13 @@ msgstr ""
 msgid "Day 3: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
-msgstr ""
+msgstr "錯誤處理"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
-msgstr ""
+msgstr "恐慌"
 
 #: src/SUMMARY.md:155
 msgid "Catching Stack Unwinding"
@@ -522,91 +532,94 @@ msgstr ""
 msgid "Propagating Errors with ?"
 msgstr ""
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
-msgstr ""
+msgstr "轉換錯誤型別"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
-msgstr ""
+msgstr "推導錯誤列舉"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
-msgstr ""
+msgstr "動態錯誤型別"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
-msgstr ""
+msgstr "為錯誤添加背景資訊"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
 msgstr "測試"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "單元測試"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
-msgstr ""
+msgstr "測試模組"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
-msgstr ""
+msgstr "說明文件測試"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
-msgstr ""
+msgstr "整合測試"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr ""
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
-msgstr ""
+msgstr "不安全的 Rust"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
-msgstr ""
+msgstr "對裸指標解參考"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
-msgstr ""
+msgstr "可變的靜態變數"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
-msgstr ""
+msgstr "聯合體"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
-msgstr ""
+msgstr "呼叫不安全的函式"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
-msgstr ""
+msgstr "編寫不安全的函式"
 
 #: src/SUMMARY.md:175
 msgid "Extern Functions"
 msgstr ""
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
-msgstr ""
+msgstr "實作不安全的特徵"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr ""
 
 #: src/SUMMARY.md:181 src/SUMMARY.md:249
+#: src/running-the-course/course-structure.md:16 src/bare-metal/android.md:1
 msgid "Android"
-msgstr ""
+msgstr "Android"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/android/setup.md:1
 msgid "Setup"
 msgstr ""
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "建構規則"
 
@@ -618,7 +631,7 @@ msgstr ""
 msgid "Library"
 msgstr ""
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/android/aidl.md:1
 msgid "AIDL"
 msgstr ""
 
@@ -634,7 +647,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:194 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr ""
 
@@ -642,15 +655,16 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:196 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "改寫 API"
 
-#: src/SUMMARY.md:197 src/SUMMARY.md:240
+#: src/SUMMARY.md:197 src/SUMMARY.md:240 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr ""
 
@@ -666,7 +680,7 @@ msgstr ""
 msgid "Calling Rust from C"
 msgstr ""
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr ""
 
@@ -690,11 +704,11 @@ msgstr ""
 msgid "alloc"
 msgstr ""
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr ""
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr ""
 
@@ -722,7 +736,7 @@ msgstr ""
 msgid "probe-rs, cargo-embed"
 msgstr ""
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr ""
 
@@ -730,7 +744,8 @@ msgstr ""
 msgid "Other Projects"
 msgstr ""
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:226 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr ""
 
@@ -762,7 +777,7 @@ msgstr ""
 msgid "A Better UART Driver"
 msgstr ""
 
-#: src/SUMMARY.md:236
+#: src/SUMMARY.md:236 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr ""
 
@@ -770,7 +785,7 @@ msgstr ""
 msgid "Multiple Registers"
 msgstr ""
 
-#: src/SUMMARY.md:238
+#: src/SUMMARY.md:238 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr ""
 
@@ -802,7 +817,7 @@ msgstr ""
 msgid "spin"
 msgstr ""
 
-#: src/SUMMARY.md:250
+#: src/SUMMARY.md:250 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr ""
 
@@ -814,25 +829,25 @@ msgstr ""
 msgid "Concurrency: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:260
+#: src/SUMMARY.md:260 src/concurrency/threads.md:1
 msgid "Threads"
-msgstr ""
+msgstr "執行緒"
 
-#: src/SUMMARY.md:261
+#: src/SUMMARY.md:261 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
-msgstr ""
+msgstr "限定範圍執行緒"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:262 src/concurrency/channels.md:1
 msgid "Channels"
-msgstr ""
+msgstr "通道"
 
-#: src/SUMMARY.md:263
+#: src/SUMMARY.md:263 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
-msgstr ""
+msgstr "無界限的通道"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
-msgstr ""
+msgstr "有界限的通道"
 
 #: src/SUMMARY.md:265
 msgid "Send and Sync"
@@ -846,13 +861,13 @@ msgstr ""
 msgid "Sync"
 msgstr ""
 
-#: src/SUMMARY.md:268
+#: src/SUMMARY.md:268 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
-msgstr ""
+msgstr "範例"
 
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md:269 src/concurrency/shared_state.md:1
 msgid "Shared State"
-msgstr ""
+msgstr "共享狀態"
 
 #: src/SUMMARY.md:270
 msgid "Arc"
@@ -863,10 +878,12 @@ msgid "Mutex"
 msgstr ""
 
 #: src/SUMMARY.md:274 src/SUMMARY.md:294
+#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr ""
 
-#: src/SUMMARY.md:275
+#: src/SUMMARY.md:275 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr ""
 
@@ -882,31 +899,32 @@ msgstr ""
 msgid "async/await"
 msgstr ""
 
-#: src/SUMMARY.md:281
+#: src/SUMMARY.md:281 src/async/futures.md:1
 msgid "Futures"
 msgstr ""
 
-#: src/SUMMARY.md:282
+#: src/SUMMARY.md:282 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr ""
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md:283 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr ""
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/exercises/concurrency/link-checker.md:106
+#: src/exercises/concurrency/chat-app.md:140 src/async/tasks.md:1
 msgid "Tasks"
 msgstr ""
 
-#: src/SUMMARY.md:285
+#: src/SUMMARY.md:285 src/async/channels.md:1
 msgid "Async Channels"
 msgstr ""
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:287 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:288
+#: src/SUMMARY.md:288 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
@@ -918,15 +936,16 @@ msgstr ""
 msgid "Blocking the Executor"
 msgstr ""
 
-#: src/SUMMARY.md:291
+#: src/SUMMARY.md:291 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr ""
 
-#: src/SUMMARY.md:292
+#: src/SUMMARY.md:292 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr ""
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md:295 src/exercises/concurrency/chat-app.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:113
 msgid "Broadcast Chat Application"
 msgstr ""
 
@@ -934,7 +953,7 @@ msgstr ""
 msgid "Final Words"
 msgstr ""
 
-#: src/SUMMARY.md:302
+#: src/SUMMARY.md:302 src/thanks.md:1
 msgid "Thanks!"
 msgstr ""
 
@@ -942,11 +961,11 @@ msgstr ""
 msgid "Other Resources"
 msgstr ""
 
-#: src/SUMMARY.md:304
+#: src/SUMMARY.md:304 src/credits.md:1
 msgid "Credits"
-msgstr ""
+msgstr "出處清單"
 
-#: src/SUMMARY.md:307
+#: src/SUMMARY.md:307 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr ""
 
@@ -978,7 +997,7 @@ msgstr ""
 msgid "Bare Metal Rust Morning"
 msgstr ""
 
-#: src/SUMMARY.md:319
+#: src/SUMMARY.md:319 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr ""
 
@@ -988,10 +1007,6 @@ msgstr ""
 
 #: src/SUMMARY.md:321
 msgid "Concurrency Afternoon"
-msgstr ""
-
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
 msgstr ""
 
 #: src/welcome.md:3
@@ -1009,8 +1024,8 @@ msgstr ""
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 msgstr ""
@@ -1023,10 +1038,9 @@ msgstr ""
 msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
 #: src/welcome.md:5
@@ -1043,308 +1057,105 @@ msgstr ""
 #: src/welcome.md:7
 msgid ""
 "This is a three day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
+msgstr ""
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr ""
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
 msgstr ""
 
 #: src/welcome.md:18
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, "
-"you're\n"
-"invited to dive into one or more specialized topics:"
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
 
 #: src/welcome.md:21
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android "
-"platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a full day class on using Rust for bare-"
-"metal\n"
-"  (embedded) development. Both microcontrollers and application processors "
-"are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a full day class on concurrency in Rust. "
-"We\n"
-"  cover both classical concurrency (preemptively scheduling using threads "
-"and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
+msgstr ""
+
+#: src/welcome.md:23
+msgid ""
+"[Bare-metal](bare-metal.md): a full day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+
+#: src/welcome.md:26
+msgid ""
+"[Concurrency](concurrency.md): a full day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
 msgstr ""
 
 #: src/welcome.md:32
-msgid "## Non-Goals"
+msgid "Non-Goals"
 msgstr ""
 
 #: src/welcome.md:34
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 
 #: src/welcome.md:37
 msgid ""
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
 
 #: src/welcome.md:41
-msgid "## Assumptions"
+msgid "Assumptions"
 msgstr ""
 
 #: src/welcome.md:43
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/scalar-types.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/references.md:21
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/methods.md:32 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:100
-#: src/structs.md:29 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums.md:31
-#: src/enums/variant-payloads.md:33 src/enums/sizes.md:27 src/methods.md:28
-#: src/methods/receiver.md:22 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:21
-#: src/control-flow/while-let-expressions.md:24
-#: src/control-flow/for-expressions.md:23
-#: src/control-flow/loop-expressions.md:25
-#: src/control-flow/match-expressions.md:26 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:42 src/exercises/day-2/afternoon.md:5
-#: src/generics/data-types.md:19 src/generics/methods.md:23
-#: src/traits/trait-objects.md:70 src/traits/default-methods.md:30
-#: src/traits/trait-bounds.md:33 src/traits/impl-trait.md:21
-#: src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/drop.md:32 src/traits/default.md:38
-#: src/traits/operators.md:24 src/traits/closures.md:23
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:46
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:25 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:5
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/android/morning.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:37 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart.md:53 src/bare-metal/aps/uart/traits.md:22
-#: src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:49 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:44
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/scoped-threads.md:35 src/concurrency/channels.md:25
-#: src/concurrency/send-sync.md:18 src/concurrency/send-sync/send.md:11
-#: src/concurrency/send-sync/sync.md:12 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21
-#: src/exercises/concurrency/morning.md:10 src/async/async-await.md:23
-#: src/async/futures.md:30 src/async/runtimes.md:18
-#: src/async/runtimes/tokio.md:31 src/async/tasks.md:51
-#: src/async/channels.md:33 src/async/control-flow/join.md:34
-#: src/async/control-flow/select.md:59
-#: src/async/pitfalls/blocking-executor.md:27 src/async/pitfalls/pin.md:66
-#: src/exercises/concurrency/afternoon.md:11
-#: src/exercises/concurrency/dining-philosophers-async.md:75
-msgid "<details>"
-msgstr "<details>"
-
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
-#: src/why-rust/modern.md:66 src/basic-syntax/scalar-types.md:43
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:29
-#: src/basic-syntax/slices.md:36 src/basic-syntax/string-slices.md:44
-#: src/basic-syntax/functions.md:41 src/basic-syntax/rustdoc.md:33
-#: src/basic-syntax/methods.md:45 src/basic-syntax/functions-interlude.md:30
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:104
-#: src/structs.md:42 src/structs/tuple-structs.md:43
-#: src/structs/field-shorthand.md:72 src/enums.md:41
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:28 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:29
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:46
-#: src/control-flow/if-expressions.md:37
-#: src/control-flow/if-let-expressions.md:41
-#: src/control-flow/while-let-expressions.md:29
-#: src/control-flow/for-expressions.md:30
-#: src/control-flow/loop-expressions.md:32
-#: src/control-flow/match-expressions.md:33 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:42 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:71 src/exercises/day-2/afternoon.md:11
-#: src/generics/data-types.md:25 src/generics/methods.md:31
-#: src/traits/trait-objects.md:83 src/traits/default-methods.md:60
-#: src/traits/trait-bounds.md:50 src/traits/impl-trait.md:44
-#: src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/drop.md:42 src/traits/default.md:47
-#: src/traits/operators.md:38 src/traits/closures.md:38
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:53
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:43 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:11
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/android/morning.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:49
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/inline-assembly.md:58 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:55 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:49
-#: src/bare-metal/useful-crates/zerocopy.md:53
-#: src/bare-metal/useful-crates/aarch64-paging.md:33
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
-#: src/bare-metal/useful-crates/tinyvec.md:26
-#: src/bare-metal/useful-crates/spin.md:30 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/scoped-threads.md:40 src/concurrency/channels.md:32
-#: src/concurrency/send-sync.md:23 src/concurrency/send-sync/send.md:16
-#: src/concurrency/send-sync/sync.md:18 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56
-#: src/exercises/concurrency/morning.md:16 src/async/async-await.md:48
-#: src/async/futures.md:45 src/async/runtimes.md:29
-#: src/async/runtimes/tokio.md:49 src/async/tasks.md:64
-#: src/async/channels.md:49 src/async/control-flow/join.md:50
-#: src/async/control-flow/select.md:77
-#: src/async/pitfalls/blocking-executor.md:50 src/async/pitfalls/pin.md:112
-#: src/async/pitfalls/async-traits.md:63
-#: src/exercises/concurrency/afternoon.md:17
-#: src/exercises/concurrency/dining-philosophers-async.md:79
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# 講授課程"
-
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> 本頁面的適用對象為課程講師。"
+msgid "This page is for the course instructor."
+msgstr "本頁面的適用對象為課程講師。"
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
+"course internally at Google."
 msgstr "以下提供一些背景資訊，說明 Google 內部近期採用的授課方式。"
 
 #: src/running-the-course.md:8
@@ -1353,172 +1164,160 @@ msgstr "在講授課程前，建議您注意下列事項："
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   to help highlight the key points (please help us by contributing more "
-"speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes "
-"in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). "
-"This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Decide on the dates. Since the course takes at least three full days, we "
-"recommend that you\n"
-"   schedule the days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-25 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself "
-"and for the\n"
-"   students: you will all need to be able to sit and work with your "
-"laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, "
-"so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups.\n"
-"   We typically spend 30-45 minutes on exercises in the morning and in the "
-"afternoon (including time to review the solutions).\n"
-"   Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. 請熟悉課程教材。我們已附上演講者備忘稿，協助突顯重點，也請您不吝提供更多演"
-"講者備忘稿內容！分享螢幕畫面時，請務必在彈出式視窗中開啟演講者備忘稿 (按一下"
+"請熟悉課程教材。我們已附上演講者備忘稿，協助突顯重點，也請您不吝提供更多演講"
+"者備忘稿內容！分享螢幕畫面時，請務必在彈出式視窗中開啟演講者備忘稿 (按一下"
 "「Speaker Notes」旁小箭頭的連結)。如此一來，您就能在課堂上分享簡潔的螢幕畫"
-"面。\n"
-"\n"
-"1. 請決定授課日期。由於課程長度至少為三個整天，建議您將授課日分散安排在兩週內。課"
-"程參與者曾表示，如果課程中間有間隔，可協助他們消化我們提供的所有資訊，對學習"
-"效果有助益。\n"
-"\n"
-"1. 找到可容納現場參與者的場地。建議的開班人數為 15 至 25 人。這樣的小班制教學"
-"可讓學員自在地提問，講師也有時間可以回答問題。請確認上課場地有_書桌_，可供講"
-"師和學員使用：您們都會需要能坐著使用筆電。\n"
-" 講師尤其會需要現場編寫許多程式碼，因此使用講台可能會造成不便。\n"
-"\n"
-"1. 在講課當天提早到上課場地完成設定。建議您直接在筆電上執行 `mdbook serve`"
-" 分享螢幕畫面 (請參閱[安裝操作說明][3])。這可確保提供最佳效能，不會在您"
-"切換頁面時發生延遲。使用筆電也可讓您修正自己或課程參與者發現的錯字。\n"
-"\n"
-"1. 讓學員獨自或分成小組做習題。我們通常會在早上和下午各安排 30 至 45 分鐘的時"
-"間做習題，這包含檢討解題方式的時間。請務必詢問學員是否遇到難題，或需要您的協"
+"面。"
+
+#: src/running-the-course.md:16
+msgid ""
+"Decide on the dates. Since the course takes at least three full days, we "
+"recommend that you schedule the days over two weeks. Course participants "
+"have said that they find it helpful to have a gap in the course since it "
+"helps them process all the information we give them."
+msgstr ""
+"請決定授課日期。由於課程長度至少為三個整天，建議您將授課日分散安排在兩週內。"
+"課程參與者曾表示，如果課程中間有間隔，可協助他們消化我們提供的所有資訊，對學"
+"習效果有助益。"
+
+#: src/running-the-course.md:21
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-25 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"找到可容納現場參與者的場地。建議的開班人數為 15 至 25 人。這樣的小班制教學可"
+"讓學員自在地提問，講師也有時間可以回答問題。請確認上課場地有_書桌\\_，可供講"
+"師和學員使用：您們都會需要能坐著使用筆電。 講師尤其會需要現場編寫許多程式碼，"
+"因此使用講台可能會造成不便。"
+
+#: src/running-the-course.md:29
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"在講課當天提早到上課場地完成設定。建議您直接在筆電上執行 `mdbook serve` 分享"
+"螢幕畫面 (請參閱[安裝操作說明](https://github.com/google/comprehensive-"
+"rust#building))。這可確保提供最佳效能，不會在您切換頁面時發生延遲。使用筆電也"
+"可讓您修正自己或課程參與者發現的錯字。"
+
+#: src/running-the-course.md:35
+msgid ""
+"Let people solve the exercises by themselves or in small groups. We "
+"typically spend 30-45 minutes on exercises in the morning and in the "
+"afternoon (including time to review the solutions). Make sure to ask people "
+"if they're stuck or if there is anything you can help with. When you see "
+"that several people have the same problem, call it out to the class and "
+"offer a solution, e.g., by showing people where to find the relevant "
+"information in the standard library."
+msgstr ""
+"讓學員獨自或分成小組做習題。我們通常會在早上和下午各安排 30 至 45 分鐘的時間"
+"做習題，這包含檢討解題方式的時間。請務必詢問學員是否遇到難題，或需要您的協"
 "助。如果發現多位學員遇到相同問題，請向全班說明該問題，並提供解決方式：例如示"
 "範如何在標準程式庫 (The Rust Standard Library) 找到相關資訊。"
 
 #: src/running-the-course.md:43
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
+"for you as it has been for us!"
 msgstr "以上為所有注意事項，祝您授課順利，並和我們一樣樂在其中！"
 
 #: src/running-the-course.md:46
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"請在授課後[提供意見回饋][1]，協助我們持續改善課程。您可以與我們分享您滿意的部"
-"分，以及值得改善的地方。也歡迎您的學生[提供意見回饋][2]！"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# 課程架構"
+"請在授課後[提供意見回饋](https://github.com/google/comprehensive-rust/"
+"discussions/86)，協助我們持續改善課程。您可以與我們分享您滿意的部分，以及值得"
+"改善的地方。也歡迎您的學生[提供意見回饋](https://github.com/google/"
+"comprehensive-rust/discussions/100)！"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "本課程步調快速，涵蓋許多層面："
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
 msgstr ""
-"* 第 1 天：Rust 基礎知識、擁有權 (ownership) 與借用檢查器 (borrow checker)。\n"
-"* 第 2 天：複合資料型別、模式比對 (pattern matching)、標準程式庫。\n"
-"* 第 3 天：特徵 (traits) 與泛型 (generics)、錯誤處理、測試、不安全的 Rust。"
+"第 1 天：Rust 基礎知識、擁有權 (ownership) 與借用檢查器 (borrow checker)。"
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
+msgstr "第 2 天：複合資料型別、模式比對 (pattern matching)、標準程式庫。"
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr ""
+"第 3 天：特徵 (traits) 與泛型 (generics)、錯誤處理、測試、不安全的 Rust。"
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
-msgstr "## 深入探索"
+msgid "Deep Dives"
+msgstr "深入探索"
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
 msgstr "除了為期 3 天的 Rust 基礎知識課程，我們也涵蓋更多專門主題："
-
-#: src/running-the-course/course-structure.md:16
-msgid "### Android"
-msgstr "### Android"
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
 "The [Android Deep Dive](../android.md) is a half-day course on using Rust "
-"for\n"
-"Android platform development. This includes interoperability with C, C++, "
-"and\n"
-"Java."
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
 "[Android 深入探索](../android.md)是半天的課程，會說明如何針對 Android 平台開"
 "發作業使用 Rust，以及與 C、C++ 和 Java 的互通性。"
 
 #: src/running-the-course/course-structure.md:22
 msgid ""
-"You will need an [AOSP checkout][1]. Make a checkout of the [course\n"
-"repository][2] on the same machine and move the `src/android/` directory "
-"into\n"
-"the root of your AOSP checkout. This will ensure that the Android build "
-"system\n"
-"sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"您會需要進行 [Android 開放原始碼計畫檢查][1]。請檢查[課程存放區][2]上相同的機"
-"器，並將 `src/android/` 目錄移至 Android 開放原始碼計畫檢查的根層級。這可確"
-"保 Android 建構系統在 `src/android/` 中看到 `Android.bp` 檔案。"
+"您會需要進行 [Android 開放原始碼計畫檢查](https://source.android.com/docs/"
+"setup/download/downloading)。請檢查[課程存放區](https://github.com/google/"
+"comprehensive-rust)上相同的機器，並將 `src/android/` 目錄移至 Android 開放原"
+"始碼計畫檢查的根層級。這可確保 Android 建構系統在 `src/android/` 中看到 "
+"`Android.bp` 檔案。"
 
 #: src/running-the-course/course-structure.md:27
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
-"all\n"
-"Android examples using `src/android/build_all.sh`. Read the script to see "
-"the\n"
-"commands it runs and make sure they work when you run them by hand."
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
 "請確保 `adb sync` 可與模擬器或實際裝置搭配使用，並運用 `src/android/"
 "build_all.sh` 預先建構所有 Android 範例。請閱讀指令碼，瞭解指令碼執行的指令，"
 "並確保可以手動執行指令。"
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
-msgstr "### 裸機"
+msgid "Bare-Metal"
+msgstr "裸機"
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
 "The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
-"for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
 "[裸機深入探索](../bare-metal.md)是一整天的課程，會說明如何使用 Rust 進行裸機 "
@@ -1526,25 +1325,23 @@ msgstr ""
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
-"針對微控制器，您會需要預先購買 [BBC\n"
-"micro:bit](https://microbit.org/) 第 2 版開發板。此外，所有人都需要按照[歡迎"
-"頁面](../bare-metal.md)上的指示安裝多種套件。"
+"針對微控制器，您會需要預先購買 [BBC micro:bit](https://microbit.org/) 第 2 版"
+"開發板。此外，所有人都需要按照[歡迎頁面](../bare-metal.md)上的指示安裝多種套"
+"件。"
 
 #: src/running-the-course/course-structure.md:45
-msgid "### Concurrency"
-msgstr "### 並行"
+msgid "Concurrency"
+msgstr "並行"
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
 "The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
-"classical\n"
-"as well as `async`/`await` concurrency."
+"classical as well as `async`/`await` concurrency."
 msgstr ""
 "[並行深入探索](../concurrency.md)是一整天的課程，會說明傳統並行與 `async`/"
 "`await` 並行。"
@@ -1552,10 +1349,8 @@ msgstr ""
 #: src/running-the-course/course-structure.md:50
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
-"to\n"
-"go. You can then copy/paste the examples into `src/main.rs` to experiment "
-"with\n"
-"them:"
+"to go. You can then copy/paste the examples into `src/main.rs` to experiment "
+"with them:"
 msgstr ""
 "您會需要設定新的 Crate，然後下載並準備執行依附元件。接著就能將範例複製貼上至 "
 "`src/main.rs`，使用這些範例進行實驗："
@@ -1577,52 +1372,76 @@ msgstr ""
 "```"
 
 #: src/running-the-course/course-structure.md:61
-msgid "## Format"
-msgstr "## 形式"
+msgid "Format"
+msgstr "形式"
 
 #: src/running-the-course/course-structure.md:63
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr "本課程極具互動性，因此建議您根據各項疑問，帶領學員瞭解 Rust！"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# 鍵盤快速鍵"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "以下為 mdBook 中實用的鍵盤快速鍵："
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>向左鍵</kbd>：前往上一頁。\n"
-"* <kbd>向右鍵</kbd>：前往下一頁。\n"
-"* <kbd>Ctrl + Enter</kbd>：執行具有焦點的程式碼範例。\n"
-"* <kbd>s</kbd>：啟用搜尋列。"
+msgid "Arrow-Left"
+msgstr "向左鍵"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# 翻譯"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr "：前往上一頁。"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "向右鍵"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr "：前往下一頁。"
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr "：執行具有焦點的程式碼範例。"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr "：啟用搜尋列。"
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
 msgstr "本課程已由一群優秀的志工翻譯成其他語言："
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
 msgstr ""
-"* [巴西葡萄牙文]][pt-BR]譯者：[@rastringer] 和 [@hugojacob]。\n"
-"* [韓文][ko]譯者：[@keispace]、[@jiyongp] 和 [@jooyunghan]。"
+"\\[巴西葡萄牙文\\]\\][pt-BR](https://google.github.io/comprehensive-rust/pt-"
+"BR/)譯者：[@rastringer](https://github.com/rastringer) 和 [@hugojacob]"
+"(https://github.com/hugojacob)。"
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
+msgstr ""
+"[韓文](https://google.github.io/comprehensive-rust/ko/)譯者：[@keispace]"
+"(https://github.com/keispace)、[@jiyongp](https://github.com/jiyongp) 和 "
+"[@jooyunghan](https://github.com/jooyunghan)。"
 
 #: src/running-the-course/translations.md:9
 msgid ""
@@ -1630,68 +1449,78 @@ msgid ""
 msgstr "使用右上角的語言選單即可切換語言。"
 
 #: src/running-the-course/translations.md:11
-msgid "## Incomplete Translations"
-msgstr "## 不完整翻譯"
+msgid "Incomplete Translations"
+msgstr "不完整翻譯"
 
 #: src/running-the-course/translations.md:13
 msgid ""
-"There is a large number of in-progress translations. We link to the most\n"
+"There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr "目前有許多正在翻譯的語言版本。以下連結為最近更新的翻譯："
 
 #: src/running-the-course/translations.md:16
 msgid ""
-"* [French][fr] by [@KookaS] and [@vcaen].\n"
-"* [German][de] by [@Throvn] and [@ronaldfw].\n"
-"* [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105]."
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
-"* [法文][fr]譯者：[@KookaS] 和 [@vcaen]。\n"
-"* [德文][de]譯者：[@Throvn]和 [@ronaldfw]。\n"
-"* [日文][ja]譯者：[@] CoinEZ-JPN] 和 [@momotaro1105]。"
+"[法文](https://google.github.io/comprehensive-rust/fr/)譯者：[@KookaS]"
+"(https://github.com/KookaS) 和 [@vcaen](https://github.com/vcaen)。"
+
+#: src/running-the-course/translations.md:17
+msgid ""
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+msgstr ""
+"[德文](https://google.github.io/comprehensive-rust/de/)譯者：[@Throvn]"
+"(https://github.com/Throvn)和 [@ronaldfw](https://github.com/ronaldfw)。"
+
+#: src/running-the-course/translations.md:18
+msgid ""
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
+msgstr ""
+"[日文](https://google.github.io/comprehensive-rust/ja/)譯者：\\[@\\] CoinEZ-"
+"JPN\\] 和 [@momotaro1105](https://github.com/momotaro1105)。"
 
 #: src/running-the-course/translations.md:20
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"如果想協助翻譯，請參閱[操作說明]，瞭解如何開始翻譯。譯者可以在[問題追蹤工具]"
-"上討論及統整翻譯。"
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# 使用 Cargo"
+"如果想協助翻譯，請參閱\\[操作說明\\]，瞭解如何開始翻譯。譯者可以在\\[問題追蹤"
+"工具\\]上討論及統整翻譯。"
 
 #: src/cargo.md:3
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
 "您開始閱讀 Rust 內容後，很快就會認識 [Cargo](https://doc.rust-lang.org/"
 "cargo/)，這是在 Rust 生態系統中使用的標準工具，用於建構及執行 Rust 應用程式。"
 "以下簡要介紹 Cargo，以及如何在更廣大的生態系統和本訓練課程中運用 Cargo。"
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## 安裝"
+msgid "Installation"
+msgstr "安裝"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (建議)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (建議)"
 
 #: src/cargo.md:12
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
 "您可以按照指示安裝 Cargo 和 Rust 編譯器，並運用 Rust Foundation 維護的 "
-"[rustup][3] 工具安裝其他標準生態系統工具。"
+"[rustup](https://rust-analyzer.github.io/) 工具安裝其他標準生態系統工具。"
 
 #: src/cargo.md:14
 msgid ""
@@ -1703,20 +1532,20 @@ msgstr ""
 "裝/切換工具鏈、設定跨平台程式碼編譯等。"
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### 套件管理員"
+msgid "Package Managers"
+msgstr "套件管理員"
 
 #: src/cargo.md:18
-msgid "#### Debian"
-msgstr "#### Debian"
+msgid "Debian"
+msgstr "Debian"
 
 #: src/cargo.md:20
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
-"您可以在 Debian/Ubuntu 上使用下列程式碼，安裝 Cargo、Rust 原始碼和 [Rust 格式設"
-"定工具][6]："
+"您可以在 Debian/Ubuntu 上使用下列程式碼，安裝 Cargo、Rust 原始碼和 [Rust 格式"
+"設定工具](https://github.com/rust-lang/rustfmt)："
 
 #: src/cargo.md:22
 msgid ""
@@ -1730,27 +1559,30 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"這樣一來，[rust-analyzer][1] 就能跳至定義。建議您使用 [VS Code][2] 編輯程式"
-"碼，不過任何與 LSP 相容的編輯器都能運作。"
+"這樣一來，\\[rust-analyzer\\]\\[1\\] 就能跳至定義。建議您使用 [VS Code]"
+"(https://code.visualstudio.com/) 編輯程式碼，不過任何與 LSP 相容的編輯器都能"
+"運作。"
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"有些人也偏好使用 [JetBrains][4] 系列的 IDE，這些工具會自行分析，但也各有缺"
-"點。如果您偏好這些工具，可以安裝 [Rust 外掛程式][5]。請注意，自 2023 年 1 月"
-"起，偵錯功能僅適用於 JetBrains IDEA 套件的 CLion 版本。"
+"有些人也偏好使用 [JetBrains](https://www.jetbrains.com/clion/) 系列的 IDE，這"
+"些工具會自行分析，但也各有缺點。如果您偏好這些工具，可以安裝 [Rust 外掛程式]"
+"(https://www.jetbrains.com/rust/)。請注意，自 2023 年 1 月起，偵錯功能僅適用"
+"於 JetBrains IDEA 套件的 CLion 版本。"
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# Rust 生態系統"
+msgid "The Rust Ecosystem"
+msgstr "Rust 生態系統"
 
 #: src/cargo/rust-ecosystem.md:3
 msgid ""
@@ -1759,33 +1591,32 @@ msgstr "Rust 生態系統包含多項工具，以下列出主要工具："
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
+msgstr "`rustc`：Rust 編譯器，可將 `.rs` 檔案轉換成二進位檔和其他中繼格式。"
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
 msgstr ""
-"* `rustc`：Rust 編譯器，可將 `.rs` 檔案轉換成二進位檔和其他中繼格式。\n"
-"\n"
-"* `cargo`：Rust 依附元件管理工具和建構工具。Cargo 知道如何下載 <https://"
-"crates.io> 上代管的依附元件，且會在建構您的專案時，將這些依附元件傳送至 "
-"`rustc`。Cargo 也提供內建測試執行元件，可用於執行單元測試。\n"
-"\n"
-"* `rustup`：Rust 工具鍊安裝程式和更新程式。新版 Rust 推出時，這項工具可用來安"
-"裝及更新 `rustc` 和 `cargo`。此外，`rustup` 也可以下載標準程式庫的說明文件。"
-"您可以一次安裝多個 Rust 版本，並視需要使用 `rustup` 切換版本。"
+"`cargo`：Rust 依附元件管理工具和建構工具。Cargo 知道如何下載 <https://crates."
+"io> 上代管的依附元件，且會在建構您的專案時，將這些依附元件傳送至 `rustc`。"
+"Cargo 也提供內建測試執行元件，可用於執行單元測試。"
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
+"`rustup`：Rust 工具鍊安裝程式和更新程式。新版 Rust 推出時，這項工具可用來安裝"
+"及更新 `rustc` 和 `cargo`。此外，`rustup` 也可以下載標準程式庫的說明文件。您"
+"可以一次安裝多個 Rust 版本，並視需要使用 `rustup` 切換版本。"
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1800,83 +1631,115 @@ msgstr "重要須知："
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust 的發布時程相當緊湊，每六週就會推出新版本。新版本可與舊版本回溯相容，且"
-"會啟用新功能。\n"
-"\n"
-"* 發布版本 (release channel) 分為三種：「穩定版」、「Beta 版」和「Nightly "
-"版」。\n"
-"\n"
-"* 「Nightly 版」會用於測試新功能，「Beta 版」則會每六週成為「穩定版」。\n"
-"\n"
-"* Rust 還具有[版本] (edition)：目前版本為 Rust 2021。先前版本為 Rust 2015 和 "
-"Rust 2018。\n"
-"\n"
-"  * 這些版本可針對語言進行回溯不相容的變更。\n"
-"\n"
-"  * 為避免破壞程式碼，版本皆為自行選擇採用：您可以透過 `Cargo.toml` 檔案選擇"
-"所需版本。\n"
-"\n"
-"  * 為避免分割生態系統，Rust 編譯器可混合寫給不同版本的程式碼。\n"
-"\n"
-"  * 請說明很少會略過 `cargo` 直接使用編譯器，大部分使用者都不會這麼做。\n"
-"\n"
-"  * 可以考慮暗示 Cargo 本身是極其強大且功能全面的工具，具有許多進階功能，包括"
-"但不限於：\n"
-"      * 專案/套件結構\n"
-"      * [工作區]\n"
-"      * 開發人員依附元件和執行階段依附元件管理/快取\n"
-"      * [建構指令碼]\n"
-"      * [全域安裝]\n"
-"      * 此外，還可以擴充使用子指令外掛程式，例如 [cargo clippy]\n"
-"  * 詳情請參閱[官方的 Cargo 手冊]。"
+"Rust 的發布時程相當緊湊，每六週就會推出新版本。新版本可與舊版本回溯相容，且會"
+"啟用新功能。"
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr ""
+"發布版本 (release channel) 分為三種：「穩定版」、「Beta 版」和「Nightly "
+"版」。"
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr "「Nightly 版」會用於測試新功能，「Beta 版」則會每六週成為「穩定版」。"
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"Rust 還具有\\[版本\\] (edition)：目前版本為 Rust 2021。先前版本為 Rust 2015 "
+"和 Rust 2018。"
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "這些版本可針對語言進行回溯不相容的變更。"
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"為避免破壞程式碼，版本皆為自行選擇採用：您可以透過 `Cargo.toml` 檔案選擇所需"
+"版本。"
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr "為避免分割生態系統，Rust 編譯器可混合寫給不同版本的程式碼。"
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr "請說明很少會略過 `cargo` 直接使用編譯器，大部分使用者都不會這麼做。"
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+"可以考慮暗示 Cargo 本身是極其強大且功能全面的工具，具有許多進階功能，包括但不"
+"限於："
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "專案/套件結構"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr "\\[工作區\\]"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr "開發人員依附元件和執行階段依附元件管理/快取"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr "\\[建構指令碼\\]"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr "\\[全域安裝\\]"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"此外，還可以擴充使用子指令外掛程式，例如 [cargo clippy](https://github.com/"
+"rust-lang/rust-clippy)"
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr "詳情請參閱\\[官方的 Cargo 手冊\\]。"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# 本訓練課程的程式碼範例"
+msgid "Code Samples in This Training"
+msgstr "本訓練課程的程式碼範例"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
 "在本訓練課程中，我們主要會透過範例瞭解 Rust 語言，這些範例可在瀏覽器中執行。"
 "這麼做可讓設定程序更輕鬆，並確保所有人獲得一致的體驗。"
@@ -1884,10 +1747,8 @@ msgstr ""
 #: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
 "我們仍建議安裝 Cargo，方便您更輕鬆做習題。在最後一天，我們會做規模較大的習"
 "題，讓您瞭解如何使用依附元件，而這需要使用 Cargo。"
@@ -1911,51 +1772,53 @@ msgstr ""
 "```"
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
-msgstr "當焦點位於文字方塊時，按下 <kbd>Ctrl + Enter</kbd> 鍵即可執行程式碼。"
+msgid "You can use "
+msgstr "當焦點位於文字方塊時，按下 "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr " 鍵即可執行程式碼。"
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
 "大部分程式碼範例都可供編輯，如上所示。有些程式碼範例無法編輯，原因如下："
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* 嵌入式遊樂場無法執行單元測試。請複製貼上程式碼，然後在實際的 Playground 中"
-"開啟，即可示範單元測試。\n"
-"\n"
-"* 當您一離開頁面，嵌入式遊樂場就會失去目前狀態！因此，學生應使用本機 Rust 安"
-"裝項目或透過 Playground 來做習題。"
+"嵌入式遊樂場無法執行單元測試。請複製貼上程式碼，然後在實際的 Playground 中開"
+"啟，即可示範單元測試。"
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"當您一離開頁面，嵌入式遊樂場就會失去目前狀態！因此，學生應使用本機 Rust 安裝"
+"項目或透過 Playground 來做習題。"
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# 使用 Cargo 在本機執行程式碼"
+msgid "Running Code Locally with Cargo"
+msgstr "使用 Cargo 在本機執行程式碼"
 
 #: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
 "如果想在自己的系統上進行程式碼實驗，您會需要先安裝 Rust。請按照 [Rust 手冊中"
-"的指示][1]操作。您應會獲得正常運作的 `rustc` 和 `cargo`。截至本文撰寫時間，最"
-"新的 Rust 穩定版具有下列版本編號："
+"的指示](https://doc.rust-lang.org/book/ch01-01-installation.html)操作。您應會"
+"獲得正常運作的 `rustc` 和 `cargo`。截至本文撰寫時間，最新的 Rust 穩定版具有下"
+"列版本編號："
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -1975,145 +1838,156 @@ msgstr ""
 
 #: src/cargo/running-locally.md:15
 msgid ""
-"With this in place, follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this in place, follow these steps to build a Rust binary from one of "
+"the examples in this training:"
 msgstr ""
 "完成上述步驟後，請按照下列步驟操作，在本訓練課程的任一範例中建構 Rust 二進位"
 "檔："
 
 #: src/cargo/running-locally.md:18
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr "在要複製的範例中，按一下「Copy to clipboard」按鈕。"
+
+#: src/cargo/running-locally.md:20
 msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in `target/"
-"debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr "使用 `cargo new exercise`，為程式碼建立新的 `exercise/` 目錄："
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
 msgstr ""
-"1. 在要複製的範例中，按一下「Copy to clipboard」按鈕。\n"
-"\n"
-"2. 使用 `cargo new exercise`，為程式碼建立新的 `exercise/` 目錄：\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. 前往 `exercise/`，使用 `cargo run` 建構並執行二進位檔：\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. 將 `src/main.rs` 中的樣板程式碼替換為自己的程式碼。以上一頁的範例為例，替"
-"換後的 `src/main.rs` 會類似如下：\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. 使用 `cargo run` 建構並執行更新版二進位檔：\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. 使用 `cargo check` 快速檢查專案中是否有錯誤，並使用 `cargo build` 在不執行"
-"的情況下編譯專案。您會在 `target/debug/` 中看到一般偵錯版本的輸出內容。使用 "
-"`cargo build --release`，在 `target/release/` 中產生經過最佳化的發布子版"
-"本。\n"
-"\n"
-"7. 只要編輯 `Cargo.toml`，即可為專案新增依附元件。執行 `cargo` 指令時，系統會"
-"自動下載及編譯缺少的依附元件。"
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr "前往 `exercise/`，使用 `cargo run` 建構並執行二進位檔："
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+"將 `src/main.rs` 中的樣板程式碼替換為自己的程式碼。以上一頁的範例為例，替換後"
+"的 `src/main.rs` 會類似如下："
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr "使用 `cargo run` 建構並執行更新版二進位檔："
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+"使用 `cargo check` 快速檢查專案中是否有錯誤，並使用 `cargo build` 在不執行的"
+"情況下編譯專案。您會在 `target/debug/` 中看到一般偵錯版本的輸出內容。使用 "
+"`cargo build --release`，在 `target/release/` 中產生經過最佳化的發布子版本。"
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
+msgstr ""
+"只要編輯 `Cargo.toml`，即可為專案新增依附元件。執行 `cargo` 指令時，系統會自"
+"動下載及編譯缺少的依附元件。"
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
 "建議您鼓勵課程參與者安裝 Cargo 及使用本機編輯器。這麼做能提供正常的開發環境，"
 "降低操作難度。"
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
+msgid "Welcome to Day 1"
 msgstr ""
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr ""
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
+msgstr ""
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
 msgstr ""
 
 #: src/welcome-day-1.md:16
@@ -2122,77 +1996,113 @@ msgstr ""
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i."
-"e.,\n"
-"    keep the discussions related to how Rust does things vs some other "
-"language. \n"
-"    It can be hard to find the right balance, but err on the side of "
-"allowing \n"
-"    discussions since they engage people much more than one-way "
-"communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
+msgstr ""
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr ""
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
+msgstr ""
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
 msgstr ""
 
 #: src/welcome-day-1.md:29
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr ""
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
 msgstr ""
 
 #: src/welcome-day-1.md:39
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
-msgstr ""
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
+"breaks, we recommend a break every hour!"
 msgstr ""
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
 
 #: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
 msgstr ""
 
 #: src/welcome-day-1/what-is-rust.md:21
@@ -2200,21 +2110,28 @@ msgid "Rust fits in the same area as C++:"
 msgstr ""
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
+msgid "High flexibility."
 msgstr ""
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr ""
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
 msgstr ""
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
 
@@ -2232,44 +2149,55 @@ msgid "What you see:"
 msgstr ""
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr ""
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr ""
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr ""
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr ""
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
 
 #: src/hello-world.md:22
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude."
-"md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/"
-"hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr ""
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
 msgstr ""
 
 #: src/hello-world/small-example.md:3
@@ -2298,37 +2226,38 @@ msgstr ""
 #: src/hello-world/small-example.md:23
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::"
-"fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library."
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
 
-#: src/why-rust.md:1
-msgid "# Why Rust?"
+#: src/hello-world/small-example.md:32
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr ""
+
+#: src/hello-world/small-example.md:34
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+
+#: src/hello-world/small-example.md:37
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+
+#: src/hello-world/small-example.md:40
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
 msgstr ""
 
 #: src/why-rust.md:3
@@ -2336,40 +2265,37 @@ msgid "Some unique selling points of Rust:"
 msgstr ""
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
+msgid "Compile time memory safety."
+msgstr ""
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr ""
+
+#: src/why-rust.md:7
+msgid "Modern language features."
 msgstr ""
 
 #: src/why-rust.md:11
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
 msgstr ""
 
 #: src/why-rust/compile-time.md:3
@@ -2377,43 +2303,72 @@ msgid "Static memory management at compile time:"
 msgstr ""
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
+msgid "No uninitialized variables."
+msgstr ""
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr ""
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr ""
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr ""
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr ""
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr ""
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr ""
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
 msgstr ""
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr ""
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
+msgstr ""
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
 msgstr ""
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
-msgstr ""
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
 
 #: src/why-rust/runtime.md:3
@@ -2421,26 +2376,27 @@ msgid "No undefined behavior at runtime:"
 msgstr ""
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
+msgid "Array access is bounds checked."
+msgstr ""
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
 msgstr ""
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
 
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
+#: src/why-rust/runtime.md:17
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
 msgstr ""
 
 #: src/why-rust/modern.md:3
@@ -2448,82 +2404,113 @@ msgid "Rust is built with all the experience gained in the last 40 years."
 msgstr ""
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
+msgid "Language Features"
 msgstr ""
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
+msgid "Enums and pattern matching."
+msgstr ""
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr ""
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr ""
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
 msgstr ""
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
+msgid "Tooling"
 msgstr ""
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
+msgid "Great compiler errors."
+msgstr ""
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr ""
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr ""
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
 msgstr ""
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
 
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr ""
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr ""
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
 msgstr ""
 
 #: src/basic-syntax.md:3
@@ -2531,36 +2518,102 @@ msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr ""
 
 #: src/basic-syntax.md:5
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/"
-"* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
+msgid "Blocks and scopes are delimited by curly braces."
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
+#: src/basic-syntax.md:6
+msgid ""
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:3
-msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | "
-"`\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr ""
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Types"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Booleans"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`bool`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`true`, `false`"
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:12
@@ -2568,11 +2621,19 @@ msgid "The types have widths as follows:"
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:14
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:15
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:16
+msgid "`char` is 32 bit wide,"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:17
+msgid "`bool` is 8 bit wide."
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:21
@@ -2581,42 +2642,57 @@ msgstr ""
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:27
 msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:8
@@ -2655,24 +2731,28 @@ msgstr ""
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
-"compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:47
@@ -2680,27 +2760,31 @@ msgid "Tuples:"
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:49
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
+msgid "Like arrays, tuples have a fixed length."
 msgstr ""
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
+#: src/basic-syntax/compound-types.md:51
+msgid "Tuples group together values of different types into a compound type."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
 msgstr ""
 
 #: src/basic-syntax/references.md:3
@@ -2725,26 +2809,28 @@ msgstr ""
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
+msgstr ""
+
+#: src/basic-syntax/references.md:17
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
 msgstr ""
 
 #: src/basic-syntax/references.md:25
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
-msgstr ""
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:3
@@ -2766,15 +2852,17 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
+msgid "A reference is said to \"borrow\" the value it refers to."
 msgstr ""
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
 msgstr ""
 
 #: src/basic-syntax/slices.md:3
@@ -2795,42 +2883,60 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
+msgid "Slices borrow data from the sliced type."
+msgstr ""
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
 msgstr ""
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr ""
+
+#: src/basic-syntax/slices.md:22
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use "
-"`&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"identical."
+msgstr ""
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+
+#: src/basic-syntax/slices.md:26
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+
+#: src/basic-syntax/slices.md:28
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"computation on slices of different sizes."
+msgstr ""
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
+msgid "`String` vs `str`"
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:3
@@ -2860,44 +2966,51 @@ msgid "Rust terminology:"
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
+msgid "`&str` an immutable reference to a string slice."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::"
-"string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
 msgstr ""
 
 #: src/basic-syntax/functions.md:3
@@ -2939,20 +3052,32 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
-"`=n`, which causes it to include the upper bound."
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:1
-msgid "# Rustdoc"
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"`=n`, which causes it to include the upper bound."
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:3
@@ -2979,36 +3104,34 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
 msgstr ""
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
-"method is\n"
-"an instance of the type it is associated with:"
+"method is an instance of the type it is associated with:"
 msgstr ""
 
 #: src/basic-syntax/methods.md:6
@@ -3040,26 +3163,31 @@ msgstr ""
 
 #: src/basic-syntax/methods.md:30
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
 
 #: src/basic-syntax/methods.md:34
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
+msgstr ""
+
+#: src/basic-syntax/methods.md:36
 msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
+msgid "Function Overloading"
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:3
@@ -3067,13 +3195,27 @@ msgid "Overloading is not supported:"
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
+msgid "Each function has a single implementation:"
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:12
@@ -3096,14 +3238,13 @@ msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
+msgid "Day 1: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-1/morning.md:3
@@ -3111,10 +3252,11 @@ msgid "In these exercises, we will explore two parts of Rust:"
 msgstr ""
 
 #: src/exercises/day-1/morning.md:5
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
+msgid "Implicit conversions between types."
+msgstr ""
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
 msgstr ""
 
 #: src/exercises/day-1/morning.md:11
@@ -3123,18 +3265,18 @@ msgstr ""
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
+msgstr ""
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
 msgstr ""
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
 
@@ -3145,18 +3287,14 @@ msgstr ""
 #: src/exercises/concurrency/morning.md:12
 #: src/exercises/concurrency/afternoon.md:13
 msgid ""
-"After looking at the exercises, you can look at the [solutions] provided."
-msgstr ""
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:6
@@ -3177,48 +3315,50 @@ msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:33
+msgid "Execute the above program and look at the compiler error."
+msgstr ""
+
+#: src/exercises/day-1/implicit-conversions.md:35
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr ""
+
+#: src/exercises/day-1/implicit-conversions.md:37
 msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:3
@@ -3250,7 +3390,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr ""
 
@@ -3277,8 +3417,7 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
 
@@ -3297,7 +3436,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
 
@@ -3333,38 +3472,32 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
+msgid "Bonus Question"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
-msgstr ""
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
 msgstr ""
 
 #: src/basic-syntax/variables.md:3
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
+"by default:"
 msgstr ""
 
 #: src/basic-syntax/variables.md:6
@@ -3381,14 +3514,14 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
-"function like syntax of `println!(\"x: {}\", x)`"
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
 msgstr ""
 
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
+"function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:3
@@ -3426,10 +3559,10 @@ msgstr ""
 #: src/basic-syntax/type-inference.md:28
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:32
@@ -3462,7 +3595,7 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
+msgid "Static and Constant Variables"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:3
@@ -3470,7 +3603,7 @@ msgid "Global state is managed with static and constant variables."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
+msgid "`const`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:7
@@ -3500,11 +3633,13 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According to the [Rust RFC Book][1] these are inlined upon use."
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
+msgid "`static`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:31
@@ -3524,10 +3659,10 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:41
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:44
@@ -3537,23 +3672,25 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:48
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
+#: src/basic-syntax/static-and-const.md:49
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
+"the same scope:"
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:6
@@ -3578,13 +3715,24 @@ msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
@@ -3601,22 +3749,20 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr "# 記憶體管理"
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr "傳統上，語言大致可分為兩種："
 
 #: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr "透過手動管理記憶體，取得完整掌控權：C、C++、Pascal..."
+
+#: src/memory-management.md:6
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
-"* 透過手動管理記憶體，取得完整掌控權：C、C++、Pascal...\n"
-"* 透過在執行階段中自動管理記憶體，取得完整安全性：Java、Python、Go、Haskell..."
+"透過在執行階段中自動管理記憶體，取得完整安全性：Java、Python、Go、Haskell..."
 
 #: src/memory-management.md:8
 msgid "Rust offers a new mix:"
@@ -3624,11 +3770,10 @@ msgstr "Rust 則融合這兩種做法："
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
-"> 透過正確的記憶體管理編譯時間強制執行措施，「同時」取得完整的掌控權和安全"
-"性。"
+"透過正確的記憶體管理編譯時間強制執行措施，「同時」取得完整的掌控權和安全性。"
 
 #: src/memory-management.md:13
 msgid "It does this with an explicit ownership concept."
@@ -3639,41 +3784,48 @@ msgid "First, let's refresh how memory management works."
 msgstr "首先，讓我們回顧記憶體管理的運作方式。"
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
-msgstr "# 堆疊與堆積"
+msgid "The Stack vs The Heap"
+msgstr "堆疊與堆積"
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* 堆疊 (Stack)：本機變數的連續記憶體區域。\n"
-"  * 值在編譯期間具有已知的固定大小。\n"
-"  * 相當快速：只需移動堆疊指標。\n"
-"  * 易於管理：追蹤函式呼叫。\n"
-"  * 良好的記憶體區域性。\n"
-"\n"
-"* 堆積 (Heap)：函式呼叫外的值儲存空間。\n"
-"  * 值在執行階段中以動態方式判斷大小。\n"
-"  * 速度稍慢於堆疊：需要作一些記錄。\n"
-"  * 不保證記憶體區域性。"
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "堆疊 (Stack)：本機變數的連續記憶體區域。"
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
-msgstr "# 堆疊記憶體"
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr "值在編譯期間具有已知的固定大小。"
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr "相當快速：只需移動堆疊指標。"
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr "易於管理：追蹤函式呼叫。"
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr "良好的記憶體區域性。"
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr "堆積 (Heap)：函式呼叫外的值儲存空間。"
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr "值在執行階段中以動態方式判斷大小。"
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "速度稍慢於堆疊：需要作一些記錄。"
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr "不保證記憶體區域性。"
 
 #: src/memory-management/stack.md:3
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 "建立 `String` 時，系統會在堆疊上放置固定大小的資料，並在堆積上放置動態調整大"
@@ -3725,64 +3877,64 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
-"* 請說明 `String` 是由 `Vec` 支援，因此具有容量和長度，而且還能成長 (前提是可"
-"透過堆積上的重新配置作業進行變動)。\n"
-"\n"
-"* 如有學員問起，您可以說明基礎記憶體是使用[系統配置器]配置的堆積，而自訂配置"
-"器可以使用[配置器 API] 實作。\n"
-"\n"
-"* 我們可以使用 `unsafe` 程式碼檢查記憶體配置。不過，您應指出這麼做非常不安"
-"全！\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"請說明 `String` 是由 `Vec` 支援，因此具有容量和長度，而且還能成長 (前提是可透"
+"過堆積上的重新配置作業進行變動)。"
 
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
-msgstr "# 手動記憶體管理"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+"如有學員問起，您可以說明基礎記憶體是使用\\[系統配置器\\]配置的堆積，而自訂配"
+"置器可以使用\\[配置器 API\\] 實作。"
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+"我們可以使用 `unsafe` 程式碼檢查記憶體配置。不過，您應指出這麼做非常不安全！"
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
 
 #: src/memory-management/manual.md:3
 msgid "You allocate and deallocate heap memory yourself."
@@ -3795,8 +3947,8 @@ msgid ""
 msgstr "如果操作時不夠小心，可能會導致當機、錯誤、安全漏洞和記憶體泄漏。"
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
-msgstr "## C 範例"
+msgid "C Example"
+msgstr "C 範例"
 
 #: src/memory-management/manual.md:9
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
@@ -3827,15 +3979,10 @@ msgstr ""
 #: src/memory-management/manual.md:21
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
 "如果函式在 `malloc` 和 `free` 之間提早傳回記憶體，就會發生記憶體泄漏：指標遺"
 "失，我們也無法釋放記憶體。"
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
-msgstr "# 作用域式記憶體管理"
 
 #: src/memory-management/scope-based.md:3
 msgid ""
@@ -3844,10 +3991,9 @@ msgstr "建構函式和解構函式可讓您掌握物件的生命週期。"
 
 #: src/memory-management/scope-based.md:5
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
 "只要在物件中包裝指標，即可在物件刪除時釋放記憶體。即使發生例外狀況，編譯器仍"
 "會保證執行這項作業。"
@@ -3855,13 +4001,12 @@ msgstr ""
 #: src/memory-management/scope-based.md:9
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr "這通常稱為「資源取得即初始化」(RAII)，且會提供智慧指標。"
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
-msgstr "## C++ 範例"
+msgid "C++ Example"
+msgstr "C++ 範例"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -3879,14 +4024,17 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:20
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
-msgstr ""
-"* `std::unique_ptr` 物件會在堆疊上配置，並指向在堆積上配置的記憶體。\n"
-"* `say_hello` 結束時，`std::unique_ptr` 解構函式就會執行。\n"
-"* 解構函式會釋放其指向的 `Person` 物件。"
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
+msgstr "`std::unique_ptr` 物件會在堆疊上配置，並指向在堆積上配置的記憶體。"
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr "`say_hello` 結束時，`std::unique_ptr` 解構函式就會執行。"
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
+msgstr "解構函式會釋放其指向的 `Person` 物件。"
 
 #: src/memory-management/scope-based.md:25
 msgid ""
@@ -3906,28 +4054,29 @@ msgstr ""
 "```"
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
-msgstr "# 自動記憶體管理"
+msgid "Automatic Memory Management"
+msgstr "自動記憶體管理"
 
 #: src/memory-management/garbage-collection.md:3
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
-msgstr "除了手動記憶體管理和作用域式記憶體管理之外，自動記憶體管理是另一種做法："
+"memory management:"
+msgstr ""
+"除了手動記憶體管理和作用域式記憶體管理之外，自動記憶體管理是另一種做法："
 
 #: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "程式設計師一律不會明確配置或釋放記憶體。"
+
+#: src/memory-management/garbage-collection.md:7
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
-msgstr ""
-"* 程式設計師一律不會明確配置或釋放記憶體。\n"
-"* 垃圾收集器會找到未使用的記憶體，並釋放給程式設計師。"
+msgstr "垃圾收集器會找到未使用的記憶體，並釋放給程式設計師。"
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
-msgstr "## Java 範例"
+msgid "Java Example"
+msgstr "Java 範例"
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
@@ -3948,29 +4097,37 @@ msgstr ""
 "```"
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
-msgstr "# Rust 中的記憶體管理"
+msgid "Memory Management in Rust"
+msgstr "Rust 中的記憶體管理"
 
 #: src/memory-management/rust.md:3
 msgid "Memory management in Rust is a mix:"
 msgstr "Rust 中的記憶體管理融合了以下特色："
 
 #: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "像 Java 一樣安全又正確，但沒有垃圾回收機制。"
+
+#: src/memory-management/rust.md:6
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+"可以是單一不重複指標、採用參考計數或採用原子參考計數，須視您選擇的抽象方法 "
+"(或抽象方法組合) 而定。"
+
+#: src/memory-management/rust.md:7
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr "像 C++ 一樣的作用域式管理，但編譯器會強制遵循完整規定。"
+
+#: src/memory-management/rust.md:8
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
-"* 像 Java 一樣安全又正確，但沒有垃圾回收機制。\n"
-"* 可以是單一不重複指標、採用參考計數或採用原子參考計數，須視您選擇的抽象方法 "
-"(或抽象方法組合) 而定。\n"
-"* 像 C++ 一樣的作用域式管理，但編譯器會強制遵循完整規定。\n"
-"* Rust 使用者可選擇適合情境的抽象方法，部分方法甚至像 C 一樣在執行階段無額外"
-"成本。"
+"Rust 使用者可選擇適合情境的抽象方法，部分方法甚至像 C 一樣在執行階段無額外成"
+"本。"
 
 #: src/memory-management/rust.md:10
 msgid "It achieves this by modeling _ownership_ explicitly."
@@ -3978,103 +4135,133 @@ msgstr "實現這種記憶體管理的方法是明確建立「所有權」模型
 
 #: src/memory-management/rust.md:14
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* 如果這時學員詢問相關做法，您可以表示這在 Rust 中通常會以 RAII 包裝函式型別"
-"處理，例如 [Box]、[Vec]、[Rc] 或 [Arc]。這些型別會透過多種方法封裝所有權和記"
-"憶體配置，防止在 C 中可能出現的錯誤。\n"
-"\n"
-"* 這時學員可能會詢問解構函式，Rust 中的類似項目就是 [Drop] 特徵。"
+"如果這時學員詢問相關做法，您可以表示這在 Rust 中通常會以 RAII 包裝函式型別處"
+"理，例如 [Box](https://doc.rust-lang.org/std/boxed/struct.Box.html)、[Vec]"
+"(https://doc.rust-lang.org/std/vec/struct.Vec.html)、[Rc](https://doc.rust-"
+"lang.org/std/rc/struct.Rc.html) 或 [Arc](https://doc.rust-lang.org/std/sync/"
+"struct.Arc.html)。這些型別會透過多種方法封裝所有權和記憶體配置，防止在 C 中可"
+"能出現的錯誤。"
 
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
-msgstr "# 比較"
+#: src/memory-management/rust.md:16
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
+msgstr ""
+"這時學員可能會詢問解構函式，Rust 中的類似項目就是 [Drop](https://doc.rust-"
+"lang.org/std/ops/trait.Drop.html) 特徵。"
 
 #: src/memory-management/comparison.md:3
 msgid "Here is a rough comparison of the memory management techniques."
 msgstr "以下概略比較各種記憶體管理技巧。"
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## 不同記憶體管理技巧的優點"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "不同記憶體管理技巧的優點"
 
-#: src/memory-management/comparison.md:7
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* 手動管理，例如 C：\n"
-" * 沒有執行階段負擔。\n"
-"* 自動管理，例如 Java：\n"
-" * 完全自動化。\n"
-" * 安全又正確。\n"
-"* 作用域式管理，例如 C++：\n"
-" * 部分自動化。\n"
-" *沒有執行階段負擔。\n"
-"* 編譯器強制執行的範圍式管理，例如 Rust：\n"
-" * 由編譯器強制執行。\n"
-" * 沒有執行階段負擔。\n"
-" * 安全又正確。"
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
+#, fuzzy
+msgid "Manual like C:"
+msgstr "手動管理，例如 C："
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+#, fuzzy
+msgid "No runtime overhead."
+msgstr "沒有執行階段負擔。"
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+#, fuzzy
+msgid "Automatic like Java:"
+msgstr "自動管理，例如 Java："
+
+#: src/memory-management/comparison.md:10
+#, fuzzy
+msgid "Fully automatic."
+msgstr "完全自動化。"
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+#, fuzzy
+msgid "Safe and correct."
+msgstr "安全又正確。"
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+#, fuzzy
+msgid "Scope-based like C++:"
+msgstr "作用域式管理，例如 C++："
+
+#: src/memory-management/comparison.md:13
+#, fuzzy
+msgid "Partially automatic."
+msgstr "部分自動化。 \\*沒有執行階段負擔。"
+
+#: src/memory-management/comparison.md:15
+#, fuzzy
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "由編譯器強制執行。"
+
+#: src/memory-management/comparison.md:16
+#, fuzzy
+msgid "Enforced by compiler."
+msgstr "沒有執行階段負擔。"
 
 #: src/memory-management/comparison.md:20
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## 不同記憶體管理技巧的缺點"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "不同記憶體管理技巧的缺點"
 
-#: src/memory-management/comparison.md:22
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* 手動管理，例如 C：\n"
-"  * 使用已釋放記憶體。\n"
-"  * 重複釋放。\n"
-"  * 記憶體泄漏。\n"
-"* 自動管理，例如 Java：\n"
-"  * 垃圾回收機制會暫停。\n"
-"  * 解構函式會延遲。\n"
-"* 範圍式管理，例如 C++：\n"
-"  * 相當複雜，由程式設計師自行選用。\n"
-"  * 可能會使用已釋放記憶體。\n"
-"* 編譯器強制執行的範圍式管理，例如 Rust：\n"
-"  * 一開始較為複雜。\n"
-"  * 可能會拒絕有效程式。"
+#: src/memory-management/comparison.md:23
+msgid "Use-after-free."
+msgstr "使用已釋放記憶體。"
 
-#: src/ownership.md:1
-msgid "# Ownership"
-msgstr "# 所有權"
+#: src/memory-management/comparison.md:24
+msgid "Double-frees."
+msgstr "重複釋放。"
+
+#: src/memory-management/comparison.md:25
+msgid "Memory leaks."
+msgstr "記憶體泄漏。"
+
+#: src/memory-management/comparison.md:27
+msgid "Garbage collection pauses."
+msgstr "垃圾回收機制會暫停。"
+
+#: src/memory-management/comparison.md:28
+msgid "Destructor delays."
+msgstr "解構函式會延遲。"
+
+#: src/memory-management/comparison.md:30
+msgid "Complex, opt-in by programmer."
+msgstr "相當複雜，由程式設計師自行選用。"
+
+#: src/memory-management/comparison.md:31
+msgid "Potential for use-after-free."
+msgstr "可能會使用已釋放記憶體。"
+
+#: src/memory-management/comparison.md:32
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "編譯器強制執行的範圍式管理，例如 Rust："
+
+#: src/memory-management/comparison.md:33
+msgid "Some upfront complexity."
+msgstr "一開始較為複雜。"
+
+#: src/memory-management/comparison.md:34
+msgid "Can reject valid programs."
+msgstr "可能會拒絕有效程式。"
 
 #: src/ownership.md:3
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
+"to use a variable outside its scope:"
 msgstr "所有變數繫結都會在特定「範圍」內有效，在範圍外使用變數會是錯誤："
 
 #: src/ownership.md:6
@@ -4105,17 +4292,16 @@ msgstr ""
 
 #: src/ownership.md:18
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
-msgstr ""
-"* 範圍結束時，變數會遭到「捨棄」，資料也會釋放。\n"
-"* 解構函式可在這時執行，用來釋放資源。\n"
-"* 我們會說變數「擁有」值。"
+"At the end of the scope, the variable is _dropped_ and the data is freed."
+msgstr "範圍結束時，變數會遭到「捨棄」，資料也會釋放。"
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
-msgstr "# 移動語意"
+#: src/ownership.md:19
+msgid "A destructor can run here to free up resources."
+msgstr "解構函式可在這時執行，用來釋放資源。"
+
+#: src/ownership.md:20
+msgid "We say that the variable _owns_ the value."
+msgstr "我們會說變數「擁有」值。"
 
 #: src/ownership/move-semantics.md:3
 msgid "An assignment will transfer ownership between variables:"
@@ -4142,34 +4328,36 @@ msgstr ""
 "```"
 
 #: src/ownership/move-semantics.md:14
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
-msgstr ""
-"* 將 `s1` 指派給 `s2` 會轉移所有權。\n"
-"* 資料已從 `s1`「移出」，`s1` 無法再供存取。\n"
-"* 當 `s1` 超出範圍時，系統不會執行任何動作，因為 `s1` 沒有所有權。\n"
-"* 當 `s2` 超出範圍時，系統會釋放字串資料。\n"
-"* 一律「只有」一個變數綁定會擁有值。"
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "將 `s1` 指派給 `s2` 會轉移所有權。"
+
+#: src/ownership/move-semantics.md:15
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr "資料已從 `s1`「移出」，`s1` 無法再供存取。"
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr "當 `s1` 超出範圍時，系統不會執行任何動作，因為 `s1` 沒有所有權。"
+
+#: src/ownership/move-semantics.md:17
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr "當 `s2` 超出範圍時，系統會釋放字串資料。"
+
+#: src/ownership/move-semantics.md:18
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr "一律「只有」一個變數綁定會擁有值。"
 
 #: src/ownership/move-semantics.md:22
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* 請說明這與 C++ 中的預設情形相反：您必須使用 `std::move`，且已定義移動建構函"
-"式，系統才會根據值進行複製。\n"
-"\n"
-"* 在 Rust 中，克隆作業皆為明確設定，方法為使用 `clone`。"
+"請說明這與 C++ 中的預設情形相反：您必須使用 `std::move`，且已定義移動建構函"
+"式，系統才會根據值進行複製。"
 
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
-msgstr "# Rust 中移動的字串"
+#: src/ownership/move-semantics.md:24
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "在 Rust 中，克隆作業皆為明確設定，方法為使用 `clone`。"
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4188,12 +4376,12 @@ msgstr ""
 "```"
 
 #: src/ownership/moved-strings-rust.md:10
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
-msgstr ""
-"* 系統會為 `s2` 重複使用 `s1` 的堆積資料。\n"
-"* 當 `s1` 超出範圍時，系統不會執行任何動作，因為 `s1` 已移出。"
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "系統會為 `s2` 重複使用 `s1` 的堆積資料。"
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgstr "當 `s1` 超出範圍時，系統不會執行任何動作，因為 `s1` 已移出。"
 
 #: src/ownership/moved-strings-rust.md:13
 msgid "Before move to `s2`:"
@@ -4279,10 +4467,6 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr "# 現代 C++ 中的雙重釋放"
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr "現代 C++ 可使用不同方式解決這個問題："
@@ -4301,12 +4485,12 @@ msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
-msgstr ""
-"* `s1` 的堆積資料會重複，`s2` 會取得專屬的獨立副本。\n"
-"* 當 `s1` 和 `s2` 超出範圍時，皆會釋放自己的記憶體。"
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+msgstr "`s1` 的堆積資料會重複，`s2` 會取得專屬的獨立副本。"
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr "當 `s1` 和 `s2` 超出範圍時，皆會釋放自己的記憶體。"
 
 #: src/ownership/double-free-modern-cpp.md:13
 msgid "Before copy-assignment:"
@@ -4390,13 +4574,9 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/moves-function-calls.md:1
-msgid "# Moves in Function Calls"
-msgstr "# 函式呼叫中的移動"
-
 #: src/ownership/moves-function-calls.md:3
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr "將值傳遞至函式時，該值會指派給函式參數。這麼做會轉移所有權："
 
@@ -4428,30 +4608,39 @@ msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* 首次呼叫 `say_hello` 時，`main` 會放棄 `name` 的所有權。之後，`name` 就無法"
-"在 `main` 內使用。\n"
-"* 為 `name` 配置的堆積記憶體會在 `say_hello` 函式結束時釋放。\n"
-"* 如果 `main` 以參照的形式傳送 `name` (`&name`)，且 `say_hello` 能以參數的形"
-"式接受參照，`main` 就可以保留所有權。\n"
-"* 另外，`main` 可在首次呼叫 (`name.clone()`) 中傳遞 `name` 的克隆。\n"
-"* 在 Rust 中，移動語意為預設做法，且強制規定程式設計師必須明確設定克隆，因此"
-"不小心建立副本的可能性就會低於在 C++ 中。"
+"首次呼叫 `say_hello` 時，`main` 會放棄 `name` 的所有權。之後，`name` 就無法"
+"在 `main` 內使用。"
 
-#: src/ownership/copy-clone.md:1
-msgid "# Copying and Cloning"
-msgstr "# 複製和克隆"
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr "為 `name` 配置的堆積記憶體會在 `say_hello` 函式結束時釋放。"
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"如果 `main` 以參照的形式傳送 `name` (`&name`)，且 `say_hello` 能以參數的形式"
+"接受參照，`main` 就可以保留所有權。"
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr "另外，`main` 可在首次呼叫 (`name.clone()`) 中傳遞 `name` 的克隆。"
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"在 Rust 中，移動語意為預設做法，且強制規定程式設計師必須明確設定克隆，因此不"
+"小心建立副本的可能性就會低於在 C++ 中。"
 
 #: src/ownership/copy-clone.md:3
 msgid ""
@@ -4513,12 +4702,12 @@ msgstr ""
 "```"
 
 #: src/ownership/copy-clone.md:30
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
-msgstr ""
-"* 指派後，`p1` 和 `p2` 都會擁有自己的資料。\n"
-"* 我們也能使用 `p1.clone()` 明確複製資料。"
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr "指派後，`p1` 和 `p2` 都會擁有自己的資料。"
+
+#: src/ownership/copy-clone.md:31
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr "我們也能使用 `p1.clone()` 明確複製資料。"
 
 #: src/ownership/copy-clone.md:35
 msgid "Copying and cloning are not the same thing:"
@@ -4526,18 +4715,24 @@ msgstr "複製和克隆並不相同："
 
 #: src/ownership/copy-clone.md:37
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C+"
-"+).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
-msgstr ""
-"* 複製是指記憶體區域的按位元複製作業，不適用於任意物件。\n"
-"* 複製不允許用於自訂邏輯，這與 C++ 中的複製建構函式不同。\n"
-"* 克隆是較廣泛的作業，而且只要實作 `Clone` 特徵，即允許用於自訂行為。\n"
-"* 複製不適用於實作 `Drop` 特徵的型別。"
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
+msgstr "複製是指記憶體區域的按位元複製作業，不適用於任意物件。"
+
+#: src/ownership/copy-clone.md:38
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr "複製不允許用於自訂邏輯，這與 C++ 中的複製建構函式不同。"
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr "克隆是較廣泛的作業，而且只要實作 `Clone` 特徵，即允許用於自訂行為。"
+
+#: src/ownership/copy-clone.md:40
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr "複製不適用於實作 `Drop` 特徵的型別。"
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 msgid "In the above example, try the following:"
@@ -4545,34 +4740,35 @@ msgstr "在上述範例中，請嘗試下列操作："
 
 #: src/ownership/copy-clone.md:44
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* 將 `String` 欄位新增至 `struct Point`。由於 `String` 不屬於 `Copy` 型別，因"
-"此不會編譯。\n"
-"* 從 `derive` 屬性中移除 `Copy`。編譯器錯誤現在位於 `p1` 的 `println!` 中。\n"
-"* 示範如果改為克隆 `p1`，就能正常運作。"
+"將 `String` 欄位新增至 `struct Point`。由於 `String` 不屬於 `Copy` 型別，因此"
+"不會編譯。"
+
+#: src/ownership/copy-clone.md:45
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"從 `derive` 屬性中移除 `Copy`。編譯器錯誤現在位於 `p1` 的 `println!` 中。"
+
+#: src/ownership/copy-clone.md:46
+msgid "Show that it works if you clone `p1` instead."
+msgstr "示範如果改為克隆 `p1`，就能正常運作。"
 
 #: src/ownership/copy-clone.md:48
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated."
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 "如有學員問起 `derive`，只需回答這是在 Rust 編譯時間中產生程式碼的方式。在這種"
 "情形下，系統會產生 `Copy` 和 `Clone` 特徵的預設實作方式。"
 
-#: src/ownership/borrowing.md:1
-msgid "# Borrowing"
-msgstr "# 借用"
-
 #: src/ownership/borrowing.md:3
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr "您可以不必在呼叫函式時轉移所有權，而是讓函式「借用」值："
 
@@ -4611,12 +4807,12 @@ msgstr ""
 "```"
 
 #: src/ownership/borrowing.md:22
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
-msgstr ""
-"* `add` 函式會「借用」兩個點，並傳回新的點。\n"
-"* 呼叫端會保留輸入內容的所有權。"
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr "`add` 函式會「借用」兩個點，並傳回新的點。"
+
+#: src/ownership/borrowing.md:23
+msgid "The caller retains ownership of the inputs."
+msgstr "呼叫端會保留輸入內容的所有權。"
 
 #: src/ownership/borrowing.md:27
 msgid "Notes on stack returns:"
@@ -4624,78 +4820,82 @@ msgstr "有關堆疊回傳的注意事項："
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can "
+"Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while they stay the same when changing to the "
-"\"RELEASE\" setting:\n"
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
+msgstr ""
+"示範因為編譯器可刪除複製操作，所以 `add` 回傳的成本較低。變更上述程式碼來顯示"
+"堆疊位址，並在 [Playground](https://play.rust-lang.org/) 上執行。在「DEBUG」"
+"最佳化等級中，位址應變更，但在變更為「RELEASE」設定時，位址應維持不變："
+
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
 "\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
 "\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
 "\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification "
-"because constructors can have side effects. In Rust, this is not an issue at "
-"all. If RVO did not happen, Rust will always performs a simple and efficient "
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr "Rust 編譯器可以執行回傳值最佳化 (RVO)。"
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always performs a simple and efficient "
 "`memcpy` copy."
 msgstr ""
-"* 示範因為編譯器可刪除複製操作，所以 `add` 回傳的成本較低。變更上述程式碼"
-"來顯示堆疊位址，並在 [Playground] 上執行。在「DEBUG」最佳化等級中，位址應變"
-"更，但在變更為「RELEASE」設定時，位址應維持不變：\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* Rust 編譯器可以執行回傳值最佳化 (RVO)。\n"
-"* 在 C++ 中，複製省略必須定義在語言規格內，因為建構函式可能有連帶效果。在 "
-"Rust 中，這完全不是問題。如未發生 RVO，Rust 一律會執行簡單有效的 `memcpy` 複"
-"製作業。"
-
-#: src/ownership/shared-unique-borrows.md:1
-msgid "# Shared and Unique Borrows"
-msgstr "# 共用借用和專屬借用"
+"在 C++ 中，複製省略必須定義在語言規格內，因為建構函式可能有連帶效果。在 Rust "
+"中，這完全不是問題。如未發生 RVO，Rust 一律會執行簡單有效的 `memcpy` 複製作"
+"業。"
 
 #: src/ownership/shared-unique-borrows.md:3
 msgid "Rust puts constraints on the ways you can borrow values:"
 msgstr "Rust 會限制借用值的方式："
 
 #: src/ownership/shared-unique-borrows.md:5
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* 隨時擁有一或多個 `&T` 值，「或是」\n"
-"* 只擁有一個 `&mut T` 值。"
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "隨時擁有一或多個 `&T` 值，「或是」"
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
+msgstr "只擁有一個 `&mut T` 值。"
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
@@ -4731,58 +4931,67 @@ msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:25
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+"上述程式碼不會編譯，因為系統會同時透過 `c` 和 `b`，以可變動項和不可變動項的格"
+"式借用 `a`。"
+
+#: src/ownership/shared-unique-borrows.md:26
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr "請將 `b` 的 `println!` 陳述式移到導入 `c` 的範圍前，即可編譯程式碼。"
+
+#: src/ownership/shared-unique-borrows.md:27
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"* 上述程式碼不會編譯，因為系統會同時透過 `c` 和 `b`，以可變動項和不可變動項的"
-"格式借用 `a`。\n"
-"* 請將 `b` 的 `println!` 陳述式移到導入 `c` 的範圍前，即可編譯程式碼。\n"
-"* 經過該變更後，編譯器會發現系統使用 `b` 的時間，只會在新可變動項透過 `c` 借"
-"用 `a` 之前。這是借用檢查器中的功能，稱為「非詞彙生命週期」(non-lexical "
+"經過該變更後，編譯器會發現系統使用 `b` 的時間，只會在新可變動項透過 `c` 借用 "
+"`a` 之前。這是借用檢查器中的功能，稱為「非詞彙生命週期」(non-lexical "
 "lifetimes)。"
-
-#: src/ownership/lifetimes.md:1
-msgid "# Lifetimes"
-msgstr "# 生命週期"
 
 #: src/ownership/lifetimes.md:3
 msgid "A borrowed value has a _lifetime_:"
 msgstr "借用的值具有「生命週期」："
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully "
-"specified,\n"
-"  but Rust allows these to be elided in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
-msgstr ""
-"* 生命週期可以採用隱含方式：`add(p1: &Point, p2: &Point) -> Point`。\n"
-"* 生命週期也可以採用明確方式：`&'a Point`、`&'document str`。\n"
-"* 請將 `&'a Point` 讀做「至少對生命週期 `a` 有效的借用 `Point`」。\n"
-"* 生命週期一律會由編譯器推論：您無法自行指派生命週期。\n"
-"  * 生命週期註解會建立限制；編譯器會驗證是否有有效的解決方案。\n"
-"* 請務必完整指定函式引數和回傳值的生命週期，不過在大部分情況下，Rust 允許使"
-"用 [一些簡單規則](https://doc.rust-lang.org/nomicon/lifetime-elision.html) 省"
-"略這些生命週期。"
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
+msgstr "生命週期可以採用隱含方式：`add(p1: &Point, p2: &Point) -> Point`。"
 
-#: src/ownership/lifetimes-function-calls.md:1
-msgid "# Lifetimes in Function Calls"
-msgstr "# 函式呼叫中的生命週期"
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr "生命週期也可以採用明確方式：`&'a Point`、`&'document str`。"
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr "請將 `&'a Point` 讀做「至少對生命週期 `a` 有效的借用 `Point`」。"
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr "生命週期一律會由編譯器推論：您無法自行指派生命週期。"
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr "生命週期註解會建立限制；編譯器會驗證是否有有效的解決方案。"
+
+#: src/ownership/lifetimes.md:13
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows these to be elided in most cases with [a few simple rules]"
+"(https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgstr ""
+"請務必完整指定函式引數和回傳值的生命週期，不過在大部分情況下，Rust 允許使用 "
+"[一些簡單規則](https://doc.rust-lang.org/nomicon/lifetime-elision.html) 省略"
+"這些生命週期。"
 
 #: src/ownership/lifetimes-function-calls.md:3
 msgid ""
@@ -4825,88 +5034,101 @@ msgstr ""
 "```"
 
 #: src/ownership/lifetimes-function-calls.md:21
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`'a` 是由編譯器推論的泛型參數。"
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr "生命週期的開頭為 `'`，一般預設名稱為 `'a`。"
+
+#: src/ownership/lifetimes-function-calls.md:25
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
-msgstr ""
-"* `'a` 是由編譯器推論的泛型參數。\n"
-"* 生命週期的開頭為 `'`，一般預設名稱為 `'a`。\n"
-"* 請將 `&'a Point` 讀做「至少對生命週期 `a` 有效的借用 `Point`」。\n"
-"  * 如果參數位於不同的範圍，「至少」一詞就至關重要。"
+"The _at least_ part is important when parameters are in different scopes."
+msgstr "如果參數位於不同的範圍，「至少」一詞就至關重要。"
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
-msgstr ""
-"* 將 `p2` 和 `p3` 的宣告移至新範圍 (`{ ... }`)，會產生以下程式碼：\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  請注意，這在 `p3` 超越 `p2` 並繼續留存後，就沒有編譯。\n"
-"\n"
-"* 重設工作區，並將函式簽章變更為 `fn left_most<'a, 'b>(p1: &'a Point, p2: "
-"&'a Point) -> &'b Point`。這不會編譯，因為生命週期 `'a` 和 `'b` 之間的關係不"
-"明確。\n"
-"* 另一種說明方式：\n"
-"  * 函式會借用兩個值的兩個參照，而函式會傳回另一個參照。\n"
-"  * 該參照必須來自這兩種輸入來源的其中之一 (或來自全域變數)。\n"
-"  * 究竟是哪一個來源？編譯器需要知道來源為何，因此在呼叫點上，所傳回參照的使"
-"用時間不會長於來自參照來源的變數。"
+"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
+"resulting in the following code:"
+msgstr "將 `p2` 和 `p3` 的宣告移至新範圍 (`{ ... }`)，會產生以下程式碼："
 
-#: src/ownership/lifetimes-data-structures.md:1
-msgid "# Lifetimes in Data Structures"
-msgstr "# 資料結構中的生命週期"
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+
+#: src/ownership/lifetimes-function-calls.md:50
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr "請注意，這在 `p3` 超越 `p2` 並繼續留存後，就沒有編譯。"
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+"重設工作區，並將函式簽章變更為 `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a "
+"Point) -> &'b Point`。這不會編譯，因為生命週期 `'a` 和 `'b` 之間的關係不明"
+"確。"
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr "另一種說明方式："
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr "函式會借用兩個值的兩個參照，而函式會傳回另一個參照。"
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr "該參照必須來自這兩種輸入來源的其中之一 (或來自全域變數)。"
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
+"究竟是哪一個來源？編譯器需要知道來源為何，因此在呼叫點上，所傳回參照的使用時"
+"間不會長於來自參照來源的變數。"
 
 #: src/ownership/lifetimes-data-structures.md:3
 msgid ""
@@ -4955,33 +5177,46 @@ msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data "
+"In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This "
-"can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one "
-"lifetime annotation. This can be necessary if there is a need to describe "
-"lifetime relationships between the references themselves, in addition to the "
-"lifetime of the struct itself. Those are very advanced use cases."
+"`Highlight` that uses that data."
 msgstr ""
-"* 在上述範例中，`Highlight` 的註解會強制執行以下規定：若是包含在內的 `&str` "
-"的基礎資料，留存時間應至少和使用該資料的所有 `Highlight` 例項一樣長。\n"
-"* 如果在 `fox` (或 `dog`) 的生命週期結束前消耗 `text`，借用檢查器會擲回錯"
-"誤。\n"
-"* 含有借用資料的型別會強制要求使用者保留原始資料。這在建立輕量檢視畫面可能很"
-"實用，但通常也會增加使用難度。\n"
-"* 請盡可能讓資料結構直接擁有資料。\n"
-"* 某些內含多個參照的結構體可擁有多個生命週期註解。如果除了結構體的生命週期之"
+"在上述範例中，`Highlight` 的註解會強制執行以下規定：若是包含在內的 `&str` 的"
+"基礎資料，留存時間應至少和使用該資料的所有 `Highlight` 例項一樣長。"
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"如果在 `fox` (或 `dog`) 的生命週期結束前消耗 `text`，借用檢查器會擲回錯誤。"
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"含有借用資料的型別會強制要求使用者保留原始資料。這在建立輕量檢視畫面可能很實"
+"用，但通常也會增加使用難度。"
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr "請盡可能讓資料結構直接擁有資料。"
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"某些內含多個參照的結構體可擁有多個生命週期註解。如果除了結構體的生命週期之"
 "外，還需要描述參照之間的生命週期關係，就可能有必要擁有多個生命週期註解。那些"
 "是相當進階的用途。"
 
 #: src/exercises/day-1/afternoon.md:1
-msgid "# Day 1: Afternoon Exercises"
+msgid "Day 1: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:3
@@ -4989,21 +5224,17 @@ msgid "We will look at two things:"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:5
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
+msgid "A small book library,"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:1
-msgid "# Designing a Library"
+#: src/exercises/day-1/afternoon.md:7
+msgid "Iterators and ownership (hard)."
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:3
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:6
@@ -5023,8 +5254,8 @@ msgstr ""
 
 #: src/exercises/day-1/book-library.md:18
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:21
@@ -5115,27 +5346,21 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-msgid "# Iterators and Ownership"
-msgstr ""
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
-msgid "## `Iterator`"
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
+msgid "`Iterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
@@ -5191,12 +5416,12 @@ msgid "Why is this type used?"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
-msgid "## `IntoIterator`"
+msgid "`IntoIterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
@@ -5215,19 +5440,21 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:62
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 
@@ -5250,15 +5477,14 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
-msgid "## `for` Loops"
+msgid "`for` Loops"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
@@ -5285,19 +5511,15 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:105
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 
 #: src/welcome-day-2.md:1
-msgid "# Welcome to Day 2"
+msgid "Welcome to Day 2"
 msgstr ""
 
 #: src/welcome-day-2.md:3
@@ -5305,25 +5527,28 @@ msgid "Now that we have seen a fair amount of Rust, we will continue with:"
 msgstr ""
 
 #: src/welcome-day-2.md:5
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
+msgid "Structs, enums, methods."
 msgstr ""
 
-#: src/structs.md:1
-msgid "# Structs"
-msgstr "# 結構體"
+#: src/welcome-day-2.md:7
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr ""
+
+#: src/welcome-day-2.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr ""
 
 #: src/structs.md:3
 msgid "Like C and C++, Rust has support for custom structs:"
@@ -5363,27 +5588,48 @@ msgid "Key Points:"
 msgstr "重點："
 
 #: src/structs.md:33
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
 msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
-
-#: src/structs/tuple-structs.md:1
-msgid "# Tuple Structs"
-msgstr "# 元組結構體"
 
 #: src/structs/tuple-structs.md:3
 msgid "If the field names are unimportant, you can use a tuple struct:"
@@ -5429,30 +5675,45 @@ msgstr ""
 
 #: src/structs/tuple-structs.md:37
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). "
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
+"如要對原始型別中值的額外資訊進行編碼，Newtypes 是絕佳的方式，舉例來說："
 
-#: src/structs/field-shorthand.md:1
-msgid "# Field Shorthand Syntax"
-msgstr "# 欄位簡寫語法"
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr "此數字會採用某些測量單位：在上例中為 `Newtons`。"
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"此值在建立時已通過某些驗證，因此往後不必在每次使用時再次驗證。例"
+"如：'PhoneNumber(String)`或`OddNumber(u32)\\` 。"
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+"示範如何透過存取 newtype 中的單一欄位，將 “f64” 值新增至 `Newtons` 類型。"
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr "Rust 通常不太能接受不明確的內容，例如自動展開或使用布林值做為整數。"
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics). "
+msgstr ""
 
 #: src/structs/field-shorthand.md:3
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
-msgstr ""
-"如果您已有名稱相同的變數，可以透過簡寫\n"
-"建立結構體："
+msgstr "如果您已有名稱相同的變數，可以透過簡寫 建立結構體："
 
 #: src/structs/field-shorthand.md:6
 msgid ""
@@ -5478,63 +5739,79 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use "
-"the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-msgid "# Enums"
-msgstr "# 列舉"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
 
 #: src/enums.md:3
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr "`enum` 關鍵字可建立具有幾個不同變體的型別："
 
 #: src/enums.md:6
@@ -5592,37 +5869,46 @@ msgstr ""
 "```"
 
 #: src/enums.md:36
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr "列舉可讓您在單一類別中收集一組值。"
+
+#: src/enums.md:37
 msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+"本頁面提供列舉類別 `CoinFlip`，以及 `Heads` 和 `Tail` 這兩個變體。您可以在使"
+"用變體時記下命名空間。"
+
+#: src/enums.md:38
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr "這或許是比較結構體和列舉的好時機："
+
+#: src/enums.md:39
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"無論使用何者，都能取得沒有欄位的簡易版本 (單元結構體)，或是具有不同欄位型別的"
+"版本 (變體負載)。"
+
+#: src/enums.md:40
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr "無論使用何者，相關函式都會在 `impl` 區塊中定義。"
+
+#: src/enums.md:41
+msgid ""
+"You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
 msgstr ""
-"* 列舉可讓您在單一類別中收集一組值。\n"
-"* 本頁面提供列舉類別 `CoinFlip`，以及 `Heads` 和 `Tail` 這兩個變體。您可以在"
-"使用變體時記下命名空間。\n"
-"* 這或許是比較結構體和列舉的好時機：\n"
-"  * 無論使用何者，都能取得沒有欄位的簡易版本 (單元結構體)，或是具有不同欄位型"
-"別的版本 (變體負載)。\n"
-"  * 無論使用何者，相關函式都會在 `impl` 區塊中定義。\n"
-"  * 您甚至可以使用獨立的結構體實作列舉的不同變體，但比起在列舉中定義全部變體"
-"的情況，這麼做會讓變體的型別有所不同。"
-
-#: src/enums/variant-payloads.md:1
-msgid "# Variant Payloads"
-msgstr "# 變體負載"
+"您甚至可以使用獨立的結構體實作列舉的不同變體，但比起在列舉中定義全部變體的情"
+"況，這麼做會讓變體的型別有所不同。"
 
 #: src/enums/variant-payloads.md:3
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 "您可以定義更豐富的列舉，讓列舉的變體攜帶資料。接著，您可以使用 `match` 陳述"
 "式，從各個變體擷取資料："
@@ -5685,48 +5971,69 @@ msgstr ""
 
 #: src/enums/variant-payloads.md:35
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There "
-"is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example.  \n"
-"  "
+"after the `=>`."
 msgstr ""
-"* 只有在與模式配對相符後，才能存取列舉變數中的值。此模式會將參照繫結至 `=>` "
-"後方「配對分支」中的欄位。\n"
-"  * 系統會從上到下將運算式與模式進行配對。在 Rust 中，不會像在 C 或 C++ 中一"
-"樣出現貫穿 (fall-through) 情形。\n"
-"  * 配對運算式具有值。此值是系統執行的配對分支中的最後一個運算式。\n"
-"  * 我們會從上方開始尋找符合該值的模式，然後執行箭頭後方的程式碼。一旦發現相"
-"符項目，就會停止。\n"
-"* 請示範非窮舉搜尋的情況。請確認系統處理所有案例的時間，指出 Rust 編譯器提供"
-"的優勢。\n"
-"* `match` 會檢查 `enum` 中隱藏的判別值欄位。\n"
-"* 只要呼叫 `std::mem::discriminant()`，就有可能擷取該判別值。`\n"
-"  * 舉例來說，如果在為結構體實作 `PartialEq` 時，比較欄位值不會對相等性造成影"
-"響，這種做法就很實用。\n"
-"* `WebEvent::Click { ... }` 與具有頂層 `struct Click { ... }` 的 `WebEvent::"
-"Click(Click)` 並非完全相同。舉例來說，內嵌版本無法實作特徵。\n"
-"  "
+"只有在與模式配對相符後，才能存取列舉變數中的值。此模式會將參照繫結至 `=>` 後"
+"方「配對分支」中的欄位。"
 
-#: src/enums/sizes.md:1
-msgid "# Enum Sizes"
-msgstr "# 列舉大小"
+#: src/enums/variant-payloads.md:36
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+"系統會從上到下將運算式與模式進行配對。在 Rust 中，不會像在 C 或 C++ 中一樣出"
+"現貫穿 (fall-through) 情形。"
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr "配對運算式具有值。此值是系統執行的配對分支中的最後一個運算式。"
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+"我們會從上方開始尋找符合該值的模式，然後執行箭頭後方的程式碼。一旦發現相符項"
+"目，就會停止。"
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+"請示範非窮舉搜尋的情況。請確認系統處理所有案例的時間，指出 Rust 編譯器提供的"
+"優勢。"
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr "`match` 會檢查 `enum` 中隱藏的判別值欄位。"
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr "只要呼叫 `std::mem::discriminant()`，就有可能擷取該判別值。\\`"
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+"舉例來說，如果在為結構體實作 `PartialEq` 時，比較欄位值不會對相等性造成影響，"
+"這種做法就很實用。"
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
+"`WebEvent::Click { ... }` 與具有頂層 `struct Click { ... }` 的 `WebEvent::"
+"Click(Click)` 並非完全相同。舉例來說，內嵌版本無法實作特徵。"
 
 #: src/enums/sizes.md:3
 msgid ""
@@ -5778,292 +6085,301 @@ msgstr ""
 
 #: src/enums/sizes.md:25
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 msgstr ""
-"* 請參閱 [Rust 參考資料](https://doc.rust-lang.org/reference/type-layout."
+"請參閱 [Rust 參考資料](https://doc.rust-lang.org/reference/type-layout."
 "html)。"
 
 #: src/enums/sizes.md:31
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr "在內部，Rust 會使用欄位 (判別值) 追蹤列舉變體。"
+
+#: src/enums/sizes.md:33
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr "您可以視需要控制判別值，例如為了與 C 相容："
+
+#: src/enums/sizes.md:35
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with "
-"C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
-"\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits "
-"2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche "
-"optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit "
-"machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge use unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* "
-"look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees "
-"regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
-"$bit_type>($e));\n"
-"         };\n"
-"     }\n"
-"\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"\n"
-"     More complex example if you want to discuss what happens when we chain "
-"more than 256 `Option`s together.\n"
-"\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
-"$bit_type>($e));\n"
-"         };\n"
-"     }\n"
-"\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
-"signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
-"\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
-"Some(Some(Some(Some(false)))));\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
 msgstr ""
-" * 在內部，Rust 會使用欄位 (判別值) 追蹤列舉變體。\n"
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * 您可以視需要控制判別值，例如為了與 C 相容：\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+
+#: src/enums/sizes.md:50
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+"如果沒有 `repr`，判別值型別會需要 2 個位元組，因為 10001 適合 2 個位元組。"
+
+#: src/enums/sizes.md:54
+msgid "Try out other types such as"
+msgstr "請嘗試其他型別，例如以下項目："
+
+#: src/enums/sizes.md:56
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr "`dbg_size!(bool)`：大小為 1 個位元組，對齊：1 個位元組。"
+
+#: src/enums/sizes.md:57
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+"`dbg_size!(Option<bool>)`：大小為 1 個位元組，對齊：1 個位元組 (區位最佳化，"
+"請見下文)。"
+
+#: src/enums/sizes.md:58
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+"`dbg_size!(&i32)`：大小為 8 個位元組，對齊：8 個位元組 (在 64 位元機器上)。"
+
+#: src/enums/sizes.md:59
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+"`dbg_size!(Option<&i32>)`：大小為 8 個位元組，對齊：8 個位元組 (空值指標最佳"
+"化，請見下文)。"
+
+#: src/enums/sizes.md:61
+msgid ""
+"Niche optimization: Rust will merge use unused bit patterns for the enum "
+"discriminant."
+msgstr "區位最佳化：Rust 會為列舉判別值合併未使用的位元模式。"
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+"空值指標最佳化：針對[部分型別](https://doc.rust-lang.org/std/option/"
+"#representation)，Rust 保證 `size_of::<T>()` 等於 `size_of::<Option<T>>()`."
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+"如果想示範位元表示法實際運作時「可能」的樣子，可以使用下列範例程式碼。請務必"
+"注意，編譯器並無對這個表示法提供保證，因此這完全不安全。"
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    如果沒有 `repr`，判別值型別會需要 2 個位元組，因為 10001 適合 2 個位元"
-"組。\n"
-"\n"
-"\n"
-" * 請嘗試其他型別，例如以下項目：\n"
-" \n"
-" * `dbg_size!(bool)`：大小為 1 個位元組，對齊：1 個位元組。\n"
-" * `dbg_size!(Option<bool>)`：大小為 1 個位元組，對齊：1 個位元組 (區位最佳"
-"化，請見下文)。\n"
-"     * `dbg_size!(&i32)`：大小為 8 個位元組，對齊：8 個位元組 (在 64 位元機器"
-"上)。\n"
-"     * `dbg_size!(Option<&i32>)`：大小為 8 個位元組，對齊：8 個位元組 (空值指"
-"標最佳化，請見下文)。\n"
-"\n"
-" * 區位最佳化：Rust 會為列舉判別值合併未使用的位元模式。\n"
-"\n"
-" * 空值指標最佳化：針對[部分型別](https://doc.rust-lang.org/std/option/"
-"#representation)，Rust 保證 `size_of::<T>()` 等於 `size_of::<Option<T>>()`.\n"
-"\n"
-"     如果想示範位元表示法實際運作時「可能」的樣子，可以使用下列範例程式碼。"
-"請務必注意，編譯器並無對這個表示法提供保證，因此這完全不安全。\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"     如果想討論將超過 256 個 `Option` 鏈結在一起的情況，可以使用下列更複雜的"
-"範例。\n"
-"\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     // 在 2^n Some() 中包裝值的巨集，n 為「@」符號的數字。\n"
-"     // 評估此巨集時，必須提高遞迴限制。\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
+"\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
+"\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+"如果想討論將超過 256 個 `Option` 鏈結在一起的情況，可以使用下列更複雜的範例。"
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
+"\n"
+"use std::mem::transmute;\n"
+"\n"
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"    };\n"
+"}\n"
+"\n"
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"signs.\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
 "Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
+"\n"
+"use std::mem::transmute;\n"
+"\n"
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"    };\n"
+"}\n"
+"\n"
+"// 在 2^n Some() 中包裝值的巨集，n 為「@」符號的數字。\n"
+"// 評估此巨集時，必須提高遞迴限制。\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
+"Some(Some(Some(Some(false)))));\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
 
 #: src/methods.md:3
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
 
 #: src/methods.md:6
@@ -6092,77 +6408,104 @@ msgid ""
 msgstr ""
 
 #: src/methods.md:31
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
 
-#: src/methods/receiver.md:1
-msgid "# Method Receiver"
+#: src/methods.md:32
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+
+#: src/methods.md:33
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+
+#: src/methods.md:34
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr ""
+
+#: src/methods.md:35
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+
+#: src/methods.md:36
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+
+#: src/methods.md:37
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+
+#: src/methods.md:38
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+
+#: src/methods.md:39
+msgid "We describe the distinction between method receivers next."
 msgstr ""
 
 #: src/methods/receiver.md:3
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
 
 #: src/methods/receiver.md:6
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted. Complete ownership does not automatically mean mutability.\n"
-"* `mut self`: same as above, but the method can mutate the object. \n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:8
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:10
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+
+#: src/methods/receiver.md:14
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+
+#: src/methods/receiver.md:15
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
 msgstr ""
 
 #: src/methods/receiver.md:18
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
 
 #: src/methods/receiver.md:24
 msgid ""
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it."
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "# Example"
-msgstr "# 範例"
 
 #: src/methods/example.md:3
 msgid ""
@@ -6211,29 +6554,38 @@ msgid ""
 msgstr ""
 
 #: src/methods/example.md:47
-msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
-"functions are called the same way in the main body. Rust enables automatic "
-"referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
-"over. We describe vectors in more detail in the afternoon. "
+msgid "All four methods here use a different method receiver."
 msgstr ""
 
-#: src/pattern-matching.md:1
-msgid "# Pattern Matching"
+#: src/methods/example.md:48
+msgid ""
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+
+#: src/methods/example.md:49
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+
+#: src/methods/example.md:50
+msgid ""
+"Note that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+
+#: src/methods/example.md:51
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
 msgstr ""
 
 #: src/pattern-matching.md:3
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
 #: src/pattern-matching.md:6
@@ -6262,30 +6614,47 @@ msgstr ""
 
 #: src/pattern-matching.md:26
 msgid ""
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:1
-msgid "# Destructuring Enums"
+#: src/pattern-matching.md:27
+msgid "`|` as an `or`"
+msgstr ""
+
+#: src/pattern-matching.md:28
+msgid "`..` can expand as much as it needs to be"
+msgstr ""
+
+#: src/pattern-matching.md:29
+msgid "`1..=5` represents an inclusive range"
+msgstr ""
+
+#: src/pattern-matching.md:30
+msgid "`_` is a wild card"
+msgstr ""
+
+#: src/pattern-matching.md:31
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+
+#: src/pattern-matching.md:32
+msgid "You can demonstrate matching on a reference."
+msgstr ""
+
+#: src/pattern-matching.md:33
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:3
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:6
@@ -6316,24 +6685,22 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:36
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:1
-msgid "# Destructuring Structs"
+#: src/pattern-matching/destructuring-enums.md:37
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:3
@@ -6362,18 +6729,18 @@ msgid ""
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard "
-"to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that "
-"it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-msgid "# Destructuring Arrays"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:25
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
@@ -6399,44 +6766,52 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were "
-"ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of "
-"elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:1
-msgid "# Match Guards"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:6
@@ -6458,21 +6833,31 @@ msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:24
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`."
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:26
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:27
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
 msgstr ""
 
 #: src/exercises/day-2/morning.md:1
-msgid "# Day 2: Morning Exercises"
+msgid "Day 2: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:3
@@ -6480,35 +6865,29 @@ msgid "We will look at implementing methods in two contexts:"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:5
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
+msgid "Simple struct which tracks health statistics."
 msgstr ""
 
-#: src/exercises/day-2/health-statistics.md:1
-msgid "# Health Statistics"
+#: src/exercises/day-2/morning.md:7
+msgid "Multiple structs and enums for a drawing library."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 
@@ -6572,16 +6951,14 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
-msgid "# Polygon Struct"
+msgid "Polygon Struct"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:3
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:7
@@ -6698,9 +7075,8 @@ msgstr ""
 #: src/exercises/day-2/points-polygons.md:117
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:120
@@ -6709,38 +7085,31 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:122
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
 
-#: src/control-flow.md:1
-msgid "# Control Flow"
-msgstr "# 控制流程"
+#: src/exercises/day-2/points-polygons.md:123
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
 
 #: src/control-flow.md:3
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
 "如同我們所見，`if` 是 Rust 中的一種表達式。它可以用來根據條件執行兩個區塊之中"
 "的一個，而區塊的執行結果可以進一步轉變成 `if` 表達式的賦值。其他控制流程表達"
 "式在 Rust 中也有類似的用法。"
 
-#: src/control-flow/blocks.md:1
-msgid "# Blocks"
-msgstr "# 區塊"
-
 #: src/control-flow/blocks.md:3
 msgid ""
 "A block in Rust has a value and a type: the value is the last expression of "
-"the\n"
-"block:"
+"the block:"
 msgstr ""
 "Rust 中的區塊 (Block) 包含一個數值以及一個型別：數值即為該區塊中的最後一行表"
 "達式："
@@ -6787,7 +7156,7 @@ msgstr ""
 
 #: src/control-flow/blocks.md:25
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr "同樣的規則也適用於函式：函式的數值即為函式本體的回傳值："
 
@@ -6821,28 +7190,26 @@ msgstr "然而，如果最後一行表達式的結尾為 `;`，則最後的數�
 
 #: src/control-flow/blocks.md:43
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr "這張投影片所表達的重點在於 Rust 中的區塊具有一個數值以及一個型別。"
+
+#: src/control-flow/blocks.md:44
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
-"* 這張投影片所表達的重點在於 Rust 中的區塊具有一個數值以及一個型別。\n"
-"* 你可以藉由改變區塊中的最後一行來觀察區塊數值的變化。舉例來說，新增或刪除一"
-"個分號，或者使用 `return`。\n"
-"   "
+"你可以藉由改變區塊中的最後一行來觀察區塊數值的變化。舉例來說，新增或刪除一個"
+"分號，或者使用 `return`。"
 
 #: src/control-flow/if-expressions.md:1
-msgid "# `if` expressions"
-msgstr "# `if` 表達式"
+msgid "`if` expressions"
+msgstr "`if` 表達式"
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
 "你可以像在其他語言中使用 `if` 陳述式那樣地使用 [`if` 表達式](https://doc."
 "rust-lang.org/reference/expressions/if-expr.html#if-expressions)："
@@ -6873,7 +7240,7 @@ msgstr ""
 
 #: src/control-flow/if-expressions.md:18
 msgid ""
-"In addition, you can use `if` as an expression. The last expression of each\n"
+"In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
 "此外，你也可以將 `if` 當作表達式使用。每個區塊中的最後一行式子將成為 `if` 表"
@@ -6913,16 +7280,14 @@ msgstr ""
 "有同樣的型別。試著在第二個範例中的 `x / 2` 之後加上 `;`，並觀察其結果。"
 
 #: src/control-flow/if-let-expressions.md:1
-msgid "# `if let` expressions"
-msgstr "# `if let` 運算式"
+msgid "`if let` expressions"
+msgstr "`if let` 運算式"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
 "[`if let` 運算式](https://doc.rust-lang.org/reference/expressions/if-expr."
 "html#if-let-expressions)可讓您根據值是否符合模式，執行不同的程式碼："
@@ -6956,66 +7321,76 @@ msgstr ""
 #: src/control-flow/match-expressions.md:23
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
 "如要進一步瞭解 Rust 中的模式，請參閱「[模式比對](../pattern-matching.md)」。"
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is "
-"interesting. In contrast, `match` requires all branches to be covered.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
+msgstr ""
+"`if let` 可以比 `match` 更為精簡，例如只有一個有趣案例時。相對地，`match` 必"
+"須涵蓋所有分支。"
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr "常見用途是在使用 `Option` 時處理 `Some` 值。"
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr "與 `match` 不同，`if let` 不會為模式比對支援成立條件子句。"
+
+#: src/control-flow/if-let-expressions.md:26
+msgid ""
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) construct allows to do a destructuring "
 "assignment, or if it fails, have a non-returning block branch (panic/return/"
-"break/continue):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"break/continue):"
 msgstr ""
-"* `if let` 可以比 `match` 更為精簡，例如只有一個有趣案例時。相對地，`match` "
-"必須涵蓋所有分支。\n"
-"* 常見用途是在使用 `Option` 時處理 `Some` 值。\n"
-"* 與 `match` 不同，`if let` 不會為模式比對支援成立條件子句。\n"
-"* 自 1.65 版起，類似的 [let-else](https://doc.rust-lang.org/rust-by-example/"
+"自 1.65 版起，類似的 [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) 結構可以解構指派項目，或在失敗時具有不會傳回的區"
-"塊分支 (panic/return/break/continue)：\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"塊分支 (panic/return/break/continue)："
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 
 #: src/control-flow/while-expressions.md:1
-msgid "# `while` loops"
-msgstr "# `while` 迴圈"
+msgid "`while` loops"
+msgstr "`while` 迴圈"
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 "[`while` 關鍵字](https://doc.rust-lang.org/reference/expressions/loop-expr."
 "html#predicate-loops)的運作方式與其他語言非常相似："
@@ -7051,14 +7426,14 @@ msgstr ""
 "```"
 
 #: src/control-flow/while-let-expressions.md:1
-msgid "# `while let` loops"
-msgstr "# `while let` 迴圈"
+msgid "`while let` loops"
+msgstr "`while let` 迴圈"
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variant which repeatedly tests a value against a pattern:"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
 "和 `if let` 的情況一樣，有一個 [`while let`](https://doc.rust-lang.org/"
 "reference/expressions/loop-expr.html#predicate-pattern-loops) 變數可針對模式"
@@ -7091,10 +7466,9 @@ msgstr ""
 #: src/control-flow/while-let-expressions.md:17
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 "`v.iter()` 傳回的疊代器會在每次呼叫 `next()` 時傳回 `Option<i32>`。疊代器會在"
 "完成後才傳回 `Some(x)`，之後則會傳回 `None`。`while let` 可讓我們持續疊代所有"
@@ -7102,26 +7476,27 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:26
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
+msgstr "請指出只要值符合模式，`while let` 迴圈就會持續運作。"
+
+#: src/control-flow/while-let-expressions.md:27
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
 "statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
-"* 請指出只要值符合模式，`while let` 迴圈就會持續運作。\n"
-"* 您可以將 `while let` 迴圈重寫為無限迴圈，並加上會在無法為 `iter.next()` 取"
-"消包裝值的情況下結束的 if 陳述式。`while let` 可為上述情況提供語法糖。\n"
-"    "
+"您可以將 `while let` 迴圈重寫為無限迴圈，並加上會在無法為 `iter.next()` 取消"
+"包裝值的情況下結束的 if 陳述式。`while let` 可為上述情況提供語法糖。"
 
 #: src/control-flow/for-expressions.md:1
-msgid "# `for` loops"
-msgstr "# `for` 迴圈"
+msgid "`for` loops"
+msgstr "`for` 迴圈"
 
 #: src/control-flow/for-expressions.md:3
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely\n"
-"related to the [`while let` loop](while-let-expression.md). It will\n"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expression.md). It will "
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
 "[`for` 迴圈](https://doc.rust-lang.org/std/keyword.for.html)與 [`while let` "
@@ -7163,29 +7538,35 @@ msgid "You can use `break` and `continue` here as usual."
 msgstr "您可以照常使用 `break` 和 `continue`。"
 
 #: src/control-flow/for-expressions.md:25
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr "在 Rust 中，索引疊代不是只適用於該情況的特殊語法。"
+
+#: src/control-flow/for-expressions.md:26
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "`(0..10)` 是實作 `Iterator` 特徵的範圍。"
+
+#: src/control-flow/for-expressions.md:27
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr "`step_by` 這個方法會傳回另一個略過其他所有元素的 `Iterator`。"
+
+#: src/control-flow/for-expressions.md:28
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
-"* 在 Rust 中，索引疊代不是只適用於該情況的特殊語法。\n"
-"* `(0..10)` 是實作 `Iterator` 特徵的範圍。\n"
-"* `step_by` 這個方法會傳回另一個略過其他所有元素的 `Iterator`。\n"
-"* 請修改向量中的元素，並說明編譯器錯誤。將向量 `v` 變更為可變動項，並將 for "
-"迴圈變更為 `for x in v.iter_mut()`。"
+"請修改向量中的元素，並說明編譯器錯誤。將向量 `v` 變更為可變動項，並將 for 迴"
+"圈變更為 `for x in v.iter_mut()`。"
 
 #: src/control-flow/loop-expressions.md:1
-msgid "# `loop` expressions"
-msgstr "# `loop` 運算式"
+msgid "`loop` expressions"
+msgstr "`loop` 運算式"
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
 "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 "最後，有一個 [`loop` 關鍵字](https://doc.rust-lang.org/reference/expressions/"
 "loop-expr.html#infinite-loops)會建立無限迴圈。"
@@ -7231,29 +7612,27 @@ msgstr ""
 "```"
 
 #: src/control-flow/loop-expressions.md:27
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr "請使用 `break 8` 等值中斷 `loop`，然後顯示出來。"
+
+#: src/control-flow/loop-expressions.md:28
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-"
-"trivial\n"
-"  value. This is because it's guaranteed to be entered at least once "
-"(unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
-"* 請使用 `break 8` 等值中斷 `loop`，然後顯示出來。\n"
-"* 請注意，`loop` 是唯一會傳回重要值的迴圈結構。這是因為系統保證至少會輸入一次"
-"此迴圈結構，這一點不同於 `while` 和 `for` 迴圈。"
+"請注意，`loop` 是唯一會傳回重要值的迴圈結構。這是因為系統保證至少會輸入一次此"
+"迴圈結構，這一點不同於 `while` 和 `for` 迴圈。"
 
 #: src/control-flow/match-expressions.md:1
-msgid "# `match` expressions"
-msgstr "# `match` 運算式"
+msgid "`match` expressions"
+msgstr "`match` 運算式"
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
 "The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
-"expr.html)\n"
-"is used to match a value against one or more patterns. In that sense, it "
-"works\n"
-"like a series of `if let` expressions:"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
 "[`match` 關鍵字](https://doc.rust-lang.org/reference/expressions/match-expr."
 "html)是用來將值與一或多個模式進行比對。因此，這個關鍵字的運作方式類似於一系列"
@@ -7289,53 +7668,65 @@ msgstr ""
 
 #: src/control-flow/match-expressions.md:20
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 "和 `if let` 一樣，每個比對臂都必須具有相同型別。型別是區塊的最後一個運算式 "
 "(如有)。在上述範例中，型別為 `()`。"
 
 #: src/control-flow/match-expressions.md:28
+msgid "Save the match expression to a variable and print it out."
+msgstr "請將比對運算式儲存為變數，然後顯示出來。"
+
+#: src/control-flow/match-expressions.md:29
+msgid "Remove `.as_deref()` and explain the error."
+msgstr "請移除 `.as_deref()` 並說明錯誤。"
+
+#: src/control-flow/match-expressions.md:30
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
 msgstr ""
-"* 請將比對運算式儲存為變數，然後顯示出來。\n"
-"* 請移除 `.as_deref()` 並說明錯誤。\n"
-"    * `std::env::args().next()` 會傳回 `Option<String>`，但我們無法與"
-"`String` 進行比對。\n"
-" * `as_deref()` 會將 `Option<T>` 轉換成 `Option<&T::Target>`。在我們的案例"
-"中，這會將 `Option<String>` 轉換成`Option<&str>`。\n"
-"    * 我們現在可以使用模式比對，與 `Option` 內的 `&str` 進行比對。"
+"`std::env::args().next()` 會傳回 `Option<String>`，但我們無法與`String` 進行"
+"比對。"
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+"`as_deref()` 會將 `Option<T>` 轉換成 `Option<&T::Target>`。在我們的案例中，這"
+"會將 `Option<String>` 轉換成`Option<&str>`。"
+
+#: src/control-flow/match-expressions.md:32
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
+msgstr "我們現在可以使用模式比對，與 `Option` 內的 `&str` 進行比對。"
 
 #: src/control-flow/break-continue.md:1
-msgid "# `break` and `continue`"
-msgstr "# `break` 和 `continue`"
+msgid "`break` and `continue`"
+msgstr "`break` 和 `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
 msgstr ""
-"- 如果你想提早跳出迴圈，可以使用 [`break`]((https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions))，\n"
-"- 如果你想立即進入下一次迭代，可以使用 [`continue`](https://doc.rust-lang."
-"org/reference/expressions/loop-expr.html#continue-expressions)。"
+"如果你想提早跳出迴圈，可以使用 [`break`]((https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions))，"
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+msgstr ""
+"如果你想立即進入下一次迭代，可以使用 [`continue`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#continue-expressions)。"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
-"used\n"
-"to break out of nested loops:"
+"used to break out of nested loops:"
 msgstr ""
 "`continue` 以及 `break` 都可以選擇性地接收一個迴圈標籤，用來跳出巢狀迴圈中的"
 "某一層："
@@ -7383,17 +7774,11 @@ msgid ""
 "In this case we break the outer loop after 3 iterations of the inner loop."
 msgstr "在這個範例中，內層迴圈經過三次迭代後，我們使用 `break` 跳出外層迴圈。"
 
-#: src/std.md:1
-msgid "# Standard Library"
-msgstr "# 標準函式庫"
-
 #: src/std.md:3
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 "Rust 提供標準函式庫，可用於建立供 Rust 函式庫和程式使用的常用型別集。如此一"
 "來，兩個函式庫會使用相同的 `String` 型別，因此能夠順暢搭配運作。"
@@ -7404,53 +7789,64 @@ msgstr "常見的詞彙型別包括："
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
-"data."
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
 msgstr ""
-"* [`Option` 和 `Result`](std/option-result.md) 型別：用於選擇性的值和[錯誤處理](error-handling.md)。\n"
-"\n"
-"* [`String`](std/string.md)：用於自有資料的預設字串型別。\n"
-"\n"
-"* [`Vec`](std/vec.md)：標準的可延伸向量。\n"
-"\n"
-"* [`HashMap`](std/hashmap.md)：採用可設定雜湊演算法的雜湊映射型別。\n"
-"\n"
-"* [`Box`](std/box.md)：堆積配置資料的擁有所有權的指標。\n"
-"\n"
-"* [`Rc`](std/rc.md)：堆積配置資料的共用參考指標。"
+"[`Option` 和 `Result`](std/option-result.md) 型別：用於選擇性的值和[錯誤處理]"
+"(error-handling.md)。"
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr "[`String`](std/string.md)：用於自有資料的預設字串型別。"
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr "[`Vec`](std/vec.md)：標準的可延伸向量。"
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr "[`HashMap`](std/hashmap.md)：採用可設定雜湊演算法的雜湊映射型別。"
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr "[`Box`](std/box.md)：堆積配置資料的擁有所有權的指標。"
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
+msgstr "[`Rc`](std/rc.md)：堆積配置資料的共用參考指標。"
 
 #: src/std.md:25
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
+msgstr "Rust 實際上含有多種層級的標準函式庫，分別是 `core`、`alloc` 和 `std`。"
+
+#: src/std.md:26
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
 msgstr ""
-"  * Rust 實際上含有多種層級的標準函式庫，分別是 `core`、`alloc` 和 `std`。\n"
-"  * `core` 包括最基本的型別與函式，這些型別與函式不依附於 `libc`、配置器或作業系統。\n"
-"  * `alloc` 包括需要全域堆積配置器的型別，例如 `Vec`、`Box` 和 `Arc`。\n"
-"  * 嵌入式 Rust 應用程式通常只使用 `core`，偶爾會使用 `alloc`。"
+"`core` 包括最基本的型別與函式，這些型別與函式不依附於 `libc`、配置器或作業系"
+"統。"
+
+#: src/std.md:28
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr "`alloc` 包括需要全域堆積配置器的型別，例如 `Vec`、`Box` 和 `Arc`。"
+
+#: src/std.md:29
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr "嵌入式 Rust 應用程式通常只使用 `core`，偶爾會使用 `alloc`。"
 
 #: src/std/option-result.md:1
-msgid "# `Option` and `Result`"
-msgstr "# `Option` 和 `Result`"
+msgid "`Option` and `Result`"
+msgstr "`Option` 和 `Result`"
 
 #: src/std/option-result.md:3
 msgid "The types represent optional data:"
@@ -7471,31 +7867,40 @@ msgid ""
 msgstr ""
 
 #: src/std/option-result.md:18
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
-msgstr ""
-"* `Option` 和 `Result` 這兩種型別的使用範圍很廣，不侷限於標準函式庫。\n"
-"* 相較於 `&T`，`Option<&T>` 的空間開銷為零。\n"
-"* `Result` 是實作錯誤處理的標準型別，我們將在第 3 天的課程中介紹。\n"
-"* `binary_search` 會回傳 `Result<usize, usize>`。\n"
-"* 如果找到該元素，`Result::Ok` 會保留該元素所在位置的索引。\n"
-"* 如果沒有找到，`Result::Err` 會包含應插入這類元素的索引。"
+msgid "`Option` and `Result` are widely used not just in the standard library."
+msgstr "`Option` 和 `Result` 這兩種型別的使用範圍很廣，不侷限於標準函式庫。"
 
-#: src/std/string.md:1
-msgid "# String"
-msgstr "# String"
+#: src/std/option-result.md:19
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "相較於 `&T`，`Option<&T>` 的空間開銷為零。"
+
+#: src/std/option-result.md:20
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr "`Result` 是實作錯誤處理的標準型別，我們將在第 3 天的課程中介紹。"
+
+#: src/std/option-result.md:21
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "`binary_search` 會回傳 `Result<usize, usize>`。"
+
+#: src/std/option-result.md:22
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr "如果找到該元素，`Result::Ok` 會保留該元素所在位置的索引。"
+
+#: src/std/option-result.md:23
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr "如果沒有找到，`Result::Err` 會包含應插入這類元素的索引。"
 
 #: src/std/string.md:3
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
-msgstr "[`String`][1] 是標準堆積配置的可成長 UTF-8 字串緩衝區："
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
+msgstr ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) 是標準堆"
+"積配置的可成長 UTF-8 字串緩衝區："
 
 #: src/std/string.md:5
 msgid ""
@@ -7519,47 +7924,90 @@ msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` 會實作 [`Deref<Target = str>`][2]。也就是說，您可以在 `String` 上呼"
-"叫所有 `str` 方法。"
+"`String` 會實作 [`Deref<Target = str>`](https://doc.rust-lang.org/std/string/"
+"struct.String.html#deref-methods-str)。也就是說，您可以在 `String` 上呼叫所"
+"有 `str` 方法。"
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to index a `String`:\n"
-"    * To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-"
-"bound, out-of-bounds.\n"
-"    * To a substring by using `s3[0..4]`, where that slice is on character "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
 #: src/std/vec.md:1
-msgid "# `Vec`"
-msgstr "# `Vec`"
+msgid "`Vec`"
+msgstr "`Vec`"
 
 #: src/std/vec.md:3
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
-msgstr "[`Vec`][1] 是可調整大小的標準堆積配置緩衝區："
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
+msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 是可調整大小的標準"
+"堆積配置緩衝區："
 
 #: src/std/vec.md:5
 msgid ""
@@ -7590,38 +8038,50 @@ msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
-"`Vec` 會實作 [`Deref<Target = [T]>`][2]。也就是說，您可以在 `Vec` 上呼叫切片"
-"方法。"
+"`Vec` 會實作 [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D)。也就是說，您可以在 `Vec` 上呼叫切片方"
+"法。"
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
-msgid "# `HashMap`"
-msgstr "# `HashMap`"
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
+msgid "`HashMap`"
+msgstr "`HashMap`"
 
 #: src/std/hashmap.md:3
 msgid "Standard hash map with protection against HashDoS attacks:"
@@ -7667,48 +8127,80 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
-msgid "# `Box`"
-msgstr "# `Box`"
+msgid "`Box`"
+msgstr "`Box`"
 
 #: src/std/box.md:3
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "[`Box`][1] 是具有所有權的指向堆積上的資料的指標："
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 是具有所有權的指"
+"向堆積上的資料的指標："
 
 #: src/std/box.md:5
 msgid ""
@@ -7739,35 +8231,48 @@ msgstr ""
 #: src/std/box.md:26
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 "`Box<T>` 會實作 `Deref<Target = T>`。也就是說，您可以[直接在 `Box<T>` 上透過 "
-"`T` 呼叫方法][2]。"
+"`T` 呼叫方法](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-"
+"deref-coercion)。"
 
 #: src/std/box.md:34
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
 msgstr ""
-"* `Box` 就像是 C++ 中的 `std::unique_ptr`，兩者的差別在於 `Box` 不會是空值。\n"
-"* 上面的範例使用 `Deref`，因此 `println!` 陳述式甚至可以省略 `*`。\n"
-"* 在以下情況下，您可以使用 `Box`：\n"
-"   * 編譯時遇到不知道大小為何的型別，但 Rust 編譯器需要知道確切大小。\n"
-"   * 想要轉移大量資料的所有權。為避免在堆疊上複製大量資料，請改將"
-"資料儲存在 `Box` 的堆積上，這樣系統就只會移動指標。"
+"`Box` 就像是 C++ 中的 `std::unique_ptr`，兩者的差別在於 `Box` 不會是空值。"
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr "上面的範例使用 `Deref`，因此 `println!` 陳述式甚至可以省略 `*`。"
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr "在以下情況下，您可以使用 `Box`："
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr "編譯時遇到不知道大小為何的型別，但 Rust 編譯器需要知道確切大小。"
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr ""
+"想要轉移大量資料的所有權。為避免在堆疊上複製大量資料，請改將資料儲存在 `Box` "
+"的堆積上，這樣系統就只會移動指標。"
 
 #: src/std/box-recursive.md:1
-msgid "# Box with Recursive Data Structures"
-msgstr "# 包含遞迴資料結構的 Box"
+msgid "Box with Recursive Data Structures"
+msgstr "包含遞迴資料結構的 Box"
 
 #: src/std/box-recursive.md:3
 msgid ""
@@ -7815,35 +8320,34 @@ msgstr ""
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly "
-"into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it "
-"would look infinite.\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
-"* 如果這裡未使用 `Box`，且我們要將 `List` 直接嵌入 `List`，編譯器就不會計算出固定的"
-"結構體記憶體大小，結構體看起來會像是無限大。\n"
-"* `Box` 大小與一般指標相同，並且只會指向堆積中的下一個 `List` 元素，因此可以解決這個問題。\n"
-"* 將 `Box` 從 List 定義中移除後，畫面上會顯示編譯器錯誤。如果您看到「Recursive with "
-"indirection」錯誤訊息，建議您使用 Box 或其他種類的參考，而不是直接儲存值。\n"
-"    "
+"如果這裡未使用 `Box`，且我們要將 `List` 直接嵌入 `List`，編譯器就不會計算出固"
+"定的結構體記憶體大小，結構體看起來會像是無限大。"
 
-#: src/std/box-niche.md:1
-msgid "# Niche Optimization"
-msgstr "# 區位最佳化"
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+"`Box` 大小與一般指標相同，並且只會指向堆積中的下一個 `List` 元素，因此可以解"
+"決這個問題。"
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
+"將 `Box` 從 List 定義中移除後，畫面上會顯示編譯器錯誤。如果您看到「Recursive "
+"with indirection」錯誤訊息，建議您使用 Box 或其他種類的參考，而不是直接儲存"
+"值。"
 
 #: src/std/box-niche.md:16
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 "`Box` 不能空白，因此指標會一律有效，而且不會是 `null`。這樣一來，編譯器可以將"
@@ -7872,17 +8376,17 @@ msgid ""
 msgstr ""
 
 #: src/std/rc.md:1
-msgid "# `Rc`"
-msgstr "# `Rc`"
+msgid "`Rc`"
+msgstr "`Rc`"
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`][1] 是參考計數的共用指標。如要在多個位置參考相同的資料，可以使用這個指"
-"標："
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) 是參考計數的共用指"
+"標。如要在多個位置參考相同的資料，可以使用這個指標："
 
 #: src/std/rc.md:6
 msgid ""
@@ -7900,49 +8404,78 @@ msgid ""
 msgstr ""
 
 #: src/std/rc.md:18
+#, fuzzy
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
 msgstr ""
-"* 如要在 `Rc` 內修改資料，必須將資料加入 [`Cell` 或 `RefCell`][2] 等型別中。"
-"* 如果是多執行緒的環境，請參閱 [`Arc`][3]。* 您可以將共用指標「降級」為 "
-"[`Weak`][4] 指標，建立之後會捨棄的循環。"
+"如要在 `Rc` 內修改資料，必須將資料加入 [`Cell` 或 `RefCell`](../concurrency/"
+"shared_state/arc.md) 等型別中。\\* 如果是多執行緒的環境，請參閱 [`Arc`]"
+"(https://doc.rust-lang.org/std/sync/struct.Mutex.html)。\\* 您可以將共用指標"
+"「降級」為 [`Weak`](https://doc.rust-lang.org/std/rc/struct.Weak.html) 指標，"
+"建立之後會捨棄的循環。"
+
+#: src/std/rc.md:20
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
 
 #: src/std/rc.md:31
 msgid ""
-"* `Rc`'s count ensures that its contained value is valid for as long as "
-"there are references.\n"
-"* Like C++'s `std::shared_ptr`.\n"
-"* `Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr "`Rc` 的計數可確保只要有參考，內含的值就會保持有效。"
+
+#: src/std/rc.md:32
+msgid "Like C++'s `std::shared_ptr`."
+msgstr "Rust 的 `Rc` 就好比是 C++ 的 `std::shared_ptr`。"
+
+#: src/std/rc.md:33
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-"
-"write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable "
-"borrows that are enforced at compile time. `RefCell` enables (im)mutable "
-"borrows that are enforced at run time and will panic if it fails at "
-"runtime.\n"
-"* `Rc::downgrade` gives you a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"be ignored when looking for performance issues in code."
 msgstr ""
-"* `Rc` 的計數可確保只要有參考，內含的值就會保持有效。\n"
-"* Rust 的 `Rc` 就好比是 C++ 的 `std::shared_ptr`。\n"
-"* `Rc::clone` 的成本很低：這個做法會建立指向相同配置的指標，並增加參考計數，"
-"而不會產生深克隆，尋找程式碼效能問題時通常可以忽略。\n"
-"* `make_mut` 實際上會在必要時克隆內部值 (「clone-on-write」)，並回"
-"傳可變動的參考。\n"
-"* 使用 `Rc::strong_count` 可查看參考計數。\n"
-"* 比較提及的不同資料型別。`Box` 可啟用在編譯時強制執行的可變/不可變借用。"
-"`RefCell` 可啟用在執行階段強制執行的可變/不可變借用，如果在執行階段失敗，將觸發恐慌。\n"
-"* `Rc::downgrade` 提供的「弱參考計數」物件，建立之後會適當捨棄的循環 (可能會搭配 "
-"`RefCell`)。"
+"`Rc::clone` 的成本很低：這個做法會建立指向相同配置的指標，並增加參考計數，而"
+"不會產生深克隆，尋找程式碼效能問題時通常可以忽略。"
+
+#: src/std/rc.md:34
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+"`make_mut` 實際上會在必要時克隆內部值 (「clone-on-write」)，並回傳可變動的參"
+"考。"
+
+#: src/std/rc.md:35
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr "使用 `Rc::strong_count` 可查看參考計數。"
+
+#: src/std/rc.md:36
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+"比較提及的不同資料型別。`Box` 可啟用在編譯時強制執行的可變/不可變借用。"
+"`RefCell` 可啟用在執行階段強制執行的可變/不可變借用，如果在執行階段失敗，將觸"
+"發恐慌。"
+
+#: src/std/rc.md:37
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
+msgstr ""
+"`Rc::downgrade` 提供的「弱參考計數」物件，建立之後會適當捨棄的循環 (可能會搭"
+"配 `RefCell`)。"
 
 #: src/std/rc.md:41
 msgid ""
@@ -7973,10 +8506,6 @@ msgid ""
 "    println!(\"graph: {root:#?}\");\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/modules.md:1
-msgid "# Modules"
 msgstr ""
 
 #: src/modules.md:3
@@ -8011,15 +8540,18 @@ msgstr ""
 
 #: src/modules.md:28
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/visibility.md:1
-msgid "# Visibility"
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
 #: src/modules/visibility.md:3
@@ -8027,12 +8559,17 @@ msgid "Modules are a privacy boundary:"
 msgstr ""
 
 #: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr ""
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr ""
+
+#: src/modules/visibility.md:7
 msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
 msgstr ""
 
 #: src/modules/visibility.md:10
@@ -8066,7 +8603,7 @@ msgid ""
 msgstr ""
 
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
+msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
 #: src/modules/visibility.md:41
@@ -8077,16 +8614,22 @@ msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
-"its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/paths.md:1
-msgid "# Paths"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
 msgstr ""
 
 #: src/modules/paths.md:3
@@ -8094,20 +8637,33 @@ msgid "Paths are resolved as follows:"
 msgstr ""
 
 #: src/modules/paths.md:5
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgid "As a relative path:"
+msgstr ""
+
+#: src/modules/paths.md:6
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+
+#: src/modules/paths.md:7
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr ""
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
 #: src/modules/paths.md:13
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
 
 #: src/modules/paths.md:16
@@ -8116,10 +8672,6 @@ msgid ""
 "use std::collections::HashSet;\n"
 "use std::mem::transmute;\n"
 "```"
-msgstr ""
-
-#: src/modules/filesystem.md:1
-msgid "# Filesystem Hierarchy"
 msgstr ""
 
 #: src/modules/filesystem.md:3
@@ -8138,9 +8690,11 @@ msgid "The `garden` module content is found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:11
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:12
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:14
@@ -8148,9 +8702,11 @@ msgid "Similarly, a `garden::vegetables` module can be found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:16
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:17
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:19
@@ -8158,16 +8714,18 @@ msgid "The `crate` root is in:"
 msgstr ""
 
 #: src/modules/filesystem.md:21
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:22
+msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
 #: src/modules/filesystem.md:24
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
-"comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 
 #: src/modules/filesystem.md:27
@@ -8191,79 +8749,93 @@ msgstr ""
 
 #: src/modules/filesystem.md:44
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:47
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:57
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:60
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:63
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:68
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
-msgid "# Day 2: Afternoon Exercises"
+msgid "Day 2: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:3
 msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr ""
 
-#: src/exercises/day-2/luhn.md:1
-msgid "# Luhn Algorithm"
-msgstr ""
-
 #: src/exercises/day-2/luhn.md:3
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:19
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 
@@ -8319,23 +8891,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-msgid "# Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/strings-iterators.md:3
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:8
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
@@ -8389,7 +8955,7 @@ msgid ""
 msgstr ""
 
 #: src/welcome-day-3.md:1
-msgid "# Welcome to Day 3"
+msgid "Welcome to Day 3"
 msgstr ""
 
 #: src/welcome-day-3.md:3
@@ -8398,37 +8964,37 @@ msgstr ""
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
 
-#: src/generics.md:1
-msgid "# Generics"
-msgstr "# 泛型"
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
 
 #: src/generics.md:3
 msgid ""
 "Rust support generics, which lets you abstract an algorithm (such as "
-"sorting)\n"
-"over the types used in the algorithm."
+"sorting) over the types used in the algorithm."
 msgstr ""
 "Rust 支援泛型 (Generics)，因此可以將一個演算法 (例如：排序) 抽象化而不需要依"
 "賴特定型別。"
-
-#: src/generics/data-types.md:1
-msgid "# Generic Data Types"
-msgstr "# 泛型資料型別"
 
 #: src/generics/data-types.md:3
 msgid "You can use generics to abstract over the concrete field type:"
@@ -8452,18 +9018,12 @@ msgid ""
 msgstr ""
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
-msgstr ""
-"* 試著宣告一個新的變數 `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* 修改程式碼，讓 points 能擁有不同型別的元素。"
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
+msgstr "試著宣告一個新的變數 `let p = Point { x: 5, y: 10.0 };`."
 
-#: src/generics/methods.md:1
-msgid "# Generic Methods"
-msgstr "# 泛型方法"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
+msgstr "修改程式碼，讓 points 能擁有不同型別的元素。"
 
 #: src/generics/methods.md:3
 msgid "You can declare a generic type on your `impl` block:"
@@ -8492,26 +9052,33 @@ msgstr ""
 
 #: src/generics/methods.md:25
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
-msgstr ""
-"* *問題：* 為什麼 `T` 在 `impl<T> Point<T> {}` 中重複出現了兩次？\n"
-"    * 因為這是一個泛型型別 `T` 的 `Point` 實作，而 `Point` 的型別為泛型 `T`。"
-"它們是各自獨立的泛型。\n"
-"    * 這表示這個方法是為了任意型別 `T` 而定義的。\n"
-"    * 你可以寫成 `impl Point<u32> { .. }`。\n"
-"      * 由於 `Point` 仍然是泛型型別，你可以使用 `Point<f64>`，但這個方法將只"
-"適用於 `Point<u32>`。"
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
+msgstr "_問題：_ 為什麼 `T` 在 `impl<T> Point<T> {}` 中重複出現了兩次？"
 
-#: src/generics/monomorphization.md:1
-msgid "# Monomorphization"
-msgstr "# 單型化"
+#: src/generics/methods.md:26
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"因為這是一個泛型型別 `T` 的 `Point` 實作，而 `Point` 的型別為泛型 `T`。它們是"
+"各自獨立的泛型。"
+
+#: src/generics/methods.md:27
+msgid "It means these methods are defined for any `T`."
+msgstr "這表示這個方法是為了任意型別 `T` 而定義的。"
+
+#: src/generics/methods.md:28
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "你可以寫成 `impl Point<u32> { .. }`。"
+
+#: src/generics/methods.md:29
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"由於 `Point` 仍然是泛型型別，你可以使用 `Point<f64>`，但這個方法將只適用於 "
+"`Point<u32>`。"
 
 #: src/generics/monomorphization.md:3
 msgid "Generic code is turned into non-generic code based on the call sites:"
@@ -8556,15 +9123,10 @@ msgstr ""
 #: src/generics/monomorphization.md:31
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 "這是一種零成本抽象：單型化的結果，等同於不使用抽象化並手動寫出資料結構的實際"
 "型別。"
-
-#: src/traits.md:1
-msgid "# Traits"
-msgstr "# 特徵"
 
 #: src/traits.md:3
 msgid ""
@@ -8610,10 +9172,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/trait-objects.md:1
-msgid "# Trait Objects"
-msgstr "# 特徵物件"
 
 #: src/traits/trait-objects.md:3
 msgid ""
@@ -8717,28 +9275,39 @@ msgstr ""
 
 #: src/traits/trait-objects.md:72
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Pet>` in the example above.\n"
-"* `dyn Pet` is a way to tell the compiler about a dynamically sized type "
-"that implements `Pet`.\n"
-"* In the example, `pets` holds *fat pointers* to objects that implement "
-"`Pet`. The fat pointer consists of two components, a pointer to the actual "
-"object and a pointer to the virtual method table for the `Pet` "
-"implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"     ```"
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Pet>` in the example above."
 msgstr ""
 
-#: src/traits/deriving-traits.md:1
-msgid "# Deriving Traits"
-msgstr "# 衍生特徵"
+#: src/traits/trait-objects.md:73
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/traits/trait-objects.md:74
+msgid ""
+"In the example, `pets` holds _fat pointers_ to objects that implement `Pet`. "
+"The fat pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Pet` implementation of "
+"that particular object."
+msgstr ""
+
+#: src/traits/trait-objects.md:75
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits/trait-objects.md:76
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
+msgstr ""
 
 #: src/traits/deriving-traits.md:3
 msgid "You can let the compiler derive a number of traits:"
@@ -8762,10 +9331,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/default-methods.md:1
-msgid "# Default Methods"
-msgstr "# 預設方法"
 
 #: src/traits/default-methods.md:3
 msgid "Traits can implement behavior in terms of other trait methods:"
@@ -8801,51 +9366,61 @@ msgstr ""
 
 #: src/traits/default-methods.md:32
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to\n"
-"  implement themselves. Methods with default implementations can rely on "
-"required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `NotEqual` a super trait for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `NotEqual` as a "
-"super trait for `Equal`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
 
-#: src/traits/trait-bounds.md:1
-msgid "# Trait Bounds"
-msgstr "# 特徵界限"
+#: src/traits/default-methods.md:35
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr ""
+
+#: src/traits/default-methods.md:37
+msgid "Make `NotEqual` a super trait for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:38
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:46
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `NotEqual` as a super "
+"trait for `Equal`."
+msgstr ""
 
 #: src/traits/trait-bounds.md:3
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
-"使用泛型時，您通常會需要該型別實作\n"
-" 某些特徵，這樣才能呼叫該特徵的方法。"
+"使用泛型時，您通常會需要該型別實作 某些特徵，這樣才能呼叫該特徵的方法。"
 
 #: src/traits/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
@@ -8904,30 +9479,30 @@ msgstr ""
 "```"
 
 #: src/traits/trait-bounds.md:46
+msgid "It declutters the function signature if you have many parameters."
+msgstr "如果您有多個參數，這個子句可以整理函式簽名。"
+
+#: src/traits/trait-bounds.md:47
+msgid "It has additional features making it more powerful."
+msgstr "這個子句具有額外功能，因此效能也更強大。"
+
+#: src/traits/trait-bounds.md:48
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":"
-"\" can be arbitrary, like `Option<T>`.\n"
-"    "
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
-"* 如果您有多個參數，這個子句可以整理函式簽名。\n"
-"* 這個子句具有額外功能，因此效能也更強大。\n"
-"    * 如果有人提問，請說明額外功能是指 \":\" 左側的類別可為任意值，例如 "
-"`Option<T>`。\n"
-"    "
+"如果有人提問，請說明額外功能是指 \":\" 左側的類別可為任意值，例如 "
+"`Option<T>`。"
 
 #: src/traits/impl-trait.md:1
-msgid "# `impl Trait`"
-msgstr "# `impl Trait`"
+msgid "`impl Trait`"
+msgstr "`impl Trait`"
 
 #: src/traits/impl-trait.md:3
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
-msgstr ""
-"與特徵界限類似，`impl Trait` 語法可用於\n"
-"函式引數和回傳值中："
+msgstr "與特徵界限類似，`impl Trait` 語法可用於 函式引數和回傳值中："
 
 #: src/traits/impl-trait.md:6
 msgid ""
@@ -8946,8 +9521,8 @@ msgid ""
 msgstr ""
 
 #: src/traits/impl-trait.md:19
-msgid "* `impl Trait` allows you to work with types which you cannot name."
-msgstr "* `impl Trait` 可讓您使用無法命名的型別。"
+msgid "`impl Trait` allows you to work with types which you cannot name."
+msgstr "`impl Trait` 可讓您使用無法命名的型別。"
 
 #: src/traits/impl-trait.md:23
 msgid ""
@@ -8956,61 +9531,48 @@ msgstr "`impl Trait` 的涵義會因使用位置而有些微不同。"
 
 #: src/traits/impl-trait.md:25
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` "
-"picks\n"
-"  the concrete type it returns, without writing it out in the source. A "
-"function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let "
-"x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
+msgstr "對參數來說，`impl Trait` 就像是具有特徵界限的匿名泛型參數。"
+
+#: src/traits/impl-trait.md:27
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
 msgstr ""
-"* 對參數來說，`impl Trait` 就像是具有特徵界限的匿名泛型參數。\n"
-"\n"
-"* 對回傳型別來說，`impl Trait` 代表回傳型別就是實作特徵的\n"
-"某些具體型別，因而不必指名特定型別。如果您不想在公用 API 中公開具體型別，\n"
-"這就非常有用。\n"
-"\n"
-"在回傳位置進行推論並不容易。回傳 `impl Foo` 的函式\n"
-"會挑選自身回傳的具體型別，而不必在來源中寫出此資訊。回傳泛型型別\n"
-" (例如 `collect<B>() -> B`) 的函式則可回傳\n"
-"符合 `B` 的任何型別\n"
-"，而呼叫端可能需要選擇一個型別，例如使用 `let x: Vec<_> = foo.collect()` 或 "
-"Turbofish：`foo.collect::<Vec<_>>()`。"
+"對回傳型別來說，`impl Trait` 代表回傳型別就是實作特徵的 某些具體型別，因而不"
+"必指名特定型別。如果您不想在公用 API 中公開具體型別， 這就非常有用。"
+
+#: src/traits/impl-trait.md:31
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
+msgstr ""
+"在回傳位置進行推論並不容易。回傳 `impl Foo` 的函式 會挑選自身回傳的具體型別，"
+"而不必在來源中寫出此資訊。回傳泛型型別 (例如 `collect<B>() -> B`) 的函式則可"
+"回傳 符合 `B` 的任何型別 ，而呼叫端可能需要選擇一個型別，例如使用 `let x: "
+"Vec<_> = foo.collect()` 或 Turbofish：`foo.collect::<Vec<_>>()`。"
 
 #: src/traits/impl-trait.md:37
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters."
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
-"這個例子非常好，因為 `impl Display` 使用了兩次。這有助於說明此處沒有\n"
-"任何項目會強制使用「相同的」`impl Display` 型別。如果我們使用單一的 \n"
-"`T: Display`，則會強制限制「輸入」`T` 和「回傳」`T` 屬於同一型別。\n"
-"但這並不適合這個特定函式，因為我們預期做為「輸入」的型別不一定\n"
-"會是 `format!` 回傳的內容。如要透過 `: Display` 語法執行相同操作，我們會\n"
-"需要兩個獨立的泛型參數。"
-
-#: src/traits/important-traits.md:1
-msgid "# Important Traits"
-msgstr "# 重要特徵"
+"這個例子非常好，因為 `impl Display` 使用了兩次。這有助於說明此處沒有 任何項目"
+"會強制使用「相同的」`impl Display` 型別。如果我們使用單一的  `T: Display`，則"
+"會強制限制「輸入」`T` 和「回傳」`T` 屬於同一型別。 但這並不適合這個特定函式，"
+"因為我們預期做為「輸入」的型別不一定 會是 `format!` 回傳的內容。如要透過 `: "
+"Display` 語法執行相同操作，我們會 需要兩個獨立的泛型參數。"
 
 #: src/traits/important-traits.md:3
 msgid ""
@@ -9020,27 +9582,67 @@ msgstr "現在來探討 Rust 標準程式庫最常見的幾個特徵："
 
 #: src/traits/important-traits.md:5
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
 msgstr ""
-"* [`Iterator`][1] 和 [`IntoIterator`][2] 用於 `for` 迴圈。\n"
-"* [`From`][3] 和 [`Into`][4] 用來轉換值。\n"
-"* [`Read`][5] 和 [`Write`][6] 用於 IO。\n"
-"* [`Add`][7]、[`Mul`][8] 等用於運算子超載。\n"
-"* [`Drop`][9] 用於定義解構函式。\n"
-"* [`Default`][10] 用於建構型別的預設執行個體。"
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) 和 "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"用於 `for` 迴圈。"
+
+#: src/traits/important-traits.md:6
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) 用來轉換值。"
+
+#: src/traits/important-traits.md:7
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) 用於 IO。"
+
+#: src/traits/important-traits.md:8
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html)、[`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html) 等用於運算子超載。"
+
+#: src/traits/important-traits.md:9
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 用於定義解構函"
+"式。"
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 用於建"
+"構型別的預設執行個體。"
 
 #: src/traits/iterator.md:1
-msgid "# Iterators"
-msgstr "# 疊代器"
+msgid "Iterators"
+msgstr "疊代器"
 
 #: src/traits/iterator.md:3
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
-msgstr "您可以自行在型別上實作 [`Iterator`][1] 特徵："
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
+msgstr ""
+"您可以自行在型別上實作 [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) 特徵："
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -9072,38 +9674,37 @@ msgstr ""
 
 #: src/traits/iterator.md:32
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
-"* `Iterator` 特徵會對集合實作許多常見的函式程式操作，例如 `map`、`filter`、"
-"  `reduce` 等等。您可以藉由此特徵找出所有相關的說明文件。在 Rust 中，這些"
-"  函式會產生程式碼，且應與對應的命令式實作項目一樣有效率。\n"
-"    \n"
-"* `IntoIterator` 是迫使 for 迴圈運作的特徵。此特徵由集合型別(例如 `Vec<T>`) "
-"  和相關參照 (`&Vec<T>` 與 `&[T]`) 實作而成。此外，範圍也會實作這項特徵。"
-"  這就說明了您為何可以透過 `for i in some_vec { .. }` 對向量進行疊代，即使沒有 "
-"`some_vec.next()` 也無妨。"
+"`Iterator` 特徵會對集合實作許多常見的函式程式操作，例如 `map`、`filter`、  "
+"`reduce` 等等。您可以藉由此特徵找出所有相關的說明文件。在 Rust 中，這些  函式"
+"會產生程式碼，且應與對應的命令式實作項目一樣有效率。"
 
-#: src/traits/from-iterator.md:1
-msgid "# FromIterator"
-msgstr "# FromIterator"
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
+"`IntoIterator` 是迫使 for 迴圈運作的特徵。此特徵由集合型別(例如 `Vec<T>`)   "
+"和相關參照 (`&Vec<T>` 與 `&[T]`) 實作而成。此外，範圍也會實作這項特徵。  這就"
+"說明了您為何可以透過 `for i in some_vec { .. }` 對向量進行疊代，即使沒有 "
+"`some_vec.next()` 也無妨。"
 
 #: src/traits/from-iterator.md:3
 msgid ""
-"[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
-msgstr "[`FromIterator`][1] 可讓您透過 [`Iterator`][2] 建構集合。"
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
+msgstr ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"可讓您透過 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator."
+"html) 建構集合。"
 
 #: src/traits/from-iterator.md:5
 msgid ""
@@ -9120,34 +9721,33 @@ msgstr ""
 
 #: src/traits/from-iterator.md:17
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 
 #: src/traits/from-iterator.md:23
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
-"您也可以利用部分實作項目完成某些酷炫操作，例如將\n"
-"`Iterator<Item = Result<V, E>>` 轉換成 `Result<Vec<V>, E>`。"
+"您也可以利用部分實作項目完成某些酷炫操作，例如將 `Iterator<Item = Result<V, "
+"E>>` 轉換成 `Result<Vec<V>, E>`。"
 
 #: src/traits/from-into.md:1
-msgid "# `From` and `Into`"
-msgstr "# `From` 和 `Into`"
+msgid "`From` and `Into`"
+msgstr "`From` 和 `Into`"
 
 #: src/traits/from-into.md:3
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
-msgstr "型別會實作 [`From`][1] 和 [`Into`][2] 以利型別轉換作業執行："
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
+msgstr ""
+"型別會實作 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) "
+"和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 以利型別轉"
+"換作業執行："
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -9164,8 +9764,13 @@ msgstr ""
 
 #: src/traits/from-into.md:15
 msgid ""
-"[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
-msgstr "實作 [`From`][1] 時，[`Into`][2] 也會自動實作："
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
+msgstr ""
+"實作 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 時，"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 也會自動實"
+"作："
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -9182,28 +9787,34 @@ msgstr ""
 
 #: src/traits/from-into.md:29
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
+msgstr "這就是為什麼通常只需實作 `From`，因為型別也會實作 `Into`。"
+
+#: src/traits/from-into.md:30
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
 msgstr ""
-"* 這就是為什麼通常只需實作 `From`，因為型別也會實作 `Into`。\n"
-"* 如要宣告函式引數輸入型別 (例如「任何可轉換成 `String` 的型別」)，規則便會相"
-"反，此時請使用 `Into`。\n"
-"您的函式會接受實作 `From` 的型別，以及「僅」實作 `Into` 的型別。\n"
-"    "
+"如要宣告函式引數輸入型別 (例如「任何可轉換成 `String` 的型別」)，規則便會相"
+"反，此時請使用 `Into`。 您的函式會接受實作 `From` 的型別，以及「僅」實作 "
+"`Into` 的型別。"
 
 #: src/traits/read-write.md:1
-msgid "# `Read` and `Write`"
-msgstr "# `Read` 和 `Write`"
+msgid "`Read` and `Write`"
+msgstr "`Read` 和 `Write`"
 
 #: src/traits/read-write.md:3
 msgid ""
-"Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
-msgstr "使用 [`Read`][1] 和 [`BufRead`][2] 即可對 `u8` 來源進行抽象化處理："
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr ""
+"使用 [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) 和 "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html) 即可對 `u8` "
+"來源進行抽象化處理："
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -9227,8 +9838,12 @@ msgid ""
 msgstr ""
 
 #: src/traits/read-write.md:23
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
-msgstr "同樣地，[`Write`][3] 則可讓您將 `u8` 接收器抽象化："
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
+msgstr ""
+"同樣地，[`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) 則可讓您"
+"將 `u8` 接收器抽象化："
 
 #: src/traits/read-write.md:25
 msgid ""
@@ -9251,14 +9866,16 @@ msgid ""
 msgstr ""
 
 #: src/traits/drop.md:1
-msgid "# The `Drop` Trait"
-msgstr "# `Drop` 特徵"
+msgid "The `Drop` Trait"
+msgstr "`Drop` 特徵"
 
 #: src/traits/drop.md:3
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
-msgstr "如果值實作了 [`Drop`][1]，即可在超出範圍時指定要執行哪個程式碼："
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
+msgstr ""
+"如果值實作了 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html)，即"
+"可在超出範圍時指定要執行哪個程式碼："
 
 #: src/traits/drop.md:5
 msgid ""
@@ -9295,28 +9912,32 @@ msgid "Discussion points:"
 msgstr "討論要點："
 
 #: src/traits/drop.md:36
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "為什麼 `Drop::drop` 不使用 `self`？"
+
+#: src/traits/drop.md:37
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
-"* 為什麼 `Drop::drop` 不使用 `self`？\n"
-"    * 簡答：如果這樣的話，系統會在\n"
-"區塊結尾呼叫 `std::mem::drop`，進而觸發另一個對 `Drop::drop` 的呼叫並造成堆"
-"疊\n"
-"溢位！\n"
-"* 請嘗試將 `drop(a)` 替換為 `a.drop()`。"
+"簡答：如果這樣的話，系統會在 區塊結尾呼叫 `std::mem::drop`，進而觸發另一個對 "
+"`Drop::drop` 的呼叫並造成堆疊 溢位！"
+
+#: src/traits/drop.md:40
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "請嘗試將 `drop(a)` 替換為 `a.drop()`。"
 
 #: src/traits/default.md:1
-msgid "# The `Default` Trait"
-msgstr "# `Default` 特徵"
+msgid "The `Default` Trait"
+msgstr "`Default` 特徵"
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait produces a default value for a type."
-msgstr "[`Default`][1] 特徵會產生型別的預設值。"
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 特徵會"
+"產生型別的預設值。"
 
 #: src/traits/default.md:5
 msgid ""
@@ -9356,32 +9977,48 @@ msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e."
-"g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr "這可以直接實作，也可以透過 `#[derive(Default)]` 衍生得出。"
+
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr "衍生的實作項目會產生一個執行個體，其中欄位全都設為預設值。"
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr "也就是說，該結構體中的所有型別也都必須實作 `Default`。"
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+"標準的 Rust 型別通常會以合理的值 (例如 `0`、`\"\"` 等等) 實作 `Default`。"
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr "部分結構體副本可與預設值完美搭配運作。"
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
-"  * 這可以直接實作，也可以透過 `#[derive(Default)]` 衍生得出。\n"
-"  * 衍生的實作項目會產生一個執行個體，其中欄位全都設為預設值。\n"
-"    * 也就是說，該結構體中的所有型別也都必須實作 `Default`。\n"
-"  * 標準的 Rust 型別通常會以合理的值 (例如 `0`、`\"\"` 等等) 實作 "
-"`Default`。\n"
-"  * 部分結構體副本可與預設值完美搭配運作。\n"
-"  * Rust 標準程式庫瞭解型別可能會實作 `Default`，因此提供了便利的使用方式。"
+"Rust 標準程式庫瞭解型別可能會實作 `Default`，因此提供了便利的使用方式。"
 
 #: src/traits/operators.md:1
-msgid "# `Add`, `Mul`, ..."
-msgstr "# `Add`、`Mul`..."
+msgid "`Add`, `Mul`, ..."
+msgstr "`Add`、`Mul`..."
 
 #: src/traits/operators.md:3
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
-msgstr "運算子超載會透過 [`std::ops`][1]: 內的特徵實作："
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
+msgstr ""
+"運算子超載會透過 [`std::ops`](https://doc.rust-lang.org/std/ops/index.html): "
+"內的特徵實作："
 
 #: src/traits/operators.md:5
 msgid ""
@@ -9407,50 +10044,57 @@ msgstr ""
 
 #: src/traits/operators.md:28
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter of "
-"the method?\n"
-"    * Short answer: Function type parameters are controlled by the caller, "
-"but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait.\n"
-"* You could implement `Add` for two different types, e.g.\n"
-"  `impl Add<(i32, i32)> for Point` would add a tuple to a `Point`."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
+msgstr "您可以針對 `&Point` 實作 `Add`。但這能在哪些情況派上用場？"
+
+#: src/traits/operators.md:29
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
 msgstr ""
-"* 您可以針對 `&Point` 實作 `Add`。但這能在哪些情況派上用場？\n"
-"    * 回答：`Add:add` 會耗用 `self`。如果您要超載運算子的型別 `T` 不是 "
-"        `Copy`，建議您一併為 `&T` 超載運算子。這可避免呼叫點中出現不必要"
-"        的複製作業。\n"
-"* 為什麼 `Output` 是關聯型別？可將其用做方法的型別參數嗎？\n"
-"    * 簡答：函式型別參數是由呼叫端控管，但 `Output` 這類關聯型別則由特徵"
-"        實作者控管。\n"
-"* 您可以針對兩種不同型別實作 `Add`，舉例來說，"
-"  `impl Add<(i32, i32)> for Point` 會將元組新增至 `Point`。"
+"回答：`Add:add` 會耗用 `self`。如果您要超載運算子的型別 `T` 不是         "
+"`Copy`，建議您一併為 `&T` 超載運算子。這可避免呼叫點中出現不必要        的複"
+"製作業。"
+
+#: src/traits/operators.md:33
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr "為什麼 `Output` 是關聯型別？可將其用做方法的型別參數嗎？"
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementor of a "
+"trait."
+msgstr ""
+"簡答：函式型別參數是由呼叫端控管，但 `Output` 這類關聯型別則由特徵        實"
+"作者控管。"
+
+#: src/traits/operators.md:37
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
+msgstr ""
+"您可以針對兩種不同型別實作 `Add`，舉例來說，  `impl Add<(i32, i32)> for "
+"Point` 會將元組新增至 `Point`。"
 
 #: src/traits/closures.md:1
-msgid "# Closures"
-msgstr "# 閉包"
+msgid "Closures"
+msgstr "閉包"
 
 #: src/traits/closures.md:3
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
-"無論是閉包還是 lambda 運算式，都含有無法命名的型別。不過，這兩者\n"
-"都會實作特殊的 [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和\n"
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) 特徵："
+"無論是閉包還是 lambda 運算式，都含有無法命名的型別。不過，這兩者 都會實作特殊"
+"的 [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、 [`FnMut`]"
+"(https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://"
+"doc.rust-lang.org/std/ops/trait.FnOnce.html) 特徵："
 
 #: src/traits/closures.md:8
 msgid ""
@@ -9485,42 +10129,34 @@ msgstr ""
 #: src/traits/closures.md:29
 msgid ""
 "An `Fn` neither consumes nor mutates captured values, or perhaps captures "
-"nothing at all, so it can\n"
-"be called multiple times concurrently."
+"nothing at all, so it can be called multiple times concurrently."
 msgstr ""
 
 #: src/traits/closures.md:43
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 "`FnMut` 是 `FnOnce` 的子型別，而 `Fn` 是 `FnMut` 和 `FnOnce` 的子型別。換句話"
-"說，您可以在任何需要呼叫 `FnOnce` 的地方使用\n"
-"`FnMut`，而在任何需要呼叫 `FnMut` 或 `FnOnce` 的地方\n"
-"使用 `Fn`。"
+"說，您可以在任何需要呼叫 `FnOnce` 的地方使用 `FnMut`，而在任何需要呼叫 "
+"`FnMut` 或 `FnOnce` 的地方 使用 `Fn`。"
 
 #: src/traits/closures.md:36
 msgid "`move` closures only implement `FnOnce`."
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
-msgid "# Day 3: Morning Exercises"
+msgid "Day 3: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:3
 msgid "We will design a classical GUI library traits and trait objects."
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:1
-msgid "# A Simple GUI Library"
-msgstr ""
-
 #: src/exercises/day-3/simple-gui.md:3
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 
@@ -9529,11 +10165,17 @@ msgid "We will have a number of widgets in our library:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:8
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:9
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:11
+msgid "`Label`: has a `label`."
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:13
@@ -9542,7 +10184,7 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:15
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
@@ -9681,11 +10323,10 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:142
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:147
@@ -9719,25 +10360,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-msgid "# Error Handling"
-msgstr "# 錯誤處理"
-
 #: src/error-handling.md:3
 msgid "Error handling in Rust is done using explicit control flow:"
 msgstr "在 Rust 中，是透過明確的控制流程完成錯誤處理作業："
 
 #: src/error-handling.md:5
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
-msgstr ""
-"* 可能含有錯誤的函式會在回傳型別中列出相關資訊。\n"
-"* 沒有任何例外。"
+msgid "Functions that can have errors list this in their return type,"
+msgstr "可能含有錯誤的函式會在回傳型別中列出相關資訊。"
 
-#: src/error-handling/panics.md:1
-msgid "# Panics"
-msgstr "# 恐慌"
+#: src/error-handling.md:6
+msgid "There are no exceptions."
+msgstr "沒有任何例外。"
 
 #: src/error-handling/panics.md:3
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
@@ -9760,18 +10393,21 @@ msgstr ""
 "```"
 
 #: src/error-handling/panics.md:12
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "恐慌代表發生無法復原的非預期錯誤。"
+
+#: src/error-handling/panics.md:13
+msgid "Panics are symptoms of bugs in the program."
+msgstr "恐慌可以反映程式中的錯誤。"
+
+#: src/error-handling/panics.md:14
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
-msgstr ""
-"* 恐慌代表發生無法復原的非預期錯誤。\n"
-"  * 恐慌可以反映程式中的錯誤。\n"
-"* 如果無法接受程式崩潰，請使用不會觸發恐慌的 API，例如 `Vec::get`。"
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+msgstr "如果無法接受程式崩潰，請使用不會觸發恐慌的 API，例如 `Vec::get`。"
 
 #: src/error-handling/panic-unwind.md:1
-msgid "# Catching the Stack Unwinding"
-msgstr "# 擷取解開堆疊的動作"
+msgid "Catching the Stack Unwinding"
+msgstr "擷取解開堆疊的動作"
 
 #: src/error-handling/panic-unwind.md:3
 msgid ""
@@ -9811,23 +10447,23 @@ msgstr ""
 
 #: src/error-handling/panic-unwind.md:21
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* 如果伺服器需要持續運作 (即使有單一要求崩潰也不例外)，這種做法就能派上用"
-"場。\n"
-"* 如果您在 `Cargo.toml` 中設定 `panic = 'abort'`，就無法採取此做法。"
+"如果伺服器需要持續運作 (即使有單一要求崩潰也不例外)，這種做法就能派上用場。"
+
+#: src/error-handling/panic-unwind.md:23
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr "如果您在 `Cargo.toml` 中設定 `panic = 'abort'`，就無法採取此做法。"
 
 #: src/error-handling/result.md:1
-msgid "# Structured Error Handling with `Result`"
-msgstr "# 使用 `Result` 進行結構化錯誤處理"
+msgid "Structured Error Handling with `Result`"
+msgstr "使用 `Result` 進行結構化錯誤處理"
 
 #: src/error-handling/result.md:3
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
 "我們先前介紹了 `Result` 列舉。當正常運作過程中預期發生錯誤時，普遍都會使用這"
 "個列舉："
@@ -9874,27 +10510,27 @@ msgstr ""
 
 #: src/error-handling/result.md:27
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
+msgstr ""
+
+#: src/error-handling/result.md:30
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
 msgstr ""
 
 #: src/error-handling/try-operator.md:1
-msgid "# Propagating Errors with `?`"
-msgstr "# 使用 `?` 傳播錯誤"
+msgid "Propagating Errors with `?`"
+msgstr "使用 `?` 傳播錯誤"
 
 #: src/error-handling/try-operator.md:3
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
+"turn the common"
 msgstr "try 運算子 `?` 用於將錯誤傳回呼叫端，讓您將下列常見的程式碼："
 
 #: src/error-handling/try-operator.md:6
@@ -9985,16 +10621,15 @@ msgstr ""
 
 #: src/error-handling/try-operator.md:50
 #: src/error-handling/converting-error-types-example.md:52
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-msgid "# Converting Error Types"
-msgstr "# 轉換錯誤型別"
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
 
 #: src/error-handling/converting-error-types.md:3
 msgid ""
@@ -10034,8 +10669,7 @@ msgstr ""
 
 #: src/error-handling/converting-error-types.md:18
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
 "這裡的 `From::from` 呼叫意味著，我們嘗試將錯誤型別轉換成函式回傳的型別："
@@ -10106,7 +10740,8 @@ msgstr ""
 "    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
 "        match self {\n"
 "            Self::IoError(e) => write!(f, \"IO error: {e}\"),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Found no username in {filename}\"),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
+"in {filename}\"),\n"
 "        }\n"
 "    }\n"
 "}\n"
@@ -10136,23 +10771,16 @@ msgstr ""
 #: src/error-handling/converting-error-types-example.md:55
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
 msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:1
-msgid "# Deriving Error Enums"
-msgstr "# 推導錯誤列舉"
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
 "[thiserror](https://docs.rs/thiserror/) crate 很常用來建立錯誤列舉，我們在上"
 "一頁就曾這麼做："
@@ -10224,25 +10852,19 @@ msgstr ""
 #: src/error-handling/deriving-error-enums.md:39
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:1
-msgid "# Dynamic Error Types"
-msgstr "# 動態錯誤型別"
-
 #: src/error-handling/dynamic-errors.md:3
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 "我們有時會想允許傳回任何型別的錯誤，而不是自行編寫涵蓋所有不同可能性的列舉。"
 "`std::error::Error` 可讓這項工作更輕鬆。"
@@ -10308,23 +10930,17 @@ msgstr ""
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
 
-#: src/error-handling/error-contexts.md:1
-msgid "# Adding Context to Errors"
-msgstr "# 為錯誤添加背景資訊"
-
 #: src/error-handling/error-contexts.md:3
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 "透過廣泛使用的 [anyhow](https://docs.rs/anyhow/) crate，您可以為錯誤添加背景"
 "資訊，並減少自訂錯誤型別的數量："
@@ -10384,40 +11000,39 @@ msgstr ""
 "```"
 
 #: src/error-handling/error-contexts.md:35
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
 
-#: src/testing.md:1
-msgid "# Testing"
-msgstr "# 測試"
+#: src/error-handling/error-contexts.md:36
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:38
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:39
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
 
 #: src/testing.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr "Rust 和 Cargo 提供了一個簡單的單元測試 (unit test) 框架："
 
 #: src/testing.md:5
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
-msgstr ""
-"* 在你的程式碼的任何地方都可添加單元測試。\n"
-"\n"
-"* 整合測試 (integration test) 則可放置在 `tests/` 資料夾下。"
+msgid "Unit tests are supported throughout your code."
+msgstr "在你的程式碼的任何地方都可添加單元測試。"
 
-#: src/testing/unit-tests.md:1
-msgid "# Unit Tests"
-msgstr "# 單元測試"
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr "整合測試 (integration test) 則可放置在 `tests/` 資料夾下。"
 
 #: src/testing/unit-tests.md:3
 msgid "Mark unit tests with `#[test]`:"
@@ -10454,17 +11069,13 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr "用 `cargo test` 尋找並執行單元測試。"
 
-#: src/testing/test-modules.md:1
-msgid "# Test Modules"
-msgstr "# 測試模組"
-
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
-"單元測試通常會位於巢狀模組中 (在\n"
-"[Playground](https://play.rust-lang.org/) 上執行測試)："
+"單元測試通常會位於巢狀模組中 (在 [Playground](https://play.rust-lang.org/) 上"
+"執行測試)："
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -10490,16 +11101,12 @@ msgid ""
 msgstr ""
 
 #: src/testing/test-modules.md:26
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
-msgstr ""
-"* 這有助於您對私人輔助程式進行單元測試。\n"
-"* 只有在執行 `cargo test` 時，`#[cfg(test)]` 屬性才會生效。"
+msgid "This lets you unit test private helpers."
+msgstr "這有助於您對私人輔助程式進行單元測試。"
 
-#: src/testing/doc-tests.md:1
-msgid "# Documentation Tests"
-msgstr "# 說明文件測試"
+#: src/testing/test-modules.md:27
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr "只有在執行 `cargo test` 時，`#[cfg(test)]` 屬性才會生效。"
 
 #: src/testing/doc-tests.md:3
 msgid "Rust has built-in support for documentation tests:"
@@ -10522,21 +11129,21 @@ msgid ""
 msgstr ""
 
 #: src/testing/doc-tests.md:18
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr "系統會自動將 `///` 註解中的程式碼區塊視為 Rust 程式碼。"
+
+#: src/testing/doc-tests.md:19
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "系統會編譯程式碼，執行 `cargo test` 時會一併執行這些程式碼。"
+
+#: src/testing/doc-tests.md:20
 msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"* 系統會自動將 `///` 註解中的程式碼區塊視為 Rust 程式碼。\n"
-"* 系統會編譯程式碼，執行 `cargo test` 時會一併執行這些程式碼。\n"
-"* 請在 [Rust Playground](https://play.rust-lang.org/?"
+"請在 [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0) "
 "上測試上述程式碼。"
-
-#: src/testing/integration-tests.md:1
-msgid "# Integration Tests"
-msgstr "# 整合測試"
 
 #: src/testing/integration-tests.md:3
 msgid "If you want to test your library as a client, use an integration test."
@@ -10563,8 +11170,8 @@ msgid "These tests only have access to the public API of your crate."
 msgstr "這些測試只能存取 crate 的公用 API。"
 
 #: src/testing/useful-crates.md:1
-msgid "## Useful crates for writing tests"
-msgstr "## 有助於編寫測試的 crate"
+msgid "Useful crates for writing tests"
+msgstr "有助於編寫測試的 crate"
 
 #: src/testing/useful-crates.md:3
 msgid "Rust comes with only basic support for writing tests."
@@ -10576,47 +11183,47 @@ msgstr "以下列出幾個額外的 crate，建議您在編寫測試時使用：
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
-"tests."
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
 msgstr ""
-"* [googletest](https://docs.rs/googletest)：這是全面性的測試斷言程式庫，沿用"
-"了 GoogleTest (適用於 C++) 的傳統運作方式。\n"
-"* [proptest](https://docs.rs/proptest)：讓您對 Rust 執行以屬性為基礎的測試"
-"。\n"
-"* [rstest](https://docs.rs/rstest)：支援 Fixture 和參數化測試。"
+"[googletest](https://docs.rs/googletest)：這是全面性的測試斷言程式庫，沿用了 "
+"GoogleTest (適用於 C++) 的傳統運作方式。"
 
-#: src/unsafe.md:1
-msgid "# Unsafe Rust"
-msgstr "# 不安全的 Rust"
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr ""
+"[proptest](https://docs.rs/proptest)：讓您對 Rust 執行以屬性為基礎的測試。"
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
+msgstr "[rstest](https://docs.rs/rstest)：支援 Fixture 和參數化測試。"
 
 #: src/unsafe.md:3
 msgid "The Rust language has two parts:"
 msgstr "Rust 語言包含兩個部分："
 
 #: src/unsafe.md:5
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr "\\*\\*安全的 Rust：\\*\\*可確保記憶體安全，無法觸發未定義的行為。"
+
+#: src/unsafe.md:6
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
-msgstr ""
-"* **安全的 Rust：**可確保記憶體安全，無法觸發未定義的行為。\n"
-"* **不安全的 Rust：**如果違反先決條件，便可能觸發未定義的行為。"
+msgstr "\\*\\*不安全的 Rust：\\*\\*如果違反先決條件，便可能觸發未定義的行為。"
 
 #: src/unsafe.md:8
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr "雖然本課程中出現的大多都是安全的 Rust，但瞭解不安全的 Rust 也很重要。"
 
 #: src/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 "不安全的程式碼通常都很簡短、受到隔離，而且封裝在安全的抽象層中。您應該仔細記"
 "錄這類程式碼的正確性。"
@@ -10626,26 +11233,30 @@ msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr "透過不安全的 Rust，可以使用五項新功能："
 
 #: src/unsafe.md:16
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
-msgstr ""
-"* 對裸指標解參考。\n"
-"* 存取或修改可變的靜態變數。\n"
-"* 存取 `union` 欄位。\n"
-"* 呼叫 `unsafe` 函式 (包括 `extern` 函式)。\n"
-"* 實作 `unsafe` 特徵。"
+msgid "Dereference raw pointers."
+msgstr "對裸指標解參考。"
+
+#: src/unsafe.md:17
+msgid "Access or modify mutable static variables."
+msgstr "存取或修改可變的靜態變數。"
+
+#: src/unsafe.md:18
+msgid "Access `union` fields."
+msgstr "存取 `union` 欄位。"
+
+#: src/unsafe.md:19
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr "呼叫 `unsafe` 函式 (包括 `extern` 函式)。"
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
+msgstr "實作 `unsafe` 特徵。"
 
 #: src/unsafe.md:22
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
+"We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 "接下來將簡單介紹不安全的功能。如需瞭解詳情，請參閱 [Rust Book 的第 19.1 章]"
 "(https://rust-lang.tw/book-tw/ch19-01-unsafe-rust.html)，以及 [Rustonomicon]"
@@ -10654,19 +11265,14 @@ msgstr ""
 #: src/unsafe.md:28
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
 "have turned off the compiler safety features and have to write correct code "
 "by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
-
-#: src/unsafe/raw-pointers.md:1
-msgid "# Dereferencing Raw Pointers"
-msgstr "# 對裸指標解參考"
 
 #: src/unsafe/raw-pointers.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
@@ -10699,10 +11305,8 @@ msgstr ""
 #: src/unsafe/raw-pointers.md:27
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 "It is good practice (and required by the Android Rust style guide) to write "
 "a comment for each `unsafe` block explaining how the code inside it "
@@ -10710,38 +11314,43 @@ msgstr ""
 
 #: src/unsafe/raw-pointers.md:31
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 "In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 
 #: src/unsafe/raw-pointers.md:34
+msgid "The pointer must be non-null."
+msgstr "The pointer must be non-null."
+
+#: src/unsafe/raw-pointers.md:35
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
 msgstr ""
-" * The pointer must be non-null.\n"
-"* The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-"* The object must not have been deallocated.\n"
-"* There must not be concurrent accesses to the same location.\n"
-"* If the pointer was obtained by casting a reference, the underlying object "
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
+
+#: src/unsafe/raw-pointers.md:36
+msgid "The object must not have been deallocated."
+msgstr "The object must not have been deallocated."
+
+#: src/unsafe/raw-pointers.md:37
+msgid "There must not be concurrent accesses to the same location."
+msgstr "There must not be concurrent accesses to the same location."
+
+#: src/unsafe/raw-pointers.md:38
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr ""
+"If the pointer was obtained by casting a reference, the underlying object "
 "must be live and no reference may be used to access the memory."
 
 #: src/unsafe/raw-pointers.md:41
 msgid "In most cases the pointer must also be properly aligned."
 msgstr "In most cases the pointer must also be properly aligned."
-
-#: src/unsafe/mutable-static-variables.md:1
-msgid "# Mutable Static Variables"
-msgstr "# 可變的靜態變數"
 
 #: src/unsafe/mutable-static-variables.md:3
 msgid "It is safe to read an immutable static variable:"
@@ -10760,7 +11369,7 @@ msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr "不過，讀取並寫入可變的靜態變數並不安全，因為可能發生資料競爭："
 
@@ -10784,17 +11393,12 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:32
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 "Using a mutable static is generally a bad idea, but there are some cases "
 "where it might make sense in low-level `no_std` code, such as implementing a "
 "heap allocator or working with some C APIs."
-
-#: src/unsafe/unions.md:1
-msgid "# Unions"
-msgstr "# 聯合體"
 
 #: src/unsafe/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
@@ -10820,34 +11424,27 @@ msgstr ""
 #: src/unsafe/unions.md:21
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
 "are occasionally needed for interacting with C library APIs."
 
 #: src/unsafe/unions.md:24
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
+"If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 "If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
 "transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
 "crates/zerocopy) crate."
 
-#: src/unsafe/calling-unsafe-functions.md:1
-msgid "# Calling Unsafe Functions"
-msgstr "# 呼叫不安全的函式"
-
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 "如果函式或方法具有額外先決條件，而您必須遵循這些條件才能避免未定義的行為，那"
 "麼就可以將該函式或方法標示為 `unsafe`："
@@ -10882,15 +11479,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-msgid "# Writing Unsafe Functions"
-msgstr "# 編寫不安全的函式"
-
 #: src/unsafe/writing-unsafe-functions.md:3
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
 "如果您的函式必須滿足特定條件才能避免未定義的行為，您可以將其標示為 `unsafe`。"
 
@@ -10933,22 +11525,20 @@ msgstr ""
 #: src/unsafe/writing-unsafe-functions.md:35
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 "Note that unsafe code is allowed within an unsafe function without an "
 "`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
 "Try adding it and see what happens."
 
 #: src/unsafe/extern-functions.md:1
-msgid "# Calling External Code"
-msgstr "# 呼叫外部程式碼"
+msgid "Calling External Code"
+msgstr "呼叫外部程式碼"
 
 #: src/unsafe/extern-functions.md:3
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr "其他語言的函式可能會違反 Rust 保證，因此呼叫這類函式並不安全："
 
@@ -10971,10 +11561,8 @@ msgstr ""
 #: src/unsafe/extern-functions.md:21
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 "This is usually only a problem for extern functions which do things with "
 "pointers which might violate Rust's memory model, but in general any C "
@@ -10982,29 +11570,22 @@ msgstr ""
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/"
-"external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-msgid "# Implementing Unsafe Traits"
-msgstr "# 實作不安全的特徵"
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 "與函式類似，如果實作程序必須保證符合特定條件才能避免未定義的行為，您可以將特"
 "徵標示為 `unsafe`。"
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 "舉例來說，`zerocopy` crate 就具有不安全的特徵，如[這個頁面](https://docs.rs/"
 "zerocopy/latest/zerocopy/trait.AsBytes.html)所示："
@@ -11035,8 +11616,7 @@ msgstr ""
 #: src/unsafe/unsafe-traits.md:30
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
 "the requirements for the trait to be safely implemented."
@@ -11054,7 +11634,7 @@ msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr "The built-in `Send` and `Sync` traits are unsafe."
 
 #: src/exercises/day-3/afternoon.md:1
-msgid "# Day 3: Afternoon Exercises"
+msgid "Day 3: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:3
@@ -11062,17 +11642,15 @@ msgid "Let us build a safe wrapper for reading directory content!"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:7
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-msgid "# Safe FFI Wrapper"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 
@@ -11081,30 +11659,72 @@ msgid "You will want to consult the manual pages:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module. There you find a "
-"number of\n"
-"string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Encoding"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Use"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"| Types                      | Encoding       | "
-"Use                            |\n"
-"|----------------------------|----------------|--------------------------------|\n"
-"| [`str`] and [`String`]     | UTF-8          | Text processing in "
-"Rust        |\n"
-"| [`CStr`] and [`CString`]   | NUL-terminated | Communicating with C "
-"functions |\n"
-"| [`OsStr`] and [`OsString`] | OS-specific    | Communicating with the "
-"OS      |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "UTF-8"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "Text processing in Rust"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "NUL-terminated"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "Communicating with C functions"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "OS-specific"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "Communicating with the OS"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
@@ -11113,30 +11733,47 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:24
 msgid ""
-"- `&str` to `CString`: you need to allocate space for a trailing `\\0` "
-"character,\n"
-"- `CString` to `*const i8`: you need a pointer to call C functions,\n"
-"- `*const i8` to `&CStr`: you need something which can find the trailing "
-"`\\0` character,\n"
-"- `&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknow data\",\n"
-"- `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
-"html)\n"
-"  to create it,\n"
-"- `&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able "
-"to return it and call\n"
-"  `readdir` again."
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
-msgid "The [Nomicon] also has a very useful chapter about FFI."
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
@@ -11231,37 +11868,28 @@ msgid ""
 msgstr ""
 
 #: src/android.md:1
-msgid "# Welcome to Rust in Android"
+msgid "Welcome to Rust in Android"
 msgstr ""
 
 #: src/android.md:3
 msgid ""
 "Rust is supported for native platform development on Android. This means "
-"that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 
 #: src/android.md:7
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try "
-"to\n"
-"> find a little corner of your code base where we can move some lines of "
-"code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
-"that\n"
-"> parses some raw bytes would be ideal."
-msgstr ""
-
-#: src/android/setup.md:1
-msgid "# Setup"
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
 
 #: src/android/setup.md:3
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
-"have\n"
-"access to one or create a new one with:"
+"have access to one or create a new one with:"
 msgstr ""
 
 #: src/android/setup.md:6
@@ -11275,76 +11903,106 @@ msgstr ""
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-
-#: src/android/build-rules.md:1
-msgid "# Build Rules"
-msgstr "# 建構規則"
 
 #: src/android/build-rules.md:3
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr "Android 的建構系統 (Soong) 透過以下模組支援 Rust："
 
 #: src/android/build-rules.md:5
+msgid "Module Type"
+msgstr "模組型態"
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr "敘述"
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr "`rust_binary`"
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr "生成一個 Rust 執行檔。"
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr "`rust_library`"
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr "生成一個 Rust 函式庫，及其對應的 `rlib` 和 `dylib` 變體。"
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr "`rust_ffi`"
+
+#: src/android/build-rules.md:9
 msgid ""
-"| Module Type       | "
-"Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust "
-"binary.                                                                            "
-"|\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
-"`dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
-"provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
-"analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard "
-"Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging "
-"`libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that "
-"provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library "
-"containing Rust bindings to C libraries.              |"
-msgstr ""
-"| 模組型態          | "
-"敘述 "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | 生成一個 Rust 執行檔。"
-"|\n"
-"| `rust_library`    | 生成一個 Rust 函式庫，及其對應的 `rlib` 和 `dylib` "
-"變體。                                     |\n"
-"| `rust_ffi`        | 生成一個可被 `cc` 模組使用的 Rust C 函式庫，及其對應的"
-"靜態和共享變體。                           |\n"
-"| `rust_proc_macro` | 生成一個 `proc-macro` Rust 函式庫，類似於編譯器 "
-"擴充。                                      |\n"
-"| `rust_test`       | 使用Rust自動化測試框架，生成一個 Rust "
-"測試檔。                                   |\n"
-"| `rust_fuzz`       | 生成一個使用 `libfuzzer` 的 Rust 模糊測試"
-"執行檔。                                   |\n"
-"| `rust_protobuf`   | 生成對應 protobuf 介面的 Rust 原始碼及函式庫。 "
-"                                         |\n"
-"| `rust_bindgen`    | 生成用於連接 C 函式庫的 Rust "
-"原始碼及函式庫。                             |"
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr "生成一個可被 `cc` 模組使用的 Rust C 函式庫，及其對應的靜態和共享變體。"
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr "`rust_proc_macro`"
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr "生成一個 `proc-macro` Rust 函式庫，類似於編譯器 擴充。"
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr "`rust_test`"
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr "使用Rust自動化測試框架，生成一個 Rust 測試檔。"
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr "`rust_fuzz`"
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr "生成一個使用 `libfuzzer` 的 Rust 模糊測試執行檔。"
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr "`rust_protobuf`"
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr "生成對應 protobuf 介面的 Rust 原始碼及函式庫。"
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr "`rust_bindgen`"
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr "生成用於連接 C 函式庫的 Rust 原始碼及函式庫。"
 
 #: src/android/build-rules.md:16
 msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr "接下來我們會探討 `rust_binary` 及 `rust_library`。"
 
 #: src/android/build-rules/binary.md:1
-msgid "# Rust Binaries"
+msgid "Rust Binaries"
 msgstr ""
 
 #: src/android/build-rules/binary.md:3
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr ""
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
@@ -11393,7 +12051,7 @@ msgid ""
 msgstr ""
 
 #: src/android/build-rules/library.md:1
-msgid "# Rust Libraries"
+msgid "Rust Libraries"
 msgstr ""
 
 #: src/android/build-rules/library.md:3
@@ -11405,10 +12063,14 @@ msgid "Here we declare a dependency on two libraries:"
 msgstr ""
 
 #: src/android/build-rules/library.md:7
+msgid "`libgreeting`, which we define below,"
+msgstr ""
+
+#: src/android/build-rules/library.md:8
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
 
 #: src/android/build-rules/library.md:15
@@ -11480,25 +12142,22 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-msgid "# AIDL"
-msgstr ""
-
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
 #: src/android/aidl.md:6
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr ""
+
+#: src/android/aidl.md:7
+msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
 #: src/android/aidl/interface.md:1
-msgid "# AIDL Interfaces"
+msgid "AIDL Interfaces"
 msgstr ""
 
 #: src/android/aidl/interface.md:3
@@ -11507,7 +12166,7 @@ msgstr ""
 
 #: src/android/aidl/interface.md:5
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:7
@@ -11524,7 +12183,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/interface.md:17
-msgid "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:19
@@ -11546,12 +12205,11 @@ msgstr ""
 #: src/android/aidl/interface.md:32
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 
 #: src/android/aidl/implementation.md:1
-msgid "# Service Implementation"
+msgid "Service Implementation"
 msgstr ""
 
 #: src/android/aidl/implementation.md:3
@@ -11559,7 +12217,7 @@ msgid "We can now implement the AIDL service:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:5
-msgid "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:7
@@ -11589,7 +12247,7 @@ msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
-msgid "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:28
@@ -11608,7 +12266,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/server.md:1
-msgid "# AIDL Server"
+msgid "AIDL Server"
 msgstr ""
 
 #: src/android/aidl/server.md:3
@@ -11616,7 +12274,7 @@ msgid "Finally, we can create a server which exposes the service:"
 msgstr ""
 
 #: src/android/aidl/server.md:5
-msgid "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
 #: src/android/aidl/server.md:7
@@ -11660,10 +12318,6 @@ msgid ""
 "    prefer_rlib: true,\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/android/aidl/deploy.md:1
-msgid "# Deploy"
 msgstr ""
 
 #: src/android/aidl/deploy.md:3
@@ -11713,7 +12367,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/client.md:1
-msgid "# AIDL Client"
+msgid "AIDL Client"
 msgstr ""
 
 #: src/android/aidl/client.md:3
@@ -11721,7 +12375,7 @@ msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
 #: src/android/aidl/client.md:5
-msgid "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
 #: src/android/aidl/client.md:7
@@ -11795,15 +12449,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-msgid "# Changing API"
-msgstr "# 改寫 API"
-
 #: src/android/aidl/changing.md:3
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr "讓我們為這個 API 擴充更多功能：我們想要讓用戶能在生日卡上指定幾行字："
 
 #: src/android/aidl/changing.md:6
@@ -11828,15 +12477,10 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-msgid "# Logging"
-msgstr ""
-
 #: src/android/logging.md:3
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
 
 #: src/android/logging.md:6
@@ -11916,36 +12560,33 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-msgid "# Interoperability"
-msgstr ""
-
 #: src/android/interoperability.md:3
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 
 #: src/android/interoperability.md:6
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
+msgid "Call Rust functions from other languages."
+msgstr ""
+
+#: src/android/interoperability.md:7
+msgid "Call functions written in other languages from Rust."
 msgstr ""
 
 #: src/android/interoperability.md:9
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:1
-msgid "# Interoperability with C"
+msgid "Interoperability with C"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:3
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
@@ -11970,14 +12611,14 @@ msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:23
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:26
@@ -11985,14 +12626,13 @@ msgid "We will look at better options next."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:1
-msgid "# Using Bindgen"
+msgid "Using Bindgen"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:3
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:6
@@ -12057,7 +12697,7 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
@@ -12165,7 +12805,7 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
-msgid "# Calling Rust"
+msgid "Calling Rust"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:3
@@ -12279,43 +12919,35 @@ msgstr ""
 #: src/android/interoperability/with-c/rust.md:83
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
-msgstr ""
-
-#: src/android/interoperability/cpp.md:1
-msgid "# With C++"
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:3
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:8
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr ""
-
 #: src/android/interoperability/cpp.md:10
-msgid "See the [CXX tutorial][2] for an full example of using this."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
 
 #: src/android/interoperability/java.md:1
-msgid "# Interoperability with Java"
+msgid "Interoperability with Java"
 msgstr ""
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 
 #: src/android/interoperability/java.md:7
@@ -12418,70 +13050,66 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
-#: src/exercises/concurrency/morning.md:1
-#: src/exercises/concurrency/afternoon.md:1
-msgid "# Exercises"
-msgstr ""
-
 #: src/exercises/android/morning.md:3
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
-"and\n"
-"try to integrate some Rust into it. Some suggestions:"
+"and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 
 #: src/exercises/android/morning.md:6
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr ""
+
+#: src/exercises/android/morning.md:8
+msgid "Move a function from your project to Rust and call it."
 msgstr ""
 
 #: src/exercises/android/morning.md:12
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
 #: src/bare-metal.md:1
-msgid "# Welcome to Bare Metal Rust"
+msgid "Welcome to Bare Metal Rust"
 msgstr ""
 
 #: src/bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/bare-metal.md:7
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 
 #: src/bare-metal.md:10
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr ""
+
+#: src/bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr ""
+
+#: src/bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr ""
+
+#: src/bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
 #: src/bare-metal.md:15
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 
@@ -12535,27 +13163,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/no_std.md:1
-msgid "# `no_std`"
-msgstr ""
-
-#: src/bare-metal/no_std.md:3
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -12563,72 +13178,100 @@ msgstr ""
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:19
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-
 #: src/bare-metal/no_std.md:24
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
+msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
-msgid ""
-"</td>\n"
-"<td>"
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr ""
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:38
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:45
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:56
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:62
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr ""
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
 #: src/bare-metal/minimal.md:1
-msgid "# A minimal `no_std` program"
+msgid "A minimal `no_std` program"
 msgstr ""
 
 #: src/bare-metal/minimal.md:3
@@ -12647,29 +13290,34 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-msgid "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -12709,25 +13357,32 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-msgid "# Microcontrollers"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
@@ -12763,21 +13418,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:1
-msgid "# Raw MMIO"
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:6
@@ -12847,8 +13499,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:66
@@ -12866,16 +13518,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
-msgid "# Peripheral Access Crates"
+msgid "Peripheral Access Crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -12923,19 +13573,31 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:61
@@ -12946,16 +13608,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
-msgid "# HAL crates"
+msgid "HAL crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -12993,11 +13654,13 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:45
@@ -13008,7 +13671,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
-msgid "# Board support crates"
+msgid "Board support crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:3
@@ -13043,13 +13706,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:28
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:36
@@ -13060,7 +13728,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
-msgid "# The type state pattern"
+msgid "The type state pattern"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:3
@@ -13098,118 +13766,177 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "# `embedded-hal`"
+msgid "`embedded-hal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
+msgid "GPIO"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid " server"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
 msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:1
-msgid "# Debugging"
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/debugging.md:3
@@ -13268,39 +13995,86 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
-msgid "# Other projects"
+msgid "Other projects"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "[RTIC](https://rtic.rs/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
 
@@ -13310,15 +14084,11 @@ msgid ""
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:1
-msgid "# Compass"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
-"serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:6
@@ -13327,45 +14097,50 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C "
-"bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:11
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:12
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:13
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:17
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:19
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `compass`\n"
-"directory for the following files."
+"look in the `compass` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 msgid "`src/main.rs`:"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
-#: src/exercises/concurrency/dining-philosophers.md:17
-#: src/exercises/concurrency/link-checker.md:55
-#: src/exercises/concurrency/dining-philosophers-async.md:11
-msgid "<!-- File src/main.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:30
@@ -13409,14 +14184,6 @@ msgstr ""
 msgid "`Cargo.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:66 src/exercises/bare-metal/rtc.md:387
-#: src/exercises/concurrency/dining-philosophers.md:63
-#: src/exercises/concurrency/link-checker.md:35
-#: src/exercises/concurrency/dining-philosophers-async.md:60
-#: src/exercises/concurrency/chat-app.md:17
-msgid "<!-- File Cargo.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
 "```toml\n"
@@ -13441,10 +14208,6 @@ msgstr ""
 msgid "`Embed.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:87
-msgid "<!-- File Embed.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
 "```toml\n"
@@ -13461,10 +14224,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
 msgid "`.cargo/config.toml` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
-msgid "<!-- File .cargo/config.toml -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:104
@@ -13506,39 +14265,47 @@ msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
 #: src/bare-metal/aps.md:1
-msgid "# Application processors"
+msgid "Application processors"
 msgstr ""
 
 #: src/bare-metal/aps.md:3
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
+msgstr ""
+
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
-msgid "# Inline assembly"
+msgid "Inline assembly"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid " to tell the firmware to power off the system:"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:6
@@ -13579,74 +14346,99 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the [`smccc`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
-"it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are "
-"conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the "
-"standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–"
-"`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do "
-"anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:51
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:56
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
-msgid "# Volatile memory access for MMIO"
+msgid "Volatile memory access for MMIO"
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:9
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:1
-msgid "# Let's write a UART driver"
+msgid "Let's write a UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -13706,31 +14498,30 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is "
-"because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i."
-"e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else "
-"aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume "
-"the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but "
-"`write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls "
-"`write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving "
-"the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:66
-msgid "</detais>"
+#: src/bare-metal/aps/uart.md:60
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:63
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:1
-msgid "# More traits"
+msgid "More traits"
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:3
@@ -13761,51 +14552,188 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with "
-"our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:25
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
-msgid "# A better UART driver"
+msgid "A better UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
+msgid "Offset"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:26
-msgid "- There are also some ID registers which have been omitted for brevity."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-msgid "# Bitflags"
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
@@ -13849,13 +14777,12 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
-"with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:1
-msgid "# Multiple registers"
+msgid "Multiple registers"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:3
@@ -13902,17 +14829,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust "
-"representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-msgid "# Driver"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -13986,21 +14907,19 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
-"fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
-msgid "# Using it"
+msgid "Using it"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
-"and echo incoming\n"
-"bytes."
+"and echo incoming bytes."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:6
@@ -14052,18 +14971,21 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
 msgid ""
-"* As in the [inline assembly](../inline-assembly.md) example, this `main` "
-"function is called from our\n"
-"  entry point code in `entry.S`. See the speaker notes there for details.\n"
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/"
-"examples`."
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:53
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -14114,7 +15036,7 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
@@ -14166,29 +15088,53 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:47
 msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
-msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling, page tables\n"
-"   * Not all very well written, so beware.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
-msgid "# Useful crates"
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:7
+msgid ""
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:9
+msgid "Not all very well written, so beware."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:11
+msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
@@ -14198,14 +15144,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "# `zerocopy`"
+msgid "`zerocopy`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
@@ -14248,34 +15194,44 @@ msgstr ""
 #: src/bare-metal/useful-crates/zerocopy.md:40
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "# `aarch64-paging`"
+msgid "`aarch64-paging`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
@@ -14303,27 +15259,37 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real "
-"hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -14346,26 +15312,27 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+msgid "PCI BARs always have alignment equal to their size."
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "# `tinyvec`"
+msgid "`tinyvec`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
@@ -14386,29 +15353,30 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:23
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
-"initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine "
-"inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:1
-msgid "# `spin`"
+msgid "`spin`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:7
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:9
@@ -14427,28 +15395,33 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/android.md:1
-msgid "# Android"
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/android.md:3
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
 #: src/bare-metal/android.md:7
@@ -14493,16 +15466,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-msgid "# vmbase"
-msgstr ""
-
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -14523,11 +15492,14 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:21
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md:3
@@ -14535,40 +15507,51 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:1
-msgid "# RTC driver"
+#: src/exercises/bare-metal/solutions-afternoon.md:3
+msgid "RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. "
-"For this exercise, you\n"
-"should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:6
 msgid ""
-"1. Use it to print the current time to the serial console. You can use the "
-"[`chrono`][2] crate for\n"
-"   date/time formatting.\n"
-"2. Use the match register and raw interrupt status to busy-wait until a "
-"given time, e.g. 3 seconds\n"
-"   in the future. (Call [`core::hint::spin_loop`][3] inside the loop.)\n"
-"3. _Extension if you have time:_ Enable and handle the interrupt generated "
-"by the RTC match. You can\n"
-"   use the driver provided in the [`arm-gic`][4] crate to configure the Arm "
-"Generic Interrupt Controller.\n"
-"   - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.\n"
-"   - Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt.\n"
-"   "
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:8
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:10
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:12
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:13
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `rtc`\n"
-"directory for the following files."
+"look in the `rtc` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:23
@@ -14633,10 +15616,6 @@ msgstr ""
 msgid ""
 "`src/exceptions.rs` (you should only need to change this for the 3rd part of "
 "the exercise):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:77
-msgid "<!-- File src/exceptions.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:79
@@ -14717,10 +15696,6 @@ msgstr ""
 msgid "`src/logger.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:151
-msgid "<!-- File src/logger.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:153
 msgid ""
 "```rust,compile_fail\n"
@@ -14784,10 +15759,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "`src/pl011.rs` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:212
-msgid "<!-- File src/pl011.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:214
@@ -14997,10 +15968,6 @@ msgstr ""
 msgid "`build.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:412
-msgid "<!-- File build.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:414
 msgid ""
 "```rust,compile_fail\n"
@@ -15038,10 +16005,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
 msgid "`entry.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:448
-msgid "<!-- File entry.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:450
@@ -15208,10 +16171,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:595
 msgid "`exceptions.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:597
-msgid "<!-- File exceptions.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:599
@@ -15412,10 +16371,6 @@ msgstr ""
 msgid "`idmap.S` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:782
-msgid "<!-- File idmap.S -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
 "```armasm\n"
@@ -15467,10 +16422,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:829
 msgid "`image.ld` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:831
-msgid "<!-- File image.ld -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:833
@@ -15588,10 +16539,6 @@ msgstr ""
 msgid "`Makefile` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:942
-msgid "<!-- File Makefile -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:944
 msgid ""
 "```makefile\n"
@@ -15651,31 +16598,23 @@ msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
 #: src/concurrency.md:1
-msgid "# Welcome to Concurrency in Rust"
-msgstr "# 歡迎使用 Rust 的並行程式設計"
+msgid "Welcome to Concurrency in Rust"
+msgstr "歡迎使用 Rust 的並行程式設計"
 
 #: src/concurrency.md:3
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
-msgstr ""
-"Rust 使用 OS 執行緒搭配著互斥鎖和通道來完整支援並行處理。"
+msgstr "Rust 使用 OS 執行緒搭配著互斥鎖和通道來完整支援並行處理。"
 
 #: src/concurrency.md:6
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
-"在將許多執行期並行錯誤轉換為編譯期錯誤的過程中，Rust 型別系統扮演了\n"
-"重要角色。這通常稱為「無懼並行」，因為你可以依賴編譯器，\n"
-"確保執行期能夠正確運作。"
-
-#: src/concurrency/threads.md:1
-msgid "# Threads"
-msgstr "# 執行緒"
+"在將許多執行期並行錯誤轉換為編譯期錯誤的過程中，Rust 型別系統扮演了 重要角"
+"色。這通常稱為「無懼並行」，因為你可以依賴編譯器， 確保執行期能夠正確運作。"
 
 #: src/concurrency/threads.md:3
 msgid "Rust threads work similarly to threads in other languages:"
@@ -15722,45 +16661,44 @@ msgstr ""
 "```"
 
 #: src/concurrency/threads.md:24
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
-msgstr ""
-"* 執行緒都是 daemon 執行緒，主執行緒不會等待這類執行緒完成運作。\n"
-"* 執行緒恐慌均為各自獨立，並非彼此相關。\n"
-"  * 如果恐慌附帶酬載，可使用 `downcast_ref` 解除封裝。"
+msgid "Threads are all daemon threads, the main thread does not wait for them."
+msgstr "執行緒都是 daemon 執行緒，主執行緒不會等待這類執行緒完成運作。"
+
+#: src/concurrency/threads.md:25
+msgid "Thread panics are independent of each other."
+msgstr "執行緒恐慌均為各自獨立，並非彼此相關。"
+
+#: src/concurrency/threads.md:26
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr "如果恐慌附帶酬載，可使用 `downcast_ref` 解除封裝。"
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
-"* 請注意，執行緒會在達到 10 之前停止運作，因為主執行緒不會\n"
-" 等待其完成運作。\n"
-"\n"
-"* 請依序使用 `let handle = thread::spawn(...)` 和 `handle.join()`，等待\n"
-" 執行緒完成運作。\n"
-"\n"
-"* 在執行緒中觸發恐慌，請注意，這不會影響 `main`。\n"
-"\n"
-"* 使用 `handle.join()` 的 `Result` 傳回值，取得恐慌酬載的\n"
-"存取權。這個階段是提起 [`Any`] 的好時機。"
+"請注意，執行緒會在達到 10 之前停止運作，因為主執行緒不會 等待其完成運作。"
 
-#: src/concurrency/scoped-threads.md:1
-msgid "# Scoped Threads"
-msgstr "# 限定範圍執行緒"
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+"請依序使用 `let handle = thread::spawn(...)` 和 `handle.join()`，等待 執行緒"
+"完成運作。"
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr "在執行緒中觸發恐慌，請注意，這不會影響 `main`。"
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
+"使用 `handle.join()` 的 `Result` 傳回值，取得恐慌酬載的 存取權。這個階段是提"
+"起 [`Any`](https://doc.rust-lang.org/std/any/index.html) 的好時機。"
 
 #: src/concurrency/scoped-threads.md:3
 msgid "Normal threads cannot borrow from their environment:"
@@ -15793,8 +16731,12 @@ msgstr ""
 "```"
 
 #: src/concurrency/scoped-threads.md:17
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "但是，你可以使用[限定範圍執行緒][1]執行這項功能："
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"但是，你可以使用[限定範圍執行緒](https://doc.rust-lang.org/std/thread/fn."
+"scope.html)執行這項功能："
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -15828,31 +16770,27 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:37
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"* 原因在於 `thread::scope` 函式完成時，能保證所有執行緒都已加入，因此能夠傳回"
-"借用的資料。\n"
-"* 適用 Rust 一般借用規則：可以由一個執行緒以可變方式借用，或者由任意數量的執"
-"行緒以不可變方式借用。\n"
-"    "
+"原因在於 `thread::scope` 函式完成時，能保證所有執行緒都已加入，因此能夠傳回借"
+"用的資料。"
 
-#: src/concurrency/channels.md:1
-msgid "# Channels"
-msgstr "# 通道"
+#: src/concurrency/scoped-threads.md:38
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"適用 Rust 一般借用規則：可以由一個執行緒以可變方式借用，或者由任意數量的執行"
+"緒以不可變方式借用。"
 
 #: src/concurrency/channels.md:3
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
-"Rust 通道分為兩個部分：`Sender<T>` 和 `Receiver<T>`。這兩個部分\n"
-"透過通道相連，但你只能看到端點。"
+"Rust 通道分為兩個部分：`Sender<T>` 和 `Receiver<T>`。這兩個部分 透過通道相"
+"連，但你只能看到端點。"
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -15896,23 +16834,20 @@ msgstr ""
 
 #: src/concurrency/channels.md:27
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* `mpsc` 代表多重生產者、唯一消費者。`Sender` 和 `SyncSender` 會實作 "
-"`Clone`\n"
-"  (用於製作多重生產者)，但 `Receiver` 不會。\n"
-"* `send()` 和 `recv()` 會傳回 `Result`。如果傳回的是 `Err`，表示對應的 "
-"`Sender` 或\n"
-"  `Receiver` 已釋放，且通道已關閉。"
+"`mpsc` 代表多重生產者、唯一消費者。`Sender` 和 `SyncSender` 會實作 `Clone` "
+"(用於製作多重生產者)，但 `Receiver` 不會。"
 
-#: src/concurrency/channels/unbounded.md:1
-msgid "# Unbounded Channels"
-msgstr "# 無界限的通道"
+#: src/concurrency/channels.md:29
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()` 和 `recv()` 會傳回 `Result`。如果傳回的是 `Err`，表示對應的 "
+"`Sender` 或 `Receiver` 已釋放，且通道已關閉。"
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
@@ -15967,10 +16902,6 @@ msgstr ""
 "    }\n"
 "}\n"
 "```"
-
-#: src/concurrency/channels/bounded.md:1
-msgid "# Bounded Channels"
-msgstr "# 有界限的通道"
 
 #: src/concurrency/channels/bounded.md:3
 msgid "Bounded and synchronous channels make `send` block the current thread:"
@@ -16027,8 +16958,8 @@ msgstr ""
 "```"
 
 #: src/concurrency/send-sync.md:1
-msgid "# `Send` and `Sync`"
-msgstr "# `Send` 和 `Sync`"
+msgid "`Send` and `Sync`"
+msgstr "`Send` 和 `Sync`"
 
 #: src/concurrency/send-sync.md:3
 msgid ""
@@ -16038,93 +16969,88 @@ msgstr "Rust 如何得知要禁止在執行緒間共享存取權？答案就在�
 
 #: src/concurrency/send-sync.md:5
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [`Send`][1]：如果可以將 `T` 在執行緒界線間安全轉移，型別 `T` 就會是 "
-"`Send`。\n"
-"\n"
-"* [`Sync`][2]：如果可以將 `&T` 在執行緒界線間安全轉移，型別 `T` 就會是\n"
-"`Sync`。"
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)：如果可以將 "
+"`T` 在執行緒界線間安全轉移，型別 `T` 就會是 `Send`。"
+
+#: src/concurrency/send-sync.md:7
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html)：如果可以將 "
+"`&T` 在執行緒界線間安全轉移，型別 `T` 就會是 `Sync`。"
 
 #: src/concurrency/send-sync.md:10
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
-"`Send` 和 `Sync` 是 [不安全的特徵][3]。如果你的型別只包含其他有 `Send` 和 `Sync` 的"
-"型別，\n"
-"編譯器就會自動根據型別為你產生 `Send` 和 `Sync`。或許如果你知道你的型別是適用的，\n"
-"也可以手動實作。"
+"`Send` 和 `Sync` 是 [不安全的特徵](../unsafe/unsafe-traits.md)。如果你的型別"
+"只包含其他有 `Send` 和 `Sync` 的型別， 編譯器就會自動根據型別為你產生 `Send` "
+"和 `Sync`。或許如果你知道你的型別是適用的， 也可以手動實作。"
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-"
-"safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
-msgstr ""
-"* 這些特徵可視為標記，表示該型別含有特定執行緒安全屬性。\n"
-"* 這些特徵就像一般特徵，可用於泛型條件約束。"
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
+msgstr "這些特徵可視為標記，表示該型別含有特定執行緒安全屬性。"
+
+#: src/concurrency/send-sync.md:21
+msgid "They can be used in the generic constraints as normal traits."
+msgstr "這些特徵就像一般特徵，可用於泛型條件約束。"
 
 #: src/concurrency/send-sync/send.md:1
-msgid "# `Send`"
-msgstr "# `Send`"
+msgid "`Send`"
+msgstr "`Send`"
 
 #: src/concurrency/send-sync/send.md:3
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
-msgstr "> 如果可以將 `T` 值安全轉移至其他執行緒，型別 `T` 就會是 [`Send`][1]。"
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
+msgstr ""
+"如果可以將 `T` 值安全轉移至其他執行緒，型別 `T` 就會是 [`Send`](https://doc."
+"rust-lang.org/std/marker/trait.Send.html)。"
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
-"將所有權轉移到其他執行緒的結果，就是「destructors」會在該執行緒中\n"
-"執行。因此問題是，何時能在一個執行緒中配置一個值，\n"
-"並在另一個執行緒中釋放這個值的記憶體。"
+"將所有權轉移到其他執行緒的結果，就是「destructors」會在該執行緒中 執行。因此"
+"問題是，何時能在一個執行緒中配置一個值， 並在另一個執行緒中釋放這個值的記憶"
+"體。"
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
-"a\n"
-"single thread."
-msgstr ""
-"舉例來說，與 SQLite 資料庫的連線必須只能透過單一執行緒\n"
-"存取。"
+"a single thread."
+msgstr "舉例來說，與 SQLite 資料庫的連線必須只能透過單一執行緒 存取。"
 
 #: src/concurrency/send-sync/sync.md:1
-msgid "# `Sync`"
-msgstr "# `Sync`"
+msgid "`Sync`"
+msgstr "`Sync`"
 
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"> 如果可以同時從多個執行緒存取 `T` 值，\n"
-"> 型別 `T` 就會是 [`Sync`][1]。"
+"如果可以同時從多個執行緒存取 `T` 值， 型別 `T` 就會是 [`Sync`](https://doc."
+"rust-lang.org/std/marker/trait.Sync.html)。"
 
 #: src/concurrency/send-sync/sync.md:6
 msgid "More precisely, the definition is:"
 msgstr "更精確的定義如下："
 
 #: src/concurrency/send-sync/sync.md:8
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
-msgstr "> `&T` 必須為 `Send`，`T` 才會是 `Sync`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
+msgstr "`&T` 必須為 `Send`，`T` 才會是 `Sync`"
 
 #: src/concurrency/send-sync/sync.md:14
 msgid ""
@@ -16132,7 +17058,8 @@ msgid ""
 "thread-safe for shared use, it is also thread-safe to pass references of it "
 "across threads."
 msgstr ""
-"這定義簡單的表示，若一個型別可以在確保執行緒安全的情況下被共用，這型別的參考值也可以安全的被傳遞於其他的執行緒。"
+"這定義簡單的表示，若一個型別可以在確保執行緒安全的情況下被共用，這型別的參考"
+"值也可以安全的被傳遞於其他的執行緒。"
 
 #: src/concurrency/send-sync/sync.md:16
 msgid ""
@@ -16146,69 +17073,74 @@ msgstr ""
 "題的風險，因此可以安全轉移到其他執行緒。此外，由於可以從任何執行緒安全存取型"
 "別參考的資料，型別參考也能安全地轉移到其他執行緒。"
 
-#: src/concurrency/send-sync/examples.md:1
-msgid "# Examples"
-msgstr "# 範例"
-
 #: src/concurrency/send-sync/examples.md:3
-msgid "## `Send + Sync`"
-msgstr "## `Send + Sync`"
+msgid "`Send + Sync`"
+msgstr "`Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:5
 msgid "Most types you come across are `Send + Sync`:"
 msgstr "你遇到的多數型別會是 `Send + Sync`："
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
-msgstr ""
-"* `i8`、`f32`、`bool`、`char`、`&str`、...\n"
-"* `(T1, T2)`、`[T; N]`、`&[T]`、`struct { x: T }`、...\n"
-"* `String`、`Option<T>`、`Vec<T>`、`Box<T>`、...\n"
-"* `Arc<T>`：透過原子參考計數明確防護執行緒安全。\n"
-"* `Mutex<T>`：透過內部鎖定系統明確防護執行緒安全。\n"
-"* `AtomicBool`、`AtomicU8`、...：使用特殊原子性指示。"
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr "`i8`、`f32`、`bool`、`char`、`&str`、..."
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr "`(T1, T2)`、`[T; N]`、`&[T]`、`struct { x: T }`、..."
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr "`String`、`Option<T>`、`Vec<T>`、`Box<T>`、..."
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr "`Arc<T>`：透過原子參考計數明確防護執行緒安全。"
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr "`Mutex<T>`：透過內部鎖定系統明確防護執行緒安全。"
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgstr "`AtomicBool`、`AtomicU8`、...：使用特殊原子性指示。"
 
 #: src/concurrency/send-sync/examples.md:14
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
-msgstr ""
-"如果型別參數是 `Send + Sync`，\n"
-"一般型別通常就會是 `Send + Sync`。"
+msgstr "如果型別參數是 `Send + Sync`， 一般型別通常就會是 `Send + Sync`。"
 
 #: src/concurrency/send-sync/examples.md:17
-msgid "## `Send + !Sync`"
-msgstr "## `Send + !Sync`"
+msgid "`Send + !Sync`"
+msgstr "`Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:19
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
-"以下型別可以轉移到其他執行緒，但不會防護執行緒安全。\n"
-"原因通常在於內部可變性："
+"以下型別可以轉移到其他執行緒，但不會防護執行緒安全。 原因通常在於內部可變性："
 
 #: src/concurrency/send-sync/examples.md:22
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Sender<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Receiver<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+msgid "`Cell<T>`"
+msgstr "`Cell<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+msgid "`RefCell<T>`"
+msgstr "`RefCell<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
-msgid "## `!Send + Sync`"
-msgstr "## `!Send + Sync`"
+msgid "`!Send + Sync`"
+msgstr "`!Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:29
 msgid ""
@@ -16217,16 +17149,15 @@ msgstr "以下型別會防護執行緒安全，但無法轉移至其他執行緒
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
-"* `MutexGuard<T>`：使用 OS 層級的原始元件，這類元件必須在建立該元件的\n"
-"執行緒上釋放記憶體。"
+"`MutexGuard<T>`：使用 OS 層級的原始元件，這類元件必須在建立該元件的 執行緒上"
+"釋放記憶體。"
 
 #: src/concurrency/send-sync/examples.md:34
-msgid "## `!Send + !Sync`"
-msgstr "## `!Send + !Sync`"
+msgid "`!Send + !Sync`"
+msgstr "`!Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:36
 msgid "These types are not thread-safe and cannot be moved to other threads:"
@@ -16234,47 +17165,52 @@ msgstr "以下型別不會防護執行緒安全，也無法轉移至其他執行
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
-"* `Rc<T>`：每個 `Rc<T>` 都有一個 `RcBox<T>` 參考，其中包含一個\n"
-"非原子參考計數。\n"
-"* `*const T`、`*mut T`：Rust 會假定原始指標可能有特殊的\n"
-"並行考量。"
+"`Rc<T>`：每個 `Rc<T>` 都有一個 `RcBox<T>` 參考，其中包含一個 非原子參考計數。"
 
-#: src/concurrency/shared_state.md:1
-msgid "# Shared State"
-msgstr "# 共享狀態"
+#: src/concurrency/send-sync/examples.md:40
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr "`*const T`、`*mut T`：Rust 會假定原始指標可能有特殊的 並行考量。"
 
 #: src/concurrency/shared_state.md:3
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
-msgstr ""
-"Rust 會使用型別系統強制同步共享的資料，主要透過兩種型別\n"
-"執行："
+msgstr "Rust 會使用型別系統強制同步共享的資料，主要透過兩種型別 執行："
 
 #: src/concurrency/shared_state.md:6
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1]，原子參考計數為 `T`：處理執行緒間的共享狀態，\n"
-"並且在最後參考被丟棄時負責釋放 `T` 的記憶體。\n"
-"* [`Mutex<T>`][2]：確保能提供 `T` 值的可變專屬存取權。"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)，原子參考計數"
+"為 `T`：處理執行緒間的共享狀態， 並且在最後參考被丟棄時負責釋放 `T` 的記憶"
+"體。"
+
+#: src/concurrency/shared_state.md:8
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)：確保能提"
+"供 `T` 值的可變專屬存取權。"
 
 #: src/concurrency/shared_state/arc.md:1
-msgid "# `Arc`"
-msgstr "# `Arc`"
+msgid "`Arc`"
+msgstr "`Arc`"
 
 #: src/concurrency/shared_state/arc.md:3
-msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
-msgstr "[`Arc<T>`][1] 可透過 `Arc::clone` 取得共享唯讀存取權："
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
+msgstr ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) 可透過 `Arc::"
+"clone` 取得共享唯讀存取權："
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -16320,40 +17256,49 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
 msgstr ""
-"* `Arc` 代表「原子參考計數」，這個 `Rc` 的執行緒安全版本會採用原子性\n"
-"運算。\n"
-"* `Arc<T>` 會實作 `Clone`，與 `T` 無關。如果 `T` 同時實作 `Send` 和 "
-"`Sync`，\n"
-"`Arc<T>` 也會實作這兩者。\n"
-"* `Arc::clone()` 會導致執行原子性運算的費用，但之後使用得到的\n"
-" `T` 不需任何費用。\n"
-"* 留意參考循環，`Arc` 並不使用垃圾收集器進行偵測。\n"
-"    * `std::sync::Weak` 可協助執行這項功能。"
+"`Arc` 代表「原子參考計數」，這個 `Rc` 的執行緒安全版本會採用原子性 運算。"
+
+#: src/concurrency/shared_state/arc.md:31
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+"`Arc<T>` 會實作 `Clone`，與 `T` 無關。如果 `T` 同時實作 `Send` 和 `Sync`， "
+"`Arc<T>` 也會實作這兩者。"
+
+#: src/concurrency/shared_state/arc.md:33
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"`Arc::clone()` 會導致執行原子性運算的費用，但之後使用得到的 `T` 不需任何費"
+"用。"
+
+#: src/concurrency/shared_state/arc.md:35
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr "留意參考循環，`Arc` 並不使用垃圾收集器進行偵測。"
+
+#: src/concurrency/shared_state/arc.md:36
+msgid "`std::sync::Weak` can help."
+msgstr "`std::sync::Weak` 可協助執行這項功能。"
 
 #: src/concurrency/shared_state/mutex.md:1
-msgid "# `Mutex`"
-msgstr "# `Mutex`"
+msgid "`Mutex`"
+msgstr "`Mutex`"
 
 #: src/concurrency/shared_state/mutex.md:3
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
-"[`Mutex<T>`][1] 可確保執行互斥功能，「並」在唯讀介面背後授予 `T`\n"
-"的可變存取權："
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) 可確保執行"
+"互斥功能，「並」在唯讀介面背後授予 `T` 的可變存取權："
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -16391,44 +17336,57 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
-"請留意我們如何進行 [`impl<T: Send> Sync for Mutex<T>`][2] 的概括性\n"
-"實作。"
+"請留意我們如何進行 [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-lang."
+"org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) 的概括性 實作。"
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
+msgstr "Rust 中的 `Mutex` 就像是只有一個元素的集合，也就是受保護的資料。"
+
+#: src/concurrency/shared_state/mutex.md:32
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr "必須先取得互斥鎖，才能存取受保護的資料。"
+
+#: src/concurrency/shared_state/mutex.md:33
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
-"* Rust 中的 `Mutex` 就像是只有一個元素的集合，也就是受保護的資料。\n"
-"    * 必須先取得互斥鎖，才能存取受保護的資料。\n"
-"* 只要使用這個鎖，就能從 `&Mutex<T>` 取得 `&mut T`。`MutexGuard` 可確保\n"
-" `&mut T` 的壽命不會超過所持有的鎖。\n"
-"* 如果 `T` 實作 `Send`，`Mutex<T>` 才會實作 `Send` 和 `Sync`。\n"
-"* 可讀寫的對應鎖 - `RwLock`。\n"
-"* 為何 `lock()` 會傳回 `Result`？\n"
-"* 如果持有 `Mutex` 的執行緒發生恐慌，`Mutex` 就會「中毒」，指出\n"
-"其保護的資料可能處於不一致的狀態。如果對已中毒的互斥鎖呼叫 `lock()`，\n"
-"會發生 [`PoisonError`] 錯誤。無論如何，你都可以對錯誤呼叫 `into_inner()` 來復"
-"原\n"
-"資料。"
+"只要使用這個鎖，就能從 `&Mutex<T>` 取得 `&mut T`。`MutexGuard` 可確保 `&mut "
+"T` 的壽命不會超過所持有的鎖。"
+
+#: src/concurrency/shared_state/mutex.md:35
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr "如果 `T` 實作 `Send`，`Mutex<T>` 才會實作 `Send` 和 `Sync`。"
+
+#: src/concurrency/shared_state/mutex.md:36
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "可讀寫的對應鎖 - `RwLock`。"
+
+#: src/concurrency/shared_state/mutex.md:37
+msgid "Why does `lock()` return a `Result`? "
+msgstr "為何 `lock()` 會傳回 `Result`？"
+
+#: src/concurrency/shared_state/mutex.md:38
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"如果持有 `Mutex` 的執行緒發生恐慌，`Mutex` 就會「中毒」，指出 其保護的資料可"
+"能處於不一致的狀態。如果對已中毒的互斥鎖呼叫 `lock()`， 會發生 "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html) "
+"錯誤。無論如何，你都可以對錯誤呼叫 `into_inner()` 來復原 資料。"
 
 #: src/concurrency/shared_state/example.md:3
 msgid "Let us see `Arc` and `Mutex` in action:"
@@ -16528,35 +17486,42 @@ msgstr "重要部分："
 
 #: src/concurrency/shared_state/example.md:51
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
-"possible."
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr "`v` 已同時納入 `Arc` 和 `Mutex`，因為兩者的考量互不相關。"
+
+#: src/concurrency/shared_state/example.md:52
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr "將 `Mutex` 納入 `Arc`，是在執行緒間共享可變狀態的常見模式。"
+
+#: src/concurrency/shared_state/example.md:53
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
 msgstr ""
-"* `v` 已同時納入 `Arc` 和 `Mutex`，因為兩者的考量互不相關。\n"
-"* 將 `Mutex` 納入 `Arc`，是在執行緒間共享可變狀態的常見模式。\n"
-"* `v: Arc<_>` 需要複製成 `v2`，才能轉移到其他執行緒。請注意，`move` 已新"
-"增至 lambda 簽章。\n"
-"* 采用區塊，盡量縮小 `LockGuard` 的範圍。"
+"`v: Arc<_>` 需要複製成 `v2`，才能轉移到其他執行緒。請注意，`move` 已新增至 "
+"lambda 簽章。"
+
+#: src/concurrency/shared_state/example.md:54
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible."
+msgstr "采用區塊，盡量縮小 `LockGuard` 的範圍。"
 
 #: src/exercises/concurrency/morning.md:3
 msgid "Let us practice our new concurrency skills with"
 msgstr ""
 
 #: src/exercises/concurrency/morning.md:5
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
+msgid "Dining philosophers: a classic problem in concurrency."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md:1
-msgid "# Dining Philosophers"
+#: src/exercises/concurrency/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:3
@@ -16565,28 +17530,21 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:5
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:13
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to a file called `src/main.rs`, fill out "
-"the\n"
-"blanks, and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:19
@@ -16648,24 +17606,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:1
-msgid "# Multi-threaded Link Checker"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:3
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:11
@@ -16679,14 +17631,14 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:17
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:20
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:22
@@ -16698,9 +17650,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:29
@@ -16734,8 +17685,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:50
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:53
@@ -16800,89 +17751,78 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:106
-#: src/exercises/concurrency/chat-app.md:140
-msgid "## Tasks"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:108
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:110
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
 
 #: src/async.md:1
-msgid "# Async Rust"
-msgstr "# 非同步的 Rust"
+msgid "Async Rust"
+msgstr "非同步的 Rust"
 
 #: src/async.md:3
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
-"concurrently by\n"
-"executing each task until it would block, then switching to another task "
-"that is\n"
-"ready to make progress. The model allows running a larger number of tasks on "
-"a\n"
-"limited number of threads. This is because the per-task overhead is "
-"typically\n"
-"very low and operating systems provide primitives for efficiently "
-"identifying\n"
-"I/O that is able to proceed."
-msgstr "「非同步（async）」是一種將多個任務併行執行的模式。在這樣的模式中，當其中一個"
-"任務進入阻塞狀態時，系統會去執行至另一個可執行的任務。這種模式允許在執行緒數量有限的"
-"環境下執行大量的任務，這是因為每個任務所造成的開銷通常都很低，而且作業系統提供的基本"
-"功能能夠有效地辨識可處理的 I/O。"
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
+msgstr ""
+"「非同步（async）」是一種將多個任務併行執行的模式。在這樣的模式中，當其中一個"
+"任務進入阻塞狀態時，系統會去執行至另一個可執行的任務。這種模式允許在執行緒數"
+"量有限的環境下執行大量的任務，這是因為每個任務所造成的開銷通常都很低，而且作"
+"業系統提供的基本功能能夠有效地辨識可處理的 I/O。"
 
 #: src/async.md:10
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
-"that\n"
-"may be completed in the future. Futures are \"polled\" until they signal "
-"that\n"
-"they are complete."
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
-"Rust 的非同步操作是透過「future」來處理，代表可能在未來完成的工作。Future "
-"會處在被「輪詢（poll）」的狀態，直到它送出信號來表示工作已經處理完成。"
+"Rust 的非同步操作是透過「future」來處理，代表可能在未來完成的工作。Future 會"
+"處在被「輪詢（poll）」的狀態，直到它送出信號來表示工作已經處理完成。"
 
 #: src/async.md:14
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
-msgstr ""
-"Future 會被非同步的執行環境（runtime）輪詢，而執行環境有許多種可選擇。"
+msgstr "Future 會被非同步的執行環境（runtime）輪詢，而執行環境有許多種可選擇。"
 
 #: src/async.md:17
-msgid "## Comparisons"
-msgstr "## 比較"
+msgid "Comparisons"
+msgstr "比較"
 
 #: src/async.md:19
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type "
-"is\n"
-"   callback-based, and not polled. Async Python programs require a "
-"\"loop\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The "
-"language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
 msgstr ""
-"* Python 有一個類似的模型 `asyncio`。不過 `asyncio` 的 `Future` 類型是根據回呼"
-"函數（callback）而非輪詢。非同步的 Python 程式需要「迴圈（loop）」來處理，"
-"類似於 Rust 的執行環境。\n"
-"\n"
-"* JavaScript 的 `Promise` 也是類似的概念，但仍是基於回呼函數。JavaScript 的語言"
+"Python 有一個類似的模型 `asyncio`。不過 `asyncio` 的 `Future` 類型是根據回呼"
+"函數（callback）而非輪詢。非同步的 Python 程式需要「迴圈（loop）」來處理，類"
+"似於 Rust 的執行環境。"
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
+msgstr ""
+"JavaScript 的 `Promise` 也是類似的概念，但仍是基於回呼函數。JavaScript 的語言"
 "執行環境實作了事件迴圈（event loop），所以隱藏了很多關於 Promise 的處理細節。"
 
 #: src/async/async-await.md:1
-msgid "# `async`/`await`"
-msgstr "# `async`/`await`"
+msgid "`async`/`await`"
+msgstr "`async`/`await`"
 
 #: src/async/async-await.md:3
 msgid ""
@@ -16914,62 +17854,63 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no "
-"long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the "
-"compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current "
-"thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. "
-"Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
-"* 注意這只是一個簡化過的程式碼，目的是要示範程式語法。這份範例程式碼當中並沒有需要"
-"長時間運行的操作，也沒有真正的併行處理！\n"
-"\n"
-"* 如何得知非同步函數的回傳型別？\n"
-"  * 在 `main` 函數中使用 `let feature: () = async_main(10);` 以查看型態。\n"
-"\n"
-"* 「async」這個關鍵字只是個程式碼語法糖。編譯器會將函數回傳型態以 future 取代。"
-"\n"
-"* 你不能把 `main` 函數標示成非同步函數，除非你對編譯器額外設定了如何處理回傳的 "
-"future 的方式。\n"
-"\n"
-"* 你需要處理器去執行非同步的程式碼。`block_on` 會阻塞當前的執行緒，直到 future 已"
-"執行完畢。\n"
-"\n"
-"* `.await` 會非同步地等待其他操作執行完畢。別於 `block_on`，`.await` 不會阻塞"
-"當前的執行緒。\n"
-"\n"
-"* `.await` 只能用在 `async` 函數（或程式碼區塊，之後會介紹）中。"
+"注意這只是一個簡化過的程式碼，目的是要示範程式語法。這份範例程式碼當中並沒有"
+"需要長時間運行的操作，也沒有真正的併行處理！"
 
-#: src/async/futures.md:1
-msgid "# Futures"
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr "如何得知非同步函數的回傳型別？"
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr "在 `main` 函數中使用 `let feature: () = async_main(10);` 以查看型態。"
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
 msgstr ""
+"「async」這個關鍵字只是個程式碼語法糖。編譯器會將函數回傳型態以 future 取代。"
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr ""
+"你不能把 `main` 函數標示成非同步函數，除非你對編譯器額外設定了如何處理回傳的 "
+"future 的方式。"
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+"你需要處理器去執行非同步的程式碼。`block_on` 會阻塞當前的執行緒，直到 future "
+"已執行完畢。"
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+"`.await` 會非同步地等待其他操作執行完畢。別於 `block_on`，`.await` 不會阻塞當"
+"前的執行緒。"
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr "`.await` 只能用在 `async` 函數（或程式碼區塊，之後會介紹）中。"
 
 #: src/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not "
-"be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
 #: src/async/futures.md:8
@@ -16994,86 +17935,86 @@ msgstr ""
 #: src/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
-"uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` "
-"returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
 
 #: src/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
-"to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers "
-"into\n"
-"    that future remain valid. This is required to allow references to "
-"remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/runtimes.md:1
-msgid "# Runtimes"
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
 msgstr ""
 
 #: src/async/runtimes.md:3
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust "
-"does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
 #: src/async/runtimes.md:7
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem "
-"of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and "
-"includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
+msgstr ""
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
 msgstr ""
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 
 #: src/async/runtimes.md:20
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most "
-"interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/"
-"O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are "
-"never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
 
-#: src/async/runtimes/tokio.md:1
-msgid "# Tokio"
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:4
@@ -17081,10 +18022,15 @@ msgid "Tokio provides: "
 msgstr ""
 
 #: src/async/runtimes/tokio.md:6
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:10
@@ -17112,12 +18058,15 @@ msgid ""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:39
@@ -17126,35 +18075,32 @@ msgstr ""
 
 #: src/async/runtimes/tokio.md:41
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to "
-"wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
 
-#: src/async/tasks.md:1
-msgid "# Tasks"
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
 msgstr ""
 
 #: src/async/tasks.md:3
 msgid ""
-"Runtimes have the concept of a \"task\", similar to a thread but much\n"
-"less resource-intensive."
+"Runtimes have the concept of a \"task\", similar to a thread but much less "
+"resource-intensive."
 msgstr ""
 
 #: src/async/tasks.md:6
 msgid ""
 "A task has a single top-level future which the executor polls to make "
-"progress.\n"
-"That future may have one or more nested futures that its `poll` method "
-"polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible "
-"by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
 
 #: src/async/tasks.md:11
@@ -17208,20 +18154,21 @@ msgstr ""
 
 #: src/async/tasks.md:55
 msgid ""
-"* Ask students to visualize what the state of the example server would be "
-"with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling "
-"using `?`."
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/async/channels.md:1
-msgid "# Async Channels"
+#: src/async/tasks.md:58
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+
+#: src/async/tasks.md:62
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
+"using `?`."
 msgstr ""
 
 #: src/async/channels.md:3
@@ -17263,49 +18210,56 @@ msgid ""
 msgstr ""
 
 #: src/async/channels.md:35
+msgid "Change the channel size to `3` and see how it affects the execution."
+msgstr ""
+
+#: src/async/channels.md:37
 msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be "
-"convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to "
-"combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
 msgstr ""
 
 #: src/async/control-flow.md:1
-msgid "# Futures Control Flow"
+msgid "Futures Control Flow"
 msgstr ""
 
 #: src/async/control-flow.md:3
 msgid ""
 "Futures can be combined together to produce concurrent compute flow graphs. "
-"We\n"
-"have already seen tasks, that function as independent threads of execution."
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
 
 #: src/async/control-flow.md:6
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
 msgstr ""
 
-#: src/async/control-flow/join.md:1
-msgid "# Join"
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
 msgstr ""
 
 #: src/async/control-flow/join.md:3
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
@@ -17341,43 +18295,39 @@ msgstr ""
 
 #: src/async/control-flow/join.md:38
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` "
-"but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this "
-"would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all "
-"requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but "
-"demonstrates `join!`."
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/select.md:1
-msgid "# Select"
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
+"demonstrates `join!`."
 msgstr ""
 
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
 msgid ""
 "This is usually a macro, similar to match, with each arm of the form "
-"`pattern =\n"
-"future => statement`. When the future is ready, the statement is executed "
-"with the\n"
-"variable bound to the future's result."
+"`pattern = future => statement`. When the future is ready, the statement is "
+"executed with the variable bound to the future's result."
 msgstr ""
 
 #: src/async/control-flow/select.md:12
@@ -17432,29 +18382,34 @@ msgstr ""
 
 #: src/async/control-flow/select.md:61
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick "
-"whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are "
-"supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts "
-"of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` moves the values it is given. It is easiest to use\n"
-"  when every execution of `select!` creates new futures. An alternative is "
-"to\n"
-"  pass `&mut future` instead of the future itself, but this can lead to\n"
-"  issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
+msgstr ""
+
+#: src/async/control-flow/select.md:66
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+
+#: src/async/control-flow/select.md:69
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:72
+msgid ""
+"Note that `select!` moves the values it is given. It is easiest to use when "
+"every execution of `select!` creates new futures. An alternative is to pass "
+"`&mut future` instead of the future itself, but this can lead to issues, "
+"further discussed in the pinning slide."
 msgstr ""
 
 #: src/async/pitfalls.md:1
-msgid "# Pitfalls of async/await"
+msgid "Pitfalls of async/await"
 msgstr ""
 
 #: src/async/pitfalls.md:3
@@ -17466,22 +18421,27 @@ msgid ""
 msgstr ""
 
 #: src/async/pitfalls.md:5
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfall/async-traits.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfall/async-traits.md)"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:1
-msgid "# Blocking the executor"
+msgid "Blocking the executor"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:3
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other "
-"tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:7
@@ -17509,58 +18469,57 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its "
-"result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an "
-"actual\n"
-"  thread and transforms its handle into a future without blocking the "
-"executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and "
-"most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, "
-"where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
-"situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause "
-"another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:1
-msgid "# Pin"
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
 "When you await a future, all local variables (that would ordinarily be "
-"stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. "
-"If your\n"
-"future has pointers to data on the stack, those pointers might get "
-"invalidated.\n"
-"This is unsafe."
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:8
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to "
-"don't\n"
+"Therefore, you must guarantee that the addresses your future points to don't "
 "change. That is why we need to `pin` futures. Using the same future "
-"repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:12
@@ -17622,60 +18581,78 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your "
-"time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!"
-"(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the "
-"`loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to "
-"the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on "
-"every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, "
-"but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that "
-"will send to a `oneshot` channel every 100ms."
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:1
-msgid "# Async Traits"
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:3
@@ -17738,26 +18715,25 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:49
-msgid "<details>  "
-msgstr ""
-
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations "
-"to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of "
-"time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:3
@@ -17767,32 +18743,32 @@ msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
-"* Dining philosophers: we already saw this problem in the morning. This "
-"time\n"
-"  you are going to implement it with Async Rust.\n"
-"\n"
-"* A Broadcast Chat Application: this is a larger project that allows you\n"
-"  experiment with more advanced Async Rust features."
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr ""
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
-msgid "# Dining Philosophers - Async"
+#: src/exercises/concurrency/solutions-afternoon.md:3
+msgid "Dining Philosophers - Async"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the\n"
+"See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 msgid ""
-"As before, you will need a local\n"
-"[Cargo installation](../../cargo/running-locally.md) for this exercise. "
-"Copy\n"
-"the code below to a file called `src/main.rs`, fill out the blanks, and "
-"test\n"
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
@@ -17845,7 +18821,7 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
 msgid ""
-"Since this time you are using Async Rust, you'll need a `tokio` dependency.\n"
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
@@ -17865,33 +18841,29 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:72
 msgid ""
-"Also note that this time you have to use the `Mutex` and the `mpsc` module\n"
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "* Can you make your implementation single-threaded? "
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:1
-msgid "# Broadcast Chat Application"
+msgid "Can you make your implementation single-threaded? "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
 msgid ""
-"In this exercise, we want to use our new knowledge to implement a broadcast\n"
+"In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
-"publish\n"
-"their messages. The client reads user messages from the standard input, and\n"
-"sends them to the server. The chat server broadcasts each message that it\n"
-"receives to all the clients."
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel][1] on the server, and\n"
-"[`tokio_websockets`][2] for the communication between the client and the\n"
-"server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:13
@@ -17919,57 +18891,69 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:32
-msgid "## The required APIs"
+msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
-"You are going to need the following functions from `tokio` and\n"
-"[`tokio_websockets`][2]. Spend a few minutes to familiarize yourself with "
-"the\n"
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
 "API. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
-"- [WebsocketStream::next()][3]: for asynchronously reading messages from a\n"
-"  Websocket Stream.\n"
-"- [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously\n"
-"  sending messages on a Websocket Stream.\n"
-"- [BufReader::read_line()][5]: for asynchronously reading user messages\n"
-"  from the standard input.\n"
-"- [Sender::subscribe()][6]: for subscribing to a broadcast channel."
+"[WebsocketStream::next()](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/proto/struct.WebsocketStream.html#method.next): for "
+"asynchronously reading messages from a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:41
+msgid ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
-msgid "## Two binaries"
+msgid "Two binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one\n"
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client,\n"
-"and one for the server. You could potentially make them two separate Cargo\n"
-"projects, but we are going to put them in a single Cargo project with two\n"
-"binaries. For this to work, the client and the server code should go under\n"
-"`src/bin` (see the [documentation][7]). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and\n"
-"`src/bin/client.rs`, respectively. Your task is to complete these files as\n"
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:59
 #: src/exercises/concurrency/solutions-afternoon.md:117
 msgid "`src/bin/server.rs`:"
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:61
-msgid "<!-- File src/bin/server.rs -->"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:63
@@ -18019,10 +19003,6 @@ msgstr ""
 msgid "`src/bin/client.rs`:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:104
-msgid "<!-- File src/bin/client.rs -->"
-msgstr ""
-
 #: src/exercises/concurrency/chat-app.md:106
 msgid ""
 "```rust,compile_fail\n"
@@ -18049,7 +19029,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:127
-msgid "## Running the binaries"
+msgid "Running the binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:128
@@ -18075,58 +19055,60 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:142
-msgid ""
-"* Implement the `handle_connection` function in `src/bin/server.rs`.\n"
-"  * Hint: Use `tokio::select!` for concurrently performing two tasks in a\n"
-"    continuous loop. One task receives messages from the client and "
-"broadcasts\n"
-"    them. The other sends messages received by the server to the client.\n"
-"* Complete the main function in `src/bin/client.rs`.\n"
-"  * Hint: As before, use `tokio::select!` in a continuous loop for "
-"concurrently\n"
-"    performing two tasks: (1) reading user messages from standard input and\n"
-"    sending them to the server, and (2) receiving messages from the server, "
-"and\n"
-"    displaying them for the user.\n"
-"* Optional: Once you are done, change the code to broadcast messages to all\n"
-"  clients, but the sender of the message."
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/thanks.md:1
-msgid "# Thanks!"
+#: src/exercises/concurrency/chat-app.md:143
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:147
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:151
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
 msgstr ""
 
 #: src/thanks.md:3
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
-"that it\n"
-"was useful."
+"that it was useful."
 msgstr ""
 
 #: src/thanks.md:6
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 
 #: src/other-resources.md:1
-msgid "# Other Rust Resources"
+msgid "Other Rust Resources"
 msgstr ""
 
 #: src/other-resources.md:3
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 
 #: src/other-resources.md:6
-msgid "## Official Documentation"
+msgid "Official Documentation"
 msgstr ""
 
 #: src/other-resources.md:8
@@ -18135,22 +19117,29 @@ msgstr ""
 
 #: src/other-resources.md:10
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
+msgstr ""
+
+#: src/other-resources.md:13
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+
+#: src/other-resources.md:17
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+
+#: src/other-resources.md:19
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
 msgstr ""
 
 #: src/other-resources.md:22
@@ -18159,22 +19148,27 @@ msgstr ""
 
 #: src/other-resources.md:24
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
+msgstr ""
+
+#: src/other-resources.md:27
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+
+#: src/other-resources.md:30
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
 msgstr ""
 
 #: src/other-resources.md:33
-msgid "## Unofficial Learning Material"
+msgid "Unofficial Learning Material"
 msgstr ""
 
 #: src/other-resources.md:35
@@ -18183,61 +19177,65 @@ msgstr ""
 
 #: src/other-resources.md:37
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
+msgstr ""
+
+#: src/other-resources.md:39
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+
+#: src/other-resources.md:42
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+
+#: src/other-resources.md:45
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+
+#: src/other-resources.md:47
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+
+#: src/other-resources.md:52
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
 msgstr ""
 
 #: src/other-resources.md:63
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
+"for even more Rust books."
 msgstr ""
-
-#: src/credits.md:1
-msgid "# Credits"
-msgstr "# 出處清單"
 
 #: src/credits.md:3
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
 "這份教材是以許多優質的 Rust 說明文件來源為基礎。請參閱 [其他資源](other-"
 "resources.md) 頁面，查看完整的實用資源清單。"
@@ -18245,21 +19243,20 @@ msgstr ""
 #: src/credits.md:7
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
 msgstr ""
 "Comprehensive Rust 的教材是根據 Apache 授權條款第 2.0 版取得授權，詳情請參閱 "
 "[`LICENSE`](../LICENSE) 頁面。"
 
 #: src/credits.md:10
-msgid "## Rust by Example"
-msgstr "## Rust by Example"
+msgid "Rust by Example"
+msgstr "Rust by Example"
 
 #: src/credits.md:12
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
 "部分範例和習題是複製自 [Rust by Example](https://doc.rust-lang.org/rust-by-"
@@ -18267,40 +19264,32 @@ msgstr ""
 "權條款。"
 
 #: src/credits.md:17
-msgid "## Rust on Exercism"
-msgstr "## Exercism 上的 Rust"
+msgid "Rust on Exercism"
+msgstr "Exercism 上的 Rust"
 
 #: src/credits.md:19
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
 "部分習題是複製自 [Exercism 上的 Rust](https://exercism.org/tracks/rust) 相關"
 "內容，並經過調整。詳情請參閱 `third_party/rust-on-exercism/` 目錄，包括授權條"
 "款。"
 
 #: src/credits.md:24
-msgid "## CXX"
-msgstr "## CXX"
+msgid "CXX"
+msgstr "CXX"
 
 #: src/credits.md:26
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 "在「互通性」該節的「[與 C++](android/interoperability/cpp.md)」部分中，所使用"
 "的圖片是出自 [CXX](https://cxx.rs/)。詳情請參閱 `third_party/cxx/` 目錄，包括"
 "授權條款。"
-
-#: src/exercises/solutions.md:1
-msgid "# Solutions"
-msgstr ""
 
 #: src/exercises/solutions.md:3
 msgid "You will find solutions to the exercises on the following pages."
@@ -18308,25 +19297,20 @@ msgstr ""
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
 
 #: src/exercises/solutions.md:10
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:1
-msgid "# Day 1 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:3
-msgid "## Arrays and `for` Loops"
+msgid "Day 1 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:5
@@ -18409,7 +19393,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
-msgid "### Bonus question"
+msgid "Bonus question"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:80
@@ -18430,7 +19414,8 @@ msgstr ""
 #: src/exercises/day-1/solutions-morning.md:84
 msgid ""
 "Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:86
@@ -18470,11 +19455,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
-msgid "# Day 1 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-msgid "## Designing a Library"
+msgid "Day 1 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:5
@@ -18677,11 +19658,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
-msgid "# Day 2 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:3
-msgid "## Points and Polygons"
+msgid "Day 2 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:5
@@ -18921,11 +19898,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
-msgid "# Day 2 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-msgid "## Luhn Algorithm"
+msgid "Day 2 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:5
@@ -19026,10 +19999,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:97
-msgid "## Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/solutions-afternoon.md:99
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
@@ -19117,11 +20086,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
-msgid "# Day 3 Morning Exercise"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:3
-msgid "## A Simple GUI Library"
+msgid "Day 3 Morning Exercise"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:5
@@ -19301,11 +20266,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
-msgid "# Day 3 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-msgid "## Safe FFI Wrapper"
+msgid "Day 3 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:5
@@ -19488,11 +20449,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-msgid "## Compass"
+msgid "Bare Metal Rust Morning Exercise"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:5
@@ -19664,14 +20621,6 @@ msgid ""
 "    max(min_value, min(value, max_value))\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "# Bare Metal Rust Afternoon"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-msgid "## RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -19968,11 +20917,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
-msgid "# Concurrency Morning Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:3
-msgid "## Dining Philosophers"
+msgid "Concurrency Morning Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:5
@@ -20080,11 +21025,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
-msgid "# Concurrency Afternoon Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:3
-msgid "## Dining Philosophers - Async"
+msgid "Concurrency Afternoon Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:5
@@ -20203,10 +21144,6 @@ msgid ""
 "    }\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:113
-msgid "## Broadcast Chat Application"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:115
@@ -20361,65 +21298,47 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/structs/tuple-structs.md:37
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics)."
+msgstr "運算子超載會在第 3 天 (泛型) 討論。"
+
+#: src/structs/tuple-structs.md:43
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics).\n"
-"* The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
 "wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
-"* 如要對原始型別中值的額外資訊進行編碼，Newtypes 是絕佳的方式，舉例來說：\n"
-" * 此數字會採用某些測量單位：在上例中為 `Newtons`。\n"
-" * 此值在建立時已通過某些驗證，因此往後不必在每次使用時再次驗證。例如："
-"'PhoneNumber(String)` 或 `OddNumber(u32)` 。\n"
-"* 示範如何透過存取 newtype 中的單一欄位，將 “f64” 值新增至 `Newtons` 類"
-"型。\n"
-"  *  Rust 通常不太能接受不明確的內容，例如自動展開或使用布林值做為整數。\n"
-"  *  運算子超載會在第 3 天 (泛型) 討論。\n"
-"* 此範例巧妙地以 [Mars Climate Orbiter](https://en.wikipedia.org/wiki/"
+"此範例巧妙地以 [Mars Climate Orbiter](https://en.wikipedia.org/wiki/"
 "Mars_Climate_Orbiter) 的失敗經驗做為參照。"
 
 #: src/traits/closures.md:34
 msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
-"perhaps captures\n"
-"nothing at all. It can be called multiple times concurrently."
+"perhaps captures nothing at all. It can be called multiple times "
+"concurrently."
 msgstr ""
-"`Fn` (例如 `add_3`) 既不會耗用也不會修改擷取的值，或許\n"
-"也可說是不會擷取任何值，因此可以多次並行呼叫。"
+"`Fn` (例如 `add_3`) 既不會耗用也不會修改擷取的值，或許 也可說是不會擷取任何"
+"值，因此可以多次並行呼叫。"
 
 #: src/traits/closures.md:37
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
-"multiple times,\n"
-"but not concurrently."
+"multiple times, but not concurrently."
 msgstr ""
-"`FnMut` (例如 `accumulate`) 可能會修改擷取的值，因此可以多次呼叫\n"
-" (但不得並行呼叫)。"
+"`FnMut` (例如 `accumulate`) 可能會修改擷取的值，因此可以多次呼叫 (但不得並行"
+"呼叫)。"
 
 #: src/traits/closures.md:40
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
-"might consume\n"
-"captured values."
+"might consume captured values."
 msgstr ""
-"如果是 `FnOnce` (例如`multiply_sum`)，也許就只能呼叫一次，因為這可能會耗用\n"
-"擷取的值。"
+"如果是 `FnOnce` (例如`multiply_sum`)，也許就只能呼叫一次，因為這可能會耗用 擷"
+"取的值。"
 
 #: src/traits/closures.md:47
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
-"`multiply_sum`),\n"
-"depending on what the closure captures."
+"`multiply_sum`), depending on what the closure captures."
 msgstr ""
 "編譯器也會根據閉包擷取到的內容來推論 `Copy` (例如針對 `add_3`) 和 `Clone` (例"
 "如 `multiply_sum`)."
@@ -20427,9 +21346,7 @@ msgstr ""
 #: src/traits/closures.md:50
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
-"keyword makes them capture\n"
-"by value."
+"keyword makes them capture by value."
 msgstr ""
 "根據預設，閉包會依據參照來擷取內容 (如果可行的話)。`move` 關鍵字則可讓閉包根"
-"據值\n"
-"來擷取內容。"
+"據值 來擷取內容。"


### PR DESCRIPTION
Before, po/zh-TW.po had these statistics:

    492 translated messages, 55 fuzzy translations, 1234 untranslated messages.

Afterwards, the statistics for po/zh-TW.po is:

    776 translated messages, 67 fuzzy translations, 1624 untranslated messages.

The number of translated messages changed from 28% to 31%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.