### PR TITLE
ja: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -5,34 +5,33 @@ msgstr ""
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
-"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.1\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr ""
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "講座の運営について"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr ""
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
-msgstr ""
+msgstr "翻訳"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
 msgstr ""
 
@@ -57,55 +56,55 @@ msgstr "Day 1： AM"
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
-msgstr ""
+msgstr "Rustとは？"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr ""
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "プログラムの例"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr ""
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
-msgstr ""
+msgstr "コンパイル時の保証"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
-msgstr ""
+msgstr "実行時の保証"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
-msgstr ""
+msgstr "現代的な機能"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr ""
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr ""
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr ""
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr ""
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr ""
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "スライス型"
 
@@ -113,15 +112,16 @@ msgstr "スライス型"
 msgid "String vs str"
 msgstr "文字列（String） vs 文字列スライス（str）"
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "関数"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr "Rustdoc"
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "メソッド"
 
@@ -132,10 +132,14 @@ msgstr "オーバーロード"
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
 #: src/SUMMARY.md:251 src/SUMMARY.md:273 src/SUMMARY.md:293
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
+#: src/exercises/concurrency/morning.md:1
+#: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "練習問題"
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "暗黙的な型変換"
 
@@ -147,11 +151,11 @@ msgstr "配列とforループ"
 msgid "Day 1: Afternoon"
 msgstr "Day 1： PM"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "変数"
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "型推論"
 
@@ -159,11 +163,11 @@ msgstr "型推論"
 msgid "static & const"
 msgstr "static & const"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "スコープとシャドーイング"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "メモリ管理"
 
@@ -171,15 +175,15 @@ msgstr "メモリ管理"
 msgid "Stack vs Heap"
 msgstr "スタック vs ヒープ"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "スタックメモリ"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "手動でのメモリ管理"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "スコープに基づくメモリ管理"
 
@@ -191,59 +195,60 @@ msgstr "ガベージコレクション"
 msgid "Rust Memory Management"
 msgstr "Rustのメモリ管理"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "比較"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
 msgstr "所有権"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "ムーブセマンティクス"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "文字列のムーブ"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "現代C++の二重解放"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "関数とムーブ"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "コピーとクローン"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "借用"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "共有参照と固有参照"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "ライフタイム"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "関数とライフタイム"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "データ構造とライフタイム"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr "ライブラリをデザイン"
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "イテレータと所有権"
 
@@ -251,63 +256,64 @@ msgstr "イテレータと所有権"
 msgid "Day 2: Morning"
 msgstr "Day 2： AM"
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
 msgstr "構造体（structs）"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "タプル構造体"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "フィールドの省略"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
 msgstr "列挙型（enums）"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "列挙子のペイロード"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "列挙型のサイズ"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "メソッドレシーバ"
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:272
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "例"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "パターンマッチング"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "列挙型編"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "構造体編"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "配列編"
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "マッチガード"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "健康統計"
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "ポイントとポリゴン"
 
@@ -315,11 +321,11 @@ msgstr "ポイントとポリゴン"
 msgid "Day 2: Afternoon"
 msgstr "Day 2： PM"
 
-#: src/SUMMARY.md:96 src/SUMMARY.md:286
+#: src/SUMMARY.md:96 src/SUMMARY.md:286 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "制御フロー"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "コードブロック"
 
@@ -355,7 +361,7 @@ msgstr "match式"
 msgid "break & continue"
 msgstr "break & continue"
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
 msgstr "標準ライブラリ"
 
@@ -363,7 +369,7 @@ msgstr "標準ライブラリ"
 msgid "Option and Result"
 msgstr "OptionとResult"
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
 msgstr "文字列（String）"
 
@@ -383,7 +389,7 @@ msgstr "ボックス（Box）"
 msgid "Recursive Data Types"
 msgstr "再帰的データ型"
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "Niche最適化"
 
@@ -391,27 +397,29 @@ msgstr "Niche最適化"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr "モジュール"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "可視性"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr "パス"
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "ファイルシステム階層"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Luhnアルゴリズム"
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:97
 msgid "Strings and Iterators"
 msgstr "文字列とイテレータ"
 
@@ -419,39 +427,39 @@ msgstr "文字列とイテレータ"
 msgid "Day 3: Morning"
 msgstr "Day 3： AM"
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/generics.md:1
 msgid "Generics"
 msgstr "ジェネリクス（generics）"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "ジェネリックデータ型"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "ジェネリックメソッド"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "単相化"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits.md:1
 msgid "Traits"
 msgstr "トレイト（trait）"
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "トレイトオブジェクト"
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "トレイトの導出"
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md:136 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "デフォルトメソッド"
 
-#: src/SUMMARY.md:137
+#: src/SUMMARY.md:137 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "トレイト境界"
 
@@ -459,7 +467,7 @@ msgstr "トレイト境界"
 msgid "impl Trait"
 msgstr "impl Trait"
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "重要なトレイト"
 
@@ -467,7 +475,7 @@ msgstr "重要なトレイト"
 msgid "Iterator"
 msgstr "Iterator"
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -495,7 +503,8 @@ msgstr "演算子： Add, Mul, …"
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr "クロージャ：Fn, FnMut, FnOnce"
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "GUIライブラリ"
 
@@ -503,11 +512,11 @@ msgstr "GUIライブラリ"
 msgid "Day 3: Afternoon"
 msgstr "Day 3： PM"
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "エラー処理"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "パニック（panic）"
 
@@ -523,67 +532,68 @@ msgstr "構造化されたエラー処理"
 msgid "Propagating Errors with ?"
 msgstr "？でエラーを伝播する"
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "エラーの型変換"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "列挙型エラーの導出"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "動的なエラー型"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "コンテキストをエラーに追加"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
 msgstr "テスト"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "ユニットテスト"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "テストモジュール"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "ドキュメンテーションテスト"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "インテグレーションテスト"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr "便利クレート"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Unsafe Rust"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "生ポインタの参照外し"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "可変なstatic変数"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "共用体"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "Unsafe関数の呼び出し"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "Unsafe関数の書き方"
 
@@ -591,23 +601,25 @@ msgstr "Unsafe関数の書き方"
 msgid "Extern Functions"
 msgstr "Extern関数"
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "Unsafeなトレイトの実装"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "安全なFFIラッパ"
 
 #: src/SUMMARY.md:181 src/SUMMARY.md:249
+#: src/running-the-course/course-structure.md:16 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/android/setup.md:1
 msgid "Setup"
 msgstr "セットアップ"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "ビルドのルール"
 
@@ -619,7 +631,7 @@ msgstr "バイナリ"
 msgid "Library"
 msgstr "ライブラリ"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL（Androidインターフェイス定義言語）"
 
@@ -635,7 +647,7 @@ msgstr "実装"
 msgid "Server"
 msgstr "サーバ"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:194 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "デプロイ"
 
@@ -643,15 +655,16 @@ msgstr "デプロイ"
 msgid "Client"
 msgstr "クライアント"
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:196 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "APIの変更"
 
-#: src/SUMMARY.md:197 src/SUMMARY.md:240
+#: src/SUMMARY.md:197 src/SUMMARY.md:240 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "ログ出力"
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "相互運用性"
 
@@ -667,7 +680,7 @@ msgstr "BindgenによるCの呼び出し"
 msgid "Calling Rust from C"
 msgstr "CからRust呼び出し"
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "C++"
 
@@ -691,11 +704,11 @@ msgstr "例"
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "マイクロコントローラ"
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "生MMIO（メモリマップトI/O）"
 
@@ -723,7 +736,7 @@ msgstr "embedded-hal"
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs, cargo-embed"
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "デバッグ"
 
@@ -731,7 +744,8 @@ msgstr "デバッグ"
 msgid "Other Projects"
 msgstr "他のプロジェクト"
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:226 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "コンパス"
 
@@ -763,7 +777,7 @@ msgstr "他のトレイト"
 msgid "A Better UART Driver"
 msgstr "UARTドライバの改善"
 
-#: src/SUMMARY.md:236
+#: src/SUMMARY.md:236 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "ビットフラッグ"
 
@@ -771,7 +785,7 @@ msgstr "ビットフラッグ"
 msgid "Multiple Registers"
 msgstr "複数のレジスタ"
 
-#: src/SUMMARY.md:238
+#: src/SUMMARY.md:238 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "ドライバ"
 
@@ -803,7 +817,7 @@ msgstr "tinyvec"
 msgid "spin"
 msgstr "spin"
 
-#: src/SUMMARY.md:250
+#: src/SUMMARY.md:250 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
@@ -815,23 +829,23 @@ msgstr "RTC（リアルタイムクロック）ドライバ"
 msgid "Concurrency: Morning"
 msgstr "並行性： AM"
 
-#: src/SUMMARY.md:260
+#: src/SUMMARY.md:260 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "スレッド"
 
-#: src/SUMMARY.md:261
+#: src/SUMMARY.md:261 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "スコープ付きスレッド"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:262 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "チャネル"
 
-#: src/SUMMARY.md:263
+#: src/SUMMARY.md:263 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Unboundedチャネル"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Boundedチャネル"
 
@@ -847,11 +861,11 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:268
+#: src/SUMMARY.md:268 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "例"
 
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md:269 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "状態共有"
 
@@ -864,10 +878,12 @@ msgid "Mutex"
 msgstr "Mutex"
 
 #: src/SUMMARY.md:274 src/SUMMARY.md:294
+#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "食事する哲学者"
 
-#: src/SUMMARY.md:275
+#: src/SUMMARY.md:275 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "マルチスレッド・リンクチェッカー"
 
@@ -883,31 +899,32 @@ msgstr "Asyncの基礎"
 msgid "async/await"
 msgstr "async/await"
 
-#: src/SUMMARY.md:281
+#: src/SUMMARY.md:281 src/async/futures.md:1
 msgid "Futures"
 msgstr "Future"
 
-#: src/SUMMARY.md:282
+#: src/SUMMARY.md:282 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "ランタイム"
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md:283 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/exercises/concurrency/link-checker.md:106
+#: src/exercises/concurrency/chat-app.md:140 src/async/tasks.md:1
 msgid "Tasks"
 msgstr "タスク"
 
-#: src/SUMMARY.md:285
+#: src/SUMMARY.md:285 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "Asyncチャネル"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:287 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:288
+#: src/SUMMARY.md:288 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
@@ -919,15 +936,16 @@ msgstr "落とし穴"
 msgid "Blocking the Executor"
 msgstr "エグゼキュータのブロッキング"
 
-#: src/SUMMARY.md:291
+#: src/SUMMARY.md:291 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr "Pin"
 
-#: src/SUMMARY.md:292
+#: src/SUMMARY.md:292 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "Asyncトレイト"
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md:295 src/exercises/concurrency/chat-app.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:113
 msgid "Broadcast Chat Application"
 msgstr "ブロードキャスト・チャットアプリ"
 
@@ -935,7 +953,7 @@ msgstr "ブロードキャスト・チャットアプリ"
 msgid "Final Words"
 msgstr "最後に"
 
-#: src/SUMMARY.md:302
+#: src/SUMMARY.md:302 src/thanks.md:1
 msgid "Thanks!"
 msgstr "ありがとうございました！"
 
@@ -943,11 +961,11 @@ msgstr "ありがとうございました！"
 msgid "Other Resources"
 msgstr "参考資料"
 
-#: src/SUMMARY.md:304
+#: src/SUMMARY.md:304 src/credits.md:1
 msgid "Credits"
 msgstr "クレジット"
 
-#: src/SUMMARY.md:307
+#: src/SUMMARY.md:307 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "解答"
 
@@ -979,7 +997,7 @@ msgstr "Day 3 PM"
 msgid "Bare Metal Rust Morning"
 msgstr "ベアメタルRust AM"
 
-#: src/SUMMARY.md:319
+#: src/SUMMARY.md:319 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "ベアメタルRust PM"
 
@@ -990,10 +1008,6 @@ msgstr "並行性 AM"
 #: src/SUMMARY.md:321
 msgid "Concurrency Afternoon"
 msgstr "並行性 PM"
-
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr ""
 
 #: src/welcome.md:3
 msgid ""
@@ -1010,15 +1024,15 @@ msgstr ""
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 msgstr ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 
@@ -1030,17 +1044,15 @@ msgstr ""
 msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 
 #: src/welcome.md:5
 msgid "GitHub stars"
@@ -1059,11 +1071,9 @@ msgstr ""
 #: src/welcome.md:7
 msgid ""
 "This is a three day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 "この資料は、GoogleのAndroidチームによって開発された3日間のRust講座です。本講"
 "座では、基本構文からジェネリクスやエラー処理など、幅広い内容をカバーします。"
@@ -1072,28 +1082,28 @@ msgstr ""
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
 "本講座の目的は、Rustを教える事です。Rustに関する前提知識は不要としており、次"
 "の目標を設定しています："
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
-msgstr ""
-"* Rustの基本構文と言語についての理解を深める。\n"
-"* 既存のプログラムを修正したり、新規プログラムをRustで書けるようにする。\n"
-"* 一般的なRustのイディオムを紹介する。"
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
+msgstr "Rustの基本構文と言語についての理解を深める。"
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr "既存のプログラムを修正したり、新規プログラムをRustで書けるようにする。"
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
+msgstr "一般的なRustのイディオムを紹介する。"
 
 #: src/welcome.md:18
 #, fuzzy
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, "
-"you're\n"
-"invited to dive into one or more specialized topics:"
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
 "最初の3日間は、Rustの基礎を学びます。その後、より専門的なトピックに進む事がで"
 "きます："
@@ -1101,65 +1111,67 @@ msgstr ""
 #: src/welcome.md:21
 #, fuzzy
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android "
-"platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a full day class on using Rust for bare-"
-"metal\n"
-"  (embedded) development. Both microcontrollers and application processors "
-"are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a full day class on concurrency in Rust. "
-"We\n"
-"  cover both classical concurrency (preemptively scheduling using threads "
-"and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"* [Android](android.md)： Androidオープンソースプラットフォーム（AOSP）でRust"
-"を使用するための半日講座。C、C++、およびJavaとの相互運用性も含まれます。\n"
-"* [Bare-metal](bare-metal.md)： ベアメタル（組み込み）開発でRustを使用するた"
-"めの1日講座。マイクロコントローラとアプリケーションプロセッサの両方が対象とな"
-"ります。\n"
-"* [Concurrency](concurrency.md)： Rustの並行性についての1日講座。並行性（ス"
-"レッドとミューテックスを用いたプリエンプティブなスケジューリング）と、async/"
-"awaitを使用した並行性（futuresを用いた協調的マルチタスク）がカバーされます。"
+"[Android](android.md)： Androidオープンソースプラットフォーム（AOSP）でRustを"
+"使用するための半日講座。C、C++、およびJavaとの相互運用性も含まれます。"
+
+#: src/welcome.md:23
+#, fuzzy
+msgid ""
+"[Bare-metal](bare-metal.md): a full day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+"[Bare-metal](bare-metal.md)： ベアメタル（組み込み）開発でRustを使用するため"
+"の1日講座。マイクロコントローラとアプリケーションプロセッサの両方が対象となり"
+"ます。"
+
+#: src/welcome.md:26
+#, fuzzy
+msgid ""
+"[Concurrency](concurrency.md): a full day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
+msgstr ""
+"[Concurrency](concurrency.md)： Rustの並行性についての1日講座。並行性（スレッ"
+"ドとミューテックスを用いたプリエンプティブなスケジューリング）と、async/await"
+"を使用した並行性（futuresを用いた協調的マルチタスク）がカバーされます。"
 
 #: src/welcome.md:32
-msgid "## Non-Goals"
-msgstr "## 本講座の対象外"
+msgid "Non-Goals"
+msgstr "本講座の対象外"
 
 #: src/welcome.md:34
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 "Rustは非常に汎用性の高い言語であり、数日で全てを網羅する事はできません。本講"
 "座の目標として設定されていないものには、以下のようなものがあります："
 
 #: src/welcome.md:37
 msgid ""
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
-"* マクロ（macro）の開発。マクロの詳細については、[Rust Book 日本語版 Ch. "
-"19.5](https://doc.rust-jp.rs/book-ja/ch19-06-macros.html)と[Rust by Example "
-"日本語版 Ch.17](http://doc.rust-jp.rs/rust-by-example-ja/macros.html)を参照し"
-"てください。"
+"マクロ（macro）の開発。マクロの詳細については、[Rust Book 日本語版 Ch. 19.5]"
+"(https://doc.rust-jp.rs/book-ja/ch19-06-macros.html)と[Rust by Example 日本語"
+"版 Ch.17](http://doc.rust-jp.rs/rust-by-example-ja/macros.html)を参照してくだ"
+"さい。"
 
 #: src/welcome.md:41
-msgid "## Assumptions"
-msgstr "## 前提知識"
+msgid "Assumptions"
+msgstr "前提知識"
 
 #: src/welcome.md:43
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
 "本講座では、既にプログラミングの知識がある事を前提としています。Rustは静的型"
 "付け言語であり、Rustのアプローチをより分かりやすく説明するために、時折CやC+"
@@ -1167,233 +1179,29 @@ msgstr ""
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 "もし受講者の知識がPythonやJavaScriptなどの動的型付け言語に限定されている場合"
 "でも、本講座の受講は可能です。"
 
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/scalar-types.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/references.md:21
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/methods.md:32 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:100
-#: src/structs.md:29 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums.md:31
-#: src/enums/variant-payloads.md:33 src/enums/sizes.md:27 src/methods.md:28
-#: src/methods/receiver.md:22 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:21
-#: src/control-flow/while-let-expressions.md:24
-#: src/control-flow/for-expressions.md:23
-#: src/control-flow/loop-expressions.md:25
-#: src/control-flow/match-expressions.md:26 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:42 src/exercises/day-2/afternoon.md:5
-#: src/generics/data-types.md:19 src/generics/methods.md:23
-#: src/traits/trait-objects.md:70 src/traits/default-methods.md:30
-#: src/traits/trait-bounds.md:33 src/traits/impl-trait.md:21
-#: src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/drop.md:32 src/traits/default.md:38
-#: src/traits/operators.md:24 src/traits/closures.md:23
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:46
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:25 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:5
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/android/morning.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:37 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart.md:53 src/bare-metal/aps/uart/traits.md:22
-#: src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:49 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:44
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/scoped-threads.md:35 src/concurrency/channels.md:25
-#: src/concurrency/send-sync.md:18 src/concurrency/send-sync/send.md:11
-#: src/concurrency/send-sync/sync.md:12 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21
-#: src/exercises/concurrency/morning.md:10 src/async/async-await.md:23
-#: src/async/futures.md:30 src/async/runtimes.md:18
-#: src/async/runtimes/tokio.md:31 src/async/tasks.md:51
-#: src/async/channels.md:33 src/async/control-flow/join.md:34
-#: src/async/control-flow/select.md:59
-#: src/async/pitfalls/blocking-executor.md:27 src/async/pitfalls/pin.md:66
-#: src/exercises/concurrency/afternoon.md:11
-#: src/exercises/concurrency/dining-philosophers-async.md:75
-msgid "<details>"
-msgstr ""
-
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 "これはスピーカーノートの一例です。これを使用してスライドを捕捉します。講師が"
 "カバーすべき要点や、授業でよく出る質問への回答などが含まれます。"
 
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
-#: src/why-rust/modern.md:66 src/basic-syntax/scalar-types.md:43
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:29
-#: src/basic-syntax/slices.md:36 src/basic-syntax/string-slices.md:44
-#: src/basic-syntax/functions.md:41 src/basic-syntax/rustdoc.md:33
-#: src/basic-syntax/methods.md:45 src/basic-syntax/functions-interlude.md:30
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:104
-#: src/structs.md:42 src/structs/tuple-structs.md:43
-#: src/structs/field-shorthand.md:72 src/enums.md:41
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:28 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:29
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:46
-#: src/control-flow/if-expressions.md:37
-#: src/control-flow/if-let-expressions.md:41
-#: src/control-flow/while-let-expressions.md:29
-#: src/control-flow/for-expressions.md:30
-#: src/control-flow/loop-expressions.md:32
-#: src/control-flow/match-expressions.md:33 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:42 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:71 src/exercises/day-2/afternoon.md:11
-#: src/generics/data-types.md:25 src/generics/methods.md:31
-#: src/traits/trait-objects.md:83 src/traits/default-methods.md:60
-#: src/traits/trait-bounds.md:50 src/traits/impl-trait.md:44
-#: src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/drop.md:42 src/traits/default.md:47
-#: src/traits/operators.md:38 src/traits/closures.md:38
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:53
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:43 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:11
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/android/morning.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:49
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/inline-assembly.md:58 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:55 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:49
-#: src/bare-metal/useful-crates/zerocopy.md:53
-#: src/bare-metal/useful-crates/aarch64-paging.md:33
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
-#: src/bare-metal/useful-crates/tinyvec.md:26
-#: src/bare-metal/useful-crates/spin.md:30 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/scoped-threads.md:40 src/concurrency/channels.md:32
-#: src/concurrency/send-sync.md:23 src/concurrency/send-sync/send.md:16
-#: src/concurrency/send-sync/sync.md:18 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56
-#: src/exercises/concurrency/morning.md:16 src/async/async-await.md:48
-#: src/async/futures.md:45 src/async/runtimes.md:29
-#: src/async/runtimes/tokio.md:49 src/async/tasks.md:64
-#: src/async/channels.md:49 src/async/control-flow/join.md:50
-#: src/async/control-flow/select.md:77
-#: src/async/pitfalls/blocking-executor.md:50 src/async/pitfalls/pin.md:112
-#: src/async/pitfalls/async-traits.md:63
-#: src/exercises/concurrency/afternoon.md:17
-#: src/exercises/concurrency/dining-philosophers-async.md:79
-msgid "</details>"
-msgstr ""
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# 講座の運営について"
-
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> このページは講師用です。"
+msgid "This page is for the course instructor."
+msgstr "このページは講師用です。"
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
+"course internally at Google."
 msgstr "以下は、Google内での講座の運営方法に関する情報です。"
 
 #: src/running-the-course.md:8
@@ -1402,78 +1210,70 @@ msgstr "講座開始までに、以下にあげる準備を済ませておくと
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   to help highlight the key points (please help us by contributing more "
-"speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes "
-"in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). "
-"This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Decide on the dates. Since the course takes at least three full days, we "
-"recommend that you\n"
-"   schedule the days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-25 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself "
-"and for the\n"
-"   students: you will all need to be able to sit and work with your "
-"laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, "
-"so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups.\n"
-"   We typically spend 30-45 minutes on exercises in the morning and in the "
-"afternoon (including time to review the solutions).\n"
-"   Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. 資料に慣れておいてください。要点を強調するためにスピーカーノートが用意され"
-"ています（内容の追加にご協力ください！）。プレゼン時には、スクリーンを見やす"
-"い状態で保つために、スピーカーノートはポップアップウィンドウで開いてください"
-"（スピーカーノートの横にある小さな矢印をクリック）。\n"
-"\n"
-"1. あらかじめ日程を決めておいてください。講座は最低でも3日かかるため、2週間に"
-"わたって日程を組む事を推奨しています。過去の受講者によると、講座の間に数日"
-"ギャップを設ける事で内容が吸収しやすくなります。\n"
-"\n"
-"1. 十分な広さの部屋を確保しておいてください。15~25名程度のクラスを推奨してい"
-"ます。受講者にとって質問がしやすい人数であり、1人の講師が質問に答える時間も確"
-"保できる規模だからです。また、皆さんはPCで作業をする必要があるため、講師を含"
-"めた人数分の机を用意しておいてください。ライブコーディング形式での実施を想定"
-"しているため、講壇は不要です。\n"
-"\n"
-"1. 当日は少し早めに到着して準備をしてください。自分のPCで実行する`mdbook "
-"serve`から直接プレゼンを行う事を推奨します（[インストール手順][3]はこちら）。"
-"これにより、ページ切り替え時に遅延なしで最適なパフォーマンスが得られます。ま"
-"た、PCを使用する事で、受講者や自分自身が見つけたタイプミスなども修正可能にな"
-"ります。\n"
-"\n"
-"1. 練習問題は個人か小さいグループで解いてください。回答をレビューする時間も含"
+"資料に慣れておいてください。要点を強調するためにスピーカーノートが用意されて"
+"います（内容の追加にご協力ください！）。プレゼン時には、スクリーンを見やすい"
+"状態で保つために、スピーカーノートはポップアップウィンドウで開いてください"
+"（スピーカーノートの横にある小さな矢印をクリック）。"
+
+#: src/running-the-course.md:16
+msgid ""
+"Decide on the dates. Since the course takes at least three full days, we "
+"recommend that you schedule the days over two weeks. Course participants "
+"have said that they find it helpful to have a gap in the course since it "
+"helps them process all the information we give them."
+msgstr ""
+"あらかじめ日程を決めておいてください。講座は最低でも3日かかるため、2週間にわ"
+"たって日程を組む事を推奨しています。過去の受講者によると、講座の間に数日"
+"ギャップを設ける事で内容が吸収しやすくなります。"
+
+#: src/running-the-course.md:21
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-25 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"十分な広さの部屋を確保しておいてください。15~25名程度のクラスを推奨していま"
+"す。受講者にとって質問がしやすい人数であり、1人の講師が質問に答える時間も確保"
+"できる規模だからです。また、皆さんはPCで作業をする必要があるため、講師を含め"
+"た人数分の机を用意しておいてください。ライブコーディング形式での実施を想定し"
+"ているため、講壇は不要です。"
+
+#: src/running-the-course.md:29
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"当日は少し早めに到着して準備をしてください。自分のPCで実行する`mdbook serve`"
+"から直接プレゼンを行う事を推奨します（[インストール手順](https://github.com/"
+"google/comprehensive-rust#building)はこちら）。これにより、ページ切り替え時に"
+"遅延なしで最適なパフォーマンスが得られます。また、PCを使用する事で、受講者や"
+"自分自身が見つけたタイプミスなども修正可能になります。"
+
+#: src/running-the-course.md:35
+msgid ""
+"Let people solve the exercises by themselves or in small groups. We "
+"typically spend 30-45 minutes on exercises in the morning and in the "
+"afternoon (including time to review the solutions). Make sure to ask people "
+"if they're stuck or if there is anything you can help with. When you see "
+"that several people have the same problem, call it out to the class and "
+"offer a solution, e.g., by showing people where to find the relevant "
+"information in the standard library."
+msgstr ""
+"練習問題は個人か小さいグループで解いてください。回答をレビューする時間も含"
 "め、各練習問題に30~45分を費やします。受講者が行き詰まっているかどうか、何か質"
 "問があるかなど確認してください。複数の受講者が同じ問題で詰まっている場合、ク"
 "ラス全体に対してそれを共有し、解決策を提供してください。例えば、探している情"
@@ -1482,63 +1282,57 @@ msgstr ""
 #: src/running-the-course.md:43
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
+"for you as it has been for us!"
 msgstr ""
 "以上です。運営頑張ってください！皆さんにとっても楽しい時間になりますように！"
 
 #: src/running-the-course.md:46
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"本講座の改善に向けて[フィードバック][1]をお願いします。うまくいった点や改善点"
-"について幅広くご意見お聞かせください。[受講者からのフィードバック][2]も歓迎し"
-"ております！"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr ""
+"本講座の改善に向けて[フィードバック](https://github.com/google/comprehensive-"
+"rust/discussions/86)をお願いします。うまくいった点や改善点について幅広くご意"
+"見お聞かせください。[受講者からのフィードバック](https://github.com/google/"
+"comprehensive-rust/discussions/100)も歓迎しております！"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "本講座はペースが早く、多くの内容をカバーします："
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust."
-msgstr ""
-"* Day 1： Rustの基本、所有権と借用チェッカー\n"
-"* Day 2： 複合データ型、パターンマッチング、標準ライブラリ\n"
-"* Day 3： トレイトとジェネリクス、エラー処理、テスト、unsafe Rust"
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "Day 1： Rustの基本、所有権と借用チェッカー"
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
+msgstr "Day 2： 複合データ型、パターンマッチング、標準ライブラリ"
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr "Day 3： トレイトとジェネリクス、エラー処理、テスト、unsafe Rust"
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
-msgstr "## 専門的なトピック"
+msgid "Deep Dives"
+msgstr "専門的なトピック"
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
 msgstr ""
 "Rustの基礎に関する3日間の講座に加え、いくつかのより専門的なトピックも用意され"
 "ています："
 
-#: src/running-the-course/course-structure.md:16
-msgid "### Android"
-msgstr ""
-
 #: src/running-the-course/course-structure.md:18
 #, fuzzy
 msgid ""
 "The [Android Deep Dive](../android.md) is a half-day course on using Rust "
-"for\n"
-"Android platform development. This includes interoperability with C, C++, "
-"and\n"
-"Java."
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
 "[Android編](../android.md)は、Androidオープンソースプラットフォーム（AOSP）で"
 "Rustを使用するための半日程度の講座です。C、C++、およびJavaとの相互運用性も含"
@@ -1546,25 +1340,23 @@ msgstr ""
 
 #: src/running-the-course/course-structure.md:22
 msgid ""
-"You will need an [AOSP checkout][1]. Make a checkout of the [course\n"
-"repository][2] on the same machine and move the `src/android/` directory "
-"into\n"
-"the root of your AOSP checkout. This will ensure that the Android build "
-"system\n"
-"sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"[AOSPのチェックアウト][1]が必要です。同じ端末から[講座のリポジトリ][2]を"
-"チェックアウトし、`src/android/`ディレクトリをAOSPチェックアウトのルートに移"
-"動してください。これにより、Androidビルドシステムが`src/android/`内の"
-"`Android.bp`を確認できるようになります。"
+"[AOSPのチェックアウト](https://source.android.com/docs/setup/download/"
+"downloading)が必要です。同じ端末から[講座のリポジトリ](https://github.com/"
+"google/comprehensive-rust)をチェックアウトし、`src/android/`ディレクトリを"
+"AOSPチェックアウトのルートに移動してください。これにより、Androidビルドシステ"
+"ムが`src/android/`内の`Android.bp`を確認できるようになります。"
 
 #: src/running-the-course/course-structure.md:27
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
-"all\n"
-"Android examples using `src/android/build_all.sh`. Read the script to see "
-"the\n"
-"commands it runs and make sure they work when you run them by hand."
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
 "エミュレータまたは実際のデバイスで`adb sync`が機能する事を確認し、`src/"
 "android/build_all.sh`を使用して全てのAndroidの例を事前にビルドしてください。"
@@ -1572,14 +1364,13 @@ msgstr ""
 "確認してください。"
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
-msgstr "### ベアメタル"
+msgid "Bare-Metal"
+msgstr "ベアメタル"
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
 "The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
-"for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
 "[ベアメタル編](../bare-metal.md)は、ベアメタル（組み込み）開発でRustを使用す"
@@ -1588,25 +1379,23 @@ msgstr ""
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
 "マイクロコントローラの章では、事前に[BBCmicro:bit](https://microbit.org/)v2開"
 "発ボードを購入する必要があります。また、[welcomeページ](../bare-metal.md)で説"
 "明されているように、複数のパッケージをインストールする必要があります。"
 
 #: src/running-the-course/course-structure.md:45
-msgid "### Concurrency"
-msgstr "### 並行性"
+msgid "Concurrency"
+msgstr "並行性"
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
 "The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
-"classical\n"
-"as well as `async`/`await` concurrency."
+"classical as well as `async`/`await` concurrency."
 msgstr ""
 "[並行性編](../concurrency.md) は、並行性とasync/awaitを使用した並行性について"
 "の1日講座です。"
@@ -1614,10 +1403,8 @@ msgstr ""
 #: src/running-the-course/course-structure.md:50
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
-"to\n"
-"go. You can then copy/paste the examples into `src/main.rs` to experiment "
-"with\n"
-"them:"
+"to go. You can then copy/paste the examples into `src/main.rs` to experiment "
+"with them:"
 msgstr ""
 "新規クレートの作成と、依存関係（dependencies）のダウンロードが必要です。その"
 "後、例を`src/main.rs`にコピペして実行する事ができます："
@@ -1633,51 +1420,71 @@ msgid ""
 msgstr ""
 
 #: src/running-the-course/course-structure.md:61
-msgid "## Format"
-msgstr "## フォーマット"
+msgid "Format"
+msgstr "フォーマット"
 
 #: src/running-the-course/course-structure.md:63
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
 "本講座はインタラクティブな形式で行います。積極的に質問して、Rustへの理解を深"
 "めてください！"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr ""
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "mdBookには、便利なショートカットキーがいくつか存在します："
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Arrow-Left</kbd>： 前のページに移動\n"
-"* <kbd>Arrow-Right</kbd>： 次のページに移動。\n"
-"* <kbd>Ctrl + Enter</kbd>： フォーカスを持つコードサンプルを実行\n"
-"* <kbd>s</kbd>： 検索バーを起動"
+msgid "Arrow-Left"
+msgstr "Arrow-Left"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# 翻訳"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr "： 前のページに移動"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Arrow-Right"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr "： 次のページに移動。"
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr "： フォーカスを持つコードサンプルを実行"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr "： 検索バーを起動"
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
 msgstr "本資料は、ボランティアによって翻訳されています："
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
+msgstr ""
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
 
 #: src/running-the-course/translations.md:9
@@ -1687,26 +1494,23 @@ msgstr "画面右上の言語切り替えボタンから、切り替えを行な
 
 #: src/running-the-course/translations.md:11
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"この取り組みにご協力いただける場合は、[our instructions]をご覧ください。翻訳"
-"は[issue tracker]で管理されています。"
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr ""
+"この取り組みにご協力いただける場合は、[our instructions](https://github.com/"
+"google/comprehensive-rust/blob/main/TRANSLATIONS.md)をご覧ください。翻訳は"
+"[issue tracker](https://github.com/google/comprehensive-rust/issues/282)で管"
+"理されています。"
 
 #: src/cargo.md:3
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
 "Rustを学び始めると、まもなくRustエコシステムで広く使われているビルドシステム"
 "兼パッケージマネージャである[Cargo](https://doc.rust-lang.org/cargo/)という標"
@@ -1714,22 +1518,22 @@ msgstr ""
 "要性について簡単に説明します。"
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## インストール"
+msgid "Installation"
+msgstr "インストール"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (推奨)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (推奨)"
 
 #: src/cargo.md:12
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
-"[rustup][3]ツールを使用して、cargoやrustコンパイラなどの標準エコシステムツー"
-"ルをインストールします。RustupはRust Foundationによってメンテナンスされていま"
-"す。"
+"[rustup](https://rust-analyzer.github.io/)ツールを使用して、cargoやrustコンパ"
+"イラなどの標準エコシステムツールをインストールします。RustupはRust Foundation"
+"によってメンテナンスされています。"
 
 #: src/cargo.md:14
 msgid ""
@@ -1742,20 +1546,21 @@ msgstr ""
 "ロスコンパイルの設定などが行えます。"
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### パッケージマネージャ"
+msgid "Package Managers"
+msgstr "パッケージマネージャ"
 
 #: src/cargo.md:18
-msgid "#### Debian"
+msgid "Debian"
 msgstr ""
 
 #: src/cargo.md:20
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
 "Debian/Ubuntuを使用している場合、以下のコマンドを使ってcargo、rustのソース"
-"コード、[Rust formatter][6]をインストールします"
+"コード、[Rust formatter](https://github.com/rust-lang/rustfmt)をインストール"
+"します"
 
 #: src/cargo.md:22
 msgid ""
@@ -1766,28 +1571,30 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"これで[rust-analyzer][1]を使って定義に飛べるようになります。コードの編集に"
-"は、[VS Code][2]を推奨しています（ただし、LSP互換エディタならどれでも大丈夫で"
-"す）。"
+"これで\\[rust-analyzer\\]\\[1\\]を使って定義に飛べるようになります。コードの"
+"編集には、[VS Code](https://code.visualstudio.com/)を推奨しています（ただし、"
+"LSP互換エディタならどれでも大丈夫です）。"
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"[JetBrains][4]ファミリのIDEを使いたい人もいるでしょう。これらは独自の分析を提"
-"供してくれますが、トレードオフもあります。もし使用したい場合、[Rust Plugin]"
-"[5]のインストールが可能です。ただし、2023年1月時点では、デバッグがJetBrains "
-"IDEA suiteのCLionバージョンでしか動作しない点に注意してください。"
+"[JetBrains](https://www.jetbrains.com/clion/)ファミリのIDEを使いたい人もいる"
+"でしょう。これらは独自の分析を提供してくれますが、トレードオフもあります。も"
+"し使用したい場合、[Rust Plugin](https://www.jetbrains.com/rust/)のインストー"
+"ルが可能です。ただし、2023年1月時点では、デバッグがJetBrains IDEA suiteの"
+"CLionバージョンでしか動作しない点に注意してください。"
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
+msgid "The Rust Ecosystem"
 msgstr ""
 
 #: src/cargo/rust-ecosystem.md:3
@@ -1797,36 +1604,36 @@ msgstr "Rustエコシステムの主要ツールは以下の通りです："
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc`： Rustのコンパイラです。`.rs`ファイルをバイナリや他の中間形式に変換"
-"します。\n"
-"\n"
-"* `cargo`： Rustのビルドシステム兼パッケージマネージャです。<https://crates."
-"io>でホストされている依存関係をダウンロードし、プロジェクトビルド時に`rustc`"
-"に渡します。Cargo に組み込まれたテストランナを使って、ユニットテストを実行す"
-"ることもできます。\n"
-"\n"
-"* `rustup`： Rustのツールチェーンを管理するためのツールです。`rustc`や`cargo`"
-"のインストールやアップデートに使用されます。標準ライブラリのドキュメントをダ"
-"ウンロードする事も可能です。また、複数のRustのバージョンがインストールされて"
-"いる場合、`rustup`で切り替えが行えます。"
+"`rustc`： Rustのコンパイラです。`.rs`ファイルをバイナリや他の中間形式に変換し"
+"ます。"
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
+msgstr ""
+"`cargo`： Rustのビルドシステム兼パッケージマネージャです。<https://crates.io>"
+"でホストされている依存関係をダウンロードし、プロジェクトビルド時に`rustc`に渡"
+"します。Cargo に組み込まれたテストランナを使って、ユニットテストを実行するこ"
+"ともできます。"
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
+"`rustup`： Rustのツールチェーンを管理するためのツールです。`rustc`や`cargo`の"
+"インストールやアップデートに使用されます。標準ライブラリのドキュメントをダウ"
+"ンロードする事も可能です。また、複数のRustのバージョンがインストールされてい"
+"る場合、`rustup`で切り替えが行えます。"
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1841,84 +1648,124 @@ msgstr "要点："
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust言語とコンパイラは、6週間のリリースサイクルを採用しています。新しいリ"
-"リースは、古いリリースとの後方互換性を維持しながら、新機能を提供します。\n"
-"\n"
-"* リリースチャネルは3つあります：「stable」「beta」「nightly」。\n"
-"\n"
-"* 新機能は「nightly」でテストされ、「beta」が6週間毎に「stable」となりま"
-"す。\n"
-"\n"
-"* Rustには[editions]（エディション）があります：現在のエディションはRust2021"
-"です。以前はRust2015とRust2018でした。\n"
-"\n"
-"  * エディションでは、後方非互換な変更を加える事ができます。\n"
-"\n"
-"  * コードの破損を防ぐために、エディションはオプトイン方式です：`Cargo.toml`"
-"で、クレートに対して適用したいエディションを選択します。\n"
-"\n"
-"  * エコシステムの分断を避けるために、コンパイラは異なるエディションのコード"
-"を混在させる事ができます。\n"
-"\n"
-"  * コンパイラを直接使用する事は非常に稀であり、基本的には`cargo`を介しま"
-"す。\n"
-"\n"
-"  * `Cargo`は非常に包括的なツールであり、多くの機能を備えています：\n"
-"      * プロジェクト・パッケージの構造管理\n"
-"      * [workspaces]（ワークスペース）\n"
-"      * 開発用とランタイム用の依存関係管理・キャッシュ\n"
-"      * [build scripting]（ビルドスクリプト）\n"
-"      * [global installation]\n"
-"      * [cargo clippy]などのサブコマンドプラグインによる拡張\n"
-"  * 詳細は[official Cargo Book]を参照してください。"
+"Rust言語とコンパイラは、6週間のリリースサイクルを採用しています。新しいリリー"
+"スは、古いリリースとの後方互換性を維持しながら、新機能を提供します。"
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "リリースチャネルは3つあります：「stable」「beta」「nightly」。"
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr ""
+"新機能は「nightly」でテストされ、「beta」が6週間毎に「stable」となります。"
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"Rustには[editions](https://doc.rust-lang.org/edition-guide/)（エディション）"
+"があります：現在のエディションはRust2021です。以前はRust2015とRust2018でし"
+"た。"
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "エディションでは、後方非互換な変更を加える事ができます。"
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"コードの破損を防ぐために、エディションはオプトイン方式です：`Cargo.toml`で、"
+"クレートに対して適用したいエディションを選択します。"
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr ""
+"エコシステムの分断を避けるために、コンパイラは異なるエディションのコードを混"
+"在させる事ができます。"
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+"コンパイラを直接使用する事は非常に稀であり、基本的には`cargo`を介します。"
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr "`Cargo`は非常に包括的なツールであり、多くの機能を備えています："
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "プロジェクト・パッケージの構造管理"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr ""
+"[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)（ワー"
+"クスペース）"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr "開発用とランタイム用の依存関係管理・キャッシュ"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)（ビルドスクリプト）"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"[cargo clippy](https://github.com/rust-lang/rust-clippy)などのサブコマンドプ"
+"ラグインによる拡張"
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr ""
+"詳細は[official Cargo Book](https://doc.rust-lang.org/cargo/)を参照してくださ"
+"い。"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# 講座のサンプルコード"
+msgid "Code Samples in This Training"
+msgstr "講座のサンプルコード"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
 "本講座は、主にブラウザ内で実行可能な例を使います。こうする事で、セットアップ"
 "が容易になり、一貫した開発環境の提供が可能となります。"
@@ -1926,10 +1773,8 @@ msgstr ""
 #: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
 "ただし、できればCargoをインストールしてください： 練習問題で使えると便利で"
 "す。また最終日に依存関係を扱う課題を扱いますが、そこではCargoが必要になりま"
@@ -1949,56 +1794,56 @@ msgid ""
 msgstr ""
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
-msgstr ""
-"ボックス内にフォーカスがある状態で<kbd>Ctrl + Enter</kbd>を押すと、コードが実"
-"行されます。"
+msgid "You can use "
+msgstr "ボックス内にフォーカスがある状態で"
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr "を押すと、コードが実行されます。"
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
 "ほとんどのサンプルコードは上記のように編集可能ですが、一部だけ以下のような理"
 "由から編集不可となっています："
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* 講座のページ内に埋め込まれたプレイグラウンドでユニットテストは実行できませ"
+"講座のページ内に埋め込まれたプレイグラウンドでユニットテストは実行できませ"
 "ん。コードを実際のプレイグラウンドで開き、デモンストレーションを行う必要があ"
-"ります。\n"
-"\n"
-"* 講座のページ内に埋め込まれたプレイグラウンドでは、ページ移動すると状態が失"
-"われます！故に、受講生はローカル環境や実際のプレイグラウンドを使用して問題を"
-"解く必要があります。"
+"ります。"
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"講座のページ内に埋め込まれたプレイグラウンドでは、ページ移動すると状態が失わ"
+"れます！故に、受講生はローカル環境や実際のプレイグラウンドを使用して問題を解"
+"く必要があります。"
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# Cargoを使ってローカルで実行"
+msgid "Running Code Locally with Cargo"
+msgstr "Cargoを使ってローカルで実行"
 
 #: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
-"コードをローカルで試したい場合、[Rust Bookの手順][1]に従ってRustをインストー"
-"ルしてください。正常にインストールされたら、`rustc`と`cargo`が使えるようにな"
-"ります。最新のstableリリースのバージョンは以下の通りです："
+"コードをローカルで試したい場合、[Rust Bookの手順](https://doc.rust-lang.org/"
+"book/ch01-01-installation.html)に従ってRustをインストールしてください。正常に"
+"インストールされたら、`rustc`と`cargo`が使えるようになります。最新のstableリ"
+"リースのバージョンは以下の通りです："
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -2013,156 +1858,165 @@ msgstr ""
 #: src/cargo/running-locally.md:15
 #, fuzzy
 msgid ""
-"With this in place, follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this in place, follow these steps to build a Rust binary from one of "
+"the examples in this training:"
 msgstr ""
 "次に、本講座の例を参考にしながら、以下の手順に従ってRustのバイナリをビルドし"
 "てください："
 
 #: src/cargo/running-locally.md:18
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr "「Copy to clipboard」でコードをコピー。"
+
+#: src/cargo/running-locally.md:20
 msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in `target/"
-"debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr "`cargo new exercise`で`exercise/`ディレクトリを作成："
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
 msgstr ""
-"1. 「Copy to clipboard」でコードをコピー。\n"
-"\n"
-"2. `cargo new exercise`で`exercise/`ディレクトリを作成：\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. `exercise/`ディレクトリに移動し、`cargo run`でバイナリをビルドして実行：\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. `src/main.rs`のボイラープレートコードを、コピーしたコードで置き換えてくだ"
-"さい。例えば、前のページの例を使った場合、`src/main.rs`は以下のようになりま"
-"す。\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. `cargo run`で更新されたバイナリをビルドして実行：\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. `cargo check`でプロジェクトのエラーチェックを行い、`cargo build`でコンパイ"
-"ルだけ（実行はせず）を行います。通常のデバッグビルドでは、生成されたファイル"
-"は`target/debug/`に格納されます。最適化されたリリースビルドには`cargo build —"
-"release`を使い、ファイルは`target/release/`に格納されます。\n"
-"\n"
-"7. プロジェクトに依存関係を追加するには、`Cargo.toml`を編集します。その後、"
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr ""
+"`exercise/`ディレクトリに移動し、`cargo run`でバイナリをビルドして実行："
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+"`src/main.rs`のボイラープレートコードを、コピーしたコードで置き換えてくださ"
+"い。例えば、前のページの例を使った場合、`src/main.rs`は以下のようになります。"
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr "`cargo run`で更新されたバイナリをビルドして実行："
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+"`cargo check`でプロジェクトのエラーチェックを行い、`cargo build`でコンパイル"
+"だけ（実行はせず）を行います。通常のデバッグビルドでは、生成されたファイルは"
+"`target/debug/`に格納されます。最適化されたリリースビルドには`cargo build —"
+"release`を使い、ファイルは`target/release/`に格納されます。"
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
+msgstr ""
+"プロジェクトに依存関係を追加するには、`Cargo.toml`を編集します。その後、"
 "`cargo`コマンドを実行すると、自動的に不足している依存関係がダウンロードされて"
 "コンパイルされます。"
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
 "受講者にCargoのインストールとローカルエディタの使用を勧めてください。通常の開"
 "発環境を持つ事で、作業がスムーズになります。"
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# Day 1へようこそ"
+msgid "Welcome to Day 1"
+msgstr "Day 1へようこそ"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr ""
 "「Comprehensive Rust」の初日です。本日は多岐にわたる内容をカバーします："
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* Rustの基本的な構文： 変数、スカラー型と複合型、列挙型、構造体、参照、関数、"
-"メソッド。\n"
-"\n"
-"* メモリ管理： スタック vs ヒープ、手動でのメモリ管理、スコープに基づくメモリ"
-"管理、ガベージコレクション。\n"
-"\n"
-"* 所有権： ムーブセマンティクス、コピーとクローン、借用、ライフタイム。"
+"Rustの基本的な構文： 変数、スカラー型と複合型、列挙型、構造体、参照、関数、メ"
+"ソッド。"
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+"メモリ管理： スタック vs ヒープ、手動でのメモリ管理、スコープに基づくメモリ管"
+"理、ガベージコレクション。"
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr "所有権： ムーブセマンティクス、コピーとクローン、借用、ライフタイム。"
 
 #: src/welcome-day-1.md:16
 msgid "Please remind the students that:"
@@ -2171,42 +2025,53 @@ msgstr "受講生に伝えてください："
 #: src/welcome-day-1.md:18
 #, fuzzy
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i."
-"e.,\n"
-"    keep the discussions related to how Rust does things vs some other "
-"language. \n"
-"    It can be hard to find the right balance, but err on the side of "
-"allowing \n"
-"    discussions since they engage people much more than one-way "
-"communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
+msgstr "分からない事があれば、最後まで待たずに質問をしてください。"
+
+#: src/welcome-day-1.md:19
+#, fuzzy
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
 msgstr ""
-"* 分からない事があれば、最後まで待たずに質問をしてください。\n"
-"* 本講座はインタラクティブな形式で行うため、積極的にディスカッションをしてく"
-"ださい！\n"
-"  * 講師の方へ： ディスカッションはなるべく関連性を有する範囲に留めましょう。"
-"例えば、他言語との比較を行う場合には、あくまでもRustとどう違うのかまでを議論"
-"の範囲に設定してください。また、バランスの取り方が難しいかもしれませんが、一"
-"方的に話すよりもなるべくディスカッションを許容するように心がけてください。\n"
-"* 質問があった場合、おそらく将来的に話す内容に触れる事になります。\n"
-"  * これは全く問題ありません！復習は学びの重要な要素です。スライドはあくまで"
-"もサポートとして用意されているものであり、ご自身の判断でスキップも可能です。"
+"本講座はインタラクティブな形式で行うため、積極的にディスカッションをしてくだ"
+"さい！"
+
+#: src/welcome-day-1.md:20
+#, fuzzy
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
+msgstr ""
+"講師の方へ： ディスカッションはなるべく関連性を有する範囲に留めましょう。例え"
+"ば、他言語との比較を行う場合には、あくまでもRustとどう違うのかまでを議論の範"
+"囲に設定してください。また、バランスの取り方が難しいかもしれませんが、一方的"
+"に話すよりもなるべくディスカッションを許容するように心がけてください。"
+
+#: src/welcome-day-1.md:24
+#, fuzzy
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr "質問があった場合、おそらく将来的に話す内容に触れる事になります。"
+
+#: src/welcome-day-1.md:25
+#, fuzzy
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"これは全く問題ありません！復習は学びの重要な要素です。スライドはあくまでもサ"
+"ポートとして用意されているものであり、ご自身の判断でスキップも可能です。"
 
 #: src/welcome-day-1.md:29
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
 "本日の目的は、Rust特有の借用チェッカーについて話ができるように、Rustについて"
 "最低限の情報提供を行う事です。Rustがメモリをどのように扱うかは重要な機能であ"
@@ -2214,91 +2079,110 @@ msgstr ""
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
 "この時点でスケジュール確認を行なってください。以下のように1日を２パートに分け"
 "て実施する事を推奨しています："
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* AM： 9:00 ~ 12:00\n"
-"* PM： 13:00 ~ 16:00"
+msgid "Morning: 9:00 to 12:00,"
+msgstr "AM： 9:00 ~ 12:00"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "PM： 13:00 ~ 16:00"
 
 #: src/welcome-day-1.md:39
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
+"breaks, we recommend a break every hour!"
 msgstr ""
 "必要に応じて調整してください。また、1時間ごとに休憩を取る事をおすすめします！"
 
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# Rustとは？"
-
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
-msgstr "Rustは[2015年に1.0版がリリース][1]された新しいプログラミング言語です："
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
+msgstr ""
+"Rustは[2015年に1.0版がリリース](https://blog.rust-lang.org/2015/05/15/"
+"Rust-1.0.html)された新しいプログラミング言語です："
 
 #: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "RustはC++と同様に、静的にコンパイルされる言語です"
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc`はバックエンドにLLVMを使用しています。"
+
+#: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"* RustはC++と同様に、静的にコンパイルされる言語です\n"
-"  * `rustc`はバックエンドにLLVMを使用しています。\n"
-"* Rustは多くの[プラットフォームとアーキテクチャ](https://doc.rust-lang.org/"
-"nightly/rustc/platform-support.html)をサポートしています：\n"
-"  * x86, ARM, WebAssembly, …\n"
-"  * Linux, Mac, Windows, …\n"
-"* Rustは様々なデバイスで使用されています：\n"
-"  * ファームウェアやブートローダ\n"
-"  * スマートディスプレイ\n"
-"  * 携帯電話\n"
-"  * デスクトップ\n"
-"  * サーバ"
+"Rustは多くの[プラットフォームとアーキテクチャ](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html)をサポートしています："
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, …"
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, …"
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rustは様々なデバイスで使用されています："
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "ファームウェアやブートローダ"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "スマートディスプレイ"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "携帯電話"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "デスクトップ"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "サーバ"
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "RustとC++が似ているところ:"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* 高い柔軟性\n"
-"* 高度な制御性\n"
-"* 携帯電話のようなデバイスにまでスケールダウンが可能\n"
-"* ランタイムやガベージコレクションがない\n"
-"* パフォーマンスを犠牲にせず、信頼性と安全性に焦点を当てている"
+msgid "High flexibility."
+msgstr "高い柔軟性"
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr ""
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "高度な制御性"
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr "携帯電話のようなデバイスにまでスケールダウンが可能"
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "ランタイムやガベージコレクションがない"
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr "パフォーマンスを犠牲にせず、信頼性と安全性に焦点を当てている"
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
 "さっそく一番シンプルなプログラムである定番のHello Worldからみてみましょう："
@@ -2317,25 +2201,30 @@ msgid "What you see:"
 msgstr "プログラムの中身："
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "関数は`fn`で導入されます。"
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "CやC++と同様に、ブロックは波括弧で囲みます。"
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "`main`関数はプログラムのエントリーポイントになります。"
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr "Rustには衛生的なマクロがあり、`println!`はその一例です。"
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
-"* 関数は`fn`で導入されます。\n"
-"* CやC++と同様に、ブロックは波括弧で囲みます。\n"
-"* `main`関数はプログラムのエントリーポイントになります。\n"
-"* Rustには衛生的なマクロがあり、`println!`はその一例です。\n"
-"* Rustの文字列はUTF-8でエンコードされ、どんなUnicode文字でも含む事ができま"
-"す。"
+"Rustの文字列はUTF-8でエンコードされ、どんなUnicode文字でも含む事ができます。"
 
 #: src/hello-world.md:22
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 "このスライドの目的は、Rustのコードに慣れてもらう事です。この4日間で大量のRust"
@@ -2344,39 +2233,39 @@ msgstr ""
 #: src/hello-world.md:27
 #, fuzzy
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude."
-"md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/"
-"hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rustは、C/C++/Java系統の言語によく似ています。Rustは、命令型（関数型ではな"
-"く）であり、必須でない限り機能の再発明はしません。\n"
-"\n"
-"* RustはUnicodeなどにも完全に対応している現代的な言語です。\n"
-"\n"
-"* Rustで可変長引数を用いたい場合は、マクロを使用します(関数[オーバーロード]"
-"(basic-syntax/functions-interlude.md)はありません)。\n"
-"\n"
-"* マクロが「衛生的 (hygienic)」であるとは、そのマクロが呼び出されるスコープに"
-"ある識別子と、そのマクロ内部の識別子が衝突しないことが保証されていることを言"
-"います。Rustのマクロは、実際には[部分的にしか衛生的](https://veykril.github."
-"io/tlborm/decl-macros/minutiae/hygiene.html)ではありません。"
+"Rustは、C/C++/Java系統の言語によく似ています。Rustは、命令型（関数型ではな"
+"く）であり、必須でない限り機能の再発明はしません。"
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
+#: src/hello-world.md:31
+#, fuzzy
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "RustはUnicodeなどにも完全に対応している現代的な言語です。"
+
+#: src/hello-world.md:33
+#, fuzzy
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
 msgstr ""
+"Rustで可変長引数を用いたい場合は、マクロを使用します(関数[オーバーロード]"
+"(basic-syntax/functions-interlude.md)はありません)。"
+
+#: src/hello-world.md:36
+#, fuzzy
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
+msgstr ""
+"マクロが「衛生的 (hygienic)」であるとは、そのマクロが呼び出されるスコープにあ"
+"る識別子と、そのマクロ内部の識別子が衝突しないことが保証されていることを言い"
+"ます。Rustのマクロは、実際には[部分的にしか衛生的](https://veykril.github.io/"
+"tlborm/decl-macros/minutiae/hygiene.html)ではありません。"
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2419,10 +2308,8 @@ msgstr ""
 #: src/hello-world/small-example.md:23
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
 "この例はCollatz予想を実装したものです： このループは必ず終了すると言われてい"
 "ますが、まだ証明はされていません。コードを編集して、異なる入力値で試してみて"
@@ -2430,129 +2317,132 @@ msgstr ""
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::"
-"fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library."
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* すべての変数が静的型付けされている事を説明してください。`i32`を削除して型推"
-"論を試してください。代わりに`i8`を使用して、実行時に整数オーバーフローを引き"
-"起こしてみてください。\n"
-"\n"
-"* `let mut x`を`let x`に変更し、コンパイルエラーについて説明してください。\n"
-"\n"
-"* `print!`の引数がフォーマット文字列と一致しない場合、コンパイルエラーが発生"
-"する事を実演してください。\n"
-"\n"
-"* 単一の変数よりも複雑な式を表示したい場合は、`{}`をプレースホルダとして使用"
-"する必要がある事を実演してください。\n"
-"\n"
-"* 受講生に標準ライブラリを紹介し、`std::fmt`の検索方法を説明してください。"
+"すべての変数が静的型付けされている事を説明してください。`i32`を削除して型推論"
+"を試してください。代わりに`i8`を使用して、実行時に整数オーバーフローを引き起"
+"こしてみてください。"
+
+#: src/hello-world/small-example.md:32
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr ""
+"`let mut x`を`let x`に変更し、コンパイルエラーについて説明してください。"
+
+#: src/hello-world/small-example.md:34
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+"`print!`の引数がフォーマット文字列と一致しない場合、コンパイルエラーが発生す"
+"る事を実演してください。"
+
+#: src/hello-world/small-example.md:37
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+"単一の変数よりも複雑な式を表示したい場合は、`{}`をプレースホルダとして使用す"
+"る必要がある事を実演してください。"
+
+#: src/hello-world/small-example.md:40
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"受講生に標準ライブラリを紹介し、`std::fmt`の検索方法を説明してください。"
 "`std::fmt`には、フォーマット機能のルールや構文が説明されています。受講者が標"
 "準ライブラリの検索に慣れておく事は重要です。"
-
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr ""
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Rustのユニークなセールスポイントをいくつか紹介します："
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* コンパイル時のメモリ安全性。\n"
-"* 未定義の実行時動作がない。\n"
-"* 現代的な言語機能。"
+msgid "Compile time memory safety."
+msgstr "コンパイル時のメモリ安全性。"
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "未定義の実行時動作がない。"
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "現代的な言語機能。"
 
 #: src/why-rust.md:11
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
 "受講者にどの言語の経験があるかを尋ねてください。回答に応じて、Rustのさまざま"
 "な特徴を強調することができます："
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* CまたはC++の経験がある場合： Rustは借用チェッカーを介して実行時エラーの一部"
-"を排除してくれます。それに加え、CやC++と同等のパフォーマンスを得ることがで"
-"き、メモリ安全性の問題はありません。さらに、パターンマッチングや組み込みの依"
-"存関係管理などの構造要素を含む現代的な言語です。\n"
-"\n"
-"* Java、Go、Python、JavaScriptなどの経験がある場合： これらの言語と同様のメモ"
-"リ安全性と、高水準言語に近い感覚を得ることができます。また、CやC++のように高"
-"速かつ予測可能なパフォーマンス（ガベージコレクタがない）を得ることができ、"
-"（必要なら）低水準なハードウェアへのアクセスも可能です"
+"CまたはC++の経験がある場合： Rustは借用チェッカーを介して実行時エラーの一部を"
+"排除してくれます。それに加え、CやC++と同等のパフォーマンスを得ることができ、"
+"メモリ安全性の問題はありません。さらに、パターンマッチングや組み込みの依存関"
+"係管理などの構造要素を含む現代的な言語です。"
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# コンパイル時の保証"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"Java、Go、Python、JavaScriptなどの経験がある場合： これらの言語と同様のメモリ"
+"安全性と、高水準言語に近い感覚を得ることができます。また、CやC++のように高速"
+"かつ予測可能なパフォーマンス（ガベージコレクタがない）を得ることができ、（必"
+"要なら）低水準なハードウェアへのアクセスも可能です"
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "コンパイル時の静的メモリの管理："
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* 未初期化の変数がない。\n"
-"* メモリリークの心配が（ほとんど）ない (ノートを参照)。\n"
-"* 二重解放が起きない。\n"
-"* 解放済みメモリ使用（use-after-free）がない。\n"
-"* `NULL`（ヌル）ポインタがない。\n"
-"* ミューテックス（mutex）のロックの解除忘れがない。\n"
-"* スレッド間でデータ競合しない。\n"
-"* イテレータが無効化されない。"
+msgid "No uninitialized variables."
+msgstr "未初期化の変数がない。"
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "メモリリークの心配が（ほとんど）ない (ノートを参照)。"
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "二重解放が起きない。"
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "解放済みメモリ使用（use-after-free）がない。"
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "`NULL`（ヌル）ポインタがない。"
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "ミューテックス（mutex）のロックの解除忘れがない。"
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "スレッド間でデータ競合しない。"
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "イテレータが無効化されない。"
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr ""
 "SafeなRustの範囲内でメモリリークを引き起こすことは可能です。例として以下のよ"
 "うな手段があります："
@@ -2560,236 +2450,330 @@ msgstr ""
 #: src/why-rust/compile-time.md:19
 #, fuzzy
 msgid ""
-"* You can use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* [`Box::leak`]を使ってポインタをリークさせることができます。この関数は実行時"
-"に初期化され、実行時にサイズが決まるstatic変数の取得などに使われます。\n"
-"* [`std::mem::forget`]を使って、コンパイラに値を忘れさせることができます (つ"
-"まり、デストラクタが実行されない)。\n"
-"* `Rc`や`Arc`を使って[循環参照（reference cycle）]を誤って作成することがあり"
-"ます。\n"
-"* コレクションを無限に拡張し続けることをメモリリークと見なす場合があり、Rust"
-"にはこれを防ぐ機能はありません。"
+"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
+"leak)を使ってポインタをリークさせることができます。この関数は実行時に初期化さ"
+"れ、実行時にサイズが決まるstatic変数の取得などに使われます。"
+
+#: src/why-rust/compile-time.md:21
+#, fuzzy
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"[`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html)を使っ"
+"て、コンパイラに値を忘れさせることができます (つまり、デストラクタが実行され"
+"ない)。"
+
+#: src/why-rust/compile-time.md:23
+#, fuzzy
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"`Rc`や`Arc`を使って\\[循環参照（reference cycle）\\]を誤って作成することがあ"
+"ります。"
+
+#: src/why-rust/compile-time.md:25
+#, fuzzy
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"コレクションを無限に拡張し続けることをメモリリークと見なす場合があり、Rustに"
+"はこれを防ぐ機能はありません。"
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"本講座での「メモリリークが起きない」は「*意図しない*メモリリークはほとんど起"
+"本講座での「メモリリークが起きない」は「_意図しない_メモリリークはほとんど起"
 "きない」と解釈すべきです。"
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# 実行時の保証"
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "実行時に未定義の動作はありません："
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
-msgstr ""
-"* 配列へのアクセスには境界チェックが行われる。\n"
-"* 整数オーバーフローの挙動が定義されている。"
+msgid "Array access is bounds checked."
+msgstr "配列へのアクセスには境界チェックが行われる。"
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
+msgstr "整数オーバーフローの挙動が定義されている。"
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* 整数オーバーフローは、コンパイル時のフラグで定義されます。選択肢として、パ"
+"整数オーバーフローは、コンパイル時のフラグで定義されます。選択肢として、パ"
 "ニック（プログラムの制御されたクラッシュ）またはラップアラウンドのセマンティ"
 "クスがあります。デフォルトとして、デバッグモード（`cargo build`）ではパニック"
 "が発生し、リリースモード（`cargo build —release`）ではラップアラウンドが行わ"
-"れます。\n"
-"\n"
-"* 境界チェックは、コンパイル時のフラグで無効にすることはできません。また、"
+"れます。"
+
+#: src/why-rust/runtime.md:17
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"境界チェックは、コンパイル時のフラグで無効にすることはできません。また、"
 "`unsafe`のキーワードを使って直接無効にすることもできません。しかし、`unsafe`"
 "を使って境界チェックを行わない`slice::get_unchecked`のような関数を呼び出すこ"
 "とができます。"
-
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# 現代的な機能"
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
 msgstr "Rustは過去40年間の経験を基に構築されています。"
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## 言語の特徴"
+msgid "Language Features"
+msgstr "言語の特徴"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* 列挙型とパターンマッチング\n"
-"* ジェネリクス\n"
-"* オーバーヘッドのないFFI\n"
-"* ゼロコスト抽象化"
+msgid "Enums and pattern matching."
+msgstr "列挙型とパターンマッチング"
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "ジェネリクス"
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "オーバーヘッドのないFFI"
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "ゼロコスト抽象化"
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
+msgid "Tooling"
 msgstr ""
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* 優秀なコンパイルエラー。\n"
-"* 組み込みの依存関係マネージャ。\n"
-"* 組み込みのテストサポート。\n"
-"* Language Server Protocol（LSP）のサポート。"
+msgid "Great compiler errors."
+msgstr "優秀なコンパイルエラー。"
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "組み込みの依存関係マネージャ。"
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "組み込みのテストサポート。"
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "Language Server Protocol（LSP）のサポート。"
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* C++と同様に、ゼロコスト抽象化とは、より高水準なプログラミング構造の利用にメ"
-"モリやCPUのコストを支払う必要がないことを意味します。例えば、`for`を使った"
-"ループの場合、`iter().fold()`構文を使った場合とおおよそ同じ低水準の処理になり"
-"ます。\n"
-"\n"
-"* Rustの列挙型は「代数的データ型」であり、「直和型」と呼ばれます。`Option<T>`"
-"や`Result<T, E>`のような要素を表現することができます。\n"
-"\n"
-"* エラーをちゃんと確認するよう注意してください。多くの開発者は、長いコンパイ"
-"ラ出力を無視することに慣れてしまっています。Rustのコンパイラは他のコンパイラ"
-"よりもわかりやすく実用的なフィードバックを提供してくれます。そして多くの場"
-"合、コードにそのままコピペできるようなフィードバックが提供されます。\n"
-"\n"
-"* Rustの標準ライブラリは、Java、Python、Goなどのそれと比べると小規模です。"
-"Rustには標準的かつ必須と思われるいくつかの機能が含まれていません：\n"
-"\n"
-"  * 乱数生成器。[rand]を確認してください。\n"
-"  * SSLやTLSのサポート。[rusttls]を確認してください。\n"
-"  * JSONのサポート。[serde_json]を確認してください。 \n"
-"\n"
-"  この理由は、標準ライブラリの機能は消えることがなく、非常に安定したものでな"
-"ければならないからです。上記の例については、Rustコミュニティが未だに最適な解"
-"決策を探し続けています。そもそも、これらに対する「最適解」は一つであるとは限"
-"らないのです。\n"
-"\n"
-"  Rustには、Cargoという外部クレートのダウンロードからコンパイルまでを簡単に"
-"行ってくれるパッケージマネージャが組み込まれています。これにより、標準ライブ"
-"ラリを小規模に保つことができています。\n"
-"\n"
-"  良い外部クレートを見つけるのは難しいときがあります。<https://lib.rs/>のよう"
-"なサイトを使うことで、クレートの評価基準を参考にしながら比較を行うことができ"
-"ます。\n"
-"  \n"
-"* [rust-analyzer]は、主要IDEやテキストエディタで使用できる、サポートが充実し"
-"ているLSPの実装です。"
+"C++と同様に、ゼロコスト抽象化とは、より高水準なプログラミング構造の利用にメモ"
+"リやCPUのコストを支払う必要がないことを意味します。例えば、`for`を使ったルー"
+"プの場合、`iter().fold()`構文を使った場合とおおよそ同じ低水準の処理になりま"
+"す。"
 
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
 msgstr ""
+"Rustの列挙型は「代数的データ型」であり、「直和型」と呼ばれます。`Option<T>`や"
+"`Result<T, E>`のような要素を表現することができます。"
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"エラーをちゃんと確認するよう注意してください。多くの開発者は、長いコンパイラ"
+"出力を無視することに慣れてしまっています。Rustのコンパイラは他のコンパイラよ"
+"りもわかりやすく実用的なフィードバックを提供してくれます。そして多くの場合、"
+"コードにそのままコピペできるようなフィードバックが提供されます。"
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+"Rustの標準ライブラリは、Java、Python、Goなどのそれと比べると小規模です。Rust"
+"には標準的かつ必須と思われるいくつかの機能が含まれていません："
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr "乱数生成器。[rand](https://docs.rs/rand/)を確認してください。"
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr ""
+"SSLやTLSのサポート。[rusttls](https://docs.rs/rustls/)を確認してください。"
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+"JSONのサポート。[serde_json](https://docs.rs/serde_json/)を確認してくださ"
+"い。 "
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+"この理由は、標準ライブラリの機能は消えることがなく、非常に安定したものでなけ"
+"ればならないからです。上記の例については、Rustコミュニティが未だに最適な解決"
+"策を探し続けています。そもそも、これらに対する「最適解」は一つであるとは限ら"
+"ないのです。"
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+"Rustには、Cargoという外部クレートのダウンロードからコンパイルまでを簡単に行っ"
+"てくれるパッケージマネージャが組み込まれています。これにより、標準ライブラリ"
+"を小規模に保つことができています。"
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+"良い外部クレートを見つけるのは難しいときがあります。<https://lib.rs/>のような"
+"サイトを使うことで、クレートの評価基準を参考にしながら比較を行うことができま"
+"す。"
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/)は、主要IDEやテキストエディ"
+"タで使用できる、サポートが充実しているLSPの実装です。"
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr ""
 
 #: src/basic-syntax.md:5
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/"
-"* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
+msgid "Blocks and scopes are delimited by curly braces."
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
+#: src/basic-syntax.md:6
+msgid ""
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
 
-#: src/basic-syntax/scalar-types.md:3
-msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | `"
-"\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr ""
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Types"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Booleans"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`bool`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`true`, `false`"
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:12
@@ -2797,11 +2781,19 @@ msgid "The types have widths as follows:"
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:14
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:15
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:16
+msgid "`char` is 32 bit wide,"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:17
+msgid "`bool` is 8 bit wide."
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:21
@@ -2810,42 +2802,57 @@ msgstr ""
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: `r"
-"\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr ""
-
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:27
 msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:8
@@ -2884,24 +2891,28 @@ msgstr ""
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
-"compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:47
@@ -2909,27 +2920,31 @@ msgid "Tuples:"
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:49
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
+msgid "Like arrays, tuples have a fixed length."
 msgstr ""
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
+#: src/basic-syntax/compound-types.md:51
+msgid "Tuples group together values of different types into a compound type."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
 msgstr ""
 
 #: src/basic-syntax/references.md:3
@@ -2954,26 +2969,28 @@ msgstr ""
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
+msgstr ""
+
+#: src/basic-syntax/references.md:17
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
 msgstr ""
 
 #: src/basic-syntax/references.md:25
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
-msgstr ""
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:3
@@ -2995,15 +3012,17 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
+msgid "A reference is said to \"borrow\" the value it refers to."
 msgstr ""
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
 msgstr ""
 
 #: src/basic-syntax/slices.md:3
@@ -3024,42 +3043,60 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
+msgid "Slices borrow data from the sliced type."
+msgstr ""
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
 msgstr ""
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
+msgstr ""
+
+#: src/basic-syntax/slices.md:22
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use "
-"`&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"identical."
+msgstr ""
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+
+#: src/basic-syntax/slices.md:26
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+
+#: src/basic-syntax/slices.md:28
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"computation on slices of different sizes."
+msgstr ""
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
+msgid "`String` vs `str`"
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:3
@@ -3089,44 +3126,51 @@ msgid "Rust terminology:"
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
+msgid "`&str` an immutable reference to a string slice."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::"
-"string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
 msgstr ""
 
 #: src/basic-syntax/functions.md:3
@@ -3168,20 +3212,32 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
-"`=n`, which causes it to include the upper bound."
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:1
-msgid "# Rustdoc"
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"`=n`, which causes it to include the upper bound."
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:3
@@ -3208,36 +3264,34 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
 msgstr ""
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
-"method is\n"
-"an instance of the type it is associated with:"
+"method is an instance of the type it is associated with:"
 msgstr ""
 
 #: src/basic-syntax/methods.md:6
@@ -3269,26 +3323,31 @@ msgstr ""
 
 #: src/basic-syntax/methods.md:30
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
 
 #: src/basic-syntax/methods.md:34
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
+msgstr ""
+
+#: src/basic-syntax/methods.md:36
 msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
+msgid "Function Overloading"
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:3
@@ -3296,13 +3355,27 @@ msgid "Overloading is not supported:"
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
+msgid "Each function has a single implementation:"
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr ""
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:12
@@ -3325,14 +3398,13 @@ msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
+msgid "Day 1: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-1/morning.md:3
@@ -3340,10 +3412,11 @@ msgid "In these exercises, we will explore two parts of Rust:"
 msgstr ""
 
 #: src/exercises/day-1/morning.md:5
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
+msgid "Implicit conversions between types."
+msgstr ""
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
 msgstr ""
 
 #: src/exercises/day-1/morning.md:11
@@ -3352,18 +3425,18 @@ msgstr ""
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
+msgstr ""
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
 msgstr ""
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
 
@@ -3374,18 +3447,14 @@ msgstr ""
 #: src/exercises/concurrency/morning.md:12
 #: src/exercises/concurrency/afternoon.md:13
 msgid ""
-"After looking at the exercises, you can look at the [solutions] provided."
-msgstr ""
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:6
@@ -3406,48 +3475,50 @@ msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:33
+msgid "Execute the above program and look at the compiler error."
+msgstr ""
+
+#: src/exercises/day-1/implicit-conversions.md:35
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr ""
+
+#: src/exercises/day-1/implicit-conversions.md:37
 msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:3
@@ -3479,7 +3550,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr ""
 
@@ -3506,8 +3577,7 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
 
@@ -3526,7 +3596,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
 
@@ -3562,38 +3632,32 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
+msgid "Bonus Question"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
-msgstr ""
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
 msgstr ""
 
 #: src/basic-syntax/variables.md:3
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
+"by default:"
 msgstr ""
 
 #: src/basic-syntax/variables.md:6
@@ -3610,14 +3674,14 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
-"function like syntax of `println!(\"x: {}\", x)`"
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
 msgstr ""
 
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
+"function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:3
@@ -3655,10 +3719,10 @@ msgstr ""
 #: src/basic-syntax/type-inference.md:28
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:32
@@ -3691,7 +3755,7 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
+msgid "Static and Constant Variables"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:3
@@ -3699,7 +3763,7 @@ msgid "Global state is managed with static and constant variables."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
+msgid "`const`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:7
@@ -3729,11 +3793,13 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According to the [Rust RFC Book][1] these are inlined upon use."
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
+msgid "`static`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:31
@@ -3753,10 +3819,10 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:41
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:44
@@ -3766,23 +3832,25 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:48
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
+#: src/basic-syntax/static-and-const.md:49
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
+"the same scope:"
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:6
@@ -3807,13 +3875,24 @@ msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
@@ -3830,18 +3909,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr ""
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr ""
 
 #: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr ""
+
+#: src/memory-management.md:6
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
 
@@ -3851,8 +3929,8 @@ msgstr ""
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
 
 #: src/memory-management.md:13
@@ -3864,31 +3942,48 @@ msgid "First, let's refresh how memory management works."
 msgstr ""
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
+msgid "The Stack vs The Heap"
 msgstr ""
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
+msgid "Stack: Continuous area of memory for local variables."
 msgstr ""
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
 msgstr ""
 
 #: src/memory-management/stack.md:3
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 
@@ -3920,37 +4015,42 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/memory-management/manual.md:3
@@ -3964,7 +4064,7 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
+msgid "C Example"
 msgstr ""
 
 #: src/memory-management/manual.md:9
@@ -3987,12 +4087,7 @@ msgstr ""
 #: src/memory-management/manual.md:21
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
-msgstr ""
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
 
 #: src/memory-management/scope-based.md:3
@@ -4002,21 +4097,19 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:5
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
 
 #: src/memory-management/scope-based.md:9
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr ""
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
+msgid "C++ Example"
 msgstr ""
 
 #: src/memory-management/scope-based.md:14
@@ -4030,10 +4123,16 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:20
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
+msgstr ""
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr ""
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
 msgstr ""
 
 #: src/memory-management/scope-based.md:25
@@ -4050,25 +4149,27 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
+msgid "Automatic Memory Management"
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:3
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
+"memory management:"
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr ""
+
+#: src/memory-management/garbage-collection.md:7
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
+msgid "Java Example"
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:11
@@ -4085,7 +4186,7 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
+msgid "Memory Management in Rust"
 msgstr ""
 
 #: src/memory-management/rust.md:3
@@ -4093,13 +4194,23 @@ msgid "Memory management in Rust is a mix:"
 msgstr ""
 
 #: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr ""
+
+#: src/memory-management/rust.md:6
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+
+#: src/memory-management/rust.md:7
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+
+#: src/memory-management/rust.md:8
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
 
@@ -4109,17 +4220,19 @@ msgstr ""
 
 #: src/memory-management/rust.md:14
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
 
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
+#: src/memory-management/rust.md:16
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
 msgstr ""
 
 #: src/memory-management/comparison.md:3
@@ -4127,55 +4240,96 @@ msgid "Here is a rough comparison of the memory management techniques."
 msgstr ""
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
+msgid "Pros of Different Memory Management Techniques"
 msgstr ""
 
-#: src/memory-management/comparison.md:7
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
+msgid "Manual like C:"
+msgstr ""
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+msgid "No runtime overhead."
+msgstr ""
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+msgid "Automatic like Java:"
+msgstr ""
+
+#: src/memory-management/comparison.md:10
+msgid "Fully automatic."
+msgstr ""
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+msgid "Safe and correct."
+msgstr ""
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+msgid "Scope-based like C++:"
+msgstr ""
+
+#: src/memory-management/comparison.md:13
+msgid "Partially automatic."
+msgstr ""
+
+#: src/memory-management/comparison.md:15
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr ""
+
+#: src/memory-management/comparison.md:16
+msgid "Enforced by compiler."
 msgstr ""
 
 #: src/memory-management/comparison.md:20
-msgid "## Cons of Different Memory Management Techniques"
+msgid "Cons of Different Memory Management Techniques"
 msgstr ""
 
-#: src/memory-management/comparison.md:22
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
+#: src/memory-management/comparison.md:23
+msgid "Use-after-free."
 msgstr ""
 
-#: src/ownership.md:1
-msgid "# Ownership"
+#: src/memory-management/comparison.md:24
+msgid "Double-frees."
+msgstr ""
+
+#: src/memory-management/comparison.md:25
+msgid "Memory leaks."
+msgstr ""
+
+#: src/memory-management/comparison.md:27
+msgid "Garbage collection pauses."
+msgstr ""
+
+#: src/memory-management/comparison.md:28
+msgid "Destructor delays."
+msgstr ""
+
+#: src/memory-management/comparison.md:30
+msgid "Complex, opt-in by programmer."
+msgstr ""
+
+#: src/memory-management/comparison.md:31
+msgid "Potential for use-after-free."
+msgstr ""
+
+#: src/memory-management/comparison.md:32
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr ""
+
+#: src/memory-management/comparison.md:33
+msgid "Some upfront complexity."
+msgstr ""
+
+#: src/memory-management/comparison.md:34
+msgid "Can reject valid programs."
 msgstr ""
 
 #: src/ownership.md:3
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
+"to use a variable outside its scope:"
 msgstr ""
 
 #: src/ownership.md:6
@@ -4195,13 +4349,15 @@ msgstr ""
 
 #: src/ownership.md:18
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr ""
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
+#: src/ownership.md:19
+msgid "A destructor can run here to free up resources."
+msgstr ""
+
+#: src/ownership.md:20
+msgid "We say that the variable _owns_ the value."
 msgstr ""
 
 #: src/ownership/move-semantics.md:3
@@ -4221,24 +4377,33 @@ msgid ""
 msgstr ""
 
 #: src/ownership/move-semantics.md:14
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr ""
+
+#: src/ownership/move-semantics.md:15
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr ""
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr ""
+
+#: src/ownership/move-semantics.md:17
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr ""
+
+#: src/ownership/move-semantics.md:18
+msgid "There is always _exactly_ one variable binding which owns a value."
 msgstr ""
 
 #: src/ownership/move-semantics.md:22
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
 
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
+#: src/ownership/move-semantics.md:24
+msgid "In Rust, clones are explicit (by using `clone`)."
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:3
@@ -4252,9 +4417,11 @@ msgid ""
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:10
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr ""
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:13
@@ -4307,10 +4474,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr ""
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr ""
@@ -4325,9 +4488,11 @@ msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
 msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:13
@@ -4379,13 +4544,9 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:1
-msgid "# Moves in Function Calls"
-msgstr ""
-
 #: src/ownership/moves-function-calls.md:3
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 
@@ -4406,21 +4567,32 @@ msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
 
-#: src/ownership/copy-clone.md:1
-msgid "# Copying and Cloning"
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
 msgstr ""
 
 #: src/ownership/copy-clone.md:3
@@ -4464,9 +4636,11 @@ msgid ""
 msgstr ""
 
 #: src/ownership/copy-clone.md:30
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr ""
+
+#: src/ownership/copy-clone.md:31
+msgid "We can also use `p1.clone()` to explicitly copy the data."
 msgstr ""
 
 #: src/ownership/copy-clone.md:35
@@ -4475,13 +4649,23 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:37
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C+"
-"+).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
+msgstr ""
+
+#: src/ownership/copy-clone.md:38
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+
+#: src/ownership/copy-clone.md:40
+msgid "Copying does not work on types that implement the `Drop` trait."
 msgstr ""
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
@@ -4490,28 +4674,30 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:44
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
+msgstr ""
+
+#: src/ownership/copy-clone.md:45
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+
+#: src/ownership/copy-clone.md:46
+msgid "Show that it works if you clone `p1` instead."
 msgstr ""
 
 #: src/ownership/copy-clone.md:48
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated."
-msgstr ""
-
-#: src/ownership/borrowing.md:1
-msgid "# Borrowing"
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 
 #: src/ownership/borrowing.md:3
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
 
@@ -4535,9 +4721,11 @@ msgid ""
 msgstr ""
 
 #: src/ownership/borrowing.md:22
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr ""
+
+#: src/ownership/borrowing.md:23
+msgid "The caller retains ownership of the inputs."
 msgstr ""
 
 #: src/ownership/borrowing.md:27
@@ -4546,39 +4734,45 @@ msgstr ""
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can "
+"Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while they stay the same when changing to the "
-"\"RELEASE\" setting:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification "
-"because constructors can have side effects. In Rust, this is not an issue at "
-"all. If RVO did not happen, Rust will always performs a simple and efficient "
-"`memcpy` copy."
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/ownership/shared-unique-borrows.md:1
-msgid "# Shared and Unique Borrows"
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr ""
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always performs a simple and efficient "
+"`memcpy` copy."
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:3
@@ -4586,9 +4780,11 @@ msgid "Rust puts constraints on the ways you can borrow values:"
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:5
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr ""
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:8
@@ -4611,17 +4807,21 @@ msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:25
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
-"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
-"checker called \"non-lexical lifetimes\"."
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
 msgstr ""
 
-#: src/ownership/lifetimes.md:1
-msgid "# Lifetimes"
+#: src/ownership/shared-unique-borrows.md:26
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+
+#: src/ownership/shared-unique-borrows.md:27
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
 msgstr ""
 
 #: src/ownership/lifetimes.md:3
@@ -4629,25 +4829,36 @@ msgid "A borrowed value has a _lifetime_:"
 msgstr ""
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully "
-"specified,\n"
-"  but Rust allows these to be elidied in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
 msgstr ""
 
-#: src/ownership/lifetimes-function-calls.md:1
-msgid "# Lifetimes in Function Calls"
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr ""
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+
+#: src/ownership/lifetimes.md:13
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows these to be elidied in most cases with [a few simple rules]"
+"(https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:3
@@ -4676,54 +4887,77 @@ msgid ""
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:21
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:25
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+"The _at least_ part is important when parameters are in different scopes."
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:1
-msgid "# Lifetimes in Data Structures"
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:50
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
@@ -4755,23 +4989,38 @@ msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data "
+"In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This "
+"`Highlight` that uses that data."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
 "can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one "
-"lifetime annotation. This can be necessary if there is a need to describe "
-"lifetime relationships between the references themselves, in addition to the "
-"lifetime of the struct itself. Those are very advanced use cases."
+"somewhat harder to use."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:1
-msgid "# Day 1: Afternoon Exercises"
+msgid "Day 1: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:3
@@ -4779,21 +5028,17 @@ msgid "We will look at two things:"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:5
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
+msgid "A small book library,"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:1
-msgid "# Designing a Library"
+#: src/exercises/day-1/afternoon.md:7
+msgid "Iterators and ownership (hard)."
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:3
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:6
@@ -4813,8 +5058,8 @@ msgstr ""
 
 #: src/exercises/day-1/book-library.md:18
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:21
@@ -4863,8 +5108,8 @@ msgid ""
 "    //}\n"
 "\n"
 "    //fn print_books(self) {\n"
-"    //    todo!(\"Iterate over `self.books` and each book's title and year"
-"\")\n"
+"    //    todo!(\"Iterate over `self.books` and each book's title and "
+"year\")\n"
 "    //}\n"
 "\n"
 "    //fn oldest_book(self) -> Option<&Book> {\n"
@@ -4905,27 +5150,21 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-msgid "# Iterators and Ownership"
-msgstr ""
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
-msgid "## `Iterator`"
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
+msgid "`Iterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
@@ -4981,12 +5220,12 @@ msgid "Why is this type used?"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
-msgid "## `IntoIterator`"
+msgid "`IntoIterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
@@ -5005,19 +5244,21 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:62
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 
@@ -5029,8 +5270,8 @@ msgstr ""
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar"
-"\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "    let mut iter = v.into_iter();\n"
 "\n"
 "    let v0: Option<..> = iter.next();\n"
@@ -5040,23 +5281,22 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
-msgid "## `for` Loops"
+msgid "`for` Loops"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar"
-"\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "\n"
 "    for word in &v {\n"
 "        println!(\"word: {word}\");\n"
@@ -5075,19 +5315,15 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:105
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 
 #: src/welcome-day-2.md:1
-msgid "# Welcome to Day 2"
+msgid "Welcome to Day 2"
 msgstr ""
 
 #: src/welcome-day-2.md:3
@@ -5095,24 +5331,27 @@ msgid "Now that we have seen a fair amount of Rust, we will continue with:"
 msgstr ""
 
 #: src/welcome-day-2.md:5
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
+msgid "Structs, enums, methods."
 msgstr ""
 
-#: src/structs.md:1
-msgid "# Structs"
+#: src/welcome-day-2.md:7
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr ""
+
+#: src/welcome-day-2.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
 msgstr ""
 
 #: src/structs.md:3
@@ -5153,26 +5392,47 @@ msgid "Key Points:"
 msgstr ""
 
 #: src/structs.md:33
-msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
-"trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
-"old struct without having to explicitly type it all out. It must always be "
-"the last element."
+msgid "Structs work like in C or C++."
 msgstr ""
 
-#: src/structs/tuple-structs.md:1
-msgid "# Tuple Structs"
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
+msgid ""
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
+"old struct without having to explicitly type it all out. It must always be "
+"the last element."
 msgstr ""
 
 #: src/structs/tuple-structs.md:3
@@ -5219,26 +5479,39 @@ msgstr ""
 
 #: src/structs/tuple-structs.md:37
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). "
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
 
-#: src/structs/field-shorthand.md:1
-msgid "# Field Shorthand Syntax"
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics). "
 msgstr ""
 
 #: src/structs/field-shorthand.md:3
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
 
@@ -5266,63 +5539,79 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use "
-"the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-msgid "# Enums"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
 msgstr ""
 
 #: src/enums.md:3
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
 
 #: src/enums.md:6
@@ -5354,28 +5643,40 @@ msgid ""
 msgstr ""
 
 #: src/enums.md:35
-msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
-"structs but then they wouldn’t be the same type as they would if they were "
-"all defined in an enum. "
+msgid "Enumerations allow you to collect a set of values under one type"
 msgstr ""
 
-#: src/enums/variant-payloads.md:1
-msgid "# Variant Payloads"
+#: src/enums.md:36
+msgid ""
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+
+#: src/enums.md:37
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr ""
+
+#: src/enums.md:38
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+
+#: src/enums.md:39
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr ""
+
+#: src/enums.md:40
+msgid ""
+"You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. "
 msgstr ""
 
 #: src/enums/variant-payloads.md:3
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 
 #: src/enums/variant-payloads.md:6
@@ -5410,31 +5711,56 @@ msgstr ""
 
 #: src/enums/variant-payloads.md:35
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There "
-"is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example.  \n"
-"  "
+"after the `=>`."
 msgstr ""
 
-#: src/enums/sizes.md:1
-msgid "# Enum Sizes"
+#: src/enums/variant-payloads.md:36
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr ""
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
 msgstr ""
 
 #: src/enums/sizes.md:3
@@ -5468,159 +5794,191 @@ msgstr ""
 
 #: src/enums/sizes.md:25
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 msgstr ""
 
 #: src/enums/sizes.md:31
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+
+#: src/enums/sizes.md:33
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr ""
+
+#: src/enums/sizes.md:35
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with "
-"C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:50
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+
+#: src/enums/sizes.md:54
+msgid "Try out other types such as"
+msgstr ""
+
+#: src/enums/sizes.md:56
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr ""
+
+#: src/enums/sizes.md:57
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+
+#: src/enums/sizes.md:58
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+
+#: src/enums/sizes.md:59
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+
+#: src/enums/sizes.md:61
+msgid ""
+"Niche optimization: Rust will merge use unused bit patterns for the enum "
+"discriminant."
+msgstr ""
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits "
-"2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche "
-"optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit "
-"machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge use unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* "
-"look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees "
-"regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
 "\n"
-"     More complex example if you want to discuss what happens when we chain "
-"more than 256 `Option`s together.\n"
+"use std::mem::transmute;\n"
 "\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
 "signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
 "Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods.md:3
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
 
 #: src/methods.md:6
@@ -5649,76 +6007,103 @@ msgid ""
 msgstr ""
 
 #: src/methods.md:31
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
 
-#: src/methods/receiver.md:1
-msgid "# Method Receiver"
+#: src/methods.md:32
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+
+#: src/methods.md:33
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+
+#: src/methods.md:34
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr ""
+
+#: src/methods.md:35
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+
+#: src/methods.md:36
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+
+#: src/methods.md:37
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+
+#: src/methods.md:38
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+
+#: src/methods.md:39
+msgid "We describe the distinction between method receivers next."
 msgstr ""
 
 #: src/methods/receiver.md:3
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
 
 #: src/methods/receiver.md:6
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted. Complete ownership does not automatically mean mutability.\n"
-"* `mut self`: same as above, but the method can mutate the object. \n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:8
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:10
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+
+#: src/methods/receiver.md:14
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+
+#: src/methods/receiver.md:15
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
 msgstr ""
 
 #: src/methods/receiver.md:18
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
 
 #: src/methods/receiver.md:24
 msgid ""
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it."
-msgstr ""
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "# Example"
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 
 #: src/methods/example.md:3
@@ -5768,29 +6153,38 @@ msgid ""
 msgstr ""
 
 #: src/methods/example.md:47
-msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
-"functions are called the same way in the main body. Rust enables automatic "
-"referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
-"over. We describe vectors in more detail in the afternoon. "
+msgid "All four methods here use a different method receiver."
 msgstr ""
 
-#: src/pattern-matching.md:1
-msgid "# Pattern Matching"
+#: src/methods/example.md:48
+msgid ""
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+
+#: src/methods/example.md:49
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+
+#: src/methods/example.md:50
+msgid ""
+"Note that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+
+#: src/methods/example.md:51
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
 msgstr ""
 
 #: src/pattern-matching.md:3
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
 #: src/pattern-matching.md:6
@@ -5819,30 +6213,47 @@ msgstr ""
 
 #: src/pattern-matching.md:26
 msgid ""
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:1
-msgid "# Destructuring Enums"
+#: src/pattern-matching.md:27
+msgid "`|` as an `or`"
+msgstr ""
+
+#: src/pattern-matching.md:28
+msgid "`..` can expand as much as it needs to be"
+msgstr ""
+
+#: src/pattern-matching.md:29
+msgid "`1..=5` represents an inclusive range"
+msgstr ""
+
+#: src/pattern-matching.md:30
+msgid "`_` is a wild card"
+msgstr ""
+
+#: src/pattern-matching.md:31
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+
+#: src/pattern-matching.md:32
+msgid "You can demonstrate matching on a reference."
+msgstr ""
+
+#: src/pattern-matching.md:33
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:3
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:6
@@ -5873,24 +6284,22 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:36
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:1
-msgid "# Destructuring Structs"
+#: src/pattern-matching/destructuring-enums.md:37
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:3
@@ -5911,26 +6320,26 @@ msgid ""
 "    match foo {\n"
 "        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
 "        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were ignored"
-"\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
 "    }\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard "
-"to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that "
-"it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-msgid "# Destructuring Arrays"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:25
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
@@ -5956,44 +6365,52 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were ignored"
-"\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of "
-"elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:1
-msgid "# Match Guards"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:6
@@ -6015,21 +6432,31 @@ msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:24
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`."
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:26
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:27
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
 msgstr ""
 
 #: src/exercises/day-2/morning.md:1
-msgid "# Day 2: Morning Exercises"
+msgid "Day 2: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:3
@@ -6037,35 +6464,29 @@ msgid "We will look at implementing methods in two contexts:"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:5
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
+msgid "Simple struct which tracks health statistics."
 msgstr ""
 
-#: src/exercises/day-2/health-statistics.md:1
-msgid "# Health Statistics"
+#: src/exercises/day-2/morning.md:7
+msgid "Multiple structs and enums for a drawing library."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 
@@ -6129,16 +6550,14 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
-msgid "# Polygon Struct"
+msgid "Polygon Struct"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:3
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:7
@@ -6255,9 +6674,8 @@ msgstr ""
 #: src/exercises/day-2/points-polygons.md:117
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:120
@@ -6266,35 +6684,28 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:122
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
 
-#: src/control-flow.md:1
-msgid "# Control Flow"
+#: src/exercises/day-2/points-polygons.md:123
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
 msgstr ""
 
 #: src/control-flow.md:3
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
-msgstr ""
-
-#: src/control-flow/blocks.md:1
-msgid "# Blocks"
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
 
 #: src/control-flow/blocks.md:3
 msgid ""
 "A block in Rust has a value and a type: the value is the last expression of "
-"the\n"
-"block:"
+"the block:"
 msgstr ""
 
 #: src/control-flow/blocks.md:6
@@ -6321,7 +6732,7 @@ msgstr ""
 
 #: src/control-flow/blocks.md:25
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
 
@@ -6346,24 +6757,24 @@ msgstr ""
 
 #: src/control-flow/blocks.md:43
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr ""
+
+#: src/control-flow/blocks.md:44
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
 
 #: src/control-flow/if-expressions.md:1
-msgid "# `if` expressions"
+msgid "`if` expressions"
 msgstr ""
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
 
 #: src/control-flow/if-expressions.md:7
@@ -6382,7 +6793,7 @@ msgstr ""
 
 #: src/control-flow/if-expressions.md:18
 msgid ""
-"In addition, you can use `if` as an expression. The last expression of each\n"
+"In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
 
@@ -6408,16 +6819,14 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:1
-msgid "# `if let` expressions"
+msgid "`if let` expressions"
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:7
@@ -6439,45 +6848,57 @@ msgstr ""
 #: src/control-flow/match-expressions.md:23
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is "
-"interesting. In contrast, `match` requires all branches to be covered.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:26
+msgid ""
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) construct allows to do a destructuring "
 "assignment, or if it fails, have a non-returning block branch (panic/return/"
-"break/continue):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"break/continue):"
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:1
-msgid "# `while` loops"
+msgid "`while` loops"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:6
@@ -6498,14 +6919,14 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
-msgid "# `while let` loops"
+msgid "`while let` loops"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variant which repeatedly tests a value against a pattern:"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:6
@@ -6525,30 +6946,32 @@ msgstr ""
 #: src/control-flow/while-let-expressions.md:17
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:26
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
+msgstr ""
+
+#: src/control-flow/while-let-expressions.md:27
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
 "statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
 
 #: src/control-flow/for-expressions.md:1
-msgid "# `for` loops"
+msgid "`for` loops"
 msgstr ""
 
 #: src/control-flow/for-expressions.md:3
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely\n"
-"related to the [`while let` loop](while-let-expression.md). It will\n"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expression.md). It will "
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
 
@@ -6574,24 +6997,33 @@ msgid "You can use `break` and `continue` here as usual."
 msgstr ""
 
 #: src/control-flow/for-expressions.md:25
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr ""
+
+#: src/control-flow/for-expressions.md:26
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr ""
+
+#: src/control-flow/for-expressions.md:27
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+
+#: src/control-flow/for-expressions.md:28
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:1
-msgid "# `loop` expressions"
+msgid "`loop` expressions"
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
 "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:6
@@ -6619,26 +7051,25 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:27
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr ""
+
+#: src/control-flow/loop-expressions.md:28
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-"
-"trivial\n"
-"  value. This is because it's guaranteed to be entered at least once "
-"(unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:1
-msgid "# `match` expressions"
+msgid "`match` expressions"
 msgstr ""
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
 "The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
-"expr.html)\n"
-"is used to match a value against one or more patterns. In that sense, it "
-"works\n"
-"like a series of `if let` expressions:"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
 
 #: src/control-flow/match-expressions.md:7
@@ -6659,40 +7090,55 @@ msgstr ""
 
 #: src/control-flow/match-expressions.md:20
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:28
+msgid "Save the match expression to a variable and print it out."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:29
+msgid "Remove `.as_deref()` and explain the error."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:30
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:32
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
 msgstr ""
 
 #: src/control-flow/break-continue.md:1
-msgid "# `break` and `continue`"
+msgid "`break` and `continue`"
 msgstr ""
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
+msgstr ""
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
 msgstr ""
 
 #: src/control-flow/break-continue.md:7
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
-"used\n"
-"to break out of nested loops:"
+"used to break out of nested loops:"
 msgstr ""
 
 #: src/control-flow/break-continue.md:10
@@ -6721,17 +7167,11 @@ msgid ""
 "In this case we break the outer loop after 3 iterations of the inner loop."
 msgstr ""
 
-#: src/std.md:1
-msgid "# Standard Library"
-msgstr ""
-
 #: src/std.md:3
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 
 #: src/std.md:7
@@ -6740,37 +7180,59 @@ msgstr ""
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
+msgstr ""
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr ""
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr ""
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr ""
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
 "data."
 msgstr ""
 
 #: src/std.md:25
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
+msgstr ""
+
+#: src/std.md:26
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+
+#: src/std.md:28
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+
+#: src/std.md:29
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
 
 #: src/std/option-result.md:1
-msgid "# `Option` and `Result`"
+msgid "`Option` and `Result`"
 msgstr ""
 
 #: src/std/option-result.md:3
@@ -6792,24 +7254,37 @@ msgid ""
 msgstr ""
 
 #: src/std/option-result.md:18
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
 
-#: src/std/string.md:1
-msgid "# String"
+#: src/std/option-result.md:19
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr ""
+
+#: src/std/option-result.md:20
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+
+#: src/std/option-result.md:21
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr ""
+
+#: src/std/option-result.md:22
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr ""
+
+#: src/std/option-result.md:23
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
 msgstr ""
 
 #: src/std/string.md:3
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
 
 #: src/std/string.md:5
@@ -6834,44 +7309,84 @@ msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to index a `String`:\n"
-"    * To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-"
-"bound, out-of-bounds.\n"
-"    * To a substring by using `s3[0..4]`, where that slice is on character "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
 #: src/std/vec.md:1
-msgid "# `Vec`"
+msgid "`Vec`"
 msgstr ""
 
 #: src/std/vec.md:3
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
 msgstr ""
 
 #: src/std/vec.md:5
@@ -6903,35 +7418,46 @@ msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
-msgid "# `HashMap`"
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
+msgid "`HashMap`"
 msgstr ""
 
 #: src/std/hashmap.md:3
@@ -6955,8 +7481,8 @@ msgid ""
 "                 page_counts.len());\n"
 "    }\n"
 "\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland"
-"\"] {\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
 "        match page_counts.get(book) {\n"
 "            Some(count) => println!(\"{book}: {count} pages\"),\n"
 "            None => println!(\"{book} is unknown.\")\n"
@@ -6964,8 +7490,8 @@ msgid ""
 "    }\n"
 "\n"
 "    // Use the .entry() method to insert a value if nothing is found.\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland"
-"\"] {\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
 "        let page_count: &mut i32 = page_counts.entry(book.to_string())."
 "or_insert(0);\n"
 "        *page_count += 1;\n"
@@ -6978,47 +7504,77 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
-msgid "# `Box`"
+msgid "`Box`"
 msgstr ""
 
 #: src/std/box.md:3
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
 msgstr ""
 
 #: src/std/box.md:5
@@ -7050,26 +7606,41 @@ msgstr ""
 #: src/std/box.md:26
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 
 #: src/std/box.md:34
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
+msgstr ""
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr ""
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
 msgstr ""
 
 #: src/std/box-recursive.md:1
-msgid "# Box with Recursive Data Structures"
+msgid "Box with Recursive Data Structures"
 msgstr ""
 
 #: src/std/box-recursive.md:3
@@ -7118,29 +7689,27 @@ msgstr ""
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly "
-"into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it "
-"would look infinite.\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
 
-#: src/std/box-niche.md:1
-msgid "# Niche Optimization"
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
 msgstr ""
 
 #: src/std/box-niche.md:16
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 
@@ -7167,14 +7736,14 @@ msgid ""
 msgstr ""
 
 #: src/std/rc.md:1
-msgid "# `Rc`"
+msgid "`Rc`"
 msgstr ""
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
 
 #: src/std/rc.md:6
@@ -7194,33 +7763,61 @@ msgstr ""
 
 #: src/std/rc.md:18
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
+msgstr ""
+
+#: src/std/rc.md:20
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
 
 #: src/std/rc.md:31
 msgid ""
-"* `Rc`'s count ensures that its contained value is valid for as long as "
-"there are references.\n"
-"* Like C++'s `std::shared_ptr`.\n"
-"* `Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr ""
+
+#: src/std/rc.md:32
+msgid "Like C++'s `std::shared_ptr`."
+msgstr ""
+
+#: src/std/rc.md:33
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-write"
-"\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable "
-"borrows that are enforced at compile time. `RefCell` enables (im)mutable "
-"borrows that are enforced at run time and will panic if it fails at "
-"runtime.\n"
-"* `Rc::downgrade` gives you a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"be ignored when looking for performance issues in code."
+msgstr ""
+
+#: src/std/rc.md:34
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+
+#: src/std/rc.md:35
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr ""
+
+#: src/std/rc.md:36
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+
+#: src/std/rc.md:37
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
 msgstr ""
 
 #: src/std/rc.md:41
@@ -7252,10 +7849,6 @@ msgid ""
 "    println!(\"graph: {root:#?}\");\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/modules.md:1
-msgid "# Modules"
 msgstr ""
 
 #: src/modules.md:3
@@ -7290,15 +7883,18 @@ msgstr ""
 
 #: src/modules.md:28
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/visibility.md:1
-msgid "# Visibility"
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
 #: src/modules/visibility.md:3
@@ -7306,12 +7902,17 @@ msgid "Modules are a privacy boundary:"
 msgstr ""
 
 #: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr ""
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr ""
+
+#: src/modules/visibility.md:7
 msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
 msgstr ""
 
 #: src/modules/visibility.md:10
@@ -7345,7 +7946,7 @@ msgid ""
 msgstr ""
 
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
+msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
 #: src/modules/visibility.md:41
@@ -7356,16 +7957,22 @@ msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
-"its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/paths.md:1
-msgid "# Paths"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
 msgstr ""
 
 #: src/modules/paths.md:3
@@ -7373,20 +7980,33 @@ msgid "Paths are resolved as follows:"
 msgstr ""
 
 #: src/modules/paths.md:5
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgid "As a relative path:"
+msgstr ""
+
+#: src/modules/paths.md:6
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+
+#: src/modules/paths.md:7
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr ""
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
 #: src/modules/paths.md:13
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
 
 #: src/modules/paths.md:16
@@ -7395,10 +8015,6 @@ msgid ""
 "use std::collections::HashSet;\n"
 "use std::mem::transmute;\n"
 "```"
-msgstr ""
-
-#: src/modules/filesystem.md:1
-msgid "# Filesystem Hierarchy"
 msgstr ""
 
 #: src/modules/filesystem.md:3
@@ -7417,9 +8033,11 @@ msgid "The `garden` module content is found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:11
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:12
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:14
@@ -7427,9 +8045,11 @@ msgid "Similarly, a `garden::vegetables` module can be found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:16
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:17
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:19
@@ -7437,16 +8057,18 @@ msgid "The `crate` root is in:"
 msgstr ""
 
 #: src/modules/filesystem.md:21
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:22
+msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
 #: src/modules/filesystem.md:24
 msgid ""
-"Modules defined in files can be documented, too, using \"inner doc comments"
-"\".\n"
-"These document the item that contains them -- in this case, a module."
+"Modules defined in files can be documented, too, using \"inner doc "
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 
 #: src/modules/filesystem.md:27
@@ -7470,79 +8092,93 @@ msgstr ""
 
 #: src/modules/filesystem.md:44
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:47
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:57
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:60
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:63
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:68
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
-msgid "# Day 2: Afternoon Exercises"
+msgid "Day 2: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:3
 msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr ""
 
-#: src/exercises/day-2/luhn.md:1
-msgid "# Luhn Algorithm"
-msgstr ""
-
 #: src/exercises/day-2/luhn.md:3
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:19
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 
@@ -7598,23 +8234,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-msgid "# Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/strings-iterators.md:3
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:8
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
@@ -7633,13 +8263,13 @@ msgid ""
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
 "abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books"
-"\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers"
-"\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -7657,8 +8287,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers"
-"\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -7668,7 +8298,7 @@ msgid ""
 msgstr ""
 
 #: src/welcome-day-3.md:1
-msgid "# Welcome to Day 3"
+msgid "Welcome to Day 3"
 msgstr ""
 
 #: src/welcome-day-3.md:3
@@ -7677,34 +8307,34 @@ msgstr ""
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
 
-#: src/generics.md:1
-msgid "# Generics"
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
 msgstr ""
 
 #: src/generics.md:3
 msgid ""
 "Rust support generics, which lets you abstract an algorithm (such as "
-"sorting)\n"
-"over the types used in the algorithm."
-msgstr ""
-
-#: src/generics/data-types.md:1
-msgid "# Generic Data Types"
+"sorting) over the types used in the algorithm."
 msgstr ""
 
 #: src/generics/data-types.md:3
@@ -7729,14 +8359,11 @@ msgid ""
 msgstr ""
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
 msgstr ""
 
-#: src/generics/methods.md:1
-msgid "# Generic Methods"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
 msgstr ""
 
 #: src/generics/methods.md:3
@@ -7766,18 +8393,28 @@ msgstr ""
 
 #: src/generics/methods.md:25
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
 
-#: src/generics/monomorphization.md:1
-msgid "# Monomorphization"
+#: src/generics/methods.md:26
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+
+#: src/generics/methods.md:27
+msgid "It means these methods are defined for any `T`."
+msgstr ""
+
+#: src/generics/methods.md:28
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr ""
+
+#: src/generics/methods.md:29
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
 msgstr ""
 
 #: src/generics/monomorphization.md:3
@@ -7821,12 +8458,7 @@ msgstr ""
 #: src/generics/monomorphization.md:31
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
-msgstr ""
-
-#: src/traits.md:1
-msgid "# Traits"
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 
 #: src/traits.md:3
@@ -7872,10 +8504,6 @@ msgid ""
 "    greet(&captain_floof);\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/traits/trait-objects.md:1
-msgid "# Trait Objects"
 msgstr ""
 
 #: src/traits/trait-objects.md:3
@@ -7980,27 +8608,38 @@ msgstr ""
 
 #: src/traits/trait-objects.md:72
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Pet>` in the example above.\n"
-"* `dyn Pet` is a way to tell the compiler about a dynamically sized type "
-"that implements `Pet`.\n"
-"* In the example, `pets` holds *fat pointers* to objects that implement "
-"`Pet`. The fat pointer consists of two components, a pointer to the actual "
-"object and a pointer to the virtual method table for the `Pet` "
-"implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"     ```"
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Pet>` in the example above."
 msgstr ""
 
-#: src/traits/deriving-traits.md:1
-msgid "# Deriving Traits"
+#: src/traits/trait-objects.md:73
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/traits/trait-objects.md:74
+msgid ""
+"In the example, `pets` holds _fat pointers_ to objects that implement `Pet`. "
+"The fat pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Pet` implementation of "
+"that particular object."
+msgstr ""
+
+#: src/traits/trait-objects.md:75
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits/trait-objects.md:76
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
 msgstr ""
 
 #: src/traits/deriving-traits.md:3
@@ -8024,10 +8663,6 @@ msgid ""
 "             if p1 == p2 { \"yes\" } else { \"no\" });\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/traits/default-methods.md:1
-msgid "# Default Methods"
 msgstr ""
 
 #: src/traits/default-methods.md:3
@@ -8064,47 +8699,58 @@ msgstr ""
 
 #: src/traits/default-methods.md:32
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to\n"
-"  implement themselves. Methods with default implementations can rely on "
-"required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `NotEqual` a super trait for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `NotEqual` as a "
-"super trait for `Equal`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
 
-#: src/traits/trait-bounds.md:1
-msgid "# Trait Bounds"
+#: src/traits/default-methods.md:35
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr ""
+
+#: src/traits/default-methods.md:37
+msgid "Make `NotEqual` a super trait for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:38
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:46
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `NotEqual` as a super "
+"trait for `Equal`."
 msgstr ""
 
 #: src/traits/trait-bounds.md:3
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 
@@ -8157,21 +8803,26 @@ msgid ""
 msgstr ""
 
 #: src/traits/trait-bounds.md:46
+msgid "It declutters the function signature if you have many parameters."
+msgstr ""
+
+#: src/traits/trait-bounds.md:47
+msgid "It has additional features making it more powerful."
+msgstr ""
+
+#: src/traits/trait-bounds.md:48
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":"
-"\" can be arbitrary, like `Option<T>`.\n"
-"    "
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
 
 #: src/traits/impl-trait.md:1
-msgid "# `impl Trait`"
+msgid "`impl Trait`"
 msgstr ""
 
 #: src/traits/impl-trait.md:3
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 
@@ -8192,7 +8843,7 @@ msgid ""
 msgstr ""
 
 #: src/traits/impl-trait.md:19
-msgid "* `impl Trait` allows you to work with types which you cannot name."
+msgid "`impl Trait` allows you to work with types which you cannot name."
 msgstr ""
 
 #: src/traits/impl-trait.md:23
@@ -8202,42 +8853,36 @@ msgstr ""
 
 #: src/traits/impl-trait.md:25
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` "
-"picks\n"
-"  the concrete type it returns, without writing it out in the source. A "
-"function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let "
-"x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
+msgstr ""
+
+#: src/traits/impl-trait.md:27
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+
+#: src/traits/impl-trait.md:31
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
 msgstr ""
 
 #: src/traits/impl-trait.md:37
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters."
-msgstr ""
-
-#: src/traits/important-traits.md:1
-msgid "# Important Traits"
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 
 #: src/traits/important-traits.md:3
@@ -8248,20 +8893,51 @@ msgstr ""
 
 #: src/traits/important-traits.md:5
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
+msgstr ""
+
+#: src/traits/important-traits.md:6
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+
+#: src/traits/important-traits.md:7
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+
+#: src/traits/important-traits.md:8
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+
+#: src/traits/important-traits.md:9
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
 msgstr ""
 
 #: src/traits/iterator.md:1
-msgid "# Iterators"
+msgid "Iterators"
 msgstr ""
 
 #: src/traits/iterator.md:3
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
 
 #: src/traits/iterator.md:5
@@ -8294,29 +8970,26 @@ msgstr ""
 
 #: src/traits/iterator.md:32
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
 
-#: src/traits/from-iterator.md:1
-msgid "# FromIterator"
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
 
 #: src/traits/from-iterator.md:3
 msgid ""
-"[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
 
 #: src/traits/from-iterator.md:5
@@ -8334,26 +9007,25 @@ msgstr ""
 
 #: src/traits/from-iterator.md:17
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
 
 #: src/traits/from-iterator.md:23
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 
 #: src/traits/from-into.md:1
-msgid "# `From` and `Into`"
+msgid "`From` and `Into`"
 msgstr ""
 
 #: src/traits/from-into.md:3
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
 
 #: src/traits/from-into.md:5
@@ -8371,7 +9043,9 @@ msgstr ""
 
 #: src/traits/from-into.md:15
 msgid ""
-"[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
 
 #: src/traits/from-into.md:17
@@ -8389,22 +9063,27 @@ msgstr ""
 
 #: src/traits/from-into.md:29
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
+msgstr ""
+
+#: src/traits/from-into.md:30
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
 msgstr ""
 
 #: src/traits/read-write.md:1
-msgid "# `Read` and `Write`"
+msgid "`Read` and `Write`"
 msgstr ""
 
 #: src/traits/read-write.md:3
 msgid ""
-"Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
 msgstr ""
 
 #: src/traits/read-write.md:5
@@ -8429,7 +9108,9 @@ msgid ""
 msgstr ""
 
 #: src/traits/read-write.md:23
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
 msgstr ""
 
 #: src/traits/read-write.md:25
@@ -8453,13 +9134,13 @@ msgid ""
 msgstr ""
 
 #: src/traits/drop.md:1
-msgid "# The `Drop` Trait"
+msgid "The `Drop` Trait"
 msgstr ""
 
 #: src/traits/drop.md:3
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
 
 #: src/traits/drop.md:5
@@ -8497,21 +9178,27 @@ msgid "Discussion points:"
 msgstr ""
 
 #: src/traits/drop.md:36
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr ""
+
+#: src/traits/drop.md:37
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
+msgstr ""
+
+#: src/traits/drop.md:40
+msgid "Try replacing `drop(a)` with `a.drop()`."
 msgstr ""
 
 #: src/traits/default.md:1
-msgid "# The `Default` Trait"
+msgid "The `Default` Trait"
 msgstr ""
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait provides a default implementation of a trait."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"provides a default implementation of a trait."
 msgstr ""
 
 #: src/traits/default.md:5
@@ -8552,24 +9239,43 @@ msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e."
-"g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr ""
+
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr ""
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr ""
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
 
 #: src/traits/operators.md:1
-msgid "# `Add`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
 msgstr ""
 
 #: src/traits/operators.md:3
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
 
 #: src/traits/operators.md:5
@@ -8596,31 +9302,35 @@ msgstr ""
 
 #: src/traits/operators.md:28
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter?\n"
-"    * Short answer: Type parameters are controlled by the caller, but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
+msgstr ""
+
+#: src/traits/operators.md:29
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+
+#: src/traits/operators.md:33
+msgid "Why is `Output` an associated type? Could it be made a type parameter?"
+msgstr ""
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Type parameters are controlled by the caller, but associated "
+"types (like `Output`) are controlled by the implementor of a trait."
 msgstr ""
 
 #: src/traits/closures.md:1
-msgid "# Closures"
+msgid "Closures"
 msgstr ""
 
 #: src/traits/closures.md:3
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
@@ -8657,17 +9367,14 @@ msgstr ""
 #: src/traits/closures.md:29
 msgid ""
 "An `Fn` neither consumes nor mutates captured values, or perhaps captures "
-"nothing at all, so it can\n"
-"be called multiple times concurrently."
+"nothing at all, so it can be called multiple times concurrently."
 msgstr ""
 
 #: src/traits/closures.md:32
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 
 #: src/traits/closures.md:36
@@ -8675,20 +9382,16 @@ msgid "`move` closures only implement `FnOnce`."
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
-msgid "# Day 3: Morning Exercises"
+msgid "Day 3: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:3
 msgid "We will design a classical GUI library traits and trait objects."
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:1
-msgid "# A Simple GUI Library"
-msgstr ""
-
 #: src/exercises/day-3/simple-gui.md:3
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 
@@ -8697,11 +9400,17 @@ msgid "We will have a number of widgets in our library:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:8
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:9
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:11
+msgid "`Label`: has a `label`."
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:13
@@ -8710,7 +9419,7 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:15
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
@@ -8849,11 +9558,10 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:142
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:147
@@ -8887,22 +9595,16 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-msgid "# Error Handling"
-msgstr ""
-
 #: src/error-handling.md:3
 msgid "Error handling in Rust is done using explicit control flow:"
 msgstr ""
 
 #: src/error-handling.md:5
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
+msgid "Functions that can have errors list this in their return type,"
 msgstr ""
 
-#: src/error-handling/panics.md:1
-msgid "# Panics"
+#: src/error-handling.md:6
+msgid "There are no exceptions."
 msgstr ""
 
 #: src/error-handling/panics.md:3
@@ -8920,14 +9622,20 @@ msgid ""
 msgstr ""
 
 #: src/error-handling/panics.md:12
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr ""
+
+#: src/error-handling/panics.md:13
+msgid "Panics are symptoms of bugs in the program."
+msgstr ""
+
+#: src/error-handling/panics.md:14
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:1
-msgid "# Catching the Stack Unwinding"
+msgid "Catching the Stack Unwinding"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:3
@@ -8955,20 +9663,22 @@ msgstr ""
 
 #: src/error-handling/panic-unwind.md:19
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:21
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
 msgstr ""
 
 #: src/error-handling/result.md:1
-msgid "# Structured Error Handling with `Result`"
+msgid "Structured Error Handling with `Result`"
 msgstr ""
 
 #: src/error-handling/result.md:3
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
 
 #: src/error-handling/result.md:6
@@ -8995,28 +9705,27 @@ msgstr ""
 
 #: src/error-handling/result.md:27
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
+msgstr ""
+
+#: src/error-handling/result.md:30
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
 msgstr ""
 
 #: src/error-handling/try-operator.md:1
-msgid "# Propagating Errors with `?`"
+msgid "Propagating Errors with `?`"
 msgstr ""
 
 #: src/error-handling/try-operator.md:3
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
+"turn the common"
 msgstr ""
 
 #: src/error-handling/try-operator.md:6
@@ -9074,15 +9783,14 @@ msgstr ""
 
 #: src/error-handling/try-operator.md:50
 #: src/error-handling/converting-error-types-example.md:52
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-msgid "# Converting Error Types"
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
 msgstr ""
 
 #: src/error-handling/converting-error-types.md:3
@@ -9114,8 +9822,7 @@ msgstr ""
 
 #: src/error-handling/converting-error-types.md:18
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
 
@@ -9171,23 +9878,16 @@ msgstr ""
 #: src/error-handling/converting-error-types-example.md:55
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:1
-msgid "# Deriving Error Enums"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:6
@@ -9227,25 +9927,19 @@ msgstr ""
 #: src/error-handling/deriving-error-enums.md:39
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:1
-msgid "# Dynamic Error Types"
-msgstr ""
-
 #: src/error-handling/dynamic-errors.md:3
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:6
@@ -9282,23 +9976,17 @@ msgstr ""
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
-msgstr ""
-
-#: src/error-handling/error-contexts.md:1
-msgid "# Adding Context to Errors"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:3
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:7
@@ -9331,21 +10019,26 @@ msgid ""
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
 
-#: src/testing.md:1
-msgid "# Testing"
+#: src/error-handling/error-contexts.md:36
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:38
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:39
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
 msgstr ""
 
 #: src/testing.md:3
@@ -9353,14 +10046,11 @@ msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr ""
 
 #: src/testing.md:5
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
+msgid "Unit tests are supported throughout your code."
 msgstr ""
 
-#: src/testing/unit-tests.md:1
-msgid "# Unit Tests"
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
 msgstr ""
 
 #: src/testing/unit-tests.md:3
@@ -9398,14 +10088,10 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr ""
 
-#: src/testing/test-modules.md:1
-msgid "# Test Modules"
-msgstr ""
-
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 
 #: src/testing/test-modules.md:6
@@ -9432,13 +10118,11 @@ msgid ""
 msgstr ""
 
 #: src/testing/test-modules.md:26
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgid "This lets you unit test private helpers."
 msgstr ""
 
-#: src/testing/doc-tests.md:1
-msgid "# Documentation Tests"
+#: src/testing/test-modules.md:27
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
 
 #: src/testing/doc-tests.md:3
@@ -9462,15 +10146,17 @@ msgid ""
 msgstr ""
 
 #: src/testing/doc-tests.md:18
-msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
-"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
 
-#: src/testing/integration-tests.md:1
-msgid "# Integration Tests"
+#: src/testing/doc-tests.md:19
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr ""
+
+#: src/testing/doc-tests.md:20
+msgid ""
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
 
 #: src/testing/integration-tests.md:3
@@ -9498,7 +10184,7 @@ msgid "These tests only have access to the public API of your crate."
 msgstr ""
 
 #: src/testing/useful-crates.md:1
-msgid "## Useful crates for writing tests"
+msgid "Useful crates for writing tests"
 msgstr ""
 
 #: src/testing/useful-crates.md:3
@@ -9511,15 +10197,18 @@ msgstr ""
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
-"tests."
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
 msgstr ""
 
-#: src/unsafe.md:1
-msgid "# Unsafe Rust"
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr ""
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
 msgstr ""
 
 #: src/unsafe.md:3
@@ -9527,24 +10216,25 @@ msgid "The Rust language has two parts:"
 msgstr ""
 
 #: src/unsafe.md:5
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr ""
+
+#: src/unsafe.md:6
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
 
 #: src/unsafe.md:8
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr ""
 
 #: src/unsafe.md:11
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 
 #: src/unsafe.md:14
@@ -9552,34 +10242,38 @@ msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr ""
 
 #: src/unsafe.md:16
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
+msgid "Dereference raw pointers."
+msgstr ""
+
+#: src/unsafe.md:17
+msgid "Access or modify mutable static variables."
+msgstr ""
+
+#: src/unsafe.md:18
+msgid "Access `union` fields."
+msgstr ""
+
+#: src/unsafe.md:19
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr ""
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
 msgstr ""
 
 #: src/unsafe.md:22
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
+"We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 
 #: src/unsafe.md:28
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
-msgstr ""
-
-#: src/unsafe/raw-pointers.md:1
-msgid "# Dereferencing Raw Pointers"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:3
@@ -9613,36 +10307,42 @@ msgstr ""
 #: src/unsafe/raw-pointers.md:27
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:31
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:34
+msgid "The pointer must be non-null."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:35
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:36
+msgid "The object must not have been deallocated."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:37
+msgid "There must not be concurrent accesses to the same location."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:38
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:41
 msgid "In most cases the pointer must also be properly aligned."
-msgstr ""
-
-#: src/unsafe/mutable-static-variables.md:1
-msgid "# Mutable Static Variables"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:3
@@ -9662,7 +10362,7 @@ msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 
@@ -9686,13 +10386,8 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:32
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
-msgstr ""
-
-#: src/unsafe/unions.md:1
-msgid "# Unions"
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 
 #: src/unsafe/unions.md:3
@@ -9719,28 +10414,21 @@ msgstr ""
 #: src/unsafe/unions.md:21
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 
 #: src/unsafe/unions.md:24
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
+"If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:1
-msgid "# Calling Unsafe Functions"
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:6
@@ -9773,15 +10461,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-msgid "# Writing Unsafe Functions"
-msgstr ""
-
 #: src/unsafe/writing-unsafe-functions.md:3
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:6
@@ -9821,19 +10504,17 @@ msgstr ""
 #: src/unsafe/writing-unsafe-functions.md:35
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 
 #: src/unsafe/extern-functions.md:1
-msgid "# Calling External Code"
+msgid "Calling External Code"
 msgstr ""
 
 #: src/unsafe/extern-functions.md:3
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
 
@@ -9856,35 +10537,26 @@ msgstr ""
 #: src/unsafe/extern-functions.md:21
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/"
-"external-blocks.html)."
-msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-msgid "# Implementing Unsafe Traits"
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:9
@@ -9913,8 +10585,7 @@ msgstr ""
 #: src/unsafe/unsafe-traits.md:30
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:33
@@ -9928,7 +10599,7 @@ msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:1
-msgid "# Day 3: Afternoon Exercises"
+msgid "Day 3: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:3
@@ -9936,17 +10607,15 @@ msgid "Let us build a safe wrapper for reading directory content!"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:7
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-msgid "# Safe FFI Wrapper"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 
@@ -9955,30 +10624,72 @@ msgid "You will want to consult the manual pages:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module. There you find a "
-"number of\n"
-"string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Encoding"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Use"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"| Types                      | Encoding       | "
-"Use                            |\n"
-"|----------------------------|----------------|--------------------------------|\n"
-"| [`str`] and [`String`]     | UTF-8          | Text processing in "
-"Rust        |\n"
-"| [`CStr`] and [`CString`]   | NUL-terminated | Communicating with C "
-"functions |\n"
-"| [`OsStr`] and [`OsString`] | OS-specific    | Communicating with the "
-"OS      |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "UTF-8"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "Text processing in Rust"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "NUL-terminated"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "Communicating with C functions"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "OS-specific"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "Communicating with the OS"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
@@ -9987,30 +10698,47 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:24
 msgid ""
-"- `&str` to `CString`: you need to allocate space for a trailing `\\0` "
-"character,\n"
-"- `CString` to `*const i8`: you need a pointer to call C functions,\n"
-"- `*const i8` to `&CStr`: you need something which can find the trailing `"
-"\\0` character,\n"
-"- `&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknow data\",\n"
-"- `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
-"html)\n"
-"  to create it,\n"
-"- `&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able "
-"to return it and call\n"
-"  `readdir` again."
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
-msgid "The [Nomicon] also has a very useful chapter about FFI."
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
@@ -10105,37 +10833,28 @@ msgid ""
 msgstr ""
 
 #: src/android.md:1
-msgid "# Welcome to Rust in Android"
+msgid "Welcome to Rust in Android"
 msgstr ""
 
 #: src/android.md:3
 msgid ""
 "Rust is supported for native platform development on Android. This means "
-"that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 
 #: src/android.md:7
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try "
-"to\n"
-"> find a little corner of your code base where we can move some lines of "
-"code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
-"that\n"
-"> parses some raw bytes would be ideal."
-msgstr ""
-
-#: src/android/setup.md:1
-msgid "# Setup"
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
 
 #: src/android/setup.md:3
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
-"have\n"
-"access to one or create a new one with:"
+"have access to one or create a new one with:"
 msgstr ""
 
 #: src/android/setup.md:6
@@ -10149,12 +10868,8 @@ msgstr ""
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
-msgstr ""
-
-#: src/android/build-rules.md:1
-msgid "# Build Rules"
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
 
 #: src/android/build-rules.md:3
@@ -10162,28 +10877,83 @@ msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr ""
 
 #: src/android/build-rules.md:5
+msgid "Module Type"
+msgstr ""
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr ""
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr ""
+
+#: src/android/build-rules.md:9
 msgid ""
-"| Module Type       | "
-"Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust "
-"binary.                                                                            "
-"|\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
-"`dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
-"provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
-"analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard "
-"Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging "
-"`libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that "
-"provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library "
-"containing Rust bindings to C libraries.              |"
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
 msgstr ""
 
 #: src/android/build-rules.md:16
@@ -10191,14 +10961,13 @@ msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr ""
 
 #: src/android/build-rules/binary.md:1
-msgid "# Rust Binaries"
+msgid "Rust Binaries"
 msgstr ""
 
 #: src/android/build-rules/binary.md:3
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr ""
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
@@ -10247,7 +11016,7 @@ msgid ""
 msgstr ""
 
 #: src/android/build-rules/library.md:1
-msgid "# Rust Libraries"
+msgid "Rust Libraries"
 msgstr ""
 
 #: src/android/build-rules/library.md:3
@@ -10259,10 +11028,14 @@ msgid "Here we declare a dependency on two libraries:"
 msgstr ""
 
 #: src/android/build-rules/library.md:7
+msgid "`libgreeting`, which we define below,"
+msgstr ""
+
+#: src/android/build-rules/library.md:8
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
 
 #: src/android/build-rules/library.md:15
@@ -10334,25 +11107,22 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-msgid "# AIDL"
-msgstr ""
-
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
 #: src/android/aidl.md:6
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr ""
+
+#: src/android/aidl.md:7
+msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
 #: src/android/aidl/interface.md:1
-msgid "# AIDL Interfaces"
+msgid "AIDL Interfaces"
 msgstr ""
 
 #: src/android/aidl/interface.md:3
@@ -10361,7 +11131,7 @@ msgstr ""
 
 #: src/android/aidl/interface.md:5
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:7
@@ -10378,7 +11148,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/interface.md:17
-msgid "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:19
@@ -10400,12 +11170,11 @@ msgstr ""
 #: src/android/aidl/interface.md:32
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 
 #: src/android/aidl/implementation.md:1
-msgid "# Service Implementation"
+msgid "Service Implementation"
 msgstr ""
 
 #: src/android/aidl/implementation.md:3
@@ -10413,7 +11182,7 @@ msgid "We can now implement the AIDL service:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:5
-msgid "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:7
@@ -10443,7 +11212,7 @@ msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
-msgid "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:28
@@ -10462,7 +11231,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/server.md:1
-msgid "# AIDL Server"
+msgid "AIDL Server"
 msgstr ""
 
 #: src/android/aidl/server.md:3
@@ -10470,7 +11239,7 @@ msgid "Finally, we can create a server which exposes the service:"
 msgstr ""
 
 #: src/android/aidl/server.md:5
-msgid "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
 #: src/android/aidl/server.md:7
@@ -10516,10 +11285,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/deploy.md:1
-msgid "# Deploy"
-msgstr ""
-
 #: src/android/aidl/deploy.md:3
 msgid "We can now build, push, and start the service:"
 msgstr ""
@@ -10528,8 +11293,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m birthday_server\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/tmp"
-"\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/birthday_server\n"
 "```"
 msgstr ""
@@ -10567,7 +11332,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/client.md:1
-msgid "# AIDL Client"
+msgid "AIDL Client"
 msgstr ""
 
 #: src/android/aidl/client.md:3
@@ -10575,7 +11340,7 @@ msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
 #: src/android/aidl/client.md:5
-msgid "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
 #: src/android/aidl/client.md:7
@@ -10605,8 +11370,8 @@ msgid ""
 "        .unwrap_or(42);\n"
 "\n"
 "    binder::ProcessState::start_thread_pool();\n"
-"    let service = connect().expect(\"Failed to connect to BirthdayService"
-"\");\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
 "    let msg = service.wishHappyBirthday(&name, years)?;\n"
 "    println!(\"{msg}\");\n"
 "    Ok(())\n"
@@ -10642,22 +11407,17 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m birthday_client\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/tmp"
-"\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/birthday_client Charlie 60\n"
 "Happy Birthday Charlie, congratulations with the 60 years!\n"
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-msgid "# Changing API"
-msgstr ""
-
 #: src/android/aidl/changing.md:3
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr ""
 
 #: src/android/aidl/changing.md:6
@@ -10673,15 +11433,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-msgid "# Logging"
-msgstr ""
-
 #: src/android/logging.md:3
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
 
 #: src/android/logging.md:6
@@ -10739,8 +11494,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m hello_rust_logs\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/tmp"
-"\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 msgstr ""
@@ -10761,36 +11516,33 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-msgid "# Interoperability"
-msgstr ""
-
 #: src/android/interoperability.md:3
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 
 #: src/android/interoperability.md:6
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
+msgid "Call Rust functions from other languages."
+msgstr ""
+
+#: src/android/interoperability.md:7
+msgid "Call functions written in other languages from Rust."
 msgstr ""
 
 #: src/android/interoperability.md:9
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:1
-msgid "# Interoperability with C"
+msgid "Interoperability with C"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:3
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
@@ -10815,14 +11567,14 @@ msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:23
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:26
@@ -10830,14 +11582,13 @@ msgid "We will look at better options next."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:1
-msgid "# Using Bindgen"
+msgid "Using Bindgen"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:3
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:6
@@ -10902,7 +11653,7 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
@@ -11010,7 +11761,7 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
-msgid "# Calling Rust"
+msgid "Calling Rust"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:3
@@ -11115,8 +11866,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m analyze_numbers\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/tmp"
-"\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/analyze_numbers\n"
 "```"
 msgstr ""
@@ -11124,43 +11875,35 @@ msgstr ""
 #: src/android/interoperability/with-c/rust.md:83
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
-msgstr ""
-
-#: src/android/interoperability/cpp.md:1
-msgid "# With C++"
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:3
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:8
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr ""
-
 #: src/android/interoperability/cpp.md:10
-msgid "See the [CXX tutorial][2] for an full example of using this."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
 
 #: src/android/interoperability/java.md:1
-msgid "# Interoperability with Java"
+msgid "Interoperability with Java"
 msgstr ""
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 
 #: src/android/interoperability/java.md:7
@@ -11263,70 +12006,66 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
-#: src/exercises/concurrency/morning.md:1
-#: src/exercises/concurrency/afternoon.md:1
-msgid "# Exercises"
-msgstr ""
-
 #: src/exercises/android/morning.md:3
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
-"and\n"
-"try to integrate some Rust into it. Some suggestions:"
+"and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 
 #: src/exercises/android/morning.md:6
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr ""
+
+#: src/exercises/android/morning.md:8
+msgid "Move a function from your project to Rust and call it."
 msgstr ""
 
 #: src/exercises/android/morning.md:12
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
 #: src/bare-metal.md:1
-msgid "# Welcome to Bare Metal Rust"
+msgid "Welcome to Bare Metal Rust"
 msgstr ""
 
 #: src/bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/bare-metal.md:7
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 
 #: src/bare-metal.md:10
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr ""
+
+#: src/bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr ""
+
+#: src/bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr ""
+
+#: src/bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
 #: src/bare-metal.md:15
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 
@@ -11355,8 +12094,8 @@ msgstr ""
 #: src/bare-metal.md:32
 msgid ""
 "```bash\n"
-"echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0d28\", MODE=\"0664\", GROUP="
-"\"plugdev\"' |\\\n"
+"echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0d28\", MODE=\"0664\", "
+"GROUP=\"plugdev\"' |\\\n"
 "  sudo tee /etc/udev/rules.d/50-microbit.rules\n"
 "sudo udevadm control --reload-rules\n"
 "```"
@@ -11380,27 +12119,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/no_std.md:1
-msgid "# `no_std`"
-msgstr ""
-
-#: src/bare-metal/no_std.md:3
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -11408,72 +12134,100 @@ msgstr ""
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:19
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-
 #: src/bare-metal/no_std.md:24
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
+msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
-msgid ""
-"</td>\n"
-"<td>"
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr ""
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:38
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:45
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:56
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:62
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr ""
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
 #: src/bare-metal/minimal.md:1
-msgid "# A minimal `no_std` program"
+msgid "A minimal `no_std` program"
 msgstr ""
 
 #: src/bare-metal/minimal.md:3
@@ -11492,29 +12246,34 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-msgid "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -11554,25 +12313,32 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-msgid "# Microcontrollers"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
@@ -11608,21 +12374,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:1
-msgid "# Raw MMIO"
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:6
@@ -11692,8 +12455,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:66
@@ -11711,16 +12474,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
-msgid "# Peripheral Access Crates"
+msgid "Peripheral Access Crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -11768,19 +12529,31 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:61
@@ -11791,16 +12564,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
-msgid "# HAL crates"
+msgid "HAL crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -11838,11 +12610,13 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:45
@@ -11853,7 +12627,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
-msgid "# Board support crates"
+msgid "Board support crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:3
@@ -11888,13 +12662,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:28
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:36
@@ -11905,7 +12684,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
-msgid "# The type state pattern"
+msgid "The type state pattern"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:3
@@ -11943,118 +12722,177 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "# `embedded-hal`"
+msgid "`embedded-hal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
+msgid "GPIO"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid " server"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
 msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:1
-msgid "# Debugging"
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/debugging.md:3
@@ -12113,39 +12951,86 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
-msgid "# Other projects"
+msgid "Other projects"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "[RTIC](https://rtic.rs/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
 
@@ -12155,15 +13040,11 @@ msgid ""
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:1
-msgid "# Compass"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
-"serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:6
@@ -12172,45 +13053,50 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C "
-"bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:11
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:12
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:13
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:17
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:19
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `compass`\n"
-"directory for the following files."
+"look in the `compass` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 msgid "`src/main.rs`:"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
-#: src/exercises/concurrency/dining-philosophers.md:17
-#: src/exercises/concurrency/link-checker.md:55
-#: src/exercises/concurrency/dining-philosophers-async.md:11
-msgid "<!-- File src/main.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:30
@@ -12254,14 +13140,6 @@ msgstr ""
 msgid "`Cargo.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:66 src/exercises/bare-metal/rtc.md:387
-#: src/exercises/concurrency/dining-philosophers.md:63
-#: src/exercises/concurrency/link-checker.md:35
-#: src/exercises/concurrency/dining-philosophers-async.md:60
-#: src/exercises/concurrency/chat-app.md:17
-msgid "<!-- File Cargo.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
 "```toml\n"
@@ -12286,10 +13164,6 @@ msgstr ""
 msgid "`Embed.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:87
-msgid "<!-- File Embed.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
 "```toml\n"
@@ -12306,10 +13180,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
 msgid "`.cargo/config.toml` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
-msgid "<!-- File .cargo/config.toml -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:104
@@ -12351,39 +13221,47 @@ msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
 #: src/bare-metal/aps.md:1
-msgid "# Application processors"
+msgid "Application processors"
 msgstr ""
 
 #: src/bare-metal/aps.md:3
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
+msgstr ""
+
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
-msgid "# Inline assembly"
+msgid "Inline assembly"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid " to tell the firmware to power off the system:"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:6
@@ -12424,74 +13302,99 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the [`smccc`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
-"it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are "
-"conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the "
-"standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–"
-"`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do "
-"anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:51
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:56
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
-msgid "# Volatile memory access for MMIO"
+msgid "Volatile memory access for MMIO"
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:9
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:1
-msgid "# Let's write a UART driver"
+msgid "Let's write a UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -12551,31 +13454,30 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is "
-"because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i."
-"e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else "
-"aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume "
-"the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but "
-"`write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls "
-"`write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving "
-"the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:66
-msgid "</detais>"
+#: src/bare-metal/aps/uart.md:60
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:63
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:1
-msgid "# More traits"
+msgid "More traits"
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:3
@@ -12606,51 +13508,188 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with "
-"our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:25
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
-msgid "# A better UART driver"
+msgid "A better UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
+msgid "Offset"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:26
-msgid "- There are also some ID registers which have been omitted for brevity."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-msgid "# Bitflags"
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
@@ -12694,13 +13733,12 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
-"with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:1
-msgid "# Multiple registers"
+msgid "Multiple registers"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:3
@@ -12747,17 +13785,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust "
-"representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-msgid "# Driver"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -12831,21 +13863,19 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
-"fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
-msgid "# Using it"
+msgid "Using it"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
-"and echo incoming\n"
-"bytes."
+"and echo incoming bytes."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:6
@@ -12897,18 +13927,21 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
 msgid ""
-"* As in the [inline assembly](../inline-assembly.md) example, this `main` "
-"function is called from our\n"
-"  entry point code in `entry.S`. See the speaker notes there for details.\n"
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/"
-"examples`."
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:53
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -12959,7 +13992,7 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
@@ -13011,29 +14044,53 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:47
 msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
-msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling, page tables\n"
-"   * Not all very well written, so beware.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
-msgid "# Useful crates"
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:7
+msgid ""
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:9
+msgid "Not all very well written, so beware."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:11
+msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
@@ -13043,14 +14100,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "# `zerocopy`"
+msgid "`zerocopy`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
@@ -13093,34 +14150,44 @@ msgstr ""
 #: src/bare-metal/useful-crates/zerocopy.md:40
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "# `aarch64-paging`"
+msgid "`aarch64-paging`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
@@ -13148,27 +14215,37 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real "
-"hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -13191,26 +14268,27 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+msgid "PCI BARs always have alignment equal to their size."
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "# `tinyvec`"
+msgid "`tinyvec`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
@@ -13231,29 +14309,30 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:23
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
-"initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine "
-"inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:1
-msgid "# `spin`"
+msgid "`spin`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:7
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:9
@@ -13272,28 +14351,33 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/android.md:1
-msgid "# Android"
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/android.md:3
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
 #: src/bare-metal/android.md:7
@@ -13338,16 +14422,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-msgid "# vmbase"
-msgstr ""
-
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -13368,11 +14448,14 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:21
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md:3
@@ -13380,40 +14463,51 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:1
-msgid "# RTC driver"
+#: src/exercises/bare-metal/solutions-afternoon.md:3
+msgid "RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. "
-"For this exercise, you\n"
-"should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:6
 msgid ""
-"1. Use it to print the current time to the serial console. You can use the "
-"[`chrono`][2] crate for\n"
-"   date/time formatting.\n"
-"2. Use the match register and raw interrupt status to busy-wait until a "
-"given time, e.g. 3 seconds\n"
-"   in the future. (Call [`core::hint::spin_loop`][3] inside the loop.)\n"
-"3. _Extension if you have time:_ Enable and handle the interrupt generated "
-"by the RTC match. You can\n"
-"   use the driver provided in the [`arm-gic`][4] crate to configure the Arm "
-"Generic Interrupt Controller.\n"
-"   - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.\n"
-"   - Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt.\n"
-"   "
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:8
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:10
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:12
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:13
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `rtc`\n"
-"directory for the following files."
+"look in the `rtc` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:23
@@ -13478,10 +14572,6 @@ msgstr ""
 msgid ""
 "`src/exceptions.rs` (you should only need to change this for the 3rd part of "
 "the exercise):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:77
-msgid "<!-- File src/exceptions.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:79
@@ -13562,10 +14652,6 @@ msgstr ""
 msgid "`src/logger.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:151
-msgid "<!-- File src/logger.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:153
 msgid ""
 "```rust,compile_fail\n"
@@ -13629,10 +14715,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "`src/pl011.rs` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:212
-msgid "<!-- File src/pl011.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:214
@@ -13842,10 +14924,6 @@ msgstr ""
 msgid "`build.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:412
-msgid "<!-- File build.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:414
 msgid ""
 "```rust,compile_fail\n"
@@ -13883,10 +14961,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
 msgid "`entry.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:448
-msgid "<!-- File entry.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:450
@@ -14053,10 +15127,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:595
 msgid "`exceptions.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:597
-msgid "<!-- File exceptions.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:599
@@ -14257,10 +15327,6 @@ msgstr ""
 msgid "`idmap.S` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:782
-msgid "<!-- File idmap.S -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
 "```armasm\n"
@@ -14312,10 +15378,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:829
 msgid "`image.ld` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:831
-msgid "<!-- File image.ld -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:833
@@ -14433,10 +15495,6 @@ msgstr ""
 msgid "`Makefile` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:942
-msgid "<!-- File Makefile -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:944
 msgid ""
 "```makefile\n"
@@ -14496,12 +15554,12 @@ msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
 #: src/concurrency.md:1
-msgid "# Welcome to Concurrency in Rust"
-msgstr "# Rustでの並行性へようこそ"
+msgid "Welcome to Concurrency in Rust"
+msgstr "Rustでの並行性へようこそ"
 
 #: src/concurrency.md:3
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 "Rustはミューテックスとチャネルを用いてOSスレッドを扱う並行性を十分にサポート"
@@ -14509,20 +15567,14 @@ msgstr ""
 
 #: src/concurrency.md:6
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 "Rustの型システムは多くの並行性にまつわるバグをコンパイル時のバグにとどめると"
 "いう点で、重要な役割を果たします。これは時に _fearless concurrency_ （「怖く"
 "ない並行性」） と呼ばれます。なぜなら、コンパイラに実行時での正しさを保証する"
 "ことをまかせてよいためです。"
-
-#: src/concurrency/threads.md:1
-msgid "# Threads"
-msgstr "# スレッド"
 
 #: src/concurrency/threads.md:3
 msgid "Rust threads work similarly to threads in other languages:"
@@ -14551,48 +15603,51 @@ msgid ""
 msgstr ""
 
 #: src/concurrency/threads.md:24
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
-"* スレッドはすべてデーモンスレッドで、メインスレッドはそれらを待ちません。\n"
-"* スレッドパニックは互いに独立です。\n"
-"  * パニックはペイロードを保持していることがあり、それは`downcast_ref`で展開"
-"可能です。"
+"スレッドはすべてデーモンスレッドで、メインスレッドはそれらを待ちません。"
+
+#: src/concurrency/threads.md:25
+msgid "Thread panics are independent of each other."
+msgstr "スレッドパニックは互いに独立です。"
+
+#: src/concurrency/threads.md:26
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr ""
+"パニックはペイロードを保持していることがあり、それは`downcast_ref`で展開可能"
+"です。"
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
-"* スレッドはカウントが10に到達するまでに止められます。メインのスレッドは待機"
-"しません。\n"
-"\n"
-"* `let handle = thread::spawn(…)`と後に`handle.join()`を使って、スレッドが完"
-"了するのを待ってみてください。\n"
-"\n"
-"* スレッド内でパニックを引き起こしてみて、それがどのように`main`に影響しない"
-"かを観察してみてください。\n"
-"\n"
-"* `handle.join()`の返り値の`Result`を使って、パニックペイロードへのアクセスを"
-"得てみてください。\n"
-"  これは[`Any`]について話すのに良いタイミングです。"
+"スレッドはカウントが10に到達するまでに止められます。メインのスレッドは待機し"
+"ません。"
 
-#: src/concurrency/scoped-threads.md:1
-msgid "# Scoped Threads"
-msgstr "# スコープ付きスレッド"
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+"`let handle = thread::spawn(…)`と後に`handle.join()`を使って、スレッドが完了"
+"するのを待ってみてください。"
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+"スレッド内でパニックを引き起こしてみて、それがどのように`main`に影響しないか"
+"を観察してみてください。"
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
+"`handle.join()`の返り値の`Result`を使って、パニックペイロードへのアクセスを得"
+"てみてください。 これは[`Any`](https://doc.rust-lang.org/std/any/index.html)"
+"について話すのに良いタイミングです。"
 
 #: src/concurrency/scoped-threads.md:3
 msgid "Normal threads cannot borrow from their environment:"
@@ -14614,8 +15669,12 @@ msgid ""
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "しかし、そのために[スコープ付きスレッド][1]を使うことができます:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"しかし、そのために[スコープ付きスレッド](https://doc.rust-lang.org/std/"
+"thread/fn.scope.html)を使うことができます:"
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -14636,32 +15695,28 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:37
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"* この理由は、関数`thread::scope`が完了するとき、全てのスレッドはjoinされるこ"
-"とが保証されているので、スレッドが借用したデータを返すことができるためで"
-"す。\n"
-"* 通常のRustの借用のルールが適用されます:　一つのスレッドがミュータブルで借用"
-"すること、または任意の数のスレッドからイミュータブルで借用すること。\n"
-"    "
+"この理由は、関数`thread::scope`が完了するとき、全てのスレッドはjoinされること"
+"が保証されているので、スレッドが借用したデータを返すことができるためです。"
 
-#: src/concurrency/channels.md:1
-msgid "# Channels"
-msgstr "# チャネル"
+#: src/concurrency/scoped-threads.md:38
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"通常のRustの借用のルールが適用されます:　一つのスレッドがミュータブルで借用す"
+"ること、または任意の数のスレッドからイミュータブルで借用すること。"
 
 #: src/concurrency/channels.md:3
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
-"Rustのチャネルには二つの部品があります： `Sender<T>` と`Receiver<T>`です。この２つの部品はチャネルに"
-"よって繋がっていますが、見ることができるのはエンドポイントだけです。"
+"Rustのチャネルには二つの部品があります： `Sender<T>` と`Receiver<T>`です。こ"
+"の２つの部品はチャネルによって繋がっていますが、見ることができるのはエンドポ"
+"イントだけです。"
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -14687,21 +15742,22 @@ msgstr ""
 
 #: src/concurrency/channels.md:27
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* `mpsc` は Multi-Producer, Single-Consumerの略称です。 `Sender`と`SyncSender`は`Clone`を実装してい"
-"る（よって複数のproducerが作成可能）のですが、`Receiver`についてはそうではありません。\n"
-"* `send()`と`recv()`は`Result`を返します。もし`Err`が返された場合、これは、対応する`Sender`か"
-"`Receiver`のいずれかがドロップされ、チャンネルが閉じられたことを意味します。"
+"`mpsc` は Multi-Producer, Single-Consumerの略称です。 `Sender`と`SyncSender`"
+"は`Clone`を実装している（よって複数のproducerが作成可能）のですが、`Receiver`"
+"についてはそうではありません。"
 
-#: src/concurrency/channels/unbounded.md:1
-msgid "# Unbounded Channels"
-msgstr "# Unboundedチャネル"
+#: src/concurrency/channels.md:29
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()`と`recv()`は`Result`を返します。もし`Err`が返された場合、これは、対応"
+"する`Sender`か`Receiver`のいずれかがドロップされ、チャンネルが閉じられたこと"
+"を意味します。"
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
@@ -14733,10 +15789,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/concurrency/channels/bounded.md:1
-msgid "# Bounded Channels"
-msgstr "# Boundedチャネル"
 
 #: src/concurrency/channels/bounded.md:3
 msgid "Bounded and synchronous channels make `send` block the current thread:"
@@ -14770,7 +15822,7 @@ msgid ""
 msgstr ""
 
 #: src/concurrency/send-sync.md:1
-msgid "# `Send` and `Sync`"
+msgid "`Send` and `Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync.md:3
@@ -14781,66 +15833,65 @@ msgstr ""
 
 #: src/concurrency/send-sync.md:5
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
+msgstr ""
+
+#: src/concurrency/send-sync.md:7
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
 msgstr ""
 
 #: src/concurrency/send-sync.md:10
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-"
-"safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
+msgstr ""
+
+#: src/concurrency/send-sync.md:21
+msgid "They can be used in the generic constraints as normal traits."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:1
-msgid "# `Send`"
+msgid "`Send`"
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:3
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
-"a\n"
-"single thread."
+"a single thread."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:1
-msgid "# `Sync`"
+msgid "`Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:6
@@ -14848,7 +15899,7 @@ msgid "More precisely, the definition is:"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:8
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:14
@@ -14867,12 +15918,8 @@ msgid ""
 "be accessed from any thread safely."
 msgstr ""
 
-#: src/concurrency/send-sync/examples.md:1
-msgid "# Examples"
-msgstr ""
-
 #: src/concurrency/send-sync/examples.md:3
-msgid "## `Send + Sync`"
+msgid "`Send + Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:5
@@ -14880,41 +15927,63 @@ msgid "Most types you come across are `Send + Sync`:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:17
-msgid "## `Send + !Sync`"
+msgid "`Send + !Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:19
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:22
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:23
+msgid "`mpsc::Receiver<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:24
+msgid "`Cell<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:25
+msgid "`RefCell<T>`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:27
-msgid "## `!Send + Sync`"
+msgid "`!Send + Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:29
@@ -14924,13 +15993,12 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:34
-msgid "## `!Send + !Sync`"
+msgid "`!Send + !Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:36
@@ -14939,37 +16007,43 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
 
-#: src/concurrency/shared_state.md:1
-msgid "# Shared State"
+#: src/concurrency/send-sync/examples.md:40
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
 msgstr ""
 
 #: src/concurrency/shared_state.md:3
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 
 #: src/concurrency/shared_state.md:6
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
+msgstr ""
+
+#: src/concurrency/shared_state.md:8
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:1
-msgid "# `Arc`"
+msgid "`Arc`"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:3
-msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:5
@@ -14997,28 +16071,41 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:31
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:33
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:35
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:36
+msgid "`std::sync::Weak` can help."
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:1
-msgid "# `Mutex`"
+msgid "`Mutex`"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:3
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:6
@@ -15042,29 +16129,48 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:32
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:33
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:35
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:36
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:37
+msgid "Why does `lock()` return a `Result`? "
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:38
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:3
@@ -15127,13 +16233,25 @@ msgstr ""
 
 #: src/concurrency/shared_state/example.md:51
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:52
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:53
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:54
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
 
@@ -15142,15 +16260,13 @@ msgid "Let us practice our new concurrency skills with"
 msgstr ""
 
 #: src/exercises/concurrency/morning.md:5
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
+msgid "Dining philosophers: a classic problem in concurrency."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md:1
-msgid "# Dining Philosophers"
+#: src/exercises/concurrency/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:3
@@ -15159,28 +16275,21 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:5
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:13
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to a file called `src/main.rs`, fill out "
-"the\n"
-"blanks, and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:19
@@ -15242,24 +16351,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:1
-msgid "# Multi-threaded Link Checker"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:3
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:11
@@ -15273,14 +16376,14 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:17
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:20
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:22
@@ -15292,9 +16395,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:29
@@ -15319,8 +16421,8 @@ msgid ""
 "publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls"
-"\"] }\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -15328,8 +16430,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:50
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:53
@@ -15394,39 +16496,31 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:106
-#: src/exercises/concurrency/chat-app.md:140
-msgid "## Tasks"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:108
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:110
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
 
 #: src/async.md:1
-msgid "# Async Rust"
-msgstr "# Asyncの基礎"
+msgid "Async Rust"
+msgstr "Asyncの基礎"
 
 #: src/async.md:3
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
-"concurrently by\n"
-"executing each task until it would block, then switching to another task "
-"that is\n"
-"ready to make progress. The model allows running a larger number of tasks on "
-"a\n"
-"limited number of threads. This is because the per-task overhead is "
-"typically\n"
-"very low and operating systems provide primitives for efficiently "
-"identifying\n"
-"I/O that is able to proceed."
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 "「Async」は複数のタスクが並行処理される並行性モデルです。それぞれのタスクはブ"
 "ロックされるまで実行され、そして次に進むことのできる他のタスクに切り替えるこ"
@@ -15438,10 +16532,8 @@ msgstr ""
 #: src/async.md:10
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
-"that\n"
-"may be completed in the future. Futures are \"polled\" until they signal "
-"that\n"
-"they are complete."
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
 "Rustの非同期的な操作は「future」に基づいていて、これは将来に完了するかもしれ"
 "ない作業を表しています。Futureは、タスクが完了したことを知らせるシグナルが得"
@@ -15449,42 +16541,40 @@ msgstr ""
 
 #: src/async.md:14
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 "Futureは非同期的なランタイムによりポーリングされます。ランタイムにはいくつか"
 "の選択肢があります。"
 
 #: src/async.md:17
-msgid "## Comparisons"
-msgstr "## 他の言語との比較"
+msgid "Comparisons"
+msgstr "他の言語との比較"
 
 #: src/async.md:19
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type "
-"is\n"
-"   callback-based, and not polled. Async Python programs require a \"loop"
-"\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The "
-"language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
 msgstr ""
-" * Pythonには似たようなモデルが`asyncio`として搭載されています。しかし、ここ"
-"での`Future`型はコールバックに基づくものであって、ポーリングによるものではあ"
-"りません。Pythonの非同期プログラムは「ループ」を必要とし、Rustのランタイムに"
-"似ています。\n"
-"\n"
-" * JavaScriptの`Promise`は似ているものの、これもまたもやコールバックに基づき"
-"ます。\n"
-"   この言語のランタイムはイベントループにより実装されているため、多くの"
+"Pythonには似たようなモデルが`asyncio`として搭載されています。しかし、ここでの"
+"`Future`型はコールバックに基づくものであって、ポーリングによるものではありま"
+"せん。Pythonの非同期プログラムは「ループ」を必要とし、Rustのランタイムに似て"
+"います。"
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
+msgstr ""
+"JavaScriptの`Promise`は似ているものの、これもまたもやコールバックに基づきま"
+"す。 この言語のランタイムはイベントループにより実装されているため、多くの"
 "Promise解決の詳細は隠されています。"
 
 #: src/async/async-await.md:1
-msgid "# `async`/`await`"
-msgstr "# `async`/`await`"
+msgid "`async`/`await`"
+msgstr "`async`/`await`"
 
 #: src/async/async-await.md:3
 msgid ""
@@ -15517,64 +16607,67 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no "
-"long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the "
-"compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current "
-"thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. "
-"Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
-"* これは構文を示すための単純化された例であることに注意してください。長く実行"
-"されうる操作や本物の並行処理はここには含まれません。\n"
-"* 非同期の呼び出しの返り値の型は？\n"
-"  * 型を知るために`main`で`let future: () = async_main(10);`を使ってみてくだ"
-"さい。\n"
-"\n"
-"* 「async」キーワードは糖衣構文です。コンパイラは返り値をfutureに置き換えま"
-"す。\n"
-"\n"
-"* コンパイラに対して、返されたfutureの値をその後どう扱うべきかという、追加の"
-"指示を含めない限り、`main`をasyncにすることはできません。\n"
-"\n"
-"* 非同期のコードを実行するためには、エグゼキュータが必要です。`block_on`は、"
-"与えられたfutureが最後まで実行されるまで、現在のスレッドをブロックします。\n"
-"\n"
-"* `.await`は非同期的に他の操作の完了を待ちます。`block_on`とは異なり、`."
-"await`は現在のスレッドをブロックしません。\n"
-"\n"
-"* `.await`はasync関数(またはasync ブロック)の中でのみ利用できます。(async関"
-"数・ブロックについては後ほど紹介します。)"
+"これは構文を示すための単純化された例であることに注意してください。長く実行さ"
+"れうる操作や本物の並行処理はここには含まれません。"
 
-#: src/async/futures.md:1
-msgid "# Futures"
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr "非同期の呼び出しの返り値の型は？"
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
 msgstr ""
+"型を知るために`main`で`let future: () = async_main(10);`を使ってみてくださ"
+"い。"
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr ""
+"「async」キーワードは糖衣構文です。コンパイラは返り値をfutureに置き換えます。"
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr ""
+"コンパイラに対して、返されたfutureの値をその後どう扱うべきかという、追加の指"
+"示を含めない限り、`main`をasyncにすることはできません。"
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+"非同期のコードを実行するためには、エグゼキュータが必要です。`block_on`は、与"
+"えられたfutureが最後まで実行されるまで、現在のスレッドをブロックします。"
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+"`.await`は非同期的に他の操作の完了を待ちます。`block_on`とは異なり、`.await`"
+"は現在のスレッドをブロックしません。"
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr ""
+"`.await`はasync関数(またはasync ブロック)の中でのみ利用できます。(async関数・"
+"ブロックについては後ほど紹介します。)"
 
 #: src/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not "
-"be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 "[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)はトレイト"
 "であり、まだ完了してないかもしれない操作を表現するオブジェクトにより実装され"
@@ -15603,10 +16696,9 @@ msgstr ""
 #: src/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
-"uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` "
-"returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
 "非同期の関数は`impl Future`を返します。自分で定義した型に対して`Future`を実装"
 "することも（あまりないことですが）可能です。例えば、`tokio::spawn`から返され"
@@ -15616,80 +16708,83 @@ msgstr ""
 #: src/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
-"to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 "Futureに適用される`.await`キーワードは、そのFutureの準備ができるまで、現在の"
 "非同期の関数の一時停止を起こし、そしてその出力を評価します。"
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers "
-"into\n"
-"    that future remain valid. This is required to allow references to "
-"remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
-"* `Future`と`Poll`の型はまさに示されたように実装されます; ドキュメントの具体"
-"的な実装を見るにはリンクをクリックしてください。\n"
-"* `Pin`と`Context`については詳しくは扱いません。なぜなら、新しく非同期のプリ"
-"ミティブを作るよりも、非同期のコードを書くことに我々は重点を置くつもりだから"
-"です。完結には以下で説明されます：\n"
-"  * `Context`は、特定のイベントが発生した時に、Futureが自分自身を再びポーリン"
-"グされるようにスケジュールすることを可能にします。\n"
-"\n"
-"  * `Pin`はfutureへのポインタが有効であり続けるために、Futureがメモリの中で移"
-"動されないことを確実にします。これは、参照が`.await`の後に有効であり続けるた"
-"めに必要です。"
+"`Future`と`Poll`の型はまさに示されたように実装されます; ドキュメントの具体的"
+"な実装を見るにはリンクをクリックしてください。"
 
-#: src/async/runtimes.md:1
-msgid "# Runtimes"
-msgstr "# ランタイム"
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+"`Pin`と`Context`については詳しくは扱いません。なぜなら、新しく非同期のプリミ"
+"ティブを作るよりも、非同期のコードを書くことに我々は重点を置くつもりだからで"
+"す。完結には以下で説明されます："
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+"`Context`は、特定のイベントが発生した時に、Futureが自分自身を再びポーリングさ"
+"れるようにスケジュールすることを可能にします。"
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
+msgstr ""
+"`Pin`はfutureへのポインタが有効であり続けるために、Futureがメモリの中で移動さ"
+"れないことを確実にします。これは、参照が`.await`の後に有効であり続けるために"
+"必要です。"
 
 #: src/async/runtimes.md:3
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust "
-"does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
-"*runtime*は非同期な演算（*reactor*）のサポートを提供し、また、futureを実行す"
-"ること（*executor*）を担当しています。Rustには「ビルトイン」のランタイムはあ"
+"_runtime_は非同期な演算（_reactor_）のサポートを提供し、また、futureを実行す"
+"ること（_executor_）を担当しています。Rustには「ビルトイン」のランタイムはあ"
 "りませんが、いくつかのランタイムの選択肢があります: "
 
 #: src/async/runtimes.md:7
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem "
-"of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and "
-"includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
 msgstr ""
-" * [Tokio](https://tokio.rs/) - パフォーマンスが高い。HTTP向けの[Hyper]"
-"(https://hyper.rs/)やgRPC向けの[Tonic](https://github.com/hyperium/tonic)のよ"
-"うな発達したエコシステムも持っている\n"
-" * [async-std](https://async.rs/) - 「async」のための「std」であることを目指"
-"したもの。また、`async::task`に基本的なランタイムを含む。\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - シンプルで軽量"
+"[Tokio](https://tokio.rs/) - パフォーマンスが高い。HTTP向けの[Hyper](https://"
+"hyper.rs/)やgRPC向けの[Tonic](https://github.com/hyperium/tonic)のような発達"
+"したエコシステムも持っている"
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+"[async-std](https://async.rs/) - 「async」のための「std」であることを目指した"
+"もの。また、`async::task`に基本的なランタイムを含む。"
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+msgstr "[smol](https://docs.rs/smol/latest/smol/) - シンプルで軽量"
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 "いくつかのより巨大なアプリケーションは、独自のランタイムを備えています。例え"
 "ば[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/"
@@ -15697,43 +16792,41 @@ msgstr ""
 
 #: src/async/runtimes.md:20
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most "
-"interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/"
-"O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are "
-"never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
-"* 上で挙げられたランタイムのうち、TokioのみがRustプレイグラウンドでサポートさ"
-"れています。このプレイグラウンドではいかなる入出力操作も許可されていないた"
-"め、大抵の興味深い非同期のあれこれは、プレイグラウンドで実行することはできま"
-"せん。\n"
-"* Futureは、ポーリングを行うエグゼキュータの存在なしには何も行わない（入出力"
-"操作さえ始めない）という点で「怠惰」です。例えば、これは、エグゼキュータがな"
-"くとも最後まで実行されるJavaScriptのPromiseとは異なります。"
+"上で挙げられたランタイムのうち、TokioのみがRustプレイグラウンドでサポートされ"
+"ています。このプレイグラウンドではいかなる入出力操作も許可されていないため、"
+"大抵の興味深い非同期のあれこれは、プレイグラウンドで実行することはできませ"
+"ん。"
 
-#: src/async/runtimes/tokio.md:1
-msgid "# Tokio"
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
 msgstr ""
+"Futureは、ポーリングを行うエグゼキュータの存在なしには何も行わない（入出力操"
+"作さえ始めない）という点で「怠惰」です。例えば、これは、エグゼキュータがなく"
+"とも最後まで実行されるJavaScriptのPromiseとは異なります。"
 
 #: src/async/runtimes/tokio.md:4
 msgid "Tokio provides: "
 msgstr "Tokioは以下を提供します: "
 
 #: src/async/runtimes/tokio.md:6
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
-msgstr ""
-"* 非同期のコードを実行するためのマルチスレッドのランタイム。\n"
-"* 標準ライブラリの非同期バージョン。\n"
-"* 大きなライブラリのエコシステム。"
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr "非同期のコードを実行するためのマルチスレッドのランタイム。"
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr "標準ライブラリの非同期バージョン。"
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
+msgstr "大きなライブラリのエコシステム。"
 
 #: src/async/runtimes/tokio.md:10
 msgid ""
@@ -15760,18 +16853,18 @@ msgid ""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr "`tokio::main`のマクロにより、`main`の非同期処理を作ることができます。"
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr "`spawn`関数は新しい並行の「タスク」を作成します。"
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
-"* `tokio::main`のマクロにより、`main`の非同期処理を作ることができます。\n"
-"\n"
-"* `spawn`関数は新しい並行の「タスク」を作成します。\n"
-"* 注意：`spawn`は`Future`を引数に取るため、`count_to`に対して`.await`を呼ぶこ"
-"とはありません。"
+"注意：`spawn`は`Future`を引数に取るため、`count_to`に対して`.await`を呼ぶこと"
+"はありません。"
 
 #: src/async/runtimes/tokio.md:39
 msgid "**Further exploration:**"
@@ -15779,29 +16872,27 @@ msgstr "**さらなる探求:**"
 
 #: src/async/runtimes/tokio.md:41
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to "
-"wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
-"* どうして`count_to`は（通常は）10に辿り着かないのでしょうか？これは非同期処"
-"理のキャンセルの例です。 `tokio::spawn`は完了まで待機するためのハンドラを返し"
-"ます。\n"
-"* プロセスを新しく作る代わりに、`count_to(10).await`を試してみてください。\n"
-"* `tokio::spawn`から返されたタスクを待機してみてください。"
+"どうして`count_to`は（通常は）10に辿り着かないのでしょうか？これは非同期処理"
+"のキャンセルの例です。 `tokio::spawn`は完了まで待機するためのハンドラを返しま"
+"す。"
 
-#: src/async/tasks.md:1
-msgid "# Tasks"
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
 msgstr ""
+"プロセスを新しく作る代わりに、`count_to(10).await`を試してみてください。"
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
+msgstr "`tokio::spawn`から返されたタスクを待機してみてください。"
 
 #: src/async/tasks.md:3
 msgid ""
-"Runtimes have the concept of a \"task\", similar to a thread but much\n"
-"less resource-intensive."
+"Runtimes have the concept of a \"task\", similar to a thread but much less "
+"resource-intensive."
 msgstr ""
 "ランタイムには「タスク」という概念があり、スレッドに似ているものの、スレッド"
 "よりリソースの消費ははるかに小さいです。"
@@ -15809,12 +16900,10 @@ msgstr ""
 #: src/async/tasks.md:6
 msgid ""
 "A task has a single top-level future which the executor polls to make "
-"progress.\n"
-"That future may have one or more nested futures that its `poll` method "
-"polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible "
-"by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
 "タスクには、単一のトップレベルのfutureがあり、これはエグゼキュータが先に進む"
 "ためにポーリングする対象となります。そのfutureには一つまたは複数のfutureがネ"
@@ -15875,30 +16964,30 @@ msgstr ""
 
 #: src/async/tasks.md:55
 msgid ""
-"* Ask students to visualize what the state of the example server would be "
-"with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling "
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
+msgstr ""
+"例のサーバーがどのような状態の時に、いくつかのクライアントと接続された状態に"
+"あるのかを、可視化するように受講者に指示してください。どんなタスクが存在して"
+"いますか？それらのfutureは何ですか？"
+
+#: src/async/tasks.md:58
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+"私たちが`async`ブロックを見かけるのは初めてですね。これはクロージャと似ていま"
+"すが、何も引数は取りません。この返り値はFutureであり、`async fn`と似ていま"
+"す。"
+
+#: src/async/tasks.md:62
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
 "using `?`."
 msgstr ""
-"* 例のサーバーがどのような状態の時に、いくつかのクライアントと接続された状態"
-"にあるのかを、可視化するように受講者に指示してください。どんなタスクが存在し"
-"ていますか？それらのfutureは何ですか？\n"
-"\n"
-"* 私たちが`async`ブロックを見かけるのは初めてですね。これはクロージャと似てい"
-"ますが、何も引数は取りません。この返り値はFutureであり、`async fn`と似ていま"
-"す。\n"
-"* mainのasyncブロックを関数にリファクタして、`?`を使ったエラーハンドリングを"
-"改善してみましょう。"
-
-#: src/async/channels.md:1
-msgid "# Async Channels"
-msgstr "# Asyncチャネル"
+"mainのasyncブロックを関数にリファクタして、`?`を使ったエラーハンドリングを改"
+"善してみましょう。"
 
 #: src/async/channels.md:3
 msgid ""
@@ -15941,64 +17030,67 @@ msgid ""
 msgstr ""
 
 #: src/async/channels.md:35
-msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be "
-"convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to "
-"combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+msgid "Change the channel size to `3` and see how it affects the execution."
 msgstr ""
-"* チャネルサイズを `3`に変えてみて、これがどのように処理に影響するか確認して"
-"みましょう。\n"
-"\n"
-"* 一般的に、このインターフェースは、[朝の講座](concurrency/channels.md)で見ら"
-"れたような`sync`チャネルに似ています。\n"
-"* `std::mem::drop`の呼び出しを除いてみましょう。何か起こるでしょうか？それは"
-"なぜでしょうか？\n"
-"\n"
-"* [Flume](https://docs.rs/flume/latest/flume/)クレートには`sync`と`async`や"
-"`send`と`recv`の両方を実装するチャネルがあります。\n"
-"これは入出力と重いCPUの処理のタスクの両方を含む、複雑なアプリケーションで便利"
-"です。\n"
-"* `async`チャネルを扱うことを好ましくするのは、チャネルと繋げるためにや、複雑"
-"なコントロールフローを作るために、チャネルを他の`future`と繋げられることで"
-"す。"
+"チャネルサイズを `3`に変えてみて、これがどのように処理に影響するか確認してみ"
+"ましょう。"
+
+#: src/async/channels.md:37
+msgid ""
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+"一般的に、このインターフェースは、[朝の講座](concurrency/channels.md)で見られ"
+"たような`sync`チャネルに似ています。"
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+"`std::mem::drop`の呼び出しを除いてみましょう。何か起こるでしょうか？それはな"
+"ぜでしょうか？"
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+"[Flume](https://docs.rs/flume/latest/flume/)クレートには`sync`と`async`や"
+"`send`と`recv`の両方を実装するチャネルがあります。 これは入出力と重いCPUの処"
+"理のタスクの両方を含む、複雑なアプリケーションで便利です。"
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
+msgstr ""
+"`async`チャネルを扱うことを好ましくするのは、チャネルと繋げるためにや、複雑な"
+"コントロールフローを作るために、チャネルを他の`future`と繋げられることです。"
 
 #: src/async/control-flow.md:1
-msgid "# Futures Control Flow"
+msgid "Futures Control Flow"
 msgstr ""
 
 #: src/async/control-flow.md:3
 msgid ""
 "Futures can be combined together to produce concurrent compute flow graphs. "
-"We\n"
-"have already seen tasks, that function as independent threads of execution."
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
 
 #: src/async/control-flow.md:6
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
 msgstr ""
 
-#: src/async/control-flow/join.md:1
-msgid "# Join"
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
 msgstr ""
 
 #: src/async/control-flow/join.md:3
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
@@ -16034,43 +17126,39 @@ msgstr ""
 
 #: src/async/control-flow/join.md:38
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` "
-"but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this "
-"would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all "
-"requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but "
-"demonstrates `join!`."
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/select.md:1
-msgid "# Select"
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
+"demonstrates `join!`."
 msgstr ""
 
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
 msgid ""
 "This is usually a macro, similar to match, with each arm of the form "
-"`pattern =\n"
-"future => statement`. When the future is ready, the statement is executed "
-"with the\n"
-"variable bound to the future's result."
+"`pattern = future => statement`. When the future is ready, the statement is "
+"executed with the variable bound to the future's result."
 msgstr ""
 
 #: src/async/control-flow/select.md:12
@@ -16125,29 +17213,34 @@ msgstr ""
 
 #: src/async/control-flow/select.md:61
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick "
-"whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are "
-"supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts "
-"of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` moves the values it is given. It is easiest to use\n"
-"  when every execution of `select!` creates new futures. An alternative is "
-"to\n"
-"  pass `&mut future` instead of the future itself, but this can lead to\n"
-"  issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
+msgstr ""
+
+#: src/async/control-flow/select.md:66
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+
+#: src/async/control-flow/select.md:69
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:72
+msgid ""
+"Note that `select!` moves the values it is given. It is easiest to use when "
+"every execution of `select!` creates new futures. An alternative is to pass "
+"`&mut future` instead of the future itself, but this can lead to issues, "
+"further discussed in the pinning slide."
 msgstr ""
 
 #: src/async/pitfalls.md:1
-msgid "# Pitfalls of async/await"
+msgid "Pitfalls of async/await"
 msgstr ""
 
 #: src/async/pitfalls.md:3
@@ -16159,22 +17252,27 @@ msgid ""
 msgstr ""
 
 #: src/async/pitfalls.md:5
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfall/async-traits.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfall/async-traits.md)"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:1
-msgid "# Blocking the executor"
+msgid "Blocking the executor"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:3
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other "
-"tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:7
@@ -16202,58 +17300,57 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its "
-"result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an "
-"actual\n"
-"  thread and transforms its handle into a future without blocking the "
-"executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and "
-"most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, "
-"where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
-"situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause "
-"another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:1
-msgid "# Pin"
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
 "When you await a future, all local variables (that would ordinarily be "
-"stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. "
-"If your\n"
-"future has pointers to data on the stack, those pointers might get "
-"invalidated.\n"
-"This is unsafe."
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:8
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to "
-"don't\n"
+"Therefore, you must guarantee that the addresses your future points to don't "
 "change. That is why we need to `pin` futures. Using the same future "
-"repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:12
@@ -16315,60 +17412,78 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your "
-"time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!"
-"(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the "
-"`loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to "
-"the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on "
-"every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, "
-"but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that "
-"will send to a `oneshot` channel every 100ms."
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:1
-msgid "# Async Traits"
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:3
@@ -16431,26 +17546,25 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:49
-msgid "<details>  "
-msgstr ""
-
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations "
-"to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of "
-"time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:3
@@ -16460,32 +17574,32 @@ msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
-"* Dining philosophers: we already saw this problem in the morning. This "
-"time\n"
-"  you are going to implement it with Async Rust.\n"
-"\n"
-"* A Broadcast Chat Application: this is a larger project that allows you\n"
-"  experiment with more advanced Async Rust features."
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr ""
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
-msgid "# Dining Philosophers - Async"
+#: src/exercises/concurrency/solutions-afternoon.md:3
+msgid "Dining Philosophers - Async"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the\n"
+"See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 msgid ""
-"As before, you will need a local\n"
-"[Cargo installation](../../cargo/running-locally.md) for this exercise. "
-"Copy\n"
-"the code below to a file called `src/main.rs`, fill out the blanks, and "
-"test\n"
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
@@ -16538,7 +17652,7 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
 msgid ""
-"Since this time you are using Async Rust, you'll need a `tokio` dependency.\n"
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
@@ -16558,33 +17672,29 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:72
 msgid ""
-"Also note that this time you have to use the `Mutex` and the `mpsc` module\n"
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "* Can you make your implementation single-threaded? "
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:1
-msgid "# Broadcast Chat Application"
+msgid "Can you make your implementation single-threaded? "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
 msgid ""
-"In this exercise, we want to use our new knowledge to implement a broadcast\n"
+"In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
-"publish\n"
-"their messages. The client reads user messages from the standard input, and\n"
-"sends them to the server. The chat server broadcasts each message that it\n"
-"receives to all the clients."
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel][1] on the server, and\n"
-"[`tokio_websockets`][2] for the communication between the client and the\n"
-"server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:13
@@ -16612,57 +17722,69 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:32
-msgid "## The required APIs"
+msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
-"You are going to need the following functions from `tokio` and\n"
-"[`tokio_websockets`][2]. Spend a few minutes to familiarize yourself with "
-"the\n"
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
 "API. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
-"- [WebsocketStream::next()][3]: for asynchronously reading messages from a\n"
-"  Websocket Stream.\n"
-"- [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously\n"
-"  sending messages on a Websocket Stream.\n"
-"- [BufReader::read_line()][5]: for asynchronously reading user messages\n"
-"  from the standard input.\n"
-"- [Sender::subscribe()][6]: for subscribing to a broadcast channel."
+"[WebsocketStream::next()](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/proto/struct.WebsocketStream.html#method.next): for "
+"asynchronously reading messages from a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:41
+msgid ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
-msgid "## Two binaries"
+msgid "Two binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one\n"
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client,\n"
-"and one for the server. You could potentially make them two separate Cargo\n"
-"projects, but we are going to put them in a single Cargo project with two\n"
-"binaries. For this to work, the client and the server code should go under\n"
-"`src/bin` (see the [documentation][7]). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and\n"
-"`src/bin/client.rs`, respectively. Your task is to complete these files as\n"
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:59
 #: src/exercises/concurrency/solutions-afternoon.md:117
 msgid "`src/bin/server.rs`:"
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:61
-msgid "<!-- File src/bin/server.rs -->"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:63
@@ -16712,10 +17834,6 @@ msgstr ""
 msgid "`src/bin/client.rs`:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:104
-msgid "<!-- File src/bin/client.rs -->"
-msgstr ""
-
 #: src/exercises/concurrency/chat-app.md:106
 msgid ""
 "```rust,compile_fail\n"
@@ -16742,7 +17860,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:127
-msgid "## Running the binaries"
+msgid "Running the binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:128
@@ -16768,58 +17886,60 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:142
-msgid ""
-"* Implement the `handle_connection` function in `src/bin/server.rs`.\n"
-"  * Hint: Use `tokio::select!` for concurrently performing two tasks in a\n"
-"    continuous loop. One task receives messages from the client and "
-"broadcasts\n"
-"    them. The other sends messages received by the server to the client.\n"
-"* Complete the main function in `src/bin/client.rs`.\n"
-"  * Hint: As before, use `tokio::select!` in a continuous loop for "
-"concurrently\n"
-"    performing two tasks: (1) reading user messages from standard input and\n"
-"    sending them to the server, and (2) receiving messages from the server, "
-"and\n"
-"    displaying them for the user.\n"
-"* Optional: Once you are done, change the code to broadcast messages to all\n"
-"  clients, but the sender of the message."
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/thanks.md:1
-msgid "# Thanks!"
+#: src/exercises/concurrency/chat-app.md:143
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:147
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:151
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
 msgstr ""
 
 #: src/thanks.md:3
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
-"it\n"
-"was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
 msgstr ""
 
 #: src/thanks.md:6
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 
 #: src/other-resources.md:1
-msgid "# Other Rust Resources"
+msgid "Other Rust Resources"
 msgstr ""
 
 #: src/other-resources.md:3
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 
 #: src/other-resources.md:6
-msgid "## Official Documentation"
+msgid "Official Documentation"
 msgstr ""
 
 #: src/other-resources.md:8
@@ -16828,22 +17948,29 @@ msgstr ""
 
 #: src/other-resources.md:10
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
+msgstr ""
+
+#: src/other-resources.md:13
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+
+#: src/other-resources.md:17
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+
+#: src/other-resources.md:19
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
 msgstr ""
 
 #: src/other-resources.md:22
@@ -16852,22 +17979,27 @@ msgstr ""
 
 #: src/other-resources.md:24
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
+msgstr ""
+
+#: src/other-resources.md:27
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+
+#: src/other-resources.md:30
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
 msgstr ""
 
 #: src/other-resources.md:33
-msgid "## Unofficial Learning Material"
+msgid "Unofficial Learning Material"
 msgstr ""
 
 #: src/other-resources.md:35
@@ -16876,110 +18008,105 @@ msgstr ""
 
 #: src/other-resources.md:37
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
+msgstr ""
+
+#: src/other-resources.md:39
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+
+#: src/other-resources.md:42
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+
+#: src/other-resources.md:45
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+
+#: src/other-resources.md:47
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+
+#: src/other-resources.md:52
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
 msgstr ""
 
 #: src/other-resources.md:63
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
-msgstr ""
-
-#: src/credits.md:1
-msgid "# Credits"
+"for even more Rust books."
 msgstr ""
 
 #: src/credits.md:3
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
 
 #: src/credits.md:7
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
 msgstr ""
 
 #: src/credits.md:10
-msgid "## Rust by Example"
+msgid "Rust by Example"
 msgstr ""
 
 #: src/credits.md:12
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
 
 #: src/credits.md:17
-msgid "## Rust on Exercism"
+msgid "Rust on Exercism"
 msgstr ""
 
 #: src/credits.md:19
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
 
 #: src/credits.md:24
-msgid "## CXX"
+msgid "CXX"
 msgstr ""
 
 #: src/credits.md:26
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
-msgstr ""
-
-#: src/exercises/solutions.md:1
-msgid "# Solutions"
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 
 #: src/exercises/solutions.md:3
@@ -16988,25 +18115,20 @@ msgstr ""
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
 
 #: src/exercises/solutions.md:10
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:1
-msgid "# Day 1 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:3
-msgid "## Arrays and `for` Loops"
+msgid "Day 1 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:5
@@ -17089,7 +18211,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
-msgid "### Bonus question"
+msgid "Bonus question"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:80
@@ -17110,7 +18232,8 @@ msgstr ""
 #: src/exercises/day-1/solutions-morning.md:84
 msgid ""
 "Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:86
@@ -17150,11 +18273,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
-msgid "# Day 1 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-msgid "## Designing a Library"
+msgid "Day 1 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:5
@@ -17242,8 +18361,8 @@ msgid ""
 "\n"
 "    // ANCHOR: Library_print_books\n"
 "    //fn print_books(self) {\n"
-"    //    todo!(\"Iterate over `self.books` and each book's title and year"
-"\")\n"
+"    //    todo!(\"Iterate over `self.books` and each book's title and "
+"year\")\n"
 "    //}\n"
 "    // ANCHOR_END: Library_print_books\n"
 "    fn print_books(&self) {\n"
@@ -17357,11 +18476,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
-msgid "# Day 2 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:3
-msgid "## Points and Polygons"
+msgid "Day 2 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:5
@@ -17601,11 +18716,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
-msgid "# Day 2 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-msgid "## Luhn Algorithm"
+msgid "Day 2 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:5
@@ -17706,10 +18817,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:97
-msgid "## Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/solutions-afternoon.md:99
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
@@ -17759,13 +18866,13 @@ msgid ""
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
 "abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books"
-"\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers"
-"\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -17783,8 +18890,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers"
-"\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -17797,11 +18904,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
-msgid "# Day 3 Morning Exercise"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:3
-msgid "## A Simple GUI Library"
+msgid "Day 3 Morning Exercise"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:5
@@ -17981,11 +19084,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
-msgid "# Day 3 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-msgid "## Safe FFI Wrapper"
+msgid "Day 3 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:5
@@ -18150,8 +19249,8 @@ msgid ""
 "    #[test]\n"
 "    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
 "        let tmp = tempfile::TempDir::new()?;\n"
-"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo Diaries\\n"
-"\")?;\n"
+"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo "
+"Diaries\\n\")?;\n"
 "        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n\")?;\n"
 "        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n\")?;\n"
 "        let iter = DirectoryIterator::new(\n"
@@ -18168,11 +19267,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-msgid "## Compass"
+msgid "Bare Metal Rust Morning Exercise"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:5
@@ -18344,14 +19439,6 @@ msgid ""
 "    max(min_value, min(value, max_value))\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "# Bare Metal Rust Afternoon"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-msgid "## RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -18648,11 +19735,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
-msgid "# Concurrency Morning Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:3
-msgid "## Dining Philosophers"
+msgid "Concurrency Morning Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:5
@@ -18760,11 +19843,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
-msgid "# Concurrency Afternoon Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:3
-msgid "## Dining Philosophers - Async"
+msgid "Concurrency Afternoon Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:5
@@ -18883,10 +19962,6 @@ msgid ""
 "    }\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:113
-msgid "## Broadcast Chat Application"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:115


### PR DESCRIPTION
Before, po/ja.po had these statistics:

    351 translated messages, 32 fuzzy translations, 1398 untranslated messages.

Afterwards, the statistics for po/ja.po is:

    472 translated messages, 46 fuzzy translations, 1949 untranslated messages.

The number of translated messages changed from 20% to 19%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.