### PR TITLE
ko: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -5,38 +5,37 @@ msgstr ""
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.2.2\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Comprehensive Rust에 오신 것을 환영합니다 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "강의 진행"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "강의 구성"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/day-4.md:1
 msgid "Day 4"
 msgstr "4일차"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "단축키"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "다른 언어들"
 
-#: src/SUMMARY.md:9
+#: src/SUMMARY.md:9 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "카고 사용하기"
 
@@ -60,55 +59,55 @@ msgstr "1일차 오전"
 msgid "Welcome"
 msgstr "개요"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "러스트란?"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Hello World!"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "작은 예제"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "러스트를 써야하는 이유"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "컴파일 시 보장되는 것들"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "런타임 시 보장되는 것들"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "현대적인 특징"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "기본 문법"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "스칼라 타입"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "복합 타입"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "참조"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "허상(dangling) 참조"
 
-#: src/SUMMARY.md:32
+#: src/SUMMARY.md:32 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "슬라이스"
 
@@ -116,11 +115,12 @@ msgstr "슬라이스"
 msgid "String vs str"
 msgstr "String과 str"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "함수"
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "메서드"
 
@@ -130,10 +130,11 @@ msgstr "오버로딩"
 
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:176 src/SUMMARY.md:199 src/SUMMARY.md:226
+#: src/exercises/day-4/morning.md:1 src/exercises/day-4/android.md:1
 msgid "Exercises"
 msgstr "연습문제"
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "묵시적 형변환"
 
@@ -145,11 +146,11 @@ msgstr "배열과 for 반복문"
 msgid "Day 1: Afternoon"
 msgstr "1일차 오후"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "변수"
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "타입 추론"
 
@@ -157,11 +158,11 @@ msgstr "타입 추론"
 msgid "static & const"
 msgstr "정적변수(static)와 상수(const)"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "범위(Scopes)와 쉐도잉(Shadowing)"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "메모리 관리"
 
@@ -169,15 +170,15 @@ msgstr "메모리 관리"
 msgid "Stack vs Heap"
 msgstr "스택(Stack)과 힙(Heap)"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "스택 메모리"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "수동 메모리 관리"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "범위기반 메모리 관리"
 
@@ -189,59 +190,60 @@ msgstr "가비지 컬렉션"
 msgid "Rust Memory Management"
 msgstr "러스트의 메모리 관리"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "비교"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
 msgstr "소유권"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "Move 문법"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "러스트에서의 문자열 이동"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "Modern C++에서 이중해제 문제"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "함수 호출에서의 이동(Move)"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "복사와 복제"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "빌림"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "공유와 고유 빌림"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "수명"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "함수 호출에서의 수명"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "구조체에서의 수명"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr "도서관 설계"
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "반복자와 소유권"
 
@@ -249,63 +251,64 @@ msgstr "반복자와 소유권"
 msgid "Day 2: Morning"
 msgstr "2일차 오전"
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
 msgstr "구조체"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "튜플"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "필드 할당 단축 문법"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
 msgstr "열거형"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "데이터를 포함하는 열거형(Variant Payloads)"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "열거형의 크기"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "메서드 리시버(Receiver)"
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:194
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "예제"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "패턴 매칭"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "열거형 분해(역구조화)"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "구조체 분해(역구조화)"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "배열 분해(역구조화)"
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "매치 가드"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "건강상태 모니터링 시스템"
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "점과 다각형"
 
@@ -313,11 +316,11 @@ msgstr "점과 다각형"
 msgid "Day 2: Afternoon"
 msgstr "2일차 오후"
 
-#: src/SUMMARY.md:96
+#: src/SUMMARY.md:96 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "흐름 제어"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "블록"
 
@@ -353,7 +356,7 @@ msgstr "match 표현식"
 msgid "break & continue"
 msgstr "break와 continue"
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
 msgstr "표준 라이브러리"
 
@@ -361,7 +364,7 @@ msgstr "표준 라이브러리"
 msgid "Option and Result"
 msgstr "Option과 Result"
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
 msgstr "String"
 
@@ -381,7 +384,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "재귀적 자료구조"
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "니치(틈새) 최적화(Niche Optimization)"
 
@@ -389,27 +392,29 @@ msgstr "니치(틈새) 최적화(Niche Optimization)"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr "모듈"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "가시성"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr "경로"
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "파일시스템 계층"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "룬 알고리즘"
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:98
 msgid "Strings and Iterators"
 msgstr "문자열과 반복자"
 
@@ -417,19 +422,19 @@ msgstr "문자열과 반복자"
 msgid "Day 3: Morning"
 msgstr "3일차 오전"
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/traits.md:1
 msgid "Traits"
 msgstr "트레잇(Trait)"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "트레잇 상속하기"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "기본 메서드"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "중요한 트레잇"
 
@@ -437,7 +442,7 @@ msgstr "중요한 트레잇"
 msgid "Iterator"
 msgstr "Iterator"
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -461,19 +466,19 @@ msgstr "Drop"
 msgid "Default"
 msgstr "Default"
 
-#: src/SUMMARY.md:140
+#: src/SUMMARY.md:140 src/generics.md:1
 msgid "Generics"
 msgstr "제네릭"
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "제네릭 데이터 타입"
 
-#: src/SUMMARY.md:142
+#: src/SUMMARY.md:142 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "제네릭 메서드"
 
-#: src/SUMMARY.md:143
+#: src/SUMMARY.md:143 src/generics/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "제네릭 타입 제한(트레잇 경계)"
 
@@ -481,19 +486,20 @@ msgstr "제네릭 타입 제한(트레잇 경계)"
 msgid "impl Trait"
 msgstr "트레잇 구현하기"
 
-#: src/SUMMARY.md:145
+#: src/SUMMARY.md:145 src/generics/closures.md:1
 msgid "Closures"
 msgstr "클로저"
 
-#: src/SUMMARY.md:146
+#: src/SUMMARY.md:146 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "단형화"
 
-#: src/SUMMARY.md:147
+#: src/SUMMARY.md:147 src/generics/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "트레잇 객체"
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "간단한 GUI 라이브러리"
 
@@ -501,11 +507,11 @@ msgstr "간단한 GUI 라이브러리"
 msgid "Day 3: Afternoon"
 msgstr "3일차 오후"
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "오류처리"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "패닉"
 
@@ -521,63 +527,64 @@ msgstr "구조화된 오류처리"
 msgid "Propagating Errors with ?"
 msgstr "'?'를 이용한 오류 전파"
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "오류타입 변환"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "또다른 오류 열거형"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "동적인 에러 타입"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "오류에 상황정보 추가"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
 msgstr "테스트"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "단위 테스트"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "테스트 모듈"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "문서화주석 테스트"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "통합 테스트"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "안전하지 않은 러스트"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "원시 포인터 역참조(따라가기)"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "정적 가변 변수"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "Unions"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "안전하지 않은 함수 호출"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "안전하지 않은 함수 작성하기"
 
@@ -585,11 +592,12 @@ msgstr "안전하지 않은 함수 작성하기"
 msgid "Extern Functions"
 msgstr "외부(다른언어) 함수들"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:175 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "안전하지 않은 트레잇 구현하기"
 
-#: src/SUMMARY.md:177
+#: src/SUMMARY.md:177 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "FFI래퍼"
 
@@ -601,27 +609,27 @@ msgstr "4일차 오전"
 msgid "Concurrency"
 msgstr "동시성"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "스레드"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "범위 스레드(Scoped Threads)"
 
-#: src/SUMMARY.md:188
+#: src/SUMMARY.md:188 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "채널"
 
-#: src/SUMMARY.md:189
+#: src/SUMMARY.md:189 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "무경계 채널"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "경계 채널"
 
-#: src/SUMMARY.md:191
+#: src/SUMMARY.md:191 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "상태 공유"
 
@@ -645,15 +653,16 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "예제"
 
-#: src/SUMMARY.md:200
+#: src/SUMMARY.md:200 src/exercises/day-4/dining-philosophers.md:1
+#: src/exercises/day-4/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "식사하는 철학자들"
 
-#: src/SUMMARY.md:201
+#: src/SUMMARY.md:201 src/exercises/day-4/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "멀티스레드 링크 검사기"
 
@@ -661,15 +670,15 @@ msgstr "멀티스레드 링크 검사기"
 msgid "Day 4: Afternoon (Android)"
 msgstr "4일차 오후 (안드로이드)"
 
-#: src/SUMMARY.md:203
+#: src/SUMMARY.md:203 src/running-the-course/day-4.md:15 src/android.md:1
 msgid "Android"
 msgstr "안드로이드"
 
-#: src/SUMMARY.md:208
+#: src/SUMMARY.md:208 src/android/setup.md:1
 msgid "Setup"
 msgstr "설치"
 
-#: src/SUMMARY.md:209
+#: src/SUMMARY.md:209 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "빌드 규칙"
 
@@ -681,7 +690,7 @@ msgstr "바이너리"
 msgid "Library"
 msgstr "라이브러리"
 
-#: src/SUMMARY.md:212
+#: src/SUMMARY.md:212 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -697,7 +706,7 @@ msgstr "서비스 구현"
 msgid "Server"
 msgstr "AIDL 서버"
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "배포"
 
@@ -705,15 +714,15 @@ msgstr "배포"
 msgid "Client"
 msgstr "클라이언트"
 
-#: src/SUMMARY.md:218
+#: src/SUMMARY.md:218 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "API 수정"
 
-#: src/SUMMARY.md:219
+#: src/SUMMARY.md:219 src/android/logging.md:1
 msgid "Logging"
 msgstr "로깅"
 
-#: src/SUMMARY.md:220
+#: src/SUMMARY.md:220 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "상호운용성"
 
@@ -729,7 +738,7 @@ msgstr "Bindgen을 사용한 C호출"
 msgid "Calling Rust from C"
 msgstr "C에서 러스트 호출"
 
-#: src/SUMMARY.md:224
+#: src/SUMMARY.md:224 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "C++와의 상호운용성"
 
@@ -741,7 +750,7 @@ msgstr "Java와의 상호운용성"
 msgid "Final Words"
 msgstr "끝으로..."
 
-#: src/SUMMARY.md:230
+#: src/SUMMARY.md:230 src/thanks.md:1
 msgid "Thanks!"
 msgstr "감사인사"
 
@@ -749,11 +758,11 @@ msgstr "감사인사"
 msgid "Other Resources"
 msgstr "러스트 참고 자료"
 
-#: src/SUMMARY.md:232
+#: src/SUMMARY.md:232 src/credits.md:1
 msgid "Credits"
 msgstr "도와주신 분들"
 
-#: src/SUMMARY.md:236
+#: src/SUMMARY.md:236 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "해답"
 
@@ -785,12 +794,11 @@ msgstr "3일차 오후"
 msgid "Day 4 Morning"
 msgstr "4일차 오전"
 
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Welcome to Comprehensive Rust 🦀"
-
 #: src/welcome.md:3
-msgid "[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml)"
+msgid ""
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
+"google/comprehensive-rust/actions/workflows/build.yml)"
 msgstr ""
 
 #: src/welcome.md:3
@@ -799,11 +807,19 @@ msgstr "빌드 워크플로"
 
 #: src/welcome.md:3
 msgid ""
-"[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
+"google/comprehensive-rust/actions/workflows/build.yml) [![GitHub "
+"contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors)"
 msgstr ""
-"[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
+"google/comprehensive-rust/actions/workflows/build.yml) [![GitHub "
+"contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors)"
 
 #: src/welcome.md:4
 msgid "GitHub contributors"
@@ -811,246 +827,167 @@ msgstr "GitHub 참여자"
 
 #: src/welcome.md:4
 msgid ""
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
+"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
+"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 
 #: src/welcome.md:5
 msgid "GitHub stars"
 msgstr "GitHub stars"
 
 #: src/welcome.md:5
-msgid "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
-msgstr "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
+msgid ""
+"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
+"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
+"stargazers)"
+msgstr ""
+"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
+"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
+"stargazers)"
 
 #: src/welcome.md:7
 msgid ""
-"This is a four day Rust course developed by the Android team. The course covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like generics\n"
-"and error handling. It also includes Android-specific content on the last day."
-msgstr "이 4일짜리 러스트 강의는 안드로이드 팀이 만들었습니다. 기본 문법부터 제네릭, 에러 핸들링과 같은 고급주제까지 러스트의 모든 것을 포함합니다. 마지막 날에는 안드로이드에 대한 것 까지 다룹니다."
+"This is a four day Rust course developed by the Android team. The course "
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
+msgstr ""
+"이 4일짜리 러스트 강의는 안드로이드 팀이 만들었습니다. 기본 문법부터 제네릭, "
+"에러 핸들링과 같은 고급주제까지 러스트의 모든 것을 포함합니다. 마지막 날에는 "
+"안드로이드에 대한 것 까지 다룹니다."
 
 #: src/welcome.md:11
 msgid ""
-"The goal of the course is to teach you Rust. We assume you don't know anything\n"
-"about Rust and hope to:"
-msgstr "강의는 당신이 러스트에 대해서 아무것도 모른다고 가정하고 아래의 목표를 가지고 있습니다:"
+"The goal of the course is to teach you Rust. We assume you don't know "
+"anything about Rust and hope to:"
+msgstr ""
+"강의는 당신이 러스트에 대해서 아무것도 모른다고 가정하고 아래의 목표를 가지"
+"고 있습니다:"
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
-msgstr ""
-"* 러스트 구문과 언어에 대한 포괄적인 이해를 제공합니다.\n"
-"* 기존 프로그램을 수정하고 러스트에서 새 프로그램을 작성할 수 있습니다.\n"
-"* 일반적인 러스트 관용구를 보여줍니다."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
+msgstr "러스트 구문과 언어에 대한 포괄적인 이해를 제공합니다."
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr "기존 프로그램을 수정하고 러스트에서 새 프로그램을 작성할 수 있습니다."
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
+msgstr "일반적인 러스트 관용구를 보여줍니다."
 
 #: src/welcome.md:18
 msgid "On Day 4, we will cover Android-specific things such as:"
 msgstr "4일차 강의에 우리는 아래와 같은 안드로이드 특화된 내용들도 설명합니다:"
 
 #: src/welcome.md:20
-msgid ""
-"* Building Android components in Rust.\n"
-"* AIDL servers and clients.\n"
-"* Interoperability with C, C++, and Java."
-msgstr ""
-"* 러스트에서 Android 구성 요소를 구축.\n"
-"* AIDL 서버 및 클라이언트.\n"
-"* C, C++ 및 Java와의 상호 운용성."
+msgid "Building Android components in Rust."
+msgstr "러스트에서 Android 구성 요소를 구축."
+
+#: src/welcome.md:21
+msgid "AIDL servers and clients."
+msgstr "AIDL 서버 및 클라이언트."
+
+#: src/welcome.md:22
+msgid "Interoperability with C, C++, and Java."
+msgstr "C, C++ 및 Java와의 상호 운용성."
 
 #: src/welcome.md:24
 msgid ""
-"It is important to note that this course does not cover Android **application** \n"
-"development in Rust, and that the Android-specific parts are specifically about\n"
-"writing code for Android itself, the operating system. "
-msgstr "이 강의에서는 러스트로 안드로이드 **애플리케이션**을 개발하는 것은 다루지 않습니다. 이 강의에서 다루는 안드로이드 특화된 내용은 안드로이드 OS의 일부를 러스트로 개발하는 것에 대한 것입니다. "
+"It is important to note that this course does not cover Android "
+"**application**  development in Rust, and that the Android-specific parts "
+"are specifically about writing code for Android itself, the operating "
+"system. "
+msgstr ""
+"이 강의에서는 러스트로 안드로이드 **애플리케이션**을 개발하는 것은 다루지 않"
+"습니다. 이 강의에서 다루는 안드로이드 특화된 내용은 안드로이드 OS의 일부를 러"
+"스트로 개발하는 것에 대한 것입니다. "
 
 #: src/welcome.md:28
-msgid "## Non-Goals"
-msgstr "## 제외사항"
+msgid "Non-Goals"
+msgstr "제외사항"
 
 #: src/welcome.md:30
 msgid ""
-"Rust is a large language and we won't be able to cover all of it in a few days.\n"
-"Some non-goals of this course are:"
-msgstr "러스트는 며칠만에 모든 것을 다루기에는 너무 큰 언어입니다. 그래서 아래와 같은것을 목표로 하지 않습니다:"
+"Rust is a large language and we won't be able to cover all of it in a few "
+"days. Some non-goals of this course are:"
+msgstr ""
+"러스트는 며칠만에 모든 것을 다루기에는 너무 큰 언어입니다. 그래서 아래와 같은"
+"것을 목표로 하지 않습니다:"
 
 #: src/welcome.md:33
 msgid ""
-"* Learn how to use async Rust --- we'll only mention async Rust when\n"
-"  covering traditional concurrency primitives. Please see [Asynchronous\n"
-"  Programming in Rust](https://rust-lang.github.io/async-book/) instead for\n"
-"  details on this topic.\n"
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to use async Rust --- we'll only mention async Rust when covering "
+"traditional concurrency primitives. Please see [Asynchronous Programming in "
+"Rust](https://rust-lang.github.io/async-book/) instead for details on this "
+"topic."
 msgstr ""
-"* 비동기적 러스트 사용법. 간단하게 언급정도는 하겠지만 좀 더 자세한 내용은 [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/)를 참조해주세요.\n"
-"* 매크로를 개발하는 방법. [Chapter 19.5 in the Rust Book](https://doc.rust-lang.org/book/ch19-06-macros.html)와 [Rust by Example](https://doc.rust-lang.org/rust-by-example/macros.html)를 참조하세요."
+"비동기적 러스트 사용법. 간단하게 언급정도는 하겠지만 좀 더 자세한 내용은 "
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/)"
+"를 참조해주세요."
+
+#: src/welcome.md:37
+msgid ""
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+msgstr ""
+"매크로를 개발하는 방법. [Chapter 19.5 in the Rust Book](https://doc.rust-"
+"lang.org/book/ch19-06-macros.html)와 [Rust by Example](https://doc.rust-lang."
+"org/rust-by-example/macros.html)를 참조하세요."
 
 #: src/welcome.md:41
-msgid "## Assumptions"
-msgstr "## 독자 수준에 대한 가정"
+msgid "Assumptions"
+msgstr "독자 수준에 대한 가정"
 
 #: src/welcome.md:43
 msgid ""
-"The course assumes that you already know how to program. Rust is a statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to better\n"
-"explain or contrast the Rust approach."
-msgstr "본 강의는 여러분이 프로그래밍 자체에 대해서는 알고 있다고 가정합니다. 러스트는 정적타입 언어이며, 강좌에서는 C/C++ 와의 비교, 대조를 통해 러스트를 설명할 것입니다."
+"The course assumes that you already know how to program. Rust is a "
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
+msgstr ""
+"본 강의는 여러분이 프로그래밍 자체에 대해서는 알고 있다고 가정합니다. 러스트"
+"는 정적타입 언어이며, 강좌에서는 C/C++ 와의 비교, 대조를 통해 러스트를 설명"
+"할 것입니다."
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically typed language such as Python or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
-msgstr "C/C++을 모르더라도 동적 타입 언어(Python이나 JavaScript 등) 프로그래밍 경험이 있다면 따라오는데 큰 문제는 없을 것입니다."
-
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/compound-types.md:28
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:102
-#: src/structs/tuple-structs.md:35 src/structs/field-shorthand.md:25
-#: src/enums.md:31 src/enums/variant-payloads.md:33 src/enums/sizes.md:27
-#: src/methods.md:28 src/methods/receiver.md:23 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:29
-#: src/control-flow/if-let-expressions.md:19
-#: src/control-flow/while-let-expressions.md:25
-#: src/control-flow/for-expressions.md:22
-#: src/control-flow/loop-expressions.md:23
-#: src/control-flow/match-expressions.md:25 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:24 src/exercises/day-2/afternoon.md:5
-#: src/traits.md:39 src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/operators.md:24 src/traits/drop.md:32
-#: src/traits/default.md:38 src/generics/methods.md:23
-#: src/generics/trait-bounds.md:33 src/generics/impl-trait.md:22
-#: src/generics/closures.md:23 src/exercises/day-3/morning.md:5
-#: src/error-handling/result.md:25 src/error-handling/try-operator.md:48
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:24 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:5 src/welcome-day-4.md:6
-#: src/concurrency/threads.md:28 src/concurrency/scoped-threads.md:35
-#: src/concurrency/channels.md:25 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21 src/concurrency/send-sync.md:18
-#: src/concurrency/send-sync/sync.md:12 src/exercises/day-4/morning.md:10
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/day-4/android.md:10
-msgid "<details>"
-msgstr "<details>"
+msgstr ""
+"C/C++을 모르더라도 동적 타입 언어(Python이나 JavaScript 등) 프로그래밍 경험"
+"이 있다면 따라오는데 큰 문제는 없을 것입니다."
 
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
-"information to the slides. This could be key points which the instructor should\n"
-"cover as well as answers to typical questions which come up in class."
-msgstr "이것은 \"발표자 노트\"의 예제입니다. 이 부분을 이용해서 추가 정보를 제공합니다. 주로 강의실에서 제기되는 일반적인 질문에 대한 답변과 강사가 다루어야 할 키 포인트일 수 있습니다."
-
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
-#: src/why-rust/modern.md:66 src/basic-syntax/compound-types.md:62
-#: src/basic-syntax/references.md:28 src/basic-syntax/slices.md:36
-#: src/basic-syntax/string-slices.md:44 src/basic-syntax/functions.md:54
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:106
-#: src/structs.md:41 src/structs/tuple-structs.md:43
-#: src/structs/field-shorthand.md:72 src/enums.md:41
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:29 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:25
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:46
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:26
-#: src/control-flow/while-let-expressions.md:30
-#: src/control-flow/for-expressions.md:29
-#: src/control-flow/loop-expressions.md:27
-#: src/control-flow/match-expressions.md:32 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:40 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:53 src/exercises/day-2/afternoon.md:11
-#: src/traits.md:53 src/traits/iterator.md:39 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/operators.md:38 src/traits/drop.md:42
-#: src/traits/default.md:47 src/generics/methods.md:31
-#: src/generics/trait-bounds.md:50 src/generics/impl-trait.md:38
-#: src/generics/closures.md:38 src/exercises/day-3/morning.md:11
-#: src/error-handling/result.md:33 src/error-handling/try-operator.md:55
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:42 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:11 src/welcome-day-4.md:11
-#: src/concurrency/threads.md:45 src/concurrency/scoped-threads.md:40
-#: src/concurrency/channels.md:32 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56 src/concurrency/send-sync.md:23
-#: src/concurrency/send-sync/sync.md:18 src/exercises/day-4/morning.md:16
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/day-4/android.md:15
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# 강의 진행 방식"
+"This is an example of a _speaker note_. We will use these to add additional "
+"information to the slides. This could be key points which the instructor "
+"should cover as well as answers to typical questions which come up in class."
+msgstr ""
+"이것은 \"발표자 노트\"의 예제입니다. 이 부분을 이용해서 추가 정보를 제공합니"
+"다. 주로 강의실에서 제기되는 일반적인 질문에 대한 답변과 강사가 다루어야 할 "
+"키 포인트일 수 있습니다."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
 #: src/running-the-course/day-4.md:3
-msgid "> This page is for the course instructor."
-msgstr "> 강사를 위한 안내 페이지입니다."
+msgid "This page is for the course instructor."
+msgstr "강사를 위한 안내 페이지입니다."
 
 #: src/running-the-course.md:5
 msgid ""
-"Here is a bit of background information about how we've been running the course\n"
-"internally at Google."
-msgstr "다음은 구글 내부에서 이 과정을 어떤식으로 운영해왔는지에 대한 배경 정보입니다."
+"Here is a bit of background information about how we've been running the "
+"course internally at Google."
+msgstr ""
+"다음은 구글 내부에서 이 과정을 어떤식으로 운영해왔는지에 대한 배경 정보입니"
+"다."
 
 #: src/running-the-course.md:8
 msgid "Before you run the course, you will want to:"
@@ -1058,282 +995,369 @@ msgstr "강의를 실행하기 위한 준비:"
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker notes\n"
-"   to help highlight the key points (please help us by contributing more speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Select your topic for the afternoon of the fourth day. This may be based on\n"
-"   the audience you expect, or on your own expertise.\n"
-"\n"
-"1. Decide on the dates. Since the course is large, we recommend that you\n"
-"   schedule the four days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-20 people. That's small enough that people are comfortable\n"
-"   asking questions --- it's also small enough that one instructor will have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself and for the\n"
-"   students: you will all need to be able to sit and work with your laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups. Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. When\n"
-"   you see that several people have the same problem, call it out to the class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library.\n"
-"\n"
-"1. Prepare anything you need to have available for the afternoon of day 4."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. 강의 자료를 숙지합니다. 주요 요점을 강조하기 위해 강의 참조 노트를 포함하였습니다. (추가적인 노트를 작성하여 제공해 주시면 감사하겠습니다.) 강의 참조 노트의 링크를 누르면 별도의 팝업으로 분리가 되며, 메인 화면에서는 사라집니다. 깔끔한 화면으로 강의를 진행할 수 있습니다.\n"
-"\n"
-"1. 4일차 오후의 주제를 선택합니다. 수강생들이 원하는, 혹은 여러분이 자신있는 주제를 고르세요.\n"
-"\n"
-"1. 강의 날짜를 정합니다. 강의 내용이 많고 수강생들이 모든 정보를 공부할 수 있도록 중간에 틈을 두어 2주에 걸쳐 4일을 잡는 것을 추천합니다.\n"
-"\n"
-"1. 충분한 공간을 확보합니다. 15에서 20명 규모의 공간을 추천합니다. 수강생과 강사가 질의를 하기에 충분한 시간과 공간이어야 합니다. 강사나 수강생 모두 책상을 사용할 수 있는 강의실이면 좋습니다. 강의 중에 강사가 라이브 코딩을 하게 될 경우가 많으며, 이때 자리에 앉아 노트북을 사용하는 것이 도움이 됩니다.\n"
-"\n"
-"1. 강의 당일 조금 일찍 와서 준비합니다. 강사 노트북에서 `mdbook serve -d book/ko`를 이용해 직접 프레젠테이션 하면 페이지 이동 시의 지연이 없습니다.([설치 방법][3]을 참조하세요.) 또한, 그렇게 하면 강의 도중 오타를 발견했을 때 그 자리에서 바로 수정 가능하다는 장점도 있습니다.\n"
-"\n"
-"1. 수강생들이 직접 (개별 혹은 그룹으로) 연습문제를 풀도록 합니다. 진행이 막혀 도움을 필요로 하는 수강생이 없는지 수시로 확인합니다. 만약 같은 문제를 여러 사람이 겪고 있다면, 그 문제를 강의실 전체 인원에게 알리고 해결책을 제시합니다. 예를 들어 표준 라이브러리 어디에 가면 그 문제에 대한 해답을 찾을 수 있는지 알려 줍니다.\n"
-"\n"
-"1. 4일차 오후에 필요한 것들을 준비하세요."
+"강의 자료를 숙지합니다. 주요 요점을 강조하기 위해 강의 참조 노트를 포함하였습"
+"니다. (추가적인 노트를 작성하여 제공해 주시면 감사하겠습니다.) 강의 참조 노트"
+"의 링크를 누르면 별도의 팝업으로 분리가 되며, 메인 화면에서는 사라집니다. 깔"
+"끔한 화면으로 강의를 진행할 수 있습니다."
+
+#: src/running-the-course.md:16
+msgid ""
+"Select your topic for the afternoon of the fourth day. This may be based on "
+"the audience you expect, or on your own expertise."
+msgstr ""
+"4일차 오후의 주제를 선택합니다. 수강생들이 원하는, 혹은 여러분이 자신있는 주"
+"제를 고르세요."
+
+#: src/running-the-course.md:19
+msgid ""
+"Decide on the dates. Since the course is large, we recommend that you "
+"schedule the four days over two weeks. Course participants have said that "
+"they find it helpful to have a gap in the course since it helps them process "
+"all the information we give them."
+msgstr ""
+"강의 날짜를 정합니다. 강의 내용이 많고 수강생들이 모든 정보를 공부할 수 있도"
+"록 중간에 틈을 두어 2주에 걸쳐 4일을 잡는 것을 추천합니다."
+
+#: src/running-the-course.md:24
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-20 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"충분한 공간을 확보합니다. 15에서 20명 규모의 공간을 추천합니다. 수강생과 강사"
+"가 질의를 하기에 충분한 시간과 공간이어야 합니다. 강사나 수강생 모두 책상을 "
+"사용할 수 있는 강의실이면 좋습니다. 강의 중에 강사가 라이브 코딩을 하게 될 경"
+"우가 많으며, 이때 자리에 앉아 노트북을 사용하는 것이 도움이 됩니다."
+
+#: src/running-the-course.md:32
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"강의 당일 조금 일찍 와서 준비합니다. 강사 노트북에서 `mdbook serve -d book/"
+"ko`를 이용해 직접 프레젠테이션 하면 페이지 이동 시의 지연이 없습니다.([설치 "
+"방법](https://github.com/google/comprehensive-rust#building)을 참조하세요.) "
+"또한, 그렇게 하면 강의 도중 오타를 발견했을 때 그 자리에서 바로 수정 가능하다"
+"는 장점도 있습니다."
+
+#: src/running-the-course.md:38
+msgid ""
+"Let people solve the exercises by themselves or in small groups. Make sure "
+"to ask people if they're stuck or if there is anything you can help with. "
+"When you see that several people have the same problem, call it out to the "
+"class and offer a solution, e.g., by showing people where to find the "
+"relevant information in the standard library."
+msgstr ""
+"수강생들이 직접 (개별 혹은 그룹으로) 연습문제를 풀도록 합니다. 진행이 막혀 도"
+"움을 필요로 하는 수강생이 없는지 수시로 확인합니다. 만약 같은 문제를 여러 사"
+"람이 겪고 있다면, 그 문제를 강의실 전체 인원에게 알리고 해결책을 제시합니다. "
+"예를 들어 표준 라이브러리 어디에 가면 그 문제에 대한 해답을 찾을 수 있는지 알"
+"려 줍니다."
+
+#: src/running-the-course.md:44
+msgid "Prepare anything you need to have available for the afternoon of day 4."
+msgstr "4일차 오후에 필요한 것들을 준비하세요."
 
 #: src/running-the-course.md:46
 msgid ""
-"That is all, good luck running the course! We hope it will be as much fun for\n"
-"you as it has been for us!"
-msgstr "이제 준비는 끝났습니다. 우리가 그랬듯이 여러분들도 이 강의를 즐기시길 바랍니다!"
+"That is all, good luck running the course! We hope it will be as much fun "
+"for you as it has been for us!"
+msgstr ""
+"이제 준비는 끝났습니다. 우리가 그랬듯이 여러분들도 이 강의를 즐기시길 바랍니"
+"다!"
 
 #: src/running-the-course.md:49
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
-msgstr "강의를 계속 개선할 수 있도록 [피드백][1]을 제공해 주십시오. 우리는 무엇이 좋았고, 무엇이 모자랐는지 듣고 싶습니다. 수강생들로 부터의 [피드백][2]도 환영합니다!"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# 강의 구성"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
+msgstr ""
+"강의를 계속 개선할 수 있도록 [피드백](https://github.com/google/"
+"comprehensive-rust/discussions/86)을 제공해 주십시오. 우리는 무엇이 좋았고, "
+"무엇이 모자랐는지 듣고 싶습니다. 수강생들로 부터의 [피드백](https://github."
+"com/google/comprehensive-rust/discussions/100)도 환영합니다!"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "강의는 빠른 속도로 진행되며, 아래 내용들을 다룹니다:"
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust.\n"
-"* Day 4: Concurrency in Rust and seeing Rust in action."
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "1일차: 러스트 기본, 소유권(ownership)과 빌림(borrow) 체크"
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
+msgstr "2일차: 복합 데이터 유형, 패턴 매칭, 표준 라이브러리"
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
 msgstr ""
-"* 1일차: 러스트 기본, 소유권(ownership)과 빌림(borrow) 체크\n"
-"* 2일차: 복합 데이터 유형, 패턴 매칭, 표준 라이브러리\n"
-"* 3일차: 트레잇(trait)와 제네릭(generic), 오류 처리, 테스트, 안전하지 않은 러스트\n"
-"* 4일차: 러스트의 동시성 및 러스트가 실제 활용되는 사례 살펴보기"
+"3일차: 트레잇(trait)와 제네릭(generic), 오류 처리, 테스트, 안전하지 않은 러스"
+"트"
+
+#: src/running-the-course/course-structure.md:10
+msgid "Day 4: Concurrency in Rust and seeing Rust in action."
+msgstr "4일차: 러스트의 동시성 및 러스트가 실제 활용되는 사례 살펴보기"
 
 #: src/running-the-course/course-structure.md:12
-msgid "## Format"
-msgstr "## 강의 형식"
+msgid "Format"
+msgstr "강의 형식"
 
 #: src/running-the-course/course-structure.md:14
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
-msgstr "이 강의는 강사와 수강생이 양방향으로 소통하면서 진행하도록 디자인 되었습니다. 다양한 질문을 통해 러스트의 여러 부분을 탐험할 수 있도록 하세요!"
-
-#: src/running-the-course/day-4.md:1
-msgid "# Day 4"
-msgstr "# 4일차"
+msgstr ""
+"이 강의는 강사와 수강생이 양방향으로 소통하면서 진행하도록 디자인 되었습니"
+"다. 다양한 질문을 통해 러스트의 여러 부분을 탐험할 수 있도록 하세요!"
 
 #: src/running-the-course/day-4.md:5
 msgid ""
-"The afternoon of the fourth day should cover a topic of your choice. Include\n"
-"the topic in the announcement of the course, so that participants know what to\n"
-"expect."
-msgstr "4일차 오후에는 여러분의 선택에 따라 다른 주제를 다룰 수 있습니다. 강의를 안내할 때 4일차 오후의 주제를 포함하여 수강생들이 미리 알 수 있게 하세요."
+"The afternoon of the fourth day should cover a topic of your choice. Include "
+"the topic in the announcement of the course, so that participants know what "
+"to expect."
+msgstr ""
+"4일차 오후에는 여러분의 선택에 따라 다른 주제를 다룰 수 있습니다. 강의를 안내"
+"할 때 4일차 오후의 주제를 포함하여 수강생들이 미리 알 수 있게 하세요."
 
 #: src/running-the-course/day-4.md:9
 msgid ""
-"This phase of the course is a chance for participants to see Rust in action on a\n"
-"codebase they might be familiar with. You can choose from the topics already\n"
-"defined here, or plan your own."
-msgstr "4일차 쯤이면, 실제 코드 베이스를 통해 러스트가 활용되는 모습을 살펴보면 좋습니다. 이미 준비된 주제 중에서 고를 수도 있고, 여러분이 직접 준비한 주제를 다룰 수도 있습니다."
+"This phase of the course is a chance for participants to see Rust in action "
+"on a codebase they might be familiar with. You can choose from the topics "
+"already defined here, or plan your own."
+msgstr ""
+"4일차 쯤이면, 실제 코드 베이스를 통해 러스트가 활용되는 모습을 살펴보면 좋습"
+"니다. 이미 준비된 주제 중에서 고를 수도 있고, 여러분이 직접 준비한 주제를 다"
+"룰 수도 있습니다."
 
 #: src/running-the-course/day-4.md:13
 msgid "Some topics need additional preparation:"
 msgstr "준비된 주제 (어떤 주제는 추가적인 준비가 필요합니다):"
 
-#: src/running-the-course/day-4.md:15
-msgid "## Android"
-msgstr "## 안드로이드"
-
 #: src/running-the-course/day-4.md:17
 msgid ""
-"If you chose Android for Day 4 afternoon, you will need an [AOSP checkout][1].\n"
-"Make a checkout of the [course repository][2] on the same machine and move the\n"
-"`src/android/` directory into the root of your AOSP checkout. This will ensure\n"
-"that the Android build system sees the `Android.bp` files in `src/android/`."
-msgstr "4일차 오후에 안드로이드를 다루기로 했다면, [AOSP 코드][1]를 체크아웃해야 합니다. 그런 다음, 같은 컴퓨터에서 [과정 저장소][2]를 체크아웃하고 `src/android/` 디렉터리를 AOSP 코드의 루트로 이동합니다. 이렇게 하면 안드로이드 빌드 시스템에서 과제용으로 추가된 `Android.bp`파일을 인식할 수 있습니다."
+"If you chose Android for Day 4 afternoon, you will need an \\[AOSP "
+"checkout\\]\\[1\\]. Make a checkout of the \\[course repository\\]\\[2\\] on "
+"the same machine and move the `src/android/` directory into the root of your "
+"AOSP checkout. This will ensure that the Android build system sees the "
+"`Android.bp` files in `src/android/`."
+msgstr ""
+"4일차 오후에 안드로이드를 다루기로 했다면, \\[AOSP 코드\\]\\[1\\]를 체크아웃"
+"해야 합니다. 그런 다음, 같은 컴퓨터에서 \\[과정 저장소\\]\\[2\\]를 체크아웃하"
+"고 `src/android/` 디렉터리를 AOSP 코드의 루트로 이동합니다. 이렇게 하면 안드"
+"로이드 빌드 시스템에서 과제용으로 추가된 `Android.bp`파일을 인식할 수 있습니"
+"다."
 
 #: src/running-the-course/day-4.md:22
 msgid ""
-"Ensure that `adb sync` works with your emulator or real device and pre-build\n"
-"all Android examples using `src/android/build_all.sh`. Read the script to see\n"
-"the commands it runs and make sure they work when you run them by hand."
-msgstr "`adb sync` 명렁어가 에뮬레이터 혹은 실제 장치와 작동하는지 확인합니다. 그리고 `src/android/build_all.sh`를 수행해서 모든 안드로이드 예제를 미리 빌드해 보세요. 그 쉘 스크립트를 읽고, 그 안에서 수행되는 명령어들을 확인한 후 각 명령어들을 수동으로 실행해도 잘 되는지 확인하세요."
+"Ensure that `adb sync` works with your emulator or real device and pre-build "
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
+msgstr ""
+"`adb sync` 명렁어가 에뮬레이터 혹은 실제 장치와 작동하는지 확인합니다. 그리"
+"고 `src/android/build_all.sh`를 수행해서 모든 안드로이드 예제를 미리 빌드해 "
+"보세요. 그 쉘 스크립트를 읽고, 그 안에서 수행되는 명령어들을 확인한 후 각 명"
+"령어들을 수동으로 실행해도 잘 되는지 확인하세요."
 
 #: src/running-the-course/day-4.md:26
-msgid "## Async"
-msgstr "## 비동기"
+msgid "Async"
+msgstr "비동기"
 
 #: src/running-the-course/day-4.md:28
 msgid ""
-"If you chose Async for Day 4 afternoon, you will need a fresh crate set up and\n"
-"the dependencies downloaded and ready to go. You can then copy/paste the\n"
+"If you chose Async for Day 4 afternoon, you will need a fresh crate set up "
+"and the dependencies downloaded and ready to go. You can then copy/paste the "
 "examples into `src/main.rs` to experiment with them."
-msgstr "4일 차 오후에 비동기를 다루기로 했다면, 새 크레이트를 설정하고 몇 가지 의존성을 다운로드해 두어야 합니다. 그런 다음 예제를 `src/main.rs`에 복사/붙여넣기 하여 실험할 수 있습니다."
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# 단축키"
+msgstr ""
+"4일 차 오후에 비동기를 다루기로 했다면, 새 크레이트를 설정하고 몇 가지 의존성"
+"을 다운로드해 두어야 합니다. 그런 다음 예제를 `src/main.rs`에 복사/붙여넣기 "
+"하여 실험할 수 있습니다."
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "mdBook 시스템(현 사이트)에서 유용한 단축키들 입니다:"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>왼쪽 화살표</kbd>: 이전 페이지로 이동합니다.\n"
-"* <kbd>오른쪽 화살표</kbd>: 다음 페이지로 이동합니다.\n"
-"* <kbd>Ctrl + Enter</kbd>: 현재 포커스를 받은 코드 샘플 블록을 실행합니다.\n"
-"* <kbd>s</kbd>: 검색창을 활성화합니다.(mdBook 문제로 23.01.19 기준 영어로만 가능합니다.)"
+msgid "Arrow-Left"
+msgstr "왼쪽 화살표"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# 다른 언어들"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr ": 이전 페이지로 이동합니다."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "오른쪽 화살표"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr ": 다음 페이지로 이동합니다."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr ": 현재 포커스를 받은 코드 샘플 블록을 실행합니다."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr ""
+": 검색창을 활성화합니다.(mdBook 문제로 23.01.19 기준 영어로만 가능합니다.)"
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
-msgstr "이 과정은 다른 언어로도 제공됩니다. 괄호 안은 번역에 도움 주신 분들입니다."
+msgstr ""
+"이 과정은 다른 언어로도 제공됩니다. 괄호 안은 번역에 도움 주신 분들입니다."
 
 #: src/running-the-course/translations.md:6
+#, fuzzy
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
+msgstr "[영어](https://google.github.io/comprehensive-rust/)"
+
+#: src/running-the-course/translations.md:7
+#, fuzzy
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
-"* [영어](https://google.github.io/comprehensive-rust/)\n"
-"* [브라질 포르투갈어][pt-BR] ([@rastringer], [@hugojacob]).\n"
-"* [한국어][ko] ([@keispace], [@jiyongp], [@jooyunghan])"
+"[브라질 포르투갈어](https://google.github.io/comprehensive-rust/pt-BR/) "
+"([@rastringer](https://github.com/rastringer), [@hugojacob](https://github."
+"com/hugojacob)).\n"
+"\n"
+"[한국어](https://google.github.io/comprehensive-rust/ko/) ([@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp), "
+"[@jooyunghan](https://github.com/jooyunghan))"
 
 #: src/running-the-course/translations.md:9
-msgid "Use the language picker in the top-right corner to switch between languages."
+msgid ""
+"Use the language picker in the top-right corner to switch between languages."
 msgstr "페이지 오른쪽 위의 메뉴를 통해 다른 언어로 전환할 수 있습니다."
 
 #: src/running-the-course/translations.md:11
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"이 과정의 번역 작업에 도움을 주고 싶다면 [여기][our instructions] 설명된 내용을 참고하세요.\n"
-"진행 중인 번역 작업에 대한 내용은 [이슈 트래커][issue tracker]를 참고하세요."
+"이 과정의 번역 작업에 도움을 주고 싶다면 [여기](https://github.com/google/"
+"comprehensive-rust/blob/main/TRANSLATIONS.md) 설명된 내용을 참고하세요. 진행 "
+"중인 번역 작업에 대한 내용은 [이슈 트래커](https://github.com/google/"
+"comprehensive-rust/issues/282)를 참고하세요."
 
 #: src/running-the-course/translations.md:13
 msgid ""
-"There is a large number of in-progress translations. We link to the most\n"
+"There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
-"진행 중인 번역이 많습니다. 최근에 업데이트된 번역본으로\n"
-"연결되는 링크는 다음과 같습니다."
+"진행 중인 번역이 많습니다. 최근에 업데이트된 번역본으로 연결되는 링크는 다음"
+"과 같습니다."
 
 #: src/running-the-course/translations.md:16
 msgid ""
-"* [French][fr] by [@KookaS] and [@vcaen].\n"
-"* [German][de] by [@Throvn] and [@ronaldfw].\n"
-"* [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105]."
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
 msgstr ""
-"* [French][fr]: [@KookaS] 및 [@vcaen] 제공\n"
-"* [German][de]: [@Throvn] 및 [@ronaldfw] 제공\n"
-"* [Japanese][ja]: [@CoinEZ-JPN] 및 [@momotaro1105] 제공"
+"[French](https://google.github.io/comprehensive-rust/fr/): [@KookaS](https://"
+"github.com/KookaS) 및 [@vcaen](https://github.com/vcaen) 제공"
+
+#: src/running-the-course/translations.md:17
+msgid ""
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+msgstr ""
+"[German](https://google.github.io/comprehensive-rust/de/): [@Throvn](https://"
+"github.com/Throvn) 및 [@ronaldfw](https://github.com/ronaldfw) 제공"
+
+#: src/running-the-course/translations.md:18
+msgid ""
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
+msgstr ""
+"[Japanese](https://google.github.io/comprehensive-rust/ja/): [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) 및 [@momotaro1105](https://github.com/"
+"momotaro1105) 제공"
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
-msgstr "## 심화 학습"
+msgid "Deep Dives"
+msgstr "심화 학습"
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
-msgstr ""
-"Rust 기초에 관한 3일 과정 외에도\n"
-"다음과 같은 전문 주제를 다룹니다."
+msgstr "Rust 기초에 관한 3일 과정 외에도 다음과 같은 전문 주제를 다룹니다."
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
 "The [Android Deep Dive](../android.md) is a half-day course on using Rust "
-"for\n"
-"Android platform development. This includes interoperability with C, C++, "
-"and\n"
-"Java."
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
-"[Android 심화 학습](../android.md)는 Android 플랫폼 개발 시 Rust 사용에 관"
-"한\n"
-"반나절 과정입니다. 여기에는 C, C++, Java와의 상호 운용성이\n"
-"포함됩니다."
+"[Android 심화 학습](../android.md)는 Android 플랫폼 개발 시 Rust 사용에 관한 "
+"반나절 과정입니다. 여기에는 C, C++, Java와의 상호 운용성이 포함됩니다."
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
-msgstr "### Bare-Metal"
+msgid "Bare-Metal"
+msgstr "Bare-Metal"
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
 "The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
-"for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
 "[Bare-Metal 심화 학습](../bare-metal.md): bare-metal(임베디드) 개발 시 Rust "
-"사용에 관한\n"
-"종일 과정입니다. 마이크로컨트롤러와 애플리케이션 프로세서를\n"
-"모두 다룹니다."
+"사용에 관한 종일 과정입니다. 마이크로컨트롤러와 애플리케이션 프로세서를 모두 "
+"다룹니다."
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
-"마이크로컨트롤러 파트를 진행하기 위해서는 [BBC micro:bit](https://microbit.org/) v2\n"
-"개발 보드를 미리 구매해야 합니다. 모든 사용자는\n"
-"[시작 페이지](../bare-metal.md)에 설명된 대로\n"
-"각종 패키지를 설치해야 합니다."
+"마이크로컨트롤러 파트를 진행하기 위해서는 [BBC micro:bit](https://microbit."
+"org/) v2 개발 보드를 미리 구매해야 합니다. 모든 사용자는 [시작 페이지](../"
+"bare-metal.md)에 설명된 대로 각종 패키지를 설치해야 합니다."
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
 "The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
-"classical\n"
-"as well as `async`/`await` concurrency."
+"classical as well as `async`/`await` concurrency."
 msgstr ""
-"[동시성 심화학습](../concurrency.md)은 고전적인 동시성 및\n"
-"`async`/`await` 동시성을 다루는 종일 과정입니다."
+"[동시성 심화학습](../concurrency.md)은 고전적인 동시성 및 `async`/`await` 동"
+"시성을 다루는 종일 과정입니다."
 
 #: src/running-the-course/course-structure.md:54
 msgid ""
@@ -1351,45 +1375,61 @@ msgstr ""
 "cargo run\n"
 "```"
 
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# 카고(Cargo) 사용하기"
-
 #: src/cargo.md:3
 msgid ""
-"When you start reading about Rust, you will soon meet [Cargo](https://doc.rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want to\n"
-"give a brief overview of what Cargo is and how it fits into the wider ecosystem\n"
-"and how it fits into this training."
-msgstr "러스트를 시작하려고하면 당신은 곧 [Cargo](https://doc.rust-lang.org/cargo/)라는, 러스트 생태계에서 사용하는 표준 빌드/실행 도구를 만날 것 입니다. 여기서는 카고가 무엇인지, 그리고 카고가 러스트 생태계에서 어떤 역할을 하는지, 그리고 이 강의에서 어떻게 사용될 지에 대해 간략히 설명하겠습니다."
+"When you start reading about Rust, you will soon meet [Cargo](https://doc."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
+msgstr ""
+"러스트를 시작하려고하면 당신은 곧 [Cargo](https://doc.rust-lang.org/cargo/)라"
+"는, 러스트 생태계에서 사용하는 표준 빌드/실행 도구를 만날 것 입니다. 여기서"
+"는 카고가 무엇인지, 그리고 카고가 러스트 생태계에서 어떤 역할을 하는지, 그리"
+"고 이 강의에서 어떻게 사용될 지에 대해 간략히 설명하겠습니다."
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## 설치하기"
+msgid "Installation"
+msgstr "설치하기"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "#### Rustup (추천)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (추천)"
 
 #: src/cargo.md:12
-msgid "You can follow the instructions to install cargo and rust compiler, among other standard ecosystem tools with the [rustup][3] tool, which is maintained by the Rust Foundation."
-msgstr "러스트 재단에서 관리하고 있는 [rustup][3] 도구를 사용하여 카고 및 러스트 컴파일러 등 표준 도구를 설치 할 수 있습니다."
+msgid ""
+"You can follow the instructions to install cargo and rust compiler, among "
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
+msgstr ""
+"러스트 재단에서 관리하고 있는 [rustup](https://rust-analyzer.github.io/) 도구"
+"를 사용하여 카고 및 러스트 컴파일러 등 표준 도구를 설치 할 수 있습니다."
 
 #: src/cargo.md:14
-msgid "Along with cargo and rustc, Rustup will install itself as a command line utility that you can use to install/switch toolchains, setup cross compilation, etc."
-msgstr "카고(cargo)와 러스트 컴파일러(rustc)와 함께, rustup은 툴체인을 설치하고, 다른 툴체인으로 전환하고, 크로스 컴파일 설정을 하는 일을 담당하는 커맨드 라인 유틸리티 입니다."
+msgid ""
+"Along with cargo and rustc, Rustup will install itself as a command line "
+"utility that you can use to install/switch toolchains, setup cross "
+"compilation, etc."
+msgstr ""
+"카고(cargo)와 러스트 컴파일러(rustc)와 함께, rustup은 툴체인을 설치하고, 다"
+"른 툴체인으로 전환하고, 크로스 컴파일 설정을 하는 일을 담당하는 커맨드 라인 "
+"유틸리티 입니다."
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### 패키지 매니저"
+msgid "Package Managers"
+msgstr "패키지 매니저"
 
 #: src/cargo.md:18
-msgid "#### Debian"
-msgstr "#### 데비안"
+msgid "Debian"
+msgstr "데비안"
 
 #: src/cargo.md:20
-msgid "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust formatter][6] with"
-msgstr "데비안이나 우분투에서 cargo, 러스트 소스코드, [러스트 포매터][6]를 아래 커맨드로 설치합니다."
+msgid ""
+"On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
+"formatter](https://github.com/rust-lang/rustfmt) with"
+msgstr ""
+"데비안이나 우분투에서 cargo, 러스트 소스코드, [러스트 포매터](https://github."
+"com/rust-lang/rustfmt)를 아래 커맨드로 설치합니다."
 
 #: src/cargo.md:22
 msgid ""
@@ -1403,43 +1443,72 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
-msgstr "이렇게 하면 [rust-analyzer][1]를 이용해서 특정 심볼이 정의된 위치로 쉽게 이동할 수 있습니다. 우리는 에디터로 [VS Code][2]를 추천합니다만, 사실 LSP를 지원한다면 어떤 에디터도 무방합니다."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
+msgstr ""
+"이렇게 하면 \\[rust-analyzer\\]\\[1\\]를 이용해서 특정 심볼이 정의된 위치로 "
+"쉽게 이동할 수 있습니다. 우리는 에디터로 [VS Code](https://code.visualstudio."
+"com/)를 추천합니다만, 사실 LSP를 지원한다면 어떤 에디터도 무방합니다."
 
 #: src/cargo.md:29
-msgid "Some folks also like to use the [JetBrains][4] family of IDEs, which do their own analysis but have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take note that as of January 2023 debugging only works on the CLion version of the JetBrains IDEA suite."
-msgstr "어떤 사람들은 [JetBrains][4] 제품군을 선호하기도 합니다. 이 제품들은 rust-analyzer 를 활용하지 않고 IDE 자체적으로 구문분석을 합니다. 만약 이 IDE를 설치하셨다면 [Rust Plugin][5]를 설치하시기 바랍니다. 다만 2023년 1월 기준, 디버깅은 JetBrains IDEA suite의 CLion 버전에서만 작동한다는 점에 유의하시기 바랍니다."
+msgid ""
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
+msgstr ""
+"어떤 사람들은 [JetBrains](https://www.jetbrains.com/clion/) 제품군을 선호하기"
+"도 합니다. 이 제품들은 rust-analyzer 를 활용하지 않고 IDE 자체적으로 구문분석"
+"을 합니다. 만약 이 IDE를 설치하셨다면 [Rust Plugin](https://www.jetbrains."
+"com/rust/)를 설치하시기 바랍니다. 다만 2023년 1월 기준, 디버깅은 JetBrains "
+"IDEA suite의 CLion 버전에서만 작동한다는 점에 유의하시기 바랍니다."
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# 러스트 생태계"
+msgid "The Rust Ecosystem"
+msgstr "러스트 생태계"
 
 #: src/cargo/rust-ecosystem.md:3
-msgid "The Rust ecosystem consists of a number of tools, of which the main ones are:"
-msgstr "러스트의 생태계는 여러가지 도구들로 구성되어 있으며, 그 중 중요한 것들은 아래와 같습니다:"
+msgid ""
+"The Rust ecosystem consists of a number of tools, of which the main ones are:"
+msgstr ""
+"러스트의 생태계는 여러가지 도구들로 구성되어 있으며, 그 중 중요한 것들은 아래"
+"와 같습니다:"
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and `rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc`: `.rs` 확장자 파일을 바이너리 혹은 다른 중간 형식으로 변환해주는 Rust 컴파일러입니다.\n"
-"\n"
-"* `cargo`: 러스트 의존성 관리자 및 빌드도구 입니다. 여러분의 프로젝트에 명시된 의존성들을 <https://crates.io>에서 자동으로 다운로드 받고, 그 소스코드를 `rustc`로 전달하여 빌드를 시킵니다. 또한 유닛 테스트를 실행하는 테스트 러너를 내장하고 있습니다.\n"
-"\n"
-"* `rustup`: 러스트 툴체인 설치 프로그램 및 업데이트 프로그램. 이 도구는 새 버전의 러스트가 출시될 때 `rustc` 및 `cargo` 설치하고 업데이트하는 데 사용됩니다. 또한 `rustup`은 표준 라이브러리에 대한 문서를 다운로드할 수도 있습니다. 한 번에 여러 버전의 러스트를 설치할 수 있으며 `rustup`을 통해 필요에 따라 이들 버전을 전환할 수 있습니다."
+"`rustc`: `.rs` 확장자 파일을 바이너리 혹은 다른 중간 형식으로 변환해주는 "
+"Rust 컴파일러입니다."
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
+msgstr ""
+"`cargo`: 러스트 의존성 관리자 및 빌드도구 입니다. 여러분의 프로젝트에 명시된 "
+"의존성들을 <https://crates.io>에서 자동으로 다운로드 받고, 그 소스코드를 "
+"`rustc`로 전달하여 빌드를 시킵니다. 또한 유닛 테스트를 실행하는 테스트 러너"
+"를 내장하고 있습니다."
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
+"`rustup`: 러스트 툴체인 설치 프로그램 및 업데이트 프로그램. 이 도구는 새 버전"
+"의 러스트가 출시될 때 `rustc` 및 `cargo` 설치하고 업데이트하는 데 사용됩니"
+"다. 또한 `rustup`은 표준 라이브러리에 대한 문서를 다운로드할 수도 있습니다. "
+"한 번에 여러 버전의 러스트를 설치할 수 있으며 `rustup`을 통해 필요에 따라 이"
+"들 버전을 전환할 수 있습니다."
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1453,81 +1522,139 @@ msgstr "키 포인트:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful and comprehensive tool.  It is capable of many advanced features including but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as [cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* 러스트는 6주마다 새로운 릴리즈가 발표되며 이전 릴리즈와의 호환성을 유지하고 있습니다.\n"
-"\n"
-"* 릴리즈는 3가지 버전으로 제공됩니다: \"stable\", \"beta\" 그리고 \"nightly\".\n"
-"\n"
-"* 새로운 기능은 \"nightly\" -> \"beta\" -(6주 후)-> \"stable\" 로 변경됩니다.\n"
-"\n"
-"* 러스트는 [에디션][editions]으로 구분됩니다. 현재는 Rust 2021 에디션입니다. 이 전 에디션으로 Rust 2015와 Rust 2018이 있습니다.\n"
-"\n"
-"  * 에디션은 이전 에디션과 호환이 되지 않을 수 있습니다.\n"
-"\n"
-"  * 에디션이 바뀌면서 프로그램이 의도치 않게 깨지는 문제를 막기 위해, 각 프로그램은 자신이 빌드될 에디션을 명시적으로 `Cargo.toml`에 지정해야 합니다.\n"
-"\n"
-"  * 러스트 생태계가 에디션 별로 파편회 되는 것을 막기 위해, 러스트 컴파일러는 서로 다른 에디션에서 작성된 코드들을 하나의 바이너리로 묶을 수 있습니다.\n"
-"\n"
-"  * `cargo`를 사용하지 않고 컴파일러를 직접 사용하는 경우는 거의 없음을 언급해 주시기 바랍니다.\n"
-"\n"
-"  * 카고 자체가 매우 강력하고 포괄적인 도구임을 적극적으로 알리세요.\n"
-"  카고는 다음과 같은 다양한 고급 기능을 제공합니다.\n"
-"      * 프로젝트/패키지 구조화\n"
-"      * [워크스페이스][workspaces]\n"
-"      * 개발/런타임 종속성 관리 및 캐싱\n"
-"      * [빌드 스크립트][build scripting]\n"
-"      * [전역 설치][global installation]\n"
-"      * [cargo clippy]와 같은 하위 플러그인으로 확장 가능\n"
-"  * [공식 Cargo Book][official Cargo Book]에서 자세한 사항을 확인하시기 바랍니다."
+"러스트는 6주마다 새로운 릴리즈가 발표되며 이전 릴리즈와의 호환성을 유지하고 "
+"있습니다."
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr ""
+"릴리즈는 3가지 버전으로 제공됩니다: \"stable\", \"beta\" 그리고 \"nightly\"."
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr ""
+"새로운 기능은 \"nightly\" -> \"beta\" -(6주 후)-> \"stable\" 로 변경됩니다."
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"러스트는 [에디션](https://doc.rust-lang.org/edition-guide/)으로 구분됩니다. "
+"현재는 Rust 2021 에디션입니다. 이 전 에디션으로 Rust 2015와 Rust 2018이 있습"
+"니다."
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "에디션은 이전 에디션과 호환이 되지 않을 수 있습니다."
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"에디션이 바뀌면서 프로그램이 의도치 않게 깨지는 문제를 막기 위해, 각 프로그램"
+"은 자신이 빌드될 에디션을 명시적으로 `Cargo.toml`에 지정해야 합니다."
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr ""
+"러스트 생태계가 에디션 별로 파편회 되는 것을 막기 위해, 러스트 컴파일러는 서"
+"로 다른 에디션에서 작성된 코드들을 하나의 바이너리로 묶을 수 있습니다."
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+"`cargo`를 사용하지 않고 컴파일러를 직접 사용하는 경우는 거의 없음을 언급해 주"
+"시기 바랍니다."
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+"카고 자체가 매우 강력하고 포괄적인 도구임을 적극적으로 알리세요. 카고는 다음"
+"과 같은 다양한 고급 기능을 제공합니다."
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "프로젝트/패키지 구조화"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr ""
+"[워크스페이스](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr "개발/런타임 종속성 관리 및 캐싱"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr ""
+"[빌드 스크립트](https://doc.rust-lang.org/cargo/reference/build-scripts.html)"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr ""
+"[전역 설치](https://doc.rust-lang.org/cargo/commands/cargo-install.html)"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"[cargo clippy](https://github.com/rust-lang/rust-clippy)와 같은 하위 플러그인"
+"으로 확장 가능"
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr ""
+"[공식 Cargo Book](https://doc.rust-lang.org/cargo/)에서 자세한 사항을 확인하"
+"시기 바랍니다."
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# 강의에서의 코드 샘플"
+msgid "Code Samples in This Training"
+msgstr "강의에서의 코드 샘플"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through examples\n"
-"which can be executed through your browser. This makes the setup much easier and\n"
-"ensures a consistent experience for everyone."
-msgstr "이 강의자료에 있는 모든 예제는 브라우저에서 바로 수행 가능합니다. 이렇게 한 이유는, 준비 과정을 단순화 시키고, 모두가 같은 환경에서 작업할 수 있도록 하기 위함입니다."
+"For this training, we will mostly explore the Rust language through examples "
+"which can be executed through your browser. This makes the setup much easier "
+"and ensures a consistent experience for everyone."
+msgstr ""
+"이 강의자료에 있는 모든 예제는 브라우저에서 바로 수행 가능합니다. 이렇게 한 "
+"이유는, 준비 과정을 단순화 시키고, 모두가 같은 환경에서 작업할 수 있도록 하"
+"기 위함입니다."
 
 #: src/cargo/code-samples.md:7
 msgid ""
-"Installing Cargo is still encouraged: it will make it easier for you to do the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how to\n"
-"work with dependencies and for that you need Cargo."
-msgstr "그럼에도 불구하고, 카고(cargo)를 직접 설치하는 것을 강력 권장합니다. 이게 과제 작성에 더 도움이 될겁니다. 또한, 마지막 날에는 의존성이 있는 예제를 작업하게 될 텐데, 그 때에는 어차피 카고가 필요합니다."
+"Installing Cargo is still encouraged: it will make it easier for you to do "
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
+msgstr ""
+"그럼에도 불구하고, 카고(cargo)를 직접 설치하는 것을 강력 권장합니다. 이게 과"
+"제 작성에 더 도움이 될겁니다. 또한, 마지막 날에는 의존성이 있는 예제를 작업하"
+"게 될 텐데, 그 때에는 어차피 카고가 필요합니다."
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -1548,42 +1675,55 @@ msgstr ""
 "```"
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in the\n"
-"text box."
-msgstr "코드 블록에 포커스를 두고 <kbd>Ctrl + Enter</kbd>를 눌러 실행해 볼 수 있습니다."
+msgid "You can use "
+msgstr "코드 블록에 포커스를 두고 "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr "를 눌러 실행해 볼 수 있습니다."
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
-msgstr "강의에서 대부분의 코드 샘플은 위와 같이 수정할수 있지만 일부 코드는 다음과 같은 이유로 수정할 수 없습니다:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
+msgstr ""
+"강의에서 대부분의 코드 샘플은 위와 같이 수정할수 있지만 일부 코드는 다음과 같"
+"은 이유로 수정할 수 없습니다:"
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* 유닛 테스트는 내장 플레이그라운드에서 실행이 안됩니다. 외부 플레이그라운드 사이트에 붙여넣어 테스트를 실행하시기 바랍니다.\n"
-"\n"
-"* 내장된 플레이그라운드에서는 페이지 이동시 작성된 모든 내용이 사라집니다. 따라서 로컬 환경이나 외부 플레이그라운드 사이트에서 연습문제를 해결하는 것이 좋습니다."
+"유닛 테스트는 내장 플레이그라운드에서 실행이 안됩니다. 외부 플레이그라운드 사"
+"이트에 붙여넣어 테스트를 실행하시기 바랍니다."
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"내장된 플레이그라운드에서는 페이지 이동시 작성된 모든 내용이 사라집니다. 따라"
+"서 로컬 환경이나 외부 플레이그라운드 사이트에서 연습문제를 해결하는 것이 좋습"
+"니다."
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# 로컬 환경의 카고"
+msgid "Running Code Locally with Cargo"
+msgstr "로컬 환경의 카고"
 
 #: src/cargo/running-locally.md:3
 msgid ""
-"If you want to experiment with the code on your own system, then you will need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time of\n"
-"writing, the latest stable Rust release has these version numbers:"
-msgstr "만약 개인용 컴퓨터에서 코드를 실행해보려면 먼저 러스트를 설치해야 합니다. [Rust Book][1]의 지침에 따라 `rustc`와 `cargo`를 함께 설치 하시기 바랍니다. 설치 후 아래 커맨드를 통해 각 툴의 버전을 확인 할 수 있습니다:"
+"If you want to experiment with the code on your own system, then you will "
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
+msgstr ""
+"만약 개인용 컴퓨터에서 코드를 실행해보려면 먼저 러스트를 설치해야 합니다. "
+"[Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html)의 지침"
+"에 따라 `rustc`와 `cargo`를 함께 설치 하시기 바랍니다. 설치 후 아래 커맨드를 "
+"통해 각 툴의 버전을 확인 할 수 있습니다:"
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -1603,134 +1743,165 @@ msgstr ""
 
 #: src/cargo/running-locally.md:15
 msgid ""
-"With this is in place, then follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
-msgstr "정상적으로 설치가 되었으면 강의의 코드 블록중 하나를 아래 단계를 따라 로컬에서 실행할 수 있습니다:"
+"With this is in place, then follow these steps to build a Rust binary from "
+"one of the examples in this training:"
+msgstr ""
+"정상적으로 설치가 되었으면 강의의 코드 블록중 하나를 아래 단계를 따라 로컬에"
+"서 실행할 수 있습니다:"
 
 #: src/cargo/running-locally.md:18
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr "예시 블록에 있는 \"Copy to clipboard\" 버튼을 클릭해서 복사합니다."
+
+#: src/cargo/running-locally.md:20
 msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo build`\n"
-"   to compile it without running it. You will find the output in `target/debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
 msgstr ""
-"1. 예시 블록에 있는 \"Copy to clipboard\" 버튼을 클릭해서 복사합니다.\n"
-"\n"
-"2. 터미널에서 `cargo new exercise`를 입력해서 새로운 `exercise/` 폴더를 만듭니다:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. `exercise/` 폴더로 이동한 후, `cargo run` 커맨드로 코드를 실행합니다:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. `src/main.rs`에 코드를 작성합니다. 예를 들어 이전 페이지의 소스를 아래와 같이 `src/main.rs`에 작성합니다\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. `cargo run`커맨드로 소스를 빌드하고 실행합니다:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. `cargo check`커맨드는 빠르게 에러를 확인할 수 있습니다. `cargo build`는 실행없이 컴파일만 합니다. 이 경우에 `target/debug/`폴더에서 output을 확인 할 수 있습니다. `cargo build --release`커맨드는 릴리즈 버전용 최적화를 켜서 컴파일하며 `target/release/`폴더에서 확인 할 수 있습니다.\n"
-"\n"
-"7. `Cargo.toml`파일에는 의존성 패키지를 추가할 수 있습니다. `cargo`커맨드를 실행하면 자동으로 의존성 패키지를 다운로드하고 컴파일 까지 해 줍니다."
+"터미널에서 `cargo new exercise`를 입력해서 새로운 `exercise/` 폴더를 만듭니"
+"다:"
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr "`exercise/` 폴더로 이동한 후, `cargo run` 커맨드로 코드를 실행합니다:"
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+"`src/main.rs`에 코드를 작성합니다. 예를 들어 이전 페이지의 소스를 아래와 같"
+"이 `src/main.rs`에 작성합니다"
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr "`cargo run`커맨드로 소스를 빌드하고 실행합니다:"
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+"`cargo check`커맨드는 빠르게 에러를 확인할 수 있습니다. `cargo build`는 실행"
+"없이 컴파일만 합니다. 이 경우에 `target/debug/`폴더에서 output을 확인 할 수 "
+"있습니다. `cargo build --release`커맨드는 릴리즈 버전용 최적화를 켜서 컴파일"
+"하며 `target/release/`폴더에서 확인 할 수 있습니다."
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
+msgstr ""
+"`Cargo.toml`파일에는 의존성 패키지를 추가할 수 있습니다. `cargo`커맨드를 실행"
+"하면 자동으로 의존성 패키지를 다운로드하고 컴파일 까지 해 줍니다."
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
-msgstr "수강생들이 카고를 설치하고 로컬 편집기를 이용하도록 독려하세요. 조금 귀찮을 수도 있지만, 이렇게 해야만 좀 더 실제와 가까운 개발환경을 갖추게 되는 것입니다."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
+msgstr ""
+"수강생들이 카고를 설치하고 로컬 편집기를 이용하도록 독려하세요. 조금 귀찮을 "
+"수도 있지만, 이렇게 해야만 좀 더 실제와 가까운 개발환경을 갖추게 되는 것입니"
+"다."
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# 1일차 개요"
+msgid "Welcome to Day 1"
+msgstr "1일차 개요"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr "강의 첫 날입니다. 오늘 배울 것이 참 많습니다:"
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* 러스트 기본 문법: 변수, 스칼라 / 복합 타입, 열거형, 구조체, 참조형, 함수와 메서드.\n"
-"\n"
-"* 메모리 관리: 스택과 힙, 수동 메모리 관리, 스코프(범위)기반 메모리 관리, 가비지 컬렉션(GC)\n"
-"\n"
-"* 소유권: Move 문법, 복사와 복제, 빌림, 수명."
+"러스트 기본 문법: 변수, 스칼라 / 복합 타입, 열거형, 구조체, 참조형, 함수와 메"
+"서드."
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+"메모리 관리: 스택과 힙, 수동 메모리 관리, 스코프(범위)기반 메모리 관리, 가비"
+"지 컬렉션(GC)"
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr "소유권: Move 문법, 복사와 복제, 빌림, 수명."
 
 #: src/welcome-day-1.md:16
 msgid "Please remind the students that:"
@@ -1738,112 +1909,160 @@ msgstr "학생들에게 다음을 상기시켜 주시기 바랍니다:"
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i.e.,\n"
-"    keep the related to how Rust does things vs some other language. It can be\n"
-"    hard to find the right balance, but err on the side of allowing discussions\n"
-"    since they engage people much more than one-way communication.\n"
-"* The questions will likely mean that we talk about things ahead of the slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
+msgstr "궁금한 점이 있으면 주저하지 말고 질문 해야 합니다."
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr "이 수업은 상호작용이 중요하고 토론을 권장합니다."
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the related to how Rust does things vs some other language. It can be "
+"hard to find the right balance, but err on the side of allowing discussions "
+"since they engage people much more than one-way communication."
 msgstr ""
-"* 궁금한 점이 있으면 주저하지 말고 질문 해야 합니다.\n"
-"* 이 수업은 상호작용이 중요하고 토론을 권장합니다.\n"
-"  * 강사로서 토론이 옆길로 새지 않게 주의하세요. 예를 들어 러스트와 다른 언어들을 비교한다든지 하는 것은 좋습니다. 적절한 균형을 찾기 애매한 경우라면 토론을 허용하는 쪽이 일방적인 강의보다는 더 많은 사람들의 참여를 이끌어 낼 수 있습니다.\n"
-"* 질문이 슬라이드보다 앞서가도 괜찮습니다.\n"
-"  * 학습에 있어서 반복은 매우 중요합니다. 슬라이드는 그저 도움을 줄 뿐, 원하는 대로 건너띄어도 됩니다."
+"강사로서 토론이 옆길로 새지 않게 주의하세요. 예를 들어 러스트와 다른 언어들"
+"을 비교한다든지 하는 것은 좋습니다. 적절한 균형을 찾기 애매한 경우라면 토론"
+"을 허용하는 쪽이 일방적인 강의보다는 더 많은 사람들의 참여를 이끌어 낼 수 있"
+"습니다."
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr "질문이 슬라이드보다 앞서가도 괜찮습니다."
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"학습에 있어서 반복은 매우 중요합니다. 슬라이드는 그저 도움을 줄 뿐, 원하는 대"
+"로 건너띄어도 됩니다."
 
 #: src/welcome-day-1.md:29
 msgid ""
-"The idea for the first day is to show _just enough_ of Rust to be able to speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major feature\n"
-"and we should show students this right away."
-msgstr "첫 날 강의의 목표는, 러스트에서 그 유명한 빌림 확인에 대해서 이야기 할 수 있을 정도 까지만 러스트를 소개하는 것입니다. 러스트의 가장 독특한 특징이 메모리를 다루는 방식이기 때문에, 학생들에게 이 부분 을 우선적으로 보여주려 합니다."
+"The idea for the first day is to show _just enough_ of Rust to be able to "
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
+msgstr ""
+"첫 날 강의의 목표는, 러스트에서 그 유명한 빌림 확인에 대해서 이야기 할 수 있"
+"을 정도 까지만 러스트를 소개하는 것입니다. 러스트의 가장 독특한 특징이 메모리"
+"를 다루는 방식이기 때문에, 학생들에게 이 부분 을 우선적으로 보여주려 합니다."
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
-msgstr "만약 당신이 강의실에서 가르치고 있다면, 이 슬라이드는 일정을 검토하기에 적합한 곳입니다. 하루치 강의를 아래처럼 오전 오후로 나누어 진행하는 것을 추천합니다. (슬라이드가 그런식으로 나뉘어 있습니다.)"
+msgstr ""
+"만약 당신이 강의실에서 가르치고 있다면, 이 슬라이드는 일정을 검토하기에 적합"
+"한 곳입니다. 하루치 강의를 아래처럼 오전 오후로 나누어 진행하는 것을 추천합니"
+"다. (슬라이드가 그런식으로 나뉘어 있습니다.)"
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* 오전: 9:00 ~ 12:00,\n"
-"* 오후: 13:00 ~ 16:00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "오전: 9:00 ~ 12:00,"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "오후: 13:00 ~ 16:00."
 
 #: src/welcome-day-1.md:39
 msgid ""
-"You can of course adjust this as necessary. Please make sure to include breaks,\n"
-"we recommend a break every hour!"
-msgstr "물론 필요에 따라 조절할 수 있습니다. 강의 중간에 쉬는시간을 넣는 것을 잊지 마세요. 매 시간 휴식을 갖는걸 추천합니다!"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# 러스트란?"
+"You can of course adjust this as necessary. Please make sure to include "
+"breaks, we recommend a break every hour!"
+msgstr ""
+"물론 필요에 따라 조절할 수 있습니다. 강의 중간에 쉬는시간을 넣는 것을 잊지 마"
+"세요. 매 시간 휴식을 갖는걸 추천합니다!"
 
 #: src/welcome-day-1/what-is-rust.md:3
-msgid "Rust is a new programming language which had its [1.0 release in 2015][1]:"
-msgstr "러스트는 2015년에 [버전 1.0][1]을 릴리즈 한 새로운 프로그램 언어입니다:"
+msgid ""
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
+msgstr ""
+"러스트는 2015년에 [버전 1.0](https://blog.rust-lang.org/2015/05/15/Rust-1.0."
+"html)을 릴리즈 한 새로운 프로그램 언어입니다:"
 
 #: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "러스트는 C++와 유사한 정적 컴파일 언어입니다."
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc`는 LLVM을 백엔드로 사용합니다."
+
+#: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
-msgstr ""
-"* 러스트는 C++와 유사한 정적 컴파일 언어입니다.\n"
-"  * `rustc`는 LLVM을 백엔드로 사용합니다.\n"
-"* 러스트는 다양한 플랫폼과 아키텍쳐를 지원합니다.\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* 러스트는 다양한 장치에서 사용될 수 있습니다:\n"
-"  * 펌웨어와 부트로더(임베디드)\n"
-"  * 스마트 디스플레이\n"
-"  * 스마트폰\n"
-"  * 데스크탑\n"
-"  * 서버"
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+msgstr "러스트는 다양한 플랫폼과 아키텍쳐를 지원합니다."
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, ..."
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "러스트는 다양한 장치에서 사용될 수 있습니다:"
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "펌웨어와 부트로더(임베디드)"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "스마트 디스플레이"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "스마트폰"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "데스크탑"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "서버"
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "러스트는 C++가 사용되는 대부분의 곳에서 사용 가능합니다:"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* 높은 유연성.\n"
-"* 높은 레벨 수준의 제어.\n"
-"* 휴대폰과 같은 매우 제한된 장치로 스케일 다운 가능.\n"
-"* 별도의 런타임을 필요로 하지 않으며, 가비지 컬렉션도 없음.\n"
-"* 성능을 타협하지 않으면서도 안정성과 안전에 중점을 둠."
+msgid "High flexibility."
+msgstr "높은 유연성."
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr "# Hello World!"
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "높은 레벨 수준의 제어."
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr "휴대폰과 같은 매우 제한된 장치로 스케일 다운 가능."
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "별도의 런타임을 필요로 하지 않으며, 가비지 컬렉션도 없음."
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr "성능을 타협하지 않으면서도 안정성과 안전에 중점을 둠."
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
-msgstr "가장 간단한 러스트 프로그램으로써, 고전적인 Hello World 를 작성해 보겠습니다:"
+msgstr ""
+"가장 간단한 러스트 프로그램으로써, 고전적인 Hello World 를 작성해 보겠습니다:"
 
 #: src/hello-world.md:6
 msgid ""
@@ -1859,51 +2078,70 @@ msgid "What you see:"
 msgstr "확인할 수 있는 것들:"
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "함수는 `fn`으로 선언합니다."
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "C/C++ 와 마찬가지로 중괄호`{}`로 블록을 표시합니다."
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "`main` 함수는 프로그램 진입점입니다."
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr ""
-"* 함수는 `fn`으로 선언합니다.\n"
-"* C/C++ 와 마찬가지로 중괄호`{}`로 블록을 표시합니다.\n"
-"* `main` 함수는 프로그램 진입점입니다.\n"
-"* 러스트는 똑똑한 매크로(hygienic macros) 시스템을 가지고 있습니다. `println!`는 그 예시입니다.\n"
-"* 러스트의 문자열은 UTF-8로 인코딩되며 이모지와 같은 유니코드 문자를 포함할 수 있습니다."
+"러스트는 똑똑한 매크로(hygienic macros) 시스템을 가지고 있습니다. `println!`"
+"는 그 예시입니다."
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr ""
+"러스트의 문자열은 UTF-8로 인코딩되며 이모지와 같은 유니코드 문자를 포함할 수 "
+"있습니다."
 
 #: src/hello-world.md:22
 msgid ""
-"This slide tries to make the students comfortable with Rust code. They will see\n"
-"a ton of it over the next four days so we start small with something familiar."
-msgstr "이 슬라이드는 학생들이 러스트 코드에 익숙해지기 위해 작성되었습니다. 앞으로 4일 동안 많은 코드를 접할 것이기 때문에 우선 친숙한 코드부터 시작합니다."
+"This slide tries to make the students comfortable with Rust code. They will "
+"see a ton of it over the next four days so we start small with something "
+"familiar."
+msgstr ""
+"이 슬라이드는 학생들이 러스트 코드에 익숙해지기 위해 작성되었습니다. 앞으로 4"
+"일 동안 많은 코드를 접할 것이기 때문에 우선 친숙한 코드부터 시작합니다."
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude.md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygenic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* 러스트는 C/C++/Java와 같은 전통적인 다른 언어와 매우 유사합니다. 러스트는 절차적(함수형 아님) 언어입니다. 정말로 필요한 경우가 아니라면, 러스트는 이미 존재하는 것을 새로 구현하려고 하지 않습니다.\n"
-"\n"
-"* 러스트는 유니코드 지원과 같은 현대 언어의 특징을 전부 지원합니다.\n"
-"\n"
-"* 러스트는 인자의 개수를 사전에 지정할 수 없는 상황에서 함수 [오버로딩](basic-syntax/functions-interlude.md)대신 매크로를 사용합니다.\n"
-"\n"
-"* 똑똑한 매크로(hygienic macro)는 매크로가 사용되는 스코프에서 의도치 않게 변수를 가로채지 않습니다. 사실 러스트 매크로는 완전히 hygenic하지는 않습니다. [링크](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)를 참고하세요."
+"러스트는 C/C++/Java와 같은 전통적인 다른 언어와 매우 유사합니다. 러스트는 절"
+"차적(함수형 아님) 언어입니다. 정말로 필요한 경우가 아니라면, 러스트는 이미 존"
+"재하는 것을 새로 구현하려고 하지 않습니다."
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# 작은 예제"
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "러스트는 유니코드 지원과 같은 현대 언어의 특징을 전부 지원합니다."
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"러스트는 인자의 개수를 사전에 지정할 수 없는 상황에서 함수 [오버로딩](basic-"
+"syntax/functions-interlude.md)대신 매크로를 사용합니다."
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygenic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+msgstr ""
+"똑똑한 매크로(hygienic macro)는 매크로가 사용되는 스코프에서 의도치 않게 변수"
+"를 가로채지 않습니다. 사실 러스트 매크로는 완전히 hygenic하지는 않습니다. [링"
+"크](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)를 참"
+"고하세요."
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -1945,346 +2183,542 @@ msgstr ""
 
 #: src/hello-world/small-example.md:23
 msgid ""
-"The code implements the Collatz conjecture: it is believed that the loop will\n"
-"always end, but this is not yet proved. Edit the code and play with different\n"
-"inputs."
-msgstr "이 코드는 콜라츠 추측(Collatz conjecture)으로 구현됩니다: 반복문이 언제나 종료될 것이라고 믿지만 증명된 것은 아닙니다. 코드를 수정하고 실행해 보시기 바랍니다."
+"The code implements the Collatz conjecture: it is believed that the loop "
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
+msgstr ""
+"이 코드는 콜라츠 추측(Collatz conjecture)으로 구현됩니다: 반복문이 언제나 종"
+"료될 것이라고 믿지만 증명된 것은 아닙니다. 코드를 수정하고 실행해 보시기 바랍"
+"니다."
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that the\n"
-"  students become familiar with searching in the standard library."
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* 모든 변수가 컴파일 시 정해진 타입을 가짐을 설명합니다. `i32`를 삭제하여 컴파일러가 타입 추론을 하도록 해 봅니다. `i32`을 `i8`로 변경하여 런타임 오버플로를 유발해 볼 수 있습니다.\n"
-"\n"
-"* `let mut x`를 `let x`로 수정하여 컴파일 오류에 대해 토론합니다.\n"
-"\n"
-"* 인자가 포맷 문자열과 일치하지 않는 경우 `print!`에서 컴파일 오류가 발생함을 언급하는 것도 좋습니다.\n"
-"\n"
-"* 단일 변수보다 복잡한 식을 출려하려면 `{}`을 자리 표시자로 사용하는 방법을 보여 줍니다.\n"
-"\n"
-"* 학생들에게 표준 라이브러리가 어디 있는지 알려 주고는, `print!`가 지원하는 포맷팅 언어의 문법을 알기 위해 `std::fmt`를 검색해야 한다는 것을 가르치세요.학생들이 표준 라이브러리의 검색 기능에 익숙해 지도록 하는 것이 중요합니다."
+"모든 변수가 컴파일 시 정해진 타입을 가짐을 설명합니다. `i32`를 삭제하여 컴파"
+"일러가 타입 추론을 하도록 해 봅니다. `i32`을 `i8`로 변경하여 런타임 오버플로"
+"를 유발해 볼 수 있습니다."
 
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# 러스트를 써야하는 이유"
+#: src/hello-world/small-example.md:32
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "`let mut x`를 `let x`로 수정하여 컴파일 오류에 대해 토론합니다."
+
+#: src/hello-world/small-example.md:34
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+"인자가 포맷 문자열과 일치하지 않는 경우 `print!`에서 컴파일 오류가 발생함을 "
+"언급하는 것도 좋습니다."
+
+#: src/hello-world/small-example.md:37
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+"단일 변수보다 복잡한 식을 출려하려면 `{}`을 자리 표시자로 사용하는 방법을 보"
+"여 줍니다."
+
+#: src/hello-world/small-example.md:40
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"학생들에게 표준 라이브러리가 어디 있는지 알려 주고는, `print!`가 지원하는 포"
+"맷팅 언어의 문법을 알기 위해 `std::fmt`를 검색해야 한다는 것을 가르치세요.학"
+"생들이 표준 라이브러리의 검색 기능에 익숙해 지도록 하는 것이 중요합니다."
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "러스트만의 독특한 세일즈 포인트(장점):"
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* 컴파일 시 메모리 안전이 보장됨.\n"
-"* 정의되지 않은 런타임 동작이 없음.\n"
-"* 현대적인 언어 기능."
+msgid "Compile time memory safety."
+msgstr "컴파일 시 메모리 안전이 보장됨."
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "정의되지 않은 런타임 동작이 없음."
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "현대적인 언어 기능."
 
 #: src/why-rust.md:11
 msgid ""
-"Make sure to ask the class which languages they have experience with. Depending\n"
-"on the answer you can highlight different features of Rust:"
-msgstr "수강생들에게 어떤 프로그래밍 언어를 사용했는지 물어보시기 바랍니다. 어떤 언어를 사용했느냐에 따라 러스트에서 어떤 점을 강조해야 할지를 고민해 보세요:"
+"Make sure to ask the class which languages they have experience with. "
+"Depending on the answer you can highlight different features of Rust:"
+msgstr ""
+"수강생들에게 어떤 프로그래밍 언어를 사용했는지 물어보시기 바랍니다. 어떤 언어"
+"를 사용했느냐에 따라 러스트에서 어떤 점을 강조해야 할지를 고민해 보세요:"
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory safety\n"
-"  as in those languages, plus a similar high-level language feeling. In addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* C/C++: 러스트는 '빌림'검사기를 통해서 수행중에 발생할 수 있는 모든 에러를 제거합니다. 러스트는 C와 C++과 비슷한 수준의 성능을 보여주면서도, 그 언어들에서 종종 발생하는 메모리 관련 오류가 없습니다. 또한, 패턴 매칭이나, 기본적으로 제공되는 종속성 관리와 같은 현대적인 언어의 기능들을 제공합니다.\n"
-"\n"
-"* Java, Go, Python, JaveScript: 이 언어들과 동일한 메모리 안정성과 함께, '하이레벨'언어의 느낌을 느낄 수 있습니다. 거기에 더해, 가비지 컬렉터가 없는 C/C++와 유사한 수준의 빠르고 예측 가능한 성능을 기대할 수 있습니다. 그리고 필요한 경우 저수준 하드웨어를 다루는 코드로 작성할 수 있습니다."
+"C/C++: 러스트는 '빌림'검사기를 통해서 수행중에 발생할 수 있는 모든 에러를 제"
+"거합니다. 러스트는 C와 C++과 비슷한 수준의 성능을 보여주면서도, 그 언어들에"
+"서 종종 발생하는 메모리 관련 오류가 없습니다. 또한, 패턴 매칭이나, 기본적으"
+"로 제공되는 종속성 관리와 같은 현대적인 언어의 기능들을 제공합니다."
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# 컴파일 시 보장되는 것들"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"Java, Go, Python, JaveScript: 이 언어들과 동일한 메모리 안정성과 함께, '하이"
+"레벨'언어의 느낌을 느낄 수 있습니다. 거기에 더해, 가비지 컬렉터가 없는 C/C+"
+"+와 유사한 수준의 빠르고 예측 가능한 성능을 기대할 수 있습니다. 그리고 필요"
+"한 경우 저수준 하드웨어를 다루는 코드로 작성할 수 있습니다."
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "컴파일 시 정적 메모리 관리:"
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* 초기화되지 않는 변수가 없습니다.\n"
-"* 메모리 누출 없음(_거의_. 강의참조노트 참고.)\n"
-"* 메모리 이중 해제가 원천적으로 불가능 합니다.\n"
-"* 메모리 해제 후 사용이 원천적으로 불가능 합니다.\n"
-"* `NULL`포인터는 없습니다.\n"
-"* 뮤텍스를 잠궈 놓고 여는 것을 잊는 실수를 할 수 없습니다.\n"
-"* 스레드간 데이터 레이스를 막아줍니다.\n"
-"* 반복자가 갑자기 무효화 되는 경우가 없습니다."
+msgid "No uninitialized variables."
+msgstr "초기화되지 않는 변수가 없습니다."
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "메모리 누출 없음(_거의_. 강의참조노트 참고.)"
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "메모리 이중 해제가 원천적으로 불가능 합니다."
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "메모리 해제 후 사용이 원천적으로 불가능 합니다."
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "`NULL`포인터는 없습니다."
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "뮤텍스를 잠궈 놓고 여는 것을 잊는 실수를 할 수 없습니다."
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "스레드간 데이터 레이스를 막아줍니다."
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "반복자가 갑자기 무효화 되는 경우가 없습니다."
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
-msgstr "(안전한) 러스트에서도 메모리 누출이 발생할 수 있는 몇 가지 경우가 있습니다:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
+msgstr ""
+"(안전한) 러스트에서도 메모리 누출이 발생할 수 있는 몇 가지 경우가 있습니다:"
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can for use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can for use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* [`Box::leak`]을 이용하여 포인터를 의도적으로 누출시킬 수 있습니다. 이를 이용해서 런타임이 생성하고 런타임이 크기를 정한 정적 변수를 가져올 수 있습니다.\n"
-"* [`std::mem::forget`]을 사용하여 컴파일러가 값에 대해 \"잊도록\" 만들 수 있습니다(소멸자가 실행되지 않음을 의미합니다).\n"
-"* `Rc` 또는 `Arc`를 사용하여 실수로 [순환참조][reference cycle]를 생성할 수도 있습니다.\n"
-"* 컬렉션을 무한정 채우는 것을 메모리 누출로 간주할 수도 있지만, 러스트는 이를 보호하진 못합니다."
+"[`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
+"leak)을 이용하여 포인터를 의도적으로 누출시킬 수 있습니다. 이를 이용해서 런타"
+"임이 생성하고 런타임이 크기를 정한 정적 변수를 가져올 수 있습니다."
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"[`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget.html)을 사용"
+"하여 컴파일러가 값에 대해 \"잊도록\" 만들 수 있습니다(소멸자가 실행되지 않음"
+"을 의미합니다)."
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"`Rc` 또는 `Arc`를 사용하여 실수로 [순환참조](https://doc.rust-lang.org/book/"
+"ch15-06-reference-cycles.html)를 생성할 수도 있습니다."
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"컬렉션을 무한정 채우는 것을 메모리 누출로 간주할 수도 있지만, 러스트는 이를 "
+"보호하진 못합니다."
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
-msgstr "본 강의에서는 \"메모리 누출 없음\"을 \"우발적인 메모리 누출 없음\"으로 이해해야 합니다."
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# 런타임 시 보장되는 것들"
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
+msgstr ""
+"본 강의에서는 \"메모리 누출 없음\"을 \"우발적인 메모리 누출 없음\"으로 이해해"
+"야 합니다."
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "런타임 시 정의되지 않음(undefined) 동작 없음:"
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
-msgstr ""
-"* 배열 접근시 경계 체크\n"
-"* 정수형 타입의 변수에서 오버플로우 발생시 동작이 잘 정의되어있습니다."
+msgid "Array access is bounds checked."
+msgstr "배열 접근시 경계 체크"
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
+msgstr "정수형 타입의 변수에서 오버플로우 발생시 동작이 잘 정의되어있습니다."
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* 정수형 오버플로우는 컴파일 타임 플레그를 통해 정의됩니다. 옵션은 패닉(프로그램 크레시) 혹은 올림(wrap-around)입니다. 기본적으로 디버그 모드(`cargo build`)에서는 패닉이, 릴리즈 모드(`cargo build --release`)에서는 wrap-around가 발생합니다.\n"
-"\n"
-"* 컴파일 플래그를 사용하여 경계체크를 무력화 할 수 없습니다. `unsafe`를 사용하더라도 마찬가지입니다. 하지만 `unsafe`에서 호출 가능한 `slice::get_unchecked`같은 함수는 경계 검사를 수행하지 않습니다."
+"정수형 오버플로우는 컴파일 타임 플레그를 통해 정의됩니다. 옵션은 패닉(프로그"
+"램 크레시) 혹은 올림(wrap-around)입니다. 기본적으로 디버그 모드(`cargo "
+"build`)에서는 패닉이, 릴리즈 모드(`cargo build --release`)에서는 wrap-around"
+"가 발생합니다."
 
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# 현대적인 특징"
+#: src/why-rust/runtime.md:17
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"컴파일 플래그를 사용하여 경계체크를 무력화 할 수 없습니다. `unsafe`를 사용하"
+"더라도 마찬가지입니다. 하지만 `unsafe`에서 호출 가능한 `slice::get_unchecked`"
+"같은 함수는 경계 검사를 수행하지 않습니다."
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
-msgstr "러스트는 지난 40년간의 모든 (프로그래밍 언어들의) 경험으로 만들어졌습니다."
+msgstr ""
+"러스트는 지난 40년간의 모든 (프로그래밍 언어들의) 경험으로 만들어졌습니다."
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## 언어적 특징"
+msgid "Language Features"
+msgstr "언어적 특징"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
+#, fuzzy
+msgid "Enums and pattern matching."
+msgstr "열거형과 패턴 매칭."
+
+#: src/why-rust/modern.md:8
+#, fuzzy
+msgid "Generics."
+msgstr "제네릭."
+
+#: src/why-rust/modern.md:9
+#, fuzzy
+msgid "No overhead FFI."
+msgstr "FFI 런타임 오버헤드 없음."
+
+#: src/why-rust/modern.md:10
+#, fuzzy
+msgid "Zero-cost abstractions."
 msgstr ""
-"* 열거형과 패턴 매칭.\n"
-"* 제네릭.\n"
-"* FFI 런타임 오버헤드 없음.\n"
-"  * _역주: FFI: Foreign Function Interface. 타 언어 코드를 호출하기 위한 인터페이스_\n"
-"* 제로 코스트 추상화."
+"_역주: FFI: Foreign Function Interface. 타 언어 코드를 호출하기 위한 인터페이"
+"스_\n"
+"\n"
+"제로 코스트 추상화."
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
-msgstr "## 도구들"
+msgid "Tooling"
+msgstr "도구들"
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* 친절한 컴파일러 오류메시지.\n"
-"* 내장 종속성 관리자.\n"
-"* 내장 테스트 지원.\n"
-"* LSP (Language Server Protocol, 언어 서버 프로토콜) 지원이 잘되어 있음."
+msgid "Great compiler errors."
+msgstr "친절한 컴파일러 오류메시지."
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "내장 종속성 관리자."
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "내장 테스트 지원."
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "LSP (Language Server Protocol, 언어 서버 프로토콜) 지원이 잘되어 있음."
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to 'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with _actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, Python,\n"
-"  and Go. Rust does not come with several things you might consider standard and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this makes\n"
-"  it trivial to download and compile third-party crates. A consequence of this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* C++ 와 유사하게 제로 코스트 추상화는 CPU나 메모리를 사용하여 상위레벨 프로그래밍 구조를 만드는데 '비용'을 지불할 필요가 없습니다. 예를 들어 `for` 루프와와 `iter().fold()` 구조를 사용하는 것과 거의 동일한 낮은 수준의 명령어가 생성될 것 입니다.\n"
-"\n"
-"* 러스트의 열거형(enum)은 합계 타입(sum type)으로 알려진 대수학적 데이터형(Algebraic Data Type)으로, 타입 시스템이 `Option<T>`와 `Result<T, E>`등을 표현할 수 있게 해줍니다.\n"
-"\n"
-"* 오류를 읽어보시기 바랍니다 --- 오랜기간 많은 개발자들이 컴파일러 출력을 무시하는데 익숙해져 있습니다. 러스트 컴파일러는 다른 컴파일러보다 더 수다스럽고, 복사-붙여넣기 할 수 있는 정도의 코드 피드백을 제공하는 경우가 많습니다.\n"
-"\n"
-"* 러스트 표준 라이브러리는 Java, Python이나 Go와 같은 언어에 비해서 규모가 작습니다. 당연히 포함되어야 한다고 생각할 수도 있는 아래와 같은 것들이 러스트의 표준 라이브러리에 없습니다:\n"
-"\n"
-"  * 난수 생성기, 하지만 [rand]문서를 참조하시기 바랍니다.\n"
-"  * SSL 또는 TLS지원, 하지만 [rusttls]문서를 참조하시기 바랍니다.\n"
-"  * JSON 지원, 하지만 [serde_json] 문서를 참조하시기 바랍니다.\n"
-"\n"
-"  그 이유는 표준 라이브러리에서 한 번 어떤 기능을 제공하면 뺄 수 없으며, 매우 안정적이어야 하기 때문입니다. 위에 언급한 기능들은 아직 러스트 커뮤니티가 최고의 솔루션을 찾지 못했기 때문에 표준 라이브러리에 포함되지 않았습니다. 어쩌면 이들 중 몇 개는 '최고의 솔루션'이 아예 존재할 수 없을 지도 모릅니다.\n"
-"\n"
-"  러스트는 카고라는 패키지 관리자가 내장되어 있고, 서드파티 크레이트를 다운로드, 컴파일 하기 매우 쉽습니다. 이 또한 표준 라이브러리가 작은 이유입니다.\n"
-"\n"
-"  좋은 서드파티 크레이트를 찾는 것은 어렵습니다. <https://lib.rs> 와 같은 사이트가 신뢰할수 있는 좋은 크레이트를 비교하여 찾는데 좋습니다.\n"
-"\n"
-"* [rust-analyzer]는 주요 IDE나 텍스트 에디터에서 사용되는 러스트용 LSP서버 입니다."
+"C++ 와 유사하게 제로 코스트 추상화는 CPU나 메모리를 사용하여 상위레벨 프로그"
+"래밍 구조를 만드는데 '비용'을 지불할 필요가 없습니다. 예를 들어 `for` 루프와"
+"와 `iter().fold()` 구조를 사용하는 것과 거의 동일한 낮은 수준의 명령어가 생성"
+"될 것 입니다."
 
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
-msgstr "# 기본 문법"
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+"러스트의 열거형(enum)은 합계 타입(sum type)으로 알려진 대수학적 데이터형"
+"(Algebraic Data Type)으로, 타입 시스템이 `Option<T>`와 `Result<T, E>`등을 표"
+"현할 수 있게 해줍니다."
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"오류를 읽어보시기 바랍니다 --- 오랜기간 많은 개발자들이 컴파일러 출력을 무시"
+"하는데 익숙해져 있습니다. 러스트 컴파일러는 다른 컴파일러보다 더 수다스럽고, "
+"복사-붙여넣기 할 수 있는 정도의 코드 피드백을 제공하는 경우가 많습니다."
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+"러스트 표준 라이브러리는 Java, Python이나 Go와 같은 언어에 비해서 규모가 작습"
+"니다. 당연히 포함되어야 한다고 생각할 수도 있는 아래와 같은 것들이 러스트의 "
+"표준 라이브러리에 없습니다:"
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr ""
+"난수 생성기, 하지만 [rand](https://docs.rs/rand/)문서를 참조하시기 바랍니다."
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr ""
+"SSL 또는 TLS지원, 하지만 [rusttls](https://docs.rs/rustls/)문서를 참조하시기 "
+"바랍니다."
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+"JSON 지원, 하지만 [serde_json](https://docs.rs/serde_json/) 문서를 참조하시"
+"기 바랍니다."
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+"그 이유는 표준 라이브러리에서 한 번 어떤 기능을 제공하면 뺄 수 없으며, 매우 "
+"안정적이어야 하기 때문입니다. 위에 언급한 기능들은 아직 러스트 커뮤니티가 최"
+"고의 솔루션을 찾지 못했기 때문에 표준 라이브러리에 포함되지 않았습니다. 어쩌"
+"면 이들 중 몇 개는 '최고의 솔루션'이 아예 존재할 수 없을 지도 모릅니다."
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+"러스트는 카고라는 패키지 관리자가 내장되어 있고, 서드파티 크레이트를 다운로"
+"드, 컴파일 하기 매우 쉽습니다. 이 또한 표준 라이브러리가 작은 이유입니다."
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+"좋은 서드파티 크레이트를 찾는 것은 어렵습니다. <https://lib.rs> 와 같은 사이"
+"트가 신뢰할수 있는 좋은 크레이트를 비교하여 찾는데 좋습니다."
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/)는 주요 IDE나 텍스트 에디터"
+"에서 사용되는 러스트용 LSP서버 입니다."
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr "대부분의 러스트 문법은 C/C++/Java 와 유사합니다:"
 
 #: src/basic-syntax.md:5
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
-msgstr ""
-"* 블록과 범위는 중괄호`{}`로 표현합니다.\n"
-"* 인라인 주석은 `//`, 블록 주석은 `/* ... */`로 사용합니다.\n"
-"* `if`나 `while`같은 키워드도 동일합니다.\n"
-"* 변수 할당은 `=`, 비교는 `==`를 사용합니다."
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "블록과 범위는 중괄호`{}`로 표현합니다."
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
-msgstr "# 스칼라 타입"
-
-#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax.md:6
 msgid ""
-"|                        | Types                                      | Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, `123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | `3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | `\"foo\"`, `r#\"\\\\\"#`            |\n"
-"| Unicode scalar values  | `char`                                     | `'a'`, `'α'`, `'∞'`           |\n"
-"| Byte strings           | `&[u8]`                                    | `b\"abc\"`, `br#\" \" \"#`         |\n"
-"| Booleans               | `bool`                                     | `true`, `false`               |"
-msgstr ""
-"|                 | 타입                                       | 스칼라 리터럴 값              |\n"
-"|-----------------|--------------------------------------------|-------------------------------|\n"
-"| 부호있는 정수   | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, `1_000`, `123i64` |\n"
-"| 부호없는 정수   | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, `123`, `10u16`           |\n"
-"| 부동소수        | `f32`, `f64`                               | `3.14`, `-10.0e20`, `2f32`    |\n"
-"| 문자열          | `&str`                                     | `\"foo\"`, `r#\"\\\\\"#`      |\n"
-"| 유니코드 문자   | `char`                                     | `'a'`, `'α'`, `'∞'`           |\n"
-"| 바이트 문자     | `&[u8]`                                    | `b\"abc\"`, `br#\" \" \"#`    |\n"
-"| 불리언          | `bool`                                     | `true`, `false`               |"
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
+msgstr "인라인 주석은 `//`, 블록 주석은 `/* ... */`로 사용합니다."
+
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "`if`나 `while`같은 키워드도 동일합니다."
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr "변수 할당은 `=`, 비교는 `==`를 사용합니다."
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Types"
+msgstr "타입"
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr "스칼라 리터럴 값"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr "부호있는 정수"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr "부호없는 정수"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr "부동소수"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr "문자열"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `r#\"\\\\\"#`"
+msgstr "`\"foo\"`, `r#\"\\\\\"#`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr "유니코드 문자"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr "`char`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Byte strings"
+msgstr "바이트 문자"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`&[u8]`"
+msgstr "`&[u8]`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`b\"abc\"`, `br#\" \" \"#`"
+msgstr "`b\"abc\"`, `br#\" \" \"#`"
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "Booleans"
+msgstr "불리언"
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`bool`"
+msgstr "`bool`"
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`true`, `false`"
+msgstr "`true`, `false`"
 
 #: src/basic-syntax/scalar-types.md:13
 msgid "The types have widths as follows:"
 msgstr "각 타입의 크기는 다음과 같습니다:"
 
 #: src/basic-syntax/scalar-types.md:15
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
+#, fuzzy
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
 msgstr ""
-"* 정수(`i`) 및 부동소수형(`f`)은 뒤의 숫자와 같은 비트 수 입니다. (`i8` = 8비트)\n"
-"* `isize` 와 `usize` 는 포인터와 같은 크기입니다.\n"
-"  * _역주: 32 비트 시스템에서는 32 비트, 64 비트 시스템에서는 64 비트. C의 `int`와 같음._\n"
-"* `char` 32 비트 입니다.\n"
-"* `bool`은 8 비트 입니다."
+"정수(`i`) 및 부동소수형(`f`)은 뒤의 숫자와 같은 비트 수 입니다. (`i8` = 8비"
+"트)"
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr "# 복합 타입"
+#: src/basic-syntax/scalar-types.md:16
+#, fuzzy
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` 와 `usize` 는 포인터와 같은 크기입니다."
 
-#: src/basic-syntax/compound-types.md:3
-msgid ""
-"|        | Types                         | Literals                          |\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          |\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... |"
+#: src/basic-syntax/scalar-types.md:17
+#, fuzzy
+msgid "`char` is 32 bit wide,"
 msgstr ""
-"|      | 타입                          | 리터럴                            |\n"
-"|------|-------------------------------|-----------------------------------|\n"
-"| 배열 | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          |\n"
-"| 튜플 | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... |"
+"_역주: 32 비트 시스템에서는 32 비트, 64 비트 시스템에서는 64 비트. C의 `int`"
+"와 같음._"
+
+#: src/basic-syntax/scalar-types.md:18
+#, fuzzy
+msgid "`bool` is 8 bit wide."
+msgstr ""
+"`char` 32 비트 입니다.\n"
+"\n"
+"`bool`은 8 비트 입니다."
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr "배열"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr "`[T; N]`"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr "`[20, 30, 40]`, `[0; 3]`"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr "튜플"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
 
 #: src/basic-syntax/compound-types.md:8
 msgid "Array assignment and access:"
@@ -2336,58 +2770,71 @@ msgstr "배열:"
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that `[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
 msgstr ""
-"* 배열은, 같은 타입 `T`의 값이 `N`개 있는 것입니다. 여기서 `N`은 컴파일 타임에 결정된 값이어야 합니다. 이 길이도 타입의 일부입니다. 따라서, `[u8; 3]`와 `[u8; 4]`은 서로 다른 타입입니다.\n"
-"\n"
-"* 리터럴을 사용하여 배열에 값을 할당할 수 있습니다.\n"
-"\n"
-"* 포매팅 문자열에서 `?`는 디버깅 출력을 의미합니다. `{}`는 기본 출력이며, `{:?}`는 디버깅 출력입니다. `{a}`, `{a:?}`와 같이 출력할 변수 이름을 포매팅 문자열에 포함시킬 수도 있으며, 이 경우 인자 `a`는 별도의 인자로 추가하지 않습니다.\n"
-"\n"
-"* `#`을 추가하면(`{a:#?}`) 좀 더 읽기 쉬운 \\\"이쁜\\\" 형태로 출력이 됩니다."
+"배열은, 같은 타입 `T`의 값이 `N`개 있는 것입니다. 여기서 `N`은 컴파일 타임에 "
+"결정된 값이어야 합니다. 이 길이도 타입의 일부입니다. 따라서, `[u8; 3]`와 "
+"`[u8; 4]`은 서로 다른 타입입니다."
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr "리터럴을 사용하여 배열에 값을 할당할 수 있습니다."
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+"포매팅 문자열에서 `?`는 디버깅 출력을 의미합니다. `{}`는 기본 출력이며, `{:?}"
+"`는 디버깅 출력입니다. `{a}`, `{a:?}`와 같이 출력할 변수 이름을 포매팅 문자열"
+"에 포함시킬 수도 있으며, 이 경우 인자 `a`는 별도의 인자로 추가하지 않습니다."
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
+msgstr ""
+"`#`을 추가하면(`{a:#?}`) 좀 더 읽기 쉬운 \"이쁜\" 형태로 출력이 됩니다."
 
 #: src/basic-syntax/compound-types.md:47
 msgid "Tuples:"
 msgstr "튜플:"
 
 #: src/basic-syntax/compound-types.md:49
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a type, and\n"
-"  the only valid value of that type - that is to say both the type and its value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
-msgstr ""
-"* 배열과 마찬가지로 튜플은 고정 길이를 갖습니다.\n"
-"\n"
-"* 튜플은 서로 다른 타입의 값들을 하나의 복합 타입으로 묶습니다.\n"
-"\n"
-"* 튜플에 속한 값은 `t.0`, `t.1`과 같이 인덱스로 접근할 수 있습니다.\n"
-"\n"
-"* 비어있는 튜플`()`은 단위 타입(unit type)이라고도 합니다. 이는 타입이면서 해당 타입의 유일하며 유효한 값입니다. 즉 타입과 값이 모두 `()`입니다. 예를 들어 함수나 식에서 반환 값이 없음을 나타낼 때 사용합니다.\n"
-"  * 다른 언어에서 익숙한 `void` 개념으로 생각할 수 있습니다."
+msgid "Like arrays, tuples have a fixed length."
+msgstr "배열과 마찬가지로 튜플은 고정 길이를 갖습니다."
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
-msgstr "# 참조"
+#: src/basic-syntax/compound-types.md:51
+msgid "Tuples group together values of different types into a compound type."
+msgstr "튜플은 서로 다른 타입의 값들을 하나의 복합 타입으로 묶습니다."
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr "튜플에 속한 값은 `t.0`, `t.1`과 같이 인덱스로 접근할 수 있습니다."
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+"비어있는 튜플`()`은 단위 타입(unit type)이라고도 합니다. 이는 타입이면서 해"
+"당 타입의 유일하며 유효한 값입니다. 즉 타입과 값이 모두 `()`입니다. 예를 들"
+"어 함수나 식에서 반환 값이 없음을 나타낼 때 사용합니다."
+
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr "다른 언어에서 익숙한 `void` 개념으로 생각할 수 있습니다."
 
 #: src/basic-syntax/references.md:3
 msgid "Like C++, Rust has references:"
@@ -2419,33 +2866,37 @@ msgstr "참고사항:"
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* `ref_x`에 값을 할당할 때, C/C++의 포인터와 유사하게 `*`를 이용해서 참조를 따라가야(역참조) 합니다.\n"
-"* 러스트는 특정한 경우(메서드 호출)에 자동으로 역참조를 합니다.(`ref_x.count_one()`을 하면 `*ref_x`가 `count_one`의 인자로 전달됩니다.)\n"
-"* `mut`로 선언된 참조는 그 변수가 살아있는 동안 다른 값을 가질 수 있습니다."
+"`ref_x`에 값을 할당할 때, C/C++의 포인터와 유사하게 `*`를 이용해서 참조를 따"
+"라가야(역참조) 합니다."
 
-#: src/basic-syntax/references.md:21
+#: src/basic-syntax/references.md:17
 msgid ""
-"<details>\n"
-"Key points:"
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
 msgstr ""
-"<details>\n"
-"키 포인트:"
+"러스트는 특정한 경우(메서드 호출)에 자동으로 역참조를 합니다.(`ref_x."
+"count_one()`을 하면 `*ref_x`가 `count_one`의 인자로 전달됩니다.)"
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"`mut`로 선언된 참조는 그 변수가 살아있는 동안 다른 값을 가질 수 있습니다."
 
 #: src/basic-syntax/references.md:24
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound to\n"
-"  different values, while the second represents a reference to a mutable value."
-msgstr "* `let mut ref_x: &i32`와 `let ref_x: &mut i32`의 차이점에 주의 하시기 바랍니다. 첫번째 값은 다른 값에 바인딩 될 수 있는 가변 참조이고, 두번째 값은 가변 값에 대한 참조입니다."
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
-msgstr "# 허상(dangling) 참조"
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
+"value."
+msgstr ""
+"`let mut ref_x: &i32`와 `let ref_x: &mut i32`의 차이점에 주의 하시기 바랍니"
+"다. 첫번째 값은 다른 값에 바인딩 될 수 있는 가변 참조이고, 두번째 값은 가변 "
+"값에 대한 참조입니다."
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -2476,19 +2927,21 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
-msgstr ""
-"* 참조는 어떤 값을 \"빌리는\" 것입니다.\n"
-"* 러스트는 참조 대상의 값이, 그 값에 대한 모든 참조들보다 더 오래 살아있음을 추적합니다.\n"
-"* 소유권에 대한 주제를 다룰 때 이 빌림에 대해 더 자세히 이야기 하겠습니다."
+msgid "A reference is said to \"borrow\" the value it refers to."
+msgstr "참조는 어떤 값을 \"빌리는\" 것입니다."
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
-msgstr "# 슬라이스"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"러스트는 참조 대상의 값이, 그 값에 대한 모든 참조들보다 더 오래 살아있음을 추"
+"적합니다."
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr ""
+"소유권에 대한 주제를 다룰 때 이 빌림에 대해 더 자세히 이야기 하겠습니다."
 
 #: src/basic-syntax/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
@@ -2517,48 +2970,76 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
-msgstr ""
-"* 슬라이스는 다른(슬라이스 된) 타입으로부터 데이터를 '빌려'옵니다.\n"
-"* 질문: `a[3]`을 수정하면 무슨 일이 있어날까요?"
+msgid "Slices borrow data from the sliced type."
+msgstr "슬라이스는 다른(슬라이스 된) 타입으로부터 데이터를 '빌려'옵니다."
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "질문: `a[3]`을 수정하면 무슨 일이 있어날까요?"
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use `&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` (`&[i32]`) no longer mentions the array length. This allows us to perform computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
 msgstr ""
-"* 슬라이스는 우선 `a`를 빌린다음, 시작과 끝 인덱스를 브래킷(`[]`)안에 지정해서 만듭니다.\n"
-"\n"
-"* 슬라이스가 인덱스 0부터 시작한다면 시작 인덱스는 생략 가능합니다. 즉 `&a[0..a.len()]`와 `&a[..a.len()]` 는 동일합니다.\n"
-"\n"
-"* 마지막 인덱스도 생략 가능합니다. 그래서 `&a[2..a.len()]` 와 `&a[2..]`는 동일합니다.\n"
-"\n"
-"* 따라서 전체 배열에 대한 슬라이스는 `&a[..]`가 됩니다.\n"
-"\n"
-"* `s`는 `i32`들로 이루어진 슬라이스에 대한 참조입니다. `s`의 타입(`&[i32]`)에 배열의 크기가 빠져있음에 주목하시기 바랍니다. 즉, 슬라이스를 이용하면 다양한 길이의 데이터를 다룰 수 있습니다.\n"
-"\n"
-"* 슬라이스는 항상 다른 객체로부터 '빌려' 옵니다. 이 예시에서 객체 `a`는 슬라이스 `s`보다 더 오래 살아 있어야만 합니다.\n"
-"\n"
-"* `a[3]`의 값을 바꿀 수 있냐는 질문은 좋은 질문입니다. 여기에 대한 답은 `a`와 `s`를 통해 데이터를 읽을 수는 있지만 수정할 수는 없으며, 이는 메모리 안전을 위해서라는 것입니다. 왜 그런지에 대한 좀더 구체적인 답은 빌림 검사 부분에서 자세히 설명합니다."
+"슬라이스는 우선 `a`를 빌린다음, 시작과 끝 인덱스를 브래킷(`[]`)안에 지정해서 "
+"만듭니다."
+
+#: src/basic-syntax/slices.md:22
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"슬라이스가 인덱스 0부터 시작한다면 시작 인덱스는 생략 가능합니다. 즉 `&a[0.."
+"a.len()]`와 `&a[..a.len()]` 는 동일합니다."
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"마지막 인덱스도 생략 가능합니다. 그래서 `&a[2..a.len()]` 와 `&a[2..]`는 동일"
+"합니다."
+
+#: src/basic-syntax/slices.md:26
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr "따라서 전체 배열에 대한 슬라이스는 `&a[..]`가 됩니다."
+
+#: src/basic-syntax/slices.md:28
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+"`s`는 `i32`들로 이루어진 슬라이스에 대한 참조입니다. `s`의 타입(`&[i32]`)에 "
+"배열의 크기가 빠져있음에 주목하시기 바랍니다. 즉, 슬라이스를 이용하면 다양한 "
+"길이의 데이터를 다룰 수 있습니다."
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"슬라이스는 항상 다른 객체로부터 '빌려' 옵니다. 이 예시에서 객체 `a`는 슬라이"
+"스 `s`보다 더 오래 살아 있어야만 합니다."
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
+"`a[3]`의 값을 바꿀 수 있냐는 질문은 좋은 질문입니다. 여기에 대한 답은 `a`와 "
+"`s`를 통해 데이터를 읽을 수는 있지만 수정할 수는 없으며, 이는 메모리 안전을 "
+"위해서라는 것입니다. 왜 그런지에 대한 좀더 구체적인 답은 빌림 검사 부분에서 "
+"자세히 설명합니다."
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
-msgstr "# `String`과 `str`"
+msgid "`String` vs `str`"
+msgstr "`String`과 `str`"
 
 #: src/basic-syntax/string-slices.md:3
 msgid "We can now understand the two string types in Rust:"
@@ -2601,52 +3082,77 @@ msgid "Rust terminology:"
 msgstr "러스트 용어:"
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* `&str`은 문자열 슬라이스에 대한 (불변) 참조입니다.\n"
-"* `String`은 문자열을 담을 수 있는 버퍼입니다."
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str`은 문자열 슬라이스에 대한 (불변) 참조입니다."
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String`은 문자열을 담을 수 있는 버퍼입니다."
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a `Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the `push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* `&str`은 문자열 슬라이스의 불변 참조입니다. 러스트에서 문자열은 UTF-8로 인코딩된 데이터를 의미합니다. 문자열 리터럴(`\"Hello\"`)은 프로그램 바이너리에 저장됩니다.\n"
-"\n"
-"* 러스트의 `String`타입은 실제로는 문자열을 이루는 바이트에 대한 백터(`Vec<u8>`)입니다. `Vec<T>`가 `T`를 소유하고 있듯이, `String`이 가리키고 있는 문자열은 `String`의 소유입니다.\n"
-"\n"
-"* 다른 많은 타입들처럼 `String::from`는 문자열 리터럴로부터 문자열을 생성합니다. `String::new()`는 새로운 빈 문자열을 생성합니다. `push()`와 `push_str()`메서드를 사용하여 문자열 데이터를 추가 할 수 있습니다.\n"
-"\n"
-"* `format!()` 매크로는 변수의 값을 문자열로 변환하는 편리한 방법입니다. 이 매크로는 `println!()` 매크로와 동일한 포맷팅 형식을 지원합니다.\n"
-"\n"
-"* `&`와 범위 연산자를 이용하여 `String`에서 `&str`슬라이스를 빌려올 수 있습니다.\n"
-"\n"
-"* 당신이 C++ 프로그래머 라면: `&str`는 C++의 `const char*`와 유사하지만 항상 유효한 문자열을 가리킨다는 점이 다릅니다. 러스트의 `String`은 C++의 `std::string` 과 대략 거의 동일합니다. (주요 차이점: 러스트의 `String`은 UTF-8 인코딩 바이트만 포함할 수 있으며 작은 문자열 최적화(small-string optimization)는 사용하지 않습니다."
+"`&str`은 문자열 슬라이스의 불변 참조입니다. 러스트에서 문자열은 UTF-8로 인코"
+"딩된 데이터를 의미합니다. 문자열 리터럴(`\"Hello\"`)은 프로그램 바이너리에 저"
+"장됩니다."
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
-msgstr "# 함수"
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+"러스트의 `String`타입은 실제로는 문자열을 이루는 바이트에 대한 백터"
+"(`Vec<u8>`)입니다. `Vec<T>`가 `T`를 소유하고 있듯이, `String`이 가리키고 있"
+"는 문자열은 `String`의 소유입니다."
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"다른 많은 타입들처럼 `String::from`는 문자열 리터럴로부터 문자열을 생성합니"
+"다. `String::new()`는 새로운 빈 문자열을 생성합니다. `push()`와 `push_str()`"
+"메서드를 사용하여 문자열 데이터를 추가 할 수 있습니다."
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+"`format!()` 매크로는 변수의 값을 문자열로 변환하는 편리한 방법입니다. 이 매크"
+"로는 `println!()` 매크로와 동일한 포맷팅 형식을 지원합니다."
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+"`&`와 범위 연산자를 이용하여 `String`에서 `&str`슬라이스를 빌려올 수 있습니"
+"다."
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"당신이 C++ 프로그래머 라면: `&str`는 C++의 `const char*`와 유사하지만 항상 유"
+"효한 문자열을 가리킨다는 점이 다릅니다. 러스트의 `String`은 C++의 `std::"
+"string` 과 대략 거의 동일합니다. (주요 차이점: 러스트의 `String`은 UTF-8 인코"
+"딩 바이트만 포함할 수 있으며 작은 문자열 최적화(small-string optimization)는 "
+"사용하지 않습니다."
 
 #: src/basic-syntax/functions.md:3
-msgid "A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
-msgstr "러스트 버전의 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 함수입니다:"
+msgid ""
+"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
+"Fizz_buzz) interview question:"
+msgstr ""
+"러스트 버전의 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 함수입니다:"
 
 #: src/basic-syntax/functions.md:5
 msgid ""
@@ -2659,10 +3165,12 @@ msgid ""
 "    if rhs == 0 {\n"
 "        return false;  // Corner case, early return\n"
 "    }\n"
-"    lhs % rhs == 0     // The last expression in a block is the return value\n"
+"    lhs % rhs == 0     // The last expression in a block is the return "
+"value\n"
 "}\n"
 "\n"
-"fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit type `()`\n"
+"fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit "
+"type `()`\n"
 "    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
 "        (true,  true)  => println!(\"fizzbuzz\"),\n"
 "        (true,  false) => println!(\"fizz\"),\n"
@@ -2680,7 +3188,8 @@ msgid ""
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
-"    fizzbuzz_to(20);   // C/C++ 와 달리 호출부 하단에 정의해도 문제 없습니다.\n"
+"    fizzbuzz_to(20);   // C/C++ 와 달리 호출부 하단에 정의해도 문제 없습니"
+"다.\n"
 "}\n"
 "\n"
 "fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
@@ -2708,53 +3217,83 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, which causes it to include the upper bound.\n"
-"* The `match` expression in `fizzbuzz()` is doing a lot of work. It is expanded below to show what is happening.\n"
-"\n"
-"  (Type annotations added for clarity, but they can be elided.)\n"
-"\n"
-"  ```rust,ignore\n"
-"  let by_3: bool = is_divisible_by(n, 3);\n"
-"  let by_5: bool = is_divisible_by(n, 5);\n"
-"  let by_35: (bool, bool) = (by_3, by_5);\n"
-"  match by_35 {\n"
-"    // ...\n"
-"  ```\n"
-"\n"
-"  "
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
 msgstr ""
-"* `main` 함수에서 그 다음에 오는 함수들을 사용할 수 있습니다. 상단에 선언이나 헤더 같은건 필요 없습니다.\n"
-"* 매개변수를 선언할 때에는 이름을 먼저 쓰고, 타입을 나중에 씁니다. 이름과 타입은 `:` 로 구분합니다. 이는 일부 언어(예를 들어 C)와 반대임에 유의하시기 바랍니다. 마찬가지로, 리턴 타입도 함수의 시작이 아닌 가장 뒷부분에 선언합니다.\n"
-"* 함수 본문의 마지막 표현식은 반환 값이 됩니다. 간단히, 식 끝에 있는 `;`를 생략하면 됩니다.\n"
-"* 반환값이 없는 함수의 경우, 유닛 타입 `()`을 반환합니다. `-> ()`가 생략된 경우 컴파일러는 이를 추론합니다.\n"
-"* `fizzbuzz_to()`함수 내 `for` 반목문의 범위 표현식 중 `=n`은 n까지 포함한다는 의미입니다.\n"
-"* `fizzbuzz()`함수의 `match` 표현식은 많은 일을 합니다. 무슨 일이 일어나는지 조금 더 이해하기 쉽도록 아래 코드를 확인하시기 바랍니다.\n"
-"\n"
-"  (명확한 설명을 위해 타입이 명시적으로 선언 되었지만 생략 가능합니다.)\n"
-"\n"
-"  ```rust,ignore\n"
-"  let by_3: bool = is_divisible_by(n, 3);\n"
-"  let by_5: bool = is_divisible_by(n, 5);\n"
-"  let by_35: (bool, bool) = (by_3, by_5);\n"
-"  match by_35 {\n"
-"    // ...\n"
-"  ```\n"
-"\n"
-"  "
+"`main` 함수에서 그 다음에 오는 함수들을 사용할 수 있습니다. 상단에 선언이나 "
+"헤더 같은건 필요 없습니다."
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
-msgstr "# 메서드"
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+"매개변수를 선언할 때에는 이름을 먼저 쓰고, 타입을 나중에 씁니다. 이름과 타입"
+"은 `:` 로 구분합니다. 이는 일부 언어(예를 들어 C)와 반대임에 유의하시기 바랍"
+"니다. 마찬가지로, 리턴 타입도 함수의 시작이 아닌 가장 뒷부분에 선언합니다."
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+"함수 본문의 마지막 표현식은 반환 값이 됩니다. 간단히, 식 끝에 있는 `;`를 생략"
+"하면 됩니다."
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+"반환값이 없는 함수의 경우, 유닛 타입 `()`을 반환합니다. `-> ()`가 생략된 경"
+"우 컴파일러는 이를 추론합니다."
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
+"which causes it to include the upper bound."
+msgstr ""
+"`fizzbuzz_to()`함수 내 `for` 반목문의 범위 표현식 중 `=n`은 n까지 포함한다는 "
+"의미입니다."
+
+#: src/basic-syntax/functions.md:40
+msgid ""
+"The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
+"expanded below to show what is happening."
+msgstr ""
+"`fizzbuzz()`함수의 `match` 표현식은 많은 일을 합니다. 무슨 일이 일어나는지 조"
+"금 더 이해하기 쉽도록 아래 코드를 확인하시기 바랍니다."
+
+#: src/basic-syntax/functions.md:42
+msgid "(Type annotations added for clarity, but they can be elided.)"
+msgstr "(명확한 설명을 위해 타입이 명시적으로 선언 되었지만 생략 가능합니다.)"
+
+#: src/basic-syntax/functions.md:44
+msgid ""
+"```rust,ignore\n"
+"let by_3: bool = is_divisible_by(n, 3);\n"
+"let by_5: bool = is_divisible_by(n, 5);\n"
+"let by_35: (bool, bool) = (by_3, by_5);\n"
+"match by_35 {\n"
+"  // ...\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"let by_3: bool = is_divisible_by(n, 3);\n"
+"let by_5: bool = is_divisible_by(n, 5);\n"
+"let by_35: (bool, bool) = (by_3, by_5);\n"
+"match by_35 {\n"
+"  // ...\n"
+"```"
 
 #: src/basic-syntax/methods.md:3
 msgid ""
-"Rust has methods, they are simply functions that are associated with a particular type. The\n"
-"first argument of a method is an instance of the type it is associated with:"
-msgstr "러스트의 메서드는 특정 타입과 연결된 함수입니다. 메서드의 첫번째 인자의 타입이 바로 그 메서드가 연결된 타입입니다:"
+"Rust has methods, they are simply functions that are associated with a "
+"particular type. The first argument of a method is an instance of the type "
+"it is associated with:"
+msgstr ""
+"러스트의 메서드는 특정 타입과 연결된 함수입니다. 메서드의 첫번째 인자의 타입"
+"이 바로 그 메서드가 연결된 타입입니다:"
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -2807,32 +3346,42 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/methods.md:30
-msgid "* We will look much more at methods in today's exercise and in tomorrow's class."
-msgstr "* 오늘과 내일 강의에서 더 많은 메서드 사용법을 다룰 것입니다."
+msgid ""
+"We will look much more at methods in today's exercise and in tomorrow's "
+"class."
+msgstr "오늘과 내일 강의에서 더 많은 메서드 사용법을 다룰 것입니다."
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
-msgstr "# (함수) 오버로딩"
+msgid "Function Overloading"
+msgstr "(함수) 오버로딩"
 
 #: src/basic-syntax/functions-interlude.md:3
 msgid "Overloading is not supported:"
 msgstr "오버로딩은 지원되지 않습니다:"
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* 개별함수는 단일 구현만 갖습니다.\n"
-"  * 항상 고정된 수의 파라매터만 갖습니다.\n"
-"  * 파라매터들의 타입은 항상 고정되어 있습니다.\n"
-"* 파라매터의 기본 값은 지원되지 않습니다.\n"
-"  * 모든 호출부에서는 동일한 수의 인자를 설정해야합니다. \n"
-"  * 이런 사항들이 제약이 될 경우, 대안으로 매크로를 사용하기도 합니다."
+msgid "Each function has a single implementation:"
+msgstr "개별함수는 단일 구현만 갖습니다."
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "항상 고정된 수의 파라매터만 갖습니다."
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "파라매터들의 타입은 항상 고정되어 있습니다."
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "파라매터의 기본 값은 지원되지 않습니다."
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr "모든 호출부에서는 동일한 수의 인자를 설정해야합니다. "
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "이런 사항들이 제약이 될 경우, 대안으로 매크로를 사용하기도 합니다."
 
 #: src/basic-syntax/functions-interlude.md:12
 msgid "However, function parameters can be generic:"
@@ -2864,31 +3413,28 @@ msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind of limited\n"
-"  polymorphism on argument types. We will see more details in a later section."
-msgstr "* 제네릭을 사용할 때 표준 라이브러리의 `Into<T>`은 타입에 대한 다형성을 제공할 수 있습니다. 나중에 자세히 설명하겠습니다."
-
-#: src/basic-syntax/functions-interlude.md:30
-msgid "</defails>"
-msgstr "</defails>"
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
+"section."
+msgstr ""
+"제네릭을 사용할 때 표준 라이브러리의 `Into<T>`은 타입에 대한 다형성을 제공할 "
+"수 있습니다. 나중에 자세히 설명하겠습니다."
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
-msgstr "# 1일차 오전 연습문제"
+msgid "Day 1: Morning Exercises"
+msgstr "1일차 오전 연습문제"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
 msgstr "이번 연습문제는 러스트의 두 부분을 알아볼 것입니다:"
 
 #: src/exercises/day-1/morning.md:5
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
-msgstr ""
-"* 타입의 묵시적 변환.\n"
-"\n"
-"* 배열과 `for` 반복문."
+msgid "Implicit conversions between types."
+msgstr "타입의 묵시적 변환."
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
+msgstr "배열과 `for` 반복문."
 
 #: src/exercises/day-1/morning.md:11
 msgid "A few things to consider while solving the exercises:"
@@ -2896,37 +3442,43 @@ msgstr "연습문제를 해결하는데 고려해야 할 사항들:"
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* 가능하다면 러스트가 설치된 로컬 환경에서 진행하세요. 그러는 편이 텍스트 에디터의 자동완성 기능의 도움을 받을 수 있어서 좋습니다. [카고 사용하기][Using Cargo] 을 참조하시기 바랍니다.\n"
-"\n"
-"* 혹은 러스트 플레이그라운드를 이용할 수 있습니다."
+"가능하다면 러스트가 설치된 로컬 환경에서 진행하세요. 그러는 편이 텍스트 에디"
+"터의 자동완성 기능의 도움을 받을 수 있어서 좋습니다. [카고 사용하기](../../"
+"cargo.md) 을 참조하시기 바랍니다."
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
+msgstr "혹은 러스트 플레이그라운드를 이용할 수 있습니다."
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
-msgstr "페이지 밖으로 이동할 경우 작성한 내용이 소실되기 때문에 제공되는 코드 스니펫은 의도적으로 편집할 수 없습니다."
+msgstr ""
+"페이지 밖으로 이동할 경우 작성한 내용이 소실되기 때문에 제공되는 코드 스니펫"
+"은 의도적으로 편집할 수 없습니다."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
 #: src/exercises/day-3/morning.md:7 src/exercises/day-4/morning.md:12
-msgid "After looking at the exercises, you can look at the [solutions] provided."
-msgstr "연습문제를 살펴 본 후, 제공된 [해답][solutions]을 살펴볼 수 있습니다."
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
-msgstr "# 묵시적 형변환"
+msgid ""
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
+msgstr ""
+"연습문제를 살펴 본 후, 제공된 \\[해답\\]\\[solutions\\]을 살펴볼 수 있습니다."
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
-"Rust will not automatically apply _implicit conversions_ between types ([unlike\n"
-"C++][3]). You can see this in a program like this:"
-msgstr "러스트는 [C++ 와 다르게][3] 타입 간 *묵시적 변환*을 자동으로 적용하지 않습니다. 아래 예시를 확인해 보세요:"
+"Rust will not automatically apply _implicit conversions_ between types "
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
+msgstr ""
+"러스트는 [C++ 와 다르게](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion) 타입 간 _묵시적 변환_을 자동으로 적용하지 않습니다. 아"
+"래 예시를 확인해 보세요:"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
@@ -2946,48 +3498,68 @@ msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single `from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted into\n"
-"another type."
-msgstr "러스트의 정수형 타입은 모두 [`From<T>`][1] 와 [`Into<T>`][2] 트레잇을 구현하고 있으며, 이를 통해 타입 변환이 이루어 집니다. `From<T>` 트레잇은 `from()` 메서드를 가지고 있고, `Into<T>`트레잇은 `into()` 메서드를 가지고 있습니다. 러스트에서는 `From`과 `Into` 트레잇을 구현함으로써, 타입 간 변환이 가능하다는 것을 표현합니다."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
+msgstr ""
+"러스트의 정수형 타입은 모두 [`From<T>`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) 와 [`Into<T>`](https://doc.rust-lang.org/std/"
+"convert/trait.Into.html) 트레잇을 구현하고 있으며, 이를 통해 타입 변환이 이루"
+"어 집니다. `From<T>` 트레잇은 `from()` 메서드를 가지고 있고, `Into<T>`트레잇"
+"은 `into()` 메서드를 가지고 있습니다. 러스트에서는 `From`과 `Into` 트레잇을 "
+"구현함으로써, 타입 간 변환이 가능하다는 것을 표현합니다."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
-"The standard library has an implementation of `From<i8> for i16`, which means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
-msgstr "표준 라이브러리에는 `From<i8> for i16`가 구현되어 있는데 이것은 `i8` 타입의 변수 `x`를 `i16::from(x)`를 호출하여 `i16`타입으로 변환할 수 있다는 의미입니다. 혹은 더 간단하게 `x.into()`를 사용할 수도 있습니다. 이것이 가능한 이유는 `From<i8> for i16` 구현을 가지고 있으면 `Into<i16> for i8` 구현이 자동으로 생성되기 때문입니다."
+"The standard library has an implementation of `From<i8> for i16`, which "
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
+msgstr ""
+"표준 라이브러리에는 `From<i8> for i16`가 구현되어 있는데 이것은 `i8` 타입의 "
+"변수 `x`를 `i16::from(x)`를 호출하여 `i16`타입으로 변환할 수 있다는 의미입니"
+"다. 혹은 더 간단하게 `x.into()`를 사용할 수도 있습니다. 이것이 가능한 이유는 "
+"`From<i8> for i16` 구현을 가지고 있으면 `Into<i16> for i8` 구현이 자동으로 생"
+"성되기 때문입니다."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
-"The same applies for your own `From` implementations for your own types, so it is\n"
-"sufficient to only implement `From` to get a respective `Into` implementation automatically."
-msgstr "이는 사용자 정의 타입에도 동일하게 적용되는 규칙입니다. 따라서 `From`만을 구현해도 `Into`까지 자동으로 구현이 됩니다."
+"The same applies for your own `From` implementations for your own types, so "
+"it is sufficient to only implement `From` to get a respective `Into` "
+"implementation automatically."
+msgstr ""
+"이는 사용자 정의 타입에도 동일하게 적용되는 규칙입니다. 따라서 `From`만을 구"
+"현해도 `Into`까지 자동으로 구현이 됩니다."
 
 #: src/exercises/day-1/implicit-conversions.md:33
+msgid "Execute the above program and look at the compiler error."
+msgstr "위 예제코드를 실행하고 어떤 컴파일 에러가 발생하는지 확인해 보세요."
+
+#: src/exercises/day-1/implicit-conversions.md:35
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr "`into()`를 사용하여 코드를 수정하세요."
+
+#: src/exercises/day-1/implicit-conversions.md:37
 msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented for\n"
-"   the pairs you check."
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
-"1. 위 예제코드를 실행하고 어떤 컴파일 에러가 발생하는지 확인해 보세요.\n"
-"\n"
-"2. `into()`를 사용하여 코드를 수정하세요.\n"
-"\n"
-"3. `x`와 `y`를 `f32`이나 `bool`, `i128` 등으로 바꿔서 해당 타입들로 변환이 되는지 확인해보세요. 작은 사이즈 타입에서 큰 사이즈로 변경해보시고 그 반대로도 해보세요. [표준 라이브러리 문서][1]에서 시도해 본 케이스가 구현되어 있는지 확인해 보세요."
+"`x`와 `y`를 `f32`이나 `bool`, `i128` 등으로 바꿔서 해당 타입들로 변환이 되는"
+"지 확인해보세요. 작은 사이즈 타입에서 큰 사이즈로 변경해보시고 그 반대로도 해"
+"보세요. [표준 라이브러리 문서](https://doc.rust-lang.org/std/convert/trait."
+"From.html)에서 시도해 본 케이스가 구현되어 있는지 확인해 보세요."
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
-msgstr "# 배열과 `for`반복문"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "배열과 `for`반복문"
 
 #: src/exercises/day-1/for-loops.md:3
 msgid "We saw that an array can be declared like this:"
@@ -3001,7 +3573,9 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:9
-msgid "You can print such an array by asking for its debug representation with `{:?}`:"
+msgid ""
+"You can print such an array by asking for its debug representation with `{:?}"
+"`:"
 msgstr "배열을 출력하려면 `{:?}`를 씁니다:"
 
 #: src/exercises/day-1/for-loops.md:11
@@ -3016,7 +3590,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr "러스트에서는 `for` 키워드를 사용해 배열이나 범위를 반복할 수 있습니다:"
 
@@ -3042,9 +3616,12 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
-"Use the above to write a function `pretty_print` which pretty-print a matrix and\n"
-"a function `transpose` which will transpose a matrix (turn rows into columns):"
-msgstr "위 코드를 이용해서, 행렬을 예쁘게 출력하는 `pretty_print`함수와, 행렬을 전치(행과 열을 서로 바꾸는)시키는 `transpose`함수를 작성해 보시기 바랍니다:"
+"Use the above to write a function `pretty_print` which pretty-print a matrix "
+"and a function `transpose` which will transpose a matrix (turn rows into "
+"columns):"
+msgstr ""
+"위 코드를 이용해서, 행렬을 예쁘게 출력하는 `pretty_print`함수와, 행렬을 전치"
+"(행과 열을 서로 바꾸는)시키는 `transpose`함수를 작성해 보시기 바랍니다:"
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3061,9 +3638,10 @@ msgstr "두 함수 모두 행렬의 크기는 3 x 3 으로 하드코딩 합니�
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
-msgstr "아래 코드를 <https://play.rust-lang.org/>에 복사해서 구현하시면 됩니다:"
+msgstr ""
+"아래 코드를 <https://play.rust-lang.org/>에 복사해서 구현하시면 됩니다:"
 
 #: src/exercises/day-1/for-loops.md:52
 msgid ""
@@ -3124,37 +3702,42 @@ msgstr ""
 "```"
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
-msgstr "## 보너스 문제"
+msgid "Bonus Question"
+msgstr "보너스 문제"
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
-msgstr "`&[i32]`슬라이스를 잘 이용하면 행렬 크기를 3 x 3으로 하드코딩 하지 않을 수 있을까요? 예컨데 `&[&[i32]]`는 2차원 슬라이스의 슬라이스 입니다. 가능하다면/하지 않다면 왜 그런가요?"
+msgstr ""
+"`&[i32]`슬라이스를 잘 이용하면 행렬 크기를 3 x 3으로 하드코딩 하지 않을 수 있"
+"을까요? 예컨데 `&[&[i32]]`는 2차원 슬라이스의 슬라이스 입니다. 가능하다면/하"
+"지 않다면 왜 그런가요?"
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
-msgstr "상용 품질의 구현에 대해서는 [`ndarray` 크레이트](https://docs.rs/ndarray/)를 참조하시기 바랍니다."
+msgstr ""
+"상용 품질의 구현에 대해서는 [`ndarray` 크레이트](https://docs.rs/ndarray/)를 "
+"참조하시기 바랍니다."
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
-msgstr "보너스 문제에 대한 답변 역시 [해답](solutions-morning.md#arrays-and-for-loops)에서 확인할 수 있습니다."
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
-msgstr "# 변수"
+msgstr ""
+"보너스 문제에 대한 답변 역시 [해답](solutions-morning.md#arrays-and-for-"
+"loops)에서 확인할 수 있습니다."
 
 #: src/basic-syntax/variables.md:3
 msgid ""
-"Rust provides type safety via static typing. Variable bindings are immutable by\n"
-"default:"
-msgstr "러스트는 정적 타이핑을 통해 타입 안전성을 제공합니다. 변수는 기본적으로 불변(immutable)합니다:"
+"Rust provides type safety via static typing. Variable bindings are immutable "
+"by default:"
+msgstr ""
+"러스트는 정적 타이핑을 통해 타입 안전성을 제공합니다. 변수는 기본적으로 불변"
+"(immutable)합니다:"
 
 #: src/basic-syntax/variables.md:6
 msgid ""
@@ -3178,15 +3761,19 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the function like syntax of `println!(\"x: {}\", x)`"
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
 msgstr ""
-"* 타입 추론에 덕분에 `i32`는 생략 가능합니다. 강의가 진행될 수록 생략 가능한 부분은 점점 생략할 것입니다.\n"
-"* `println!(\"x: {}\", x)`는 함수 호출 처럼 보이지만 실은 매크로 호출이며 `x`는 이동되지 않습니다."
+"타입 추론에 덕분에 `i32`는 생략 가능합니다. 강의가 진행될 수록 생략 가능한 부"
+"분은 점점 생략할 것입니다."
 
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
-msgstr "# 타입 추론"
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
+"function like syntax of `println!(\"x: {}\", x)`"
+msgstr ""
+"`println!(\"x: {}\", x)`는 함수 호출 처럼 보이지만 실은 매크로 호출이며 `x`"
+"는 이동되지 않습니다."
 
 #: src/basic-syntax/type-inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
@@ -3233,19 +3820,35 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/type-inference.md:26
-msgid "This slide demonstrates how the Rust compiler infers types based on constraints given by variable declarations and usages."
-msgstr "이 슬라이드는, 러스트 컴파일러가 변수가 어떻게 선언되어 있고, 어떻게 사용되는지를 제약 조건으로 삼아서 변수의 타입을 추론하는 모습을 보여줍니다."
+msgid ""
+"This slide demonstrates how the Rust compiler infers types based on "
+"constraints given by variable declarations and usages."
+msgstr ""
+"이 슬라이드는, 러스트 컴파일러가 변수가 어떻게 선언되어 있고, 어떻게 사용되는"
+"지를 제약 조건으로 삼아서 변수의 타입을 추론하는 모습을 보여줍니다."
 
 #: src/basic-syntax/type-inference.md:28
 msgid ""
-"It is very important to emphasize that variables declared like this are not of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
-msgstr "여기서 중요한 것은, 이렇게 명시적인 타입을 생략하고 선언되었다고 해서 \"어떤 타입\"이라도 다 담을 수 있는 타입이 되는 것은 아니라는 점입니다. 명시적인 타입 선언이 있던 없던, 컴파일러가 생성한 머신코드는 동일합니다. 컴파일러는 단지 타입 선언을 생략할 수 있도록 해서 프로그래머가 더 간결한 코드를 쓸 수 있도록 도와줄 뿐입니다."
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
+msgstr ""
+"여기서 중요한 것은, 이렇게 명시적인 타입을 생략하고 선언되었다고 해서 \"어떤 "
+"타입\"이라도 다 담을 수 있는 타입이 되는 것은 아니라는 점입니다. 명시적인 타"
+"입 선언이 있던 없던, 컴파일러가 생성한 머신코드는 동일합니다. 컴파일러는 단"
+"지 타입 선언을 생략할 수 있도록 해서 프로그래머가 더 간결한 코드를 쓸 수 있도"
+"록 도와줄 뿐입니다."
 
 #: src/basic-syntax/type-inference.md:32
-msgid "The following code tells the compiler to copy into a certain generic container without the code ever explicitly specifying the contained type, using `_` as a placeholder:"
-msgstr "아래 코드는, 제네릭 컨테이너를 쓸 때 컨테이터 안에 포함된 데이터의 타입을 명시적으로 쓰지 않고 `_`로 대체하여도 된다는 것을 보여줍니다:"
+msgid ""
+"The following code tells the compiler to copy into a certain generic "
+"container without the code ever explicitly specifying the contained type, "
+"using `_` as a placeholder:"
+msgstr ""
+"아래 코드는, 제네릭 컨테이너를 쓸 때 컨테이터 안에 포함된 데이터의 타입을 명"
+"시적으로 쓰지 않고 `_`로 대체하여도 된다는 것을 보여줍니다:"
 
 #: src/basic-syntax/type-inference.md:34
 msgid ""
@@ -3274,20 +3877,26 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/type-inference.md:46
-msgid "[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) relies on `FromIterator`, which [`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) implements."
-msgstr "[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect)는 [`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html)을 구현한 `FromIterator`에 의존합니다."
+msgid ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) relies on `FromIterator`, which [`HashSet`](https://doc."
+"rust-lang.org/std/iter/trait.FromIterator.html) implements."
+msgstr ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect)는 [`HashSet`](https://doc.rust-lang.org/std/iter/trait."
+"FromIterator.html)을 구현한 `FromIterator`에 의존합니다."
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
-msgstr "# 정적변수(static)과 상수(const)"
+msgid "Static and Constant Variables"
+msgstr "정적변수(static)과 상수(const)"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid "Global state is managed with static and constant variables."
 msgstr "프로그램의 글로벌 상태는 결국 정적 변수와 상수로 표현됩니다."
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
-msgstr "## 상수(`const`)"
+msgid "`const`"
+msgstr "상수(`const`)"
 
 #: src/basic-syntax/static-and-const.md:7
 msgid "You can declare compile-time constants:"
@@ -3302,7 +3911,8 @@ msgid ""
 "fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
 "    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
 "    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
-"        digest[idx % DIGEST_SIZE] = digest[idx % DIGEST_SIZE].wrapping_add(b);\n"
+"        digest[idx % DIGEST_SIZE] = digest[idx % DIGEST_SIZE]."
+"wrapping_add(b);\n"
 "    }\n"
 "    digest\n"
 "}\n"
@@ -3333,12 +3943,16 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According the the [Rust RFC Book][1] these are inlined upon use."
-msgstr "[Rust RFC Book][1]에 따르면 상수는, 그 상수가 사용되는 곳에 인라인 됩니다."
+msgid ""
+"According the the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-"
+"const-vs-static.html) these are inlined upon use."
+msgstr ""
+"[Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html)"
+"에 따르면 상수는, 그 상수가 사용되는 곳에 인라인 됩니다."
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
-msgstr "## 정적변수(`static`)"
+msgid "`static`"
+msgstr "정적변수(`static`)"
 
 #: src/basic-syntax/static-and-const.md:31
 msgid "You can also declare static variables:"
@@ -3363,32 +3977,49 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/static-and-const.md:41
-msgid "As noted in the [Rust RFC Book][1], these are not inlined upon use and have an actual associated memory location.  This is useful for unsafe and embedded code, and the variable lives through the entirety of the program execution."
-msgstr "[Rust RFC Book][1]에서 언급한 바와 같이, 정적 변수는 별도의 메모리 공간을 가지며, 인라인 되지 않습니다. 정적 변수는 안전하지 않은(unsafe) 러스트와 임베디드 시스템용 코드에서 유용합니다. 이들의 수명은 프로그램이 수행되는 전체 시간과 동일합니다."
+msgid ""
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
+msgstr ""
+"[Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static.html)에"
+"서 언급한 바와 같이, 정적 변수는 별도의 메모리 공간을 가지며, 인라인 되지 않"
+"습니다. 정적 변수는 안전하지 않은(unsafe) 러스트와 임베디드 시스템용 코드에"
+"서 유용합니다. 이들의 수명은 프로그램이 수행되는 전체 시간과 동일합니다."
 
 #: src/basic-syntax/static-and-const.md:44
-msgid "We will look at mutating static data in the [chapter on Unsafe Rust](../unsafe.md)."
-msgstr "가변 정적 데이터에 대해서는 [안전하지 않은 러스트](../unsafe.md)에서 살펴봅니다."
+msgid ""
+"We will look at mutating static data in the [chapter on Unsafe Rust](../"
+"unsafe.md)."
+msgstr ""
+"가변 정적 데이터에 대해서는 [안전하지 않은 러스트](../unsafe.md)에서 살펴봅니"
+"다."
 
 #: src/basic-syntax/static-and-const.md:48
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, but it is helpful and safer than using a static."
-msgstr ""
-"* `const`는 C++의 `constexpr`과 매우 비슷합니다.\n"
-"* 반면에 `static`은 C++의 `const`나 가변 정적 변수와 훨씬 더 유사합니다.\n"
-"* 프로그램 수행시 그 값이 정해지는 상수가 필요한 경우는 드뭅니다. 그러나 그렇다고 해도, 정적 변수를 사용하는 것 보다는 더 유용하고 안전합니다."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
+msgstr "`const`는 C++의 `constexpr`과 매우 비슷합니다."
 
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
-msgstr "# 범위(Scope)와 쉐도잉(Shadowing)"
+#: src/basic-syntax/static-and-const.md:49
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr "반면에 `static`은 C++의 `const`나 가변 정적 변수와 훨씬 더 유사합니다."
+
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+"프로그램 수행시 그 값이 정해지는 상수가 필요한 경우는 드뭅니다. 그러나 그렇다"
+"고 해도, 정적 변수를 사용하는 것 보다는 더 유용하고 안전합니다."
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
-"You can shadow variables, both those from outer scopes and variables from the\n"
-"same scope:"
-msgstr "현재 범위에 있는 변수와, 바깥 범위에 있는 변수 모두 가릴(쉐도잉)수 있습니다:"
+"You can shadow variables, both those from outer scopes and variables from "
+"the same scope:"
+msgstr ""
+"현재 범위에 있는 변수와, 바깥 범위에 있는 변수 모두 가릴(쉐도잉)수 있습니다:"
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
@@ -3428,15 +4059,37 @@ msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing both variable's memory locations exist at the same time. Both are available under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory locations when shadowing an immutable variable in a scope, even if the type does not change."
+"Definition: Shadowing is different from mutation, because after shadowing "
+"both variable's memory locations exist at the same time. Both are available "
+"under the same name, depending where you use it in the code. "
 msgstr ""
-"* 쉐도잉은 기존 변수에 새로운 값을 할당하는 것이 아닙니다. 쉐도잉을 하면 새로운 변수가 생기며, 이전 변수와 새 변수는 메모리의 서로 다른 위치에 존재합니다. 그 두 변수는 단지 이름이 같은 뿐이며, 코드 중 어디에서 그 이름이 사용되었느냐에 따라 어떤 변수를 지칭하는 지가 결정됩니다.\n"
-"* 쉐도잉 시 타입을 바꿀 수 있습니다.\n"
-"* 처음에 쉐도잉을 보면 코드를 더 모호하게 만든다고 생각할 수 도 있습니다. 그러나 실제로 쉐도잉을 이용하면, 어떤 변수에서 `.unwrap()` 된 값을 새로운 변수에 담을 경우 새로운 이름을 지을 필요 없이 기존 이름을 유지할 수 있어서 편리합니다.\n"
-"* 아래 코드는 불변 변수를 쉐도잉할 때 타입이 동일하더라도 새 변수가 원래 변수의 메모리 위치를 재사용 할 수 없는지 그 이유를 보여줍니다."
+"쉐도잉은 기존 변수에 새로운 값을 할당하는 것이 아닙니다. 쉐도잉을 하면 새로"
+"운 변수가 생기며, 이전 변수와 새 변수는 메모리의 서로 다른 위치에 존재합니"
+"다. 그 두 변수는 단지 이름이 같은 뿐이며, 코드 중 어디에서 그 이름이 사용되었"
+"느냐에 따라 어떤 변수를 지칭하는 지가 결정됩니다."
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr "쉐도잉 시 타입을 바꿀 수 있습니다."
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+"처음에 쉐도잉을 보면 코드를 더 모호하게 만든다고 생각할 수 도 있습니다. 그러"
+"나 실제로 쉐도잉을 이용하면, 어떤 변수에서 `.unwrap()` 된 값을 새로운 변수에 "
+"담을 경우 새로운 이름을 지을 필요 없이 기존 이름을 유지할 수 있어서 편리합니"
+"다."
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
+"locations when shadowing an immutable variable in a scope, even if the type "
+"does not change."
+msgstr ""
+"아래 코드는 불변 변수를 쉐도잉할 때 타입이 동일하더라도 새 변수가 원래 변수"
+"의 메모리 위치를 재사용 할 수 없는지 그 이유를 보여줍니다."
 
 #: src/basic-syntax/scopes-shadowing.md:30
 msgid ""
@@ -3458,21 +4111,23 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr "# 메모리 관리"
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr "전통적으로, 두 종류의 프로그래밍 언어가 있습니다:"
 
 #: src/memory-management.md:5
-msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, Haskell, ..."
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
 msgstr ""
-"* 메모리 관리가 프로그래머의 완전한 통제하에 있지만 수동(그래서 안전하지 않을 수 있는)인 언어: C, C++, Pascal, ...\n"
-"* 메모리 관리가 런타임에 의해 되므로 안전하지만 자동(그래서 프로그래머가 개입할 여지가 적거나 없는)인 언어: Java, Python, Go, Haskell, ..."
+"메모리 관리가 프로그래머의 완전한 통제하에 있지만 수동(그래서 안전하지 않을 "
+"수 있는)인 언어: C, C++, Pascal, ..."
+
+#: src/memory-management.md:6
+msgid ""
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Haskell, ..."
+msgstr ""
+"메모리 관리가 런타임에 의해 되므로 안전하지만 자동(그래서 프로그래머가 개입"
+"할 여지가 적거나 없는)인 언어: Java, Python, Go, Haskell, ..."
 
 #: src/memory-management.md:8
 msgid "Rust offers a new mix:"
@@ -3480,9 +4135,10 @@ msgstr "러스트는 이 둘을 혼합한 새로운 형태의 메모리 관리 �
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
-msgstr "> 컴파일 시 올바른 메모리 관리를 강제함으로써 완전한 통제와 안전성 모두 제공"
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
+msgstr ""
+"컴파일 시 올바른 메모리 관리를 강제함으로써 완전한 통제와 안전성 모두 제공"
 
 #: src/memory-management.md:13
 msgid "It does this with an explicit ownership concept."
@@ -3493,42 +4149,56 @@ msgid "First, let's refresh how memory management works."
 msgstr "우선 메모리 관리가 이뤄지는 방식을 다시 살펴 보겠습니다."
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
-msgstr "# 스택(Stack)과 힙(Heap)"
+msgid "The Stack vs The Heap"
+msgstr "스택(Stack)과 힙(Heap)"
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* 스택: 지역 변수를 위한 연속적인 메모리 영역\n"
-"  * 여기 저장되는 값은 컴파일 시 결정되는 고정 크기를 갖습니다. \n"
-"  * 매우 빠름: 메모리 할당/반환이 단지 스택 포인터의 이동만으로 구현됩니다.\n"
-"  * 관리가 쉬움: 함수가 호출되면 할당되고, 리턴하면 반환됩니다.\n"
-"  * 스택에 있는 값들은 매우 높은 메모리 인접성을 가집니다(_역주_: 그래서 캐시를 효과적으로 활용할 수 있습니다)\n"
-"\n"
-"* 힙: 함수 호출/리턴과 상관 없이 유지되는 값이 저장되는 곳\n"
-"  * 여기 저장되는 값은 프로그램 수행시 그 크기가 결정됩니다.\n"
-"  * 스택 보다는 느림: 메모리 할당/반환시 해야 할 일이 좀 더 있습니다.\n"
-"  * 메모리 인접성을 보장하지 않습니다."
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "스택: 지역 변수를 위한 연속적인 메모리 영역"
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
-msgstr "# 스택 메모리"
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr "여기 저장되는 값은 컴파일 시 결정되는 고정 크기를 갖습니다. "
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr ""
+"매우 빠름: 메모리 할당/반환이 단지 스택 포인터의 이동만으로 구현됩니다."
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr "관리가 쉬움: 함수가 호출되면 할당되고, 리턴하면 반환됩니다."
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr ""
+"스택에 있는 값들은 매우 높은 메모리 인접성을 가집니다(_역주_: 그래서 캐시를 "
+"효과적으로 활용할 수 있습니다)"
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr "힙: 함수 호출/리턴과 상관 없이 유지되는 값이 저장되는 곳"
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr "여기 저장되는 값은 프로그램 수행시 그 크기가 결정됩니다."
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "스택 보다는 느림: 메모리 할당/반환시 해야 할 일이 좀 더 있습니다."
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr "메모리 인접성을 보장하지 않습니다."
 
 #: src/memory-management/stack.md:3
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
-msgstr "`String` 타입은 고정 크기 데이터(_역주_: 문자열의 길이, 문자열이 저장된 버퍼의 주소 등)는 스택에 저장하고, 가변 크기 데이터(_역주_: 문자열 버퍼)는 힙에 저장합니다:"
+msgstr ""
+"`String` 타입은 고정 크기 데이터(_역주_: 문자열의 길이, 문자열이 저장된 버퍼"
+"의 주소 등)는 스택에 저장하고, 가변 크기 데이터(_역주_: 문자열 버퍼)는 힙에 "
+"저장합니다:"
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -3576,63 +4246,83 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is heap allocated using the [System Allocator] and custom allocators can be implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
-"* 문자열(`String`)은 실제로는 `Vec`입니다. 크기(capacity)와 현재 길이(length) 정보를 가지며, 더 큰 크기가 필요할 경우 힙에서 재 할당을 합니다.\n"
-"\n"
-"* 힙은 기본적으로 [System Allocator]를 통해 할당됩니다. 그리고 [Allocator API]를 이용해서 커스텀 메모리 할당자를 만들 수도 있습니다.\n"
-"\n"
-"* `unsafe` 코드로 메모리 레이아웃을 살펴볼 수 있습니다. 물론 이 코드가 안전하지 않다는 점을 알려주세요!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"문자열(`String`)은 실제로는 `Vec`입니다. 크기(capacity)와 현재 길이(length) "
+"정보를 가지며, 더 큰 크기가 필요할 경우 힙에서 재 할당을 합니다."
 
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
-msgstr "# 수동 메모리 관리"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+"힙은 기본적으로 [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html)를 통해 할당됩니다. 그리고 [Allocator API](https://doc."
+"rust-lang.org/std/alloc/index.html)를 이용해서 커스텀 메모리 할당자를 만들 수"
+"도 있습니다."
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+"`unsafe` 코드로 메모리 레이아웃을 살펴볼 수 있습니다. 물론 이 코드가 안전하"
+"지 않다는 점을 알려주세요!"
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
 
 #: src/memory-management/manual.md:3
 msgid "You allocate and deallocate heap memory yourself."
 msgstr "사용자가 직접 메모리를 할당, 해제 합니다."
 
 #: src/memory-management/manual.md:5
-msgid "If not done with care, this can lead to crashes, bugs, security vulnerabilities, and memory leaks."
-msgstr "조심하지 않으면, 충돌(crash), 버그, 보안취약성 및 메모리 누출이 발생할 수 있습니다."
+msgid ""
+"If not done with care, this can lead to crashes, bugs, security "
+"vulnerabilities, and memory leaks."
+msgstr ""
+"조심하지 않으면, 충돌(crash), 버그, 보안취약성 및 메모리 누출이 발생할 수 있"
+"습니다."
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
-msgstr "## C 언어 예제"
+msgid "C Example"
+msgstr "C 언어 예제"
 
 #: src/memory-management/manual.md:9
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
@@ -3662,34 +4352,41 @@ msgstr ""
 
 #: src/memory-management/manual.md:21
 msgid ""
-"Memory is leaked if the function returns early between `malloc` and `free`: the\n"
-"pointer is lost and we cannot deallocate the memory."
-msgstr "만약 `malloc` 과 `free` 사이에서 함수가 일찍 반환되면 메모리 누출이 일어납니다: 포인터를 잃어버리게 되어 메모리를 반환할 수 없게 됩니다."
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
-msgstr "# 범위기반 메모리 관리"
+"Memory is leaked if the function returns early between `malloc` and `free`: "
+"the pointer is lost and we cannot deallocate the memory."
+msgstr ""
+"만약 `malloc` 과 `free` 사이에서 함수가 일찍 반환되면 메모리 누출이 일어납니"
+"다: 포인터를 잃어버리게 되어 메모리를 반환할 수 없게 됩니다."
 
 #: src/memory-management/scope-based.md:3
-msgid "Constructors and destructors let you hook into the lifetime of an object."
-msgstr "생성자와 소멸자를 사용하여 객체의 생명주기에 따라 메모리 할당/해제가 일어나도록 할 수 있습니다."
+msgid ""
+"Constructors and destructors let you hook into the lifetime of an object."
+msgstr ""
+"생성자와 소멸자를 사용하여 객체의 생명주기에 따라 메모리 할당/해제가 일어나도"
+"록 할 수 있습니다."
 
 #: src/memory-management/scope-based.md:5
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
-"destroyed. The compiler guarantees that this happens, even if an exception is\n"
-"raised."
-msgstr "포인터를 객체로 감싸도록 하면, 그 객체가 소멸될 때 그 포인터가 가리키는 메모리가 해제되도록 할 수 있습니다. 컴파일러는 객체가 소멸될 때 반드시 소멸자가 호출되는 것을 보장합니다. 심지어는 예외(exception)가 발생(_역주_: 함수의 리턴이나 스코프의 종료 뿐만이 아니라) 하더라도요."
+"By wrapping a pointer in an object, you can free memory when the object is "
+"destroyed. The compiler guarantees that this happens, even if an exception "
+"is raised."
+msgstr ""
+"포인터를 객체로 감싸도록 하면, 그 객체가 소멸될 때 그 포인터가 가리키는 메모"
+"리가 해제되도록 할 수 있습니다. 컴파일러는 객체가 소멸될 때 반드시 소멸자가 "
+"호출되는 것을 보장합니다. 심지어는 예외(exception)가 발생(_역주_: 함수의 리턴"
+"이나 스코프의 종료 뿐만이 아니라) 하더라도요."
 
 #: src/memory-management/scope-based.md:9
 msgid ""
-"This is often called _resource acquisition is initialization_ (RAII) and gives\n"
-"you smart pointers."
-msgstr "이를 종종 RAII (Resource Acquisition Is Initialization)라고 하며, 이런 객체는 일종의 스마트 포인터 역할을 합니다."
+"This is often called _resource acquisition is initialization_ (RAII) and "
+"gives you smart pointers."
+msgstr ""
+"이를 종종 RAII (Resource Acquisition Is Initialization)라고 하며, 이런 객체"
+"는 일종의 스마트 포인터 역할을 합니다."
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
-msgstr "## C++ 예제"
+msgid "C++ Example"
+msgstr "C++ 예제"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -3707,17 +4404,22 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:20
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
 msgstr ""
-"* `std::unique_ptr`객체는 스택에 할당되며, 힙에 할당된 메모리를 가리킵니다.\n"
-"* `say_hello`함수가 끝나면 `std::unique_ptr`의 소멸자가 실행됩니다.\n"
-"* 소멸자는 `Person` 객체가 가리키는 메모리를 해제합니다."
+"`std::unique_ptr`객체는 스택에 할당되며, 힙에 할당된 메모리를 가리킵니다."
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr "`say_hello`함수가 끝나면 `std::unique_ptr`의 소멸자가 실행됩니다."
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
+msgstr "소멸자는 `Person` 객체가 가리키는 메모리를 해제합니다."
 
 #: src/memory-management/scope-based.md:25
-msgid "Special move constructors are used when passing ownership to a function:"
+msgid ""
+"Special move constructors are used when passing ownership to a function:"
 msgstr "이동 생성자는 함수 호출 시 소유권을 전달할때 사용됩니다:"
 
 #: src/memory-management/scope-based.md:27
@@ -3733,30 +4435,35 @@ msgstr ""
 "```"
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
-msgstr "# 자동 메모리 관리"
+msgid "Automatic Memory Management"
+msgstr "자동 메모리 관리"
 
 #: src/memory-management/garbage-collection.md:3
 msgid ""
-"An alternative to manual and scope-based memory management is automatic memory\n"
-"management:"
-msgstr "수동, 스코프기반 메모리 관리의 대안으로 자동 메모리 관리 방식이 있습니다:"
+"An alternative to manual and scope-based memory management is automatic "
+"memory management:"
+msgstr ""
+"수동, 스코프기반 메모리 관리의 대안으로 자동 메모리 관리 방식이 있습니다:"
 
 #: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "개발자는 메모리를 명시적으로 할당/해제 하지 않습니다."
+
+#: src/memory-management/garbage-collection.md:7
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the programmer."
-msgstr ""
-"* 개발자는 메모리를 명시적으로 할당/해제 하지 않습니다.\n"
-"* 가비지 컬렉터(GC)는 사용되지 않는 메모리를 찾아 해제합니다."
+"A garbage collector finds unused memory and deallocates it for the "
+"programmer."
+msgstr "가비지 컬렉터(GC)는 사용되지 않는 메모리를 찾아 해제합니다."
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
-msgstr "## Jave 예제"
+msgid "Java Example"
+msgstr "Jave 예제"
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
-msgstr "`person`객체는 `sayHello`함수 반환 후에도 해제되지 않습니다. (_역주_: GC가 나중에 알아서 해제합니다.)"
+msgstr ""
+"`person`객체는 `sayHello`함수 반환 후에도 해제되지 않습니다. (_역주_: GC가 나"
+"중에 알아서 해제합니다.)"
 
 #: src/memory-management/garbage-collection.md:13
 msgid ""
@@ -3773,122 +4480,170 @@ msgstr ""
 "```"
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
-msgstr "# 러스트에서의 메모리 관리"
+msgid "Memory Management in Rust"
+msgstr "러스트에서의 메모리 관리"
 
 #: src/memory-management/rust.md:3
 msgid "Memory management in Rust is a mix:"
 msgstr "러스트의 메모리 관리는 지금까지 설명한 방식들을 혼합해서 사용합니다:"
 
 #: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "자바처럼 안전하고 정확합니다. 하지만 GC는 없습니다."
+
+#: src/memory-management/rust.md:6
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you choose, can be a single unique pointer, reference counted, or atomically reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even have no cost at runtime like C."
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
 msgstr ""
-"* 자바처럼 안전하고 정확합니다. 하지만 GC는 없습니다.\n"
-"* 다양한 추상화를 제공합니다: 단일 포인터, 참조 카운트, 아토믹(atomic) 참조 카운트.\n"
-"* C++ 처럼 범위(스코프) 기반입니다. 하지만 컴파일러가 훨씬 더 엄격합니다.\n"
-"* 사용자는 상황에 따라 적합한 추상화를 선택할 수 있습니다. 그 중에는 C 언어 처럼 런타임 오버헤드가 없는 것도 있습니다."
+"다양한 추상화를 제공합니다: 단일 포인터, 참조 카운트, 아토믹(atomic) 참조 카"
+"운트."
+
+#: src/memory-management/rust.md:7
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+"C++ 처럼 범위(스코프) 기반입니다. 하지만 컴파일러가 훨씬 더 엄격합니다."
+
+#: src/memory-management/rust.md:8
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
+"have no cost at runtime like C."
+msgstr ""
+"사용자는 상황에 따라 적합한 추상화를 선택할 수 있습니다. 그 중에는 C 언어 처"
+"럼 런타임 오버헤드가 없는 것도 있습니다."
 
 #: src/memory-management/rust.md:10
 msgid "It achieves this by modeling _ownership_ explicitly."
-msgstr "러스트는 *소유권*을 언어 차원에서 명시적으로 모델링 함으로써 이를 이룹니다."
+msgstr ""
+"러스트는 _소유권_을 언어 차원에서 명시적으로 모델링 함으로써 이를 이룹니다."
 
 #: src/memory-management/rust.md:14
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These encapsulate ownership and memory allocation via various means, and prevent the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* 이 시점에서 그게 어떻게 가능하냐는 질문이 있으면, 러스트에서 이 작업은 일반적으로 [Box], [Vec], [Rc] 또는 [Arc]와 같은 RAII 타입에 의해 처리된다고 답변할 수 있습니다. 이들은 다양한 방법을 통해 소유권과 메모리 할당에 대한 구체적인 내용을을 캡슐화하여, C 언어였다면 발생할 수 있었을 다양한 에러를 막습니다.\n"
-"\n"
-"* 소멸자에 대한 질문도 있을 수 있습니다. [Drop] 트레잇이 답입니다."
+"이 시점에서 그게 어떻게 가능하냐는 질문이 있으면, 러스트에서 이 작업은 일반적"
+"으로 [Box](https://doc.rust-lang.org/std/boxed/struct.Box.html), [Vec]"
+"(https://doc.rust-lang.org/std/vec/struct.Vec.html), [Rc](https://doc.rust-"
+"lang.org/std/rc/struct.Rc.html) 또는 [Arc](https://doc.rust-lang.org/std/"
+"sync/struct.Arc.html)와 같은 RAII 타입에 의해 처리된다고 답변할 수 있습니다. "
+"이들은 다양한 방법을 통해 소유권과 메모리 할당에 대한 구체적인 내용을을 캡슐"
+"화하여, C 언어였다면 발생할 수 있었을 다양한 에러를 막습니다."
 
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
-msgstr "# 비교"
+#: src/memory-management/rust.md:16
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
+msgstr ""
+"소멸자에 대한 질문도 있을 수 있습니다. [Drop](https://doc.rust-lang.org/std/"
+"ops/trait.Drop.html) 트레잇이 답입니다."
 
 #: src/memory-management/comparison.md:3
 msgid "Here is a rough comparison of the memory management techniques."
 msgstr "메모리 관리 기술의 대략적인 비교입니다."
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## 메모리 관리 방법 별 장점"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "메모리 관리 방법 별 장점"
 
-#: src/memory-management/comparison.md:7
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* C와 같은 수동 관리: \n"
-"  * 런타임 오버헤드가 없음. \n"
-"* JAVA와 같은 자동화 관리: \n"
-"  * 완전한 자동화.\n"
-"  * 안전하고 정확함.\n"
-"* C++ 와 같은 범위 기반 관리: \n"
-"  * 부분 자동화\n"
-"  * 런타임 오버헤드가 없음.\n"
-"* 러스트와 같은 컴파일러 수행 범위 기반 관리: \n"
-"  * 컴파일러에 의해 수행됩니다.\n"
-"  * 런타임 오버헤드가 없습니다. \n"
-"  * 안전하고 정확합니다."
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
+msgid "Manual like C:"
+msgstr "C와 같은 수동 관리: "
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+msgid "No runtime overhead."
+msgstr "런타임 오버헤드가 없음. "
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+msgid "Automatic like Java:"
+msgstr "JAVA와 같은 자동화 관리: "
+
+#: src/memory-management/comparison.md:10
+msgid "Fully automatic."
+msgstr "완전한 자동화."
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+msgid "Safe and correct."
+msgstr "안전하고 정확함."
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+msgid "Scope-based like C++:"
+msgstr "C++ 와 같은 범위 기반 관리: "
+
+#: src/memory-management/comparison.md:13
+msgid "Partially automatic."
+msgstr "부분 자동화"
+
+#: src/memory-management/comparison.md:15
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "러스트와 같은 컴파일러 수행 범위 기반 관리: "
+
+#: src/memory-management/comparison.md:16
+msgid "Enforced by compiler."
+msgstr "컴파일러에 의해 수행됩니다."
 
 #: src/memory-management/comparison.md:20
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## 메모리 관리 방법 별 단점"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "메모리 관리 방법 별 단점"
 
-#: src/memory-management/comparison.md:22
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
+#: src/memory-management/comparison.md:23
+msgid "Use-after-free."
+msgstr "사용 후 해제 문제."
+
+#: src/memory-management/comparison.md:24
+msgid "Double-frees."
+msgstr "이중 해제 문제."
+
+#: src/memory-management/comparison.md:25
+msgid "Memory leaks."
+msgstr "메모리 누출 문제."
+
+#: src/memory-management/comparison.md:27
+msgid "Garbage collection pauses."
+msgstr "GC동작으로 인한 멈춤."
+
+#: src/memory-management/comparison.md:28
+msgid "Destructor delays."
 msgstr ""
-"* C와 같은 수동 관리:\n"
-"  * 사용 후 해제 문제.\n"
-"  * 이중 해제 문제.\n"
-"  * 메모리 누출 문제.\n"
-"* JAVA와 같은 자동화 관리:\n"
-"  * GC동작으로 인한 멈춤.\n"
-"  * 소멸자 지연 (_역주_: 특정 메모리를 더이상 사용하지 않더라도 곧바로 해제 되지 않고 GC가 동작할 때 까지 기다려야 한다는 점)\n"
-"* C++ 와 같은 범위 기반 관리:\n"
-"  * 복잡하며, 개발자의 선택사항임.\n"
-"  * 사용 후 해제 문제 가능성 있음.\n"
-"* 러스트와 같은 컴파일러가 강제하는 수행 범위 기반 관리:\n"
-"  * 약간의 초기 복잡성.\n"
-"  * 올바른 프로그램이지만 컴파일러가 거부할 수 있음."
+"소멸자 지연 (_역주_: 특정 메모리를 더이상 사용하지 않더라도 곧바로 해제 되지 "
+"않고 GC가 동작할 때 까지 기다려야 한다는 점)"
 
-#: src/ownership.md:1
-msgid "# Ownership"
-msgstr "# 소유권"
+#: src/memory-management/comparison.md:30
+msgid "Complex, opt-in by programmer."
+msgstr "복잡하며, 개발자의 선택사항임."
+
+#: src/memory-management/comparison.md:31
+msgid "Potential for use-after-free."
+msgstr "사용 후 해제 문제 가능성 있음."
+
+#: src/memory-management/comparison.md:32
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "러스트와 같은 컴파일러가 강제하는 수행 범위 기반 관리:"
+
+#: src/memory-management/comparison.md:33
+msgid "Some upfront complexity."
+msgstr "약간의 초기 복잡성."
+
+#: src/memory-management/comparison.md:34
+msgid "Can reject valid programs."
+msgstr "올바른 프로그램이지만 컴파일러가 거부할 수 있음."
 
 #: src/ownership.md:3
 msgid ""
-"All variable bindings have a _scope_ where they are valid and it is an error to\n"
-"use a variable outside its scope:"
-msgstr "모든 변수 바인딩은 유효한 \"범위(스코프)\"를 가지며, 범위 밖에서 변수 사용하면 에러가 발생합니다:"
+"All variable bindings have a _scope_ where they are valid and it is an error "
+"to use a variable outside its scope:"
+msgstr ""
+"모든 변수 바인딩은 유효한 \"범위(스코프)\"를 가지며, 범위 밖에서 변수 사용하"
+"면 에러가 발생합니다:"
 
 #: src/ownership.md:6
 msgid ""
@@ -3918,17 +4673,20 @@ msgstr ""
 
 #: src/ownership.md:18
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr ""
-"* 스코프가 종료되면 변수는 \"삭제(drop)\"되었다고 하며 그 변수의 데이터는 메모리에서 해제됩니다.\n"
-"* 스코프가 종료될 때 다른 리소스를 해제하기 위해 소멸자가 호출되도록 할 수 있습니다.\n"
-"* 이것을 두고 변수가 값을 \"소유\"한다고 표현합니다."
+"스코프가 종료되면 변수는 \"삭제(drop)\"되었다고 하며 그 변수의 데이터는 메모"
+"리에서 해제됩니다."
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
-msgstr "# Move 문법(Move Semantics)"
+#: src/ownership.md:19
+msgid "A destructor can run here to free up resources."
+msgstr ""
+"스코프가 종료될 때 다른 리소스를 해제하기 위해 소멸자가 호출되도록 할 수 있습"
+"니다."
+
+#: src/ownership.md:20
+msgid "We say that the variable _owns_ the value."
+msgstr "이것을 두고 변수가 값을 \"소유\"한다고 표현합니다."
 
 #: src/ownership/move-semantics.md:3
 msgid "An assignment will transfer ownership between variables:"
@@ -3955,32 +4713,40 @@ msgstr ""
 "```"
 
 #: src/ownership/move-semantics.md:14
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "`s1`을 `s2`에 할당하여 소유권을 이전시킵니다."
+
+#: src/ownership/move-semantics.md:15
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
 msgstr ""
-"* `s1`을 `s2`에 할당하여 소유권을 이전시킵니다.\n"
-"* 데이터는 `s1`에서 _이동_됩니다. 따라서 프로그래머는 `s1`은 더 이상 접근 할 수 없습니다.\n"
-"* `s1`의 스코프가 종료되면 아무 일도 없습니다: 왜냐하면 `s1`은 아무런 소유권이 없기 때문입니다.\n"
-"* `s2`의 스코프가 종료되면 문자열 데이터는 해제됩니다.\n"
-"* 값(데이터)의 소유권을 갖는 변수는 항상 *단* 하나 입니다."
+"데이터는 `s1`에서 \\_이동_됩니다. 따라서 프로그래머는 `s1`은 더 이상 접근 할 "
+"수 없습니다."
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr ""
+"`s1`의 스코프가 종료되면 아무 일도 없습니다: 왜냐하면 `s1`은 아무런 소유권이 "
+"없기 때문입니다."
+
+#: src/ownership/move-semantics.md:17
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr "`s2`의 스코프가 종료되면 문자열 데이터는 해제됩니다."
+
+#: src/ownership/move-semantics.md:18
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr "값(데이터)의 소유권을 갖는 변수는 항상 _단_ 하나 입니다."
 
 #: src/ownership/move-semantics.md:22
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* 이는 C++과 정반대 임을 설명하세요. C++에서는 복사가 기본이고, `std::move` 를 이용해야만 (그리고 이동 생성자가 정의되어 있어야만!) 소유권 이전이 됩니다.\n"
-"\n"
-"* 러스트에서는 복사할때에는 명시적으로 `clone`을 사용합니다."
+"이는 C++과 정반대 임을 설명하세요. C++에서는 복사가 기본이고, `std::move` 를 "
+"이용해야만 (그리고 이동 생성자가 정의되어 있어야만!) 소유권 이전이 됩니다."
 
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
-msgstr "# 러스트에서의 문자열 이동(Move)"
+#: src/ownership/move-semantics.md:24
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "러스트에서는 복사할때에는 명시적으로 `clone`을 사용합니다."
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -3999,12 +4765,13 @@ msgstr ""
 "```"
 
 #: src/ownership/moved-strings-rust.md:10
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "`s1`의 힙 데이터는 `s2`에서 재사용 됩니다."
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
 msgstr ""
-"* `s1`의 힙 데이터는 `s2`에서 재사용 됩니다.\n"
-"* `s1`의 스코프가 종료되면 아무일도 일어나지 않습니다.(이미 이동되었습니다.)"
+"`s1`의 스코프가 종료되면 아무일도 일어나지 않습니다.(이미 이동되었습니다.)"
 
 #: src/ownership/moved-strings-rust.md:13
 msgid "Before move to `s2`:"
@@ -4090,10 +4857,6 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr "# Modern C++에서 이중해제 문제"
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr "Modern C++은 이 문제를 다르게 해결합니다:"
@@ -4112,11 +4875,12 @@ msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
-msgstr ""
-"* `s1`의 힙 데이터는 복제되고, `s2`는 독립적인 복사본을 얻습니다.\n"
-"* `s1` 와 `s2`의 스코프가 종료되면 각각의 메모리가 해제됩니다."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+msgstr "`s1`의 힙 데이터는 복제되고, `s2`는 독립적인 복사본을 얻습니다."
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr "`s1` 와 `s2`의 스코프가 종료되면 각각의 메모리가 해제됩니다."
 
 #: src/ownership/double-free-modern-cpp.md:13
 msgid "Before copy-assignment:"
@@ -4200,15 +4964,13 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/moves-function-calls.md:1
-msgid "# Moves in Function Calls"
-msgstr "# 함수 호출에서의 이동(Move)"
-
 #: src/ownership/moves-function-calls.md:3
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
-msgstr "값을 함수에 전달할때, 그 값은 매개변수에 할당됩니다. 이때 소유권의 이동이 일어납니다:"
+msgstr ""
+"값을 함수에 전달할때, 그 값은 매개변수에 할당됩니다. 이때 소유권의 이동이 일"
+"어납니다:"
 
 #: src/ownership/moves-function-calls.md:6
 msgid ""
@@ -4238,24 +5000,46 @@ msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the `say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name.clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making move semantics the default, and by forcing programmers to make clones explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* `say_hello`함수의 첫번째 호출시 `main`함수는 자신이 가진 `name`에 대한 소유권을 포기하므로, 이후 `main`함수에서는 `name`을 사용할 수 없습니다.\n"
-"* `name`에 할당되있는 힙 메모리는 `say_hello`함수의 끝에서 해제됩니다.\n"
-"* `main`함수에서 `name`을 참조로 전달(빌림)하고(`&name`), `say_hello`에서 매개변수를 참조형으로 수정한다면 `main`함수는 `name`의 소유권을 유지할 수 있습니다.\n"
-"* 또는 첫번째 호출 시 `main`함수에서 `name`을 복제하여 전달할 수도 있습니다.(`name.clone()`)\n"
-"* 러스트는 이동을 기본으로 하고 복제를 명시적으로 선언하도록 만듬으로, 의도치 않게 복사본을 만드는 것이 C++에서보다 어렵습니다."
+"`say_hello`함수의 첫번째 호출시 `main`함수는 자신이 가진 `name`에 대한 소유권"
+"을 포기하므로, 이후 `main`함수에서는 `name`을 사용할 수 없습니다."
 
-#: src/ownership/copy-clone.md:1
-msgid "# Copying and Cloning"
-msgstr "# 복사(copy)와 복제(clone)"
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr "`name`에 할당되있는 힙 메모리는 `say_hello`함수의 끝에서 해제됩니다."
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"`main`함수에서 `name`을 참조로 전달(빌림)하고(`&name`), `say_hello`에서 매개"
+"변수를 참조형으로 수정한다면 `main`함수는 `name`의 소유권을 유지할 수 있습니"
+"다."
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+"또는 첫번째 호출 시 `main`함수에서 `name`을 복제하여 전달할 수도 있습니다."
+"(`name.clone()`)"
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"러스트는 이동을 기본으로 하고 복제를 명시적으로 선언하도록 만듬으로, 의도치 "
+"않게 복사본을 만드는 것이 C++에서보다 어렵습니다."
 
 #: src/ownership/copy-clone.md:3
-msgid "While move semantics are the default, certain types are copied by default:"
+msgid ""
+"While move semantics are the default, certain types are copied by default:"
 msgstr "이동이 기본 설정이지만, 특정 타입은 복사됩니다:"
 
 #: src/ownership/copy-clone.md:5
@@ -4313,12 +5097,12 @@ msgstr ""
 "```"
 
 #: src/ownership/copy-clone.md:30
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
-msgstr ""
-"* 할당 후, `p1`와 `p2`는 자신의 데이터를 소유합니다.\n"
-"* 명시적으로 `p1.clone()`를 사용하여 데이터를 복사할 수 있습니다."
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr "할당 후, `p1`와 `p2`는 자신의 데이터를 소유합니다."
+
+#: src/ownership/copy-clone.md:31
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr "명시적으로 `p1.clone()`를 사용하여 데이터를 복사할 수 있습니다."
 
 #: src/ownership/copy-clone.md:35
 msgid "Copying and cloning are not the same thing:"
@@ -4326,15 +5110,30 @@ msgstr "복사(copy)와 복제(clone)는 같지 않습니다:"
 
 #: src/ownership/copy-clone.md:37
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C++).\n"
-"* Cloning is a more general operation and also allows for custom behavior by implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
 msgstr ""
-"* 복사는 메모리의 내용을 그대로 한 벌 더 만드는 것을 의미하며, 아무 객체에서나 다 지원하지는 않습니다.\n"
-"* 복사는 커스터마이즈 할 수 없습니다. (C++에서 복사 생성자를 통해 복사 동작을 임의로 구현할 수 있는 것과 비교가 됩니다.)\n"
-"* 복제는 보다 일반적인 작업이며, `Clone`트레잇을 구현하여 복제시 동작을 커스터마이즈 할 수 있습니다.\n"
-"* `Drop` 트레잇을 구현한 타입은 복사되지 않습니다."
+"복사는 메모리의 내용을 그대로 한 벌 더 만드는 것을 의미하며, 아무 객체에서나 "
+"다 지원하지는 않습니다."
+
+#: src/ownership/copy-clone.md:38
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+"복사는 커스터마이즈 할 수 없습니다. (C++에서 복사 생성자를 통해 복사 동작을 "
+"임의로 구현할 수 있는 것과 비교가 됩니다.)"
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+"복제는 보다 일반적인 작업이며, `Clone`트레잇을 구현하여 복제시 동작을 커스터"
+"마이즈 할 수 있습니다."
+
+#: src/ownership/copy-clone.md:40
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr "`Drop` 트레잇을 구현한 타입은 복사되지 않습니다."
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 msgid "In the above example, try the following:"
@@ -4342,29 +5141,40 @@ msgstr "위의 예시에서 다음을 시도해 보시기 바랍니다:"
 
 #: src/ownership/copy-clone.md:44
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because `String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* `Point`구조체에 `String`필드를 추가하세요. 컴파일 되지 않을 것입니다. 왜냐하면 `String`은 `Copy`트레잇을 구현하고 있지 않기 때문입니다.\n"
-"* `derive` 속성에서 `Copy`를 제거해 보세요. `p1`을 `println!` 할 때 컴파일 에러가 발생할 것입니다.\n"
-"* `p1`을 복제하면 잘 동작함을 확인해 보세요."
+"`Point`구조체에 `String`필드를 추가하세요. 컴파일 되지 않을 것입니다. 왜냐하"
+"면 `String`은 `Copy`트레잇을 구현하고 있지 않기 때문입니다."
+
+#: src/ownership/copy-clone.md:45
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"`derive` 속성에서 `Copy`를 제거해 보세요. `p1`을 `println!` 할 때 컴파일 에러"
+"가 발생할 것입니다."
+
+#: src/ownership/copy-clone.md:46
+msgid "Show that it works if you clone `p1` instead."
+msgstr "`p1`을 복제하면 잘 동작함을 확인해 보세요."
 
 #: src/ownership/copy-clone.md:48
 msgid ""
-"If students ask about `derive`, it is sufficient to say that this is a way to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and `Clone` traits are generated."
-msgstr "만약 학생들이 `derive`에 대해 묻는다면, 컴파일 시 러스트에서 코드를 생성하는방법이라고 말하는 것으로 충분합니다. 위 경우 `Copy`와 `Clone` 트레잇에 대한 기본 구현이 생성됩니다."
-
-#: src/ownership/borrowing.md:1
-msgid "# Borrowing"
-msgstr "# 빌림(Borrowing)"
+"If students ask about `derive`, it is sufficient to say that this is a way "
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
+msgstr ""
+"만약 학생들이 `derive`에 대해 묻는다면, 컴파일 시 러스트에서 코드를 생성하는"
+"방법이라고 말하는 것으로 충분합니다. 위 경우 `Copy`와 `Clone` 트레잇에 대한 "
+"기본 구현이 생성됩니다."
 
 #: src/ownership/borrowing.md:3
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
-msgstr "함수 호출시 값의 소유권을 이동하는 대신의 함수가 값을 *빌려올 수* 있습니다:"
+msgstr ""
+"함수 호출시 값의 소유권을 이동하는 대신의 함수가 값을 _빌려올 수_ 있습니다:"
 
 #: src/ownership/borrowing.md:6
 msgid ""
@@ -4401,12 +5211,14 @@ msgstr ""
 "```"
 
 #: src/ownership/borrowing.md:22
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
+msgid "The `add` function _borrows_ two points and returns a new point."
 msgstr ""
-"* `add` 함수는 두 `Point` 객체 값을 _빌려_와서 새로운 `Point` 객체를 반환합니다.\n"
-"* `p1`과 `p2`의 소유권은 여전히 호출자(`main`함수)에 있습니다."
+"`add` 함수는 두 `Point` 객체 값을 \\_빌려_와서 새로운 `Point` 객체를 반환합니"
+"다."
+
+#: src/ownership/borrowing.md:23
+msgid "The caller retains ownership of the inputs."
+msgstr "`p1`과 `p2`의 소유권은 여전히 호출자(`main`함수)에 있습니다."
 
 #: src/ownership/borrowing.md:27
 msgid "Notes on stack returns:"
@@ -4414,67 +5226,84 @@ msgstr "스택에 할당된 값을 리턴하는 것에 대한 참고:"
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can eliminate the copy operation. Change the above code to print stack addresses and run it on the [Playground]. In the \"DEBUG\" optimization level, the addresses should change, while they stay the same when changing to the \"RELEASE\" setting:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification because constructors can have side effects. In Rust, this is not an issue at all. If RVO did not happen, Rust will always performs a simple and efficient `memcpy` copy."
+"Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
-"* `add`에서 값을 반환하는 것은 매우 값이 싸다는 것을 설명하세요. 왜냐하면, 컴파일러가 복사 과정을 생략할 수 있기 때문입니다. 위 코드를 스택 주소를 출력하도록 수정하고 [Playground]에서 수행해 보세요. \\\"디버그\\\" 최적화 레벨에서는 주소가 바뀌지만, \\\"릴리즈\\\" 레벨에서는 바뀌지 않습니다:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* 러스트 컴파일러는 반환값 최적화(RVO)를 수행할 수 있습니다.\n"
-"* C++에서 copy elision은 생성자의 부수효과 가능성이 있어 언어레벨의 정의가 필요하지만 러스트에서는 문제가 되지 않습니다. 만약 RVO가 발생하지 않으면 러스트는 항상 간단하고 효율적인 `memcpy`복사를 수행할 것입니다."
+"`add`에서 값을 반환하는 것은 매우 값이 싸다는 것을 설명하세요. 왜냐하면, 컴파"
+"일러가 복사 과정을 생략할 수 있기 때문입니다. 위 코드를 스택 주소를 출력하도"
+"록 수정하고 [Playground](https://play.rust-lang.org/)에서 수행해 보세요. \"디"
+"버그\" 최적화 레벨에서는 주소가 바뀌지만, \"릴리즈\" 레벨에서는 바뀌지 않습니"
+"다:"
 
-#: src/ownership/shared-unique-borrows.md:1
-msgid "# Shared and Unique Borrows"
-msgstr "# 공유와 고유 빌림"
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr "러스트 컴파일러는 반환값 최적화(RVO)를 수행할 수 있습니다."
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always performs a simple and efficient "
+"`memcpy` copy."
+msgstr ""
+"C++에서 copy elision은 생성자의 부수효과 가능성이 있어 언어레벨의 정의가 필요"
+"하지만 러스트에서는 문제가 되지 않습니다. 만약 RVO가 발생하지 않으면 러스트"
+"는 항상 간단하고 효율적인 `memcpy`복사를 수행할 것입니다."
 
 #: src/ownership/shared-unique-borrows.md:3
 msgid "Rust puts constraints on the ways you can borrow values:"
 msgstr "러스트에서는 값을 빌릴 때 다음과 같은 제약조건이 있습니다:"
 
 #: src/ownership/shared-unique-borrows.md:5
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* 한번에 하나 이상의 `&T` 값을 가지거나, _또는_\n"
-"* 정확히 하나의 `&mut T` 값만을 가질 수 있습니다."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "한번에 하나 이상의 `&T` 값을 가지거나, _또는_"
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
+msgstr "정확히 하나의 `&mut T` 값만을 가질 수 있습니다."
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
@@ -4509,47 +5338,80 @@ msgstr ""
 "```"
 
 #: src/ownership/shared-unique-borrows.md:25
+#, fuzzy
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable (through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before the new mutable borrow of `a` through `c`. This is a feature of the borrow checker called \"non-lexical lifetimes\"."
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
 msgstr ""
-"* 위 코드 컴파일 되지 않습니다. 왜냐하면 `c`는 `a`를 가변 변수로 빌렸고, 이와 동시에 `b`는 `a`를 불변 변수로 빌렸기 때문입니다.\n"
-"* `b`에 대한 `println!` 구분을 `c`가 있는 스코프 앞으로 이동하면 컴파일이 됩니다.\n"
-"* 이렇게 바꾸면, 컴파일러는 `c`가 `a`를 가변 변수로 빌리기 전에만 `b`가 사용된다는 것을 확인할 수 있습니다. 빌림 검사기의 이러한 기능을 \"non-lexical lifetime\" 이라고 합니다.\n"
-"  * 단순히 스코프만 보면 `b`의 수명은 `main`함수의 전체라고 생각할 수 있습니다. 때문에 `c`의 블록 안에서는 `a`에 대한 가변 빌림과 불변 빌림이 동시에 존재하는 것 처럼 보이며, 이는 위 제약 조건을 위반하는 것으로 생각할 수 있습니다. 그러나 컴파일러는 `b`가 `c`블록이 시작되기 전에만 사용된다는 점을 적극 활용해서 `b`의 수명을 `c`블록의 시작 전 까지로 줄입니다. 그러면 `b`와 `c`의 수명은 겹치지 않고, 따라서 제약 조건을 위반하지 않습니다."
+"위 코드 컴파일 되지 않습니다. 왜냐하면 `c`는 `a`를 가변 변수로 빌렸고, 이와 "
+"동시에 `b`는 `a`를 불변 변수로 빌렸기 때문입니다."
 
-#: src/ownership/lifetimes.md:1
-msgid "# Lifetimes"
-msgstr "# 수명"
+#: src/ownership/shared-unique-borrows.md:26
+#, fuzzy
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"`b`에 대한 `println!` 구분을 `c`가 있는 스코프 앞으로 이동하면 컴파일이 됩니"
+"다."
+
+#: src/ownership/shared-unique-borrows.md:27
+#, fuzzy
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
+msgstr ""
+"이렇게 바꾸면, 컴파일러는 `c`가 `a`를 가변 변수로 빌리기 전에만 `b`가 사용된"
+"다는 것을 확인할 수 있습니다. 빌림 검사기의 이러한 기능을 \"non-lexical "
+"lifetime\" 이라고 합니다.\n"
+"\n"
+"단순히 스코프만 보면 `b`의 수명은 `main`함수의 전체라고 생각할 수 있습니다. "
+"때문에 `c`의 블록 안에서는 `a`에 대한 가변 빌림과 불변 빌림이 동시에 존재하"
+"는 것 처럼 보이며, 이는 위 제약 조건을 위반하는 것으로 생각할 수 있습니다. 그"
+"러나 컴파일러는 `b`가 `c`블록이 시작되기 전에만 사용된다는 점을 적극 활용해"
+"서 `b`의 수명을 `c`블록의 시작 전 까지로 줄입니다. 그러면 `b`와 `c`의 수명은 "
+"겹치지 않고, 따라서 제약 조건을 위반하지 않습니다."
 
 #: src/ownership/lifetimes.md:3
 msgid "A borrowed value has a _lifetime_:"
-msgstr "빌려온 값은 *수명*을 갖습니다:"
+msgstr "빌려온 값은 _수명_을 갖습니다:"
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that there is\n"
-"    a valid solution."
-msgstr ""
-"* 수명은 생략할 수 있습니다: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* 물론 명시할 수도 있습니다: `&'a Point`, `&'document str`.\n"
-"* `&'a Point` 는 `Point`의 수명이 최소한 `'a`라는 수명보다는 같거나 더 길다는 것을 의미합니다.\n"
-"* 수명은 항상 컴파일러가 자동으로 추론합니다. 직접 수명을 지정할 수는 없습니다.\n"
-"  * 수명 표기(`'`)은 수명 추론시 제약조건이 됩니다. 컴파일러는 이 제약조건을 만족시키는 유요한 수명을 추론할 수 있는지 검사를 합니다."
+msgid "The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`."
+msgstr "수명은 생략할 수 있습니다: `add(p1: &Point, p2: &Point) -> Point`."
 
-#: src/ownership/lifetimes-function-calls.md:1
-msgid "# Lifetimes in Function Calls"
-msgstr "# 함수 호출에서의 수명"
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr "물론 명시할 수도 있습니다: `&'a Point`, `&'document str`."
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+"`&'a Point` 는 `Point`의 수명이 최소한 `'a`라는 수명보다는 같거나 더 길다는 "
+"것을 의미합니다."
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+"수명은 항상 컴파일러가 자동으로 추론합니다. 직접 수명을 지정할 수는 없습니다."
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+"수명 표기(`'`)은 수명 추론시 제약조건이 됩니다. 컴파일러는 이 제약조건을 만족"
+"시키는 유요한 수명을 추론할 수 있는지 검사를 합니다."
 
 #: src/ownership/lifetimes-function-calls.md:3
-msgid "In addition to borrowing its arguments, a function can return a borrowed value:"
+msgid ""
+"In addition to borrowing its arguments, a function can return a borrowed "
+"value:"
 msgstr "함수는 인수를 빌리는 것 외에도 빌린 값을 반환할 수 있습니다:"
 
 #: src/ownership/lifetimes-function-calls.md:5
@@ -4587,83 +5449,113 @@ msgstr ""
 "```"
 
 #: src/ownership/lifetimes-function-calls.md:21
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`'a`는 제네릭 매개변수로 컴파일러로에 의해 추론됩니다."
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr "수명의 이름은 `'` 로 시작하며 보통 `'a`를 많이 씁니다."
+
+#: src/ownership/lifetimes-function-calls.md:25
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+"The _at least_ part is important when parameters are in different scopes."
 msgstr ""
-"* `'a`는 제네릭 매개변수로 컴파일러로에 의해 추론됩니다.\n"
-"* 수명의 이름은 `'` 로 시작하며 보통 `'a`를 많이 씁니다.\n"
-"* `&'a Point` 는 `Point`의 수명이 `'a` 수명과 최소한 같거나 더 길다는 것을 의미합니다.\n"
-"  * 매개변수들이 서로 다른 스코프에 있을 경우 \"최소한\"이라는 조건이 중요합니다."
+"매개변수들이 서로 다른 스코프에 있을 경우 \"최소한\"이라는 조건이 중요합니다."
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global variable).\n"
-"  * Which one is it? The compiler needs to to know, so at the call site the returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
-msgstr ""
-"* `p2`와 `p3`를 새로운 범위(`{...}`)로 아래 코드와 같이 이동해 봅니다:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  `p3`의 수명이 `p2` 보다 길기 때문에 이 예제는 컴파일되지 않음을 확인하시기 바랍니다.\n"
-"\n"
-"* 작업공간을 초기화 한 후 함수 시그니처를 `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`로 변경해 봅니다. 이 경우 `'a`와 `'b`사이의 관계가 불분명하기 때문에 컴파일 되지 않습니다.\n"
-"* 이 에러를 설명하는 또 다른 방법은 다음과 같습니다:\n"
-"  * 이 함수는 두 값을 빌려서, 새로운 참조를 반환합니다.\n"
-"  * 이 반환된 참조는 두 입력 중 하나로 부터 와야 합니다. (아니면 전역 변수로 부터)\n"
-"  * 두 입력 중 어떤 것일까요? 컴파일러는 이를 알아야 합니다. 그래야만 함수 호출부에서 봤을 때, 반환된 참조의 수명이 원래 값을 수명보다 길지 않음을 확인할 수 있기 때문입니다."
+"Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:"
+msgstr "`p2`와 `p3`를 새로운 범위(`{...}`)로 아래 코드와 같이 이동해 봅니다:"
 
-#: src/ownership/lifetimes-data-structures.md:1
-msgid "# Lifetimes in Data Structures"
-msgstr "# 구조체에서의 수명"
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+
+#: src/ownership/lifetimes-function-calls.md:50
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+"`p3`의 수명이 `p2` 보다 길기 때문에 이 예제는 컴파일되지 않음을 확인하시기 바"
+"랍니다."
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+"작업공간을 초기화 한 후 함수 시그니처를 `fn left_most<'a, 'b>(p1: &'a Point, "
+"p2: &'a Point) -> &'b Point`로 변경해 봅니다. 이 경우 `'a`와 `'b`사이의 관계"
+"가 불분명하기 때문에 컴파일 되지 않습니다."
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr "이 에러를 설명하는 또 다른 방법은 다음과 같습니다:"
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr "이 함수는 두 값을 빌려서, 새로운 참조를 반환합니다."
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+"이 반환된 참조는 두 입력 중 하나로 부터 와야 합니다. (아니면 전역 변수로 부"
+"터)"
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
+"두 입력 중 어떤 것일까요? 컴파일러는 이를 알아야 합니다. 그래야만 함수 호출부"
+"에서 봤을 때, 반환된 참조의 수명이 원래 값을 수명보다 길지 않음을 확인할 수 "
+"있기 때문입니다."
 
 #: src/ownership/lifetimes-data-structures.md:3
-msgid "If a data type stores borrowed data, it must be annotated with a lifetime:"
-msgstr "어떤 타입이 빌려온 데이터를 저장하고 있다면, 반드시 수명을 표시해야 합니다:"
+msgid ""
+"If a data type stores borrowed data, it must be annotated with a lifetime:"
+msgstr ""
+"어떤 타입이 빌려온 데이터를 저장하고 있다면, 반드시 수명을 표시해야 합니다:"
 
 #: src/ownership/lifetimes-data-structures.md:5
 msgid ""
@@ -4676,7 +5568,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy dog.\");\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
 "    let fox = Highlight(&text[4..19]);\n"
 "    let dog = Highlight(&text[35..43]);\n"
 "    // erase(text);\n"
@@ -4706,45 +5599,72 @@ msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data underlying the contained `&str` lives at least as long as any instance of `Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This can be useful for creating lightweight views, but it generally makes them somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one lifetime annotation. This can be necessary if there is a need to describe lifetime relationships between the references themselves, in addition to the lifetime of the struct itself. Those are very advanced use cases."
+"In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data."
 msgstr ""
-"* 위의 예제에서 `Highlight`의 어노테이션(`<'doc>`)은 적어도 `Highlight` 인스턴스가 살아있는 동안에는 그 내부의 `&str`가 가리키는 데이터 역시 살아있어야 한다는 것을 의미합니다.\n"
-"* 만약 `text`가 `fox` (혹은 `dog`)의 수명이 다하기 전에 `erase`함수 호출 등으로 사라지게 된다면 빌림 검사기가 에러를 발생합니다.\n"
-"* 빌린 데이터를 가지고 있는 타입은 사용자로 하여금 원본 데이터를 유지하도록 강제합니다. 이런 타입은 경량 뷰(lightweight view)를 만드는데 유용하지만, 이 제약 조건 때문에 이런 타입을 사용하는 것이 쉽지만은 않습니다.\n"
-"* 따라서, 가능하다면, 구조체가 자신의 데이터를 직접 소유하도록 하는 것이 좋습니다.\n"
-"* 한 구조체안에 여러 참조가 있으면서, 이 참조들의 수명이 서로 다르게 지정되는 경우도 있습니다. 이는 참조와 그 구조체 간의 관계 뿐만이 아니라, 그 참조들 사이의 수명 관계를 설명해야 할 경우에 필요합니다. 매우 고급 기술입니다."
+"위의 예제에서 `Highlight`의 어노테이션(`<'doc>`)은 적어도 `Highlight` 인스턴"
+"스가 살아있는 동안에는 그 내부의 `&str`가 가리키는 데이터 역시 살아있어야 한"
+"다는 것을 의미합니다."
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"만약 `text`가 `fox` (혹은 `dog`)의 수명이 다하기 전에 `erase`함수 호출 등으"
+"로 사라지게 된다면 빌림 검사기가 에러를 발생합니다."
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"빌린 데이터를 가지고 있는 타입은 사용자로 하여금 원본 데이터를 유지하도록 강"
+"제합니다. 이런 타입은 경량 뷰(lightweight view)를 만드는데 유용하지만, 이 제"
+"약 조건 때문에 이런 타입을 사용하는 것이 쉽지만은 않습니다."
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+"따라서, 가능하다면, 구조체가 자신의 데이터를 직접 소유하도록 하는 것이 좋습니"
+"다."
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"한 구조체안에 여러 참조가 있으면서, 이 참조들의 수명이 서로 다르게 지정되는 "
+"경우도 있습니다. 이는 참조와 그 구조체 간의 관계 뿐만이 아니라, 그 참조들 사"
+"이의 수명 관계를 설명해야 할 경우에 필요합니다. 매우 고급 기술입니다."
 
 #: src/exercises/day-1/afternoon.md:1
-msgid "# Day 1: Afternoon Exercises"
-msgstr "# 1일차 오후 연습문제"
+msgid "Day 1: Afternoon Exercises"
+msgstr "1일차 오후 연습문제"
 
 #: src/exercises/day-1/afternoon.md:3
 msgid "We will look at two things:"
 msgstr "이번 연습문제는 아래 두가지입니다:"
 
 #: src/exercises/day-1/afternoon.md:5
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
-msgstr ""
-"* 작은 도서관\n"
-"\n"
-"* 반복자와 소유권 (어려움)"
+msgid "A small book library,"
+msgstr "작은 도서관"
 
-#: src/exercises/day-1/book-library.md:1
-msgid "# Designing a Library"
-msgstr "# 도서관 설계"
+#: src/exercises/day-1/afternoon.md:7
+msgid "Iterators and ownership (hard)."
+msgstr "반복자와 소유권 (어려움)"
 
 #: src/exercises/day-1/book-library.md:3
 msgid ""
-"We will learn much more about structs and the `Vec<T>` type tomorrow. For now,\n"
-"you just need to know part of its API:"
-msgstr "우리는 내일 구조체와 `Vec<T>`에 대해 더 많은 것을 배울 것입니다. 일단 오늘은 API의 일부만 알면 됩니다:"
+"We will learn much more about structs and the `Vec<T>` type tomorrow. For "
+"now, you just need to know part of its API:"
+msgstr ""
+"우리는 내일 구조체와 `Vec<T>`에 대해 더 많은 것을 배울 것입니다. 일단 오늘은 "
+"API의 일부만 알면 됩니다:"
 
 #: src/exercises/day-1/book-library.md:6
 msgid ""
@@ -4762,9 +5682,11 @@ msgstr ""
 
 #: src/exercises/day-1/book-library.md:17
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
-msgstr "도서관 프로그램을 만들기 위해 아래 코드를 <https://play.rust-lang.org/>에 복사해서 구현하시면 됩니다:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
+msgstr ""
+"도서관 프로그램을 만들기 위해 아래 코드를 <https://play.rust-lang.org/>에 복"
+"사해서 구현하시면 됩니다:"
 
 #: src/exercises/day-1/book-library.md:20
 msgid ""
@@ -4832,9 +5754,11 @@ msgid ""
 "    //println!(\"Our library is empty: {}\", library.is_empty());\n"
 "\n"
 "    let favorite_book = Book::new(\"Lord of the Rings\", 1954);\n"
-"    println!(\"Our favorite book {favorite_book} should go in the library\");\n"
+"    println!(\"Our favorite book {favorite_book} should go in the "
+"library\");\n"
 "    //library.add_book(favorite_book);\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    //\n"
 "    //library.print_books();\n"
 "    //\n"
@@ -4855,27 +5779,31 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr "[해답](solutions-afternoon.md#designing-a-library)"
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-msgid "# Iterators and Ownership"
-msgstr "# 반복자와 소유권"
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
-msgstr "러스트의 소유권 모델은 많은 API에 반영이 되어 있습니다. 예를들어 [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) 와 [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) 같은 트레잇이 있습니다."
+msgstr ""
+"러스트의 소유권 모델은 많은 API에 반영이 되어 있습니다. 예를들어 [`Iterator`]"
+"(https://doc.rust-lang.org/std/iter/trait.Iterator.html) 와 [`IntoIterator`]"
+"(https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) 같은 트레잇이 있"
+"습니다."
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
-msgid "## `Iterator`"
-msgstr "## `Iterator`"
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
+msgid "`Iterator`"
+msgstr "`Iterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. The\n"
-"`Iterator` trait simply says that you can call `next` until you get `None` back:"
-msgstr "트레잇은 타입에 대한 행동(메서드)를 설명한다는 점에서 인터페이스와 유사합니다. `Iterator`는 단순히 `None`이 나올때까지 `next`를 호출하는 것이 가능하다는 것을 나타내는 트레잇입니다:"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
+"`Iterator` trait simply says that you can call `next` until you get `None` "
+"back:"
+msgstr ""
+"트레잇은 타입에 대한 행동(메서드)를 설명한다는 점에서 인터페이스와 유사합니"
+"다. `Iterator`는 단순히 `None`이 나올때까지 `next`를 호출하는 것이 가능하다"
+"는 것을 나타내는 트레잇입니다:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
 msgid ""
@@ -4937,14 +5865,17 @@ msgid "Why is this type used?"
 msgstr "왜 이런 타입이 사용되는 것일까요?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
-msgid "## `IntoIterator`"
-msgstr "## `IntoIterator`"
+msgid "`IntoIterator`"
+msgstr "`IntoIterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
-"iterator. The related trait `IntoIterator` tells you how to create the iterator:"
-msgstr "`Iterator` 트레잇은 생성된 반복자를 *사용*하는 방법을 알려줍니다. 반면 `IntoIterator` 트레잇은 반복자를 *생성*하는 방법을 알려줍니다:"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
+"iterator. The related trait `IntoIterator` tells you how to create the "
+"iterator:"
+msgstr ""
+"`Iterator` 트레잇은 생성된 반복자를 _사용_하는 방법을 알려줍니다. 반면 "
+"`IntoIterator` 트레잇은 반복자를 _생성_하는 방법을 알려줍니다:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:53
 msgid ""
@@ -4960,23 +5891,26 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:62
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr "`IntoIterator`의 모든 구현은 반드시 다음의 두 타입을 선언해야합니다:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
-msgstr ""
-"* `Item`: `i8`과 같이 반복되는 값의 타입\n"
-"* `IntoIter`: `into_iter` 메서드에서 반환되는 `Iterator`타입."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr "`Item`: `i8`과 같이 반복되는 값의 타입"
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr "`IntoIter`: `into_iter` 메서드에서 반환되는 `Iterator`타입."
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
-msgstr "`IntoIter`에는 `Item`이 연결되어 있음을 주목하세요. `IntoIter` 반복자는 `Item` 타입의 데이터를 가리켜야 합니다. 즉, 반복자는 `Option<Item>`을 리턴합니다."
+msgstr ""
+"`IntoIter`에는 `Item`이 연결되어 있음을 주목하세요. `IntoIter` 반복자는 "
+"`Item` 타입의 데이터를 가리켜야 합니다. 즉, 반복자는 `Option<Item>`을 리턴합"
+"니다."
 
 #: src/exercises/day-1/iterators-and-ownership.md:71
 msgid "Like before, what  is the type returned by the iterator?"
@@ -4986,7 +5920,8 @@ msgstr "이전과 마찬가지로, 반복자가 반환하는 타입은 무엇입
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "    let mut iter = v.into_iter();\n"
 "\n"
 "    let v0: Option<..> = iter.next();\n"
@@ -4996,21 +5931,25 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
-msgid "## `for` Loops"
-msgstr "## 배열과 `for` 반복문"
+msgid "`for` Loops"
+msgstr "배열과 `for` 반복문"
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 msgid ""
-"Now that we know both `Iterator` and `IntoIterator`, we can build `for` loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
-msgstr "자, 이제 우리는 `Iterator`와 `IntoIterator`를 알았으므로 `for` 루프를 만들 수 있습니다. `for` 루프는 `into_iter()`를 호출하여 반복자를 만든 다음 그 반복자를 이용하여 요소들을 반복해서 접근합니다:"
+"Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
+msgstr ""
+"자, 이제 우리는 `Iterator`와 `IntoIterator`를 알았으므로 `for` 루프를 만들 "
+"수 있습니다. `for` 루프는 `into_iter()`를 호출하여 반복자를 만든 다음 그 반복"
+"자를 이용하여 요소들을 반복해서 접근합니다:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "\n"
 "    for word in &v {\n"
 "        println!(\"word: {word}\");\n"
@@ -5029,49 +5968,52 @@ msgstr "매 루프에서 `word`의 타입은 무엇입니까?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:105
 msgid ""
-"Experiment with the code above and then consult the documentation for [`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
-msgstr "위 코드에서 실험 해 본 후 다음 문서를 참조해서 답변을 확인하시기 바랍니다: [`impl IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E), [`impl IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)"
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
+msgstr ""
+"위 코드에서 실험 해 본 후 다음 문서를 참조해서 답변을 확인하시기 바랍니다: "
+"[`impl IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct."
+"Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E), [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)"
 
 #: src/welcome-day-2.md:1
-msgid "# Welcome to Day 2"
-msgstr "# 2일차 개요"
+msgid "Welcome to Day 2"
+msgstr "2일차 개요"
 
 #: src/welcome-day-2.md:3
 msgid "Now that we have seen a fair amount of Rust, we will continue with:"
 msgstr "상당한 분량의 러스트에 대해 보았고, 이어서 오늘 강의를 진행하겠습니다:"
 
 #: src/welcome-day-2.md:5
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, `Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
-msgstr ""
-"* 구조체, 열거형, 메서드.\n"
-"\n"
-"* 패턴 매칭: 열거형, 구조체 그리고 배열 분해.\n"
-"\n"
-"* 흐름 제어: `if`, `if let`, `while`, `while let`, `break`, 그리고 `continue`.\n"
-"\n"
-"* 표준 라이브러리: `String`, `Option` 과 `Result`, `Vec`, `HashMap`, `Rc` 그리고 `Arc`.\n"
-"\n"
-"* 모듈: 가시성, 경로 및 파일 시스템 계층."
+msgid "Structs, enums, methods."
+msgstr "구조체, 열거형, 메서드."
 
-#: src/structs.md:1
-msgid "# Structs"
-msgstr "# 구조체"
+#: src/welcome-day-2.md:7
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr "패턴 매칭: 열거형, 구조체 그리고 배열 분해."
+
+#: src/welcome-day-2.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+"흐름 제어: `if`, `if let`, `while`, `while let`, `break`, 그리고 `continue`."
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+"표준 라이브러리: `String`, `Option` 과 `Result`, `Vec`, `HashMap`, `Rc` 그리"
+"고 `Arc`."
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr "모듈: 가시성, 경로 및 파일 시스템 계층."
 
 #: src/structs.md:3
 msgid "Like C and C++, Rust has support for custom structs:"
@@ -5127,37 +6069,58 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/structs.md:29
-msgid ""
-"<details>\n"
-"Key Points: "
-msgstr ""
-"<details>\n"
-"키 포인트: "
-
 #: src/structs.md:32
-msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following slides.\n"
-"* This may be a good time to let people know there are different types of structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a trait on some type but don’t have any data that you want to store in the value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the old struct without having to explicitly type it all out. It must always be the last element."
-msgstr ""
-"* 구조체는 C/C++ 와 유사합니다.\n"
-"  * C++ 와 같지만 C와는 달리 타입을 정의하기 위해 'typedef'가 필요하지 않습니다.\n"
-"  * C++ 와 달리 구조체 간 상속은 없습니다.\n"
-"* 메서드는 `impl`블록에 정의 합니다. 다음 슬라이드에서 확인 할 수 있습니다.\n"
-"* 사람들에게 다른 종류의 구조체가 있음을 알게 하기에 좋은 시간일 것입니다.\n"
-"  * 0 크기 구조체(예: `struct Foo;`)는 데이터를 가지고 있지 않지만 특정 타입의 트레잇을 구현할 때 유용합니다.\n"
-"  * 다음 슬라이드에서는 필드 이름이 덜 중요할 때 사용할 수 있는 튜플 구조체를 소개합니다.\n"
-"* `..peter` 문법은 한 구조체에서 다른 구조체로 대부분의 값을 복사하려고 하는 경우에 하나하나 타이핑하는 수고를 덜어줍니다. 반드시 맨 마지막에 와야 합니다."
+msgid "Structs work like in C or C++."
+msgstr "구조체는 C/C++ 와 유사합니다."
 
-#: src/structs/tuple-structs.md:1
-msgid "# Tuple Structs"
-msgstr "# 튜플"
+#: src/structs.md:33
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+"C++ 와 같지만 C와는 달리 타입을 정의하기 위해 'typedef'가 필요하지 않습니다."
+
+#: src/structs.md:34
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr "C++ 와 달리 구조체 간 상속은 없습니다."
+
+#: src/structs.md:35
+msgid ""
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+"메서드는 `impl`블록에 정의 합니다. 다음 슬라이드에서 확인 할 수 있습니다."
+
+#: src/structs.md:36
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+"사람들에게 다른 종류의 구조체가 있음을 알게 하기에 좋은 시간일 것입니다."
+
+#: src/structs.md:37
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself. "
+msgstr ""
+"0 크기 구조체(예: `struct Foo;`)는 데이터를 가지고 있지 않지만 특정 타입의 트"
+"레잇을 구현할 때 유용합니다."
+
+#: src/structs.md:38
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+"다음 슬라이드에서는 필드 이름이 덜 중요할 때 사용할 수 있는 튜플 구조체를 소"
+"개합니다."
+
+#: src/structs.md:39
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
+"old struct without having to explicitly type it all out. It must always be "
+"the last element."
+msgstr ""
+"`..peter` 문법은 한 구조체에서 다른 구조체로 대부분의 값을 복사하려고 하는 경"
+"우에 하나하나 타이핑하는 수고를 덜어줍니다. 반드시 맨 마지막에 와야 합니다."
 
 #: src/structs/tuple-structs.md:3
 msgid "If the field names are unimportant, you can use a tuple struct:"
@@ -5185,7 +6148,9 @@ msgstr ""
 
 #: src/structs/tuple-structs.md:14
 msgid "This is often used for single-field wrappers (called newtypes):"
-msgstr "튜플 구조체는 종종 단일 필드의 래퍼(wrapper, 러스트에서 뉴타입(newtype)이라고 부름)로 사용됩니다:"
+msgstr ""
+"튜플 구조체는 종종 단일 필드의 래퍼(wrapper, 러스트에서 뉴타입(newtype)이라"
+"고 부름)로 사용됩니다:"
 
 #: src/structs/tuple-structs.md:16
 msgid ""
@@ -5229,29 +6194,48 @@ msgstr ""
 
 #: src/structs/tuple-structs.md:37
 msgid ""
-"* Newtypes are a great way to encode additional information about the value in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer have to validate it again at every use: 'PhoneNumber(String)` or `OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). "
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
-"* 뉴타입은 다음과 같은 원시타입 값에 특별한 의미를 부여하는 데 유용합니다.\n"
-"  * 단위 표시를 위한 숫자: 위 예제에서는 뉴턴 단위 표기를 위해 사용합니다.\n"
-"  * 값이 생성될 때 이미 유효성 검사를 통과 했으므로 추가적인 검사가 필요없는 경우: `PhoneNumber(String)`또는 `OddNumber(u32)`\n"
-"* `Newtons` 타입의 값에 `f64` 값을 더하는 방법을 보여주세요.\n"
-"  * 러스트는 대체로 분명하지 않은 것을 싫어합니다. 예를 들면 자동으로 unwrap하거나 불리언 값을 정수 값으로 사용하는 것들이 그렇습니다.\n"
-"  * 연산자 재정의는 3일차 제네릭 부분에서 다룹니다."
+"뉴타입은 다음과 같은 원시타입 값에 특별한 의미를 부여하는 데 유용합니다."
 
-#: src/structs/field-shorthand.md:1
-msgid "# Field Shorthand Syntax"
-msgstr "# 필드 할당 단축 문법(Field Shorthand Syntax)"
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr "단위 표시를 위한 숫자: 위 예제에서는 뉴턴 단위 표기를 위해 사용합니다."
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"값이 생성될 때 이미 유효성 검사를 통과 했으므로 추가적인 검사가 필요없는 경"
+"우: `PhoneNumber(String)`또는 `OddNumber(u32)`"
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr "`Newtons` 타입의 값에 `f64` 값을 더하는 방법을 보여주세요."
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+"러스트는 대체로 분명하지 않은 것을 싫어합니다. 예를 들면 자동으로 unwrap하거"
+"나 불리언 값을 정수 값으로 사용하는 것들이 그렇습니다."
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics). "
+msgstr "연산자 재정의는 3일차 제네릭 부분에서 다룹니다."
 
 #: src/structs/field-shorthand.md:3
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
-msgstr "구조체 필드와 동일한 이름의 변수가 있다면 아래와 같이 \"짧은 문법\"으로 구조체를 생성할 수 있습니다:"
+msgstr ""
+"구조체 필드와 동일한 이름의 변수가 있다면 아래와 같이 \"짧은 문법\"으로 구조"
+"체를 생성할 수 있습니다:"
 
 #: src/structs/field-shorthand.md:6
 msgid ""
@@ -5295,104 +6279,120 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
-"* `new`함수를 다음처럼 구조체 이름 대신 `Self`를 사용하여 작성해도 됩니다.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* `Default` 트레잇을 구현해보세요. 필드 몇개는 초기화하고 나머지 필드는 디폴트 값을 사용할 수 있습니다.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* 메서드는 `impl` 블록에 정의됩니다.\n"
-"* `peter`와 구조체 업데이트 문법을 사용하여 새로운 구조체 인스턴스를 만들어보세요. 이때, `peter`는 더이상 사용할 수 없게 됩니다.\n"
-"* 구조체를 `Debug` 형태로 출력하려면 `{:#?}`를 사용하세요."
+"`new`함수를 다음처럼 구조체 이름 대신 `Self`를 사용하여 작성해도 됩니다."
 
-#: src/enums.md:1
-msgid "# Enums"
-msgstr "# 열거형"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+"`Default` 트레잇을 구현해보세요. 필드 몇개는 초기화하고 나머지 필드는 디폴트 "
+"값을 사용할 수 있습니다."
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr "메서드는 `impl` 블록에 정의됩니다."
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+"`peter`와 구조체 업데이트 문법을 사용하여 새로운 구조체 인스턴스를 만들어보세"
+"요. 이때, `peter`는 더이상 사용할 수 없게 됩니다."
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr "구조체를 `Debug` 형태로 출력하려면 `{:#?}`를 사용하세요."
 
 #: src/enums.md:3
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr "`enum` 키워드는 몇가지 유형(variant)으로 표현되는 타입을 생성합니다:"
 
 #: src/enums.md:6
@@ -5430,30 +6430,49 @@ msgid "Key Points:"
 msgstr "키 포인트:"
 
 #: src/enums.md:35
-msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and `Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate structs but then they wouldn’t be the same type as they would if they were all defined in an enum. "
-msgstr ""
-"* 열거형은 값들의 집합을 하나의 타입으로 표현할 수 있게 합니다.\n"
-"* 위의 `CoinFlip` 열거형 타입은 `Heads`와 `Tail` 두가지 variant를 가집니다. 열거형 타입의 variant는 네임스페이스를 붙여서 사용합니다.\n"
-"* 구조체와 열거형을 비교해 볼까요?\n"
-"  * 구조체나 열거형 모두, 필드가 하나도 없는 단순한 형태도 가능 하고, 여러 타입의 필드를 가질 수도 있습니다.\n"
-"  * 둘 다 연관함수를 `impl`블록으로 정의 할 수 있습니다.\n"
-"  * 열거형 타입의 각 variant를 별도의 구조체로 정의할 수도 있지만, 그러면 열거형을 사용했을 때처럼 하나의 타입으로 취급할 수 없습니다."
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr "열거형은 값들의 집합을 하나의 타입으로 표현할 수 있게 합니다."
 
-#: src/enums/variant-payloads.md:1
-msgid "# Variant Payloads"
-msgstr "# 데이터를 포함하는 열거형(Variant Payloads)"
+#: src/enums.md:36
+msgid ""
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+"위의 `CoinFlip` 열거형 타입은 `Heads`와 `Tail` 두가지 variant를 가집니다. 열"
+"거형 타입의 variant는 네임스페이스를 붙여서 사용합니다."
+
+#: src/enums.md:37
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr "구조체와 열거형을 비교해 볼까요?"
+
+#: src/enums.md:38
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"구조체나 열거형 모두, 필드가 하나도 없는 단순한 형태도 가능 하고, 여러 타입"
+"의 필드를 가질 수도 있습니다."
+
+#: src/enums.md:39
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr "둘 다 연관함수를 `impl`블록으로 정의 할 수 있습니다."
+
+#: src/enums.md:40
+msgid ""
+"You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. "
+msgstr ""
+"열거형 타입의 각 variant를 별도의 구조체로 정의할 수도 있지만, 그러면 열거형"
+"을 사용했을 때처럼 하나의 타입으로 취급할 수 없습니다."
 
 #: src/enums/variant-payloads.md:3
 msgid ""
-"You can define richer enums where the variants carry data. You can then use the\n"
-"`match` statement to extract the data from each variant:"
-msgstr "좀더 복잡한 열거형의 경우 variant에 데이터(payload)를 포함시키도 합니다. 각 variant에 담긴 데이터는 `match`문을 이용해 추출합니다:"
+"You can define richer enums where the variants carry data. You can then use "
+"the `match` statement to extract the data from each variant:"
+msgstr ""
+"좀더 복잡한 열거형의 경우 variant에 데이터(payload)를 포함시키도 합니다. 각 "
+"variant에 담긴 데이터는 `match`문을 이용해 추출합니다:"
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -5513,35 +6532,84 @@ msgstr ""
 
 #: src/enums/variant-payloads.md:35
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern matched. The pattern binds references to the fields in the \"match arm\" after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the advantage the Rust compiler provides by confirming when all cases are handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::Click(Click)` with a top level `struct Click { ... }`. The inlined version cannot implement traits, for example.  \n"
-"  "
+"The values in the enum variants can only be accessed after being pattern "
+"matched. The pattern binds references to the fields in the \"match arm\" "
+"after the `=>`."
 msgstr ""
-"* 열거형 안의 값은 패턴 매칭이 되고 난 이후에만 접근 가능합니다. 그 값에 대한 레퍼런스는 `=>` 이후에 사용가능합니다.\n"
-"  * 매치 패턴들은 위에서 아래로 순서에 따라 검사합니다. C나 C++에서와 같은 fall-through는 없습니다.\n"
-"  * 매치 표현식 자체는 값을 가집니다. 그 값은 매칭이 된 패턴에서 가장 마지막에 수행된 표현식이 됩니다.\n"
-"  * 가장 위에서 부터 어떤 패턴이 주어진 값과 매칭하는지 검사한 다음, 매칭된 것이 발견되면 화살표를 따라 코드를 수행합니다. 한 번 매칭이 되고 코드가 수행이 되면, 더이상의 매칭은 없습니다.\n"
-"* 매칭 패턴들이 불충분 하다면 어떤 일이 일어나는지 설명하세요. 러스트 컴파일러는 모든 가능한 케이스들이 핸들링 되는지 체크한다는 점을 상기시키세요.\n"
-"* `match`는 주어진 열거형 값이 실제로 어떤 variant인지 판단하기 위해, 그 variant의 종류가 기록된, 숨겨진 필드(식별자)의 값을 검사합니다.\n"
-"* `std::mem::discriminant()`를 이용하여 식별자를 얻을 수도 있습니다.\n"
-"  * 이는 각 필드 값을 굳이 비교할 필요 없는 구조체에 대해 `PartialEq` 트레잇을 구현할 때 유용합니다.\n"
-"* `WebEvent::Click { ... }`은 최상위 레벨 구조체 `struct Click {...}`를 따로 정의하고 `WebEvent::Click(Click)`처럼 튜플 형태로 정의한 것과 정확히 같진 않습니다. 예를 들어 `WebEvent::Click { ... }` 로 정의한 경우, 구조체 형태와 유사하지만 트레잇을 구현 할 수 없습니다.\n"
-"  "
+"열거형 안의 값은 패턴 매칭이 되고 난 이후에만 접근 가능합니다. 그 값에 대한 "
+"레퍼런스는 `=>` 이후에 사용가능합니다."
 
-#: src/enums/sizes.md:1
-msgid "# Enum Sizes"
-msgstr "# 열거형 타입의 크기"
+#: src/enums/variant-payloads.md:36
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+"매치 패턴들은 위에서 아래로 순서에 따라 검사합니다. C나 C++에서와 같은 fall-"
+"through는 없습니다."
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+"매치 표현식 자체는 값을 가집니다. 그 값은 매칭이 된 패턴에서 가장 마지막에 수"
+"행된 표현식이 됩니다."
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+"가장 위에서 부터 어떤 패턴이 주어진 값과 매칭하는지 검사한 다음, 매칭된 것이 "
+"발견되면 화살표를 따라 코드를 수행합니다. 한 번 매칭이 되고 코드가 수행이 되"
+"면, 더이상의 매칭은 없습니다."
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+"매칭 패턴들이 불충분 하다면 어떤 일이 일어나는지 설명하세요. 러스트 컴파일러"
+"는 모든 가능한 케이스들이 핸들링 되는지 체크한다는 점을 상기시키세요."
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr ""
+"`match`는 주어진 열거형 값이 실제로 어떤 variant인지 판단하기 위해, 그 "
+"variant의 종류가 기록된, 숨겨진 필드(식별자)의 값을 검사합니다."
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr "`std::mem::discriminant()`를 이용하여 식별자를 얻을 수도 있습니다."
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+"이는 각 필드 값을 굳이 비교할 필요 없는 구조체에 대해 `PartialEq` 트레잇을 구"
+"현할 때 유용합니다."
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
+"`WebEvent::Click { ... }`은 최상위 레벨 구조체 `struct Click {...}`를 따로 정"
+"의하고 `WebEvent::Click(Click)`처럼 튜플 형태로 정의한 것과 정확히 같진 않습"
+"니다. 예를 들어 `WebEvent::Click { ... }` 로 정의한 경우, 구조체 형태와 유사"
+"하지만 트레잇을 구현 할 수 없습니다."
 
 #: src/enums/sizes.md:3
-msgid "Rust enums are packed tightly, taking constraints due to alignment into account:"
-msgstr "러스트의 열거형은 정렬(alignment)로 인한 제약을 고려하여 크기를 빽빽하게 잡습니다:"
+msgid ""
+"Rust enums are packed tightly, taking constraints due to alignment into "
+"account:"
+msgstr ""
+"러스트의 열거형은 정렬(alignment)로 인한 제약을 고려하여 크기를 빽빽하게 잡습"
+"니다:"
 
 #: src/enums/sizes.md:5
 msgid ""
@@ -5586,170 +6654,230 @@ msgstr ""
 "```"
 
 #: src/enums/sizes.md:25
-msgid "* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout.html)."
-msgstr "* 자세한 사항은 [공식문서](https://doc.rust-lang.org/reference/type-layout.html)를 확인하세요."
+msgid ""
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"html)."
+msgstr ""
+"자세한 사항은 [공식문서](https://doc.rust-lang.org/reference/type-layout."
+"html)를 확인하세요."
 
 #: src/enums/sizes.md:31
+#, fuzzy
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum variant.\n"
-"\n"
-" * You can control the discriminant if needed (e.g., for compatibility with C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
-"\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge use unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, $bit_type>($e));\n"
-"         };\n"
-"     }\n"
-"\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
-"\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"\n"
-"     More complex example if you want to discuss what happens when we chain more than 256 `Option`s together.\n"
-"\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, $bit_type>($e));\n"
-"         };\n"
-"     }\n"
-"\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
-"\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), Some(Some(Some(Some(false)))));\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
 msgstr ""
-"* 러스트는 열거형 variant를 구분하기 위해 내부적으로 식별자(discriminant) 필드를 사용합니다.\n"
+"러스트는 열거형 variant를 구분하기 위해 내부적으로 식별자(discriminant) 필드"
+"를 사용합니다."
+
+#: src/enums/sizes.md:33
+#, fuzzy
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr "C와의 연동과 같은 이유로 식별자를 직접 지정할 수도 있습니다:"
+
+#: src/enums/sizes.md:35
+#, fuzzy
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-"* C와의 연동과 같은 이유로 식별자를 직접 지정할 수도 있습니다:\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-"    `repr` 속성이 없다면 10001이 2 바이트로 표현가능하기 때문에 식별자의 타입 크기는 2 바이트가 됩니다.\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+
+#: src/enums/sizes.md:50
+#, fuzzy
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+"`repr` 속성이 없다면 10001이 2 바이트로 표현가능하기 때문에 식별자의 타입 크"
+"기는 2 바이트가 됩니다."
+
+#: src/enums/sizes.md:54
+#, fuzzy
+msgid "Try out other types such as"
+msgstr "다른 타입들도 확인해보세요."
+
+#: src/enums/sizes.md:56
+#, fuzzy
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes"
+
+#: src/enums/sizes.md:57
+#, fuzzy
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (니치 최적화, 아래 설"
+"명 참조)"
+
+#: src/enums/sizes.md:58
+#, fuzzy
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (64비트 머신인 경우)"
+
+#: src/enums/sizes.md:59
+#, fuzzy
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (널포인터 최적화, 아"
+"래 설명 참조)"
+
+#: src/enums/sizes.md:61
+#, fuzzy
+msgid ""
+"Niche optimization: Rust will merge use unused bit patterns for the enum "
+"discriminant."
+msgstr ""
+"니치 최적화: 러스트는 열거형 식별자를 사용되지 않은 비트 패턴과 병합합니다."
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"* 다른 타입들도 확인해보세요.\n"
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"    };\n"
+"}\n"
 "\n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (니치 최적화, 아래 설명 참조)\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (64비트 머신인 경우)\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (널포인터 최적화, 아래 설명 참조)\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"* 니치 최적화: 러스트는 열거형 식별자를 사용되지 않은 비트 패턴과 병합합니다."
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
+"\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
+"\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
+"\n"
+"use std::mem::transmute;\n"
+"\n"
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"    };\n"
+"}\n"
+"\n"
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"signs.\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
+"Some(Some(Some(Some(false)))));\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"\n"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/methods.md:3
 msgid ""
-"Rust allows you to associate functions with your new types. You do this with an\n"
-"`impl` block:"
-msgstr "러스트에서 선언된 타입에 대해 `impl`블록에 함수를 선언하여 메서드를 연결 할 수 있습니다:"
+"Rust allows you to associate functions with your new types. You do this with "
+"an `impl` block:"
+msgstr ""
+"러스트에서 선언된 타입에 대해 `impl`블록에 함수를 선언하여 메서드를 연결 할 "
+"수 있습니다:"
 
 #: src/methods.md:6
 msgid ""
@@ -5798,77 +6926,139 @@ msgstr ""
 "```"
 
 #: src/methods.md:31
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method receiver syntax and to help keep them more organized. By using methods we can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from `self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
-msgstr ""
-"* 메서드를 함수와 비교하여 소개하는 것도 도움이 될 수 있습니다.\n"
-"  * 메서드는 구조체나 열거형과 같은 타입의 인스턴스에서 호출 되며, 첫번째 매개변수(파라메터)는 인스턴스를 `self`로 표기합니다.\n"
-"  * 메서드를 이용하면 receiver 문법을 사용할 수 있고 코드를 좀더 체계적으로 정리할 수 있습니다. 메서드들이 예측 가능한 위치에 모여 있으니 찾기 쉽습니다.\n"
-"* 메서드 receiver인 `self` 키워드 사용을 언급해 주시기 바랍니다.\n"
-"  * 예제의 경우 `self: &Self`의 줄인 버전임을 알려주고, 구조체의 이름을 직접 사용하면 어떻게 되는지 보여주는 것도 좋습니다.\n"
-"  * `impl` 블록 내부에서는 `Self`가 해당 타입의 이름 대용으로 사용될 수 있음을 알려주세요.\n"
-"  * 구조체의 필드를 접근할 때 점 표기를 사용하듯이 `self`에 점 표기를 사용하여 개별 필드들을 접근할 수 있습니다.\n"
-"  * `say_hello` 함수가 두 번 호출되도록 코드를 수정하여 `&self`와 `self`가 어떻게 다른지 보여주는 것도 좋습니다.\n"
-"* 다음 슬라이드에서 receiver의 구분을 설명합니다.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
+msgstr "메서드를 함수와 비교하여 소개하는 것도 도움이 될 수 있습니다."
 
-#: src/methods/receiver.md:1
-msgid "# Method Receiver"
-msgstr "# 메서드 리시버(Receiver)"
+#: src/methods.md:32
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+"메서드는 구조체나 열거형과 같은 타입의 인스턴스에서 호출 되며, 첫번째 매개변"
+"수(파라메터)는 인스턴스를 `self`로 표기합니다."
+
+#: src/methods.md:33
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+"메서드를 이용하면 receiver 문법을 사용할 수 있고 코드를 좀더 체계적으로 정리"
+"할 수 있습니다. 메서드들이 예측 가능한 위치에 모여 있으니 찾기 쉽습니다."
+
+#: src/methods.md:34
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr "메서드 receiver인 `self` 키워드 사용을 언급해 주시기 바랍니다."
+
+#: src/methods.md:35
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+"예제의 경우 `self: &Self`의 줄인 버전임을 알려주고, 구조체의 이름을 직접 사용"
+"하면 어떻게 되는지 보여주는 것도 좋습니다."
+
+#: src/methods.md:36
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+"`impl` 블록 내부에서는 `Self`가 해당 타입의 이름 대용으로 사용될 수 있음을 알"
+"려주세요."
+
+#: src/methods.md:37
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+"구조체의 필드를 접근할 때 점 표기를 사용하듯이 `self`에 점 표기를 사용하여 개"
+"별 필드들을 접근할 수 있습니다."
+
+#: src/methods.md:38
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+"`say_hello` 함수가 두 번 호출되도록 코드를 수정하여 `&self`와 `self`가 어떻"
+"게 다른지 보여주는 것도 좋습니다."
+
+#: src/methods.md:39
+msgid "We describe the distinction between method receivers next."
+msgstr "다음 슬라이드에서 receiver의 구분을 설명합니다."
 
 #: src/methods/receiver.md:3
 msgid ""
-"The `&self` above indicates that the method borrows the object immutably. There\n"
-"are other possible receivers for a method:"
-msgstr "`&self`는 메서드가 객체를 불변하게 빌려옴을 나타냅니다. 메서드의 리시버는 다음의 형태들이 가능합니다:"
+"The `&self` above indicates that the method borrows the object immutably. "
+"There are other possible receivers for a method:"
+msgstr ""
+"`&self`는 메서드가 객체를 불변하게 빌려옴을 나타냅니다. 메서드의 리시버는 다"
+"음의 형태들이 가능합니다:"
 
 #: src/methods/receiver.md:6
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. The\n"
-"  method becomes the owner of the object. The object will be dropped (deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted.\n"
-"* `mut self`: same as above, but while the method owns the object, it can\n"
-"  mutate it too. Complete ownership does not automatically mean mutability.\n"
-"* No receiver: this becomes a static method on the struct. Typically used to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
 msgstr ""
-"* `&self`: 호출자로부터 공유가능한 불변 참조 방식으로 객체를 빌려옴을 나타냅니다. 객체는 메소드 호출 뒤에도 사용될 수 있습니다.\n"
-"* `&mut self`: 호출자로부터 유일한 가변 참조 방식으로 객체를 빌려옴을 나타냅니다. 객체는 메소드 호출 뒤에도 사용될 수 있습니다.\n"
-"* `self`: 호출자로부터 객체의 소유권을 가져오고 객체는 호출자로부터 메소드로 이동됩니다. 메소드가 객체를 소유하게 되며 따라서 명시적으로 소유권을 다른 곳으로 전달하지 않는다면 메서드 종료와 함께 객체는 drop(해제)됩니다.\n"
-"* `mut self`: 위와 동일하지만 메서드가 객체의 소유권을 가지면서 동시에 객체를 수정할 수도 있습니다. 소유권을 가지는 것이 수정할 수 있음을 의미하는 것은 아닙니다.\n"
-"* 리시버 없음: 구조체의 정적 메서드가 됩니다. 주로 생성자를 만들때 사용하게 되며, 생성자는 흔히 `new`라고 이름붙입니다."
+"`&self`: 호출자로부터 공유가능한 불변 참조 방식으로 객체를 빌려옴을 나타냅니"
+"다. 객체는 메소드 호출 뒤에도 사용될 수 있습니다."
+
+#: src/methods/receiver.md:8
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+"`&mut self`: 호출자로부터 유일한 가변 참조 방식으로 객체를 빌려옴을 나타냅니"
+"다. 객체는 메소드 호출 뒤에도 사용될 수 있습니다."
+
+#: src/methods/receiver.md:10
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted."
+msgstr ""
+"`self`: 호출자로부터 객체의 소유권을 가져오고 객체는 호출자로부터 메소드로 이"
+"동됩니다. 메소드가 객체를 소유하게 되며 따라서 명시적으로 소유권을 다른 곳으"
+"로 전달하지 않는다면 메서드 종료와 함께 객체는 drop(해제)됩니다."
+
+#: src/methods/receiver.md:14
+msgid ""
+"`mut self`: same as above, but while the method owns the object, it can "
+"mutate it too. Complete ownership does not automatically mean mutability."
+msgstr ""
+"`mut self`: 위와 동일하지만 메서드가 객체의 소유권을 가지면서 동시에 객체를 "
+"수정할 수도 있습니다. 소유권을 가지는 것이 수정할 수 있음을 의미하는 것은 아"
+"닙니다."
+
+#: src/methods/receiver.md:16
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
+msgstr ""
+"리시버 없음: 구조체의 정적 메서드가 됩니다. 주로 생성자를 만들때 사용하게 되"
+"며, 생성자는 흔히 `new`라고 이름붙입니다."
 
 #: src/methods/receiver.md:19
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
-msgstr "`self`를 사용하는 이같은 변형들 외에도 `Box<Self>`와 같이 리시버 타입으로 허용되는 [특별한 래퍼 타입](https://doc.rust-lang.org/reference/special-types-and-traits.html)이 있습니다."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
+msgstr ""
+"`self`를 사용하는 이같은 변형들 외에도 `Box<Self>`와 같이 리시버 타입으로 허"
+"용되는 [특별한 래퍼 타입](https://doc.rust-lang.org/reference/special-types-"
+"and-traits.html)이 있습니다."
 
 #: src/methods/receiver.md:25
 msgid ""
-"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) method on it."
-msgstr "\"공유가능한 불변\"과 \"유일한 가변\" 부분은 강조할 만합니다. 이러한 제약은 러스트의 빌림 검사기(borrow checker) 규칙으로 늘 붙어다닙니다. `self`도 예외는 아닙니다. 여러 위치에서 구조체를 참조하면서 객체를 수정하는(`&mut self`를 리시버로 하는) 메서드를 호출하는 것은 불가능합니다."
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "# Example"
-msgstr "# 예제"
+"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
+msgstr ""
+"\"공유가능한 불변\"과 \"유일한 가변\" 부분은 강조할 만합니다. 이러한 제약은 "
+"러스트의 빌림 검사기(borrow checker) 규칙으로 늘 붙어다닙니다. `self`도 예외"
+"는 아닙니다. 여러 위치에서 구조체를 참조하면서 객체를 수정하는(`&mut self`를 "
+"리시버로 하는) 메서드를 호출하는 것은 불가능합니다."
 
 #: src/methods/example.md:3
 msgid ""
@@ -5884,7 +7074,8 @@ msgid ""
 "        Race { name: String::from(name), laps: Vec::new() }\n"
 "    }\n"
 "\n"
-"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write access to self\n"
+"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
+"access to self\n"
 "        self.laps.push(lap);\n"
 "    }\n"
 "\n"
@@ -5897,7 +7088,8 @@ msgid ""
 "\n"
 "    fn finish(self) {  // Exclusive ownership of self\n"
 "        let total = self.laps.iter().sum::<i32>();\n"
-"        println!(\"Race {} is finished, total lap time: {}\", self.name, total);\n"
+"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"total);\n"
 "    }\n"
 "}\n"
 "\n"
@@ -5957,28 +7149,49 @@ msgstr ""
 "```"
 
 #: src/methods/example.md:47
-msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` twice.\n"
-"* Note that although the method receivers are different, the non-static functions are called the same way in the main body. Rust enables automatic referencing and dereferencing when calling methods. Rust automatically adds in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated over. We describe vectors in more detail in the afternoon. "
-msgstr ""
-"* 4가지 유형의 메서드 receiver에 대해 설명합니다.\n"
-"  * receiver 유형에 따라 함수가 할 수 있는 일이 달라지고, 또 메소드를 호출한 뒤 `main`에서 해당 객체를 사용할 수 있는지 여부도 달라진다는 점을 강조하세요.\n"
-"  * `finish`를 두번 호출하여 오류가 발생하는 것을 보일 수 있습니다.\n"
-"* 비록 메서드 receiver는 다르지만 main 함수에서 비 정적 함수를 부르는 방법은 같습니다. 러스트는 메서드를 호출할 때 자동으로 참조/역참조(따라가기)를 수행합니다. 러스트는 객체와 매서드 시그니처가 서로 매치되도록 객체에 `&`, `*`, `muts`를 자동으로 붙여줍니다.\n"
-"* `print_laps`함수에서 벡터를 어떤 식으로 사용하고 있는지 언급하는 것도 좋습니다. 벡터는 오후 강의에서 더 자세히 설명할 것입니다. "
+msgid "All four methods here use a different method receiver."
+msgstr "4가지 유형의 메서드 receiver에 대해 설명합니다."
 
-#: src/pattern-matching.md:1
-msgid "# Pattern Matching"
-msgstr "# 패턴 매칭"
+#: src/methods/example.md:48
+msgid ""
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+"receiver 유형에 따라 함수가 할 수 있는 일이 달라지고, 또 메소드를 호출한 뒤 "
+"`main`에서 해당 객체를 사용할 수 있는지 여부도 달라진다는 점을 강조하세요."
+
+#: src/methods/example.md:49
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr "`finish`를 두번 호출하여 오류가 발생하는 것을 보일 수 있습니다."
+
+#: src/methods/example.md:50
+msgid ""
+"Note that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+"비록 메서드 receiver는 다르지만 main 함수에서 비 정적 함수를 부르는 방법은 같"
+"습니다. 러스트는 메서드를 호출할 때 자동으로 참조/역참조(따라가기)를 수행합니"
+"다. 러스트는 객체와 매서드 시그니처가 서로 매치되도록 객체에 `&`, `*`, `muts`"
+"를 자동으로 붙여줍니다."
+
+#: src/methods/example.md:51
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
+msgstr ""
+"`print_laps`함수에서 벡터를 어떤 식으로 사용하고 있는지 언급하는 것도 좋습니"
+"다. 벡터는 오후 강의에서 더 자세히 설명할 것입니다. "
 
 #: src/pattern-matching.md:3
 msgid ""
-"The `match` keyword let you match a value against one or more _patterns_. The\n"
-"comparisons are done from top to bottom and the first match wins."
-msgstr "`match`키워드는 값을 여러 형태의 패턴과 매치시킬 수 있습니다. 맨 위 패턴부터 하나씩 매치되는지 검사하며, 처음으로 매치되는 패턴이 선택됩니다."
+"The `match` keyword let you match a value against one or more _patterns_. "
+"The comparisons are done from top to bottom and the first match wins."
+msgstr ""
+"`match`키워드는 값을 여러 형태의 패턴과 매치시킬 수 있습니다. 맨 위 패턴부터 "
+"하나씩 매치되는지 검사하며, 처음으로 매치되는 패턴이 선택됩니다."
 
 #: src/pattern-matching.md:6
 msgid "The patterns can be simple values, similarly to `switch` in C and C++:"
@@ -6018,35 +7231,54 @@ msgstr "`_`패턴은 어떤 값과도 매칭되는 와일드카드입니다."
 
 #: src/pattern-matching.md:26
 msgid ""
-"* You might point out how some specific characters are being used when in a pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, as the term can show up in error messages.\n"
-"   "
-msgstr ""
-"* 패턴에서 사용되는 특수 문자들을 알려주세요.\n"
-"  * `|`: or 기호입니다.\n"
-"  * `..`: 필요한 만큼 확장합니다.\n"
-"  * `1..=5`: 끝 값(여기서는 5)을 포함하는 범위를 나타냅니다.\n"
-"  * `_`: 와일드카드입니다.\n"
-"* 와일드카드 문자를 변수로 바꾸거나 `q`의 따옴표를 제거하는 식으로 수정하면서 바인딩이 어떻게 작동하는지 보여주는 것도 유용할 수 있습니다.\n"
-"* 참조를 매칭하는 것도 시연할 수 있습니다.\n"
-"* 에러 메시지에 \"반박 불가능 패턴(irrefutable pattern)\"이란 용어가 등장하기도 합니다. 지금 그 의미를 소개하는 것도 좋을 것 같습니다.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
+msgstr "패턴에서 사용되는 특수 문자들을 알려주세요."
 
-#: src/pattern-matching/destructuring-enums.md:1
-msgid "# Destructuring Enums"
-msgstr "# 열거형 분해(역구조화)"
+#: src/pattern-matching.md:27
+msgid "`|` as an `or`"
+msgstr "`|`: or 기호입니다."
+
+#: src/pattern-matching.md:28
+msgid "`..` can expand as much as it needs to be"
+msgstr "`..`: 필요한 만큼 확장합니다."
+
+#: src/pattern-matching.md:29
+msgid "`1..=5` represents an inclusive range"
+msgstr "`1..=5`: 끝 값(여기서는 5)을 포함하는 범위를 나타냅니다."
+
+#: src/pattern-matching.md:30
+msgid "`_` is a wild card"
+msgstr "`_`: 와일드카드입니다."
+
+#: src/pattern-matching.md:31
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+"와일드카드 문자를 변수로 바꾸거나 `q`의 따옴표를 제거하는 식으로 수정하면서 "
+"바인딩이 어떻게 작동하는지 보여주는 것도 유용할 수 있습니다."
+
+#: src/pattern-matching.md:32
+msgid "You can demonstrate matching on a reference."
+msgstr "참조를 매칭하는 것도 시연할 수 있습니다."
+
+#: src/pattern-matching.md:33
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
+msgstr ""
+"에러 메시지에 \"반박 불가능 패턴(irrefutable pattern)\"이란 용어가 등장하기"
+"도 합니다. 지금 그 의미를 소개하는 것도 좋을 것 같습니다."
 
 #: src/pattern-matching/destructuring-enums.md:3
 msgid ""
-"Patterns can also be used to bind variables to parts of your values. This is how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` type:"
-msgstr "구조체나 열거형 값의 일부를 패턴 매치를 통해 변수에 바인딩할 수 있습니다. 간단한 `enum` 타입을 먼저 살펴보겠습니다:"
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
+msgstr ""
+"구조체나 열거형 값의 일부를 패턴 매치를 통해 변수에 바인딩할 수 있습니다. 간"
+"단한 `enum` 타입을 먼저 살펴보겠습니다:"
 
 #: src/pattern-matching/destructuring-enums.md:6
 msgid ""
@@ -6098,22 +7330,31 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the first\n"
-"arm, `half` is bound to the value inside the `Ok` variant. In the second arm,\n"
-"`msg` is bound to the error message."
-msgstr "`match`구문에서 `divide_in_two`함수에서 반환되는 `Result` 값을 두 개의 팔(혹은 가지)로 _분해(destructure)_ 하였습니다. 첫번째 팔에서 `half`는 `Ok` variant에 담긴 값으로 바인딩됩니다. 두번째 팔에서 `msg`는 오류 메시지 문자열에 바인딩됩니다."
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm, `msg` is bound to the error message."
+msgstr ""
+"`match`구문에서 `divide_in_two`함수에서 반환되는 `Result` 값을 두 개의 팔(혹"
+"은 가지)로 _분해(destructure)_ 하였습니다. 첫번째 팔에서 `half`는 `Ok` "
+"variant에 담긴 값으로 바인딩됩니다. 두번째 팔에서 `msg`는 오류 메시지 문자열"
+"에 바인딩됩니다."
 
 #: src/pattern-matching/destructuring-enums.md:36
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying the errors when running the code. Point out the places where your code is now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
-"* `if`/`else` 표현식은 열거형을 반환하고, 이 값은 나중에 `match`로 분해됩니다.\n"
-"* 열거형에 세번째 variant를 추가하고 코드를 실행하여 오류를 표시해보세요. 코드 어느 부분에 누락이 있는지, 그리고 컴파일러가 어떤 식으로 힌트를 주는지 같이 살펴보세요."
+"`if`/`else` 표현식은 열거형을 반환하고, 이 값은 나중에 `match`로 분해됩니다."
 
-#: src/pattern-matching/destructuring-structs.md:1
-msgid "# Destructuring Structs"
-msgstr "# 구조체 분해(역구조화)"
+#: src/pattern-matching/destructuring-enums.md:37
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
+msgstr ""
+"열거형에 세번째 variant를 추가하고 코드를 실행하여 오류를 표시해보세요. 코드 "
+"어느 부분에 누락이 있는지, 그리고 컴파일러가 어떤 식으로 힌트를 주는지 같이 "
+"살펴보세요."
 
 #: src/pattern-matching/destructuring-structs.md:3
 msgid "You can also destructure `structs`:"
@@ -6133,7 +7374,8 @@ msgid ""
 "    match foo {\n"
 "        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
 "        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were ignored\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
 "    }\n"
 "}\n"
 "```"
@@ -6150,43 +7392,37 @@ msgstr ""
 "    match foo {\n"
 "        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
 "        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were ignored\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
 "    }\n"
 "}\n"
 "```"
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
-"* `foo` 인스턴스 생성에 사용된 리터럴 값을 변경해서 다른 패턴에 매치되도록 해보세요.\n"
-"* `Foo` 구조체에 새 필드를 추가하고 패턴도 바꿔보세요."
+"`foo` 인스턴스 생성에 사용된 리터럴 값을 변경해서 다른 패턴에 매치되도록 해보"
+"세요."
 
-#: src/pattern-matching/destructuring-structs.md:23
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr "`Foo` 구조체에 새 필드를 추가하고 패턴도 바꿔보세요."
+
+#: src/pattern-matching/destructuring-structs.md:25
 msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard "
-"to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that "
-"it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
-"* `foo`의 리터럴 값을 다른 패턴과 일치하도록 변경합니다.\n"
-"* `Foo`에 새 필드를 추가하고 필요에 따라 패턴을 변경합니다.\n"
-"* 캡처와 상수 표현식은\n"
-"구분하기 어려울 수 있습니다. 두 번째 부문의 `2`를 변수로 변경해 보고 "
-"작동하지\n"
-"않는 것을 확인하세요. `const`로 변경하고 다시 작동하는지 확인합니다."
-
-#: src/pattern-matching/destructuring-arrays.md:1
-msgid "# Destructuring Arrays"
-msgstr "# 배열 분해(역구조화)"
+"캡처와 상수 표현식은 구분하기 어려울 수 있습니다. 두 번째 부문의 `2`를 변수"
+"로 변경해 보고 작동하지 않는 것을 확인하세요. `const`로 변경하고 다시 작동하"
+"는지 확인합니다."
 
 #: src/pattern-matching/destructuring-arrays.md:3
-msgid "You can destructure arrays, tuples, and slices by matching on their elements:"
-msgstr "배열이나 튜플, 슬라이스도 그 요소들에 대해 패턴 매칭으로 분해할 수 있습니다:"
+msgid ""
+"You can destructure arrays, tuples, and slices by matching on their elements:"
+msgstr ""
+"배열이나 튜플, 슬라이스도 그 요소들에 대해 패턴 매칭으로 분해할 수 있습니다:"
 
 #: src/pattern-matching/destructuring-arrays.md:5
 msgid ""
@@ -6218,65 +7454,73 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
-"* 길이를 알 수 없는 슬라이스에 대해서도 고정 길이 패턴으로 분해할 수 있습니다.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* `_`를 사용하여 요소를 매칭하는 패턴을 추가해보세요.\n"
-"* 배열에 값을 더 추가해보세요.\n"
-"* `..`가 요소 개수에 상관없이 매치될 수 있음을 알려주세요.\n"
-"* `[.., b]`나 `[a@.., b]`와 같은 패턴으로 꼬리 부분을 매칭하는 것을 보여주세요."
+"길이를 알 수 없는 슬라이스에 대해서도 고정 길이 패턴으로 분해할 수 있습니다."
 
-#: src/pattern-matching/match-guards.md:1
-msgid "# Match Guards"
-msgstr "# 매치 가드"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr "`_`를 사용하여 요소를 매칭하는 패턴을 추가해보세요."
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr "배열에 값을 더 추가해보세요."
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr "`..`가 요소 개수에 상관없이 매치될 수 있음을 알려주세요."
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr ""
+"`[.., b]`나 `[a@.., b]`와 같은 패턴으로 꼬리 부분을 매칭하는 것을 보여주세요."
 
 #: src/pattern-matching/match-guards.md:3
 msgid ""
-"When matching, you can add a _guard_ to a pattern. This is an arbitrary Boolean\n"
-"expression which will be executed if the pattern matches:"
-msgstr "패턴 뒤에 가드(guard, 조건식)를 덧붙일 수 있습니다. 가드는 패턴이 매치되면 추가로 따져보는 불리언 표현식입니다:"
+"When matching, you can add a _guard_ to a pattern. This is an arbitrary "
+"Boolean expression which will be executed if the pattern matches:"
+msgstr ""
+"패턴 뒤에 가드(guard, 조건식)를 덧붙일 수 있습니다. 가드는 패턴이 매치되면 추"
+"가로 따져보는 불리언 표현식입니다:"
 
 #: src/pattern-matching/match-guards.md:6
 msgid ""
@@ -6310,57 +7554,73 @@ msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when we wish to concisely express more complex ideas than patterns alone would allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. An `if` expression inside of the branch block (after `=>`) happens after the match arm is selected. Failing the `if` condition inside of that block won't result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a pattern with an `|`."
+"Match guards as a separate syntax feature are important and necessary when "
+"we wish to concisely express more complex ideas than patterns alone would "
+"allow."
 msgstr ""
-"* 매치 가드는 별도의 문법 요소로서 패턴 자체만으로 표현하기 어려운 복잡한 경우를 간결하게 표현하고자 할 때 유용합니다.\n"
-"* 매치의 각 팔(혹은 가지) 안에 따로 `if`를 사용한 것과 다릅니다. 매치 가지의 `=>` 뒤에 사용된 `if` 표현식은 해당 가지가 선택된 다음에 실행됩니다. 따라서 여기서 `if` 조건이 실패하더라도 원래 `match`의 다른 가지는 고려되지 않습니다.\n"
-"* 패턴에 정의된 변수를 가드의 표현식에서 사용할 수 있습니다.\n"
-"* 가드에 정의된 조건은 `|` 를 포함하는 패턴의 모든 표현식에 적용됩니다."
+"매치 가드는 별도의 문법 요소로서 패턴 자체만으로 표현하기 어려운 복잡한 경우"
+"를 간결하게 표현하고자 할 때 유용합니다."
+
+#: src/pattern-matching/match-guards.md:24
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
+"An `if` expression inside of the branch block (after `=>`) happens after the "
+"match arm is selected. Failing the `if` condition inside of that block won't "
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+"매치의 각 팔(혹은 가지) 안에 따로 `if`를 사용한 것과 다릅니다. 매치 가지의 "
+"`=>` 뒤에 사용된 `if` 표현식은 해당 가지가 선택된 다음에 실행됩니다. 따라서 "
+"여기서 `if` 조건이 실패하더라도 원래 `match`의 다른 가지는 고려되지 않습니다."
+
+#: src/pattern-matching/match-guards.md:26
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr "패턴에 정의된 변수를 가드의 표현식에서 사용할 수 있습니다."
+
+#: src/pattern-matching/match-guards.md:27
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr "가드에 정의된 조건은 `|` 를 포함하는 패턴의 모든 표현식에 적용됩니다."
 
 #: src/exercises/day-2/morning.md:1
-msgid "# Day 2: Morning Exercises"
-msgstr "# 2일차 오전 연습문제"
+msgid "Day 2: Morning Exercises"
+msgstr "2일차 오전 연습문제"
 
 #: src/exercises/day-2/morning.md:3
 msgid "We will look at implementing methods in two contexts:"
 msgstr "이번 연습문제들은 두가지 맥락에서 메서드 구현방법을 다룹니다:"
 
 #: src/exercises/day-2/morning.md:5
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
-msgstr ""
-"* 건강 상태 통계를 추적하는 프로그램의 간단한 구조체.\n"
-"\n"
-"* 드로잉 라이브러리를 위한 구조체 및 열거헝."
+msgid "Simple struct which tracks health statistics."
+msgstr "건강 상태 통계를 추적하는 프로그램의 간단한 구조체."
 
-#: src/exercises/day-2/health-statistics.md:1
-msgid "# Health Statistics"
-msgstr "# 건강상태 모니터링 시스템"
+#: src/exercises/day-2/morning.md:7
+msgid "Multiple structs and enums for a drawing library."
+msgstr "드로잉 라이브러리를 위한 구조체 및 열거헝."
 
 #: src/exercises/day-2/health-statistics.md:3
 msgid ""
-"You're working on implementing a health-monitoring system. As part of that, you\n"
-"need to keep track of users' health statistics."
-msgstr "당신은 건강 상태를 모니터링하는 시스템을 구현하는 일을 하고 있습니다. 그 일환으로 당신은 사용자의 건강 상태 통계를 추적해야합니다."
+"You're working on implementing a health-monitoring system. As part of that, "
+"you need to keep track of users' health statistics."
+msgstr ""
+"당신은 건강 상태를 모니터링하는 시스템을 구현하는 일을 하고 있습니다. 그 일환"
+"으로 당신은 사용자의 건강 상태 통계를 추적해야합니다."
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
-"You'll start with some stubbed functions in an `impl` block as well as a `User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
-msgstr "당신의 목표는 `User` 구조체의 `impl` 블록의 빈 함수를 구현하는 것입니다."
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
+msgstr ""
+"당신의 목표는 `User` 구조체의 `impl` 블록의 빈 함수를 구현하는 것입니다."
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
-msgstr "아래 코드를 <https://play.rust-lang.org/>에 복사해서 빠진 메서드를 구현하면 됩니다:"
+msgstr ""
+"아래 코드를 <https://play.rust-lang.org/>에 복사해서 빠진 메서드를 구현하면 "
+"됩니다:"
 
 #: src/exercises/day-2/health-statistics.md:13
 msgid ""
@@ -6422,15 +7682,18 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
-msgid "# Polygon Struct"
-msgstr "# Polygon 구조체"
+msgid "Polygon Struct"
+msgstr "Polygon 구조체"
 
 #: src/exercises/day-2/points-polygons.md:3
 msgid ""
-"We will create a `Polygon` struct which contain some points. Copy the code below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make the\n"
-"tests pass:"
-msgstr "우리는 몇개의 꼭지점을 가진 다각형을 표현하는 `Polygon` 구조체를 만들 것입니다. 아래 코드를 <https://play.rust-lang.org/>에 복사해서 테스트가 통과하도록 빠진 메서드를 구현하시면 됩니다:"
+"We will create a `Polygon` struct which contain some points. Copy the code "
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
+msgstr ""
+"우리는 몇개의 꼭지점을 가진 다각형을 표현하는 `Polygon` 구조체를 만들 것입니"
+"다. 아래 코드를 <https://play.rust-lang.org/>에 복사해서 테스트가 통과하도록 "
+"빠진 메서드를 구현하시면 됩니다:"
 
 #: src/exercises/day-2/points-polygons.md:7
 msgid ""
@@ -6545,9 +7808,12 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:117
 msgid ""
-"Since the method signatures are missing from the problem statements, the key part\n"
-"of the exercise is to specify those correctly. You don't have to modify the tests."
-msgstr "누락된 메서드 시그니처를 올바르게 정의하는 것이 문제의 핵심 부분입니다. 테스트는 수정하면 안됩니다."
+"Since the method signatures are missing from the problem statements, the key "
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
+msgstr ""
+"누락된 메서드 시그니처를 올바르게 정의하는 것이 문제의 핵심 부분입니다. 테스"
+"트는 수정하면 안됩니다."
 
 #: src/exercises/day-2/points-polygons.md:120
 msgid "Other interesting parts of the exercise:"
@@ -6555,33 +7821,38 @@ msgstr "연습문제의 다른 흥미로운 부분:"
 
 #: src/exercises/day-2/points-polygons.md:122
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
-"* 테스트 코드를 보면 어떤 메서드들은 인자를 borrow하는 대신 `Copy` 트레잇을 사용하기도 합니다. 구조체가 `Copy` 트레잇을 상속(derive)하도록 하면 됩니다.\n"
-"* \"+\"를 사용하여 두 객체를 서로 더하려면 `Add` 트레잇을 구현해야 합니다. 이는 3일차에 다룰 내용입니다."
+"테스트 코드를 보면 어떤 메서드들은 인자를 borrow하는 대신 `Copy` 트레잇을 사"
+"용하기도 합니다. 구조체가 `Copy` 트레잇을 상속(derive)하도록 하면 됩니다."
 
-#: src/control-flow.md:1
-msgid "# Control Flow"
-msgstr "# 흐름 제어"
+#: src/exercises/day-2/points-polygons.md:123
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
+"\"+\"를 사용하여 두 객체를 서로 더하려면 `Add` 트레잇을 구현해야 합니다. 이"
+"는 3일차에 다룰 내용입니다."
 
 #: src/control-flow.md:3
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
-"evaluate one of two blocks, but the blocks can have a value which then becomes\n"
-"the value of the `if` expression. Other control flow expressions work similarly\n"
-"in Rust."
-msgstr "앞에서 살펴본 바와 같이 러스트에서 `if`는 표현식입니다. 조건에 따라 두 블록 중 하나를 평가하며, 그 결과값이 `if` 표현식의 값이 됩니다. 다른 흐름제어 표현식도 유사하게 작동합니다."
-
-#: src/control-flow/blocks.md:1
-msgid "# Blocks"
-msgstr "# 블록"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
+"evaluate one of two blocks, but the blocks can have a value which then "
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
+msgstr ""
+"앞에서 살펴본 바와 같이 러스트에서 `if`는 표현식입니다. 조건에 따라 두 블록 "
+"중 하나를 평가하며, 그 결과값이 `if` 표현식의 값이 됩니다. 다른 흐름제어 표현"
+"식도 유사하게 작동합니다."
 
 #: src/control-flow/blocks.md:3
 msgid ""
-"A block in Rust has a value and a type: the value is the last expression of the\n"
-"block:"
-msgstr "러스트에서 블록은 값과 타입을 갖습니다. 블록의 마지막 표현식이 블록의 값이 됩니다:"
+"A block in Rust has a value and a type: the value is the last expression of "
+"the block:"
+msgstr ""
+"러스트에서 블록은 값과 타입을 갖습니다. 블록의 마지막 표현식이 블록의 값이 됩"
+"니다:"
 
 #: src/control-flow/blocks.md:6
 msgid ""
@@ -6625,9 +7896,11 @@ msgstr ""
 
 #: src/control-flow/blocks.md:25
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
-msgstr "함수에도 동일한 규칙이 적용됩니다. 함수 바디를 이루는 블록의 값이 반환값이 됩니다:"
+msgstr ""
+"함수에도 동일한 규칙이 적용됩니다. 함수 바디를 이루는 블록의 값이 반환값이 됩"
+"니다:"
 
 #: src/control-flow/blocks.md:28
 msgid ""
@@ -6652,22 +7925,31 @@ msgstr ""
 "```"
 
 #: src/control-flow/blocks.md:38
-msgid "However if the last expression ends with `;`, then the resulting value and type is `()`."
-msgstr "위의 `main` 함수는 마지막 표현식이 `;`로 끝나기 때문에 반환되는 값과 타입이 `()`입니다."
+msgid ""
+"However if the last expression ends with `;`, then the resulting value and "
+"type is `()`."
+msgstr ""
+"위의 `main` 함수는 마지막 표현식이 `;`로 끝나기 때문에 반환되는 값과 타입이 "
+"`()`입니다."
 
 #: src/control-flow/blocks.md:43
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in Rust. \n"
-"* You can show how the value of the block changes by changing the last line in the block. For instance, adding/removing a semicolon or using a `return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
 msgstr ""
-"* 러스트에서는 블록이 타입과 값을 가진다는 점이 이 슬라이드의 핵심입니다.\n"
-"* 블록 마지막 줄을 수정하면서 블록의 값이 어떻게 바뀌는지 보여주세요. 예를 들어, 세미콜론을 넣거나 뺀다든지, 아니면 `return`을 사용해 보세요.\n"
-"   "
+"러스트에서는 블록이 타입과 값을 가진다는 점이 이 슬라이드의 핵심입니다."
+
+#: src/control-flow/blocks.md:44
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
+msgstr ""
+"블록 마지막 줄을 수정하면서 블록의 값이 어떻게 바뀌는지 보여주세요. 예를 들"
+"어, 세미콜론을 넣거나 뺀다든지, 아니면 `return`을 사용해 보세요."
 
 #: src/control-flow/if-expressions.md:1
-msgid "# `if` expressions"
-msgstr "# `if` 표현식"
+msgid "`if` expressions"
+msgstr "`if` 표현식"
 
 #: src/control-flow/if-expressions.md:3
 msgid "You use `if` very similarly to how you would in other languages:"
@@ -6698,8 +7980,10 @@ msgstr ""
 "```"
 
 #: src/control-flow/if-expressions.md:16
-msgid "In addition, you can use it as an expression. This does the same as above:"
-msgstr "게다가 `if`는 표현식으로 사용할 수도 있습니다. 아래 코드는 위와 동일합니다:"
+msgid ""
+"In addition, you can use it as an expression. This does the same as above:"
+msgstr ""
+"게다가 `if`는 표현식으로 사용할 수도 있습니다. 아래 코드는 위와 동일합니다:"
 
 #: src/control-flow/if-expressions.md:22
 msgid ""
@@ -6726,16 +8010,23 @@ msgstr ""
 "```"
 
 #: src/control-flow/if-expressions.md:31
-msgid "Because `if` is an expression and must have a particular type, both of its branch blocks must have the same type. Consider showing what happens if you add `;` after `x / 2` in the second example."
-msgstr "`if`는 표현식이고 타입을 가져야 하므로 분기 블록은 모두 같은 타입을 가져야 합니다. 두번째 예시의 `x / 2` 뒤에 `;`를 추가하여 어떻게 되는지 확인해 보시기 바랍니다."
+msgid ""
+"Because `if` is an expression and must have a particular type, both of its "
+"branch blocks must have the same type. Consider showing what happens if you "
+"add `;` after `x / 2` in the second example."
+msgstr ""
+"`if`는 표현식이고 타입을 가져야 하므로 분기 블록은 모두 같은 타입을 가져야 합"
+"니다. 두번째 예시의 `x / 2` 뒤에 `;`를 추가하여 어떻게 되는지 확인해 보시기 "
+"바랍니다."
 
 #: src/control-flow/if-let-expressions.md:1
-msgid "# `if let` expressions"
-msgstr "# `if let` 표현식"
+msgid "`if let` expressions"
+msgstr "`if let` 표현식"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid "If you want to match a value against a pattern, you can use `if let`:"
-msgstr "어떤 값이 패턴에 매치되는지 검사하려면 `if let` 표현식을 사용하면 됩니다:"
+msgstr ""
+"어떤 값이 패턴에 매치되는지 검사하려면 `if let` 표현식을 사용하면 됩니다:"
 
 #: src/control-flow/if-let-expressions.md:7
 msgid ""
@@ -6765,25 +8056,42 @@ msgstr ""
 #: src/control-flow/while-let-expressions.md:21
 #: src/control-flow/match-expressions.md:22
 msgid ""
-"See [pattern matching](../pattern-matching.md) for more details on patterns in\n"
-"Rust."
+"See [pattern matching](../pattern-matching.md) for more details on patterns "
+"in Rust."
 msgstr "패턴에 관한 설명은 [패턴 매칭](../pattern-matching.md)을 참조하세요."
 
 #: src/control-flow/if-let-expressions.md:21
+#: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is interesting. In contrast, `match` requires all branches to be covered.\n"
-"    * For the similar use case consider demonstrating a newly stabilized [`let else`](https://github.com/rust-lang/rust/pull/93628) feature.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern matching."
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
 msgstr ""
-"* `if let`은 `match`보다 더 간결할 수 있습니다. 예를 들어 특정한 경우만 고려하고 싶더라도 `match`는 모든 분기를 포함해야 합니다.\n"
-"  * 비슷한 사용례로 새롭게 \"stable\" 릴리즈 된 [`let else`](https://github.com/rust-lang/rust/pull/93628) 기능을 시연하는 것도 고려해 보시기 바랍니다.\n"
-"* 일반적으로 `Option`으로 작업할 때 `Some` 값을 처리하는 식으로 사용됩니다.\n"
-"* `match`와 다르게 `if let` 패턴 매칭에서는 가드를 지원하지 않습니다."
+"`if let`은 `match`보다 더 간결할 수 있습니다. 예를 들어 특정한 경우만 고려하"
+"고 싶더라도 `match`는 모든 분기를 포함해야 합니다."
+
+#: src/control-flow/if-let-expressions.md:22
+msgid ""
+"For the similar use case consider demonstrating a newly stabilized [`let "
+"else`](https://github.com/rust-lang/rust/pull/93628) feature."
+msgstr ""
+"비슷한 사용례로 새롭게 \"stable\" 릴리즈 된 [`let else`](https://github.com/"
+"rust-lang/rust/pull/93628) 기능을 시연하는 것도 고려해 보시기 바랍니다."
+
+#: src/control-flow/if-let-expressions.md:23
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+"일반적으로 `Option`으로 작업할 때 `Some` 값을 처리하는 식으로 사용됩니다."
+
+#: src/control-flow/if-let-expressions.md:24
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr "`match`와 다르게 `if let` 패턴 매칭에서는 가드를 지원하지 않습니다."
 
 #: src/control-flow/while-expressions.md:1
-msgid "# `while` expressions"
-msgstr "# `while` 표현식"
+msgid "`while` expressions"
+msgstr "`while` 표현식"
 
 #: src/control-flow/while-expressions.md:3
 msgid "The `while` keyword works very similar to other languages:"
@@ -6820,13 +8128,13 @@ msgstr ""
 "```"
 
 #: src/control-flow/while-let-expressions.md:1
-msgid "# `while let` expressions"
-msgstr "# `while let` 표현식"
+msgid "`while let` expressions"
+msgstr "`while let` 표현식"
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
-"Like with `if`, there is a `while let` variant which repeatedly tests a value\n"
-"against a pattern:"
+"Like with `if`, there is a `while let` variant which repeatedly tests a "
+"value against a pattern:"
 msgstr "`if`와 동일하게 `while let`구문 역시 패턴매칭에 사용 할 수 있습니다:"
 
 #: src/control-flow/while-let-expressions.md:6
@@ -6855,30 +8163,43 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:17
 msgid ""
-"Here the iterator returned by `v.iter()` will return a `Option<i32>` on every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
-msgstr "`v.into_iter()`가 반환한 반복자는 `next()`가 호출될 때마다 `Option<i32>`를 반환합니다. 반복자가 완료될 때까지는 `Some(x)`를 반환하고 마지막엔 `None`을 반환합니다. `while let`을 통해 반복자의 모든 아이템을 확인할 수 있습니다."
+"Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
+msgstr ""
+"`v.into_iter()`가 반환한 반복자는 `next()`가 호출될 때마다 `Option<i32>`를 반"
+"환합니다. 반복자가 완료될 때까지는 `Some(x)`를 반환하고 마지막엔 `None`을 반"
+"환합니다. `while let`을 통해 반복자의 모든 아이템을 확인할 수 있습니다."
 
 #: src/control-flow/while-let-expressions.md:27
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if statement that breaks when there is no value to unwrap for `iter.next()`. The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
+msgstr "`while let`은 값이 패턴에 매치되는 동안 계속됩니다."
+
+#: src/control-flow/while-let-expressions.md:28
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
-"* `while let`은 값이 패턴에 매치되는 동안 계속됩니다.\n"
-"* `while let` 루프 대신 무한 루프를 사용하고 `iter.next()`가 빈 값을 반환할 때 루프를 빠져나오도록 작성할수도 있습니다. `while let`은 그러한 경우를 위한 문법적 편의를 제공합니다.\n"
-"    "
+"`while let` 루프 대신 무한 루프를 사용하고 `iter.next()`가 빈 값을 반환할 때 "
+"루프를 빠져나오도록 작성할수도 있습니다. `while let`은 그러한 경우를 위한 문"
+"법적 편의를 제공합니다."
 
 #: src/control-flow/for-expressions.md:1
-msgid "# `for` expressions"
-msgstr "# `for` 표현식"
+msgid "`for` expressions"
+msgstr "`for` 표현식"
 
 #: src/control-flow/for-expressions.md:3
 msgid ""
-"The `for` expression is closely related to the `while let` expression. It will\n"
-"automatically call `into_iter()` on the expression and then iterate over it:"
-msgstr "`for`표현식은 `while let` 표현식과 매우 유사합니다. `for`표현식은 자동으로 `into_iter()`를 호출한 다음 이를 반복합니다:"
+"The `for` expression is closely related to the `while let` expression. It "
+"will automatically call `into_iter()` on the expression and then iterate "
+"over it:"
+msgstr ""
+"`for`표현식은 `while let` 표현식과 매우 유사합니다. `for`표현식은 자동으로 "
+"`into_iter()`를 호출한 다음 이를 반복합니다:"
 
 #: src/control-flow/for-expressions.md:6
 msgid ""
@@ -6915,26 +8236,40 @@ msgid "You can use `break` and `continue` here as usual."
 msgstr "다른 언어와 마찬가지로 `break` 와 `continue`를 사용할 수 있습니다."
 
 #: src/control-flow/for-expressions.md:24
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr "러스트는 인덱스 반복을 위해 별도의 문법을 사용하지 않습니다. "
+
+#: src/control-flow/for-expressions.md:25
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "`(0..10)`은 `Iterator` 트레잇을 구현하는 범위(range) 값입니다. "
+
+#: src/control-flow/for-expressions.md:26
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
 msgstr ""
-"* 러스트는 인덱스 반복을 위해 별도의 문법을 사용하지 않습니다. \n"
-"* `(0..10)`은 `Iterator` 트레잇을 구현하는 범위(range) 값입니다. \n"
-"* `step_by`는 반복자의 요소들을 건너뛰는 또다른 `Iterator`를 반환하는 메서드입니다.\n"
-"* 벡터 요소들을 수정하려고 하면 나오는 컴파일러 에러를 같이 살펴보세요. `v` 벡터를 가변 변수로 변경하고 루프는 `for x in v.iter_mut()`로 수정하세요."
+"`step_by`는 반복자의 요소들을 건너뛰는 또다른 `Iterator`를 반환하는 메서드입"
+"니다."
+
+#: src/control-flow/for-expressions.md:27
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
+"vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
+msgstr ""
+"벡터 요소들을 수정하려고 하면 나오는 컴파일러 에러를 같이 살펴보세요. `v` 벡"
+"터를 가변 변수로 변경하고 루프는 `for x in v.iter_mut()`로 수정하세요."
 
 #: src/control-flow/loop-expressions.md:1
-msgid "# `loop` expressions"
-msgstr "# `loop` 표현식"
+msgid "`loop` expressions"
+msgstr "`loop` 표현식"
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
-"Finally, there is a `loop` keyword which creates an endless loop. Here you must\n"
-"either `break` or `return` to stop the loop:"
-msgstr "마지막으로 `loop`키워드는 무한 루프를 생성합니다. 따라서 반드시 `break` 또는 `return`을 사용해서 루프를 정지해야 합니다:"
+"Finally, there is a `loop` keyword which creates an endless loop. Here you "
+"must either `break` or `return` to stop the loop:"
+msgstr ""
+"마지막으로 `loop`키워드는 무한 루프를 생성합니다. 따라서 반드시 `break` 또는 "
+"`return`을 사용해서 루프를 정지해야 합니다:"
 
 #: src/control-flow/loop-expressions.md:8
 msgid ""
@@ -6973,18 +8308,22 @@ msgstr ""
 "```"
 
 #: src/control-flow/loop-expressions.md:25
-msgid "* Break the `loop` with a value (e.g. `break 8`) and print it out."
-msgstr "* `loop` 블록을 빠져나올 때 `break 8`처럼 값을 지정하고 그걸 출력해보세요."
+#: src/control-flow/loop-expressions.md:27
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr ""
+"`loop` 블록을 빠져나올 때 `break 8`처럼 값을 지정하고 그걸 출력해보세요."
 
 #: src/control-flow/match-expressions.md:1
-msgid "# `match` expressions"
-msgstr "# `match` 표현식"
+msgid "`match` expressions"
+msgstr "`match` 표현식"
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
-"The `match` keyword is used to match a value against one or more patterns. In\n"
-"that sense, it works like a series of `if let` expressions:"
-msgstr "`match`키워드는 어떤 값을 하나 이상의 패턴에 대해 매치하는데 사용합니다. 그런 면에서 `if let` 표현식을 여러개 이어 놓은 것과 같습니다:"
+"The `match` keyword is used to match a value against one or more patterns. "
+"In that sense, it works like a series of `if let` expressions:"
+msgstr ""
+"`match`키워드는 어떤 값을 하나 이상의 패턴에 대해 매치하는데 사용합니다. 그"
+"런 면에서 `if let` 표현식을 여러개 이어 놓은 것과 같습니다:"
 
 #: src/control-flow/match-expressions.md:6
 msgid ""
@@ -7016,34 +8355,54 @@ msgstr ""
 
 #: src/control-flow/match-expressions.md:19
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
-msgstr "`if let`과 마찬가지로 매치의 모든 팔(arm)은 같은 타입이어야 합니다. 팔이 블록이라면 블록의 마지막 표현식이 그 타입이 됩니다. 위의 예제에서 매치 표현식의 타입은 `()`입니다."
+msgstr ""
+"`if let`과 마찬가지로 매치의 모든 팔(arm)은 같은 타입이어야 합니다. 팔이 블록"
+"이라면 블록의 마지막 표현식이 그 타입이 됩니다. 위의 예제에서 매치 표현식의 "
+"타입은 `()`입니다."
 
 #: src/control-flow/match-expressions.md:27
+msgid "Save the match expression to a variable and print it out."
+msgstr "`match` 표현식을 변수에 할당하고 그 값을 출력해보세요."
+
+#: src/control-flow/match-expressions.md:28
+msgid "Remove `.as_deref()` and explain the error."
+msgstr "`.as_deref()`를 지워보고, 이 때 나오는 에러를 설명해주세요."
+
+#: src/control-flow/match-expressions.md:29
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside `Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
 msgstr ""
-"* `match` 표현식을 변수에 할당하고 그 값을 출력해보세요.\n"
-"* `.as_deref()`를 지워보고, 이 때 나오는 에러를 설명해주세요.\n"
-"    * `std::env::args().next()`는 `Option<String>` 값을 반환하는데, `String`은 직접 매치할 수 없습니다.\n"
-"    * `as_deref()`는 `Option<T>`를 `Option<&T::Target>`으로 바꿔줍니다. 이 경우는 `Option<String>`에서 `Option<&str>`로 바뀝니다.\n"
-"    * 이제는 패턴 매칭으로 `Option` 안의 `&str`을 매치할 수 있습니다."
+"`std::env::args().next()`는 `Option<String>` 값을 반환하는데, `String`은 직"
+"접 매치할 수 없습니다."
+
+#: src/control-flow/match-expressions.md:30
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+"`as_deref()`는 `Option<T>`를 `Option<&T::Target>`으로 바꿔줍니다. 이 경우는 "
+"`Option<String>`에서 `Option<&str>`로 바뀝니다."
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
+msgstr "이제는 패턴 매칭으로 `Option` 안의 `&str`을 매치할 수 있습니다."
 
 #: src/control-flow/break-continue.md:1
-msgid "# `break` and `continue`"
-msgstr "# `break`와 `continue`"
+msgid "`break` and `continue`"
+msgstr "`break`와 `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"If you want to exit a loop early, use `break`, if you want to immediately start\n"
-"the next iteration use `continue`. Both `continue` and `break` can optionally\n"
-"take a label argument which is used to break out of nested loops:"
-msgstr "루프를 빠져나가려면 `break`를, 다음 반복으로 넘어가기 위해서는 `continue`를 사용합니다. 중첩 루프에서는 레이블과 함께 사용할 수 있습니다:"
+"If you want to exit a loop early, use `break`, if you want to immediately "
+"start the next iteration use `continue`. Both `continue` and `break` can "
+"optionally take a label argument which is used to break out of nested loops:"
+msgstr ""
+"루프를 빠져나가려면 `break`를, 다음 반복으로 넘어가기 위해서는 `continue`를 "
+"사용합니다. 중첩 루프에서는 레이블과 함께 사용할 수 있습니다:"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
@@ -7084,19 +8443,21 @@ msgstr ""
 "```"
 
 #: src/control-flow/break-continue.md:25
-msgid "In this case we break the outer loop after 3 iterations of the inner loop."
-msgstr "위 예제는 내부의 `while` 루프를 3회 반복한 후 바깥 루프를 빠져나갑니다."
-
-#: src/std.md:1
-msgid "# Standard Library"
-msgstr "# 표준 라이브러리"
+msgid ""
+"In this case we break the outer loop after 3 iterations of the inner loop."
+msgstr ""
+"위 예제는 내부의 `while` 루프를 3회 반복한 후 바깥 루프를 빠져나갑니다."
 
 #: src/std.md:3
 msgid ""
-"Rust comes with a standard library which helps establish a set of common types\n"
-"used by Rust library and programs. This way, two libraries can work together\n"
-"smoothly because they both use the same `String` type."
-msgstr "러스트에서 제공하는 표준 라이브러리는 러스트로 라이브러리나 프로그램을 작성할 때 공통적으로 사용할 수 있는 여러 타입들을 포함하고 있습니다. 이를 통해 서로 다른 두 라이브러리라 하더라도 함께 사용하는데 큰 어려움이 없게 됩니다. 예를 들면 두 라이브러리 모두 같은 `String` 타입을 사용하기 때문입니다."
+"Rust comes with a standard library which helps establish a set of common "
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
+msgstr ""
+"러스트에서 제공하는 표준 라이브러리는 러스트로 라이브러리나 프로그램을 작성"
+"할 때 공통적으로 사용할 수 있는 여러 타입들을 포함하고 있습니다. 이를 통해 서"
+"로 다른 두 라이브러리라 하더라도 함께 사용하는데 큰 어려움이 없게 됩니다. 예"
+"를 들면 두 라이브러리 모두 같은 `String` 타입을 사용하기 때문입니다."
 
 #: src/std.md:7
 msgid "The common vocabulary types include:"
@@ -7104,48 +8465,74 @@ msgstr "일반적인 타입은 아래와 같습니다:"
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated data."
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
 msgstr ""
-"* [`Option`과 `Result`](std/option-result.md) : 어떤 값이 있거나 없거나 하는 경우, 그리고 [오류 처리](error-handling.md)에 사용합니다.\n"
-"\n"
-"* [`String`](std/string.md): 기본적인 문자열 타입으로, 문자열 데이터를 소유하는 경우에 사용합니다.\n"
-"\n"
-"* [`Vec`](std/vec.md): 가변 크기의 표준 벡터 타입입니다.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): 해시 알고리즘을 따로 지정할 수도 있는 해시맵 타입입니다.\n"
-"\n"
-"* [`Box`](std/box.md): 힙 데이터에 대한 소유 포인터입니다.\n"
-"\n"
-"* [`Rc`](std/rc.md): 힙에 할당된 데이터에 대한 참조 카운팅 공유 포인터입니다."
+"[`Option`과 `Result`](std/option-result.md) : 어떤 값이 있거나 없거나 하는 경"
+"우, 그리고 [오류 처리](error-handling.md)에 사용합니다."
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+"[`String`](std/string.md): 기본적인 문자열 타입으로, 문자열 데이터를 소유하"
+"는 경우에 사용합니다."
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr "[`Vec`](std/vec.md): 가변 크기의 표준 벡터 타입입니다."
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr ""
+"[`HashMap`](std/hashmap.md): 해시 알고리즘을 따로 지정할 수도 있는 해시맵 타"
+"입입니다."
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr "[`Box`](std/box.md): 힙 데이터에 대한 소유 포인터입니다."
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
+msgstr ""
+"[`Rc`](std/rc.md): 힙에 할당된 데이터에 대한 참조 카운팅 공유 포인터입니다."
 
 #: src/std.md:25
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, `alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on `libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as `Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
 msgstr ""
-"  * 사실, 러스트의 표준 라이브러리는 `core`, `alloc`, `std`와 같이 계층(layer)으로 나눠집니다.\n"
-"  * `core`는 `libc`나 할당자(allocator), 심지어 OS에도 의존하지 않는 가장 기본적인 함수와 타입을 포함합니다.\n"
-"  * `alloc`은 `Vec`, `Box`, `Arc`와 같이 전역 힙 할당이 필요한 타입을 포함합니다.\n"
-"  * 임베디드 러스트 응용프로그램은 주로 `core`만 사용하거나 가끔 `alloc`을 함께 사용합니다."
+"사실, 러스트의 표준 라이브러리는 `core`, `alloc`, `std`와 같이 계층(layer)으"
+"로 나눠집니다."
+
+#: src/std.md:26
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+"`core`는 `libc`나 할당자(allocator), 심지어 OS에도 의존하지 않는 가장 기본적"
+"인 함수와 타입을 포함합니다."
+
+#: src/std.md:28
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+"`alloc`은 `Vec`, `Box`, `Arc`와 같이 전역 힙 할당이 필요한 타입을 포함합니다."
+
+#: src/std.md:29
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"임베디드 러스트 응용프로그램은 주로 `core`만 사용하거나 가끔 `alloc`을 함께 "
+"사용합니다."
 
 #: src/std/option-result.md:1
-msgid "# `Option` and `Result`"
-msgstr "# `Option`과 `Result`"
+msgid "`Option` and `Result`"
+msgstr "`Option`과 `Result`"
 
 #: src/std/option-result.md:3
 msgid "The types represent optional data:"
@@ -7176,28 +8563,44 @@ msgstr ""
 "```"
 
 #: src/std/option-result.md:18
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
-"* `Option`과 `Result`는 표준 라이브러리뿐만아니라 매우 광범위하게 사용되는 타입입니다.\n"
-"* `Option<&T>` 는 `&T`에 비해 공간 오버헤드가 없습니다.\n"
-"* `Result`는 오류 처리를 위한 표준 타입입니다. 3일차 과정에서 살펴봅니다.\n"
-"* `binary_search`는 `Result<usize, usize>`를 반환합니다.\n"
-"  * 요소가 발견된다면, `Result::Ok`는 발견된 요소의 인덱스를 보유합니다.\n"
-"  * 아니면, `Result::Err`에는 요소가 삽입되야 하는 인덱스가 포함되어 있습니다."
+"`Option`과 `Result`는 표준 라이브러리뿐만아니라 매우 광범위하게 사용되는 타입"
+"입니다."
 
-#: src/std/string.md:1
-msgid "# String"
-msgstr "# `String` 문자열"
+#: src/std/option-result.md:19
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "`Option<&T>` 는 `&T`에 비해 공간 오버헤드가 없습니다."
+
+#: src/std/option-result.md:20
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+"`Result`는 오류 처리를 위한 표준 타입입니다. 3일차 과정에서 살펴봅니다."
+
+#: src/std/option-result.md:21
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "`binary_search`는 `Result<usize, usize>`를 반환합니다."
+
+#: src/std/option-result.md:22
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr "요소가 발견된다면, `Result::Ok`는 발견된 요소의 인덱스를 보유합니다."
+
+#: src/std/option-result.md:23
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr ""
+"아니면, `Result::Err`에는 요소가 삽입되야 하는 인덱스가 포함되어 있습니다."
 
 #: src/std/string.md:3
-msgid "[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
-msgstr "[`String`][1]은 힙에 할당되고 가변 길이의 표준 UTF-8 문자열 버퍼입니다:"
+msgid ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
+msgstr ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html)은 힙에 할"
+"당되고 가변 길이의 표준 UTF-8 문자열 버퍼입니다:"
 
 #: src/std/string.md:5
 msgid ""
@@ -7237,39 +8640,100 @@ msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can call all\n"
-"`str` methods on a `String`."
-msgstr "`String`은 [`Deref<Target = str>`][2]을 구현합니다. 이는 , `String` 값에 대해서도 `str`의 모든 메서드를 호출 할 수 있다는 의미 입니다."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
+msgstr ""
+"`String`은 [`Deref<Target = str>`](https://doc.rust-lang.org/std/string/"
+"struct.String.html#deref-methods-str)을 구현합니다. 이는 , `String` 값에 대해"
+"서도 `str`의 모든 메서드를 호출 할 수 있다는 의미 입니다."
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that a `char` can be different from what a human will consider a \"character\" due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or `String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the operations you see supported on vectors are also supported on `String`, but with some extra guarantees.\n"
-"* Compare the different ways to index a `String` by using `s3[i]` and `s3.chars().nth(i).unwrap()` where `i` is in-bound, out-of-bounds, and \"on\" the flag Unicode character."
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
 msgstr ""
-"* `String::new`는 새로운 빈 문자열을 반환합니다. `String::with_capacity`는 새로 만들 문자열 버퍼에 넣을 데이터 크기를 알고 있는 경우에 사용할 수 있습니다.\n"
-"* `String::len`은 `String`의 바이트 크기를 반환합니다. (실제 문자 개수와는 다를 수 있습니다.)\n"
-"* `String::chars`는 실제 문자(character)들에 대한 이터레이터를 반환합니다. `char`로 표현되는 문자는 우리가 실제로 인식하고 사용하는 문자와는 다를 수 있습니다. 자소 결합으로 문자를 표현하는 경우가 있기 때문입니다. 이에 대해서는 [Grapheme Cluster](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html)를 참고하세요.\n"
-"* 문자열이라고 언급하는 경우는 `&str`이거나 `String`일 수 있습니다.\n"
-"* 어떤 타입이 `Deref<Target = T>`를 구현하고 있으면, 컴파일러는 여러분이 `T`의 메소드들을 호출할 수 있게 도와줍니다.\n"
-"    * `String`은 `Deref<Target = str>`을 구현하고 있기 때문에 `String`에 대해서도 `str` 메소드들을 호출할 수 있습니다.\n"
-"    * `let s3 = s1.deref();`와 `let s3 = &*s1;`을 비교해보세요.\n"
-"* `String`은 바이트 벡터의 래퍼로 구현되어 있습니다. 벡터가 지원하는 여러가지 연산들을 `String`도 지원합니다. 다만 `String`은 몇가지 보장 내용이 더 있습니다.\n"
-"* `String`을 인덱스로 접근하는 방법들을 비교해보세요. `s3[i]`와 `s3.chars().nth(i).unwrap()` 방법에 대해 `i`값이 범위를 벗어날 때, 벗어나지 않을 때, 혹은 플래그 유니코드 문자에 딱 걸린 경우 등을 비교 설명해주세요."
+"`String::new`는 새로운 빈 문자열을 반환합니다. `String::with_capacity`는 새"
+"로 만들 문자열 버퍼에 넣을 데이터 크기를 알고 있는 경우에 사용할 수 있습니다."
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+"`String::len`은 `String`의 바이트 크기를 반환합니다. (실제 문자 개수와는 다"
+"를 수 있습니다.)"
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+"`String::chars`는 실제 문자(character)들에 대한 이터레이터를 반환합니다. "
+"`char`로 표현되는 문자는 우리가 실제로 인식하고 사용하는 문자와는 다를 수 있"
+"습니다. 자소 결합으로 문자를 표현하는 경우가 있기 때문입니다. 이에 대해서는 "
+"[Grapheme Cluster](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)를 참고하세요."
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr "문자열이라고 언급하는 경우는 `&str`이거나 `String`일 수 있습니다."
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+"어떤 타입이 `Deref<Target = T>`를 구현하고 있으면, 컴파일러는 여러분이 `T`의 "
+"메소드들을 호출할 수 있게 도와줍니다."
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+"`String`은 `Deref<Target = str>`을 구현하고 있기 때문에 `String`에 대해서도 "
+"`str` 메소드들을 호출할 수 있습니다."
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr "`let s3 = s1.deref();`와 `let s3 = &*s1;`을 비교해보세요."
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
+"operations you see supported on vectors are also supported on `String`, but "
+"with some extra guarantees."
+msgstr ""
+"`String`은 바이트 벡터의 래퍼로 구현되어 있습니다. 벡터가 지원하는 여러가지 "
+"연산들을 `String`도 지원합니다. 다만 `String`은 몇가지 보장 내용이 더 있습니"
+"다."
+
+#: src/std/string.md:38
+msgid ""
+"Compare the different ways to index a `String` by using `s3[i]` and `s3."
+"chars().nth(i).unwrap()` where `i` is in-bound, out-of-bounds, and \"on\" "
+"the flag Unicode character."
+msgstr ""
+"`String`을 인덱스로 접근하는 방법들을 비교해보세요. `s3[i]`와 `s3.chars()."
+"nth(i).unwrap()` 방법에 대해 `i`값이 범위를 벗어날 때, 벗어나지 않을 때, 혹"
+"은 플래그 유니코드 문자에 딱 걸린 경우 등을 비교 설명해주세요."
 
 #: src/std/vec.md:1
-msgid "# `Vec`"
-msgstr "# `Vec`"
+msgid "`Vec`"
+msgstr "`Vec`"
 
 #: src/std/vec.md:3
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
-msgstr "[`Vec`][1] 는 힙에 할당된 표준 가변 크기 버퍼입니다:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
+msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) 는 힙에 할당된 표"
+"준 가변 크기 버퍼입니다:"
 
 #: src/std/vec.md:5
 msgid ""
@@ -7323,33 +8787,63 @@ msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
-msgstr "`Vec`은 [`Deref<Target = [T]>`][2]를 구현합니다. 이는 `Vec`에서 슬라이스 메서드를 호출 할 수 있다는 의미입니다."
+msgstr ""
+"`Vec`은 [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#deref-methods-%5BT%5D)를 구현합니다. 이는 `Vec`에서 슬라이스 메서드를 호"
+"출 할 수 있다는 의미입니다."
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
-"* `Vec`은 `String`이나 `HashMap`과 같은 컬렉션 타입입니다. 벡터는 데이터를 힙에 저장합니다. 이는 컴파일 시점에 데이터 크기를 알 필요가 없다는 의미고, 런타임에 더 커질 수도 작아질 수도 있습니다.\n"
-"* `Vec<T>`는 제네릭 타입이기도 합니다. 하지만 `T`를 꼭 지정해줄 필요는 없습니다. 이 경우, 러스트 타입 추론이 벡터에 처음 `push`하는 데이터로 `T`를 알 수 있었습니다.\n"
-"* `vec![...]`는 `Vec::new()` 대신 쓸 수 있는 표준 매크로로서, 초기 데이터를 추가한 벡터를 생성할 수 있습니다.\n"
-"* 벡터는 `[` `]`를 사용하여 인덱스로 접근할 수 있습니다. 하지만 범위를 벗어나면 패닉이 발생합니다. 대신 `get`을 사용하면 `Option`을 반환합니다. `pop` 함수는 마지막 요소를 제거합니다.\n"
-"* 벡터를 순회하면서 값을 변경할 수도 있음을 보여주세요: `for e in &mut v { *e += 50; }`"
+"`Vec`은 `String`이나 `HashMap`과 같은 컬렉션 타입입니다. 벡터는 데이터를 힙"
+"에 저장합니다. 이는 컴파일 시점에 데이터 크기를 알 필요가 없다는 의미고, 런타"
+"임에 더 커질 수도 작아질 수도 있습니다."
 
-#: src/std/hashmap.md:1
-msgid "# `HashMap`"
-msgstr "# `HashMap`"
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+"`Vec<T>`는 제네릭 타입이기도 합니다. 하지만 `T`를 꼭 지정해줄 필요는 없습니"
+"다. 이 경우, 러스트 타입 추론이 벡터에 처음 `push`하는 데이터로 `T`를 알 수 "
+"있었습니다."
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+"`vec![...]`는 `Vec::new()` 대신 쓸 수 있는 표준 매크로로서, 초기 데이터를 추"
+"가한 벡터를 생성할 수 있습니다."
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+"벡터는 `[` `]`를 사용하여 인덱스로 접근할 수 있습니다. 하지만 범위를 벗어나"
+"면 패닉이 발생합니다. 대신 `get`을 사용하면 `Option`을 반환합니다. `pop` 함수"
+"는 마지막 요소를 제거합니다."
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+"벡터를 순회하면서 값을 변경할 수도 있음을 보여주세요: `for e in &mut v { *e "
+"+= 50; }`"
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
+msgid "`HashMap`"
+msgstr "`HashMap`"
 
 #: src/std/hashmap.md:3
 msgid "Standard hash map with protection against HashDoS attacks:"
@@ -7362,7 +8856,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut page_counts = HashMap::new();\n"
-"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), 207);\n"
+"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
+"207);\n"
 "    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
 "    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);\n"
 "\n"
@@ -7371,7 +8866,8 @@ msgid ""
 "                 page_counts.len());\n"
 "    }\n"
 "\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] {\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
 "        match page_counts.get(book) {\n"
 "            Some(count) => println!(\"{book}: {count} pages\"),\n"
 "            None => println!(\"{book} is unknown.\")\n"
@@ -7379,8 +8875,10 @@ msgid ""
 "    }\n"
 "\n"
 "    // Use the .entry() method to insert a value if nothing is found.\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] {\n"
-"        let page_count: &mut i32 = page_counts.entry(book.to_string()).or_insert(0);\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        let page_count: &mut i32 = page_counts.entry(book.to_string())."
+"or_insert(0);\n"
 "        *page_count += 1;\n"
 "    }\n"
 "\n"
@@ -7426,64 +8924,107 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into scope.\n"
-"* Try the following lines of code. The first line will see if a book is in the hashmap and if not return an alternative value. The second line will insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make examples easier. Using references in collections can, of course, be done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still compiles. Where do you think we might run into issues?"
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
 msgstr ""
-"* `HashMap`은 prelude에 정의되어 있지 않기 때문에 명시적으로 추가해줘야 합니다.\n"
-"* 아래 코드를 테스트해보세요. 첫 문장에서는 해시맵에 책이 있는지 검사하여, 없으면 디폴트 값을 반환합니다. 두번 째 문장에서는 해시맵에 해당 책이 없는 경우, 지정한 값을 해시맵에 추가한 뒤 그 값을 반환합니다.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* 안타깝지만 `hashmap!`같은 매크로가 없습니다.\n"
-"  * 러스트 1.56부터는 `HashMap`이 [`From<[(K, V); N]>`][1]을 구현하기 때문에 배열 리터럴을 이용하여 쉽게 해시맵을 초기화할 수 있습니다:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * 키-값 쌍에 대한 `Iterator`로 해시맵을 만들 수도 있습니다.\n"
-"* 예제 코드에서는 편의상 해시맵의 키로 `&str`를 사용하지 않았습니다. 물론 컬렉션에 참조를 사용할 수도 있습니다. 다만 참조를 사용하게 되면 빌림 검사기 때문에 복잡해 질 수 있습니다.\n"
-"  * 예제 코드에서 `to_string()`을 없애도 컴파일에 문제가 없는지 확인해보세요. 어떤 문제에 부딪힐까요?"
+"`HashMap`은 prelude에 정의되어 있지 않기 때문에 명시적으로 추가해줘야 합니다."
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+"아래 코드를 테스트해보세요. 첫 문장에서는 해시맵에 책이 있는지 검사하여, 없으"
+"면 디폴트 값을 반환합니다. 두번 째 문장에서는 해시맵에 해당 책이 없는 경우, "
+"지정한 값을 해시맵에 추가한 뒤 그 값을 반환합니다."
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr "안타깝지만 `hashmap!`같은 매크로가 없습니다."
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+"러스트 1.56부터는 `HashMap`이 [`From<[(K, V); N]>`](https://doc.rust-lang."
+"org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K,+V);"
+"+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E)을 구현하기 때문에 배열 리터럴을 "
+"이용하여 쉽게 해시맵을 초기화할 수 있습니다:"
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr "키-값 쌍에 대한 `Iterator`로 해시맵을 만들 수도 있습니다."
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+"예제 코드에서는 편의상 해시맵의 키로 `&str`를 사용하지 않았습니다. 물론 컬렉"
+"션에 참조를 사용할 수도 있습니다. 다만 참조를 사용하게 되면 빌림 검사기 때문"
+"에 복잡해 질 수 있습니다."
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
+"compiles. Where do you think we might run into issues?"
+msgstr ""
+"예제 코드에서 `to_string()`을 없애도 컴파일에 문제가 없는지 확인해보세요. 어"
+"떤 문제에 부딪힐까요?"
 
 #: src/std/box.md:1
-msgid "# `Box`"
-msgstr "# `Box`"
+msgid "`Box`"
+msgstr "`Box`"
 
 #: src/std/box.md:3
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "[`Box`][1]는 힙 데이터에 대한 소유 포인터입니다:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html)는 힙 데이터에 대"
+"한 소유 포인터입니다:"
 
 #: src/std/box.md:5
 msgid ""
@@ -7531,30 +9072,56 @@ msgstr ""
 
 #: src/std/box.md:26
 msgid ""
-"`Box<T>` implements `Deref<Target = T>`, which means that you can [call methods\n"
-"from `T` directly on a `Box<T>`][2]."
-msgstr "`Box<T>`은 [`Deref<Target = T>`][2]를 구현합니다. 이는 [`Box<T>`에서 `T` 메서드를 직접 호출][2] 할 수 있다는 의미입니다."
+"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
+msgstr ""
+"`Box<T>`은 [`Deref<Target = T>`](https://doc.rust-lang.org/std/ops/trait."
+"Deref.html#more-on-deref-coercion)를 구현합니다. 이는 [`Box<T>`에서 `T` 메서"
+"드를 직접 호출](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-"
+"deref-coercion) 할 수 있다는 의미입니다."
 
 #: src/std/box.md:34
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying large amounts of data on the stack, instead store the data on the heap in a `Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
 msgstr ""
-"* `Box`는 C++의 `std::unique_ptr`과 비슷합니다. 차이라면 `Box`는 널이 아님을 보장한다는 점입니다.\n"
-"* `Deref` 덕분에 위 예제의 `println!`문에 사용된 `*`를 빼도 문제가 없습니다.\n"
-"* `Box`는 아래의 경우에 유용합니다:\n"
-"   * 타입 크기를 컴파일 시점에 알 수 없는 경우.\n"
-"   * 아주 큰 데이터의 소유권을 전달하고 싶은 경우. 스택에 있는 큰 데이터를 복사하는 대신 `Box`를 이용하여 데이터는 힙에 저장하고 포인터만 이동하면 됩니다."
+"`Box`는 C++의 `std::unique_ptr`과 비슷합니다. 차이라면 `Box`는 널이 아님을 보"
+"장한다는 점입니다."
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+"`Deref` 덕분에 위 예제의 `println!`문에 사용된 `*`를 빼도 문제가 없습니다."
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr "`Box`는 아래의 경우에 유용합니다:"
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr "타입 크기를 컴파일 시점에 알 수 없는 경우."
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr ""
+"아주 큰 데이터의 소유권을 전달하고 싶은 경우. 스택에 있는 큰 데이터를 복사하"
+"는 대신 `Box`를 이용하여 데이터는 힙에 저장하고 포인터만 이동하면 됩니다."
 
 #: src/std/box-recursive.md:1
-msgid "# Box with Recursive Data Structures"
-msgstr "# 재귀자료 구조에서의 `Box`"
+msgid "Box with Recursive Data Structures"
+msgstr "재귀자료 구조에서의 `Box`"
 
 #: src/std/box-recursive.md:3
-msgid "Recursive data types or data types with dynamic sizes need to use a `Box`:"
+msgid ""
+"Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr "재귀 데이터나 동적크기의 데이터 타입은 `Box`타입을 사용해야 합니다:"
 
 #: src/std/box-recursive.md:5 src/std/box-niche.md:3
@@ -7567,7 +9134,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil))));\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::"
+"new(List::Nil))));\n"
 "    println!(\"{list:?}\");\n"
 "}\n"
 "```"
@@ -7590,94 +9158,130 @@ msgstr ""
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
 ":                         :     :                                               :\n"
-":    list                 :     :                                               :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
-":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // |   :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
+":    "
+"list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
+":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
+"|   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
 ":                         :     :                                               :\n"
 ":                         :     :                                               :\n"
-"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
+"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
 "```"
 msgstr ""
 "```bob\n"
 "  스택                             힙\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
 ":                         :     :                                               :\n"
-":    list                 :     :                                               :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
-":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // |   :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
+":    "
+"list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
+":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
+"|   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
 ":                         :     :                                               :\n"
 ":                         :     :                                               :\n"
-"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
+"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
 "```"
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it would look infinite.\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. \"Recursive with indirection\" is a hint you might want to use a Box or reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
-"* 만일 `Box`를 사용하지 않고 `List`에 직접 `List`를 포함하려고 시도한다면, 컴파일러는 구조체의 고정 크기를 계산할 수 없습니다. 컴파일러가 보기에 무한대의 크기로 보일 것입니다.\n"
-"\n"
-"* `Box`는 일반 포인터와 크기가 같기 때문에 크기를 계산하는 데 문제가 없습니다. 다만 힙에 위치한 `List`의 다음 요소를 가리킬 뿐입니다.\n"
-"\n"
-"* `List` 정의에서 `Box`를 제거하면 어떤 컴파일러 에러가 나오는지 같이 살펴보세요. “Recursive with indirection”라는 메시지를 보면, 값을 직접 저장하는 대신 `Box`나 비슷한 다른 종류의 참조 타입이 필요하다는 힌트를 얻을 수 있습니다."
+"만일 `Box`를 사용하지 않고 `List`에 직접 `List`를 포함하려고 시도한다면, 컴파"
+"일러는 구조체의 고정 크기를 계산할 수 없습니다. 컴파일러가 보기에 무한대의 크"
+"기로 보일 것입니다."
 
-#: src/std/box-niche.md:1
-msgid "# Niche Optimization"
-msgstr "# 틈새 최적화(Niche Optimization)"
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+"`Box`는 일반 포인터와 크기가 같기 때문에 크기를 계산하는 데 문제가 없습니다. "
+"다만 힙에 위치한 `List`의 다음 요소를 가리킬 뿐입니다."
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
+"`List` 정의에서 `Box`를 제거하면 어떤 컴파일러 에러가 나오는지 같이 살펴보세"
+"요. “Recursive with indirection”라는 메시지를 보면, 값을 직접 저장하는 대신 "
+"`Box`나 비슷한 다른 종류의 참조 타입이 필요하다는 힌트를 얻을 수 있습니다."
 
 #: src/std/box-niche.md:16
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
-msgstr "`Box`는 비어있을 수 없습니다. 따라서 포인터는 항상 유효하며 `null`이 아닙니다. 이는 컴파일러가 메모리 레이아웃을 최적화 할 수 있게 해줍니다:"
+msgstr ""
+"`Box`는 비어있을 수 없습니다. 따라서 포인터는 항상 유효하며 `null`이 아닙니"
+"다. 이는 컴파일러가 메모리 레이아웃을 최적화 할 수 있게 해줍니다:"
 
 #: src/std/box-niche.md:19
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"-.\n"
 ":                         :     :                                             :\n"
-":    list                 :     :                                             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
+":    "
+"list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
+"|             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
 ":                         :     :                                             :\n"
 ":                         :     :                                             :\n"
-"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
 "```"
 msgstr ""
 "```bob\n"
 "  스택                            힙\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"-.\n"
 ":                         :     :                                             :\n"
-":    list                 :     :                                             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
+":    "
+"list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
+"|             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
 ":                         :     :                                             :\n"
 ":                         :     :                                             :\n"
-"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
 "```"
 
 #: src/std/rc.md:1
-msgid "# `Rc`"
-msgstr "# `Rc`"
+msgid "`Rc`"
+msgstr "`Rc`"
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to refer\n"
-"to the same data from multiple places:"
-msgstr "[`Rc`][1]는 참조 카운팅 공유 포인터입니다. 여러 위치에서 동일한 데이터를 참조해야할 경우 사용합니다:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
+msgstr ""
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html)는 참조 카운팅 공유 포"
+"인터입니다. 여러 위치에서 동일한 데이터를 참조해야할 경우 사용합니다:"
 
 #: src/std/rc.md:6
 msgid ""
@@ -7707,35 +9311,83 @@ msgstr ""
 
 #: src/std/rc.md:18
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
 msgstr ""
-"* `Rc`내부의 데이터를 변경해야 하는 경우, 데이터를 [`Cell` 또는 `RefCell`][2]로 래핑해야합니다.\n"
-"* 멀티스레드인 경우 [`Arc`][3]를 참조하시기 바랍니다.\n"
-"* drop 가능한 순환 구조를 만들기 위해 공유 포인터를 [`Weak`][4] 포인터로 **다운그레이드**할 수도 있습니다."
+"`Rc`내부의 데이터를 변경해야 하는 경우, 데이터를 [`Cell` 또는 `RefCell`](../"
+"concurrency/shared_state/arc.md)로 래핑해야합니다."
+
+#: src/std/rc.md:20
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+"멀티스레드인 경우 [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex."
+"html)를 참조하시기 바랍니다."
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
+"drop 가능한 순환 구조를 만들기 위해 공유 포인터를 [`Weak`](https://doc.rust-"
+"lang.org/std/rc/struct.Weak.html) 포인터로 **다운그레이드**할 수도 있습니다."
 
 #: src/std/rc.md:31
 msgid ""
-"* `Rc`'s Count ensures that its contained value is valid for as long as there are references.\n"
-"* Like C++'s `std::shared_ptr`.\n"
-"* `clone` is cheap: it creates a pointer to the same allocation and increases the reference count. Does not make a deep clone and can generally be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable borrows that are enforced at compile time. `RefCell` enables (im)mutable borrows that are enforced at run time and will panic if it fails at runtime.\n"
-"* You can `downgrade()` a `Rc` into a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"`Rc`'s Count ensures that its contained value is valid for as long as there "
+"are references."
 msgstr ""
-"* `Rc`는 참조 카운트를 통해 참조가 있는 동안은 `Rc`가 가리키고 있는 값이 메모리에서 해제되지 않음을 보장합니다.\n"
-"* C++의 `std::shared_ptr`와 유사합니다.\n"
-"* `clone`은 저렴합니다. 같은 곳을 가리키는 포인터를 하나 더 만들고, 참조 카운트를 늘립니다. 포인터가 가리키는 값 자체가 복제(깊은 복제)되지는 않으며, 그래서 코드에서 성능 문제가 있는지 검토할 때 일반적으로 `Rc`를 `clone`하는 것은 무시할 수 있습니다.\n"
-"* `make_mut`는 실제로 필요한 경우에 내부 값을 복제하고(\"clone-on-write\") 가변 참조를 반환합니다.\n"
-"* 참조 카운트를 확인하려면 `Rc::strong_count`를 사용하세요.\n"
-"* 여기 언급된 몇가지 데이터 타입을 비교해보세요. `Box`는 불변/가변 빌림(borrow)을 컴파일 시점에 강제합니다. `RefCell`은 실행 시점에 불변/가변 빌림을 강제하며, 만약 런타임 시에 빌림 문제가 발생하면 패닉을 일으킵니다.\n"
-"* `Rc`는 `downgrade()`로 다운그레이드하여 **weak 참조 카운트**로 변경할 수 있습니다. 그러면 순환구조라 하더라도 drop이 가능합니다. (아마도 `RefCell` 을 함께 사용해야 할 것입니다.)"
+"`Rc`는 참조 카운트를 통해 참조가 있는 동안은 `Rc`가 가리키고 있는 값이 메모리"
+"에서 해제되지 않음을 보장합니다."
+
+#: src/std/rc.md:32
+msgid "Like C++'s `std::shared_ptr`."
+msgstr "C++의 `std::shared_ptr`와 유사합니다."
+
+#: src/std/rc.md:33
+msgid ""
+"`clone` is cheap: it creates a pointer to the same allocation and increases "
+"the reference count. Does not make a deep clone and can generally be ignored "
+"when looking for performance issues in code."
+msgstr ""
+"`clone`은 저렴합니다. 같은 곳을 가리키는 포인터를 하나 더 만들고, 참조 카운트"
+"를 늘립니다. 포인터가 가리키는 값 자체가 복제(깊은 복제)되지는 않으며, 그래"
+"서 코드에서 성능 문제가 있는지 검토할 때 일반적으로 `Rc`를 `clone`하는 것은 "
+"무시할 수 있습니다."
+
+#: src/std/rc.md:34
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+"`make_mut`는 실제로 필요한 경우에 내부 값을 복제하고(\"clone-on-write\") 가"
+"변 참조를 반환합니다."
+
+#: src/std/rc.md:35
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr "참조 카운트를 확인하려면 `Rc::strong_count`를 사용하세요."
+
+#: src/std/rc.md:36
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+"여기 언급된 몇가지 데이터 타입을 비교해보세요. `Box`는 불변/가변 빌림(borrow)"
+"을 컴파일 시점에 강제합니다. `RefCell`은 실행 시점에 불변/가변 빌림을 강제하"
+"며, 만약 런타임 시에 빌림 문제가 발생하면 패닉을 일으킵니다."
+
+#: src/std/rc.md:37
+msgid ""
+"You can `downgrade()` a `Rc` into a _weakly reference-counted_ object to "
+"create cycles that will be dropped properly (likely in combination with "
+"`RefCell`)."
+msgstr ""
+"`Rc`는 `downgrade()`로 다운그레이드하여 **weak 참조 카운트**로 변경할 수 있습"
+"니다. 그러면 순환구조라 하더라도 drop이 가능합니다. (아마도 `RefCell` 을 함"
+"께 사용해야 할 것입니다.)"
 
 #: src/std/rc.md:41
 msgid ""
@@ -7795,10 +9447,6 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/modules.md:1
-msgid "# Modules"
-msgstr "# 모듈"
-
 #: src/modules.md:3
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
 msgstr "`impl`블록은 해당 타입의 함수들에 대한 네임스페이스를 제공합니다."
@@ -7849,32 +9497,43 @@ msgstr ""
 
 #: src/modules.md:28
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
-"* 패키지는 기능을 제공하며 하나의 대표 `Cargo.toml` 파일을 포함합니다. 패키지를 구성하는 크레이트들을 빌드하는 방법이 이 파일에 기술됩니다.\n"
-"* 크레이트는 모듈의 트리입니다. 바이너리 크레이트는 실행파일로 빌드되고, 라이브러리 크레이트는 라이브러리로 빌드됩니다.\n"
-"* 모듈은 코드를 조직화하고 스코프를 정의하는 단위입니다."
+"패키지는 기능을 제공하며 하나의 대표 `Cargo.toml` 파일을 포함합니다. 패키지"
+"를 구성하는 크레이트들을 빌드하는 방법이 이 파일에 기술됩니다."
 
-#: src/modules/visibility.md:1
-msgid "# Visibility"
-msgstr "# 가시성"
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+"크레이트는 모듈의 트리입니다. 바이너리 크레이트는 실행파일로 빌드되고, 라이브"
+"러리 크레이트는 라이브러리로 빌드됩니다."
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr "모듈은 코드를 조직화하고 스코프를 정의하는 단위입니다."
 
 #: src/modules/visibility.md:3
 msgid "Modules are a privacy boundary:"
 msgstr "모듈의 타입이나 함수는 기본적으로 바깥에 노출되지 않습니다:"
 
 #: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr "따라서 모듈의 세부 구현 내용이 감춰집니다."
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr "부모와 이웃 항목은 언제나 접근 가능합니다."
+
+#: src/modules/visibility.md:7
 msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all the\n"
-"  descendants of `foo`."
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
 msgstr ""
-"* 따라서 모듈의 세부 구현 내용이 감춰집니다.\n"
-"* 부모와 이웃 항목은 언제나 접근 가능합니다.\n"
-"* 즉, 모듈 `foo`에서 접근 가능한 항목이라면 `foo` 아래의 모든 모듈에서 접근가능합니다."
+"즉, 모듈 `foo`에서 접근 가능한 항목이라면 `foo` 아래의 모든 모듈에서 접근가능"
+"합니다."
 
 #: src/modules/visibility.md:10
 msgid ""
@@ -7933,58 +9592,76 @@ msgstr ""
 "```"
 
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
-msgstr "* `pub` 키워드는 모듈에도 사용할 수 있습니다."
+msgid "Use the `pub` keyword to make modules public."
+msgstr "`pub` 키워드는 모듈에도 사용할 수 있습니다."
 
 #: src/modules/visibility.md:41
-msgid "Additionally, there are advanced `pub(...)` specifiers to restrict the scope of public visibility."
-msgstr "또한, 고급 기능으로 `pub(...)` 지정자를 사용하여 공개 범위를 제한할 수 있습니다."
+msgid ""
+"Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
+"of public visibility."
+msgstr ""
+"또한, 고급 기능으로 `pub(...)` 지정자를 사용하여 공개 범위를 제한할 수 있습니"
+"다."
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
-"* [공식 문서](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)를 참고하세요.\n"
-"* `pub(crate)`로 가시성을 지정하는 것이 자주 쓰입니다.\n"
-"* 자주 쓰이진 않지만 특정 경로에 대해서만 가시성을 부여할 수 있습니다.\n"
-"* 어떤 경우이든 가시성이 부여되면 해당 모듈을 포함하여 하위의 모든 모듈이 적용받습니다."
+"[공식 문서](https://doc.rust-lang.org/reference/visibility-and-privacy."
+"html#pubin-path-pubcrate-pubsuper-and-pubself)를 참고하세요."
 
-#: src/modules/paths.md:1
-msgid "# Paths"
-msgstr "# 경로"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr "`pub(crate)`로 가시성을 지정하는 것이 자주 쓰입니다."
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr "자주 쓰이진 않지만 특정 경로에 대해서만 가시성을 부여할 수 있습니다."
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
+msgstr ""
+"어떤 경우이든 가시성이 부여되면 해당 모듈을 포함하여 하위의 모든 모듈이 적용"
+"받습니다."
 
 #: src/modules/paths.md:3
 msgid "Paths are resolved as follows:"
 msgstr "경로는 아래와 같이 구분합니다:"
 
 #: src/modules/paths.md:5
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
-msgstr ""
-"1. 상대 경로\n"
-"   *  `foo` 또는 `self::foo`는 현재 모듈 내부의 `foo`를 가리킵니다.\n"
-"   * `super::foo`는 부모 모듈의 `foo`를 가리킵니다.\n"
-"\n"
-"2. 절대 경로\n"
-"   * `crate::foo`는 현재 크레이트 루트의 `foo`를 가리킵니다.\n"
-"   * `bar::foo`는 `bar`크레이트의 `foo`를 가리킵니다."
+msgid "As a relative path:"
+msgstr "상대 경로"
+
+#: src/modules/paths.md:6
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr "`foo` 또는 `self::foo`는 현재 모듈 내부의 `foo`를 가리킵니다."
+
+#: src/modules/paths.md:7
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr "`super::foo`는 부모 모듈의 `foo`를 가리킵니다."
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr "절대 경로"
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr "`crate::foo`는 현재 크레이트 루트의 `foo`를 가리킵니다."
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr "`bar::foo`는 `bar`크레이트의 `foo`를 가리킵니다."
 
 #: src/modules/paths.md:13
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
-"모듈은 `use`를 사용하여 다른 모듈의 심볼을 내 스코프로 가져올 수 있습니다.\n"
-"일반적으로 각 모듈의 상단에 다음과 같은 내용이 옵니다."
+"모듈은 `use`를 사용하여 다른 모듈의 심볼을 내 스코프로 가져올 수 있습니다. 일"
+"반적으로 각 모듈의 상단에 다음과 같은 내용이 옵니다."
 
 #: src/modules/paths.md:16
 msgid ""
@@ -7997,10 +9674,6 @@ msgstr ""
 "use std::collections::HashSet;\n"
 "use std::mem::transmute;\n"
 "```"
-
-#: src/modules/filesystem.md:1
-msgid "# Filesystem Hierarchy"
-msgstr "# 파일시스템 계층"
 
 #: src/modules/filesystem.md:3
 msgid "The module content can be omitted:"
@@ -8021,97 +9694,112 @@ msgid "The `garden` module content is found at:"
 msgstr "`garden` 모듈의 내용은 아래 위치에서 확인 할 수 있습니다:"
 
 #: src/modules/filesystem.md:11
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden.rs`(최신 Rust 2018 스타일)\n"
-"* `src/garden/mod.rs`(이전 Rust 2015 스타일)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr "`src/garden.rs`(최신 Rust 2018 스타일)"
+
+#: src/modules/filesystem.md:12
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/mod.rs`(이전 Rust 2015 스타일)"
 
 #: src/modules/filesystem.md:14
 msgid "Similarly, a `garden::vegetables` module can be found at:"
 msgstr "유사하게 `garden::vegetables` 모듈은 아래 위치에서 확인할 수 있습니다:"
 
 #: src/modules/filesystem.md:16
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden/vegetables.rs`(최신 Rust 2018 스타일)\n"
-"* `src/garden/vegetables/mod.rs`(이전 Rust 2015 스타일)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr "`src/garden/vegetables.rs`(최신 Rust 2018 스타일)"
+
+#: src/modules/filesystem.md:17
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/vegetables/mod.rs`(이전 Rust 2015 스타일)"
 
 #: src/modules/filesystem.md:19
 msgid "The `crate` root is in:"
 msgstr "`crate(크레이트)`의 루트는 아래 경로 입니다:"
 
 #: src/modules/filesystem.md:21
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
-msgstr ""
-"* `src/lib.rs` (라이브러리 크레이트)\n"
-"* `src/main.rs` (바이너리 크레이트)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr "`src/lib.rs` (라이브러리 크레이트)"
+
+#: src/modules/filesystem.md:22
+msgid "`src/main.rs` (for a binary crate)"
+msgstr "`src/main.rs` (바이너리 크레이트)"
 
 #: src/modules/filesystem.md:24
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
-"comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
-"모듈도 \"내부 문서 주석\"을 사용하여 문서화할 수 있습니다.\n"
-"이러한 모듈은 모듈이 포함된 항목(이 경우에는 모듈)을 문서화합니다."
+"모듈도 \"내부 문서 주석\"을 사용하여 문서화할 수 있습니다. 이러한 모듈은 모듈"
+"이 포함된 항목(이 경우에는 모듈)을 문서화합니다."
 
 #: src/modules/filesystem.md:26
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
 msgstr ""
-"* `module/mod.rs`를 `module.rs`로 바꾼다 하더라도 Rust 2018에서는 하위 모듈을 사용할 수 있습니다. (Rust 2015에서는 하위 모듈이 있는 모듈은 `module/mod.rs` 형태여야 했습니다.)\n"
-"\n"
-"  아래처럼 구성하는데 아무런 문제가 없습니다:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* 이렇게 변경된 주된 이유는 모두 똑같은 이름의 `mod.rs` 파일이 잔뜩 생기는 것을 방지하기 위해서 입니다. IDE에서는 이들을 구분하기가 까다로웠습니다.\n"
-"\n"
-"* 러스트는 모듈을 찾을 때 `modulename/mod.rs`와 `modulename.rs` 파일을 검사하는데, 컴파일러 디렉티브로 이를 변경할 수 있습니다.\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  Go언어 에서처럼 어떤 모듈의 테스트를 `some_module_test.rs` 같은 파일에 두고 싶은 경우에 유용합니다."
+"`module/mod.rs`를 `module.rs`로 바꾼다 하더라도 Rust 2018에서는 하위 모듈을 "
+"사용할 수 있습니다. (Rust 2015에서는 하위 모듈이 있는 모듈은 `module/mod.rs` "
+"형태여야 했습니다.)"
+
+#: src/modules/filesystem.md:29
+msgid "The following is valid:"
+msgstr "아래처럼 구성하는데 아무런 문제가 없습니다:"
+
+#: src/modules/filesystem.md:31
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+
+#: src/modules/filesystem.md:39
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+"이렇게 변경된 주된 이유는 모두 똑같은 이름의 `mod.rs` 파일이 잔뜩 생기는 것"
+"을 방지하기 위해서 입니다. IDE에서는 이들을 구분하기가 까다로웠습니다."
+
+#: src/modules/filesystem.md:42
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+"러스트는 모듈을 찾을 때 `modulename/mod.rs`와 `modulename.rs` 파일을 검사하는"
+"데, 컴파일러 디렉티브로 이를 변경할 수 있습니다."
+
+#: src/modules/filesystem.md:45
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+
+#: src/modules/filesystem.md:50
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
+msgstr ""
+"Go언어 에서처럼 어떤 모듈의 테스트를 `some_module_test.rs` 같은 파일에 두고 "
+"싶은 경우에 유용합니다."
 
 #: src/modules/filesystem.md:27
 msgid ""
@@ -8147,53 +9835,59 @@ msgstr ""
 "```"
 
 #: src/exercises/day-2/afternoon.md:1
-msgid "# Day 2: Afternoon Exercises"
-msgstr "# 2일차 오후 연습문제"
+msgid "Day 2: Afternoon Exercises"
+msgstr "2일차 오후 연습문제"
 
 #: src/exercises/day-2/afternoon.md:3
 msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr "이번 연습문제는 문자열과 반복자에 초점을 맞출 것입니다."
 
-#: src/exercises/day-2/luhn.md:1
-msgid "# Luhn Algorithm"
-msgstr "# 룬(Luhn) 알고리즘"
-
 #: src/exercises/day-2/luhn.md:3
 msgid ""
-"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used to\n"
-"validate credit card numbers. The algorithm takes a string as input and does the\n"
-"following to validate the credit card number:"
-msgstr "[룬(Luhn) 알고리즘](https://ko.wikipedia.org/wiki/%EB%A3%AC_%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98)은 신용카드 번호 검증에 사용되는 알고리즘 입니다. 이 알고리즘은 신용카드 번호를 `문자열`로 입력받고, 아래의 순서에 따라 신용카드 번호의 유효성을 확인합니다:"
+"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
+msgstr ""
+"[룬(Luhn) 알고리즘](https://ko.wikipedia.org/wiki/"
+"%EB%A3%AC_%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98)은 신용카드 번호 검증에 사용되"
+"는 알고리즘 입니다. 이 알고리즘은 신용카드 번호를 `문자열`로 입력받고, 아래"
+"의 순서에 따라 신용카드 번호의 유효성을 확인합니다:"
 
 #: src/exercises/day-2/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr "모든 공백을 무시합니다. 2자리 미만 숫자는 무시합니다."
+
+#: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number `1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
 msgstr ""
-"* 모든 공백을 무시합니다. 2자리 미만 숫자는 무시합니다.\n"
-"\n"
-"* 오른쪽에서 왼쪽으로 이동하며 2번째 자리마다 숫자를 2배 증가시킵니다. 예를 들어 `1234`에서 `3`과 `1`에 각각 2를 곱합니다.\n"
-"\n"
-"* 두배로 만든 숫자가 2자리라면 각 자리 숫자를 더합니다. 예를 들어, `7`은 두배로 만들면 `14`이므로 `5`가 됩니다.\n"
-"\n"
-"* 모든 자리의 숫자를 더합니다.\n"
-"\n"
-"* 합계의 끝자리가 `0`인 경우 유효한 신용카드 번호입니다."
+"오른쪽에서 왼쪽으로 이동하며 2번째 자리마다 숫자를 2배 증가시킵니다. 예를 들"
+"어 `1234`에서 `3`과 `1`에 각각 2를 곱합니다."
+
+#: src/exercises/day-2/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+"두배로 만든 숫자가 2자리라면 각 자리 숫자를 더합니다. 예를 들어, `7`은 두배"
+"로 만들면 `14`이므로 `5`가 됩니다."
+
+#: src/exercises/day-2/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr "모든 자리의 숫자를 더합니다."
+
+#: src/exercises/day-2/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
+msgstr "합계의 끝자리가 `0`인 경우 유효한 신용카드 번호입니다."
 
 #: src/exercises/day-2/luhn.md:19
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
-msgstr "아래 코드를 <https://play.rust-lang.org/>에 복사하고 함수를 구현해 보시기 바랍니다:"
+msgstr ""
+"아래 코드를 <https://play.rust-lang.org/>에 복사하고 함수를 구현해 보시기 바"
+"랍니다:"
 
 #: src/exercises/day-2/luhn.md:23
 msgid ""
@@ -8247,23 +9941,25 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-msgid "# Strings and Iterators"
-msgstr "# 문자열과 반복자"
-
 #: src/exercises/day-2/strings-iterators.md:3
 msgid ""
-"In this exercise, you are implementing a routing component of a web server. The\n"
-"server is configured with a number of _path prefixes_ which are matched against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
-msgstr "이번 훈련은 웹 서버의 라우팅 컴포넌트를 구현합니다. 서버는 _요청 경로(request path)_ 를 처리할 수 있는 여러 개의 _경로 접두사(path prefix)_ 로 구성됩니다. 경로 접두사는 와일드카드문자를 포함할 수 있습니다.  아래 단위 테스트 코드를 참조하세요."
+"In this exercise, you are implementing a routing component of a web server. "
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
+msgstr ""
+"이번 훈련은 웹 서버의 라우팅 컴포넌트를 구현합니다. 서버는 _요청 경로"
+"(request path)_ 를 처리할 수 있는 여러 개의 _경로 접두사(path prefix)_ 로 구"
+"성됩니다. 경로 접두사는 와일드카드문자를 포함할 수 있습니다.  아래 단위 테스"
+"트 코드를 참조하세요."
 
 #: src/exercises/day-2/strings-iterators.md:8
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
-msgstr "아래 코드를 <https://play.rust-lang.org/>에 복사하고 테스트를 통과해 보시기 바랍니다. 중간 결과값을 `Vec`에 할당하지 않도록 주의 하시기 바랍니다:"
+msgstr ""
+"아래 코드를 <https://play.rust-lang.org/>에 복사하고 테스트를 통과해 보시기 "
+"바랍니다. 중간 결과값을 `Vec`에 할당하지 않도록 주의 하시기 바랍니다:"
 
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
@@ -8278,12 +9974,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -8301,7 +10000,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -8311,8 +10011,8 @@ msgid ""
 msgstr ""
 
 #: src/welcome-day-3.md:1
-msgid "# Welcome to Day 3"
-msgstr "# 3일차 개요"
+msgid "Welcome to Day 3"
+msgstr "3일차 개요"
 
 #: src/welcome-day-3.md:3
 msgid "Today, we will cover some more advanced topics of Rust:"
@@ -8320,35 +10020,39 @@ msgstr "오늘은 몇 가지 고급 주제를 다룹니다:"
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
-"* 트레잇: 트레잇 상속(derive), 디폴트 메서드, 표준 라이브러에 있는 중요한 트레잇들.\n"
-"\n"
-"* 제네릭: 제네릭 데이터 타입, 제네릭 메서드, 단형화(monomorphization), 트레잇 객체.\n"
-"\n"
-"* 오류처리(에러 핸들링): 패닉, `Result`, `?` 연산자.\n"
-"\n"
-"* 테스트: 단위 테스트, 문서 테스트 및 통합 테스트.\n"
-"\n"
-"* 안전하지 않은 러스트: 원시(raw) 포인터, 정적 변수, 안전하지 않은 함수, 외부 함수."
+"트레잇: 트레잇 상속(derive), 디폴트 메서드, 표준 라이브러에 있는 중요한 트레"
+"잇들."
 
-#: src/traits.md:1
-msgid "# Traits"
-msgstr "# 트레잇(Trait)"
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+"제네릭: 제네릭 데이터 타입, 제네릭 메서드, 단형화(monomorphization), 트레잇 "
+"객체."
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr "오류처리(에러 핸들링): 패닉, `Result`, `?` 연산자."
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr "테스트: 단위 테스트, 문서 테스트 및 통합 테스트."
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
+"안전하지 않은 러스트: 원시(raw) 포인터, 정적 변수, 안전하지 않은 함수, 외부 "
+"함수."
 
 #: src/traits.md:3
-msgid "Rust lets you abstract over types with traits. They're similar to interfaces:"
+msgid ""
+"Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr "트레잇은 타입을 추상화 하는데 사용됩니다. 인터페이스와 비슷합니다:"
 
 #: src/traits.md:5
@@ -8427,104 +10131,136 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/traits/default-methods.md:32
+#: src/traits/default-methods.md:32 src/traits.md:41
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to\n"
-"  implement themselves. Methods with default implementations can rely on "
-"required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `NotEqual` a super trait for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `NotEqual` as a "
-"super trait for `Equal`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
-"* 트레잇은 사전 구현된 (기본값) 메서드와 사용자가 직접 구현해야 하는\n"
-"  메서드를 지정할 수 있습니다. 기본 구현이 있는 메서드는 필수 메서드를 사용"
-"할 수 있습니다.\n"
-"\n"
-"* `not_equal` 메서드를 새로운 트레잇인 `NotEqual`로 이동합니다.\n"
-"\n"
-"* `NotEqual`을 `Equal`의 슈퍼 트레잇으로 만듭니다.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* `Equal`에 `NotEqual`의 포괄적 구현을 제공합니다.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * 포괄적 구현을 사용하면 더 이상 `NotEqual`이 `Equal`의 슈퍼 트레잇으로 필"
-"요하지 않습니다.\n"
-"    "
+"트레잇은 사전 구현된 (기본값) 메서드와 사용자가 직접 구현해야 하는 메서드를 "
+"지정할 수 있습니다. 기본 구현이 있는 메서드는 필수 메서드를 사용할 수 있습니"
+"다."
 
-#: src/traits.md:41
+#: src/traits/default-methods.md:35
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr "`not_equal` 메서드를 새로운 트레잇인 `NotEqual`로 이동합니다."
+
+#: src/traits/default-methods.md:37
+msgid "Make `NotEqual` a super trait for `Equal`."
+msgstr "`NotEqual`을 `Equal`의 슈퍼 트레잇으로 만듭니다."
+
+#: src/traits/default-methods.md:38
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that users are required to implement themselves. Methods with default implementations can rely on required methods.\n"
-"* Types that implement a given trait may be of different sizes. This makes it impossible to have things like `Vec<Greet>` in the example above.\n"
-"* `dyn Greet` is a way to tell the compiler about a dynamically sized type that implements `Greet`.\n"
-"* In the example, `pets` holds Fat Pointers to objects that implement `Greet`. The Fat Pointer consists of two components, a pointer to the actual object and a pointer to the virtual method table for the `Greet` implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
-"     ```"
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
-"* 트레잇은 사용자가 직접 구현해야 하는 메서드와 사전 구현된(디폴트) 메서드를 지정할 수 있습니다. 기본 구현된 메서드는 (다른)필수 메서드를 의존할 수 있습니다.\n"
-"* 여러 타입이 같은 트레잇을 구현하더라도 그 크기는 서로 다를 수 있습니다. 그래서 `Vec<Greeet>`같은 것은 불가능합니다. 왜냐하면 `Greet`트레잇을 구현하는 타입들 중 어떤 크기의 타입이 실제로 사용될 지, 컴파일 시에 알 방법이 없는 반면, `Vec<>`는 타입의 크기를 컴파일 시에 알고자 하기 때문입니다.\n"
-"* `dyn Greet`는 `Greet`을 구현하는, 가변 크기의 타입을 의미합니다.\n"
-"* 예제에서 `pets`는 `Greet`을 구현하는 객체들의 Fat pointer를 담고 있습니다. Fat pointer는 실제 객체에 대한 포인터와 그 객체가 `Greet`을 구현하고 있는 가상 함수 테이블에 대한 포인터를 가집니다.\n"
-"* 아래 코드의 결과와 비교해보세요:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
-"     ```"
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
 
-#: src/traits/deriving-traits.md:1
-msgid "# Deriving Traits"
-msgstr "# 트레잇 상속하기(Deriving Traits)"
+#: src/traits/default-methods.md:46
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr "`Equal`에 `NotEqual`의 포괄적 구현을 제공합니다."
+
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `NotEqual` as a super "
+"trait for `Equal`."
+msgstr ""
+"포괄적 구현을 사용하면 더 이상 `NotEqual`이 `Equal`의 슈퍼 트레잇으로 필요하"
+"지 않습니다."
+
+#: src/traits.md:42
+msgid ""
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Greet>` in the example above."
+msgstr ""
+"여러 타입이 같은 트레잇을 구현하더라도 그 크기는 서로 다를 수 있습니다. 그래"
+"서 `Vec<Greeet>`같은 것은 불가능합니다. 왜냐하면 `Greet`트레잇을 구현하는 타"
+"입들 중 어떤 크기의 타입이 실제로 사용될 지, 컴파일 시에 알 방법이 없는 반"
+"면, `Vec<>`는 타입의 크기를 컴파일 시에 알고자 하기 때문입니다."
+
+#: src/traits.md:43
+msgid ""
+"`dyn Greet` is a way to tell the compiler about a dynamically sized type "
+"that implements `Greet`."
+msgstr "`dyn Greet`는 `Greet`을 구현하는, 가변 크기의 타입을 의미합니다."
+
+#: src/traits.md:44
+msgid ""
+"In the example, `pets` holds Fat Pointers to objects that implement `Greet`. "
+"The Fat Pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Greet` implementation of "
+"that particular object."
+msgstr ""
+"예제에서 `pets`는 `Greet`을 구현하는 객체들의 Fat pointer를 담고 있습니다. "
+"Fat pointer는 실제 객체에 대한 포인터와 그 객체가 `Greet`을 구현하고 있는 가"
+"상 함수 테이블에 대한 포인터를 가집니다."
+
+#: src/traits.md:45
+msgid "Compare these outputs in the above example:"
+msgstr "아래 코드의 결과와 비교해보세요:"
+
+#: src/traits.md:46
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
+"```"
 
 #: src/traits/deriving-traits.md:3
 msgid "You can let the compiler derive a number of traits:"
-msgstr "컴파일러가 여러가지 트레잇을 상속(derive)하도록 할 수 있습니다. 이 경우 컴파일러가 트레잇을 자동으로 구현합니다:"
+msgstr ""
+"컴파일러가 여러가지 트레잇을 상속(derive)하도록 할 수 있습니다. 이 경우 컴파"
+"일러가 트레잇을 자동으로 구현합니다:"
 
 #: src/traits/deriving-traits.md:5
 msgid ""
@@ -8560,13 +10296,10 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/traits/default-methods.md:1
-msgid "# Default Methods"
-msgstr "# 디폴트 메서드"
-
 #: src/traits/default-methods.md:3
 msgid "Traits can implement behavior in terms of other trait methods:"
-msgstr "트레잇의 디폴트 메서드에서 다른(구현되지 않은) 메소드를 이용할 수 있습니다:"
+msgstr ""
+"트레잇의 디폴트 메서드에서 다른(구현되지 않은) 메소드를 이용할 수 있습니다:"
 
 #: src/traits/default-methods.md:5
 msgid ""
@@ -8620,36 +10353,76 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/traits/important-traits.md:1
-msgid "# Important Traits"
-msgstr "# 중요한 트레잇들"
-
 #: src/traits/important-traits.md:3
-msgid "We will now look at some of the most common traits of the Rust standard library:"
-msgstr "러스트 표준 라이브러리에는 다음과 같은 범용 트레잇들이 정의되어 있습니다:"
+msgid ""
+"We will now look at some of the most common traits of the Rust standard "
+"library:"
+msgstr ""
+"러스트 표준 라이브러리에는 다음과 같은 범용 트레잇들이 정의되어 있습니다:"
 
 #: src/traits/important-traits.md:5
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
 msgstr ""
-"* [`Iterator`][1]와 [`IntoIterator`][2] 트레잇은 `for` 루프에서 사용됩니다.\n"
-"* [`From`][3]과 [`Into`][4] 트레잇은 값을 변환할 때 사용됩니다.\n"
-"* [`Read`][5]와 [`Write`][6] 트레잇은 I/O에 사용됩니다.\n"
-"* [`Add`][7], [`Mul`][8] 등의 트레잇들은 연산자 오버로딩(overloading)에 사용됩니다.\n"
-"* [`Drop`][9] 트레잇은 소멸자 정의에 사용됩니다.\n"
-"* [`Default`][10] 트레잇은 어떤 타입의 기본값 인스턴스를 만들때 사용됩니다."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html)와 "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"트레잇은 `for` 루프에서 사용됩니다."
+
+#: src/traits/important-traits.md:6
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html)과 [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) 트레잇은 값을 변환할 "
+"때 사용됩니다."
+
+#: src/traits/important-traits.md:7
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html)와 [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) 트레잇은 I/O에 사용됩니"
+"다."
+
+#: src/traits/important-traits.md:8
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html) 등의 트레잇들은 연산자 오버로딩"
+"(overloading)에 사용됩니다."
+
+#: src/traits/important-traits.md:9
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) 트레잇은 소멸자 "
+"정의에 사용됩니다."
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 트레잇"
+"은 어떤 타입의 기본값 인스턴스를 만들때 사용됩니다."
 
 #: src/traits/iterator.md:1
-msgid "# Iterators"
-msgstr "# Iterators"
+msgid "Iterators"
+msgstr "Iterators"
 
 #: src/traits/iterator.md:3
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr "`Iterator`트레잇을 여러분이 정의한 타입에서 구현해 보겠습니다:"
 
 #: src/traits/iterator.md:5
@@ -8706,56 +10479,48 @@ msgstr ""
 
 #: src/traits/iterator.md:32
 msgid ""
-"* `IntoIterator` is the trait that makes for loops work. It is implemented by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also implement it.\n"
-"* The `Iterator` trait implements many common functional programming operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient as equivalent imperative\n"
-"  implementations.\n"
-"    "
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it."
 msgstr ""
-"* `IntoIterator`는 루프가 작동하도록 만드는 트레잇입니다. `Vec<T>`와 같은 컬렉션 타입과 그에 대한 참조 타입(`&Vec<T>`, `&[T]`)들 모두 이 트레잇을 구현합니다. Range 역시 이를 구현합니다.\n"
-"* `Iterator` 트레잇은 컬렉션에 대해 다양한 함수형 프로그래밍 연산 (`map`, `filter`, `reduce` 등)을 구현합니다. 이 연산들에 대한 자세한 설명은 `Iterator` 트레잇의 API 레퍼런스에서 찾을 수 있습니다. 러스트에서 이러한 함수형 연산들은 절차형으로 구현된 코드와 동일한 성능을 보여줍니다.\n"
-"    "
+"`IntoIterator`는 루프가 작동하도록 만드는 트레잇입니다. `Vec<T>`와 같은 컬렉"
+"션 타입과 그에 대한 참조 타입(`&Vec<T>`, `&[T]`)들 모두 이 트레잇을 구현합니"
+"다. Range 역시 이를 구현합니다."
 
-#: src/traits/iterator.md:32
+#: src/traits/iterator.md:34 src/traits/iterator.md:32
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
-"* `Iterator` 트레잇은 컬렉션에 대한 여러 일반적인 함수 프로그래밍 작업(예: "
-"`map`, `filter`, `reduce` 등)을\n"
-"  구현합니다. 이는 관련 문서를 모두 찾을 수 있는\n"
-"  트레잇입니다. Rust에서는 이러한 함수가, 이와 동일한 일을 하는 명령형 구현만큼 효율적인 코"
-"드를\n"
-"  생성합니다.\n"
-"    \n"
-"* `IntoIterator`는 루프를 작동하게 만드는 트레잇입니다. 이는 `Vec<T>`와 같은 "
-"컬렉션 유형과\n"
-"  `&Vec<T>` 및 `&[T]`와 같은 이에 대한 참조에 의해 구현됩니다. 범위도 이를 구"
-"현합니다. 이런 이유로\n"
-"  `for i in some_vec { .. }`를 사용하여 벡터를 반복할 수 있지만\n"
-"  `some_vec.next()`는 존재하지 않습니다."
+"`Iterator` 트레잇은 컬렉션에 대해 다양한 함수형 프로그래밍 연산 (`map`, "
+"`filter`, `reduce` 등)을 구현합니다. 이 연산들에 대한 자세한 설명은 "
+"`Iterator` 트레잇의 API 레퍼런스에서 찾을 수 있습니다. 러스트에서 이러한 함수"
+"형 연산들은 절차형으로 구현된 코드와 동일한 성능을 보여줍니다."
 
-#: src/traits/from-iterator.md:1
-msgid "# FromIterator"
-msgstr "# FromIterator"
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
+"`IntoIterator`는 루프를 작동하게 만드는 트레잇입니다. 이는 `Vec<T>`와 같은 컬"
+"렉션 유형과 `&Vec<T>` 및 `&[T]`와 같은 이에 대한 참조에 의해 구현됩니다. 범위"
+"도 이를 구현합니다. 이런 이유로 `for i in some_vec { .. }`를 사용하여 벡터를 "
+"반복할 수 있지만 `some_vec.next()`는 존재하지 않습니다."
 
 #: src/traits/from-iterator.md:3
-msgid "[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
-msgstr "어떤 컬렉션이 [`FromIterator`][1]를 구현하고 있다면 [`Iterator`][2]로부터 그 컬렉션을 만들 수 있습니다."
+msgid ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
+msgstr ""
+"어떤 컬렉션이 [`FromIterator`](https://doc.rust-lang.org/std/iter/trait."
+"FromIterator.html)를 구현하고 있다면 [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)로부터 그 컬렉션을 만들 수 있습니다."
 
 #: src/traits/from-iterator.md:5
 msgid ""
@@ -8781,31 +10546,33 @@ msgstr ""
 
 #: src/traits/from-iterator.md:17
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"`Iterator`에는 다음 함수가 정의되어 있습니다:\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator`에는 다음 함수가 정의되어 있습니다: `fn collect<B>(self) -> B "
+"where B: FromIterator<Self::Item>, Self: Sized`"
 
 #: src/traits/from-iterator.md:23
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
-msgstr "`Iterator<Item = Result<V, E>>`을 `Result<Vec<V>, E>`로 변환할 수 있는 멋진 기능들도 구현되어 있습니다."
+msgstr ""
+"`Iterator<Item = Result<V, E>>`을 `Result<Vec<V>, E>`로 변환할 수 있는 멋진 "
+"기능들도 구현되어 있습니다."
 
 #: src/traits/from-into.md:1
-msgid "# `From` and `Into`"
-msgstr "# `From`과 `Into`"
+msgid "`From` and `Into`"
+msgstr "`From`과 `Into`"
 
 #: src/traits/from-into.md:3
-msgid "Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
-msgstr "타입은 용이한 형변환을 위해 [`From`][1]과 [`Into`][2]를 구현합니다:"
+msgid ""
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
+msgstr ""
+"타입은 용이한 형변환을 위해 [`From`](https://doc.rust-lang.org/std/convert/"
+"trait.From.html)과 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into."
+"html)를 구현합니다:"
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -8830,8 +10597,14 @@ msgstr ""
 "```"
 
 #: src/traits/from-into.md:15
-msgid "[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
-msgstr "[`From`][1]이 구현되면 [`Into`][2] 역시 자동으로 구현됩니다:"
+msgid ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html)이 구현되면 "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 역시 자동으"
+"로 구현됩니다:"
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -8857,22 +10630,36 @@ msgstr ""
 
 #: src/traits/from-into.md:29
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get `Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that _only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
 msgstr ""
-"* 그렇기 때문에 사용자 정의 타입의 경우에도 `From` 만 구현하는 것이 일반적입니다.\n"
-"* \"`String`으로 변환할 수 있는 모든 것\"과 같은 함수의 인수 타입을 선언할 때에는 `Into`를 사용해야 함을 조심하세요. 그래야만, 함수는 `From`을 구현한 타입과 `Into` _만_ 구현한 타입 모두를 인자로 받을 수 있습니다.\n"
-"    "
+"그렇기 때문에 사용자 정의 타입의 경우에도 `From` 만 구현하는 것이 일반적입니"
+"다."
+
+#: src/traits/from-into.md:30
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
+msgstr ""
+"\"`String`으로 변환할 수 있는 모든 것\"과 같은 함수의 인수 타입을 선언할 때에"
+"는 `Into`를 사용해야 함을 조심하세요. 그래야만, 함수는 `From`을 구현한 타입"
+"과 `Into` _만_ 구현한 타입 모두를 인자로 받을 수 있습니다."
 
 #: src/traits/read-write.md:1
-msgid "# `Read` and `Write`"
-msgstr "# `Read`와 `Write`"
+msgid "`Read` and `Write`"
+msgstr "`Read`와 `Write`"
 
 #: src/traits/read-write.md:3
-msgid "Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
-msgstr "[`Read`][1]와 [`BufRead`][2]를 사용하면 `u8` 타입의 데이터 스트림을 읽을 수 있습니다:"
+msgid ""
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html)와 [`BufRead`]"
+"(https://doc.rust-lang.org/std/io/trait.BufRead.html)를 사용하면 `u8` 타입의 "
+"데이터 스트림을 읽을 수 있습니다:"
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -8913,7 +10700,9 @@ msgstr ""
 "```"
 
 #: src/traits/read-write.md:23
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
 msgstr "이와 비슷하게, `Write`를 사옹하면 `u8` 타입의 데이터를 쓸 수 있습니다:"
 
 #: src/traits/read-write.md:25
@@ -8953,11 +10742,13 @@ msgstr ""
 "```"
 
 #: src/traits/operators.md:1
-msgid "# `Add`, `Mul`, ..."
-msgstr "# `Add`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
+msgstr "`Add`, `Mul`, ..."
 
 #: src/traits/operators.md:3
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr "연산자 오버로드는 `std::ops`에 있는 다양한 트레잇들을 통해 구현됩니다:"
 
 #: src/traits/operators.md:5
@@ -9006,28 +10797,43 @@ msgstr "논의점:"
 
 #: src/traits/operators.md:28
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter?\n"
-"    * Short answer: Type parameters are controlled by the caller, but\n"
-"        associated types (like `Output`) are controlled by the implementor of a\n"
-"        trait."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
 msgstr ""
-"* `&Point`가 `Add`를 구현하도록 할 수도 있습니다. 이게 어떤 경우에 유용할까요?\n"
-"  * 답: `Add:add`는 `self`를 소모합니다. 만약 타입 `T`가 `Copy`트레잇을 구현하고 있지 않다면 `&T`에 대해서도 연산자 오버로딩을 고려해야 합니다. 이렇게 하면 호출부에서 불필요한 복사를 피할 수 있습니다.\n"
-"* 왜 `Output`이 연관된 타입인가요? 타입 파라메터로 만들 수 있을까요?\n"
-"  * 답: 타입 파라메터를 호출하는 쪽에서 결정합니다. 반면 연관된 타입(`Output`같은) 은 트레잇을 구현하는 쪽에서 제어 가능합니다."
+"`&Point`가 `Add`를 구현하도록 할 수도 있습니다. 이게 어떤 경우에 유용할까요?"
+
+#: src/traits/operators.md:29
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"답: `Add:add`는 `self`를 소모합니다. 만약 타입 `T`가 `Copy`트레잇을 구현하고 "
+"있지 않다면 `&T`에 대해서도 연산자 오버로딩을 고려해야 합니다. 이렇게 하면 호"
+"출부에서 불필요한 복사를 피할 수 있습니다."
+
+#: src/traits/operators.md:33
+msgid "Why is `Output` an associated type? Could it be made a type parameter?"
+msgstr "왜 `Output`이 연관된 타입인가요? 타입 파라메터로 만들 수 있을까요?"
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Type parameters are controlled by the caller, but associated "
+"types (like `Output`) are controlled by the implementor of a trait."
+msgstr ""
+"답: 타입 파라메터를 호출하는 쪽에서 결정합니다. 반면 연관된 타입(`Output`같"
+"은) 은 트레잇을 구현하는 쪽에서 제어 가능합니다."
 
 #: src/traits/drop.md:1
-msgid "# The `Drop` Trait"
-msgstr "# `Drop` 트레잇"
+msgid "The `Drop` Trait"
+msgstr "`Drop` 트레잇"
 
 #: src/traits/drop.md:3
-msgid "Values which implement [`Drop`][1] can specify code to run when they go out of scope:"
-msgstr "[`Drop`][1]트레잇을 구현하면, 그 값이 스코프 밖으로 나갈 때 실행될 코드를 작성할 수 있습니다:"
+msgid ""
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html)트레잇을 구현하"
+"면, 그 값이 스코프 밖으로 나갈 때 실행될 코드를 작성할 수 있습니다:"
 
 #: src/traits/drop.md:5
 msgid ""
@@ -9086,24 +10892,32 @@ msgstr ""
 "```"
 
 #: src/traits/drop.md:36
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "`Drop::drop`은 왜 `self`를 인자로 받지 않습니까?"
+
+#: src/traits/drop.md:37
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
-"* `Drop::drop`은 왜 `self`를 인자로 받지 않습니까?\n"
-"  * 짧은 대답: 만약 그렇게 된다면 `std::mem::drop`이 블록의 끝에서 호출되고, 다시 `Drop::drop`을 호출하게되 스택 오버플로가 발생합니다.\n"
-"* `drop(a)`를 `a.drop()`로 변경해 보시기 바랍니다."
+"짧은 대답: 만약 그렇게 된다면 `std::mem::drop`이 블록의 끝에서 호출되고, 다"
+"시 `Drop::drop`을 호출하게되 스택 오버플로가 발생합니다."
+
+#: src/traits/drop.md:40
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "`drop(a)`를 `a.drop()`로 변경해 보시기 바랍니다."
 
 #: src/traits/default.md:1
-msgid "# The `Default` Trait"
-msgstr "# `Default` 트레잇"
+msgid "The `Default` Trait"
+msgstr "`Default` 트레잇"
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait provides a default implementation of a trait."
-msgstr "[`Default`][1] 트레잇은 기본 구현을 제공합니다."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"provides a default implementation of a trait."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) 트레잇"
+"은 기본 구현을 제공합니다."
 
 #: src/traits/default.md:5
 msgid ""
@@ -9175,33 +10989,50 @@ msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via `#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e.g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and provides convenience methods that use it."
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
 msgstr ""
-"  * 트레잇을 직접 구현하거나 `#[derive(Default)]`를 붙여서 컴파일러에게 구현을 맡길 수 있습니다.\n"
-"  * 컴파일러가 제공하는 자동 구현의 경우 모든 필드에 대해 기본 값을 설정한 새 인스턴스를 반환합니다.\n"
-"    * 구조체의 각 필드 타입들이 모두 `Default`를 구현해야 함을 의미합니다.\n"
-"  * 러스트 표준 타입들은 대부분 `Default`를 구현하고 있으며, 기본 값은 `0`이나 `\"\"`처럼 예상 가능한 값들입니다.\n"
-"  * 구조체 부분 복사를 할때 `default`를 편리하게 사용할 수 있습니다.\n"
-"  * 러스트 표준 라이브러리는 `Default` 트레잇을 구현한 타입을 위한 편의 메서드를 제공하기도 합니다."
+"트레잇을 직접 구현하거나 `#[derive(Default)]`를 붙여서 컴파일러에게 구현을 맡"
+"길 수 있습니다."
 
-#: src/generics.md:1
-msgid "# Generics"
-msgstr "# 제네릭"
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr ""
+"컴파일러가 제공하는 자동 구현의 경우 모든 필드에 대해 기본 값을 설정한 새 인"
+"스턴스를 반환합니다."
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr "구조체의 각 필드 타입들이 모두 `Default`를 구현해야 함을 의미합니다."
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+"러스트 표준 타입들은 대부분 `Default`를 구현하고 있으며, 기본 값은 `0`이나 "
+"`\"\"`처럼 예상 가능한 값들입니다."
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr "구조체 부분 복사를 할때 `default`를 편리하게 사용할 수 있습니다."
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
+"provides convenience methods that use it."
+msgstr ""
+"러스트 표준 라이브러리는 `Default` 트레잇을 구현한 타입을 위한 편의 메서드를 "
+"제공하기도 합니다."
 
 #: src/generics.md:3
 msgid ""
-"Rust support generics, which lets you abstract an algorithm (such as sorting)\n"
-"over the types used in the algorithm."
-msgstr "러스트는 제네릭을 지원합니다. 이를 이용하면 알고리즘(정렬과 같은)을 추상화 하여 특정 타입에 의존하지 않도록 할 수 있습니다."
-
-#: src/generics/data-types.md:1
-msgid "# Generic Data Types"
-msgstr "# 제네릭 데이터 타입"
+"Rust support generics, which lets you abstract an algorithm (such as "
+"sorting) over the types used in the algorithm."
+msgstr ""
+"러스트는 제네릭을 지원합니다. 이를 이용하면 알고리즘(정렬과 같은)을 추상화 하"
+"여 특정 타입에 의존하지 않도록 할 수 있습니다."
 
 #: src/generics/data-types.md:3
 msgid "You can use generics to abstract over the concrete field type:"
@@ -9238,18 +11069,14 @@ msgstr ""
 "```"
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
-msgstr ""
-"* 새 변수 `let p = Point { x: 5, y: 10.0 };`를 선언해 보세요.\n"
-"\n"
-"* `Point`가 서로 다른 타입의 값들으로 이루어져도 컴파일 되도록 코드를 수정해 보세요."
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
+msgstr "새 변수 `let p = Point { x: 5, y: 10.0 };`를 선언해 보세요."
 
-#: src/generics/methods.md:1
-msgid "# Generic Methods"
-msgstr "# 제네릭 메서드"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
+msgstr ""
+"`Point`가 서로 다른 타입의 값들으로 이루어져도 컴파일 되도록 코드를 수정해 보"
+"세요."
 
 #: src/generics/methods.md:3
 msgid "You can declare a generic type on your `impl` block:"
@@ -9295,27 +11122,42 @@ msgstr ""
 
 #: src/generics/methods.md:25
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that redundant?\n"
-"    * This is because it is a generic implementation section for generic type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods in this block will only be available for `Point<u32>`."
-msgstr ""
-"* *질문:* `impl<T> Point<T> {}`에서 `T`가 왜 두 번 사용됩니까?\n"
-"  * 제네릭 타입에 대한 제네릭 구현 이기 때문입니다. 이 두 제네릭은 서로 독립적입니다.\n"
-"  * 이는 임의의 모든 `T`에 대해서 이 메소드들이 정의된다는 것을 의미합니다.\n"
-"  * `impl Point<u32> { .. }`와 같이 작성하는 것도 가능합니다.\n"
-"    * `Point`는 여전히 제네릭이며 `Point<f64>`를 사용할 수도 있지만 이 블록의 메서드는 `Point<u32>`만 쓸 수 있습니다."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
+msgstr "_질문:_ `impl<T> Point<T> {}`에서 `T`가 왜 두 번 사용됩니까?"
 
-#: src/generics/trait-bounds.md:1
-msgid "# Trait Bounds"
-msgstr "# 제네릭 타입 제한(트레잇 경계, Trait Bounds)"
+#: src/generics/methods.md:26
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"제네릭 타입에 대한 제네릭 구현 이기 때문입니다. 이 두 제네릭은 서로 독립적입"
+"니다."
+
+#: src/generics/methods.md:27
+msgid "It means these methods are defined for any `T`."
+msgstr ""
+"이는 임의의 모든 `T`에 대해서 이 메소드들이 정의된다는 것을 의미합니다."
+
+#: src/generics/methods.md:28
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "`impl Point<u32> { .. }`와 같이 작성하는 것도 가능합니다."
+
+#: src/generics/methods.md:29
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"`Point`는 여전히 제네릭이며 `Point<f64>`를 사용할 수도 있지만 이 블록의 메서"
+"드는 `Point<u32>`만 쓸 수 있습니다."
 
 #: src/generics/trait-bounds.md:3
 msgid ""
-"When working with generics, you often want to require the types to implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
-msgstr "제네릭을 이용하다 보면 타입이 어떤 트레잇을 구현하고 있어야 하는 경우가 있습니다. 그래야 그 트레잇의 메서드를 호출할 수 있기 때문입니다."
+msgstr ""
+"제네릭을 이용하다 보면 타입이 어떤 트레잇을 구현하고 있어야 하는 경우가 있습"
+"니다. 그래야 그 트레잇의 메서드를 호출할 수 있기 때문입니다."
 
 #: src/generics/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
@@ -9375,7 +11217,9 @@ msgstr ""
 
 #: src/generics/trait-bounds.md:35
 msgid "Show a `where` clause, students will encounter it when reading code."
-msgstr "`where` 문법을 사용할 수도 있습니다. 수강생들도 코드를 읽다가 그 문법을 마주할 수 있습니다."
+msgstr ""
+"`where` 문법을 사용할 수도 있습니다. 수강생들도 코드를 읽다가 그 문법을 마주"
+"할 수 있습니다."
 
 #: src/generics/trait-bounds.md:37
 msgid ""
@@ -9398,26 +11242,32 @@ msgstr ""
 "```"
 
 #: src/generics/trait-bounds.md:46
-msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":\" can be arbitrary, like `Option<T>`.\n"
-"    "
+msgid "It declutters the function signature if you have many parameters."
 msgstr ""
-"* 이를 이용하면 타입 파라메터가 많은 경우 함수 시그니처를 간결하게 정리하는 데 도움이 됩니다.\n"
-"* 좀 더 강력한 추가 기능도 제공합니다.\n"
-"  * `:` 왼쪽에 임의의 타입(예를 들어 `Option<T>`)을 사용할 수 있습니다.\n"
-"    "
+"이를 이용하면 타입 파라메터가 많은 경우 함수 시그니처를 간결하게 정리하는 데 "
+"도움이 됩니다."
+
+#: src/generics/trait-bounds.md:47
+msgid "It has additional features making it more powerful."
+msgstr "좀 더 강력한 추가 기능도 제공합니다."
+
+#: src/generics/trait-bounds.md:48
+msgid ""
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
+msgstr "`:` 왼쪽에 임의의 타입(예를 들어 `Option<T>`)을 사용할 수 있습니다."
 
 #: src/generics/impl-trait.md:1
-msgid "# `impl Trait`"
-msgstr "# 트레잇 구현하기(`impl Trait`)"
+msgid "`impl Trait`"
+msgstr "트레잇 구현하기(`impl Trait`)"
 
 #: src/generics/impl-trait.md:3
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
-msgstr "트레잇 바운드와 유사하게 `impl Trait` 문법은 함수의 인자와 반환값에도 적용 가능합니다:"
+msgstr ""
+"트레잇 바운드와 유사하게 `impl Trait` 문법은 함수의 인자와 반환값에도 적용 가"
+"능합니다:"
 
 #: src/traits/impl-trait.md:6
 msgid ""
@@ -9448,48 +11298,65 @@ msgstr ""
 "```"
 
 #: src/generics/impl-trait.md:19
-msgid ""
-"* `impl Trait` cannot be used with the `::<>` turbo fish syntax.\n"
-"* `impl Trait` allows you to work with types which you cannot name."
-msgstr ""
-"* `impl Trait`를 터보피쉬문법(`::<>`)과 함께 사용할 수는 없습니다.\n"
-"* `impl Trait`를 이용하면 이름이 없는 타입을 다룰 수 있습니다."
+msgid "`impl Trait` cannot be used with the `::<>` turbo fish syntax."
+msgstr "`impl Trait`를 터보피쉬문법(`::<>`)과 함께 사용할 수는 없습니다."
+
+#: src/generics/impl-trait.md:20
+msgid "`impl Trait` allows you to work with types which you cannot name."
+msgstr "`impl Trait`를 이용하면 이름이 없는 타입을 다룰 수 있습니다."
 
 #: src/generics/impl-trait.md:24
-msgid "The meaning of `impl Trait` is a bit different in the different positions."
+msgid ""
+"The meaning of `impl Trait` is a bit different in the different positions."
 msgstr "`impl Trait`는 어디에 사용되었느냐에 따라 의미가 조금씩 다릅니다."
 
 #: src/generics/impl-trait.md:26
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with a trait bound.\n"
-"* For a return type, it means that the return type is some concrete type that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose the concrete type in a\n"
-"  public API."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
 msgstr ""
-"* 함수 인자의 타입으로 사용되었을 경우에는 `impl Trait`는 트레잇 경계가 있는 익명의 제네릭 타입을 의미합니다.\n"
-"* 리턴 타입으로 사용되었을 경우에는, 그 트레잇을 구현하는 구체적인 타입인데, 타입 이름을 프로그래머가 짓지 않았다는 것을 의미합니다. 이는 그 구체적인 타입 이름을 API로 공개하고 싶지 않은 경우에 유용합니다."
+"함수 인자의 타입으로 사용되었을 경우에는 `impl Trait`는 트레잇 경계가 있는 익"
+"명의 제네릭 타입을 의미합니다."
+
+#: src/generics/impl-trait.md:27
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+"리턴 타입으로 사용되었을 경우에는, 그 트레잇을 구현하는 구체적인 타입인데, 타"
+"입 이름을 프로그래머가 짓지 않았다는 것을 의미합니다. 이는 그 구체적인 타입 "
+"이름을 API로 공개하고 싶지 않은 경우에 유용합니다."
 
 #: src/generics/impl-trait.md:31
 msgid ""
-"This example is great, because it uses `impl Display` twice. It helps to explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` type are the same type.\n"
-"It would not work for this particular function, as the type we expect as input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, we'd need two\n"
-"independent generic parameters."
-msgstr "이 예시는 `impl Display`가 두번 사용 되었다는 점에서 훌륭합니다. 여기서 중요한 것은 이 두 `impl Display`가 실제로 같은 타입일 필요가 없다는 것입니다. 만약 `T: Display`로 트레잇 경계를 정하고 입력 파라메터와 리턴 값의 타입을 모두 `T`로 했다면, 이는 입력과 리턴값이 같은 타입임을 강제합니다. 이렇게 했다면 위의 예제는 동작하지 않았을 것입니다. 왜냐하면, 입력 값의 타입이 `format!`이 리턴하는 타입과 같지 않을 가능성이 높기 때문입니다. 만약 `: Display` 문법을 사용하고 싶다면 독립적인 제네릭 매개변수가 두 개가 필요합니다."
-
-#: src/generics/closures.md:1
-msgid "# Closures"
-msgstr "# 클로저(Closure)"
+"This example is great, because it uses `impl Display` twice. It helps to "
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
+msgstr ""
+"이 예시는 `impl Display`가 두번 사용 되었다는 점에서 훌륭합니다. 여기서 중요"
+"한 것은 이 두 `impl Display`가 실제로 같은 타입일 필요가 없다는 것입니다. 만"
+"약 `T: Display`로 트레잇 경계를 정하고 입력 파라메터와 리턴 값의 타입을 모두 "
+"`T`로 했다면, 이는 입력과 리턴값이 같은 타입임을 강제합니다. 이렇게 했다면 위"
+"의 예제는 동작하지 않았을 것입니다. 왜냐하면, 입력 값의 타입이 `format!`이 리"
+"턴하는 타입과 같지 않을 가능성이 높기 때문입니다. 만약 `: Display` 문법을 사"
+"용하고 싶다면 독립적인 제네릭 매개변수가 두 개가 필요합니다."
 
 #: src/generics/closures.md:3
 msgid ""
-"Closures or lambda expressions have types which cannot be named. However, they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"Closures or lambda expressions have types which cannot be named. However, "
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
-msgstr "클로저 혹은 람다표현식은 익명타입입니다. 이들은 [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) 라는 특별한 트레잇을 구현합니다:"
+msgstr ""
+"클로저 혹은 람다표현식은 익명타입입니다. 이들은 [`Fn`](https://doc.rust-lang."
+"org/std/ops/trait.Fn.html),[`FnMut`](https://doc.rust-lang.org/std/ops/trait."
+"FnMut.html), [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) "
+"라는 특별한 트레잇을 구현합니다:"
 
 #: src/traits/closures.md:8
 msgid ""
@@ -9524,33 +11391,41 @@ msgstr ""
 "```"
 
 #: src/generics/closures.md:25
-msgid "If you have an `FnOnce`, you may only call it once. It might consume captured values."
+msgid ""
+"If you have an `FnOnce`, you may only call it once. It might consume "
+"captured values."
 msgstr "`FnOnce`는 한번만 호출되며 캡처된 값을 소모합니다."
 
 #: src/generics/closures.md:27
-msgid "An `FnMut` might mutate captured values, so you can call it multiple times but not concurrently."
-msgstr "`FnMut`는 캡처된 값을 변경할 수 있으므로 여러번 호출은 가능하지만 동시에 호출 할 수는 없습니다."
+msgid ""
+"An `FnMut` might mutate captured values, so you can call it multiple times "
+"but not concurrently."
+msgstr ""
+"`FnMut`는 캡처된 값을 변경할 수 있으므로 여러번 호출은 가능하지만 동시에 호"
+"출 할 수는 없습니다."
 
 #: src/generics/closures.md:29
 msgid ""
-"An `Fn` neither consumes nor mutates captured values, or perhaps captures nothing at all, so it can\n"
-"be called multiple times concurrently."
-msgstr "`Fn`은 캡처된 값을 소모도 변경도 하지 않고, 혹은 어떤 것도 캡쳐하지 않았을 수도 있기 때문에 동시에 여러번 호출할 수 있습니다."
+"An `Fn` neither consumes nor mutates captured values, or perhaps captures "
+"nothing at all, so it can be called multiple times concurrently."
+msgstr ""
+"`Fn`은 캡처된 값을 소모도 변경도 하지 않고, 혹은 어떤 것도 캡쳐하지 않았을 수"
+"도 있기 때문에 동시에 여러번 호출할 수 있습니다."
 
 #: src/generics/closures.md:32
 msgid ""
-"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever an `FnMut` or `FnOnce`\n"
-"is called for."
-msgstr "`FnMut` 는 `FnOnce`의 하위타입입니다. `Fn`은 `FnMut`과 `FnOnce`의 하위 타입입니다. 즉, `FnMut`는 `FnOnce`가 호출되는 곳이면 어디서나 사용 할 수 있고 `Fn`은 `FnMut`와 `FnOnce`가 호출되는 곳이면 어디든 사용할 수 있습니다."
+"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
+msgstr ""
+"`FnMut` 는 `FnOnce`의 하위타입입니다. `Fn`은 `FnMut`과 `FnOnce`의 하위 타입입"
+"니다. 즉, `FnMut`는 `FnOnce`가 호출되는 곳이면 어디서나 사용 할 수 있고 `Fn`"
+"은 `FnMut`와 `FnOnce`가 호출되는 곳이면 어디든 사용할 수 있습니다."
 
 #: src/generics/closures.md:36
 msgid "`move` closures only implement `FnOnce`."
-msgstr "클로저가 `move`와 함께 선언되었다면 그 클로저는 오직 `FnOnce`만 구현합니다."
-
-#: src/generics/monomorphization.md:1
-msgid "# Monomorphization"
-msgstr "# 단형화(Monomorphization)"
+msgstr ""
+"클로저가 `move`와 함께 선언되었다면 그 클로저는 오직 `FnOnce`만 구현합니다."
 
 #: src/generics/monomorphization.md:3
 msgid "Generic code is turned into non-generic code based on the call sites:"
@@ -9614,24 +11489,26 @@ msgstr ""
 
 #: src/generics/monomorphization.md:31
 msgid ""
-"This is a zero-cost abstraction: you get exactly the same result as if you had\n"
-"hand-coded the data structures without the abstraction."
-msgstr "이것이 바로 비용이 들지 않는 (zero-cost) 추상화 입니다: 러스트의 제네릭은 추상화를 거치지 않고 직접 구체적인 타입을 써서 코딩한 것과 정확히 동일한 결과를 보여줍니다."
-
-#: src/generics/trait-objects.md:1
-msgid "# Trait Objects"
-msgstr "# 트레잇 객체"
+"This is a zero-cost abstraction: you get exactly the same result as if you "
+"had hand-coded the data structures without the abstraction."
+msgstr ""
+"이것이 바로 비용이 들지 않는 (zero-cost) 추상화 입니다: 러스트의 제네릭은 추"
+"상화를 거치지 않고 직접 구체적인 타입을 써서 코딩한 것과 정확히 동일한 결과"
+"를 보여줍니다."
 
 #: src/generics/trait-objects.md:3
 msgid "We've seen how a function can take arguments which implement a trait:"
-msgstr "함수가 특정 트레잇을 구현하는 인자를 입력으로 받도록 하는 방법에 대해 설명했었습니다:"
-
+msgstr ""
+"함수가 특정 트레잇을 구현하는 인자를 입력으로 받도록 하는 방법에 대해 설명했"
+"었습니다:"
 
 #: src/traits/trait-objects.md:3
 msgid ""
 "Trait objects allow for values of different types, for instance in a "
 "collection:"
-msgstr "트레잇 객체는 타입이 다른 값(예를 들어 컬렉션에 속한 각 값)들을 가질 수 있습니다."
+msgstr ""
+"트레잇 객체는 타입이 다른 값(예를 들어 컬렉션에 속한 각 값)들을 가질 수 있습"
+"니다."
 
 #: src/traits/trait-objects.md:5
 msgid ""
@@ -9706,8 +11583,12 @@ msgstr ""
 "```"
 
 #: src/generics/trait-objects.md:18
-msgid "However, how can we store a collection of mixed types which implement `Display`?"
-msgstr "그런데, 아래와 같이 `Display`를 구현하는 서로 다른 타입들의 콜렉션을 저장하고 싶다면 어떻게 해야 할까요?"
+msgid ""
+"However, how can we store a collection of mixed types which implement "
+"`Display`?"
+msgstr ""
+"그런데, 아래와 같이 `Display`를 구현하는 서로 다른 타입들의 콜렉션을 저장하"
+"고 싶다면 어떻게 해야 할까요?"
 
 #: src/generics/trait-objects.md:20
 msgid ""
@@ -9728,7 +11609,8 @@ msgid ""
 "use std::fmt::Display;\n"
 "\n"
 "fn main() {\n"
-"    let xs: Vec<Box<dyn Display>> = vec![Box::new(123), Box::new(\"Hello\")];\n"
+"    let xs: Vec<Box<dyn Display>> = vec![Box::new(123), Box::"
+"new(\"Hello\")];\n"
 "    for x in xs {\n"
 "        println!(\"x: {x}\");\n"
 "    }\n"
@@ -9744,65 +11626,109 @@ msgstr "`xs`가 할당될때 메모리 레이아웃:"
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- - -.\n"
 ":                           :     :                                               :\n"
-":    xs                     :     :                                               :\n"
-":   +-----------+-------+   :     :   +-----+-----+                               :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |                               :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+                               :\n"
-":   | capacity  |     2 |   :     :     | |   | |   +----+----+----+----+----+    :\n"
-":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  |    :\n"
-":                           :     :     | |   |     +----+----+----+----+----+    :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |                                   :\n"
-"                                  :     | |   |     +-------------------------+   :\n"
-"                                  :     | |   '---->| \"<str as Display>::fmt\" |   :\n"
-"                                  :     | |         +-------------------------+   :\n"
-"                                  :     | |                                       :\n"
-"                                  :     | |   +----+----+----+----+               :\n"
-"                                  :     | '-->| 7b | 00 | 00 | 00 |               :\n"
-"                                  :     |     +----+----+----+----+               :\n"
-"                                  :     |                                         :\n"
-"                                  :     |     +-------------------------+         :\n"
-"                                  :     '---->| \"<i32 as Display>::fmt\" |         :\n"
-"                                  :           +-------------------------+         :\n"
+":    "
+"xs                     :     :                                               :\n"
+":   +-----------+-------+   :     :   +-----+-----"
+"+                               :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o "
+"|                               :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-"
+"+                               :\n"
+":   | capacity  |     2 |   :     :     | |   | |   +----+----+----+----+----"
+"+    :\n"
+":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  "
+"|    :\n"
+":                           :     :     | |   |     +----+----+----+----+----"
+"+    :\n"
+"`- - - - - - - - - - - - - -'     :     | |   "
+"|                                   :\n"
+"                                  :     | |   |     "
+"+-------------------------+   :\n"
+"                                  :     | |   '---->| \"<str as Display>::"
+"fmt\" |   :\n"
+"                                  :     | |         "
+"+-------------------------+   :\n"
+"                                  :     | "
+"|                                       :\n"
+"                                  :     | |   +----+----+----+----"
+"+               :\n"
+"                                  :     | '-->| 7b | 00 | 00 | 00 "
+"|               :\n"
+"                                  :     |     +----+----+----+----"
+"+               :\n"
+"                                  :     "
+"|                                         :\n"
+"                                  :     |     +-------------------------"
+"+         :\n"
+"                                  :     '---->| \"<i32 as Display>::fmt\" "
+"|         :\n"
+"                                  :           +-------------------------"
+"+         :\n"
 "                                  :                                               :\n"
 "                                  :                                               :\n"
-"                                  '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- - -'\n"
 "```"
 msgstr ""
 "```bob\n"
 "  스택                               힙\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- - -.\n"
 ":                           :     :                                               :\n"
-":    xs                     :     :                                               :\n"
-":   +-----------+-------+   :     :   +-----+-----+                               :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |                               :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+                               :\n"
-":   | capacity  |     2 |   :     :     | |   | |   +----+----+----+----+----+    :\n"
-":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  |    :\n"
-":                           :     :     | |   |     +----+----+----+----+----+    :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |                                   :\n"
-"                                  :     | |   |     +-------------------------+   :\n"
-"                                  :     | |   '---->| \"<str as Display>::fmt\" |   :\n"
-"                                  :     | |         +-------------------------+   :\n"
-"                                  :     | |                                       :\n"
-"                                  :     | |   +----+----+----+----+               :\n"
-"                                  :     | '-->| 7b | 00 | 00 | 00 |               :\n"
-"                                  :     |     +----+----+----+----+               :\n"
-"                                  :     |                                         :\n"
-"                                  :     |     +-------------------------+         :\n"
-"                                  :     '---->| \"<i32 as Display>::fmt\" |         :\n"
-"                                  :           +-------------------------+         :\n"
+":    "
+"xs                     :     :                                               :\n"
+":   +-----------+-------+   :     :   +-----+-----"
+"+                               :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o "
+"|                               :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-"
+"+                               :\n"
+":   | capacity  |     2 |   :     :     | |   | |   +----+----+----+----+----"
+"+    :\n"
+":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  "
+"|    :\n"
+":                           :     :     | |   |     +----+----+----+----+----"
+"+    :\n"
+"`- - - - - - - - - - - - - -'     :     | |   "
+"|                                   :\n"
+"                                  :     | |   |     "
+"+-------------------------+   :\n"
+"                                  :     | |   '---->| \"<str as Display>::"
+"fmt\" |   :\n"
+"                                  :     | |         "
+"+-------------------------+   :\n"
+"                                  :     | "
+"|                                       :\n"
+"                                  :     | |   +----+----+----+----"
+"+               :\n"
+"                                  :     | '-->| 7b | 00 | 00 | 00 "
+"|               :\n"
+"                                  :     |     +----+----+----+----"
+"+               :\n"
+"                                  :     "
+"|                                         :\n"
+"                                  :     |     +-------------------------"
+"+         :\n"
+"                                  :     '---->| \"<i32 as Display>::fmt\" "
+"|         :\n"
+"                                  :           +-------------------------"
+"+         :\n"
 "                                  :                                               :\n"
 "                                  :                                               :\n"
-"                                  '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- - -'\n"
 "```"
 
 #: src/generics/trait-objects.md:69
 msgid ""
-"Similarly, you need a trait object if you want to return different types\n"
+"Similarly, you need a trait object if you want to return different types "
 "implementing a trait:"
-msgstr "마찬가지로, 같은 트레잇을 구현하는 서로 다른 타입의 값을 리턴할 때에도 트레잇 객체가 필요합니다:"
+msgstr ""
+"마찬가지로, 같은 트레잇을 구현하는 서로 다른 타입의 값을 리턴할 때에도 트레"
+"잇 객체가 필요합니다:"
 
 #: src/generics/trait-objects.md:72
 msgid ""
@@ -9824,37 +11750,43 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
-msgid "# Day 3: Morning Exercises"
-msgstr "# 3일차 오전 연습문제"
+msgid "Day 3: Morning Exercises"
+msgstr "3일차 오전 연습문제"
 
 #: src/exercises/day-3/morning.md:3
 msgid "We will design a classical GUI library traits and trait objects."
-msgstr "이번 연습문제에서는 트레잇와 트레잇 객체를 통해 고전적인 GUI 라이브러리를 설계할 것입니다."
-
-#: src/exercises/day-3/simple-gui.md:1
-msgid "# A Simple GUI Library"
-msgstr "# 간단한 GUI 라이브러리"
+msgstr ""
+"이번 연습문제에서는 트레잇와 트레잇 객체를 통해 고전적인 GUI 라이브러리를 설"
+"계할 것입니다."
 
 #: src/exercises/day-3/simple-gui.md:3
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
-msgstr "이번 연습문제에서는 트레잇와 트레잇 객체에 대해 배운것을 활용하여 고전적인 GUI 라이브러리를 설계할 것입니다."
+msgstr ""
+"이번 연습문제에서는 트레잇와 트레잇 객체에 대해 배운것을 활용하여 고전적인 "
+"GUI 라이브러리를 설계할 것입니다."
 
 #: src/exercises/day-3/simple-gui.md:6
 msgid "We will have a number of widgets in our library:"
 msgstr "라이브러리에는 몇 가지 위젯이 있습니다:"
 
 #: src/exercises/day-3/simple-gui.md:8
-msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+msgid "`Window`: has a `title` and contains other widgets."
 msgstr ""
-"* `Window`: `title` 속성을 가지고 있으며, 다른 위젯들을 포함할 수 있습니다.\n"
-"* `Button`: `label` 속성을 가지고 있으며, 버튼이 눌렸을때 실행되는 콜백 함수가 있습니다.\n"
-"* `Label`: `label` 속성을 가지고 있습니다."
+"`Window`: `title` 속성을 가지고 있으며, 다른 위젯들을 포함할 수 있습니다."
+
+#: src/exercises/day-3/simple-gui.md:9
+msgid ""
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
+msgstr ""
+"`Button`: `label` 속성을 가지고 있으며, 버튼이 눌렸을때 실행되는 콜백 함수가 "
+"있습니다."
+
+#: src/exercises/day-3/simple-gui.md:11
+msgid "`Label`: has a `label`."
+msgstr "`Label`: `label` 속성을 가지고 있습니다."
 
 #: src/exercises/day-3/simple-gui.md:13
 msgid "The widgets will implement a `Widget` trait, see below."
@@ -9862,9 +11794,11 @@ msgstr "위젯들은 모두 `Widget` 트레잇을 구현합니다. 아래 코드
 
 #: src/exercises/day-3/simple-gui.md:15
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
-msgstr "아래 코드를 <https://play.rust-lang.org/>에 복사하고 누락된 `draw_into`메서드를 채워 넣어 `Widget` 트레잇을 완성해봅시다:"
+msgstr ""
+"아래 코드를 <https://play.rust-lang.org/>에 복사하고 누락된 `draw_into`메서드"
+"를 채워 넣어 `Widget` 트레잇을 완성해봅시다:"
 
 #: src/exercises/day-3/simple-gui.md:18
 msgid ""
@@ -9964,7 +11898,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\",\n"
 "        Box::new(|| println!(\"You clicked the button!\")),\n"
@@ -9993,11 +11928,14 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:135
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
-msgstr "텍스트를 줄맞춤 해서 그리려면 [fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)를 참조하시기 바랍니다. 특수 문자(여기서는 `'/'`)로 패딩을 주는 방법과 정렬을 제어하는 방법을 확인하시기 바랍니다:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
+msgstr ""
+"텍스트를 줄맞춤 해서 그리려면 [fill/alignment](https://doc.rust-lang.org/std/"
+"fmt/index.html#fillalignment)를 참조하시기 바랍니다. 특수 문자(여기서는 "
+"`'/'`)로 패딩을 주는 방법과 정렬을 제어하는 방법을 확인하시기 바랍니다:"
 
 #: src/exercises/day-3/simple-gui.md:140
 msgid ""
@@ -10012,7 +11950,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:149
-msgid "Using such alignment tricks, you can for example produce output like this:"
+msgid ""
+"Using such alignment tricks, you can for example produce output like this:"
 msgstr "위의 정렬 트릭을 사용하여 다음과 같은 출력을 생성할 수 있습니다:"
 
 #: src/exercises/day-3/simple-gui.md:151
@@ -10029,25 +11968,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-msgid "# Error Handling"
-msgstr "# 오류처리"
-
 #: src/error-handling.md:3
 msgid "Error handling in Rust is done using explicit control flow:"
 msgstr "러스트에서 오류는 명시적인 흐름을 따라 처리가 됩니다:"
 
 #: src/error-handling.md:5
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
-msgstr ""
-"* 오류를 발생할 수 있는 함수는 반환 타입에 이를 명시해야 합니다.\n"
-"* 예외(exception) 기능은 없습니다."
+msgid "Functions that can have errors list this in their return type,"
+msgstr "오류를 발생할 수 있는 함수는 반환 타입에 이를 명시해야 합니다."
 
-#: src/error-handling/panics.md:1
-msgid "# Panics"
-msgstr "# 패닉"
+#: src/error-handling.md:6
+msgid "There are no exceptions."
+msgstr "예외(exception) 기능은 없습니다."
 
 #: src/error-handling/panics.md:3
 msgid "Rust will trigger a panic if a fatal error happens at runtime:"
@@ -10070,22 +12001,31 @@ msgstr ""
 "```"
 
 #: src/error-handling/panics.md:12
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "패닉은 복구할 수 없고 예상치 못한 오류입니다."
+
+#: src/error-handling/panics.md:13
+msgid "Panics are symptoms of bugs in the program."
+msgstr "패닉은 프로그램에 버그가 있다는 것을 나타냅니다."
+
+#: src/error-handling/panics.md:14
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
-"* 패닉은 복구할 수 없고 예상치 못한 오류입니다.\n"
-"  * 패닉은 프로그램에 버그가 있다는 것을 나타냅니다.\n"
-"* 충돌(크래시)을 허용하지 않아야 하는 경우, 패닉을 유발하지 않는 API(`Vec::get`등)를 사용하면 됩니다."
+"충돌(크래시)을 허용하지 않아야 하는 경우, 패닉을 유발하지 않는 API(`Vec::get`"
+"등)를 사용하면 됩니다."
 
 #: src/error-handling/panic-unwind.md:1
-msgid "# Catching the Stack Unwinding"
-msgstr "# 스택 되감기"
+msgid "Catching the Stack Unwinding"
+msgstr "스택 되감기"
 
 #: src/error-handling/panic-unwind.md:3
-msgid "By default, a panic will cause the stack to unwind. The unwinding can be caught:"
-msgstr "기본적으로, 패닉이 발생하면 스택 되감기를 합니다. 스택 되감기는 다음과 같이 캐치가 가능합니다:"
+msgid ""
+"By default, a panic will cause the stack to unwind. The unwinding can be "
+"caught:"
+msgstr ""
+"기본적으로, 패닉이 발생하면 스택 되감기를 합니다. 스택 되감기는 다음과 같이 "
+"캐치가 가능합니다:"
 
 #: src/error-handling/panic-unwind.md:5
 msgid ""
@@ -10136,22 +12076,29 @@ msgstr ""
 
 #: src/error-handling/panic-unwind.md:19
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* 이것은 단일 요청이 크래시 되더라도 프로그램이 계속 실행되야 하는 서버에 유용합니다.\n"
-"* 만약 `Cargo.toml`설정파일에 `panic = abort`을 설정했다면 크래시를 캐치할 수 없습니다."
+"이것은 단일 요청이 크래시 되더라도 프로그램이 계속 실행되야 하는 서버에 유용"
+"합니다."
+
+#: src/error-handling/panic-unwind.md:21
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+"만약 `Cargo.toml`설정파일에 `panic = abort`을 설정했다면 크래시를 캐치할 수 "
+"없습니다."
 
 #: src/error-handling/result.md:1
-msgid "# Structured Error Handling with `Result`"
-msgstr "# `Result`를 이용한 구조화된 오류처리"
+msgid "Structured Error Handling with `Result`"
+msgstr "`Result`를 이용한 구조화된 오류처리"
 
 #: src/error-handling/result.md:3
 msgid ""
-"We have already seen the `Result` enum. This is used pervasively when errors are\n"
-"expected as part of normal operation:"
-msgstr "여러분은 이미 `Result` 열거형을 몇 번 봤습니다. 이 타입은 프로그램의 정상적인 수행 중에 발생할 수 있는 오류값들을 나타내기 위해 사용됩니다:"
+"We have already seen the `Result` enum. This is used pervasively when errors "
+"are expected as part of normal operation:"
+msgstr ""
+"여러분은 이미 `Result` 열거형을 몇 번 봤습니다. 이 타입은 프로그램의 정상적"
+"인 수행 중에 발생할 수 있는 오류값들을 나타내기 위해 사용됩니다:"
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10217,26 +12164,37 @@ msgstr ""
 
 #: src/error-handling/result.md:27
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
 msgstr ""
-"  * `Option`와 마찬가지로, 성공한 경우의 값은 `Result` 내부에 있습니다. 그래서, 개발자는 명시적으로 이를 추출하여야 합니다. 이렇게 함으로써 값을 읽기 전에 오류 발생 여부를 반드시 체크하도록 유도하고 있습니다. 만일 오류가 절대 발생하지 않는 경우라면 `unwrap()`이나 `expect()`를 사용할 수 있으며, 이는 개발자의 의도(_역주_: 오류가 발생할 수 없음)을 명시적으로 나타내는 방법이기도 합니다.\n"
-"  * 수업중엔 아니지만 `Result`의 API 레퍼런스를 읽는 것을 권장합니다. 함수형 프로그래밍 스타일에 도움이 되는 편리한 메서드와 함수를 많이 배울 수 있습니다.\n"
-"    "
+"`Option`와 마찬가지로, 성공한 경우의 값은 `Result` 내부에 있습니다. 그래서, "
+"개발자는 명시적으로 이를 추출하여야 합니다. 이렇게 함으로써 값을 읽기 전에 오"
+"류 발생 여부를 반드시 체크하도록 유도하고 있습니다. 만일 오류가 절대 발생하"
+"지 않는 경우라면 `unwrap()`이나 `expect()`를 사용할 수 있으며, 이는 개발자의 "
+"의도(_역주_: 오류가 발생할 수 없음)을 명시적으로 나타내는 방법이기도 합니다."
+
+#: src/error-handling/result.md:30
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr ""
+"수업중엔 아니지만 `Result`의 API 레퍼런스를 읽는 것을 권장합니다. 함수형 프로"
+"그래밍 스타일에 도움이 되는 편리한 메서드와 함수를 많이 배울 수 있습니다."
 
 #: src/error-handling/try-operator.md:1
-msgid "# Propagating Errors with `?`"
-msgstr "# `?`를 이용한 오류 전파"
+msgid "Propagating Errors with `?`"
+msgstr "`?`를 이용한 오류 전파"
 
 #: src/error-handling/try-operator.md:3
 msgid ""
-"The try-operator `?` is used to return errors to the caller. It lets you turn\n"
-"the common"
-msgstr "연산자 `?`는 호출자에게 오류를 반환할 때 사용합니다. 이를 이용하면 이런 코드를"
+"The try-operator `?` is used to return errors to the caller. It lets you "
+"turn the common"
+msgstr ""
+"연산자 `?`는 호출자에게 오류를 반환할 때 사용합니다. 이를 이용하면 이런 코드"
+"를"
 
 #: src/error-handling/try-operator.md:6
 msgid ""
@@ -10304,20 +12262,22 @@ msgstr ""
 
 #: src/error-handling/try-operator.md:52
 #: src/error-handling/converting-error-types-example.md:52
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, empty file, file with username."
-msgstr ""
-"* `username` 변수는 `Ok(string)`이거나 `Err(error)`일 수 있습니다.\n"
-"* `fs::write` 메서드를 사용하여 파일이 없거나, 비었거나, 중복되는 경우 등을 테스트해 봅니다."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr "`username` 변수는 `Ok(string)`이거나 `Err(error)`일 수 있습니다."
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-msgid "# Converting Error Types"
-msgstr "# 에러 타입이 다를 경우"
+#: src/error-handling/try-operator.md:53
+#: src/error-handling/converting-error-types-example.md:53
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
+"`fs::write` 메서드를 사용하여 파일이 없거나, 비었거나, 중복되는 경우 등을 테"
+"스트해 봅니다."
 
 #: src/error-handling/converting-error-types.md:3
-msgid "The effective expansion of `?` is a little more complicated than previously indicated:"
+msgid ""
+"The effective expansion of `?` is a little more complicated than previously "
+"indicated:"
 msgstr "실제로 `?`가 적용되는 과정은 아까 설명한 것 보다 좀 더 복잡합니다:"
 
 #: src/error-handling/converting-error-types.md:5
@@ -10352,9 +12312,11 @@ msgstr ""
 
 #: src/error-handling/converting-error-types.md:18
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
-msgstr "`From::from`을 통해 원래의 에러 타입을 이 함수가 반환하는 에러 타입으로 변환하고 있습니다:"
+msgstr ""
+"`From::from`을 통해 원래의 에러 타입을 이 함수가 반환하는 에러 타입으로 변환"
+"하고 있습니다:"
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -10376,7 +12338,8 @@ msgid ""
 "    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
 "        match self {\n"
 "            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Found no username in {}\", filename),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
+"in {}\", filename),\n"
 "        }\n"
 "    }\n"
 "}\n"
@@ -10500,21 +12463,25 @@ msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:55
 msgid ""
-"It is good practice for all error types to implement `std::error::Error`, which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't easily do so, because\n"
+"It is good practice for all error types to implement `std::error::Error`, "
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
-msgstr "에러 타입이 `std::error::Error`를 구현하도록 하는 것은 좋은 습관입니다. 그러면 `Debug`와 `Display` 트레잇 또한 구현을 해야 합니다. 가능하다면 `Clone`과 `Eq` 트레잇도 구현하도록 하세요. 여러분의 라이브러리가 테스트 하기 쉬워지고, 사용하기 좋아질 겁니다. 다만, 이 예제에서는 그렇게 하기 힘듭니다. 왜냐하면 `io::Error`는 이 트레잇들을 구현하고 있지 않기 때문입니다."
-
-#: src/error-handling/deriving-error-enums.md:1
-msgid "# Deriving Error Enums"
-msgstr "# 또다른 오류 열거형"
+msgstr ""
+"에러 타입이 `std::error::Error`를 구현하도록 하는 것은 좋은 습관입니다. 그러"
+"면 `Debug`와 `Display` 트레잇 또한 구현을 해야 합니다. 가능하다면 `Clone`과 "
+"`Eq` 트레잇도 구현하도록 하세요. 여러분의 라이브러리가 테스트 하기 쉬워지고, "
+"사용하기 좋아질 겁니다. 다만, 이 예제에서는 그렇게 하기 힘듭니다. 왜냐하면 "
+"`io::Error`는 이 트레잇들을 구현하고 있지 않기 때문입니다."
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
-"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create an\n"
-"error enum like we did on the previous page:"
-msgstr "[thiserror](https://docs.rs/thiserror/)는, 이전 페이지에서 보았던 것과 같은 에러 열거형을 쉽게 만들 수 있게 해 주는 유명한 크레이트 입니다:"
+"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
+"an error enum like we did on the previous page:"
+msgstr ""
+"[thiserror](https://docs.rs/thiserror/)는, 이전 페이지에서 보았던 것과 같은 "
+"에러 열거형을 쉽게 만들 수 있게 해 주는 유명한 크레이트 입니다:"
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -10582,24 +12549,30 @@ msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:39
 msgid ""
-"`thiserror`'s derive macro automatically implements `std::error::Error`, and optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the `#[from]` attribute is added).\n"
-"It also works for structs."
-msgstr "`thiserror`의 derive 매크로를 이용하면 `std::error::Error`과 `Display`(만약 `#[error(...)]` 어트리뷰트를 추가했을 경우), `From`(만약 `#[from]` 어트리뷰트를 추가했을 경우) 트레잇들이 자동으로 구현이 됩니다. 구조체에 대해서도 사용 가능합니다."
+"`thiserror`'s derive macro automatically implements `std::error::Error`, and "
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
+msgstr ""
+"`thiserror`의 derive 매크로를 이용하면 `std::error::Error`과 `Display`(만약 "
+"`#[error(...)]` 어트리뷰트를 추가했을 경우), `From`(만약 `#[from]` 어트리뷰트"
+"를 추가했을 경우) 트레잇들이 자동으로 구현이 됩니다. 구조체에 대해서도 사용 "
+"가능합니다."
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
-msgstr "이 매크로를 사용해도 밖으로 노출되는 API가 변경되지는 않습니다. 라이브러리를 만들 경우에는 이게 중요하죠."
-
-#: src/error-handling/dynamic-errors.md:1
-msgid "# Dynamic Error Types"
-msgstr "# 동적인 에러 타입"
+msgstr ""
+"이 매크로를 사용해도 밖으로 노출되는 API가 변경되지는 않습니다. 라이브러리를 "
+"만들 경우에는 이게 중요하죠."
 
 #: src/error-handling/dynamic-errors.md:3
 msgid ""
-"Sometimes we want to allow any type of error to be returned without writing our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
-msgstr "때때로 우리는, 발생 가능한 모든 에러를 일일히 열거하지 않고, 어떤 종류의 에러라도 상관없이 리턴하고 싶을 때가 있습니다. `std::error::Error`를 이용하면 쉽습니다."
+"Sometimes we want to allow any type of error to be returned without writing "
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
+msgstr ""
+"때때로 우리는, 발생 가능한 모든 에러를 일일히 열거하지 않고, 어떤 종류의 에러"
+"라도 상관없이 리턴하고 싶을 때가 있습니다. `std::error::Error`를 이용하면 쉽"
+"습니다."
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -10661,22 +12634,26 @@ msgstr ""
 
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
-"This saves on code, but gives up the ability to cleanly handle different error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` in the public API of a\n"
-"library, but it can be a good option in a program where you just want to display the error message\n"
+"This saves on code, but gives up the ability to cleanly handle different "
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
-msgstr "이렇게 하면 코드의 양을 줄일 수 있습니다. 그러나 서로 다른 종류의 에러를 구별하여 다르게 처리하는 것이 불가능해 집니다. 때문에, `Box<dyn Error>`를 라이브러리의 API로 노출하는게 좋은 디자인은 아닙니다. 에러 발생 시, 그저 에러 메시지를 출력하고 싶은 경우와 같이 제한된 상황에서는 유용할 수 있습니다."
-
-#: src/error-handling/error-contexts.md:1
-msgid "# Adding Context to Errors"
-msgstr "# 오류에 문맥 추가"
+msgstr ""
+"이렇게 하면 코드의 양을 줄일 수 있습니다. 그러나 서로 다른 종류의 에러를 구별"
+"하여 다르게 처리하는 것이 불가능해 집니다. 때문에, `Box<dyn Error>`를 라이브"
+"러리의 API로 노출하는게 좋은 디자인은 아닙니다. 에러 발생 시, 그저 에러 메시"
+"지를 출력하고 싶은 경우와 같이 제한된 상황에서는 유용할 수 있습니다."
 
 #: src/error-handling/error-contexts.md:3
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
-msgstr "[anyhow](https://docs.rs/anyhow/) 크레이트는 에러에 에러가 발생한 문맥에 대한 정보를 추가하기 위해 널리 사용되며, 이를 이용하면 서로 다른 문맥을 나타내기 사용자 정의 오류 타입을 많이 만들어야 하는 불편함을 피할 수 있습니다:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
+msgstr ""
+"[anyhow](https://docs.rs/anyhow/) 크레이트는 에러에 에러가 발생한 문맥에 대"
+"한 정보를 추가하기 위해 널리 사용되며, 이를 이용하면 서로 다른 문맥을 나타내"
+"기 사용자 정의 오류 타입을 많이 만들어야 하는 불편함을 피할 수 있습니다:"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -10733,40 +12710,49 @@ msgstr ""
 "```"
 
 #: src/error-handling/error-contexts.md:35
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in applications.\n"
-"* Actual error type inside of it can be extracted for examination if necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
-"* `anyhow::Result<V>`는 `Result<V, anyhow::Error>`의 타입 앨리어스(alias)입니다.\n"
-"* `anyhow::Error`는 `Box<dyn Error>`의 래퍼 타입이라 할 수 있습니다. 따라서 라이브러리의 공개 API로서 사용하기에 부적합하다고 할 수 있지만 많은 애플리케이션에 널리 사용되고 있습니다.\n"
-"* 필요하다면 `anyhow::Error`에 저장된 진짜 에러 타입을 꺼내어 검사할 수도 있습니다.\n"
-"* `anyhow::Result<T>`가 제공하는 기능들이 Go 언어 개발자들에게는 익숙할 것입니다. Go언어에서 반환 값으로 사용하는 `(T, error)` 패턴과 비슷하기 때문입니다."
+"`anyhow::Result<V>`는 `Result<V, anyhow::Error>`의 타입 앨리어스(alias)입니"
+"다."
 
-#: src/testing.md:1
-msgid "# Testing"
-msgstr "# 테스팅"
+#: src/error-handling/error-contexts.md:36
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+"`anyhow::Error`는 `Box<dyn Error>`의 래퍼 타입이라 할 수 있습니다. 따라서 라"
+"이브러리의 공개 API로서 사용하기에 부적합하다고 할 수 있지만 많은 애플리케이"
+"션에 널리 사용되고 있습니다."
+
+#: src/error-handling/error-contexts.md:38
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+"필요하다면 `anyhow::Error`에 저장된 진짜 에러 타입을 꺼내어 검사할 수도 있습"
+"니다."
+
+#: src/error-handling/error-contexts.md:39
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"`anyhow::Result<T>`가 제공하는 기능들이 Go 언어 개발자들에게는 익숙할 것입니"
+"다. Go언어에서 반환 값으로 사용하는 `(T, error)` 패턴과 비슷하기 때문입니다."
 
 #: src/testing.md:3
 msgid "Rust and Cargo come with a simple unit test framework:"
-msgstr "러스트와 카고(cargo)는 간단한 단위 테스트 프레임워크와 함께 제공됩니다:"
+msgstr ""
+"러스트와 카고(cargo)는 간단한 단위 테스트 프레임워크와 함께 제공됩니다:"
 
 #: src/testing.md:5
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
-msgstr ""
-"* 단위 테스트는 코드 전반에서 지원됩니다.\n"
-"\n"
-"* 통합 테스트는 `tests/` 디렉터리를 통해 지원됩니다."
+msgid "Unit tests are supported throughout your code."
+msgstr "단위 테스트는 코드 전반에서 지원됩니다."
 
-#: src/testing/unit-tests.md:1
-msgid "# Unit Tests"
-msgstr "# 단위 테스트"
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr "통합 테스트는 `tests/` 디렉터리를 통해 지원됩니다."
 
 #: src/testing/unit-tests.md:3
 msgid "Mark unit tests with `#[test]`:"
@@ -10854,8 +12840,8 @@ msgstr ""
 "```"
 
 #: src/testing/useful-crates.md:1
-msgid "## Useful crates for writing tests"
-msgstr "## 테스트 작성에 유용한 크레이트"
+msgid "Useful crates for writing tests"
+msgstr "테스트 작성에 유용한 크레이트"
 
 #: src/testing/useful-crates.md:5
 msgid "Here are some additional crates which we recommend for writing tests:"
@@ -10863,26 +12849,30 @@ msgstr "다음은 테스트를 작성할 때 권장되는 추가 크레이트입
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
+msgstr ""
+"[googletest](https://docs.rs/googletest): C++용 GoogleTest의 방식을 따르는 테"
+"스트 라이브러리 입니다."
+
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr "[proptest](https://docs.rs/proptest): Rust용 속성 기반 테스트입니다."
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
 "tests."
 msgstr ""
-"* [googletest](https://docs.rs/googletest): C++용 GoogleTest의 방식을 따르는 테스트 라이브러리 입니다.\n"
-"* [proptest](https://docs.rs/proptest): Rust용 속성 기반 테스트입니다.\n"
-"* [rstest](https://docs.rs/rstest): 픽스처 및 매개변수화된 테스트를 지원합니"
-"다."
-
-#: src/testing/test-modules.md:1
-msgid "# Test Modules"
-msgstr "# 테스트 모듈"
+"[rstest](https://docs.rs/rstest): 픽스처 및 매개변수화된 테스트를 지원합니다."
 
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
-msgstr "단위 테스트는 원래 모듈 밑에 서브 모듈로 만드는 경우가 많습니다. ([플레이그라운드](https://play.rust-lang.org/)에서 다음 테스트를 수행해 보세요):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
+msgstr ""
+"단위 테스트는 원래 모듈 밑에 서브 모듈로 만드는 경우가 많습니다. ([플레이그라"
+"운드](https://play.rust-lang.org/)에서 다음 테스트를 수행해 보세요):"
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -10927,16 +12917,16 @@ msgstr ""
 "```"
 
 #: src/testing/test-modules.md:26
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgid "This lets you unit test private helpers."
 msgstr ""
-"* 이렇게 서브 모듈로 테스트를 만들면 private한 헬퍼 함수에 대한 단위 테스트도 가능합니다.\n"
-"* `#[cfg(test)]` 어트리뷰트가 추가된 항목은 `cargo test`를 수행했을 경우에만 동작합니다."
+"이렇게 서브 모듈로 테스트를 만들면 private한 헬퍼 함수에 대한 단위 테스트도 "
+"가능합니다."
 
-#: src/testing/doc-tests.md:1
-msgid "# Documentation Tests"
-msgstr "# 문서화주석 테스트"
+#: src/testing/test-modules.md:27
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr ""
+"`#[cfg(test)]` 어트리뷰트가 추가된 항목은 `cargo test`를 수행했을 경우에만 동"
+"작합니다."
 
 #: src/testing/doc-tests.md:3
 msgid "Rust has built-in support for documentation tests:"
@@ -10971,18 +12961,21 @@ msgstr ""
 "```"
 
 #: src/testing/doc-tests.md:18
-msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
-msgstr ""
-"* `///` 주석안의 코드 블록은 자동으로 러스트 코드로 인식됩니다.\n"
-"* 이 코드 블록은 `cargo test` 호출하면 자동으로 컴파일되고 실행됩니다.\n"
-"* 위 코드를 [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)에서 테스트 해 보시기 바랍니다."
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr "`///` 주석안의 코드 블록은 자동으로 러스트 코드로 인식됩니다."
 
-#: src/testing/integration-tests.md:1
-msgid "# Integration Tests"
-msgstr "# 통합 테스트"
+#: src/testing/doc-tests.md:19
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "이 코드 블록은 `cargo test` 호출하면 자동으로 컴파일되고 실행됩니다."
+
+#: src/testing/doc-tests.md:20
+msgid ""
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgstr ""
+"위 코드를 [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)"
+"에서 테스트 해 보시기 바랍니다."
 
 #: src/testing/integration-tests.md:3
 msgid "If you want to test your library as a client, use an integration test."
@@ -11016,73 +13009,92 @@ msgstr ""
 msgid "These tests only have access to the public API of your crate."
 msgstr "이 테스트는 크레이트의 공개 API에만 접근할 수 있습니다."
 
-#: src/unsafe.md:1
-msgid "# Unsafe Rust"
-msgstr "# 안전하지 않은 러스트"
-
 #: src/unsafe.md:3
 msgid "The Rust language has two parts:"
 msgstr "러스트로 작성된 프로그램은 크게 두 부분으로 나뉩니다:"
 
 #: src/unsafe.md:5
-msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are violated."
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
 msgstr ""
-"* **안전한 러스트:** 메모리 관련 오류 발생 불가능, 정의되지 않은 동작 없음.\n"
-"* **안전하지 않은 러스트:** 특별한 조건을 만족하지 않은채로 사용되면 정의되지 않은 동작을 유발할 수 있음."
+"**안전한 러스트:** 메모리 관련 오류 발생 불가능, 정의되지 않은 동작 없음."
+
+#: src/unsafe.md:6
+msgid ""
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"violated."
+msgstr ""
+"**안전하지 않은 러스트:** 특별한 조건을 만족하지 않은채로 사용되면 정의되지 "
+"않은 동작을 유발할 수 있음."
 
 #: src/unsafe.md:8
 msgid ""
-"We will be seeing mostly safe Rust in this course, but it's important to know\n"
-"what Unsafe Rust is."
-msgstr "이 강의는 대부분 안전한 러스트에 대해 다루지만 안전하지 않은 러스트가 무엇인지는 알아 두어야 합니다."
+"We will be seeing mostly safe Rust in this course, but it's important to "
+"know what Unsafe Rust is."
+msgstr ""
+"이 강의는 대부분 안전한 러스트에 대해 다루지만 안전하지 않은 러스트가 무엇인"
+"지는 알아 두어야 합니다."
 
 #: src/unsafe.md:11
 msgid ""
-"Unsafe code is usually small and isolated, and its correctness should be carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
-msgstr "보통, 안전하지 않은 러스트 코드는 크기가 작으며, 독립적으로 존재합니다. 그리고 코드가 왜 잘 작동하는지에 대해 세밀하게 문서화가 되어 있습니다. 그리고, 많은 경우 안전한 러스트 코드를 통해서 추상화를 시킨 후 사용하게 됩니다."
+"Unsafe code is usually small and isolated, and its correctness should be "
+"carefully documented. It is usually wrapped in a safe abstraction layer."
+msgstr ""
+"보통, 안전하지 않은 러스트 코드는 크기가 작으며, 독립적으로 존재합니다. 그리"
+"고 코드가 왜 잘 작동하는지에 대해 세밀하게 문서화가 되어 있습니다. 그리고, 많"
+"은 경우 안전한 러스트 코드를 통해서 추상화를 시킨 후 사용하게 됩니다."
 
 #: src/unsafe.md:14
 msgid "Unsafe Rust gives you access to five new capabilities:"
-msgstr "안전하지 않은 러스트를 이용하면 다음과 같은 다섯 가지 것들이 가능해 집니다:"
+msgstr ""
+"안전하지 않은 러스트를 이용하면 다음과 같은 다섯 가지 것들이 가능해 집니다:"
 
 #: src/unsafe.md:16
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
-msgstr ""
-"* 원시 포인터 역참조(따라가기)\n"
-"* 정적 가변변수 접근 및 수정\n"
-"* `union` 필드 접근\n"
-"* `extern` 함수를 포함한 `unsafe` 함수 호출\n"
-"* `unsafe` 트레잇 구현."
+msgid "Dereference raw pointers."
+msgstr "원시 포인터 역참조(따라가기)"
+
+#: src/unsafe.md:17
+msgid "Access or modify mutable static variables."
+msgstr "정적 가변변수 접근 및 수정"
+
+#: src/unsafe.md:18
+msgid "Access `union` fields."
+msgstr "`union` 필드 접근"
+
+#: src/unsafe.md:19
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr "`extern` 함수를 포함한 `unsafe` 함수 호출"
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
+msgstr "`unsafe` 트레잇 구현."
 
 #: src/unsafe.md:22
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please see\n"
-"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
-msgstr "위 기능들에 대해 간략히 살펴보겠습니다. 자세한 내용은 [러스트 프로그래밍 언어, 19.1절](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)과 [Rustonomicon](https://doc.rust-lang.org/nomicon/)를 참조하세요."
+"We will briefly cover unsafe capabilities next. For full details, please see "
+"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+msgstr ""
+"위 기능들에 대해 간략히 살펴보겠습니다. 자세한 내용은 [러스트 프로그래밍 언"
+"어, 19.1절](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)과 "
+"[Rustonomicon](https://doc.rust-lang.org/nomicon/)를 참조하세요."
 
 #: src/unsafe.md:28
 msgid ""
-"Unsafe Rust does not mean the code is incorrect. It means that developers have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety rules."
-msgstr "안전하지 않은 러스트라고 해서 코드가 부정확 하다는 뜻은 아닙니다. 여기서 안전하지 않다의 의미는 컴파일러가 제공해주는 안전 장치들이 꺼진 상태이며, 개발자가 스스로 정확하고 안전한 코드를 작성해야 함을 의미합니다. 이는 컴파일러가 더 이상 러스트의 메모리 안전과 관련된 규칙들을 적용하지 않는다는 것입니다."
-
-#: src/unsafe/raw-pointers.md:1
-msgid "# Dereferencing Raw Pointers"
-msgstr "# 원시 포인터 역참조(따라가기)"
+"Unsafe Rust does not mean the code is incorrect. It means that developers "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
+"rules."
+msgstr ""
+"안전하지 않은 러스트라고 해서 코드가 부정확 하다는 뜻은 아닙니다. 여기서 안전"
+"하지 않다의 의미는 컴파일러가 제공해주는 안전 장치들이 꺼진 상태이며, 개발자"
+"가 스스로 정확하고 안전한 코드를 작성해야 함을 의미합니다. 이는 컴파일러가 "
+"더 이상 러스트의 메모리 안전과 관련된 규칙들을 적용하지 않는다는 것입니다."
 
 #: src/unsafe/raw-pointers.md:3
 msgid "Creating pointers is safe, but dereferencing them requires `unsafe`:"
-msgstr "포인터를 만드는 것은 안전합니다. 하지만 역참조(따라가기)할 경우 `unsafe`가 필요합니다:"
+msgstr ""
+"포인터를 만드는 것은 안전합니다. 하지만 역참조(따라가기)할 경우 `unsafe`가 필"
+"요합니다:"
 
 #: src/unsafe/raw-pointers.md:5
 msgid ""
@@ -11093,9 +13105,12 @@ msgid ""
 "    let r1 = &mut num as *mut i32;\n"
 "    let r2 = r1 as *const i32;\n"
 "\n"
-"    // Safe because r1 and r2 were obtained from references and so are guaranteed to be non-null and\n"
-"    // properly aligned, the objects underlying the references from which they were obtained are\n"
-"    // live throughout the whole unsafe block, and they are not accessed either through the\n"
+"    // Safe because r1 and r2 were obtained from references and so are "
+"guaranteed to be non-null and\n"
+"    // properly aligned, the objects underlying the references from which "
+"they were obtained are\n"
+"    // live throughout the whole unsafe block, and they are not accessed "
+"either through the\n"
 "    // references or concurrently through any other pointers.\n"
 "    unsafe {\n"
 "        println!(\"r1 is: {}\", *r1);\n"
@@ -11112,9 +13127,12 @@ msgstr ""
 "    let r1 = &mut num as *mut i32;\n"
 "    let r2 = r1 as *const i32;\n"
 "\n"
-"    // 아래 코드는 안전합니다. r1과 r2는 참조로 부터 만들어 졌기 때문에 null이 아니며\n"
-"    // align이 맞다는 것이 보장됩니다. 참조가 가리키는 객체들은 unsafe 블럭이 수행되는\n"
-"    // 동안 메모리에 살아있습니다. 그리고 이 객체들은 r1과 r2가 아닌 다른 어떤 참조나\n"
+"    // 아래 코드는 안전합니다. r1과 r2는 참조로 부터 만들어 졌기 때문에 null"
+"이 아니며\n"
+"    // align이 맞다는 것이 보장됩니다. 참조가 가리키는 객체들은 unsafe 블럭"
+"이 수행되는\n"
+"    // 동안 메모리에 살아있습니다. 그리고 이 객체들은 r1과 r2가 아닌 다른 어"
+"떤 참조나\n"
 "    // 포인터로도 접근이 안되고 있습니다.\n"
 "    unsafe {\n"
 "        println!(\"r1 is: {}\", *r1);\n"
@@ -11126,39 +13144,53 @@ msgstr ""
 
 #: src/unsafe/raw-pointers.md:26
 msgid ""
-"It is good practice (and required by the Android Rust style guide) to write a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety requirements of the unsafe\n"
-"operations it is doing."
-msgstr "모든 `unsafe` 블록에 대해 왜 그 코드가 안전한지에 대한 설명을 주석으로 다는 것은 좋은 습관입니다(사실 안드로이드의 러스트 스타일 가이드에서는 이게 필수입니다)."
+"It is good practice (and required by the Android Rust style guide) to write "
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
+msgstr ""
+"모든 `unsafe` 블록에 대해 왜 그 코드가 안전한지에 대한 설명을 주석으로 다는 "
+"것은 좋은 습관입니다(사실 안드로이드의 러스트 스타일 가이드에서는 이게 필수입"
+"니다)."
 
 #: src/unsafe/raw-pointers.md:30
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
-msgstr "포인터 역참조를 할 경우, 포인터가 [_유효_](https://doc.rust-lang.org/std/ptr/index.html#safety)해야 합니다. 예를 들어:"
+msgstr ""
+"포인터 역참조를 할 경우, 포인터가 [_유효_](https://doc.rust-lang.org/std/ptr/"
+"index.html#safety)해야 합니다. 예를 들어:"
 
 #: src/unsafe/raw-pointers.md:33
+msgid "The pointer must be non-null."
+msgstr "포인터는 null이면 안됩니다."
+
+#: src/unsafe/raw-pointers.md:34
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
 msgstr ""
-" * 포인터는 null이면 안됩니다.\n"
-" * 포인터는 따라가기가 가능해야 합니다 (객체의 어느 한 부분을 가리키고 있어야 합니다).\n"
-" * 이미 반환된 객체를 가리키면 안됩니다.\n"
-" * 같은 위치에 대해 동시적인 접근이 있으면 안됩니다.\n"
-" * 참조를 캐스팅 해서 포인터를 만들었다면, 그 참조가 가리키는 객체는 살아 있어야 하며, 그 객체의 메모리를 접근하는 참조가 하나도 없어야 합니다."
+"포인터는 따라가기가 가능해야 합니다 (객체의 어느 한 부분을 가리키고 있어야 합"
+"니다)."
+
+#: src/unsafe/raw-pointers.md:35
+msgid "The object must not have been deallocated."
+msgstr "이미 반환된 객체를 가리키면 안됩니다."
+
+#: src/unsafe/raw-pointers.md:36
+msgid "There must not be concurrent accesses to the same location."
+msgstr "같은 위치에 대해 동시적인 접근이 있으면 안됩니다."
+
+#: src/unsafe/raw-pointers.md:37
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr ""
+"참조를 캐스팅 해서 포인터를 만들었다면, 그 참조가 가리키는 객체는 살아 있어"
+"야 하며, 그 객체의 메모리를 접근하는 참조가 하나도 없어야 합니다."
 
 #: src/unsafe/raw-pointers.md:40
 msgid "In most cases the pointer must also be properly aligned."
 msgstr "대부분의 경우 포인터는 align되어 있어야 합니다."
-
-#: src/unsafe/mutable-static-variables.md:1
-msgid "# Mutable Static Variables"
-msgstr "# 정적 가변 변수"
 
 #: src/unsafe/mutable-static-variables.md:3
 msgid "It is safe to read an immutable static variable:"
@@ -11184,9 +13216,11 @@ msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
-msgstr "하지만, 데이터 레이스가 발생할 수 있으므로 정적 가변변수를 읽고 쓰는 것은 안전하지 않습니다:"
+msgstr ""
+"하지만, 데이터 레이스가 발생할 수 있으므로 정적 가변변수를 읽고 쓰는 것은 안"
+"전하지 않습니다:"
 
 #: src/unsafe/mutable-static-variables.md:16
 msgid ""
@@ -11220,17 +13254,19 @@ msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:32
 msgid ""
-"Using a mutable static is generally a bad idea, but there are some cases where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working with some C APIs."
-msgstr "일반적으로 이야기 해서, 정적 가변 변수를 쓰는 것은 좋은 아이디어가 아닙니다. 그러나 `no_std`와 같은 저수준 코딩을 할 경우에는 필요하기도 합니다. 예를 들어 힙 할당기를 구현하거나, C API를 사용하는 게 그런 경우입니다."
-
-#: src/unsafe/unions.md:1
-msgid "# Unions"
-msgstr "# 유니온"
+"Using a mutable static is generally a bad idea, but there are some cases "
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
+msgstr ""
+"일반적으로 이야기 해서, 정적 가변 변수를 쓰는 것은 좋은 아이디어가 아닙니다. "
+"그러나 `no_std`와 같은 저수준 코딩을 할 경우에는 필요하기도 합니다. 예를 들"
+"어 힙 할당기를 구현하거나, C API를 사용하는 게 그런 경우입니다."
 
 #: src/unsafe/unions.md:3
 msgid "Unions are like enums, but you need to track the active field yourself:"
-msgstr "유니온 타입은 열거형(enum)과 비슷하지만, 어떤 필드에 해당하는 값을 가지고 있는지 여부를 프로그래머가 수동으로 추적해야 합니다:"
+msgstr ""
+"유니온 타입은 열거형(enum)과 비슷하지만, 어떤 필드에 해당하는 값을 가지고 있"
+"는지 여부를 프로그래머가 수동으로 추적해야 합니다:"
 
 #: src/unsafe/unions.md:5
 msgid ""
@@ -11264,26 +13300,30 @@ msgstr ""
 
 #: src/unsafe/unions.md:21
 msgid ""
-"Unions are very rarely needed in Rust as you can usually use an enum. They are occasionally needed\n"
-"for interacting with C library APIs."
-msgstr "러스트에는 열거형이 있기 때문에 유니온이 필요한 경우는 극히 드뭅니다. 유니온은 C 라이브러리 API를 사용할 때 가끔 필요합니다."
+"Unions are very rarely needed in Rust as you can usually use an enum. They "
+"are occasionally needed for interacting with C library APIs."
+msgstr ""
+"러스트에는 열거형이 있기 때문에 유니온이 필요한 경우는 극히 드뭅니다. 유니온"
+"은 C 라이브러리 API를 사용할 때 가끔 필요합니다."
 
 #: src/unsafe/unions.md:24
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably want\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
-msgstr "바이트들을 특정 타입으로 재해석 하고 싶다면 [`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html)나 좀 더 안전한 [`zerocopy`](https://crates.io/crates/zerocopy) 크레이트를 사용하세요."
-
-#: src/unsafe/calling-unsafe-functions.md:1
-msgid "# Calling Unsafe Functions"
-msgstr "# '안전하지 않은' 함수 호출"
+"If you just want to reinterpret bytes as a different type, you probably want "
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
+msgstr ""
+"바이트들을 특정 타입으로 재해석 하고 싶다면 [`std::mem::transmute`](https://"
+"doc.rust-lang.org/stable/std/mem/fn.transmute.html)나 좀 더 안전한 "
+"[`zerocopy`](https://crates.io/crates/zerocopy) 크레이트를 사용하세요."
 
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
-"A function or method can be marked `unsafe` if it has extra preconditions you\n"
-"must uphold to avoid undefined behaviour:"
-msgstr "함수나 메서드가 정의되지 않은 동작으로 빠지지 않게 하기 위해서 만족해야 하는 전제 조건이 있는 경우, 그 함수나 메서드를 `unsafe`로 표시할 수 있습니다:"
+"A function or method can be marked `unsafe` if it has extra preconditions "
+"you must uphold to avoid undefined behaviour:"
+msgstr ""
+"함수나 메서드가 정의되지 않은 동작으로 빠지지 않게 하기 위해서 만족해야 하는 "
+"전제 조건이 있는 경우, 그 함수나 메서드를 `unsafe`로 표시할 수 있습니다:"
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
@@ -11291,7 +13331,8 @@ msgid ""
 "fn main() {\n"
 "    let emojis = \"🗻∈🌏\";\n"
 "\n"
-"    // Safe because the indices are in the correct order, within the bounds of\n"
+"    // Safe because the indices are in the correct order, within the bounds "
+"of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
 "    unsafe {\n"
 "        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
@@ -11299,11 +13340,13 @@ msgid ""
 "        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
 "    }\n"
 "\n"
-"    println!(\"char count: {}\", count_chars(unsafe { emojis.get_unchecked(0..7) }));\n"
+"    println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..7) }));\n"
 "\n"
 "    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe { emojis.get_unchecked(0..3) }));\n"
+"    // println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..3) }));\n"
 "}\n"
 "\n"
 "fn count_chars(s: &str) -> usize {\n"
@@ -11338,15 +13381,13 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/unsafe/writing-unsafe-functions.md:1
-msgid "# Writing Unsafe Functions"
-msgstr "# '안전하지 않은' 함수 작성하기"
-
 #: src/unsafe/writing-unsafe-functions.md:3
 msgid ""
-"You can mark your own functions as `unsafe` if they require particular conditions to avoid undefined\n"
-"behaviour."
-msgstr "여러분이 작성한 함수를 사용할 때 어떤 특별한 조건을 만족해야 한다면, `unsafe`로 마킹할 수 있습니다."
+"You can mark your own functions as `unsafe` if they require particular "
+"conditions to avoid undefined behaviour."
+msgstr ""
+"여러분이 작성한 함수를 사용할 때 어떤 특별한 조건을 만족해야 한다면, `unsafe`"
+"로 마킹할 수 있습니다."
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -11401,24 +13442,35 @@ msgstr ""
 "```"
 
 #: src/unsafe/writing-unsafe-functions.md:33
-msgid "We wouldn't actually use pointers for this because it can be done safely with references."
-msgstr "참조를 사용하면 안전하게 구현할 수 있기 때문에, 실제로 포인터를 사용할 필요는 없습니다."
+msgid ""
+"We wouldn't actually use pointers for this because it can be done safely "
+"with references."
+msgstr ""
+"참조를 사용하면 안전하게 구현할 수 있기 때문에, 실제로 포인터를 사용할 필요"
+"는 없습니다."
 
 #: src/unsafe/writing-unsafe-functions.md:35
 msgid ""
-"Note that unsafe code is allowed within an unsafe function without an `unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see what happens."
-msgstr "unsafe 코드가 unsafe 함수의 내부에서 호출될 경우에는 `unsafe`블록을 지정하지 않아도 됩니다. `unsafe`블록을 항상 지정하도록 하고 싶다면 `#[deny(unsafe_op_in_unsafe_fn)]`를 이용하세요. 이 어트리뷰트를 추가해 보고 어떤 일이 일어나는지 확인해 보세요."
+"Note that unsafe code is allowed within an unsafe function without an "
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
+msgstr ""
+"unsafe 코드가 unsafe 함수의 내부에서 호출될 경우에는 `unsafe`블록을 지정하지 "
+"않아도 됩니다. `unsafe`블록을 항상 지정하도록 하고 싶다면 "
+"`#[deny(unsafe_op_in_unsafe_fn)]`를 이용하세요. 이 어트리뷰트를 추가해 보고 "
+"어떤 일이 일어나는지 확인해 보세요."
 
 #: src/unsafe/extern-functions.md:1
-msgid "# Calling External Code"
-msgstr "# 외부 코드 호출"
+msgid "Calling External Code"
+msgstr "외부 코드 호출"
 
 #: src/unsafe/extern-functions.md:3
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
-msgstr "다른 언어의 함수는 러스트의 보증을 위반할 수 있습니다. 따라서 이를 호출하는 것은 안전하지 않습니다:"
+msgstr ""
+"다른 언어의 함수는 러스트의 보증을 위반할 수 있습니다. 따라서 이를 호출하는 "
+"것은 안전하지 않습니다:"
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
@@ -11450,32 +13502,37 @@ msgstr ""
 
 #: src/unsafe/extern-functions.md:21
 msgid ""
-"This is usually only a problem for extern functions which do things with pointers which might\n"
-"violate Rust's memory model, but in general any C function might have undefined behaviour under any\n"
-"arbitrary circumstances."
-msgstr "이게 문제가 되는 경우는 대부분 외부 함수가 러스트의 메모리 모델을 위반하고 있을 경우입니다. 그러나 어떤 C함수라도 어떤 임의의 상황에서는 정의되지 않은 동작을 할 수 있기 때문에, 엄밀히 말해서는 모든 외부 함수에 대해서 문제입니다."
+"This is usually only a problem for extern functions which do things with "
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
+msgstr ""
+"이게 문제가 되는 경우는 대부분 외부 함수가 러스트의 메모리 모델을 위반하고 있"
+"을 경우입니다. 그러나 어떤 C함수라도 어떤 임의의 상황에서는 정의되지 않은 동"
+"작을 할 수 있기 때문에, 엄밀히 말해서는 모든 외부 함수에 대해서 문제입니다."
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
-msgstr "위 예제 코드에서 `\"C\"`는 ABI를 의미합니다. [다른 ABI도 있습니다.](https://doc.rust-lang.org/reference/items/external-blocks.html)"
-
-#: src/unsafe/unsafe-traits.md:1
-msgid "# Implementing Unsafe Traits"
-msgstr "# 안전하지 않은 트레잇 구현하기"
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
+msgstr ""
+"위 예제 코드에서 `\"C\"`는 ABI를 의미합니다. [다른 ABI도 있습니다.](https://"
+"doc.rust-lang.org/reference/items/external-blocks.html)"
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
-"Like with functions, you can mark a trait as `unsafe` if the implementation must guarantee\n"
-"particular conditions to avoid undefined behaviour."
-msgstr "함수에서와 마찬가지로 트레잇도 `unsafe`로 마킹 가능합니다. 만약 그 트레잇을 구현할 때 정의되지 않은 동작을 피하기 위해 특별한 조건이 필요하다면 말이지요."
+"Like with functions, you can mark a trait as `unsafe` if the implementation "
+"must guarantee particular conditions to avoid undefined behaviour."
+msgstr ""
+"함수에서와 마찬가지로 트레잇도 `unsafe`로 마킹 가능합니다. 만약 그 트레잇을 "
+"구현할 때 정의되지 않은 동작을 피하기 위해 특별한 조건이 필요하다면 말이지요."
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
-msgstr "예를 들어 `zerocopy` 크레이트에는 [안전하지 않은 트레잇](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html)이 있습니다:"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+msgstr ""
+"예를 들어 `zerocopy` 크레이트에는 [안전하지 않은 트레잇](https://docs.rs/"
+"zerocopy/latest/zerocopy/trait.AsBytes.html)이 있습니다:"
 
 #: src/unsafe/unsafe-traits.md:9
 msgid ""
@@ -11489,7 +13546,8 @@ msgid ""
 "pub unsafe trait AsBytes {\n"
 "    fn as_bytes(&self) -> &[u8] {\n"
 "        unsafe {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, size_of_val(self))\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
 "        }\n"
 "    }\n"
 "}\n"
@@ -11508,7 +13566,8 @@ msgstr ""
 "pub unsafe trait AsBytes {\n"
 "    fn as_bytes(&self) -> &[u8] {\n"
 "        unsafe {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, size_of_val(self))\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
 "        }\n"
 "    }\n"
 "}\n"
@@ -11519,67 +13578,87 @@ msgstr ""
 
 #: src/unsafe/unsafe-traits.md:30
 msgid ""
-"There should be a `# Safety` section on the Rustdoc for the trait explaining the requirements for\n"
-"the trait to be safely implemented."
-msgstr "안전하지 않은 트레잇을 만들 때에는 주석에 `# Safety` 항목이 있어서 이 트레잇을 안전하게 구현하려면 어떤 요구사항들을 만족해야 하는지를 설명해야 합니다."
+"There should be a `# Safety` section on the Rustdoc for the trait explaining "
+"the requirements for the trait to be safely implemented."
+msgstr ""
+"안전하지 않은 트레잇을 만들 때에는 주석에 `# Safety` 항목이 있어서 이 트레잇"
+"을 안전하게 구현하려면 어떤 요구사항들을 만족해야 하는지를 설명해야 합니다."
 
 #: src/unsafe/unsafe-traits.md:33
-msgid "The actual safety section for `AsBytes` is rather longer and more complicated."
-msgstr "`AsBytes`에서 지켜야 할 안전성에 대한 실제 설명은 좀 더 길고 복잡합니다."
+msgid ""
+"The actual safety section for `AsBytes` is rather longer and more "
+"complicated."
+msgstr ""
+"`AsBytes`에서 지켜야 할 안전성에 대한 실제 설명은 좀 더 길고 복잡합니다."
 
 #: src/unsafe/unsafe-traits.md:35
 msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr "빌트인 트레잇인 `Send`와 `Sync`는 안전하지 않은 트레잇 입니다."
 
 #: src/exercises/day-3/afternoon.md:1
-msgid "# Day 3: Afternoon Exercises"
-msgstr "# 3일차 오후 연습문제"
+msgid "Day 3: Afternoon Exercises"
+msgstr "3일차 오후 연습문제"
 
 #: src/exercises/day-3/afternoon.md:3
 msgid "Let us build a safe wrapper for reading directory content!"
 msgstr "디렉터리의 내용을 읽는 안전한 래퍼 코드를 작성해 봅시다!"
 
 #: src/exercises/day-3/afternoon.md:7
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr "연습문제를 살펴 본 후, 제공된 [해답][solution]을 살펴볼 수 있습니다."
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-msgid "# Safe FFI Wrapper"
-msgstr "# FFI래퍼"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
+msgstr ""
+"연습문제를 살펴 본 후, 제공된 [해답](solutions-afternoon.md)을 살펴볼 수 있습"
+"니다."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
-msgstr "러스트는 _외부 기능 호출(FFI)_을 지원합니다. 우리는 이를 이용하여 디렉터리에서 파일 이름을 읽어오는 `libc` 함수에 대한 안전한 래퍼를 만들 것입니다."
+msgstr ""
+"러스트는 \\_외부 기능 호출(FFI)\\_을 지원합니다. 우리는 이를 이용하여 디렉터"
+"리에서 파일 이름을 읽어오는 `libc` 함수에 대한 안전한 래퍼를 만들 것입니다."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:7
 msgid "You will want to consult the manual pages:"
 msgstr "아래 리눅스 메뉴얼 문서들을 참조하시기 바랍니다:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
-msgstr ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module, particular for [`CStr`]\n"
-"and [`CString`] types which are used to hold NUL-terminated strings coming from\n"
-"C. The [Nomicon] also has a very useful chapter about FFI."
-msgstr "[`std::ffi`] 모듈을 탐색하는게 필요할 지도 모르겠습니다. C에서 사용되는 NUL-terminated 문자열을 담기 위한 [`CStr`]과 [`CString`] 타입을 확인해 보세요. [Nomicon]문서 또한 FFI에 대한 유용한 내용을 담고 있습니다."
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module, particular for [`CStr`](https://doc.rust-lang.org/std/ffi/"
+"struct.CStr.html) and [`CString`](https://doc.rust-lang.org/std/ffi/struct."
+"CString.html) types which are used to hold NUL-terminated strings coming "
+"from C. The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a "
+"very useful chapter about FFI."
+msgstr ""
+"[`std::ffi`](https://doc.rust-lang.org/std/ffi/) 모듈을 탐색하는게 필요할 지"
+"도 모르겠습니다. C에서 사용되는 NUL-terminated 문자열을 담기 위한 [`CStr`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CStr.html)과 [`CString`](https://"
+"doc.rust-lang.org/std/ffi/struct.CString.html) 타입을 확인해 보세요. "
+"[Nomicon](https://doc.rust-lang.org/nomicon/ffi.html)문서 또한 FFI에 대한 유"
+"용한 내용을 담고 있습니다."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
-msgstr "아래 코드를 <https://play.rust-lang.org/>에 복사하고 빠진 함수와 메서드를 채워봅니다:"
+msgstr ""
+"아래 코드를 <https://play.rust-lang.org/>에 복사하고 빠진 함수와 메서드를 채"
+"워봅니다:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
@@ -11594,10 +13673,12 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
-"    // Layout as per readdir(3) and definitions in /usr/include/x86_64-linux-gnu.\n"
+"    // Layout as per readdir(3) and definitions in /usr/include/x86_64-linux-"
+"gnu.\n"
 "    #[repr(C)]\n"
 "    pub struct dirent {\n"
 "        pub d_ino: c_long,\n"
@@ -11655,43 +13736,46 @@ msgid ""
 msgstr ""
 
 #: src/welcome-day-4.md:1
-msgid "# Welcome to Day 4"
-msgstr "# 4일차 개요"
+msgid "Welcome to Day 4"
+msgstr "4일차 개요"
 
 #: src/welcome-day-4.md:3
 msgid ""
-"This morning, we will focus on Concurrency: threads, channels, shared state, `Send` and `Sync`.\n"
-"In the afternoon, we will have a chance to see Rust in action."
+"This morning, we will focus on Concurrency: threads, channels, shared state, "
+"`Send` and `Sync`. In the afternoon, we will have a chance to see Rust in "
+"action."
 msgstr ""
-"오전에는 동시성을 다룹니다: 쓰레드, 채널, 공유 상태, `Send`와 `Sync`.\n"
-"오후에는 러스트가 실제 사용되는 사례를 살펴봅니다."
+"오전에는 동시성을 다룹니다: 쓰레드, 채널, 공유 상태, `Send`와 `Sync`. 오후에"
+"는 러스트가 실제 사용되는 사례를 살펴봅니다."
 
 #: src/welcome-day-4.md:8
 msgid ""
-"This is a good time to give an outline of what you will cover in the afternoon\n"
-"section, as announced in the course offering."
+"This is a good time to give an outline of what you will cover in the "
+"afternoon section, as announced in the course offering."
 msgstr "오후에 다룰 내용의 개요를 소개하는 것도 좋습니다."
 
 #: src/concurrency.md:1
-msgid "# Fearless Concurrency"
-msgstr "# 겂없는 동시성"
+msgid "Fearless Concurrency"
+msgstr "겂없는 동시성"
 
 #: src/concurrency.md:3
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
-msgstr "러스트는 동시성 지원이 막강합니다. 운영체제 레벨의 스레드를 사용하며, 뮤택스와 채널도 지원합니다."
+msgstr ""
+"러스트는 동시성 지원이 막강합니다. 운영체제 레벨의 스레드를 사용하며, 뮤택스"
+"와 채널도 지원합니다."
 
 #: src/concurrency.md:6
 msgid ""
-"The Rust type system plays an important role in making many concurrency bugs\n"
-"compile time bugs. This is often referred to as _fearless concurrency_ since you\n"
-"can rely on the compiler to ensure correctness at runtime."
-msgstr "러스트의 타입 시스템은 프로그램에 동시성 버그가 있을 경우, 컴파일 시에 에러가 발생하도록 해 줍니다. 컴파일러를 이용해서 프로그램이 수행시에 정확히 동작함을 미리 보장해 주기 때문에, 사람들은 이를 종종 _겁없는 동시성_ 이라고 합니다."
-
-#: src/concurrency/threads.md:1
-msgid "# Threads"
-msgstr "# 스레드"
+"The Rust type system plays an important role in making many concurrency bugs "
+"compile time bugs. This is often referred to as _fearless concurrency_ since "
+"you can rely on the compiler to ensure correctness at runtime."
+msgstr ""
+"러스트의 타입 시스템은 프로그램에 동시성 버그가 있을 경우, 컴파일 시에 에러"
+"가 발생하도록 해 줍니다. 컴파일러를 이용해서 프로그램이 수행시에 정확히 동작"
+"함을 미리 보장해 주기 때문에, 사람들은 이를 종종 _겁없는 동시성_ 이라고 합니"
+"다."
 
 #: src/concurrency/threads.md:3
 msgid "Rust threads work similarly to threads in other languages:"
@@ -11738,39 +13822,53 @@ msgstr ""
 "```"
 
 #: src/concurrency/threads.md:24
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
-"* 스레드는 모두 데몬 스레드입니다. 따라서 메인 스레드는 이 스레드들이 끝나기를 기다리지 않습니다.\n"
-"* 한 스레드에서 발생한 패닉은 다른 스레드에게 영향을 끼치지 않습니다.\n"
-"  * 패닉은 추가정보(페이로드)를 포함할 수 있으며, 이는 `downcast_ref`로 풀어볼 수 있습니다."
+"스레드는 모두 데몬 스레드입니다. 따라서 메인 스레드는 이 스레드들이 끝나기를 "
+"기다리지 않습니다."
+
+#: src/concurrency/threads.md:25
+msgid "Thread panics are independent of each other."
+msgstr "한 스레드에서 발생한 패닉은 다른 스레드에게 영향을 끼치지 않습니다."
+
+#: src/concurrency/threads.md:26
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr ""
+"패닉은 추가정보(페이로드)를 포함할 수 있으며, 이는 `downcast_ref`로 풀어볼 "
+"수 있습니다."
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
-"* 메인 스레드가 자식 스레드를 기다리지 않기 때문에 자식 스레드의 for문은 10까지 가지 않습니다.\n"
-"\n"
-"* 만약 메인 스레드가 자식 스레드가 끝날 때 까지 기다리기를 원한다면 `let handle = thread::spawn(...)`으로 스레드를 선언한 후 `handle.join()`로 연결하여 사용합니다.\n"
-"\n"
-"* 자식 스레드에서 발생한 패닉이 메인 스레드에는 영향을 주지 않음을 확인하시기 바랍니다.\n"
-"\n"
-"* `handle.join()`사용시 `Result` 반환값을 통해 패닉의 추가정보에 접근할 수 있습니다. 이 시점에서 [`Any`]에 대해 이야기를 해 보면 좋습니다."
+"메인 스레드가 자식 스레드를 기다리지 않기 때문에 자식 스레드의 for문은 10까"
+"지 가지 않습니다."
 
-#: src/concurrency/scoped-threads.md:1
-msgid "# Scoped Threads"
-msgstr "# 범위 스레드(Scoped Threads)"
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+"만약 메인 스레드가 자식 스레드가 끝날 때 까지 기다리기를 원한다면 `let "
+"handle = thread::spawn(...)`으로 스레드를 선언한 후 `handle.join()`로 연결하"
+"여 사용합니다."
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+"자식 스레드에서 발생한 패닉이 메인 스레드에는 영향을 주지 않음을 확인하시기 "
+"바랍니다."
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
+"`handle.join()`사용시 `Result` 반환값을 통해 패닉의 추가정보에 접근할 수 있습"
+"니다. 이 시점에서 [`Any`](https://doc.rust-lang.org/std/any/index.html)에 대"
+"해 이야기를 해 보면 좋습니다."
 
 #: src/concurrency/scoped-threads.md:3
 msgid "Normal threads cannot borrow from their environment:"
@@ -11803,8 +13901,12 @@ msgstr ""
 "```"
 
 #: src/concurrency/scoped-threads.md:17
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "하지만, [scoped thread][1]에서는 가능합니다:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"하지만, [scoped thread](https://doc.rust-lang.org/std/thread/fn.scope.html)에"
+"서는 가능합니다:"
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -11838,23 +13940,28 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:37
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, all the threads are guaranteed to be joined, so they can return borrowed data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"* `thread::scope` 함수가 완료되면 그 안에서 생성된 모든 스레드들이 종료했음이 보장되기 때문에, 그 때 빌렸던 데이터들을 다시 반환할 수 있기 때문입니다.\n"
-"* 일반적인 러스트의 빌림 규칙이 적용됩니다: 한 스레드에 의한 가변 빌림 또는 여러 스레드에 대한 불변 빌림중 하나만 가능합니다.\n"
-"    "
+"`thread::scope` 함수가 완료되면 그 안에서 생성된 모든 스레드들이 종료했음이 "
+"보장되기 때문에, 그 때 빌렸던 데이터들을 다시 반환할 수 있기 때문입니다."
 
-#: src/concurrency/channels.md:1
-msgid "# Channels"
-msgstr "# 채널"
+#: src/concurrency/scoped-threads.md:38
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"일반적인 러스트의 빌림 규칙이 적용됩니다: 한 스레드에 의한 가변 빌림 또는 여"
+"러 스레드에 대한 불변 빌림중 하나만 가능합니다."
 
 #: src/concurrency/channels.md:3
 msgid ""
-"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two parts\n"
-"are connected via the channel, but you only see the end-points."
-msgstr "러스트의 채널은 `Sender<T>` 와 `Receiver<T>` 두 부분으로 구성됩니다. 이 둘은 채널을 통해 서로 연결되어 있지만, 우리는 채널을 볼 수는 없고 이 양 끝단만을 사용하게 됩니다."
+"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
+"parts are connected via the channel, but you only see the end-points."
+msgstr ""
+"러스트의 채널은 `Sender<T>` 와 `Receiver<T>` 두 부분으로 구성됩니다. 이 둘은 "
+"채널을 통해 서로 연결되어 있지만, 우리는 채널을 볼 수는 없고 이 양 끝단만을 "
+"사용하게 됩니다."
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -11898,17 +14005,21 @@ msgstr ""
 
 #: src/concurrency/channels.md:27
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* `mpsc`는 “Multi-Produce, Single-Consumer”를 의미합니다. `Sender`와 `SyncSender`는 `Clone`을 구현하지만 (즉, 여러개의 producer를 만들수 있습니다) `Receiver`는 `Clone`을 구현하지 않습니다.\n"
-"* `send()`와 `recv()`는 `Result`를 반환합니다. 만일 `Err`가 반환된다면, 상대방의 `Sender`또는 `Receiver`가 삭제되었고 채널이 닫혔다는 뜻입니다."
+"`mpsc`는 “Multi-Produce, Single-Consumer”를 의미합니다. `Sender`와 "
+"`SyncSender`는 `Clone`을 구현하지만 (즉, 여러개의 producer를 만들수 있습니"
+"다) `Receiver`는 `Clone`을 구현하지 않습니다."
 
-#: src/concurrency/channels/unbounded.md:1
-msgid "# Unbounded Channels"
-msgstr "# 무경계 채널(Unbounded Channels)"
+#: src/concurrency/channels.md:29
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()`와 `recv()`는 `Result`를 반환합니다. 만일 `Err`가 반환된다면, 상대방"
+"의 `Sender`또는 `Receiver`가 삭제되었고 채널이 닫혔다는 뜻입니다."
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
@@ -11991,10 +14102,6 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/concurrency/channels/bounded.md:1
-msgid "# Bounded Channels"
-msgstr "# 경계가 있는 채널(Bounded Channels)"
-
 #: src/concurrency/channels/bounded.md:3
 msgid "Bounded and synchronous channels make `send` block the current thread:"
 msgstr "경계가 있는 동기 채널은 `send`가 현제 스레드를 블로킹 하도록 만듭니다:"
@@ -12049,32 +14156,43 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/concurrency/shared_state.md:1
-msgid "# Shared State"
-msgstr "# 상태 공유(Shared State)"
-
 #: src/concurrency/shared_state.md:3
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
-msgstr "러스트는 주로 아래 두 가지 타입을 이용해서 공유 데이터 동기화를 수행합니다:"
+msgstr ""
+"러스트는 주로 아래 두 가지 타입을 이용해서 공유 데이터 동기화를 수행합니다:"
 
 #: src/concurrency/shared_state.md:6
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1], `T`에 대한 아토믹 참조 카운트: 이 참조는 다수의 스레드 사이에서 공유될 수 있고, 참조하던 마지막 스레드가 종료할 경우 `T`를 반환합니다.\n"
-"* [`Mutex<T>`][2]: `T`값에 대한 상호 배제 엑세스를 보장합니다."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), `T`에 대한 아"
+"토믹 참조 카운트: 이 참조는 다수의 스레드 사이에서 공유될 수 있고, 참조하던 "
+"마지막 스레드가 종료할 경우 `T`를 반환합니다."
+
+#: src/concurrency/shared_state.md:8
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): `T`값에 "
+"대한 상호 배제 엑세스를 보장합니다."
 
 #: src/concurrency/shared_state/arc.md:1
-msgid "# `Arc`"
-msgstr "# `Arc`"
+msgid "`Arc`"
+msgstr "`Arc`"
 
 #: src/concurrency/shared_state/arc.md:3
-msgid "[`Arc<T>`][1] allows shared read-only access via its `clone` method:"
-msgstr "[`Arc<T>`][1]의 `clone` 메서드를 이용하면 여러 스레드가 한 데이터를 동시에 (_역주_: 그리고 안전하게. 스레드가 하나라도 살아있는 동안에는 `T`가 반환되지 않음) 읽을 수 있습니다:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via its `clone` method:"
+msgstr ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)의 `clone` 메서"
+"드를 이용하면 여러 스레드가 한 데이터를 동시에 (_역주_: 그리고 안전하게. 스레"
+"드가 하나라도 살아있는 동안에는 `T`가 반환되지 않음) 읽을 수 있습니다:"
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -12101,30 +14219,53 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
 msgstr ""
-"* `Arc`는 \"Atomic Reference Counted\"를 의미하며, 스레드 안정성을 보장하는 `Rc`라고 생각하면 됩니다.\n"
-"* `T`가 `Clone`을 구현하든 안하든 `Arc<T>`는 `Clone`을 구현합니다. `Send`와 `Sync`는 `T`가 이들을 구현하는 경우에만 구현됩니다.\n"
-"* `Arc::clone()`는 아토믹 연산을 수행하기 때문에 그 때 코스트가 좀 있지만, 일단 `clone()`이 끝난 후 `T`를 사용하는 대에는 아무런 오버헤드가 없습니다.\n"
-"* 순환 참조가 발생하지 않도록 주의해야 합니다. 러스트는 순환 참조를 감지하는 가비지 컬랙터가 없습니다.\n"
-"    * 순환 참조를 피하는데 `std::sync::Weak`가 도움이 될 것입니다."
+"`Arc`는 \"Atomic Reference Counted\"를 의미하며, 스레드 안정성을 보장하는 "
+"`Rc`라고 생각하면 됩니다."
+
+#: src/concurrency/shared_state/arc.md:31
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+"`T`가 `Clone`을 구현하든 안하든 `Arc<T>`는 `Clone`을 구현합니다. `Send`와 "
+"`Sync`는 `T`가 이들을 구현하는 경우에만 구현됩니다."
+
+#: src/concurrency/shared_state/arc.md:33
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"`Arc::clone()`는 아토믹 연산을 수행하기 때문에 그 때 코스트가 좀 있지만, 일"
+"단 `clone()`이 끝난 후 `T`를 사용하는 대에는 아무런 오버헤드가 없습니다."
+
+#: src/concurrency/shared_state/arc.md:35
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+"순환 참조가 발생하지 않도록 주의해야 합니다. 러스트는 순환 참조를 감지하는 가"
+"비지 컬랙터가 없습니다."
+
+#: src/concurrency/shared_state/arc.md:36
+msgid "`std::sync::Weak` can help."
+msgstr "순환 참조를 피하는데 `std::sync::Weak`가 도움이 될 것입니다."
 
 #: src/concurrency/shared_state/mutex.md:1
-msgid "# `Mutex`"
-msgstr "# `Mutex`"
+msgid "`Mutex`"
+msgstr "`Mutex`"
 
 #: src/concurrency/shared_state/mutex.md:3
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
-msgstr "[`Mutex<T>`][1]를 이용하면 불변 참조를 통해서도 `T`의 값을 수정할 수가 있으며, _이에 더해서_ 한 번에 한 스레드만 `T`의 값을 접근(읽거나 쓰거나)함을 보장해 줍니다:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html)를 이용하"
+"면 불변 참조를 통해서도 `T`의 값을 수정할 수가 있으며, _이에 더해서_ 한 번에 "
+"한 스레드만 `T`의 값을 접근(읽거나 쓰거나)함을 보장해 줍니다:"
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -12162,31 +14303,66 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
-msgstr "모든 `Mutex<T>`는 [`impl<T: Send> Sync for Mutex<T>`][2]를 자동으로 구현함을 참조하세요."
+msgstr ""
+"모든 `Mutex<T>`는 [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-lang."
+"org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E)를 자동으로 구현함"
+"을 참조하세요."
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The `MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes \"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling `lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
 msgstr ""
-"* 러스트의 `Mutex`는 오직 하나의 데이터만 담을 수 있는 컬렉션처럼 볼 수도 있습니다. 다른 컬렉션과 다른 점은, 그 데이터가 동시성 문제로부터 자유롭다는 점입니다.\n"
-"  * `Mutex`는 뮤텍스를 획득하지 않으면 보호된 데이터에 접근하는 것이 불가능  하도록 디자인 되어 있습니다.\n"
-"* `&Mutex<T>`에 대해 lock을 획득하면 `&mut T`를 얻을 수 있습니다. `MutexGuard`는 `&mut T`가 획득한 lock보다 오래 살아남지 않음을 보장합니다.\n"
-"* `Mutex<T>`는 오직 `T`가 `Send`를 구현하는 경우에만 `Send`와 `Sync`를 구현합니다.\n"
-"* 읽기-쓰기 lock은 `RwLock`을 사용합니다.\n"
-"* 왜 `lock()`이 `Result`를 반환할까요?\n"
-"  * `Mutex`를 획득한 스레드에서 패닉이 발생하면, 데이터가 올바르지 않은 상황이 될 수 있습니다. 이를 `Mutex`가 \"중독(poisoned)\" 되었다고 표현하며, 중독된 뮤텍스에서 `lock()`을 호출하면 실패하고 [`PoisonError`]가 발생합니다. 이러한 오류로부터 데이터를 복구하기 위해 `into_inner()`를 호출할 수 있습니다."
+"러스트의 `Mutex`는 오직 하나의 데이터만 담을 수 있는 컬렉션처럼 볼 수도 있습"
+"니다. 다른 컬렉션과 다른 점은, 그 데이터가 동시성 문제로부터 자유롭다는 점입"
+"니다."
+
+#: src/concurrency/shared_state/mutex.md:32
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr ""
+"`Mutex`는 뮤텍스를 획득하지 않으면 보호된 데이터에 접근하는 것이 불가능  하도"
+"록 디자인 되어 있습니다."
+
+#: src/concurrency/shared_state/mutex.md:33
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+"`&Mutex<T>`에 대해 lock을 획득하면 `&mut T`를 얻을 수 있습니다. `MutexGuard`"
+"는 `&mut T`가 획득한 lock보다 오래 살아남지 않음을 보장합니다."
+
+#: src/concurrency/shared_state/mutex.md:35
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr ""
+"`Mutex<T>`는 오직 `T`가 `Send`를 구현하는 경우에만 `Send`와 `Sync`를 구현합니"
+"다."
+
+#: src/concurrency/shared_state/mutex.md:36
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "읽기-쓰기 lock은 `RwLock`을 사용합니다."
+
+#: src/concurrency/shared_state/mutex.md:37
+msgid "Why does `lock()` return a `Result`? "
+msgstr "왜 `lock()`이 `Result`를 반환할까요?"
+
+#: src/concurrency/shared_state/mutex.md:38
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"`Mutex`를 획득한 스레드에서 패닉이 발생하면, 데이터가 올바르지 않은 상황이 "
+"될 수 있습니다. 이를 `Mutex`가 \"중독(poisoned)\" 되었다고 표현하며, 중독된 "
+"뮤텍스에서 `lock()`을 호출하면 실패하고 [`PoisonError`](https://doc.rust-"
+"lang.org/std/sync/struct.PoisonError.html)가 발생합니다. 이러한 오류로부터 데"
+"이터를 복구하기 위해 `into_inner()`를 호출할 수 있습니다."
 
 #: src/concurrency/shared_state/example.md:3
 msgid "Let us see `Arc` and `Mutex` in action:"
@@ -12248,188 +14424,270 @@ msgstr "눈여겨 볼 부분:"
 
 #: src/concurrency/shared_state/example.md:51
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as possible."
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
 msgstr ""
-"* `v`는 `Arc`와 `Mutex` 모두에 포함되어 있습니다. 이는 `Arc`와 `Mutex`가 서로 완전히 다른 문제를 위한 도구이기 때문입니다.\n"
-"  * `Mutex`를 `Arc`로 래핑하는 것은 가변 상태를 스레드들 간에 공유할 때 흔히 사용하는 패턴입니다.\n"
-"* `v: Arc<_>`를 다른 스레드에서 사용하려면, 먼저 `v2`로 복사를 하고 이를 그 스레드로 이동 해야 합니다. 그래서 람다의 시그니처에 `move`가 있는 것입니다.\n"
-"* 블록은 `LockGuard`의 범위를 최대한 좁히기 위해 사용되었습니다."
+"`v`는 `Arc`와 `Mutex` 모두에 포함되어 있습니다. 이는 `Arc`와 `Mutex`가 서로 "
+"완전히 다른 문제를 위한 도구이기 때문입니다."
+
+#: src/concurrency/shared_state/example.md:52
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+"`Mutex`를 `Arc`로 래핑하는 것은 가변 상태를 스레드들 간에 공유할 때 흔히 사용"
+"하는 패턴입니다."
+
+#: src/concurrency/shared_state/example.md:53
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+"`v: Arc<_>`를 다른 스레드에서 사용하려면, 먼저 `v2`로 복사를 하고 이를 그 스"
+"레드로 이동 해야 합니다. 그래서 람다의 시그니처에 `move`가 있는 것입니다."
+
+#: src/concurrency/shared_state/example.md:54
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible."
+msgstr "블록은 `LockGuard`의 범위를 최대한 좁히기 위해 사용되었습니다."
 
 #: src/concurrency/send-sync.md:1
-msgid "# `Send` and `Sync`"
-msgstr "# `Send`와 `Sync`"
+msgid "`Send` and `Sync`"
+msgstr "`Send`와 `Sync`"
 
 #: src/concurrency/send-sync.md:3
-msgid "How does Rust know to forbid shared access across thread? The answer is in two traits:"
-msgstr "러스트는 어떻게 해서 스레드 간에 특정 데이터 타입이 공유될 수 있거나, 안된다는 것을 알까요? 정답은 다음 두 트레잇에 있습니다:"
+msgid ""
+"How does Rust know to forbid shared access across thread? The answer is in "
+"two traits:"
+msgstr ""
+"러스트는 어떻게 해서 스레드 간에 특정 데이터 타입이 공유될 수 있거나, 안된다"
+"는 것을 알까요? 정답은 다음 두 트레잇에 있습니다:"
 
 #: src/concurrency/send-sync.md:5
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [`Send`][1]: `T`가 스레드 간 이동이 안전하다면, `T`의 타입은 `Send`입니다.\n"
-"* [`Sync`][2]: `&T`가 스레드 간 이동이 안전하다면, `&T`의 타입은 `Sync`입니다."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): `T`가 스레드 "
+"간 이동이 안전하다면, `T`의 타입은 `Send`입니다."
+
+#: src/concurrency/send-sync.md:7
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): `&T`가 스레"
+"드 간 이동이 안전하다면, `&T`의 타입은 `Sync`입니다."
 
 #: src/concurrency/send-sync.md:10
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement them manually when you\n"
-"know it is valid."
-msgstr "`Send`와 `Sync` 트레잇은 [안전하지 않은 트레잇][3]입니다. 컴파일러는 타입의 요소들이 모두 `Send`와 `Sync` 타입이면 자동으로 이 트레잇들을 적용시켜 줍니다. 물론 여러분 스스로 맞다고 알고 있다면 직접 구현해도 됩니다."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
+msgstr ""
+"`Send`와 `Sync` 트레잇은 [안전하지 않은 트레잇](../unsafe/unsafe-traits.md)입"
+"니다. 컴파일러는 타입의 요소들이 모두 `Send`와 `Sync` 타입이면 자동으로 이 트"
+"레잇들을 적용시켜 줍니다. 물론 여러분 스스로 맞다고 알고 있다면 직접 구현해"
+"도 됩니다."
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr ""
-"* `Sync`와 `Send`는 어떤 타입이 특정한 스레드-안전 속성을 가짐을 나타내는 마커로 생각할 수 있습니다.\n"
-"* 이 두 트레이트는 제너릭에서 제약 조건을 나타내는 트레이트로 사용될 수도 있습니다.\n"
-"  "
+"`Sync`와 `Send`는 어떤 타입이 특정한 스레드-안전 속성을 가짐을 나타내는 마커"
+"로 생각할 수 있습니다."
+
+#: src/concurrency/send-sync.md:21
+msgid "They can be used in the generic constraints as normal traits."
+msgstr ""
+"이 두 트레이트는 제너릭에서 제약 조건을 나타내는 트레이트로 사용될 수도 있습"
+"니다."
 
 #: src/concurrency/send-sync/send.md:1
-msgid "# `Send`"
-msgstr "# `Send`"
+msgid "`Send`"
+msgstr "`Send`"
 
 #: src/concurrency/send-sync/send.md:3
-msgid "> A type `T` is [`Send`][1] if it is safe to move a `T` value to another thread."
-msgstr "> `T`가 스레드 간에 안전하게 이동될 수 있다면, `T`의 타입은 `Send`입니다."
+msgid ""
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
+msgstr ""
+"`T`가 스레드 간에 안전하게 이동될 수 있다면, `T`의 타입은 `Send`입니다."
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
-"The effect of moving ownership to another thread is that _destructors_ will run\n"
-"in that thread. So the question is when you can allocate a value in one thread\n"
-"and deallocate it in another."
-msgstr "소유권을 다른 스레드로 이동하면 소멸자가 해당 스레드에서 실행됩니다. 여기서 의문은 \"언제 한 스레드에서 값을 할당하고 다른 스레드에서 값을 할당 해제할 수 있는가\" 입니다."
+"The effect of moving ownership to another thread is that _destructors_ will "
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
+msgstr ""
+"소유권을 다른 스레드로 이동하면 소멸자가 해당 스레드에서 실행됩니다. 여기서 "
+"의문은 \"언제 한 스레드에서 값을 할당하고 다른 스레드에서 값을 할당 해제할 "
+"수 있는가\" 입니다."
 
 #: src/concurrency/send-sync/sync.md:1
-msgid "# `Sync`"
-msgstr "# `Sync`"
+msgid "`Sync`"
+msgstr "`Sync`"
 
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from multiple\n"
-"> threads at the same time."
-msgstr "> `&T`가 여러 스레드에서 안전하게 접근될 수 있다면, `&T`의 타입은 `Sync`입니다."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
+msgstr ""
+"`&T`가 여러 스레드에서 안전하게 접근될 수 있다면, `&T`의 타입은 `Sync`입니다."
 
 #: src/concurrency/send-sync/sync.md:6
 msgid "More precisely, the definition is:"
 msgstr "좀 더 정확한 정의는 다음과 같습니다:"
 
 #: src/concurrency/send-sync/sync.md:8
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr "`&T`가 `Send`인 경우에만 `T`의 타입이 `Sync`가 됩니다"
 
 #: src/concurrency/send-sync/sync.md:14
-msgid "This statement is essentially a shorthand way of saying that if a type is thread-safe for shared use, it is also thread-safe to pass references of it across threads."
-msgstr "위 문장을 풀어서 이야기 하면, 어떤 타입이 스레드 간에 공유되어서 사용되기에 안전하다면 그 타입의 참조 타입은 스레드 간에 이동 가능하다는 것입니다."
+msgid ""
+"This statement is essentially a shorthand way of saying that if a type is "
+"thread-safe for shared use, it is also thread-safe to pass references of it "
+"across threads."
+msgstr ""
+"위 문장을 풀어서 이야기 하면, 어떤 타입이 스레드 간에 공유되어서 사용되기에 "
+"안전하다면 그 타입의 참조 타입은 스레드 간에 이동 가능하다는 것입니다."
 
 #: src/concurrency/send-sync/sync.md:16
-msgid "This is because if a type is Sync it means that it can be shared across multiple threads without the risk of data races or other synchronization issues, so it is safe to move it to another thread. A reference to the type is also safe to move to another thread, because the data it references can be accessed from any thread safely."
-msgstr "이는 다음과 같이 증명할 수 있습니다: 어떤 타입이 `Sync`라는 말은 곧 그 타입이 여러 스레드들 사이에서 데이터 레이스나 여타 동기화 문제 없이 공유 가능하다는 말입니다. 스레드 간 공유가 안전하다면, 스레드간 이동도 안전할 수 밖에 없습니다. 어떤 타입의 스레드간 이동이 안전하다면, 그 타입의 참조 또한 스레드간 이동이 안전할 수 밖에 없습니다."
-
-#: src/concurrency/send-sync/examples.md:1
-msgid "# Examples"
-msgstr "# 예제"
+msgid ""
+"This is because if a type is Sync it means that it can be shared across "
+"multiple threads without the risk of data races or other synchronization "
+"issues, so it is safe to move it to another thread. A reference to the type "
+"is also safe to move to another thread, because the data it references can "
+"be accessed from any thread safely."
+msgstr ""
+"이는 다음과 같이 증명할 수 있습니다: 어떤 타입이 `Sync`라는 말은 곧 그 타입"
+"이 여러 스레드들 사이에서 데이터 레이스나 여타 동기화 문제 없이 공유 가능하다"
+"는 말입니다. 스레드 간 공유가 안전하다면, 스레드간 이동도 안전할 수 밖에 없습"
+"니다. 어떤 타입의 스레드간 이동이 안전하다면, 그 타입의 참조 또한 스레드간 이"
+"동이 안전할 수 밖에 없습니다."
 
 #: src/concurrency/send-sync/examples.md:3
-msgid "## `Send + Sync`"
-msgstr "## `Send + Sync`"
+msgid "`Send + Sync`"
+msgstr "`Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:5
 msgid "Most types you come across are `Send + Sync`:"
 msgstr "여러분이 다루게 될 대부분의 타입은 `Send + Sync`입니다:"
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr "`Arc<T>`: 참조 카운트 조작을 아토믹 하기 때문에 스레드 안전함."
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
 msgstr ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: 참조 카운트 조작을 아토믹 하기 때문에 스레드 안전함.\n"
-"* `Mutex<T>`: 값을 접근하기 위해 뮤택스를 잠궈야 하기 때문에 스레드 안전함.\n"
-"* `AtomicBool`, `AtomicU8`, ...: 값을 접근할 때 특별한 아토믹 명령어들을 사용합니다."
+"`Mutex<T>`: 값을 접근하기 위해 뮤택스를 잠궈야 하기 때문에 스레드 안전함."
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgstr ""
+"`AtomicBool`, `AtomicU8`, ...: 값을 접근할 때 특별한 아토믹 명령어들을 사용합"
+"니다."
 
 #: src/concurrency/send-sync/examples.md:14
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
-msgstr "제네릭 타입은 일반적으로 타입 파라메터가 `Send + Sync`이면 `Send + Sync` 입니다."
+msgstr ""
+"제네릭 타입은 일반적으로 타입 파라메터가 `Send + Sync`이면 `Send + Sync` 입니"
+"다."
 
 #: src/concurrency/send-sync/examples.md:17
-msgid "## `Send + !Sync`"
-msgstr "## `Send + !Sync`"
+msgid "`Send + !Sync`"
+msgstr "`Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:19
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
-msgstr "아래 타입들은 다른 스레드로 이동될 수 있지만 내부적으로 값이 변경될 수 있기 때문에 스레드 안전하지 않습니다:"
+msgstr ""
+"아래 타입들은 다른 스레드로 이동될 수 있지만 내부적으로 값이 변경될 수 있기 "
+"때문에 스레드 안전하지 않습니다:"
 
 #: src/concurrency/send-sync/examples.md:22
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Sender<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Receiver<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+msgid "`Cell<T>`"
+msgstr "`Cell<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+msgid "`RefCell<T>`"
+msgstr "`RefCell<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
-msgid "## `!Send + Sync`"
-msgstr "## `!Send + Sync`"
+msgid "`!Send + Sync`"
+msgstr "`!Send + Sync`"
 
 #: src/concurrency/send-sync/examples.md:29
-msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgid ""
+"These types are thread-safe, but they cannot be moved to another thread:"
 msgstr "아래 타입들은 스레드 안전하지만 다른 스레드로 이동될 수 없습니다:"
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on the\n"
-"  thread which created them."
-msgstr "* `MutexGuard<T>`: 내부적으로, 운영체제가 제공하는 primitive를 사용하는데, 이 primitive는 생성된 스레드에서 해제가 이루어져야 합니다. (_역주_: 그래서 다른 스레드로 옮길 수 없습니다.)"
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
+msgstr ""
+"`MutexGuard<T>`: 내부적으로, 운영체제가 제공하는 primitive를 사용하는데, 이 "
+"primitive는 생성된 스레드에서 해제가 이루어져야 합니다. (_역주_: 그래서 다른 "
+"스레드로 옮길 수 없습니다.)"
 
 #: src/concurrency/send-sync/examples.md:34
-msgid "## `!Send + !Sync`"
-msgstr "## `!Send + !Sync`"
+msgid "`!Send + !Sync`"
+msgstr "`!Send + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:36
 msgid "These types are not thread-safe and cannot be moved to other threads:"
-msgstr "아래 타입들은 스레드 안전하지도 않고 다른 스레드로 이동될 수도 없습니다:"
+msgstr ""
+"아래 타입들은 스레드 안전하지도 않고 다른 스레드로 이동될 수도 없습니다:"
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
-"* `Rc<T>`: `Rc<T>` 는 아토믹하지 않은 방식으로 참조 카운트를 조작하는 `RcBox<T>`를 참조합니다.\n"
-"* `*const T`, `*mut T`: 러스트는 포인터가 스레드 안전하지 않다고 가정합니다."
+"`Rc<T>`: `Rc<T>` 는 아토믹하지 않은 방식으로 참조 카운트를 조작하는 "
+"`RcBox<T>`를 참조합니다."
+
+#: src/concurrency/send-sync/examples.md:40
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr ""
+"`*const T`, `*mut T`: 러스트는 포인터가 스레드 안전하지 않다고 가정합니다."
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
-"a\n"
-"single thread."
+"a single thread."
 msgstr ""
-"예를 들어 SQLite 라이브러리 연결은 단일 스레드에서만\n"
-"액세스해야 합니다."
+"예를 들어 SQLite 라이브러리 연결은 단일 스레드에서만 액세스해야 합니다."
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -12526,77 +14784,67 @@ msgstr ""
 #: src/async.md:3
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
-"concurrently by\n"
-"executing each task until it would block, then switching to another task "
-"that is\n"
-"ready to make progress. The model allows running a larger number of tasks on "
-"a\n"
-"limited number of threads. This is because the per-task overhead is "
-"typically\n"
-"very low and operating systems provide primitives for efficiently "
-"identifying\n"
-"I/O that is able to proceed."
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
-"\"Async\"는 블럭될(더 이상 진행할 수 없을) 때까지 각 작업을 실행한 다음\n"
-"진행할 준비가 된 다른 작업으로 전환하여\n"
-"여러 작업을 동시에 실행하는 동시 실행 모델입니다. 이 모델을 사용하면 제한된 "
-"수의 스레드에서 더 많은 작업을\n"
-"실행할 수 있습니다. 이는, 한 작업을 유지하고 수행하는데 필요한 오버헤드가 (스레드에 비해) 매우 낮고\n"
-"운영체제가 여러 I/O들에서 현재 진행 가능한 I/O들을 효과적으로 식별해 주는 프리미티브를\n"
-"제공하기 때문입니다."
+"\"Async\"는 블럭될(더 이상 진행할 수 없을) 때까지 각 작업을 실행한 다음 진행"
+"할 준비가 된 다른 작업으로 전환하여 여러 작업을 동시에 실행하는 동시 실행 모"
+"델입니다. 이 모델을 사용하면 제한된 수의 스레드에서 더 많은 작업을 실행할 수 "
+"있습니다. 이는, 한 작업을 유지하고 수행하는데 필요한 오버헤드가 (스레드에 비"
+"해) 매우 낮고 운영체제가 여러 I/O들에서 현재 진행 가능한 I/O들을 효과적으로 "
+"식별해 주는 프리미티브를 제공하기 때문입니다."
 
 #: src/async.md:10
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
-"that\n"
-"may be completed in the future. Futures are \"polled\" until they signal "
-"that\n"
-"they are complete."
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
-"Rust의 비동기 작업은 \"futures\"를 기반으로 하며 이는 미래에 완료될 수 있는\n"
-"작업을 나타냅니다. Futures는 완료되었다는 신호를 보낼 때까지\n"
-"\"폴링\"됩니다."
+"Rust의 비동기 작업은 \"futures\"를 기반으로 하며 이는 미래에 완료될 수 있는 "
+"작업을 나타냅니다. Futures는 완료되었다는 신호를 보낼 때까지 \"폴링\"됩니다."
 
 #: src/async.md:14
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
-"Futures는 비동기 런타임에 의해 폴링되며, 비동기 런타임에는 여러 다양한 종류가\n"
-"있습니다."
+"Futures는 비동기 런타임에 의해 폴링되며, 비동기 런타임에는 여러 다양한 종류"
+"가 있습니다."
 
 #: src/async.md:19
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type "
-"is\n"
-"   callback-based, and not polled. Async Python programs require a "
-"\"loop\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The "
-"language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
 msgstr ""
-" * 파이썬에도 `asyncio`라는 유사한 모델이 있습니다. 그러나 파이썬의 `Future` 타입은\n"
-"콜백 기반이며 폴링되지 않습니다. 파이썬으로 비동기 프로그래밍을 할 때에는, Rust에서 런타임이 "
-"내부적으로 해 주는 것과 유사한, \n"
-"\"루프\"를 명시적으로 사용해야 합니다.\n"
-"\n"
-" * 자바스크립트의 `Promise`도 비슷하지만 역시 콜백 기반입니다. 자바스크립트에서는 이벤트 루프가"
-"런타임 엔진에서 구현되므로\n"
-"`Promise`가 처리되는 세부 과정이\n"
+"파이썬에도 `asyncio`라는 유사한 모델이 있습니다. 그러나 파이썬의 `Future` 타"
+"입은 콜백 기반이며 폴링되지 않습니다. 파이썬으로 비동기 프로그래밍을 할 때에"
+"는, Rust에서 런타임이 내부적으로 해 주는 것과 유사한,  \"루프\"를 명시적으로 "
+"사용해야 합니다."
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
+msgstr ""
+"자바스크립트의 `Promise`도 비슷하지만 역시 콜백 기반입니다. 자바스크립트에서"
+"는 이벤트 루프가런타임 엔진에서 구현되므로 `Promise`가 처리되는 세부 과정이 "
 "숨겨집니다."
 
 #: src/async/async-await.md:1
-msgid "# `async`/`await`"
-msgstr "# `async`/`await`"
+msgid "`async`/`await`"
+msgstr "`async`/`await`"
 
 #: src/async/async-await.md:3
 msgid ""
 "At a high level, async Rust code looks very much like \"normal\" sequential "
 "code:"
-msgstr "겉에서 보았을 때, 비동기 Rust 코드는 일반적인 절차적 코드와 매우 유사합니다."
+msgstr ""
+"겉에서 보았을 때, 비동기 Rust 코드는 일반적인 절차적 코드와 매우 유사합니다."
 
 #: src/async/async-await.md:5
 msgid ""
@@ -12638,69 +14886,72 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no "
-"long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the "
-"compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current "
-"thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. "
-"Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
-"* Rust 비동기 문법을 보여주는 간단한 예시입니다. 여기에는 오래 실행되는 작업이나, 실제로 동시에\n"
-"  수행되는 것들은 없습니다.\n"
-"\n"
-"* `async`함수의 리턴 타입은 무엇인가요?\n"
-"  * `main`에서 `let future: () = async_main(10);을 사용하여 타입을 확인하세"
-"요.\n"
-"\n"
-"* \"async\" 키워드는 문법 설탕(syntactic sugar)입니다. 컴파일러가 리턴 타입을 future로\n"
-"  바꿉니다. \n"
-"\n"
-"* `main`을 비동기 함수로 만들수는 없습니다. 만약 그렇게 할 경우 컴파일러는 리턴 타입인 future를\n"
-"  어떻게 사용할 지 모르기 때문입니다.\n"
-"\n"
-"* 비동기 코드를 실행하려면 실행자(executor)가 필요합니다. `block_on` 실행자는 제공된 future"
-"가\n"
-"  완료될 때까지 현재 스레드를 블록합니다. \n"
-"\n"
-"* `.await`는 다른 작업이 완료될 때까지 비동기적으로 대기합니다. `block_on`과 "
-"달리\n"
-"  `.await`는 현재 스레드를 블록하지 않습니다.\n"
-"\n"
-"* `.await`는 `async` 함수(또는 나중에 소개될 `async` 블록) 안에서만\n"
-"  사용할 수 있습니다. "
+"Rust 비동기 문법을 보여주는 간단한 예시입니다. 여기에는 오래 실행되는 작업이"
+"나, 실제로 동시에 수행되는 것들은 없습니다."
+
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr "`async`함수의 리턴 타입은 무엇인가요?"
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr ""
+"`main`에서 \\`let future: () = async_main(10);을 사용하여 타입을 확인하세요."
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr ""
+"\"async\" 키워드는 문법 설탕(syntactic sugar)입니다. 컴파일러가 리턴 타입을 "
+"future로 바꿉니다. "
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr ""
+"`main`을 비동기 함수로 만들수는 없습니다. 만약 그렇게 할 경우 컴파일러는 리"
+"턴 타입인 future를 어떻게 사용할 지 모르기 때문입니다."
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+"비동기 코드를 실행하려면 실행자(executor)가 필요합니다. `block_on` 실행자는 "
+"제공된 future가 완료될 때까지 현재 스레드를 블록합니다. "
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+"`.await`는 다른 작업이 완료될 때까지 비동기적으로 대기합니다. `block_on`과 달"
+"리 `.await`는 현재 스레드를 블록하지 않습니다."
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr ""
+"`.await`는 `async` 함수(또는 나중에 소개될 `async` 블록) 안에서만 사용할 수 "
+"있습니다. "
 
 #: src/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not "
-"be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)는 트레잇입니다."
-"이 트레잇은 아직\n"
-"완료되지 않았을 수도 있는 작업을 나타냅니다.\n"
-"Future는 `poll` 함수를 통해 폴링될 수 있으며, 이 함수는\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)을 반환합니다."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)는 트레잇입"
+"니다.이 트레잇은 아직 완료되지 않았을 수도 있는 작업을 나타냅니다. Future는 "
+"`poll` 함수를 통해 폴링될 수 있으며, 이 함수는 [`Poll`](https://doc.rust-"
+"lang.org/std/task/enum.Poll.html)을 반환합니다."
 
 #: src/async/futures.md:8
 msgid ""
@@ -12739,140 +14990,141 @@ msgstr ""
 #: src/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
-"uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` "
-"returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
-"비동기 함수는 `impl Future`를 반환합니다. 새로운 타입을 만들고 이 타입이 `Future`를 구현하게 할 수도 "
-"있지만\n"
-"일반적이지는 않습니다. 예를 들어 `tokio::spawn`가 리턴하는 `JoinHandle`은\n"
-"`Future`를 구현하며, 이를 통해 생성된 스레드에 join할 수 있습니다."
+"비동기 함수는 `impl Future`를 반환합니다. 새로운 타입을 만들고 이 타입이 "
+"`Future`를 구현하게 할 수도 있지만 일반적이지는 않습니다. 예를 들어 `tokio::"
+"spawn`가 리턴하는 `JoinHandle`은 `Future`를 구현하며, 이를 통해 생성된 스레드"
+"에 join할 수 있습니다."
 
 #: src/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
-"to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
-"Future에 `.await`를 호출하면, 해당 Future가 준비될 때까지 현재 비동기 함"
-"수가 일시 중지됩니다. 그런 다음 Future가 준비가 되면, 그 값이 `.await` 구문의 값이 됩니다."
+"Future에 `.await`를 호출하면, 해당 Future가 준비될 때까지 현재 비동기 함수가 "
+"일시 중지됩니다. 그런 다음 Future가 준비가 되면, 그 값이 `.await` 구문의 값"
+"이 됩니다."
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers "
-"into\n"
-"    that future remain valid. This is required to allow references to "
-"remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
-"* `Future` 와 `Poll` 타입의 실제 정의는 위에 보이는 그대로 입니다. 링크를 클릭하면\n"
-"  Rust 문서에서 한 번 더 확인할 수 있습니다.\n"
-"\n"
-"* 본 강의의 목적은 비동기 코드를 작성하는데 있기 때문에, 새로운 비동기 프리미티브를 만드는데 필요한 \n"
-"  `Pin`과 `Context`는 다루지 않습니다. 이들에 대해 간단히 설명하자면:\n"
-"\n"
-"  * `Context`를 사용하면 Future가 이벤트가 발생할 때 다시 폴링되도록\n"
-"    예약할 수 있습니다.\n"
-"\n"
-" * 'Pin'을 사용하면 메모리에서 Future의 위치가 고정되기 때문에 해당 future의 "
-"포인터가\n"
-"    항상 유효하게 유지됩니다. 이는 `.await` 후에 참조를 유효한 상태로 유지하기 위"
-"해\n"
-"    필요합니다."
+"`Future` 와 `Poll` 타입의 실제 정의는 위에 보이는 그대로 입니다. 링크를 클릭"
+"하면 Rust 문서에서 한 번 더 확인할 수 있습니다."
+
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+"본 강의의 목적은 비동기 코드를 작성하는데 있기 때문에, 새로운 비동기 프리미티"
+"브를 만드는데 필요한  `Pin`과 `Context`는 다루지 않습니다. 이들에 대해 간단"
+"히 설명하자면:"
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+"`Context`를 사용하면 Future가 이벤트가 발생할 때 다시 폴링되도록 예약할 수 있"
+"습니다."
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
+msgstr ""
+"'Pin'을 사용하면 메모리에서 Future의 위치가 고정되기 때문에 해당 future의 포"
+"인터가 항상 유효하게 유지됩니다. 이는 `.await` 후에 참조를 유효한 상태로 유지"
+"하기 위해 필요합니다."
 
 #: src/async/runtimes.md:3
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust "
-"does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
-"비동기 *런타임*은 *리액터* (비동기식 작업 실행을 지원)와 *실행자* (futures를 실행)"
-"의 두 가지 역할을 합니다. Rust 언어 자체에서 기본 제공하는 비동기 런타임은 없습니다. 그러나 다음과 같은\n"
-"비동기 런타임 크레잇들이 있습니다."
+"비동기 _런타임_은 _리액터_ (비동기식 작업 실행을 지원)와 _실행자_ (futures를 "
+"실행)의 두 가지 역할을 합니다. Rust 언어 자체에서 기본 제공하는 비동기 런타임"
+"은 없습니다. 그러나 다음과 같은 비동기 런타임 크레잇들이 있습니다."
 
 #: src/async/runtimes.md:7
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem "
-"of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and "
-"includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
 msgstr ""
-" * [Tokio](https://tokio.rs/) - 성능이 우수합니다. 그리고 HTTP를 지원하는 [Hyper](https://hyper."
-"rs/) 와\n"
-"   gRPC를 지원하는 [Tonic](https://github.com/hyperium/tonic)과 같은 잘 발달된\n"
-"   라이브러리 생태계가 있습니다.\n"
-" * [async-std](https://async.rs/) - 비동기에서의 `std`를 목표로 하고 있습니다. `async::"
-"task`에 기본 런타임이\n"
-"포함되어 있습니다.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - 간단하고 가볍습니다."
+"[Tokio](https://tokio.rs/) - 성능이 우수합니다. 그리고 HTTP를 지원하는 "
+"[Hyper](https://hyper.rs/) 와 gRPC를 지원하는 [Tonic](https://github.com/"
+"hyperium/tonic)과 같은 잘 발달된 라이브러리 생태계가 있습니다."
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+"[async-std](https://async.rs/) - 비동기에서의 `std`를 목표로 하고 있습니다. "
+"`async::task`에 기본 런타임이 포함되어 있습니다."
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+msgstr "[smol](https://docs.rs/smol/latest/smol/) - 간단하고 가볍습니다."
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
-"여러 대규모 애플리케이션에는 자체 런타임이 있는 경우도 있습니다. 예들 들어 \n"
+"여러 대규모 애플리케이션에는 자체 런타임이 있는 경우도 있습니다. 예들 들어  "
 "[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
 "fuchsia-async/src/lib.rs)가 있습니다."
 
 #: src/async/runtimes.md:20
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most "
-"interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/"
-"O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are "
-"never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
-"* Rust 플레이그라운드에서는 위에 나열된 비동기 런타임 중에서 Tokio만\n"
-"  사용할 수 있습니다. 또한 Rust 플레이그라운드는 I/O를 허용하지 않으므로 async를 가지고 할 수 있는\n"
-"  많은 흥미로운 작업들이 불가능 합니다.\n"
-"\n"
-"* Futures는 실행자가 폴링하지 않는 한 아무것도 하지 않는다는 점에서(I/O 작업"
-"조차 시작하지 않음)\n"
-"  \"비활성\" 상태입니다. 이는 사용되지 않는 경우에도\n"
-"  완료될 때 까지 실행되는, 자바 스크립트의 promise와\n"
-"  다릅니다."
+"Rust 플레이그라운드에서는 위에 나열된 비동기 런타임 중에서 Tokio만 사용할 수 "
+"있습니다. 또한 Rust 플레이그라운드는 I/O를 허용하지 않으므로 async를 가지고 "
+"할 수 있는 많은 흥미로운 작업들이 불가능 합니다."
 
-#: src/async/runtimes/tokio.md:1
-msgid "# Tokio"
-msgstr "# Tokio"
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
+msgstr ""
+"Futures는 실행자가 폴링하지 않는 한 아무것도 하지 않는다는 점에서(I/O 작업조"
+"차 시작하지 않음) \"비활성\" 상태입니다. 이는 사용되지 않는 경우에도 완료될 "
+"때 까지 실행되는, 자바 스크립트의 promise와 다릅니다."
+
+#: src/async/runtimes/tokio.md:1 src/SUMMARY.md:283
+msgid "Tokio"
+msgstr "Tokio"
 
 #: src/async/runtimes/tokio.md:4
 msgid "Tokio provides: "
 msgstr "Tokio는 다음을 제공합니다. "
 
 #: src/async/runtimes/tokio.md:6
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
-msgstr ""
-"* 비동기 코드 실행을 위한 멀티스레드 런타임\n"
-"* 표준 라이브러리의 비동기 버전\n"
-"* 대규모 라이브러리 생태계"
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr "비동기 코드 실행을 위한 멀티스레드 런타임"
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr "표준 라이브러리의 비동기 버전"
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
+msgstr "대규모 라이브러리 생태계"
 
 #: src/async/runtimes/tokio.md:10
 msgid ""
@@ -12919,19 +15171,19 @@ msgstr ""
 "```"
 
 #: src/async/runtimes/tokio.md:33
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
 msgstr ""
-"* 이제 `tokio::main` 매크로를 사용하면 `main`을 비동기로 만들 수 있습니다.\n"
-"\n"
-"* `spawn` 함수는 동시 실행되는 새로운 \"작업\"을 만듭니다.\n"
-"\n"
-"* 참고: `spawn`은 `Future`를 인자로 받습니다. 때문에 `count_to`에 `.await`를 호출하지 "
-"않는 점을 주목하세요."
+"이제 `tokio::main` 매크로를 사용하면 `main`을 비동기로 만들 수 있습니다."
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr "`spawn` 함수는 동시 실행되는 새로운 \"작업\"을 만듭니다."
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgstr ""
+"참고: `spawn`은 `Future`를 인자로 받습니다. 때문에 `count_to`에 `.await`를 호"
+"출하지 않는 점을 주목하세요."
 
 #: src/async/runtimes/tokio.md:39
 msgid "**Further exploration:**"
@@ -12939,22 +15191,21 @@ msgstr "**심화 학습:**"
 
 #: src/async/runtimes/tokio.md:41
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to "
-"wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
-"* `count_to`가 10에 도달하지 않는 경우가 많은데 그 이유는 무엇일까요? 이는 비동"
-"기적인 취소를\n"
-"  보여주는 예입니다. `tokio::spawn`이 리턴하는 것은 완료될 때까지 기다리도록 대기하는데 사용되는 핸들입니다.\n"
-"\n"
-"* `tokio::spawn` 대신 `count_to(10).await`를 사용해 보세요.\n"
-"\n"
-"* `tokio::spawn`에서 반환된 작업을 `await` 해 보세요."
+"`count_to`가 10에 도달하지 않는 경우가 많은데 그 이유는 무엇일까요? 이는 비동"
+"기적인 취소를 보여주는 예입니다. `tokio::spawn`이 리턴하는 것은 완료될 때까"
+"지 기다리도록 대기하는데 사용되는 핸들입니다."
+
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr "`tokio::spawn` 대신 `count_to(10).await`를 사용해 보세요."
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
+msgstr "`tokio::spawn`에서 반환된 작업을 `await` 해 보세요."
 
 #: src/async/tasks.md:3
 msgid "Rust has a task system, which is a form of lightweight threading."
@@ -12963,19 +15214,17 @@ msgstr "Rust의 태스크(작업) 시스템은 경량 스레딩의 한 종류로
 #: src/async/tasks.md:5
 msgid ""
 "A task has a single top-level future which the executor polls to make "
-"progress.\n"
-"That future may have one or more nested futures that its `poll` method "
-"polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible "
-"by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
-"하나의 작업에는, 실행자가 이 작업을 진행하기 위해 계속 폴링하는, 최상위 future가 한 개 있습니다.\n"
-"이 future에는 `poll` 메서드가 폴링하는 중첩된 future가 한 개 이상 있을 수 있습"
-"니다.\n"
-"이러한 중첩된 future는 일반적인 함수 호출 스택하고 비슷한 역할을 합니다. 한 작업 안에서 여러 자식 future들을 "
-"폴링하면, 타이머를 켜는 것과 어떤 I/O작업을 동시에 수행시킨 후 타이머와 I/O 중 먼저 끝나는 것을 기다리는 것과 같은"
-"동시성도 구현할 수 있습니다."
+"하나의 작업에는, 실행자가 이 작업을 진행하기 위해 계속 폴링하는, 최상위 "
+"future가 한 개 있습니다. 이 future에는 `poll` 메서드가 폴링하는 중첩된 future"
+"가 한 개 이상 있을 수 있습니다. 이러한 중첩된 future는 일반적인 함수 호출 스"
+"택하고 비슷한 역할을 합니다. 한 작업 안에서 여러 자식 future들을 폴링하면, 타"
+"이머를 켜는 것과 어떤 I/O작업을 동시에 수행시킨 후 타이머와 I/O 중 먼저 끝나"
+"는 것을 기다리는 것과 같은동시성도 구현할 수 있습니다."
 
 #: src/async/tasks.md:10
 msgid ""
@@ -13064,36 +15313,41 @@ msgstr ""
 #: src/async/tasks.md:52 src/async/control-flow/join.md:36
 msgid ""
 "Copy this example into your prepared `src/main.rs` and run it from there."
-msgstr "이 예제를, 로컬 컴퓨터에 만들어 둔 `src/main.rs`에 복사하고 거기에서 실행하세요."
+msgstr ""
+"이 예제를, 로컬 컴퓨터에 만들어 둔 `src/main.rs`에 복사하고 거기에서 실행하세"
+"요."
 
 #: src/async/tasks.md:54
 msgid ""
-"* Ask students to visualize what the state of the example server would be "
-"with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling "
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
+msgstr ""
+"수강생들에게 이 서버에 몇 개의 클라이언트가 연결되면 이 서버의 상태가 어떻게 "
+"변할지 그림을 그려보도록 하세요. 어떤 태스크들이 있는지, 이 태스크들의 Future"
+"는 어떤 상태에 있는지 물어봅니다."
+
+#: src/async/tasks.md:57
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+"`async` 블록을 처음 보게 되었습니다. 이것은 클로저와 비슷하지만 인자를 받지 "
+"않습니다. 리턴 타입은 `async fn`과 비슷한 Future입니다. "
+
+#: src/async/tasks.md:61
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
 "using `?`."
 msgstr ""
-"* 수강생들에게 이 서버에 몇 개의 클라이언트가 연결되면 이 서버의 상태가 어떻게 변할지 그림을 그려보도록 하세요.\n"
-" 어떤 태스크들이 있는지, 이 태스크들의 Future는 어떤 상태에 있는지 물어봅니다.\n"
-"\n"
-"* `async` 블록을 처음 보게 되었습니다. 이것은 클로저와 비슷하지만\n"
-"  인자를 받지 않습니다. 리턴 타입은 `async fn`과 비슷한\n"
-"  Future입니다. \n"
-"\n"
-"* Async 블록을 함수로 리팩터링하고 `?`를 사용하여 오류 처리를 개선해 봅시다."
+"Async 블록을 함수로 리팩터링하고 `?`를 사용하여 오류 처리를 개선해 봅시다."
 
 #: src/async/channels.md:3
 msgid ""
 "Several crates have support for asynchronous channels. For instance `tokio`:"
 msgstr ""
-"여러 크레이트에서 비동기 채널을 지원합니다. 예를 들어 `tokio`에서는 아래와 같이"
-"합니다."
+"여러 크레이트에서 비동기 채널을 지원합니다. 예를 들어 `tokio`에서는 아래와 같"
+"이합니다."
 
 #: src/async/channels.md:5
 msgid ""
@@ -13156,69 +15410,73 @@ msgstr ""
 "```"
 
 #: src/async/channels.md:35
+msgid "Change the channel size to `3` and see how it affects the execution."
+msgstr "채널 크기를 `3`으로 변경하고 동작이 어떻게 바뀌는지 확인하세요."
+
+#: src/async/channels.md:37
 msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be "
-"convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to "
-"combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
 msgstr ""
-"* 채널 크기를 `3`으로 변경하고 동작이 어떻게 바뀌는지 확인하세요.\n"
-"\n"
-"* 비동기 채널을 사용하기 위한 인터페이스는 [오전 과정](concurrency/channels.md)에서 배운\n"
-"  `sync` 채널과 비슷합니다.\n"
-"\n"
-"* `std::mem::drop` 호출하는 줄을 삭제해 보세요. 어떤 결과가 나타나나요? 이유가 무엇"
-"인가요?\n"
-"\n"
-"* [Flume](https://docs.rs/flume/latest/flume/) 크레이트에는 `sync`와 "
-"`async`, `send`와 `recv`를\n"
-"  모두 구현하는 채널이 있습니다. 이것은 IO와 CPU 처리 작업이 많은\n"
-"  복잡한 애플리케이션을 구현할 때 매우 유용합니다.\n"
-"\n"
-"* `async` 채널을 사용하는 것이 더 좋은 이유는 이를 다른 `future`와 결합하여\n"
-"  복잡한 제어 흐름을 만들 수 있기 때문입니다."
+"비동기 채널을 사용하기 위한 인터페이스는 [오전 과정](concurrency/channels.md)"
+"에서 배운 `sync` 채널과 비슷합니다."
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+"`std::mem::drop` 호출하는 줄을 삭제해 보세요. 어떤 결과가 나타나나요? 이유가 "
+"무엇인가요?"
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+"[Flume](https://docs.rs/flume/latest/flume/) 크레이트에는 `sync`와 `async`, "
+"`send`와 `recv`를 모두 구현하는 채널이 있습니다. 이것은 IO와 CPU 처리 작업이 "
+"많은 복잡한 애플리케이션을 구현할 때 매우 유용합니다."
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
+msgstr ""
+"`async` 채널을 사용하는 것이 더 좋은 이유는 이를 다른 `future`와 결합하여 복"
+"잡한 제어 흐름을 만들 수 있기 때문입니다."
 
 #: src/async/control-flow.md:3
 msgid ""
 "Futures can be combined together to produce concurrent compute flow graphs. "
-"We\n"
-"have already seen tasks, that function as independent threads of execution."
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
-"Future들을 결합하여 계산 과정을 동시성이 있는 플로우 그래프 형태로 모델링 할 수 있습니다. 앞서 배운, \n"
-"각 태스크가 독립적으로 수행되도록 하는 것도 Future들을 결합하는 한 방법으로 볼 수 있습니다."
+"Future들을 결합하여 계산 과정을 동시성이 있는 플로우 그래프 형태로 모델링 할 "
+"수 있습니다. 앞서 배운,  각 태스크가 독립적으로 수행되도록 하는 것도 Future들"
+"을 결합하는 한 방법으로 볼 수 있습니다."
 
 #: src/async/control-flow.md:6
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
-msgstr ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
+msgstr "[Join](control-flow/join.md)"
 
-#: src/async/control-flow/join.md:1
-msgid "# Join"
-msgstr "# Join"
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
+msgstr "[Select](control-flow/select.md)"
+
+#: src/async/control-flow/join.md:1 src/SUMMARY.md:287
+msgid "Join"
+msgstr "Join"
 
 #: src/async/control-flow/join.md:3
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
-"Join 연산은 모든 future가 준비될 때까지 기다린 후, 각 future의 결과값을 담은 컬렉션을\n"
-"리턴합니다. 이는 자바스크립트의 `Promise.all`이나 파이썬의 `asyncio.gather`와\n"
-"유사합니다."
+"Join 연산은 모든 future가 준비될 때까지 기다린 후, 각 future의 결과값을 담은 "
+"컬렉션을 리턴합니다. 이는 자바스크립트의 `Promise.all`이나 파이썬의 `asyncio."
+"gather`와 유사합니다."
 
 #: src/async/control-flow/join.md:7
 msgid ""
@@ -13278,63 +15536,62 @@ msgstr ""
 
 #: src/async/control-flow/join.md:38
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` "
-"but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this "
-"would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all "
-"requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but "
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
+msgstr ""
+"서로 다른 타입을 가지는 여러 여러 futures들을 join하고자 할 경우 `std::"
+"future::join!`을 사용할 수 있습니다. 이 매크로를 사용하려면 futures가 몇 개"
+"나 있을지 컴파일 할 때 알아야 한다는 점을 주의하세요. 이 매크로는 지금은 "
+"'futures' 크레이트에 있으며 곧 안정화 되어 `std::future`에 포함될 예정입니다."
+
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+"'join'의 위험성은 futures들 중 하나가 영영 끝나지 않을 수도 있다는 것입니다. "
+"그러면 프로그램이 더이상 진행을 못하고 멈춰있을(stall) 수 있습니다. "
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
 "demonstrates `join!`."
 msgstr ""
-"* 서로 다른 타입을 가지는 여러 여러 futures들을 join하고자 할 경우 `std::future::join!`을 사용할 수 있습니다.\n"
-"  이 매크로를 사용하려면 futures가 몇 개나 있을지 컴파일 할 때 알아야 한다는 점을 주의하세요. 이 매크로는 지금은\n"
-"  'futures' 크레이트에 있으며 곧 안정화 되어 `std::future`에 포함될 예정입니다.\n"
-"\n"
-"* 'join'의 위험성은 futures들 중 하나가 영영 끝나지 않을 수도 있다는 것입니다. 그러"
-"면\n"
-"  프로그램이 더이상 진행을 못하고 멈춰있을(stall) 수 있습니다. \n"
-"\n"
-"* `join_all`을 `join!`과 결합하여 http 서비스와 데이터베이스에 대한 모든 요청들을 한꺼번에 진행시킬 수도 있습니다.\n"
-"  `futures::join!`을 사용하여\n"
-"  `tokio::time::sleep`을 future에 추가해 보세요. 이건 타임아웃을 구현하는 것이 아님을 주의하세요. \n"
-" 실제로, 타임아웃은 다음 장에서 설명하는 `select!`를 사용해서 구현해야 합니다. "
-" 여기서는 `tokio::time::sleep`을 사용한 것은 단순히 `join!`의 동작을 설명하기 위함입니다."
+"`join_all`을 `join!`과 결합하여 http 서비스와 데이터베이스에 대한 모든 요청들"
+"을 한꺼번에 진행시킬 수도 있습니다. `futures::join!`을 사용하여 `tokio::"
+"time::sleep`을 future에 추가해 보세요. 이건 타임아웃을 구현하는 것이 아님을 "
+"주의하세요.  실제로, 타임아웃은 다음 장에서 설명하는 `select!`를 사용해서 구"
+"현해야 합니다.  여기서는 `tokio::time::sleep`을 사용한 것은 단순히 `join!`의 "
+"동작을 설명하기 위함입니다."
 
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
-"Select 연산은 여러 future들 모두에 대해서 준비될 때 까지 기다리다가, 그 중 어떤 한 future가 최초로 준비 상태가 되면 해당 future의 결과값을\n"
-"리턴합니다.  이것은 자바스크립트에서의 `Promise.race`와 비슷합니다. 파이썬에서라면\n"
-"`asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`가 하는 동작과 비슷합니다."
+"Select 연산은 여러 future들 모두에 대해서 준비될 때 까지 기다리다가, 그 중 어"
+"떤 한 future가 최초로 준비 상태가 되면 해당 future의 결과값을 리턴합니다.  이"
+"것은 자바스크립트에서의 `Promise.race`와 비슷합니다. 파이썬에서라면 `asyncio."
+"wait(task_set, return_when=asyncio.FIRST_COMPLETED)`가 하는 동작과 비슷합니"
+"다."
 
 #: src/async/control-flow/select.md:8
 msgid ""
 "Similar to a match statement, the body of `select!` has a number of arms, "
-"each\n"
-"of the form `pattern = future => statement`. When the `future` is ready, "
-"the\n"
-"`statement` is executed with the variables in `pattern` bound to the "
-"`future`'s\n"
-"result."
+"each of the form `pattern = future => statement`. When the `future` is "
+"ready, the `statement` is executed with the variables in `pattern` bound to "
+"the `future`'s result."
 msgstr ""
-" `select!` 안에는, `match`문과 비슷하게, `pattern = future => "
-"statement` 형태의 브랜치(arm)\n"
-"들이 있습니다. 어떤 'future'가 진행 가능 상태가 되면\n"
-"'그 `future`의 결과값이 `pattern`으로 바인딩 되며, 그 상태에서 `statement'가 수행됩니다."
+"`select!` 안에는, `match`문과 비슷하게, `pattern = future => statement` 형태"
+"의 브랜치(arm) 들이 있습니다. 어떤 'future'가 진행 가능 상태가 되면 '그 "
+"`future`의 결과값이 `pattern`으로 바인딩 되며, 그 상태에서 \\`statement'가 수"
+"행됩니다."
 
 #: src/async/control-flow/select.md:13
 msgid ""
@@ -13434,48 +15691,49 @@ msgstr ""
 
 #: src/async/control-flow/select.md:62
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick "
-"whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are "
-"supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts "
-"of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` moves the values it is given. It is easiest to use\n"
-"  when every execution of `select!` creates new futures. An alternative is "
-"to\n"
-"  pass `&mut future` instead of the future itself, but this can lead to\n"
-"  issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
 msgstr ""
-"* 이 예제에서는 고양이와 개를 경주시켰습니다(동시에 시작시킨 후, 둘 중 먼저 끝나는 쪽이 이김).\n"
-"  `first_animal_to_finish_race`함수는 두 채널 모두에 귀기울이고(listen하고) 있다가, 메시지가 먼저 도착한 채널"
-"을\n"
-"  선택합니다. 개는 50ms만에 작업을 끝내고 고양이는 500ms가 걸리기 때문에, 개가\n"
-"  이깁니다.\n"
-"\n"
-"* 이 예제에서는 `oneshot` 채널을 사용하는 것이 더 좋은 디자인 입니다. 각 채널이\n"
-"  한 번의 `send`만 수신해야 하는 것이 보장되기 때문입니다.\n"
-"\n"
-"* 이 경주에 타임아웃을 추가해서, 서로 다른 종류의 futures들을 동시에 `select`할 수 있음을\n"
-"  확인해 보세요.\n"
-"\n"
-"* `select!`는 매칭되지 않은 다른 모든 브랜치에 대해 drop을 수행합니다. 따라서 경쟁에서 진 모든 future들은 \n"
-"  취소(cancel) 됩니다. `select!`를 실행할 때마다\n"
-"  새로운 futures가 만들어지는 경우라면, 이러한 점이 매우 편하게 느껴질 것입니다.\n"
-"  Future가 취소되는 것을 막기 위해 future를 직접 전달하는 대신 `&mut future`를 전달하는 것도 가능합니다. \n"
-"  하지만 이렇게 하면 문제가\n"
-"  발생할 수 있습니다 (왜 그런지는 `Pin`설명할 때 자세히 설명하겠습니다)."
+"이 예제에서는 고양이와 개를 경주시켰습니다(동시에 시작시킨 후, 둘 중 먼저 끝"
+"나는 쪽이 이김). `first_animal_to_finish_race`함수는 두 채널 모두에 귀기울이"
+"고(listen하고) 있다가, 메시지가 먼저 도착한 채널을 선택합니다. 개는 50ms만에 "
+"작업을 끝내고 고양이는 500ms가 걸리기 때문에, 개가 이깁니다."
+
+#: src/async/control-flow/select.md:67
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+"이 예제에서는 `oneshot` 채널을 사용하는 것이 더 좋은 디자인 입니다. 각 채널"
+"이 한 번의 `send`만 수신해야 하는 것이 보장되기 때문입니다."
+
+#: src/async/control-flow/select.md:70
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+"이 경주에 타임아웃을 추가해서, 서로 다른 종류의 futures들을 동시에 `select`"
+"할 수 있음을 확인해 보세요."
+
+#: src/async/control-flow/select.md:73
+msgid ""
+"Note that `select!` moves the values it is given. It is easiest to use when "
+"every execution of `select!` creates new futures. An alternative is to pass "
+"`&mut future` instead of the future itself, but this can lead to issues, "
+"further discussed in the pinning slide."
+msgstr ""
+"`select!`는 매칭되지 않은 다른 모든 브랜치에 대해 drop을 수행합니다. 따라서 "
+"경쟁에서 진 모든 future들은  취소(cancel) 됩니다. `select!`를 실행할 때마다 "
+"새로운 futures가 만들어지는 경우라면, 이러한 점이 매우 편하게 느껴질 것입니"
+"다. Future가 취소되는 것을 막기 위해 future를 직접 전달하는 대신 `&mut "
+"future`를 전달하는 것도 가능합니다.  하지만 이렇게 하면 문제가 발생할 수 있습"
+"니다 (왜 그런지는 `Pin`설명할 때 자세히 설명하겠습니다)."
 
 #: src/async/pitfalls.md:1
-msgid "# Pitfalls of async/await"
-msgstr "# async/await에서 주의해야할 함정"
+msgid "Pitfalls of async/await"
+msgstr "async/await에서 주의해야할 함정"
 
 #: src/async/pitfalls.md:3
 msgid ""
@@ -13489,29 +15747,32 @@ msgstr ""
 "지 예를 살펴보겠습니다."
 
 #: src/async/pitfalls.md:5
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfall/async-traits.md)"
-msgstr ""
-"- [실행자 차단](pitfalls/blocking-executor.md)\n"
-"- [고정](pitfalls/pin.md)\n"
-"- [비동기 트레잇](pitfall/async-traits.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr "[실행자 차단](pitfalls/blocking-executor.md)"
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr "[고정](pitfalls/pin.md)"
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfall/async-traits.md)"
+msgstr "[비동기 트레잇](pitfall/async-traits.md)"
 
 #: src/async/pitfalls/blocking-executor.md:1
-msgid "# Blocking the executor"
-msgstr "# 실행자(executor)를 블록시킴"
+msgid "Blocking the executor"
+msgstr "실행자(executor)를 블록시킴"
 
 #: src/async/pitfalls/blocking-executor.md:3
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other "
-"tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
-"대부분의 비동기 런타임은 IO 작업만 동시에 실행되도록 허용합니다.\n"
-"즉, CPU를 블럭하는 태스크가 있는 경우, 이는 실행자(executor)를 블럭하게 되며, 그 결과로 다른 태스크가 실행되지 않습니다.\n"
-"이 문제를 해결하는 간단한 방법은, 항상 async를 지원하는 메서드를 사용하는 것입니다."
+"대부분의 비동기 런타임은 IO 작업만 동시에 실행되도록 허용합니다. 즉, CPU를 블"
+"럭하는 태스크가 있는 경우, 이는 실행자(executor)를 블럭하게 되며, 그 결과로 "
+"다른 태스크가 실행되지 않습니다. 이 문제를 해결하는 간단한 방법은, 항상 async"
+"를 지원하는 메서드를 사용하는 것입니다."
 
 #: src/async/pitfalls/blocking-executor.md:7
 msgid ""
@@ -13557,91 +15818,87 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its "
-"result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an "
-"actual\n"
-"  thread and transforms its handle into a future without blocking the "
-"executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and "
-"most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, "
-"where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
-"situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause "
-"another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
-"* 코드를 실행하여 sleep들이 동시에 진행되지 않고 순차적으로으로\n"
-"  진행되는지 확인하세요.\n"
-"\n"
-"* `flavor`를 `\"current_thread\"` 로 설정하면 모든 태스크가 하나의 스레드에서 수행됩니다. 이렇"
-"게 하면 문제 상황이 더 분명히 드러납니다. 그러나\n"
-"  이 버그는 멀티스레드인 경우에도 여전히\n"
-"  존재합니다.\n"
-"\n"
-"* `std::thread::sleep`을 `tokio::time::sleep`으로 바꾸고 그 결과를 `await`해 보세요.\n"
-"\n"
-"* 또 다른 해결 방법은 `tokio::task::spawn_blocking`입니다. 이는 실제 스레드를\n"
-"  생성하고, 그 스레드에 대한 핸들을 future로 변환함으로써 실행자가 블록되는 것을 막습니다.\n"
-"\n"
-"* 태스크를 OS 스레드라고 생각하면 안 됩니다. 태스크와 OS스레드는 일대일 매핑 관계에 있지 않습니다.\n"
-"  대부분의 실행자는 하나의 OS 스레드에서 최대한 많은 태스크를 수행하도록 설계되어 있습니다. 이"
-"점은\n"
-"  FFI를 통해 다른 라이브러리와 상호작용할 때 특히 문제가 됩니다.\n"
-"  예를 들어, 해당 라이브러리가 스레드 로컬 저장소를 이용하거나 특정 OS 스레드에\n"
-"  매핑될 수 있습니다(예: CUDA). 이러한 상황에서는 `tokio::task::"
-"spawn_blocking`을 사용하는 것이 좋습니다.\n"
-"\n"
-"* 동기화 뮤텍스를 주의해서 사용하세요. `.await` 위에 뮤텍스를 적용하면 다른 "
-"작업이\n"
-"  차단될 수 있으며 해당 작업은 동일한 스레드에서 실행 중일 수 있습니다."
+"코드를 실행하여 sleep들이 동시에 진행되지 않고 순차적으로으로 진행되는지 확인"
+"하세요."
 
-#: src/async/pitfalls/pin.md:1
-msgid "# Pin"
-msgstr "# Future 고정(Pin)하기"
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+"`flavor`를 `\"current_thread\"` 로 설정하면 모든 태스크가 하나의 스레드에서 "
+"수행됩니다. 이렇게 하면 문제 상황이 더 분명히 드러납니다. 그러나 이 버그는 멀"
+"티스레드인 경우에도 여전히 존재합니다."
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+"`std::thread::sleep`을 `tokio::time::sleep`으로 바꾸고 그 결과를 `await`해 보"
+"세요."
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+"또 다른 해결 방법은 `tokio::task::spawn_blocking`입니다. 이는 실제 스레드를 "
+"생성하고, 그 스레드에 대한 핸들을 future로 변환함으로써 실행자가 블록되는 것"
+"을 막습니다."
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+"태스크를 OS 스레드라고 생각하면 안 됩니다. 태스크와 OS스레드는 일대일 매핑 관"
+"계에 있지 않습니다. 대부분의 실행자는 하나의 OS 스레드에서 최대한 많은 태스크"
+"를 수행하도록 설계되어 있습니다. 이점은 FFI를 통해 다른 라이브러리와 상호작용"
+"할 때 특히 문제가 됩니다. 예를 들어, 해당 라이브러리가 스레드 로컬 저장소를 "
+"이용하거나 특정 OS 스레드에 매핑될 수 있습니다(예: CUDA). 이러한 상황에서는 "
+"`tokio::task::spawn_blocking`을 사용하는 것이 좋습니다."
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
+msgstr ""
+"동기화 뮤텍스를 주의해서 사용하세요. `.await` 위에 뮤텍스를 적용하면 다른 작"
+"업이 차단될 수 있으며 해당 작업은 동일한 스레드에서 실행 중일 수 있습니다."
+
+#: src/async/pitfalls/pin.md:1 src/SUMMARY.md:291
+msgid "Pin"
+msgstr "Future 고정(Pin)하기"
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
 "When you await a future, all local variables (that would ordinarily be "
-"stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. "
-"If your\n"
-"future has pointers to data on the stack, those pointers might get "
-"invalidated.\n"
-"This is unsafe."
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
-"Future에 대해 `await`를 호출하여 그 future가 준비되기를 기다릴 때, 모든 로컬 변수(일반적으로 스택 프레임에 저장됨)는\n"
-"그 future객체 안에 저장됩니다.  만약 그 future에\n"
-"스택에 있는 어떤 데이터로의 포인터가 있으면 이러한 포인터는 올바르지 않을 수 있습니다.\n"
-"안전하지 않습니다."
+"Future에 대해 `await`를 호출하여 그 future가 준비되기를 기다릴 때, 모든 로컬 "
+"변수(일반적으로 스택 프레임에 저장됨)는 그 future객체 안에 저장됩니다.  만약 "
+"그 future에 스택에 있는 어떤 데이터로의 포인터가 있으면 이러한 포인터는 올바"
+"르지 않을 수 있습니다. 안전하지 않습니다."
 
 #: src/async/pitfalls/pin.md:8
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to "
-"don't\n"
+"Therefore, you must guarantee that the addresses your future points to don't "
 "change. That is why we need to `pin` futures. Using the same future "
-"repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
-"따라서 future가 가리키는 주소가 변경되지 않도록\n"
-"해야 합니다. 이것이 future를 `pin`(고정)해야 하는 이유입니다. `select!`에서 동"
-"일한 future를\n"
-"반복적으로 사용하면 고정 값 문제가 발생하는 경우가 많습니다."
+"따라서 future가 가리키는 주소가 변경되지 않도록 해야 합니다. 이것이 future를 "
+"`pin`(고정)해야 하는 이유입니다. `select!`에서 동일한 future를 반복적으로 사"
+"용하면 고정 값 문제가 발생하는 경우가 많습니다."
 
 #: src/async/pitfalls/pin.md:12
 msgid ""
@@ -13755,105 +16012,112 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your "
-"time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!"
-"(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the "
-"`loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to "
-"the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on "
-"every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, "
-"but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that "
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
+msgstr ""
+"위에서 소개한 것은 액터(actor) 패턴의 한 예라고 봐도 무방합니다. 액터는 일반"
+"적으로 루프 안에서 `select!`를 호출합니다."
+
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr "이전 강의 몇 개의 내용을 요약한 것이기 때문에 천천히 살펴보세요."
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+"`_ = sleep(Duration::from_millis(100)) => { println!(..) }`을 `select!`에 추"
+"가해 보세요. 이 작업은 실행되지 않습니다. 왜 그럴까요?"
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+"대신, 해당 future가 포함된 `timeout_fut`를 `loop` 외부에 추가해 보세요."
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+"여전히 작동하지 않습니다. 컴파일러 오류를 따라 `select!`의 `timeout_fut`에 "
+"`&mut`를 추가하여 Move 시멘틱 관련한 문제를 해결하고 `Box::pin`을 사용하세요."
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+"이는 컴파일은 되지만 타임 아웃이 되면 매번 반복할 때 마다 `Poll::Ready`가 됩"
+"니다(융합된 future가 도움이 될 수 있음). 타임 아웃 될 때마다 `timeout_fut`를 "
+"리셋하도록 수정하세요."
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+"Box는 힙에 할당합니다. 경우에 따라 `std::pin::pin!`(최근에야 안정화되었으며 "
+"이전 코드는 `tokio::pin!`을 사용하는 경우가 많음)도 사용할 수 있지만 이는 재"
+"할당된 future에 사용하기가 어렵습니다."
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
 "will send to a `oneshot` channel every 100ms."
 msgstr ""
-"* 위에서 소개한 것은 액터(actor) 패턴의 한 예라고 봐도 무방합니다. 액터는 일반적으로 루프 안에서\n"
-"  `select!`를 호출합니다.\n"
-"\n"
-"* 이전 강의 몇 개의 내용을 요약한 것이기 때문에 천천히\n"
-"  살펴보세요.\n"
-"\n"
-"    * `_ = sleep(Duration::from_millis(100)) => { println!(..) }`을 `select!`"
-"에 추가해 보세요.\n"
-"      이 작업은 실행되지 않습니다. 왜 그럴까요?\n"
-"\n"
-"    * 대신, 해당 future가 포함된 `timeout_fut`를 `loop` 외부에 추가해 보세요.\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * 여전히 작동하지 않습니다. 컴파일러 오류를 따라 `select!`의 "
-"`timeout_fut`에\n"
-"      `&mut`를 추가하여 Move 시멘틱 관련한 문제를 해결하고 `Box::pin`을\n"
-"      사용하세요.\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * 이는 컴파일은 되지만 타임 아웃이 되면 매번 반복할 때 마다\n"
-"      `Poll::Ready`가 됩니다(융합된 future가 도움이 될 수 있음). 타임 아웃 될 때마"
-"다\n"
-"      `timeout_fut`를 리셋하도록 수정하세요.\n"
-"\n"
-"* Box는 힙에 할당합니다. 경우에 따라 `std::pin::pin!`(최근에야 안정화되었으"
-"며 이전 코드는\n"
-"  `tokio::pin!`을 사용하는 경우가 많음)도 사용할 수 있지만\n"
-"  이는 재할당된 future에 사용하기가 어렵습니다.\n"
-"\n"
-"* 또 다른 방법은 `pin`을 아예 사용하지 않고 100ms마다 `oneshot` 채널에 전송"
-"할 다른 작업을 생성하는 것입니다."
+"또 다른 방법은 `pin`을 아예 사용하지 않고 100ms마다 `oneshot` 채널에 전송할 "
+"다른 작업을 생성하는 것입니다."
 
 #: src/async/pitfalls/async-traits.md:3
 msgid ""
@@ -13862,9 +16126,9 @@ msgid ""
 "term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-"
 "nightly.html))"
 msgstr ""
-"트레잇에 async 메소드를 추가하는 것은 아직 안정화 버전 채널에서 지원되지 않습니다([실험용 "
-"기능은 nightly에 존재하며 조만간 안정화 될 것입니다](https://blog.rust-lang.org/inside-"
-"rust/2022/11/17/async-fn-in-trait-nightly.html))."
+"트레잇에 async 메소드를 추가하는 것은 아직 안정화 버전 채널에서 지원되지 않습"
+"니다([실험용 기능은 nightly에 존재하며 조만간 안정화 될 것입니다](https://"
+"blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html))."
 
 #: src/async/pitfalls/async-traits.md:5
 msgid ""
@@ -13964,56 +16228,49 @@ msgstr ""
 
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations "
-"to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of "
-"time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
 msgstr ""
-"* `async_trait`은 사용하기 쉽지만 이를 위해 힙에 메모리를  할당한다는 점에\n"
-"  유의하세요. 이 힙 할당에는 성능 오버헤드가 있습니다.\n"
-"\n"
-"* `async trait` 를 언어 차원에서 지원하는 것과 관련된 문제는 매우 전문적인 토픽이며\n"
-"  따라서 이 강의에서 다룰 내용은 아닙니다. [이 게시물](https://smallcultfollowing."
-"com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)에\n"
-"  이에 관한 니코 마사키스의 좋은 설명이\n"
-"  있으므로 관심이 있다면\n"
-"  참고하세요.\n"
-"\n"
-"* 임의의 시간 동안 sleep 하는 새로운 sleeper 구조체를 만들어\n"
-"  Vec에 추가해 보세요."
+"`async_trait`은 사용하기 쉽지만 이를 위해 힙에 메모리를  할당한다는 점에 유의"
+"하세요. 이 힙 할당에는 성능 오버헤드가 있습니다."
 
-#: src/exercises/day-4/morning.md:1 src/exercises/day-4/android.md:1
-msgid "# Exercises"
-msgstr "# 연습문제"
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+"`async trait` 를 언어 차원에서 지원하는 것과 관련된 문제는 매우 전문적인 토픽"
+"이며 따라서 이 강의에서 다룰 내용은 아닙니다. [이 게시물](https://"
+"smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-"
+"hard/)에 이에 관한 니코 마사키스의 좋은 설명이 있으므로 관심이 있다면 참고하"
+"세요."
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
+msgstr ""
+"임의의 시간 동안 sleep 하는 새로운 sleeper 구조체를 만들어 Vec에 추가해 보세"
+"요."
 
 #: src/exercises/day-4/morning.md:3
 msgid "Let us practice our new concurrency skills with"
 msgstr "동시성 기법들을 연습해 봅시다"
 
 #: src/exercises/day-4/morning.md:5
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
-msgstr ""
-"* 식사하는 철학자 문제: 고적적인 동시성 문제입니다.\n"
-"\n"
-"* 멀티 스레드 링크 검사기: 병렬적으로 웹페이지의 링크들을 체크합니다. 카고를 통해 몇 가지 의존성들을 다운도르 받아야 하는 큰 프로젝트 입니다."
+msgid "Dining philosophers: a classic problem in concurrency."
+msgstr "식사하는 철학자 문제: 고적적인 동시성 문제입니다."
 
-#: src/exercises/day-4/dining-philosophers.md:1
-msgid "# Dining Philosophers"
-msgstr "# 식사하는 철학자들"
+#: src/exercises/day-4/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
+msgstr ""
+"멀티 스레드 링크 검사기: 병렬적으로 웹페이지의 링크들을 체크합니다. 카고를 통"
+"해 몇 가지 의존성들을 다운도르 받아야 하는 큰 프로젝트 입니다."
 
 #: src/exercises/day-4/dining-philosophers.md:3
 msgid "The dining philosophers problem is a classic problem in concurrency:"
@@ -14021,29 +16278,32 @@ msgstr "식사하는 철학자 문제는 동시성에 있어서 고전적인 문
 
 #: src/exercises/day-4/dining-philosophers.md:5
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has their\n"
-"> own place at the table. There is a fork between each plate. The dish served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will only\n"
-"> be available when their two nearest neighbors are thinking, not eating. After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
-"> 5명의 철학자가 원탁에서 식사를 하고 있습니다. \n"
-"> 철학자는 원탁에서 자신의 자리에 앉아있습니다.\n"
-"> 포크는 각 접시 사이에 있습니다. \n"
-"> 제공되는 요리를 먹기 위해서는 두 개의 포크를 모두 사용해야합니다.\n"
-"> 철학자는 생각을 하다가 배가 고프면 자신의 좌,우의 포크를 들어 요리를 먹습니다.\n"
-"> 철학자는 요리를 먹은 후에는 포크를 다시 자리에 내려놓습니다.\n"
-"> 철학자는 자신의 좌,우에 포크가 있을때만 요리를 먹을 수 있습니다.\n"
-"> 따라서 두 개의 포크는 오직 자신의 좌,우 철학자가 생각을 할 때만 사용할 수 있습니다."
+"5명의 철학자가 원탁에서 식사를 하고 있습니다.  철학자는 원탁에서 자신의 자리"
+"에 앉아있습니다. 포크는 각 접시 사이에 있습니다.  제공되는 요리를 먹기 위해서"
+"는 두 개의 포크를 모두 사용해야합니다. 철학자는 생각을 하다가 배가 고프면 자"
+"신의 좌,우의 포크를 들어 요리를 먹습니다. 철학자는 요리를 먹은 후에는 포크를 "
+"다시 자리에 내려놓습니다. 철학자는 자신의 좌,우에 포크가 있을때만 요리를 먹"
+"을 수 있습니다. 따라서 두 개의 포크는 오직 자신의 좌,우 철학자가 생각을 할 때"
+"만 사용할 수 있습니다."
 
 #: src/exercises/day-4/dining-philosophers.md:13
 msgid ""
-"You will need a local [Cargo installation](../../cargo/running-locally.md) for\n"
-"this exercise. Copy the code below to `src/main.rs` file, fill out the blanks,\n"
-"and test that `cargo run` does not deadlock:"
-msgstr "이번 훈련에서는 [카고 설치하기](../../cargo/running-locally.md)가 필요합니다. 아래 코드를 복사해서 `src/main.rs`에 붙여놓고 빈 부분을 채우고, `cargo run` 커맨드로 테스트 해서 교착상태(데드락)가 발생하지 않는지 확인합니다:"
+"You will need a local [Cargo installation](../../cargo/running-locally.md) "
+"for this exercise. Copy the code below to `src/main.rs` file, fill out the "
+"blanks, and test that `cargo run` does not deadlock:"
+msgstr ""
+"이번 훈련에서는 [카고 설치하기](../../cargo/running-locally.md)가 필요합니"
+"다. 아래 코드를 복사해서 `src/main.rs`에 붙여놓고 빈 부분을 채우고, `cargo "
+"run` 커맨드로 테스트 해서 교착상태(데드락)가 발생하지 않는지 확인합니다:"
 
 #: src/exercises/day-4/dining-philosophers.md:17
 msgid ""
@@ -14091,23 +16351,24 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-4/link-checker.md:1
-msgid "# Multi-threaded Link Checker"
-msgstr "# 멀티스레드 링크 검사기"
-
 #: src/exercises/day-4/link-checker.md:3
 msgid ""
-"Let us use our new knowledge to create a multi-threaded link checker. It should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until all\n"
-"pages have been validated."
-msgstr "새로 배운것들을 활용해서 멀티 스레드 링크 검사기를 만듭니다. 이 검사기는 웹페이지 안에 있는 링크들이 유효한지 확인합니다. 그리고 재귀적으로 동일 도메인의 다른 모든 페이지가 유효한지 확인합니다."
+"Let us use our new knowledge to create a multi-threaded link checker. It "
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
+msgstr ""
+"새로 배운것들을 활용해서 멀티 스레드 링크 검사기를 만듭니다. 이 검사기는 웹페"
+"이지 안에 있는 링크들이 유효한지 확인합니다. 그리고 재귀적으로 동일 도메인의 "
+"다른 모든 페이지가 유효한지 확인합니다."
 
 #: src/exercises/day-4/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
-msgstr "이를 위해서 [`reqwest`][1]와 같은 HTTP 클라이언트가 필요합니다. 새로운 로컬 프로젝트를 만들고 [`reqwest`][1]를 의존성에 추가하십시요:"
+"For this, you will need an HTTP client such as \\[`reqwest`\\]\\[1\\]. "
+"Create a new Cargo project and `reqwest` it as a dependency with:"
+msgstr ""
+"이를 위해서 \\[`reqwest`\\]\\[1\\]와 같은 HTTP 클라이언트가 필요합니다. 새로"
+"운 로컬 프로젝트를 만들고 \\[`reqwest`\\]\\[1\\]를 의존성에 추가하십시요:"
 
 #: src/exercises/day-4/link-checker.md:11
 msgid ""
@@ -14120,13 +16381,17 @@ msgstr ""
 
 #: src/exercises/day-4/link-checker.md:17
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
-msgstr "> 만일 `cargo add` 커맨드가 `error: no such subcommand` 로 실패한다면 `Cargo.toml` 파일을 직접 수정해도 됩니다. 아래에 전체 의존성 내용이 있습니다."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
+msgstr ""
+"만일 `cargo add` 커맨드가 `error: no such subcommand` 로 실패한다면 `Cargo."
+"toml` 파일을 직접 수정해도 됩니다. 아래에 전체 의존성 내용이 있습니다."
 
 #: src/exercises/day-4/link-checker.md:20
-msgid "You will also need a way to find links. We can use [`scraper`][2] for that:"
-msgstr "링크를 찾기 위해서 [`scraper`][2]도 추가합니다:"
+msgid ""
+"You will also need a way to find links. We can use \\[`scraper`\\]\\[2\\] "
+"for that:"
+msgstr "링크를 찾기 위해서 \\[`scraper`\\]\\[2\\]도 추가합니다:"
 
 #: src/exercises/day-4/link-checker.md:22
 msgid ""
@@ -14137,9 +16402,10 @@ msgstr ""
 
 #: src/exercises/day-4/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] for\n"
-"that:"
-msgstr "마지막으로 오류 처리하는 방법으로 [`thiserror`][3]도 추가합니다:"
+"Finally, we'll need some way of handling errors. We use "
+"\\[`thiserror`\\]\\[3\\] for that:"
+msgstr ""
+"마지막으로 오류 처리하는 방법으로 \\[`thiserror`\\]\\[3\\]도 추가합니다:"
 
 #: src/exercises/day-4/link-checker.md:29
 msgid ""
@@ -14149,14 +16415,16 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:33
-msgid "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
+msgid ""
+"The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr "모든 `cargo add`가 끝나면 `Cargo.toml`에 아래 내용이 추가됩니다:"
 
 #: src/exercises/day-4/link-checker.md:35
 msgid ""
 "```toml\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] }\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -14164,8 +16432,8 @@ msgstr ""
 
 #: src/exercises/day-4/link-checker.md:42
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr "이제 `https://www.google.org/` 같은 웹 페이지를 탐색할 수 있습니다."
 
 #: src/exercises/day-4/link-checker.md:45
@@ -14198,7 +16466,8 @@ msgid ""
 "            match base_url.join(href) {\n"
 "                Ok(url) => valid_urls.push(url),\n"
 "                Err(err) => {\n"
-"                    println!(\"On {base_url}: could not parse {href:?}: {err} (ignored)\",);\n"
+"                    println!(\"On {base_url}: could not parse {href:?}: "
+"{err} (ignored)\",);\n"
 "                }\n"
 "            }\n"
 "        }\n"
@@ -14230,48 +16499,53 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:96
-msgid "## Tasks"
-msgstr "## 할 일"
+msgid "Tasks"
+msgstr "할 일"
 
 #: src/exercises/day-4/link-checker.md:98
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
 msgstr ""
-"* 스레드를 사용하여 링크를 병렬로 확인합니다: URL을 채널로 보내서 몇 개의 스레드가 URL을 병렬로 체크하도록 합니다.\n"
-"* `www.google.org`도메인의 모든 페이지를 재귀적으로 확인하기 위해 코드를 확장해서 작성합니다: 차단당하지 않도록 100페이지 정도로 제한을 두시기 바랍니다."
+"스레드를 사용하여 링크를 병렬로 확인합니다: URL을 채널로 보내서 몇 개의 스레"
+"드가 URL을 병렬로 체크하도록 합니다."
 
-#: src/android.md:1
-msgid "# Android"
-msgstr "# 안드로이드"
+#: src/exercises/day-4/link-checker.md:100
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
+msgstr ""
+"`www.google.org`도메인의 모든 페이지를 재귀적으로 확인하기 위해 코드를 확장해"
+"서 작성합니다: 차단당하지 않도록 100페이지 정도로 제한을 두시기 바랍니다."
 
 #: src/android.md:3
 msgid ""
-"Rust is supported for native platform development on Android. This means that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
-msgstr "러스트는 안드로이드 네이티브 플랫폼 개발을 지원합니다. 기존의 OS 서비스를 확장하거나, 새로운 서비스를 만드는데 러스트를 쓸 수 있습니다."
+"Rust is supported for native platform development on Android. This means "
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
+msgstr ""
+"러스트는 안드로이드 네이티브 플랫폼 개발을 지원합니다. 기존의 OS 서비스를 확"
+"장하거나, 새로운 서비스를 만드는데 러스트를 쓸 수 있습니다."
 
 #: src/android.md:7
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try to\n"
-"> find a little corner of your code base where we can move some lines of code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something that\n"
-"> parses some raw bytes would be ideal."
-msgstr "> 우리는 오늘 여러분의 프로젝트에서 러스트 코드를 호출해볼 것입니다. 그 프로젝트에서 러스트로 옮길만 한 작은 부분을 정하세요. 의존성이 적고 \"특이한\" 타입이 적을 수록 좋습니다. 바이트 몇 개를 파싱하는 코드라면 완벽합니다."
-
-#: src/android/setup.md:1
-msgid "# Setup"
-msgstr "# 설치"
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
+msgstr ""
+"우리는 오늘 여러분의 프로젝트에서 러스트 코드를 호출해볼 것입니다. 그 프로젝"
+"트에서 러스트로 옮길만 한 작은 부분을 정하세요. 의존성이 적고 \"특이한\" 타입"
+"이 적을 수록 좋습니다. 바이트 몇 개를 파싱하는 코드라면 완벽합니다."
 
 #: src/android/setup.md:3
 msgid ""
-"We will be using an Android Virtual Device to test our code. Make sure you have\n"
-"access to one or create a new one with:"
-msgstr "안드로이드 가상 디바이스(Android Virtual Device)를 사용하여 여러분의 코드를 수행할 겁니다. 새로운 가상 디바이스를 생성하려면 아래의 명령어를 사용하세요:"
+"We will be using an Android Virtual Device to test our code. Make sure you "
+"have access to one or create a new one with:"
+msgstr ""
+"안드로이드 가상 디바이스(Android Virtual Device)를 사용하여 여러분의 코드를 "
+"수행할 겁니다. 새로운 가상 디바이스를 생성하려면 아래의 명령어를 사용하세요:"
 
 #: src/android/setup.md:6
 msgid ""
@@ -14289,55 +16563,117 @@ msgstr ""
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
-msgstr "자세한 내용은 [Android Developer Codelab](https://source.android.com/docs/setup/start)을 참조하십시오."
-
-#: src/android/build-rules.md:1
-msgid "# Build Rules"
-msgstr "# 빌드 규칙(Build Rules)"
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
+msgstr ""
+"자세한 내용은 [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start)을 참조하십시오."
 
 #: src/android/build-rules.md:3
 msgid "The Android build system (Soong) supports Rust via a number of modules:"
-msgstr "안드로이드 빌드 시스템(Soong)은 다음과 같은 여러 모듈을 통해 러스트를 지원합니다:"
+msgstr ""
+"안드로이드 빌드 시스템(Soong)은 다음과 같은 여러 모듈을 통해 러스트를 지원합"
+"니다:"
 
 #: src/android/build-rules.md:5
+msgid "Module Type"
+msgstr "Module Type"
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr "Description"
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr "`rust_binary`"
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr "러스트 바이너리를 생성합니다."
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr "`rust_library`"
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr "러스트 라이브러리(rlib혹은 dylib)를 생성합니다."
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr "`rust_ffi`"
+
+#: src/android/build-rules.md:9
 msgid ""
-"| Module Type       | Description                                                                                        |\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust binary.                                                                            |\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and `dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging `libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library containing Rust bindings to C libraries.              |"
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr "cc 모듈에서 사용할 수 있는 C library (정적 혹은 동적)를 생성합니다."
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr "`rust_proc_macro`"
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
 msgstr ""
-"| Module Type       | Description                                          |\n"
-"|-------------------|------------------------------------------------------|\n"
-"| `rust_binary`     | 러스트 바이너리를 생성합니다.|\n"
-"| `rust_library`    | 러스트 라이브러리(rlib혹은 dylib)를 생성합니다.|\n"
-"| `rust_ffi`        | cc 모듈에서 사용할 수 있는 C library (정적 혹은 동적)를 생성합니다.|\n"
-"| `rust_proc_macro` | `proc-macro`를 구현하는 러스트 라이브러리를 생성합니다. 컴파일러의 플러그인으로 생각해도 좋습니다.|\n"
-"| `rust_test`       | 표준 러스트 테스트 러너를 사용하는 테스트 바이너리를 생성합니다.|\n"
-"| `rust_fuzz`       | `libfuzzer`를 사용하여 fuzz 바이너리를 생성합니다.|\n"
-"| `rust_protobuf`   | 프로토버프(protobuf) 인터페이스를 제공하는 러스트 라이브러리를 생성합니다.|\n"
-"| `rust_bindgen`    | C 라이브러리에 대한 러스트 바인딩을 제공하는 러스트 라이브러리를 생성합니다.|"
+"`proc-macro`를 구현하는 러스트 라이브러리를 생성합니다. 컴파일러의 플러그인으"
+"로 생각해도 좋습니다."
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr "`rust_test`"
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr "표준 러스트 테스트 러너를 사용하는 테스트 바이너리를 생성합니다."
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr "`rust_fuzz`"
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr "`libfuzzer`를 사용하여 fuzz 바이너리를 생성합니다."
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr "`rust_protobuf`"
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+"프로토버프(protobuf) 인터페이스를 제공하는 러스트 라이브러리를 생성합니다."
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr "`rust_bindgen`"
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr ""
+"C 라이브러리에 대한 러스트 바인딩을 제공하는 러스트 라이브러리를 생성합니다."
 
 #: src/android/build-rules.md:16
 msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr "다음은 `rust_binary`와 `rust_library`를 살펴봅니다."
 
 #: src/android/build-rules/binary.md:1
-msgid "# Rust Binaries"
-msgstr "# 러스트 바이너리"
+msgid "Rust Binaries"
+msgstr "러스트 바이너리"
 
 #: src/android/build-rules/binary.md:3
 msgid ""
-"Let us start with a simple application. At the root of an AOSP checkout, create\n"
-"the following files:"
-msgstr "간단한 응용 프로그램으로 시작해 보겠습니다. AOSP 체크아웃의 루트에서 다음 파일을 생성합니다:"
+"Let us start with a simple application. At the root of an AOSP checkout, "
+"create the following files:"
+msgstr ""
+"간단한 응용 프로그램으로 시작해 보겠습니다. AOSP 체크아웃의 루트에서 다음 파"
+"일을 생성합니다:"
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 msgid "_hello_rust/Android.bp_:"
@@ -14416,25 +16752,30 @@ msgstr ""
 "```"
 
 #: src/android/build-rules/library.md:1
-msgid "# Rust Libraries"
-msgstr "# 러스트 라이브러리"
+msgid "Rust Libraries"
+msgstr "러스트 라이브러리"
 
 #: src/android/build-rules/library.md:3
 msgid "You use `rust_library` to create a new Rust library for Android."
-msgstr "`rust_library`를 사용하여 안드로이드용 새 러스트 라이브러리를 만듭니다."
+msgstr ""
+"`rust_library`를 사용하여 안드로이드용 새 러스트 라이브러리를 만듭니다."
 
 #: src/android/build-rules/library.md:5
 msgid "Here we declare a dependency on two libraries:"
 msgstr "여기서 두 개의 라이브러리에 대한 의존성을 선언합니다:"
 
 #: src/android/build-rules/library.md:7
+msgid "`libgreeting`, which we define below,"
+msgstr "아래에 정의한 `libgreeting`."
+
+#: src/android/build-rules/library.md:8
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"* 아래에 정의한 `libgreeting`.\n"
-"* [`external/rust/crates/`][crates]에 존재하는 `libtextwrap`."
+"[`external/rust/crates/`](https://cs.android.com/android/platform/"
+"superproject/+/master:external/rust/crates/)에 존재하는 `libtextwrap`."
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -14534,7 +16875,8 @@ msgstr "이전처럼, 빌드하고, 가상 디바이스로 넣고, 실행합니�
 msgid ""
 "```shell\n"
 "$ m hello_rust_with_dep\n"
-"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/tmp\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
+"tmp\n"
 "$ adb shell /data/local/tmp/hello_rust_with_dep\n"
 "Hello Bob, it is very\n"
 "nice to meet you!\n"
@@ -14577,36 +16919,35 @@ msgstr ""
 "$ adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 
-#: src/android/aidl.md:1
-msgid "# AIDL"
-msgstr "# AIDL"
-
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in Rust:"
-msgstr "러스트는 [안드로이드 인터페이스 정의 언어(AIDL)](https://developer.android.com/guide/components/aidl)를 지원합니다:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
+msgstr ""
+"러스트는 [안드로이드 인터페이스 정의 언어(AIDL)](https://developer.android."
+"com/guide/components/aidl)를 지원합니다:"
 
 #: src/android/aidl.md:6
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
-msgstr ""
-"* 러스트 코드에서 기존 AIDL 서버를 호출 할 수 있습니다. \n"
-"* 러스트에서 새로운 AIDL 서버를 생성할 수 있습니다."
+msgid "Rust code can call existing AIDL servers,"
+msgstr "러스트 코드에서 기존 AIDL 서버를 호출 할 수 있습니다. "
+
+#: src/android/aidl.md:7
+msgid "You can create new AIDL servers in Rust."
+msgstr "러스트에서 새로운 AIDL 서버를 생성할 수 있습니다."
 
 #: src/android/aidl/interface.md:1
-msgid "# AIDL Interfaces"
-msgstr "# AIDL 인터페이스"
+msgid "AIDL Interfaces"
+msgstr "AIDL 인터페이스"
 
 #: src/android/aidl/interface.md:3
 msgid "You declare the API of your service using an AIDL interface:"
 msgstr "AIDL 인터페이스를 이용해서 서비스의 API를 선언합니다:"
 
 #: src/android/aidl/interface.md:5
-msgid "*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+msgid ""
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 
 #: src/android/aidl/interface.md:7
 msgid ""
@@ -14631,8 +16972,8 @@ msgstr ""
 "```"
 
 #: src/android/aidl/interface.md:17
-msgid "*birthday_service/aidl/Android.bp*:"
-msgstr "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_birthday_service/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md:19
 msgid ""
@@ -14664,27 +17005,30 @@ msgstr ""
 
 #: src/android/aidl/interface.md:32
 msgid ""
-"Add `vendor_available: true` if your AIDL file is used by a binary in the vendor\n"
-"partition."
-msgstr "AIDL 파일이 벤더 파티션에 있는 바이너리에서 사용될 경우 `vendor_available: true`를 추가합니다."
+"Add `vendor_available: true` if your AIDL file is used by a binary in the "
+"vendor partition."
+msgstr ""
+"AIDL 파일이 벤더 파티션에 있는 바이너리에서 사용될 경우 `vendor_available: "
+"true`를 추가합니다."
 
 #: src/android/aidl/implementation.md:1
-msgid "# Service Implementation"
-msgstr "# 서비스 구현"
+msgid "Service Implementation"
+msgstr "서비스 구현"
 
 #: src/android/aidl/implementation.md:3
 msgid "We can now implement the AIDL service:"
 msgstr "이제 AIDL서비스를 구현할 수 있습니다:"
 
 #: src/android/aidl/implementation.md:5
-msgid "*birthday_service/src/lib.rs*:"
-msgstr "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
+msgstr "_birthday_service/src/lib.rs_:"
 
 #: src/android/aidl/implementation.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "/// The `IBirthdayService` implementation.\n"
@@ -14693,9 +17037,11 @@ msgid ""
 "impl binder::Interface for BirthdayService {}\n"
 "\n"
 "impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::Result<String> {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
+"Result<String> {\n"
 "        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} years!\"\n"
+"            \"Happy Birthday {name}, congratulations with the {years} years!"
+"\"\n"
 "        ))\n"
 "    }\n"
 "}\n"
@@ -14725,8 +17071,8 @@ msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
-msgid "*birthday_service/Android.bp*:"
-msgstr "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
+msgstr "_birthday_service/Android.bp_:"
 
 #: src/android/aidl/implementation.md:28
 msgid ""
@@ -14755,23 +17101,24 @@ msgstr ""
 "```"
 
 #: src/android/aidl/server.md:1
-msgid "# AIDL Server"
-msgstr "# AIDL 서버"
+msgid "AIDL Server"
+msgstr "AIDL 서버"
 
 #: src/android/aidl/server.md:3
 msgid "Finally, we can create a server which exposes the service:"
 msgstr "마지막으로 서비스를 제공하는 서버를 만들 수 있습니다:"
 
 #: src/android/aidl/server.md:5
-msgid "*birthday_service/src/server.rs*:"
-msgstr "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_birthday_service/src/server.rs_:"
 
 #: src/android/aidl/server.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
 "use birthdayservice::BirthdayService;\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
@@ -14783,7 +17130,8 @@ msgid ""
 "        birthday_service,\n"
 "        binder::BinderFeatures::default(),\n"
 "    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder.as_binder())\n"
+"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
+"as_binder())\n"
 "        .expect(\"Failed to register service\");\n"
 "    binder::ProcessState::join_thread_pool()\n"
 "}\n"
@@ -14841,10 +17189,6 @@ msgstr ""
 "    prefer_rlib: true,\n"
 "}\n"
 "```"
-
-#: src/android/aidl/deploy.md:1
-msgid "# Deploy"
-msgstr "# 배포"
 
 #: src/android/aidl/deploy.md:3
 msgid "We can now build, push, and start the service:"
@@ -14924,28 +17268,31 @@ msgstr ""
 "```"
 
 #: src/android/aidl/client.md:1
-msgid "# AIDL Client"
-msgstr "# AIDL 클라이언트"
+msgid "AIDL Client"
+msgstr "AIDL 클라이언트"
 
 #: src/android/aidl/client.md:3
 msgid "Finally, we can create a Rust client for our new service."
-msgstr "마지막으로, 아까 추가한 서비스에 대한 클라이언트를 러스트로 만들겠습니다."
+msgstr ""
+"마지막으로, 아까 추가한 서비스에 대한 클라이언트를 러스트로 만들겠습니다."
 
 #: src/android/aidl/client.md:5
-msgid "*birthday_service/src/client.rs*:"
-msgstr "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
+msgstr "_birthday_service/src/client.rs_:"
 
 #: src/android/aidl/client.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
 "\n"
 "/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::StatusCode> {\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
+"StatusCode> {\n"
 "    binder::get_interface(SERVICE_IDENTIFIER)\n"
 "}\n"
 "\n"
@@ -14960,7 +17307,8 @@ msgid ""
 "        .unwrap_or(42);\n"
 "\n"
 "    binder::ProcessState::start_thread_pool();\n"
-"    let service = connect().expect(\"Failed to connect to BirthdayService\");\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
 "    let msg = service.wishHappyBirthday(&name, years)?;\n"
 "    println!(\"{msg}\");\n"
 "    Ok(())\n"
@@ -15064,15 +17412,13 @@ msgstr ""
 "Happy Birthday Charlie, congratulations with the 60 years!\n"
 "```"
 
-#: src/android/aidl/changing.md:1
-msgid "# Changing API"
-msgstr "# API 수정"
-
 #: src/android/aidl/changing.md:3
 msgid ""
-"Let us extend the API with more functionality: we want to let clients specify a\n"
-"list of lines for the birthday card:"
-msgstr "API를 확장하여 더 많은 기능을 제공해 봅시다. 클라이언트가 생일 카드에 담길 내용을 지정할 수 있도록 하겠습니다:"
+"Let us extend the API with more functionality: we want to let clients "
+"specify a list of lines for the birthday card:"
+msgstr ""
+"API를 확장하여 더 많은 기능을 제공해 봅시다. 클라이언트가 생일 카드에 담길 내"
+"용을 지정할 수 있도록 하겠습니다:"
 
 #: src/android/aidl/changing.md:6
 msgid ""
@@ -15096,15 +17442,14 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/android/logging.md:1
-msgid "# Logging"
-msgstr "# 로깅"
-
 #: src/android/logging.md:3
 msgid ""
-"You should use the `log` crate to automatically log to `logcat` (on-device) or\n"
-"`stdout` (on-host):"
-msgstr "`log` 크레이트를 사용하면 안드로이드 디바이스 안에서 수행될 때에는 `logcat`으로, 호스트에서 수행될 때에는 `stdout`으로 로그가 자동으로 출력이 되도록 할 수 있습니다:"
+"You should use the `log` crate to automatically log to `logcat` (on-device) "
+"or `stdout` (on-host):"
+msgstr ""
+"`log` 크레이트를 사용하면 안드로이드 디바이스 안에서 수행될 때에는 `logcat`으"
+"로, 호스트에서 수행될 때에는 `stdout`으로 로그가 자동으로 출력이 되도록 할 "
+"수 있습니다:"
 
 #: src/android/logging.md:6
 msgid "_hello_rust_logs/Android.bp_:"
@@ -15205,8 +17550,10 @@ msgid ""
 "```shell\n"
 "$ adb logcat -s rust\n"
 "09-08 08:38:32.454  2420  2420 D rust: hello_rust_logs: Starting program.\n"
-"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going fine.\n"
-"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went wrong!\n"
+"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going "
+"fine.\n"
+"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went "
+"wrong!\n"
 "```"
 msgstr ""
 "```shell\n"
@@ -15218,39 +17565,39 @@ msgstr ""
 "wrong!\n"
 "```"
 
-#: src/android/interoperability.md:1
-msgid "# Interoperability"
-msgstr "# 상호운용성(Interoperability)"
-
 #: src/android/interoperability.md:3
 msgid ""
-"Rust has excellent support for interoperability with other languages. This means\n"
-"that you can:"
+"Rust has excellent support for interoperability with other languages. This "
+"means that you can:"
 msgstr "러스트는 다음과 같이 다른 언어와의 상호운용성을 훌륭히 지원합니다:"
 
 #: src/android/interoperability.md:6
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
-msgstr ""
-"* 타 언어에서 러스트 함수를 호출합니다.\n"
-"* 타 언어의 함수를 러스트에서 호출합니다."
+msgid "Call Rust functions from other languages."
+msgstr "타 언어에서 러스트 함수를 호출합니다."
+
+#: src/android/interoperability.md:7
+msgid "Call functions written in other languages from Rust."
+msgstr "타 언어의 함수를 러스트에서 호출합니다."
 
 #: src/android/interoperability.md:9
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
-msgstr "타 언어의 함수를 호출해서 사용하는 것을 FFI(foreign function interface)라고 합니다."
+msgstr ""
+"타 언어의 함수를 호출해서 사용하는 것을 FFI(foreign function interface)라고 "
+"합니다."
 
 #: src/android/interoperability/with-c.md:1
-msgid "# Interoperability with C"
-msgstr "# C와의 상호운용성"
+msgid "Interoperability with C"
+msgstr "C와의 상호운용성"
 
 #: src/android/interoperability/with-c.md:3
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
-msgstr "러스트는 C 호출규약을 따르는 오브젝트 파일과 링킹할 수 있습니다. 또한, 반대로 러스트 함수를 내보내서 C에서 호출 할 수 도 있습니다."
+msgstr ""
+"러스트는 C 호출규약을 따르는 오브젝트 파일과 링킹할 수 있습니다. 또한, 반대"
+"로 러스트 함수를 내보내서 C에서 호출 할 수 도 있습니다."
 
 #: src/android/interoperability/with-c.md:6
 msgid "You can do it by hand if you want:"
@@ -15284,29 +17631,35 @@ msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
-msgstr "우리는 이미 [Safe FFI 래퍼 연습문제](../../exercises/day-3/safe-ffi-wrapper.md)에서 이를 다루었습니다."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
+msgstr ""
+"우리는 이미 [Safe FFI 래퍼 연습문제](../../exercises/day-3/safe-ffi-wrapper."
+"md)에서 이를 다루었습니다."
 
 #: src/android/interoperability/with-c.md:23
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
-msgstr "> 이러한 방법은 타겟 플랫폼의 모든 부분을 사전에 알고 있다는 전제를 깔고 있습니다. 상용 프로젝트에서는 권장하지 않습니다."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
+msgstr ""
+"이러한 방법은 타겟 플랫폼의 모든 부분을 사전에 알고 있다는 전제를 깔고 있습니"
+"다. 상용 프로젝트에서는 권장하지 않습니다."
 
 #: src/android/interoperability/with-c.md:26
 msgid "We will look at better options next."
 msgstr "좀 더 나은 옵션을 살펴보겠습니다."
 
 #: src/android/interoperability/with-c/bindgen.md:1
-msgid "# Using Bindgen"
-msgstr "# Bindgen 사용하기"
+msgid "Using Bindgen"
+msgstr "Bindgen 사용하기"
 
 #: src/android/interoperability/with-c/bindgen.md:3
 msgid ""
-"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) tool\n"
-"can auto-generate bindings from a C header file."
-msgstr "[bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html)는 C 헤더파일에서 러스트 바인딩을 자동으로 생성하는 도구입니다."
+"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
+"tool can auto-generate bindings from a C header file."
+msgstr ""
+"[bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html)는 C 헤"
+"더파일에서 러스트 바인딩을 자동으로 생성하는 도구입니다."
 
 #: src/android/interoperability/with-c/bindgen.md:6
 msgid "First create a small C library:"
@@ -15370,9 +17723,11 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
-msgstr "라이브러리에 대한 헤더 파일을 만듭니다(이 예시에서는 반드시 필요한 것은 아닙니다.):"
+msgstr ""
+"라이브러리에 대한 헤더 파일을 만듭니다(이 예시에서는 반드시 필요한 것은 아닙"
+"니다.):"
 
 #: src/android/interoperability/with-c/bindgen.md:47
 msgid "_interoperability/bindgen/libbirthday_wrapper.h_:"
@@ -15445,14 +17800,17 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m print_birthday_card\n"
-"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/tmp\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/"
+"tmp\n"
 "$ adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:106
 msgid "Finally, we can run auto-generated tests to ensure the bindings work:"
-msgstr "마지막으로, 바인딩이 잘 작동하는지 확인하기 위해, 자동 생성된 테스트를 실행해 보겠습니다:"
+msgstr ""
+"마지막으로, 바인딩이 잘 작동하는지 확인하기 위해, 자동 생성된 테스트를 실행"
+"해 보겠습니다:"
 
 #: src/android/interoperability/with-c/bindgen.md:110
 msgid ""
@@ -15477,8 +17835,8 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
-msgid "# Calling Rust"
-msgstr "# C에서 러스트 호출"
+msgid "Calling Rust"
+msgstr "C에서 러스트 호출"
 
 #: src/android/interoperability/with-c/rust.md:3
 msgid "Exporting Rust functions and types to C is easy:"
@@ -15589,42 +17947,47 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:83
 msgid ""
-"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify whatever name you want."
-msgstr "`#[no_mangle]`은 러스트의 네임 맹글링(name mangling)을 비활성화하므로 외부로 노출되는 심볼의 이름은 함수의 이름 그대로가 됩니다. 심볼 이름을 바꾸고 싶다면 `#[export_name = \"some_name\"]`을 사용합니다."
-
-#: src/android/interoperability/cpp.md:1
-msgid "# With C++"
-msgstr "# C++ 와의 상호운용성"
+"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
+msgstr ""
+"`#[no_mangle]`은 러스트의 네임 맹글링(name mangling)을 비활성화하므로 외부로 "
+"노출되는 심볼의 이름은 함수의 이름 그대로가 됩니다. 심볼 이름을 바꾸고 싶다"
+"면 `#[export_name = \"some_name\"]`을 사용합니다."
 
 #: src/android/interoperability/cpp.md:3
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between Rust\n"
-"and C++."
-msgstr "[CXX 크레이트][1]는 러스트와 C++ 사이의 안전한 상호운용성을 가능하게 해줍니다."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
+msgstr ""
+"[CXX 크레이트](https://cxx.rs/)는 러스트와 C++ 사이의 안전한 상호운용성을 가"
+"능하게 해줍니다."
 
 #: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr "전체적인 접근 방법은 다음과 같습니다:"
 
-#: src/android/interoperability/cpp.md:8
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr "<img src=\"cpp/overview.svg\">"
-
 #: src/android/interoperability/cpp.md:10
-msgid "See the [CXX tutorial][2] for an full example of using this."
-msgstr "사용하는 방법에 대해서는[CXX 튜토리얼][2] 를 참조합니다."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
+msgstr ""
+"사용하는 방법에 대해서는[CXX 튜토리얼](https://cxx.rs/tutorial.html) 를 참조"
+"합니다."
 
 #: src/android/interoperability/java.md:1
-msgid "# Interoperability with Java"
-msgstr "# Java와의 상호운용성"
+msgid "Interoperability with Java"
+msgstr "Java와의 상호운용성"
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
-msgstr "자바는 [Java Native Interface(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface)를 통해 공유 라이브러리를 로드할 수 있습니다. [`jni` 크레이트](https://docs.rs/jni/)를 사용하여 JNI 라이브러리를 만들 수 있습니다."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
+msgstr ""
+"자바는 [Java Native Interface(JNI)](https://en.wikipedia.org/wiki/"
+"Java_Native_Interface)를 통해 공유 라이브러리를 로드할 수 있습니다. [`jni` 크"
+"레이트](https://docs.rs/jni/)를 사용하여 JNI 라이브러리를 만들 수 있습니다."
 
 #: src/android/interoperability/java.md:7
 msgid "First, we create a Rust function to export to Java:"
@@ -15783,82 +18146,82 @@ msgstr ""
 
 #: src/exercises/day-4/android.md:3
 msgid ""
-"For the last exercise, we will look at one of the projects you work with. Let us\n"
-"group up and do this together. Some suggestions:"
-msgstr "마지막 연습문제는 여러분이 작업하고 있는 프로젝트 중 하나를 FFI로 러스트와 연계 해보는 것입니다. 몇 가지 예시입니다:"
+"For the last exercise, we will look at one of the projects you work with. "
+"Let us group up and do this together. Some suggestions:"
+msgstr ""
+"마지막 연습문제는 여러분이 작업하고 있는 프로젝트 중 하나를 FFI로 러스트와 연"
+"계 해보는 것입니다. 몇 가지 예시입니다:"
 
 #: src/exercises/day-4/android.md:6
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
-msgstr ""
-"* 당신의 AIDL서비스를 러스트 클라이언트에서 호출해봅니다.\n"
-"\n"
-"* 당신의 프로젝트의 함수를 러스트로 옮기고 호출해봅니다."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr "당신의 AIDL서비스를 러스트 클라이언트에서 호출해봅니다."
+
+#: src/exercises/day-4/android.md:8
+msgid "Move a function from your project to Rust and call it."
+msgstr "당신의 프로젝트의 함수를 러스트로 옮기고 호출해봅니다."
 
 #: src/exercises/day-4/android.md:12
 msgid ""
-"No solution is provided here since this is open-ended: it relies on someone in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
-msgstr "이 연습문제는 열려있기 때문에 해답이 제공되지 않습니다. 클래스에서 제출된 코드에 의존합니다."
+"No solution is provided here since this is open-ended: it relies on someone "
+"in the class having a piece of code which you can turn in to Rust on the fly."
+msgstr ""
+"이 연습문제는 열려있기 때문에 해답이 제공되지 않습니다. 클래스에서 제출된 코"
+"드에 의존합니다."
 
 #: src/bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
-"이 과정은 Rust에 대해 어느정도 경험이 있고 (아마도 Comprehensive Rust 과정을 통해) C와 "
-"같은 다른 언어로\n"
-"bare-metal 프로그래밍을 해 본 사용자를 대상으로 하는 bare-metal Rust에 관한\n"
-" 독립적인 1일 과정입니다."
+"이 과정은 Rust에 대해 어느정도 경험이 있고 (아마도 Comprehensive Rust 과정을 "
+"통해) C와 같은 다른 언어로 bare-metal 프로그래밍을 해 본 사용자를 대상으로 하"
+"는 bare-metal Rust에 관한 독립적인 1일 과정입니다."
 
 #: src/bare-metal.md:7
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 "오늘은 OS를 사용하지 않고 Rust 코드를 실행하는 'bare-metal' Rust에 관해 알아"
-"봅니다. 본 강의의\n"
-"구성은 다음과 같습니다."
+"봅니다. 본 강의의 구성은 다음과 같습니다."
 
 #: src/bare-metal.md:10
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
-msgstr ""
-"- `no_std` Rust란 무엇인가요?\n"
-"- 마이크로컨트롤러용 펌웨어 작성\n"
-"- 애플리케이션 프로세서를 위한 부트로더 / 커널 코드 작성\n"
-"- bare-metal Rust 개발을 위한 유용한 크레이트"
+msgid "What is `no_std` Rust?"
+msgstr "`no_std` Rust란 무엇인가요?"
+
+#: src/bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr "마이크로컨트롤러용 펌웨어 작성"
+
+#: src/bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr "애플리케이션 프로세서를 위한 부트로더 / 커널 코드 작성"
+
+#: src/bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
+msgstr "bare-metal Rust 개발을 위한 유용한 크레이트"
 
 #: src/bare-metal.md:15
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
-"이 강의에서는 [BBC micro:bit](https://microbit.org/) v2"
-"마이크로컨트롤러를 사용합니다.\n"
-"이 마이크로컨트롤러는 Nordic nRF51822 마이크로컨트롤러에 기반한\n"
-"[개발 보드](https://tech.microbit.org/hardware/)로써,\n"
-"LED와 버튼, I2C 연결 가속도계 및 나침반, 온보드 "
-"SWD 디버거를 포함하고 있습니다."
+"이 강의에서는 [BBC micro:bit](https://microbit.org/) v2마이크로컨트롤러를 사"
+"용합니다. 이 마이크로컨트롤러는 Nordic nRF51822 마이크로컨트롤러에 기반한 [개"
+"발 보드](https://tech.microbit.org/hardware/)로써, LED와 버튼, I2C 연결 가속"
+"도계 및 나침반, 온보드 SWD 디버거를 포함하고 있습니다."
 
 #: src/bare-metal.md:20
 msgid ""
 "To get started, install some tools we'll need later. On gLinux or Debian:"
-msgstr "시작하기전에, 앞으로 사용할 도구를 설치해야 합니다. gLinux 또는 Debian를 사용하고 있다면 아래와 같이 하세요."
+msgstr ""
+"시작하기전에, 앞으로 사용할 도구를 설치해야 합니다. gLinux 또는 Debian를 사용"
+"하고 있다면 아래와 같이 하세요."
 
 #: src/bare-metal.md:22
 msgid ""
@@ -15884,8 +18247,8 @@ msgstr ""
 msgid ""
 "And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
-"`plugdev` 그룹의 사용자에게 micro:bit 프로그래머 장치에 대한 액세스 권한을 부여합"
-"니다."
+"`plugdev` 그룹의 사용자에게 micro:bit 프로그래머 장치에 대한 액세스 권한을 부"
+"여합니다."
 
 #: src/bare-metal.md:32
 msgid ""
@@ -15930,32 +18293,14 @@ msgstr ""
 "```"
 
 #: src/bare-metal/no_std.md:1
-msgid "# `no_std`"
-msgstr "# `no_std`"
-
-#: src/bare-metal/no_std.md:3
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
-msgstr ""
-"<table>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
+msgstr "`no_std`"
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr "`core`"
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-"</th>\n"
-"<th>"
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr "`alloc`"
 
@@ -15963,109 +18308,101 @@ msgstr "`alloc`"
 msgid "`std`"
 msgstr "`std`"
 
-#: src/bare-metal/no_std.md:19
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-
 #: src/bare-metal/no_std.md:24
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
-msgstr ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` 및 모든 일반적인 포인터 관련 함수\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
+msgid "Slices, `&str`, `CStr`"
+msgstr "Slices, `&str`, `CStr`"
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
-msgid ""
-"</td>\n"
-"<td>"
-msgstr ""
-"</td>\n"
-"<td>"
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr "`NonZeroU8`..."
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr "`Option`, `Result`"
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr "`Display`, `Debug`, `write!`..."
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr "`panic!`, `assert_eq!`..."
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr "`NonNull` 및 모든 일반적인 포인터 관련 함수"
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr "`Future` and `async`/`await`"
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
+msgstr "`Duration`"
 
 #: src/bare-metal/no_std.md:38
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
-msgstr ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr "`Box`, `Cow`, `Arc`, `Rc`"
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
+msgstr "`String`, `CString`, `format!`"
 
 #: src/bare-metal/no_std.md:45
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
-msgstr ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` 및 나머지 `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` 및 나머지 `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` 및 나머지 `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
+msgstr "`Error`"
 
-#: src/bare-metal/no_std.md:56
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
-msgstr ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr "`File` 및 나머지 `fs`"
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr "`println!`, `Read`, `Write`, `Stdin`, `Stdout` 및 나머지 `io`"
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr "`Path`, `OsString`"
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr "`net`"
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr "`Command`, `Child`, `ExitCode`"
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr "`spawn`, `sleep` 및 나머지 `thread`"
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
+msgstr "`SystemTime`, `Instant`"
 
 #: src/bare-metal/no_std.md:62
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
-msgstr ""
-"* `HashMap`은 RNG에 의존합니다.\n"
-"* `std`는 `core` 및 `alloc`를 포함합니다."
+msgid "`HashMap` depends on RNG."
+msgstr "`HashMap`은 RNG에 의존합니다."
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
+msgstr "`std`는 `core` 및 `alloc`를 포함합니다."
 
 #: src/bare-metal/minimal.md:1
-msgid "# A minimal `no_std` program"
-msgstr "# 최소한의 `no_std` 프로그램"
+msgid "A minimal `no_std` program"
+msgstr "최소한의 `no_std` 프로그램"
 
 #: src/bare-metal/minimal.md:3
 msgid ""
@@ -16094,42 +18431,43 @@ msgstr ""
 "```"
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
-msgstr ""
-"* 이 코드는 빈 바이너리로 컴파일됩니다.\n"
-"* `std`는 패닉 핸들러를 제공하지만, 우리는 자체적으로 핸들러를 만들어야"
-"합니다.\n"
-"*  패닉 핸들러는 `panic-halt`와 같은 크레이트를 통해서 만들수도 있습니다.\n"
-"* 타겟에 따라 `panic = \"abort\"`로 컴파일해야 할 수 있습니다. 이는 "
-"`eh_personality`에 관한 오류를\n"
-"  방지하기 위함입니다.\n"
-"* `main` 과 같은 프로그램 진입점이 없습니다. 개발자가 자체적으로 진입점을 정의해야\n"
-"  합니다. 진입점을 정의하는 작업은, 일반적으로 링커 스크립트와 어셈블리 코드를 필요로 합니다."
+msgid "This will compile to an empty binary."
+msgstr "이 코드는 빈 바이너리로 컴파일됩니다."
 
-#: src/bare-metal/alloc.md:1
-msgid "# `alloc`"
-msgstr "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+"`std`는 패닉 핸들러를 제공하지만, 우리는 자체적으로 핸들러를 만들어야합니다."
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr "패닉 핸들러는 `panic-halt`와 같은 크레이트를 통해서 만들수도 있습니다."
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+"타겟에 따라 `panic = \"abort\"`로 컴파일해야 할 수 있습니다. 이는 "
+"`eh_personality`에 관한 오류를 방지하기 위함입니다."
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
+msgstr ""
+"`main` 과 같은 프로그램 진입점이 없습니다. 개발자가 자체적으로 진입점을 정의"
+"해야 합니다. 진입점을 정의하는 작업은, 일반적으로 링커 스크립트와 어셈블리 코"
+"드를 필요로 합니다."
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 "`alloc`을 사용하려면 [전역 (힙) 할당자](https://doc.rust-lang.org/stable/std/"
-"alloc/trait.GlobalAlloc.html)를\n"
-"구현해야 합니다."
+"alloc/trait.GlobalAlloc.html)를 구현해야 합니다."
 
 #: src/bare-metal/alloc.md:6
 msgid ""
@@ -16199,46 +18537,57 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
-"* `buddy_system_allocator`는 간단한 버디 시스템 할당자를 구현하는 서드 파티 크"
-"레이트입니다. 이 외에도, 다른\n"
-"  크레이트를 사용하거나, 직접 할당자를 만들거나, 이미 존재하는 다른 할당자에 후킹할 수 있습니다.\n"
-"* `LockHeap` 타입의 const 매개변수는 할당자의 최대 크기를 2진수로 표현했을 때의 자릿수입니다. 즉, 이 경우처럼 32인 경우 최대 "
-"2**32바이트 크기의\n"
-"  영역을 다룰 수 있습니다.\n"
-"* 한 바이너리에서 `alloc`에 의존하는 크레이트가 하나라도 있다면\n"
-"바이너리 전체에서 전역 할당자가 반드시 하나 존재해야 합니다. 일반적으로 전역 할당자를 선언하는 작업은 최상위 바이너리 크레이트"
-"에서 이루어집니다.\n"
-"* `panic_halt` 크레이트가 연결되어 패닉 핸들러를 가져오도록 하려면\n"
-"  `extern crate panic_halt as _`가 필요합니다.\n"
-"* 이 예시 코드는 빌드는 되지만, 진입점이 없기 때문에 실행되지는 않습니다."
+"`buddy_system_allocator`는 간단한 버디 시스템 할당자를 구현하는 서드 파티 크"
+"레이트입니다. 이 외에도, 다른 크레이트를 사용하거나, 직접 할당자를 만들거나, "
+"이미 존재하는 다른 할당자에 후킹할 수 있습니다."
 
-#: src/bare-metal/microcontrollers.md:1
-msgid "# Microcontrollers"
-msgstr "# 마이크로컨트롤러"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+"`LockHeap` 타입의 const 매개변수는 할당자의 최대 크기를 2진수로 표현했을 때"
+"의 자릿수입니다. 즉, 이 경우처럼 32인 경우 최대 2\\*\\*32바이트 크기의 영역"
+"을 다룰 수 있습니다."
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+"한 바이너리에서 `alloc`에 의존하는 크레이트가 하나라도 있다면 바이너리 전체에"
+"서 전역 할당자가 반드시 하나 존재해야 합니다. 일반적으로 전역 할당자를 선언하"
+"는 작업은 최상위 바이너리 크레이트에서 이루어집니다."
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+"`panic_halt` 크레이트가 연결되어 패닉 핸들러를 가져오도록 하려면 `extern "
+"crate panic_halt as _`가 필요합니다."
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
+msgstr ""
+"이 예시 코드는 빌드는 되지만, 진입점이 없기 때문에 실행되지는 않습니다."
+
+#: src/bare-metal/microcontrollers.md:1 src/SUMMARY.md:215
+msgid "Microcontrollers"
+msgstr "마이크로컨트롤러"
 
 #: src/bare-metal/microcontrollers.md:3
 msgid ""
 "The `cortex_m_rt` crate provides (among other things) a reset handler for "
 "Cortex M microcontrollers."
 msgstr ""
-"'cortex_m_rt' 크레이트는 Cortex M 마이크로컨트롤러를 초기화 하는 핸들러"
-"를 제공합니다."
+"'cortex_m_rt' 크레이트는 Cortex M 마이크로컨트롤러를 초기화 하는 핸들러를 제"
+"공합니다."
 
 #: src/bare-metal/microcontrollers.md:5
 msgid ""
@@ -16279,32 +18628,33 @@ msgid ""
 "Next we'll look at how to access peripherals, with increasing levels of "
 "abstraction."
 msgstr ""
-"이제, 주변장치에 액세스하는 방법을 알아보겠습니다. 가장 기계에 가까운 낮은 단계에서 시작해서 점점 추상화 수준을 올리겠습니다."
+"이제, 주변장치에 액세스하는 방법을 알아보겠습니다. 가장 기계에 가까운 낮은 단"
+"계에서 시작해서 점점 추상화 수준을 올리겠습니다."
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
-"* `cortex_m_rt::entry` 매크로는 진입점으로 사용되는 함수가`fn() -> !` 타입(즉, 리턴하지 않는)임을 요구합니다. "
-"만약, 리턴하게 되면, 프로그램 수행 후 리셋 핸들러로 돌아가게 되는 것인데 이는 말이 되지 않기 때문입니다.\n"
-"* `cargo embed --bin minimal`을 사용하여 예시를 실행합니다."
+"`cortex_m_rt::entry` 매크로는 진입점으로 사용되는 함수가`fn() -> !` 타입(즉, "
+"리턴하지 않는)임을 요구합니다. 만약, 리턴하게 되면, 프로그램 수행 후 리셋 핸"
+"들러로 돌아가게 되는 것인데 이는 말이 되지 않기 때문입니다."
 
-#: src/bare-metal/microcontrollers/mmio.md:1
-msgid "# Raw MMIO"
-msgstr "# 원시 MMIO"
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
+msgstr "`cargo embed --bin minimal`을 사용하여 예시를 실행합니다."
+
+#: src/bare-metal/microcontrollers/mmio.md:1 src/SUMMARY.md:216
+msgid "Raw MMIO"
+msgstr "원시 MMIO"
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 "대부분의 마이크로컨트롤러는 메모리 매핑 IO를 통해 주변기기에 액세스합니다. "
-"micro:bit에서 LED를\n"
-"켜보겠습니다."
+"micro:bit에서 LED를 켜보겠습니다."
 
 #: src/bare-metal/microcontrollers/mmio.md:6
 msgid ""
@@ -16433,11 +18783,11 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
-"* GPIO 0 핀 21은 LED 매트릭스의 첫 번째 열에 연결되고 핀 28은 첫 번째 행에 연"
-"결됩니다."
+"GPIO 0 핀 21은 LED 매트릭스의 첫 번째 열에 연결되고 핀 28은 첫 번째 행에 연결"
+"됩니다."
 
 #: src/bare-metal/microcontrollers/mmio.md:66
 #: src/bare-metal/microcontrollers/pacs.md:59
@@ -16457,21 +18807,18 @@ msgstr ""
 "```"
 
 #: src/bare-metal/microcontrollers/pacs.md:1
-msgid "# Peripheral Access Crates"
-msgstr "# 주변기기 액세스 크레이트"
+msgid "Peripheral Access Crates"
+msgstr "주변기기 액세스 크레이트"
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
-"[`svd2rust`](https://crates.io/crates/svd2rust) 크레이트를 이용하면 메모리 매핑된 "
-"주변장치를 기술하는 [CMSIS-SVD](https://www."
-"keil.com/pack/doc/CMSIS/SVD/html/index.html) 파일로부터\n"
-"Rust 래퍼를 생성할 수 있습니다."
+"[`svd2rust`](https://crates.io/crates/svd2rust) 크레이트를 이용하면 메모리 매"
+"핑된 주변장치를 기술하는 [CMSIS-SVD](https://www.keil.com/pack/doc/CMSIS/SVD/"
+"html/index.html) 파일로부터 Rust 래퍼를 생성할 수 있습니다."
 
 #: src/bare-metal/microcontrollers/pacs.md:7
 msgid ""
@@ -16557,30 +18904,39 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
 msgstr ""
-"* SVD(System View Description) 파일은 일반적으로 실리콘 공급업체에서 제공하"
-"는 XML 파일로,\n"
-"  기기의 메모리 맵을 기술합니다.\n"
-"  * 주변기기, 레지스터, 필드, 값으로 구성되며 이름, 설명, 주소 등이\n"
-"    포함됩니다.\n"
-"  * SVD 파일에는 버그가 있을 수 있고 불완전하기 때문에, 이러한 문제들을 패치하는 다양한 프로젝트들이 있습니다.\n"
-"* `cortex-m-rt`는 무엇보다도 벡터 테이블을 제공합니다.\n"
-"* `cargo install cargo-binutils`을 실행한 후, `cargo objdump --bin pac -- -d --no-"
-"show-raw-insn`을 실행하여\n"
-"  생성된 바이너리의 내용을 확인할 수 있습니다."
+"SVD(System View Description) 파일은 일반적으로 실리콘 공급업체에서 제공하는 "
+"XML 파일로, 기기의 메모리 맵을 기술합니다."
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+"주변기기, 레지스터, 필드, 값으로 구성되며 이름, 설명, 주소 등이 포함됩니다."
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+"SVD 파일에는 버그가 있을 수 있고 불완전하기 때문에, 이러한 문제들을 패치하는 "
+"다양한 프로젝트들이 있습니다."
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr "`cortex-m-rt`는 무엇보다도 벡터 테이블을 제공합니다."
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
+msgstr ""
+"`cargo install cargo-binutils`을 실행한 후, `cargo objdump --bin pac -- -d --"
+"no-show-raw-insn`을 실행하여 생성된 바이너리의 내용을 확인할 수 있습니다."
 
 #: src/bare-metal/microcontrollers/pacs.md:61
 msgid ""
@@ -16593,21 +18949,20 @@ msgstr ""
 "```"
 
 #: src/bare-metal/microcontrollers/hals.md:1
-msgid "# HAL crates"
-msgstr "# HAL 크레이트들"
+msgid "HAL crates"
+msgstr "HAL 크레이트들"
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
-"다양한 주변 장치에 대한 래퍼를 제공하는 [HAL 크레이트](https://github.com/rust-embedded/"
-"awesome-embedded-rust#hal-implementation-crates)들이 있습니다. 이 크레이트들은 일반적으로\n"
-"[`embedded-hal`](https://crates.io/crates/embedded-hal)의 트레잇을 구현합니"
-"다."
+"다양한 주변 장치에 대한 래퍼를 제공하는 [HAL 크레이트](https://github.com/"
+"rust-embedded/awesome-embedded-rust#hal-implementation-crates)들이 있습니다. "
+"이 크레이트들은 일반적으로 [`embedded-hal`](https://crates.io/crates/"
+"embedded-hal)의 트레잇을 구현합니다."
 
 #: src/bare-metal/microcontrollers/hals.md:7
 msgid ""
@@ -16673,16 +19028,17 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
 msgstr ""
-" * `set_low` 및 `set_high`는 `embedded_hal` `OutputPin` 트레잇의 메서드입니"
-"다.\n"
-" * 다양한 STM32, GD32, nRF, NXP, MSP430, AVR, PIC 마이크로컨트롤러를 비롯한\n"
-"   많은 Cortex-M 및 RISC-V 기기를 위한 HAL 크레이트가 있습니다"
+"`set_low` 및 `set_high`는 `embedded_hal` `OutputPin` 트레잇의 메서드입니다."
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
+msgstr ""
+"다양한 STM32, GD32, nRF, NXP, MSP430, AVR, PIC 마이크로컨트롤러를 비롯한 많"
+"은 Cortex-M 및 RISC-V 기기를 위한 HAL 크레이트가 있습니다"
 
 #: src/bare-metal/microcontrollers/hals.md:45
 msgid ""
@@ -16699,7 +19055,8 @@ msgid ""
 "Board support crates provide a further level of wrapping for a specific "
 "board for convenience."
 msgstr ""
-"보드 지원 크레이트들은, 특정 보드를 더 손쉽게 사용할 수 있게 해 주는 더 높은 수준의 추상화를 제공합니다."
+"보드 지원 크레이트들은, 특정 보드를 더 손쉽게 사용할 수 있게 해 주는 더 높은 "
+"수준의 추상화를 제공합니다."
 
 #: src/bare-metal/microcontrollers/board-support.md:5
 msgid ""
@@ -16747,20 +19104,24 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:28
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
 msgstr ""
-" * 이 경우 보드 지원 크레이트는 좀 더 직관적인 이름들과 적당한 수준의 초기화를\n"
-"   제공합니다.\n"
-" * 이 크레이트는 마이크로컨트롤 밖에 있는 (즉, 보드에 설치된) 장치에 대한 드라이버도\n"
-"   포함할 수 있습니다.\n"
-"   * `microbit-v2`에는 LED 매트릭스를 위한 간단한 드라이버가 포함되어 있습니"
-"다."
+"이 경우 보드 지원 크레이트는 좀 더 직관적인 이름들과 적당한 수준의 초기화를 "
+"제공합니다."
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+"이 크레이트는 마이크로컨트롤 밖에 있는 (즉, 보드에 설치된) 장치에 대한 드라이"
+"버도 포함할 수 있습니다."
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
+msgstr ""
+"`microbit-v2`에는 LED 매트릭스를 위한 간단한 드라이버가 포함되어 있습니다."
 
 #: src/bare-metal/microcontrollers/board-support.md:36
 msgid ""
@@ -16773,8 +19134,8 @@ msgstr ""
 "```"
 
 #: src/bare-metal/microcontrollers/type-state.md:1
-msgid "# The type state pattern"
-msgstr "# 타입 상태 패턴"
+msgid "The type state pattern"
+msgstr "타입 상태 패턴"
 
 #: src/bare-metal/microcontrollers/type-state.md:3
 msgid ""
@@ -16840,171 +19201,217 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
 msgstr ""
-" * 핀은 `Copy` 또는 `Clone`을 구현하지 않으므로 각각 하나의 인스턴스만 존재"
-"할 수 있습니다. 핀을\n"
-"   포트 구조체 밖으로 이동하면 아무도 사용할 수 없습니다.\n"
-" * 핀 구성을 변경하면 이전 핀 인스턴스가 사용되므로 이후에\n"
-"   이전 인스턴스를 계속 사용할 수 없습니다.\n"
-" * 값 유형은 현재 상태를 나타냅니다. 예를 들어 이 경우에는\n"
-"   GPIO 핀의 구성 상태입니다. 이렇게 하면 상태 머신이 유형 시스템으로 인코딩"
-"되며, 먼저 올바르게\n"
-"   구성한 후 특정 방식으로 핀을 사용하도록 합니다. 잘못된 상태 전환은 컴파일 "
-"시간에\n"
-"   포착됩니다.\n"
-" * 입력 핀에서 `is_high`를 호출하고 출력 핀에서 `set_high`를 호출할 수 있지"
-"만 그 반대로는 안 됩니다.\n"
-" * 많은 HAL 크레이트들이 이 패턴을 따릅니다."
+"핀은 `Copy` 또는 `Clone`을 구현하지 않으므로 각각 하나의 인스턴스만 존재할 "
+"수 있습니다. 핀을 포트 구조체 밖으로 이동하면 아무도 사용할 수 없습니다."
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+"핀 구성을 변경하면 이전 핀 인스턴스가 사용되므로 이후에 이전 인스턴스를 계속 "
+"사용할 수 없습니다."
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+"값 유형은 현재 상태를 나타냅니다. 예를 들어 이 경우에는 GPIO 핀의 구성 상태입"
+"니다. 이렇게 하면 상태 머신이 유형 시스템으로 인코딩되며, 먼저 올바르게 구성"
+"한 후 특정 방식으로 핀을 사용하도록 합니다. 잘못된 상태 전환은 컴파일 시간에 "
+"포착됩니다."
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+"입력 핀에서 `is_high`를 호출하고 출력 핀에서 `set_high`를 호출할 수 있지만 "
+"그 반대로는 안 됩니다."
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
+msgstr "많은 HAL 크레이트들이 이 패턴을 따릅니다."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "# `embedded-hal`"
-msgstr "# `embedded-hal`"
+msgid "`embedded-hal`"
+msgstr "`embedded-hal`"
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
-"[`embedded-hal`](https://crates.io/crates/embedded-hal) 크레이트는 "
-"다양한 마이크로컨트롤러에서 공통적으로 찾아볼 수 있는 주변기기를 추상회 하는 다양한\n"
-"트레잇을 제공합니다."
+"[`embedded-hal`](https://crates.io/crates/embedded-hal) 크레이트는 다양한 마"
+"이크로컨트롤러에서 공통적으로 찾아볼 수 있는 주변기기를 추상회 하는 다양한 트"
+"레잇을 제공합니다."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
-msgstr ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * 타이머\n"
-" * 워치독"
+msgid "GPIO"
+msgstr "GPIO"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr "ADC"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr "I2C, SPI, UART, CAN"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr "RNG"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr "타이머"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
+msgstr "워치독"
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 "그러면 다른 크레이트는 이 트레잇들을 활용하여 [드라이버](https://github.com/"
-"rust-embedded/awesome-embedded-rust#driver-crates)를\n"
-"구현합니다. 예를 들어 가속도계 드라이버를 구현할 떄 I2C 또는 SPI 버스 구현을\n"
-"사용할 수 있습니다."
+"rust-embedded/awesome-embedded-rust#driver-crates)를 구현합니다. 예를 들어 가"
+"속도계 드라이버를 구현할 떄 I2C 또는 SPI 버스 구현을 사용할 수 있습니다."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+"라스베리 파이에서 돌아가는 리눅스 같은 플랫폼 뿐만 아니라 다른 여러 마이크로"
+"컨트롤러에 대한 구현이 있습니다."
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
-" * 라스베리 파이에서 돌아가는 리눅스 같은 플랫폼 뿐만 아니라 다른 여러 마이크로컨트롤러"
-"에 대한\n"
-"구현이 있습니다.\n"
-" * `embedded-hal`의 'async' 버전에 관한 작업이 진행 중이지만 아직 안정적이지 "
-"않습니다."
+"`embedded-hal`의 'async' 버전에 관한 작업이 진행 중이지만 아직 안정적이지 않"
+"습니다."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "# `probe-rs`, `cargo-embed`"
-msgstr "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
+msgstr "`probe-rs`, `cargo-embed`"
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
-"[probe-rs](https://probe.rs/)는 임베디드 시스템을 위한 도구 모임입니다. OpenOCD와 비슷하지만, "
-"Rust에 더 잘 통합되어 있습니다."
+"[probe-rs](https://probe.rs/)는 임베디드 시스템을 위한 도구 모임입니다. "
+"OpenOCD와 비슷하지만, Rust에 더 잘 통합되어 있습니다."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
-msgstr ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> 및 JTAG(CMSIS-DAP, ST-Link, J-"
-"Link 프로브를 통함)\n"
-"* GDB 스텁 및 Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> 서"
-"버\n"
-"* Cargo에 통합됨"
+msgid "SWD"
+msgstr "SWD"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr " 및 JTAG(CMSIS-DAP, ST-Link, J-Link 프로브를 통함)"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr "GDB 스텁 및 Microsoft "
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr "DAP"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid " server"
+msgstr " 서버"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
+msgstr "Cargo에 통합됨"
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
-msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
 msgstr ""
-"`cargo-embed`는 cargo의 서브 커맨트로써, 바이너리를 빌드하고 플래시하며, <abbr title=\"Real Time "
-"Transfers\">RTT</abbr> 출력을 기록하고,\n"
-"GDB를 연결해 줍니다. 이 명령어의 세부 동작은 프로젝트 디렉터리의\n"
-"`Embed.toml` 파일을 통해 설정합니다."
+"`cargo-embed`는 cargo의 서브 커맨트로써, 바이너리를 빌드하고 플래시하며, "
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr "RTT"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid ""
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
+msgstr ""
+" 출력을 기록하고, GDB를 연결해 줍니다. 이 명령어의 세부 동작은 프로젝트 디렉"
+"터리의 `Embed.toml` 파일을 통해 설정합니다."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html)는 "
-"Arm에서 정의한 프로토콜로, USB를 통해 Arm Cortex 프로세서의 CoreSight 디버그 액세스 포트에 "
-"접근할 수 있게 해 줍니다. BBC micro:bit에 있는 온보드 디버거도 이  프로토콜을 지원합니다.\n"
-"* ST-Link는 ST Microelectronics사에서 만든 in-circuit 디버거들이며, J-Link는\n"
-"  SEGGER사의 in-circuit 디버거들입니다.\n"
-"* 디버그 액세스 포트의 물리적인 구성은 일반적으로 5핀 JTAG 인터페이스 혹은, 2핀 Serial Wire Debug "
-"인터페이스 입니다.\n"
-"* probe-rs는 라이브러리로 구현되어 있어서, 다른 도구들에 통합되기가 쉽습니다.\n"
-"* [Microsoft 디버그 어댑터 프로토콜](https://microsoft.github.io/debug-"
-"adapter-protocol/)을 사용하면 VSCode나 다른 IDE 상에서 마이크로컨트롤러에서 수행중인 코드를 디버깅 할 수 있습니다.\n"
-"* cargo-embed는 probe-rs 라이브러리를 사용하여 빌드된 바이너리입니다.\n"
-"* RTT(Real Time Transfers)는 여러 링 버퍼를 통해 디버그 호스트와 타겟 간에\n"
-"  데이터를 전송하는 메커니즘입니다."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html)는 Arm"
+"에서 정의한 프로토콜로, USB를 통해 Arm Cortex 프로세서의 CoreSight 디버그 액"
+"세스 포트에 접근할 수 있게 해 줍니다. BBC micro:bit에 있는 온보드 디버거도 "
+"이  프로토콜을 지원합니다."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+"ST-Link는 ST Microelectronics사에서 만든 in-circuit 디버거들이며, J-Link는 "
+"SEGGER사의 in-circuit 디버거들입니다."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+"디버그 액세스 포트의 물리적인 구성은 일반적으로 5핀 JTAG 인터페이스 혹은, 2"
+"핀 Serial Wire Debug 인터페이스 입니다."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+"probe-rs는 라이브러리로 구현되어 있어서, 다른 도구들에 통합되기가 쉽습니다."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+"[Microsoft 디버그 어댑터 프로토콜](https://microsoft.github.io/debug-adapter-"
+"protocol/)을 사용하면 VSCode나 다른 IDE 상에서 마이크로컨트롤러에서 수행중인 "
+"코드를 디버깅 할 수 있습니다."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr "cargo-embed는 probe-rs 라이브러리를 사용하여 빌드된 바이너리입니다."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
+msgstr ""
+"RTT(Real Time Transfers)는 여러 링 버퍼를 통해 디버그 호스트와 타겟 간에 데이"
+"터를 전송하는 메커니즘입니다."
 
 #: src/bare-metal/microcontrollers/debugging.md:3
 msgid "Embed.toml:"
@@ -17080,113 +19487,157 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
-msgid "# Other projects"
-msgstr "# 다른 프로젝트"
+msgid "Other projects"
+msgstr "다른 프로젝트"
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
-msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+msgid "[RTIC](https://rtic.rs/)"
+msgstr "[RTIC](https://rtic.rs/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
 msgstr ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"실시간 인터럽트 기반 동시 실행(Real-Time Interrupt-driven Concurrency)\"\n"
-"   * 공유 리소스 관리, 메시지 전달, 태스크 스케줄링, 타이머 대기열 지원\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * 우선순위, 타이머, 네트워킹, USB가 포함된 `async` 실행자\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * 선점형 스케줄링 및 MMU를 지원하는, 보안에 중점을 둔 실시간 운영체제\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Oxide Computer Company에서 만든 마이크로커널 기반 실시간 운영체제로, 메모리 보호,  권한이 없이 수행되는 드라이버 등을 지원함.\n"
-" * [FreeRTOS용 바인딩](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * `std`가 구현된 플랫폼도 있습니다(예: [esp-idf](https://esp-rs.github.io/book/"
+"\"실시간 인터럽트 기반 동시 실행(Real-Time Interrupt-driven Concurrency)\""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
+msgid ""
+"Shared resource management, message passing, task scheduling, timer queue"
+msgstr "공유 리소스 관리, 메시지 전달, 태스크 스케줄링, 타이머 대기열 지원"
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr "[Embassy](https://embassy.dev/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr "우선순위, 타이머, 네트워킹, USB가 포함된 `async` 실행자"
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr "[TockOS](https://www.tockos.org/documentation/getting-started)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr "선점형 스케줄링 및 MMU를 지원하는, 보안에 중점을 둔 실시간 운영체제"
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr "[Hubris](https://hubris.oxide.computer/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+"Oxide Computer Company에서 만든 마이크로커널 기반 실시간 운영체제로, 메모리 "
+"보호,  권한이 없이 수행되는 드라이버 등을 지원함."
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr "[FreeRTOS용 바인딩](https://github.com/lobaro/FreeRTOS-rust)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
+msgstr ""
+"`std`가 구현된 플랫폼도 있습니다(예: [esp-idf](https://esp-rs.github.io/book/"
 "overview/using-the-standard-library.html))."
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+"RTIC는 실시간 운영체제로 볼 수도 있고, 동시성 지원을 위한 프레임워크로 볼 수"
+"도 있습니다."
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr "HAL을 포함하지는 않습니다."
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+"스케줄링은 커널이 아니라 Cortex-M NVIC(Nested Virtual Interrupt Controller)"
+"로 구현이 됩니다."
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr "Cortex-M 전용입니다."
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+"Google에서는 Titan 보안 키에 사용되는 Haven 마이크로컨트롤러에서 TockOS를 사"
+"용합니다."
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
-" * RTIC는 실시간 운영체제로 볼 수도 있고, 동시성 지원을 위한 프레임워크로 볼 수도 있습니다.\n"
-"   * HAL을 포함하지는 않습니다.\n"
-"   * 스케줄링은 커널이 아니라 Cortex-M NVIC(Nested Virtual Interrupt Controller)로 구현이 됩니다.\n"
-"   * Cortex-M 전용입니다.\n"
-" * Google에서는 Titan 보안 키에 사용되는 Haven 마이크로컨트롤러에서 TockOS를 사용합니"
-"다.\n"
-" * FreeRTOS는 대부분 C로 작성되지만, 애플리케이션을 Rust로 작성할 수 있도록 해 주는 Rust 바인딩이 "
-"제공됩니다."
+"FreeRTOS는 대부분 C로 작성되지만, 애플리케이션을 Rust로 작성할 수 있도록 해 "
+"주는 Rust 바인딩이 제공됩니다."
 
 #: src/bare-metal/aps.md:1
-msgid "# Application processors"
-msgstr "# 애플리케이션 프로세서"
+msgid "Application processors"
+msgstr "애플리케이션 프로세서"
 
 #: src/bare-metal/aps.md:3
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 "지금까지 Arm Cortex-M 시리즈와 같은 마이크로컨트롤러에 관해 알아봤습니다. 이"
-"제\n"
-"애플리케이션 프로세서인 Cortex-A를 위한 코드를 작성해 보겠습니다. 편의상 QEMU의 aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) 보드를 사"
-"용합니다."
+"제 애플리케이션 프로세서인 Cortex-A를 위한 코드를 작성해 보겠습니다. 편의상 "
+"QEMU의 aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt."
+"html) 보드를 사용합니다."
 
 #: src/bare-metal/aps.md:9
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
 msgstr ""
-"* 일반적으로 마이크로컨트롤러에는 MMU 또는 다중 레벨 권한(Arm CPU에서는 "
-"익셉션 레벨(exception level), x86에서는 링(ring))이 없습니다.\n"
-"애플리케이션 프로세서는 이들을 가지고 있습니다.\n"
-"* QEMU는 아키텍처별로 다양한 머신 또는 보드 모델을 에뮬레이션할 수 있습니"
-"다. 'virt' 보드는\n"
-"특정 실제 하드웨어를 에뮬레이션 하지 않으며, 가상 머신용으로만\n"
+"일반적으로 마이크로컨트롤러에는 MMU 또는 다중 레벨 권한(Arm CPU에서는 익셉션 "
+"레벨(exception level), x86에서는 링(ring))이 없습니다. 애플리케이션 프로세서"
+"는 이들을 가지고 있습니다."
+
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
+msgstr ""
+"QEMU는 아키텍처별로 다양한 머신 또는 보드 모델을 에뮬레이션할 수 있습니다. "
+"'virt' 보드는 특정 실제 하드웨어를 에뮬레이션 하지 않으며, 가상 머신용으로만 "
 "설계되었습니다."
 
 #: src/bare-metal/aps/inline-assembly.md:1
-msgid "# Inline assembly"
-msgstr "# 인라인 어셈블리"
+msgid "Inline assembly"
+msgstr "인라인 어셈블리"
 
 #: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
 msgstr ""
-"가끔 Rust 코드로는 구현이 불가능한 작업들이 있으며, 이 경우 어셈블리를 사용해야 합니다. 예"
-"를 들어\n"
-" 펌웨어를 향해서 시스템 전원을 끄라고 <abbr title=\"hypervisor "
-"call\">HVC</abbr>를 호출하는  방법은 다음과 같습니다."
+"가끔 Rust 코드로는 구현이 불가능한 작업들이 있으며, 이 경우 어셈블리를 사용해"
+"야 합니다. 예를 들어 펌웨어를 향해서 시스템 전원을 끄라고 "
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr "HVC"
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid " to tell the firmware to power off the system:"
+msgstr "를 호출하는  방법은 다음과 같습니다."
 
 #: src/bare-metal/aps/inline-assembly.md:6
 msgid ""
@@ -17258,114 +19709,131 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the [`smccc`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
-"실제로 이를 실행하려면 이러한 모든 함수를 위한 래퍼가 포함된 [`smccc`][1] 크"
-"레이트를 사용하세요."
+"실제로 이를 실행하려면 이러한 모든 함수를 위한 래퍼가 포함된 [`smccc`]"
+"(https://crates.io/crates/smccc) 크레이트를 사용하세요."
 
 #: src/bare-metal/aps/inline-assembly.md:43
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
-"it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are "
-"conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the "
-"standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–"
-"`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do "
-"anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+"PSCI (Power State Coordination Interface)는 시스템 및 CPU 전원 상태를 관리하"
+"는 Arm의 표준 인터페이스입니다. 이 인터페이스는 EL3 펌웨어와 하이퍼바이저에 "
+"의해 구현됩니다."
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+"`0 => _` 문법은 인라인 어셈블리 코드를 실행하기 전에 레지스터를 0으로 초기화"
+"하고 그 후에는 그 레지스터의 값을 무시함을 의미합니다. 호출 시 레지스터의 값"
+"이 덮어 써질 수 있으므로 `in` 대신 `inout`을 사용해야 합니다."
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+"이 `main` 함수는 `#[no_mangle]` 및 `extern \"C\"`여야 합니다.  왜냐하면 이 함"
+"수는 Rust 코드가 아닌, 어셈블러로 작성된 `entry.S`에서 호출되기 때문입니다."
+
+#: src/bare-metal/aps/inline-assembly.md:51
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+"`_x0`–`_x3`는 `x0`에서 `x3` 레지스터들의 값입니다. 이 레지스터들은  일반적으"
+"로 부트로더에서  디바이스 트리에 대한 포인터 등을 전달할 때 사용됩니다. 표준 "
+"aarch64 호출 규약(`extern \"C\"`에서 사용하도록 지정)에 따라 레지스터 `x0`에"
+"서 `x7`이 함수에 전달된 처음 8개 인수에 사용되므로 `entry.S`는 이러한 레지스"
+"터를 변경하지 않는지 확인하는 것 외에는 특별히 할 작업이 없습니다."
+
+#: src/bare-metal/aps/inline-assembly.md:56
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
-"* PSCI (Power State Coordination Interface)는 시스템 및 CPU 전원 상태를 관리하는 Arm의 표준 인터페이스입니다.\n"
-"  이 인터페이스는 EL3 펌웨어와 하이"
-"퍼바이저에 의해\n"
-"구현됩니다.\n"
-"* `0 => _` 문법은 인라인 어셈블리 코드를 실행하기 전에 레지스터를 0으로 초기"
-"화하고\n"
-"  그 후에는 그 레지스터의 값을 무시함을 의미합니다. 호출 시 레지스터의 값이\n"
-" 덮어 써질 수 있으므로\n"
-"  `in` 대신 `inout`을 사용해야 합니다.\n"
-"* 이 `main` 함수는 `#[no_mangle]` 및 `extern \"C\"`여야 합니다.  왜냐하면 이 함수는 Rust 코드가 아닌, "
-"어셈블러로 작성된 `entry.S`에서 호출되기 때문입니다.\n"
-"* `_x0`–`_x3`는 `x0`에서 `x3` 레지스터들의 값입니다. 이 레지스터들은  일반적으로 부트로더에서 "
-" 디바이스 트리에 대한 포인터 등을 전달할 때 사용됩니다."
-" 표준 aarch64 호출 규약(`extern "
-"\"C\"`에서 사용하도록 지정)에 따라\n"
-"  레지스터 `x0`에서 `x7`이 함수에 전달된 처음 8개 인수에 사용되므로\n"
-"  `entry.S`는 이러한 레지스터를 변경하지 않는지 확인하는 것 외에는\n"
-"  특별히 할 작업이 없습니다.\n"
-"* `src/bare-metal/aps/examples`에서 `make qemu_psci`를 사용하여 QEMU에서 예시"
+"`src/bare-metal/aps/examples`에서 `make qemu_psci`를 사용하여 QEMU에서 예시"
 "를 실행합니다."
 
 #: src/bare-metal/aps/mmio.md:1
-msgid "# Volatile memory access for MMIO"
-msgstr "# MMIO를 위한 휘발성(volatile) 메모리 액세스"
+msgid "Volatile memory access for MMIO"
+msgstr "MMIO를 위한 휘발성(volatile) 메모리 액세스"
 
 #: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr "`pointer::read_volatile` 및 `pointer::write_volatile`을 사용하세요."
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr "참조를 유지하지 마세요."
+
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
-" * `pointer::read_volatile` 및 `pointer::write_volatile`을 사용하세요.\n"
-" * 참조를 유지하지 마세요.\n"
-" * `addr_of!`를 사용하면 임시 용도의 참조를 만들지 않고도 구조체 필드를 가져올 수 있"
-"습니다."
+"`addr_of!`를 사용하면 임시 용도의 참조를 만들지 않고도 구조체 필드를 가져올 "
+"수 있습니다."
 
 #: src/bare-metal/aps/mmio.md:9
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
 msgstr ""
-" * 휘발성(volatile) 액세스: 읽기 또는 쓰기 작업이 부수 효과(side effect)를 동반할 수 있기 때문에 컴파일러"
-"나 하드웨어가\n"
-"   임의로 이를 읽기 쓰기 작업의 순서를 바꾸거나, 중복해서 수행하거나 또는 제거하지 못하게 합니다.\n"
-"   * 일반적으로 쓰고 난 후 읽으면(예: 변경 가능한 참조를 통해) 컴파일러는\n"
-"     읽은 값이 방금 쓴 값과 동일하다고 가정하고 실제로 메모리를 읽지 않을 수 "
-"있습니다.\n"
-" * 하드웨어에 대한 휘발성 액세스를 위한 일부 기존 크레이트는 참조를 유지하지"
-"만 이는 올바른 것이 아닙니다.\n"
-"  참조가 있을 때마다 컴파일러는 이를 역참조하도록 선택할 수 있습니다.\n"
-" * `addr_of!` 매크로를 사용하여 구조체 포인터에서 구조체 필드 포인터를 가져옵"
-"니다."
+"휘발성(volatile) 액세스: 읽기 또는 쓰기 작업이 부수 효과(side effect)를 동반"
+"할 수 있기 때문에 컴파일러나 하드웨어가 임의로 이를 읽기 쓰기 작업의 순서를 "
+"바꾸거나, 중복해서 수행하거나 또는 제거하지 못하게 합니다."
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+"일반적으로 쓰고 난 후 읽으면(예: 변경 가능한 참조를 통해) 컴파일러는 읽은 값"
+"이 방금 쓴 값과 동일하다고 가정하고 실제로 메모리를 읽지 않을 수 있습니다."
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+"하드웨어에 대한 휘발성 액세스를 위한 일부 기존 크레이트는 참조를 유지하지만 "
+"이는 올바른 것이 아닙니다. 참조가 있을 때마다 컴파일러는 이를 역참조하도록 선"
+"택할 수 있습니다."
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
+msgstr ""
+"`addr_of!` 매크로를 사용하여 구조체 포인터에서 구조체 필드 포인터를 가져옵니"
+"다."
 
 #: src/bare-metal/aps/uart.md:1
-msgid "# Let's write a UART driver"
-msgstr "# UART 드라이버 작성"
+msgid "Let's write a UART driver"
+msgstr "UART 드라이버 작성"
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
-"QEMU의 'virt' 보드에는 [PL011][1] UART가 있으므로 이를 위한 드라이버를 작성해 "
-"보겠습니다."
+"QEMU의 'virt' 보드에는 [PL011](https://developer.arm.com/documentation/"
+"ddi0183/g) UART가 있으므로 이를 위한 드라이버를 작성해 보겠습니다."
 
 #: src/bare-metal/aps/uart.md:5
 msgid ""
@@ -17453,7 +19921,8 @@ msgstr ""
 "        // Wait until there is room in the TX buffer.\n"
 "        while self.read_flag_register() & FR_TXFF != 0 {}\n"
 "\n"
-"        //  `base_address`가 PL011의 컨트롤 레지스터가 매핑된 주소를 가리키고\n"
+"        //  `base_address`가 PL011의 컨트롤 레지스터가 매핑된 주소를 가리키"
+"고\n"
 "        // 있으므로 안전합니다.\n"
 "        unsafe {\n"
 "            // Write to the TX buffer.\n"
@@ -17475,105 +19944,225 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is "
-"because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i."
-"e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else "
-"aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume "
-"the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but "
-"`write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls "
-"`write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving "
-"the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
-"* `Uart::new`는 안전하지 않지만(usafe), 그 외 다른 메서드들은 안전한(safe) 점에 주목하세요."
-"다른 메서드들이 안전할 수 있는 이유는, `Uart::new`의 안전 요구사항(즉, 지정된 UART의 드라이버 인스턴"
-"스가 하나만 있으며\n"
-"  주소 공간에 별칭을 지정하는 다른 항목이 없음)\n"
-"이 만족되기만 하면 `write_byte`와 같은 함수를 안전하게 호출하는데 있어서 필요한 모든 전제조건이 만족되기"
-"  때문입니다.\n"
-"* 반대 방법으로도 실행할 수 있지만(`new`를 안전하게 만들고 `write_byte`를 안"
-"전하지 않게 만듦)\n"
-"  이는 `write_byte`를 호출하는 모든 위치에서 안전성에 관해 추론해야 하므로\n"
-"  사용 편의성이 훨씬 떨어집니다.\n"
-"* 이는 안전하지 않은 코드의 안전한 래퍼를 작성하는 일반적인 패턴입니다. 안전"
-"에 관한\n"
-"  증명 부담을 여러 많은 위치에서 소수의 위치로 옮기는 것입니다."
+"`Uart::new`는 안전하지 않지만(usafe), 그 외 다른 메서드들은 안전한(safe) 점"
+"에 주목하세요.다른 메서드들이 안전할 수 있는 이유는, `Uart::new`의 안전 요구"
+"사항(즉, 지정된 UART의 드라이버 인스턴스가 하나만 있으며 주소 공간에 별칭을 "
+"지정하는 다른 항목이 없음) 이 만족되기만 하면 `write_byte`와 같은 함수를 안전"
+"하게 호출하는데 있어서 필요한 모든 전제조건이 만족되기  때문입니다."
+
+#: src/bare-metal/aps/uart.md:60
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+"반대 방법으로도 실행할 수 있지만(`new`를 안전하게 만들고 `write_byte`를 안전"
+"하지 않게 만듦) 이는 `write_byte`를 호출하는 모든 위치에서 안전성에 관해 추론"
+"해야 하므로 사용 편의성이 훨씬 떨어집니다."
+
+#: src/bare-metal/aps/uart.md:63
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
+msgstr ""
+"이는 안전하지 않은 코드의 안전한 래퍼를 작성하는 일반적인 패턴입니다. 안전에 "
+"관한 증명 부담을 여러 많은 위치에서 소수의 위치로 옮기는 것입니다."
 
 #: src/bare-metal/aps/better-uart.md:1
-msgid "# A better UART driver"
-msgstr "# 더 나은 UART 드라이버"
+msgid "A better UART driver"
+msgstr "더 나은 UART 드라이버"
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
-"PL011에는 실제로 [훨씬 더 많은 레지스터][1]가 있으며, 이에 액세스할 포인터를 "
-"구성하기 위해 오프셋을\n"
-"추가하면 오류가 발생하기 쉽고 읽기 어렵습니다. 또한 그중 일부는 구조화된 방식"
-"으로 액세스할 수 있는\n"
-"비트 필드입니다."
+"PL011에는 실제로 [훨씬 더 많은 레지스터](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers)가 있으며, 이"
+"에 액세스할 포인터를 구성하기 위해 오프셋을 추가하면 오류가 발생하기 쉽고 읽"
+"기 어렵습니다. 또한 그중 일부는 구조화된 방식으로 액세스할 수 있는 비트 필드"
+"입니다."
 
 #: src/bare-metal/aps/better-uart.md:7
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
-msgstr ""
-"| 오프셋 | 레지스터 이름 | 너비 |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
+msgid "Offset"
+msgstr "오프셋"
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr "레지스터 이름"
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr "너비"
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr "0x00"
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr "DR"
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr "12"
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr "0x04"
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr "RSR"
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr "4"
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr "0x18"
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr "FR"
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr "9"
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr "0x20"
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr "ILPR"
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr "8"
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr "0x24"
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr "IBRD"
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr "16"
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr "0x28"
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr "FBRD"
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr "6"
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr "0x2c"
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr "LCR_H"
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr "0x30"
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr "CR"
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr "0x34"
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr "IFLS"
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr "0x38"
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr "IMSC"
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr "11"
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr "0x3c"
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr "RIS"
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr "0x40"
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr "MIS"
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr "0x44"
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr "ICR"
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr "0x48"
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr "DMACR"
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
+msgstr "3"
 
 #: src/bare-metal/aps/better-uart.md:26
-msgid "- There are also some ID registers which have been omitted for brevity."
-msgstr "- 간결성을 위해 일부 ID 레지스터는 생략되었습니다."
+msgid "There are also some ID registers which have been omitted for brevity."
+msgstr "간결성을 위해 일부 ID 레지스터는 생략되었습니다."
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
-"[`log`][1] 크레이트의 로깅 매크로를 사용할 수 있으면 좋습니다. 이는 `Log` 트"
-"레잇을\n"
-"구현하면 됩니다."
+"[`log`](https://crates.io/crates/log) 크레이트의 로깅 매크로를 사용할 수 있으"
+"면 좋습니다. 이는 `Log` 트레잇을 구현하면 됩니다."
 
 #: src/bare-metal/aps/logging.md:6
 msgid ""
@@ -17665,41 +20254,59 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
-"* `log`함수 안에서 `unwrap`하는 것은 괜찮습니다.. 왜냐하면  `set_logger`를 호출하기 전에 `LOGGER`를 초"
-"기화하기 때문입니다."
+"`log`함수 안에서 `unwrap`하는 것은 괜찮습니다.. 왜냐하면  `set_logger`를 호출"
+"하기 전에 `LOGGER`를 초기화하기 때문입니다."
 
 #: src/bare-metal/aps/other-projects.md:3
-msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling, page tables\n"
-"   * Not all very well written, so beware.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
-msgstr ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"C가 없는 coreboot\"\n"
-"   * x86, aarch64, RISC-V를 지원합니다.\n"
-"   * 자체적으로 여러 드라이버를 보유하는 대신 LinuxBoot에 의존합니다.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * 초기화, UART 드라이버, 간단한 부트로더, JTAG, 예외 수준, 예외 처리, 페이"
-"지 테이블\n"
-"   * 잘 작성되지 않은 것도 있으므로 주의하세요.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * 최대 스택 사용량을 결정하는 정적 분석"
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
+msgstr "[oreboot](https://github.com/oreboot/oreboot)"
 
-#: src/bare-metal/useful-crates.md:1
-msgid "# Useful crates"
-msgstr "# 유용한 크레이트"
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr "\"C가 없는 coreboot\""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr "x86, aarch64, RISC-V를 지원합니다."
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr "자체적으로 여러 드라이버를 보유하는 대신 LinuxBoot에 의존합니다."
+
+#: src/bare-metal/aps/other-projects.md:7
+msgid ""
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+"초기화, UART 드라이버, 간단한 부트로더, JTAG, 예외 수준, 예외 처리, 페이지 테"
+"이블"
+
+#: src/bare-metal/aps/other-projects.md:9
+msgid "Not all very well written, so beware."
+msgstr "잘 작성되지 않은 것도 있으므로 주의하세요."
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+
+#: src/bare-metal/aps/other-projects.md:11
+msgid "Static analysis to determine maximum stack usage."
+msgstr "최대 스택 사용량을 결정하는 정적 분석"
+
+#: src/bare-metal/useful-crates.md:1 src/SUMMARY.md:168
+msgid "Useful crates"
+msgstr "유용한 크레이트"
 
 #: src/bare-metal/useful-crates.md:3
 msgid ""
@@ -17710,18 +20317,17 @@ msgstr ""
 "다."
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "# `zerocopy`"
-msgstr "# `zerocopy`"
+msgid "`zerocopy`"
+msgstr "`zerocopy`"
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
-"Fuchsia팀이 만든 [`zerocopy`][1] 크레이트는 바이트 시퀀스를 다른 타입으로 안전하게 "
-"변환하기 위한\n"
-"트레잇 및 매크로를 제공합니다."
+"Fuchsia팀이 만든 [`zerocopy`](https://docs.rs/zerocopy/) 크레이트는 바이트 시"
+"퀀스를 다른 타입으로 안전하게 변환하기 위한 트레잇 및 매크로를 제공합니다."
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
 msgid ""
@@ -17796,52 +20402,61 @@ msgstr ""
 #: src/bare-metal/useful-crates/zerocopy.md:40
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
-"이 크레이트는 휘발성(volatile) 읽기 및 쓰기를 사용하지 않으므로 MMIO에 적합하지 않지만, 하드웨어"
-"와 공유되거나(예: DMA에서)\n"
-"외장 인터페이스를 통해 전송되는 구조체를 다루는 데에는 유용할 수 있습니다."
+"이 크레이트는 휘발성(volatile) 읽기 및 쓰기를 사용하지 않으므로 MMIO에 적합하"
+"지 않지만, 하드웨어와 공유되거나(예: DMA에서) 외장 인터페이스를 통해 전송되"
+"는 구조체를 다루는 데에는 유용할 수 있습니다."
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
 msgstr ""
-"* 어떤 타입이 가능한 모든 바이트 패턴들에 대해 올바른 값을 가질 때에만 , 그 타입이 `FromBytes`를 구현할 수 있습니다.\n"
-"  그렇게 해서 신뢰할 수 없는 바이트 시퀀스를 안전하게 해당 타입으로 변환할 수 있습니다.\n"
-"* 위 코드에서 정의한 타입에 대해 `FromBytes`를 구현하려고 하면 에러가 발생합니다. `RequestType`은 가"
-"능한 모든 u32 값을\n"
-"  식별자로 받아들이지 않기 때문입니다. 즉 모든 바이트 패턴이 유효한 `RequestType`값은 아"
-"닙니다.\n"
-"* `zerocopy::byteorder`에는 바이트 오더에 따른 서로 다른 표현 방식을 지원하는 숫자 타입을 제공합니"
-"다.\n"
-"* `src/bare-metal/useful-crates/zerocopy-example/`에서 `cargo run`을 사용하"
-"여 예시를 실행합니다(종속성 문제로 인해\n"
-"  플레이그라운드에서는 실행되지 않습니다)."
+"어떤 타입이 가능한 모든 바이트 패턴들에 대해 올바른 값을 가질 때에만 , 그 타"
+"입이 `FromBytes`를 구현할 수 있습니다. 그렇게 해서 신뢰할 수 없는 바이트 시퀀"
+"스를 안전하게 해당 타입으로 변환할 수 있습니다."
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+"위 코드에서 정의한 타입에 대해 `FromBytes`를 구현하려고 하면 에러가 발생합니"
+"다. `RequestType`은 가능한 모든 u32 값을 식별자로 받아들이지 않기 때문입니"
+"다. 즉 모든 바이트 패턴이 유효한 `RequestType`값은 아닙니다."
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+"`zerocopy::byteorder`에는 바이트 오더에 따른 서로 다른 표현 방식을 지원하는 "
+"숫자 타입을 제공합니다."
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
+msgstr ""
+"`src/bare-metal/useful-crates/zerocopy-example/`에서 `cargo run`을 사용하여 "
+"예시를 실행합니다(종속성 문제로 인해 플레이그라운드에서는 실행되지 않습니다)."
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "# `aarch64-paging`"
-msgstr "# `aarch64-paging`"
+msgid "`aarch64-paging`"
+msgstr "`aarch64-paging`"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
-"[`aarch64-paging`][1] 크레이트를 사용하면 AArch64 가상 메모리 시스템 아키텍처"
-"에 따라 페이지 테이블을\n"
-"만들 수 있습니다."
+"[`aarch64-paging`](https://crates.io/crates/aarch64-paging) 크레이트를 사용하"
+"면 AArch64 가상 메모리 시스템 아키텍처에 따라 페이지 테이블을 만들 수 있습니"
+"다."
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
 msgid ""
@@ -17887,39 +20502,52 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real "
-"hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
 msgstr ""
-"* 현재는 EL1만 지원하지만 다른 익셉션 레벨(Exception Level: EL)도 어렵지 않게 추가할 수\n"
-"  있습니다.\n"
-"* Android에서 [보호된 VM 펌웨어][2]에 사용됩니다.\n"
-"* 이 예시를 간단하게 실행하는 방법은 없습니다. 실제 하드웨어 또는 QEMU에서 실"
-"행해야 하기 때문입니다."
+"현재는 EL1만 지원하지만 다른 익셉션 레벨(Exception Level: EL)도 어렵지 않게 "
+"추가할 수 있습니다."
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+"Android에서 [보호된 VM 펌웨어](https://cs.android.com/android/platform/"
+"superproject/+/master:packages/modules/Virtualization/pvmfw/)에 사용됩니다."
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
+msgstr ""
+"이 예시를 간단하게 실행하는 방법은 없습니다. 실제 하드웨어 또는 QEMU에서 실행"
+"해야 하기 때문입니다."
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "# `buddy_system_allocator`"
-msgstr "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
+msgstr "`buddy_system_allocator`"
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
-"[`buddy_system_allocator`][1]는 버디 시스템 할당자를 구현하는 서드 파티 "
-"크레이트입니다.\n"
-"이 크레이트의 [`LockedHeap`][2]은 [`GlobalAlloc`][3]를 구현합니다. 따라서 여러분은 버디 시스템 할당자를 "
-"'alloc' 크레이트를 통해서 사용할 수 있습니다([이전][4]에 확인함).\n"
-"또는 다른 주소 공간을 할당하는 데 사용할 수 있습니다. 예를 들어\n"
-"PCI BAR에 MMIO 공간을 할당할 수 있습니다."
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator)"
+"는 버디 시스템 할당자를 구현하는 서드 파티 크레이트입니다. 이 크레이트의 "
+"[`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html)은 [`GlobalAlloc`](https://doc."
+"rust-lang.org/core/alloc/trait.GlobalAlloc.html)를 구현합니다. 따라서 여러분"
+"은 버디 시스템 할당자를 'alloc' 크레이트를 통해서 사용할 수 있습니다([이전]"
+"(../alloc.md)에 확인함). 또는 다른 주소 공간을 할당하는 데 사용할 수 있습니"
+"다. 예를 들어 PCI BAR에 MMIO 공간을 할당할 수 있습니다."
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
 msgid ""
@@ -17956,36 +20584,36 @@ msgstr ""
 "```"
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+msgid "PCI BARs always have alignment equal to their size."
+msgstr "PCI BAR는 BAR영역의 크기에 맞추어 정렬됩니다."
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
-"* PCI BAR는 BAR영역의 크기에 맞추어 정렬됩니다.\n"
-"* `src/bare-metal/useful-crates/allocator-example/`에서 `cargo run`을 사용하"
-"여 예시를 실행합니다(종속성 문제로 인해\n"
-"  플레이그라운드에서는 실행되지 않습니다)."
+"`src/bare-metal/useful-crates/allocator-example/`에서 `cargo run`을 사용하여 "
+"예시를 실행합니다(종속성 문제로 인해 플레이그라운드에서는 실행되지 않습니다)."
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "# `tinyvec`"
-msgstr "# `tinyvec`"
+msgid "`tinyvec`"
+msgstr "`tinyvec`"
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
-"힙에 메모리 할당하지 않고 크기 조절이 가능한 컨테이너(예: `Vec` 같은)가 필요할 때가 있습니다.\n"
-"[`tinyvec`][1]을 사용하면 됩니다. `tinyvec`에서 벡터는 배열 또는 슬라이스로부터 생성이 되며, "
-"이들은 정적으로 할당되었거나 스택에 할당되어 있을 수 있습니다."
-"`tinyvec`은 현재 벡터 안에 얼마나 많은 엘리먼트들이 존재하는 지를 추적하고 있으며, 할당된 양보다 더 많이 사용하려고 하면\n"
-"패닉을 발생시킵니다."
+"힙에 메모리 할당하지 않고 크기 조절이 가능한 컨테이너(예: `Vec` 같은)가 필요"
+"할 때가 있습니다. [`tinyvec`](https://crates.io/crates/tinyvec)을 사용하면 됩"
+"니다. `tinyvec`에서 벡터는 배열 또는 슬라이스로부터 생성이 되며, 이들은 정적"
+"으로 할당되었거나 스택에 할당되어 있을 수 있습니다.`tinyvec`은 현재 벡터 안"
+"에 얼마나 많은 엘리먼트들이 존재하는 지를 추적하고 있으며, 할당된 양보다 더 "
+"많이 사용하려고 하면 패닉을 발생시킵니다."
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
 msgid ""
@@ -18017,34 +20645,36 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:23
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
-"initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine "
-"inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
 msgstr ""
-"* `tinyvec`를 사용하려면 엘리먼트의 타입이 `Default`를 통해 초기화 될 수 있어야 합니"
-"다.\n"
-"* Rust 플레이그라운드에는 `tinyvec`가 포함되어 있으므로 이 예시는 인라인으로 "
-"실행됩니다."
+"`tinyvec`를 사용하려면 엘리먼트의 타입이 `Default`를 통해 초기화 될 수 있어"
+"야 합니다."
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
+msgstr ""
+"Rust 플레이그라운드에는 `tinyvec`가 포함되어 있으므로 이 예시는 인라인으로 실"
+"행됩니다."
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 "`std::sync::Mutex` 및 `std::sync`의 기타 동기화 프리미티브는 `core` 또는 "
-"`alloc`에서\n"
-"사용할 수 없습니다. 그러면 어떻게 동기화 또는 interior mutability와 같은 기능이 필요할 경우 어떻게 해야 할까요? "
+"`alloc`에서 사용할 수 없습니다. 그러면 어떻게 동기화 또는 interior mutability"
+"와 같은 기능이 필요할 경우 어떻게 해야 할까요? "
 
 #: src/bare-metal/useful-crates/spin.md:7
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
-"[`spin`][1] 크레이트는 이러한 동기화 프리미티브들을 스핀록으로 구현하고 있습니다."
+"[`spin`](https://crates.io/crates/spin) 크레이트는 이러한 동기화 프리미티브들"
+"을 스핀록으로 구현하고 있습니다."
 
 #: src/bare-metal/useful-crates/spin.md:9
 msgid ""
@@ -18073,40 +20703,47 @@ msgstr ""
 "```"
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
-"* 인터럽트 핸들러에서 락을 걸 경우, 교착 상태가 발생하지 않도록 주의하세"
-"요.\n"
-"* `spin`에는 티켓 잠금 뮤텍스 구현도 있습니다. `std::sync`의 `RwLock`, "
-"`Barrier`, `Once` 에 해당하는 것들이 제공되며, \n"
-" 지연된 초기화를 위한 `Lazy`에 해당하는 것도 제공됩니다.\n"
-"* [`once_cell`][2] 크레이트에는 지연된 초기화를 위한 몇 가지 유용한 타입이 있는"
-"데\n"
-"  `spin::once::Once`와는 약간 다른 접근 방식을 사용합니다.\n"
-"* Rust 플레이그라운드에는 `spin`이 포함되어 있으므로 이 예시는 인라인으로 실"
-"행됩니다."
+"인터럽트 핸들러에서 락을 걸 경우, 교착 상태가 발생하지 않도록 주의하세요."
+
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+"`spin`에는 티켓 잠금 뮤텍스 구현도 있습니다. `std::sync`의 `RwLock`, "
+"`Barrier`, `Once` 에 해당하는 것들이 제공되며,  지연된 초기화를 위한 `Lazy`"
+"에 해당하는 것도 제공됩니다."
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+"[`once_cell`](https://crates.io/crates/once_cell) 크레이트에는 지연된 초기화"
+"를 위한 몇 가지 유용한 타입이 있는데 `spin::once::Once`와는 약간 다른 접근 방"
+"식을 사용합니다."
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
+msgstr ""
+"Rust 플레이그라운드에는 `spin`이 포함되어 있으므로 이 예시는 인라인으로 실행"
+"됩니다."
 
 #: src/bare-metal/android.md:3
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
-"AOSP에서 bare-metal Rust 바이너리를 빌드하려면 `rust_ffi_static` "
-"을 사용하여 Rust 코드를\n"
-"빌드하고, 링커 스크립트가 포함된 `cc_binary`를 사용하여 ELF 바이너리를 생성"
-"하고, `raw_binary`를 사용해\n"
-"ELF를 곧바로 수행될 수 있는 원시(raw) 바이너리로 변환합니다."
+"AOSP에서 bare-metal Rust 바이너리를 빌드하려면 `rust_ffi_static` 을 사용하여 "
+"Rust 코드를 빌드하고, 링커 스크립트가 포함된 `cc_binary`를 사용하여 ELF 바이"
+"너리를 생성하고, `raw_binary`를 사용해 ELF를 곧바로 수행될 수 있는 원시(raw) "
+"바이너리로 변환합니다."
 
 #: src/bare-metal/android.md:7
 msgid ""
@@ -18188,19 +20825,21 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/bare-metal/android/vmbase.md:1
-msgid "# vmbase"
-msgstr "# vmbase"
+#: src/bare-metal/android/vmbase.md:1 src/SUMMARY.md:250
+msgid "vmbase"
+msgstr "vmbase"
 
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
-"[vmbase][1] 라이브러리는, aarch64의 crosvm에서 실행되는 VM을 타겟하여, 진입점, "
-"UART 콘솔 로깅, 링커 스크립트, 빌드 룰 등에 대한 기본 구현들을 제공합니다."
+"[vmbase](https://android.googlesource.com/platform/packages/modules/"
+"Virtualization/+/refs/heads/master/vmbase/) 라이브러리는, aarch64의 crosvm에"
+"서 실행되는 VM을 타겟하여, 진입점, UART 콘솔 로깅, 링커 스크립트, 빌드 룰 등"
+"에 대한 기본 구현들을 제공합니다."
 
 #: src/bare-metal/android/vmbase.md:6
 msgid ""
@@ -18232,71 +20871,92 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:21
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
-msgstr ""
-"* `main!` 매크로는 `vmbase` 진입점에서 호출될 main 함수를 표시합니다.\n"
-"* `vmbase`가 제공하는 진입점은 콘솔을 초기화 하며, main 함수가 리턴하면 "
-" PSCI_SYSTEM_OFF 메시지를 PSCI를 통해 보내어서  VM을 종료시킵니다."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr "`main!` 매크로는 `vmbase` 진입점에서 호출될 main 함수를 표시합니다."
 
-#: src/thanks.md:1
-msgid "# Thanks!"
-msgstr "# 감사인사"
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
+msgstr ""
+"`vmbase`가 제공하는 진입점은 콘솔을 초기화 하며, main 함수가 리턴하면  "
+"PSCI_SYSTEM_OFF 메시지를 PSCI를 통해 보내어서  VM을 종료시킵니다."
 
 #: src/thanks.md:3
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that it\n"
-"was useful."
-msgstr "Comprehensive Rust 🦀를 이용해 주셔서 감사합니다. 즐겁고 유익한 시간이었기를 바랍니다."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
+msgstr ""
+"Comprehensive Rust 🦀를 이용해 주셔서 감사합니다. 즐겁고 유익한 시간이었기를 "
+"바랍니다."
 
 #: src/thanks.md:6
 msgid ""
-"We've had a lot of fun putting the course together. The course is not perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would love\n"
-"to hear from you."
-msgstr "강의가 완벽하진 않으니 실수나 개선점이 있다면 언제든지 [깃허브](https://github.com/google/comprehensive-rust/discussions)로 연락주세요."
+"We've had a lot of fun putting the course together. The course is not "
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
+msgstr ""
+"강의가 완벽하진 않으니 실수나 개선점이 있다면 언제든지 [깃허브](https://"
+"github.com/google/comprehensive-rust/discussions)로 연락주세요."
 
 #: src/other-resources.md:1
-msgid "# Other Rust Resources"
-msgstr "# 러스트 참고 자료"
+msgid "Other Rust Resources"
+msgstr "러스트 참고 자료"
 
 #: src/other-resources.md:3
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr "러스트 커뮤니티는 온라인에서 고품질의 무료 소스를 만들었습니다."
 
 #: src/other-resources.md:6
-msgid "## Official Documentation"
-msgstr "## 공식 문서들"
+msgid "Official Documentation"
+msgstr "공식 문서들"
 
 #: src/other-resources.md:8
 msgid "The Rust project hosts many resources. These cover Rust in general:"
-msgstr "러스트 프로젝트에는 참조할 만한 자료가 많습니다. 일반적인 내용을 다루는 몇가지 참고 문서들입니다:"
+msgstr ""
+"러스트 프로젝트에는 참조할 만한 자료가 많습니다. 일반적인 내용을 다루는 몇가"
+"지 참고 문서들입니다:"
 
 #: src/other-resources.md:10
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the Rust\n"
-"  syntax via a series of examples which showcase different constructs. Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
 msgstr ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): 러스트에 대한 무료 표준 서적입니다. 언어에 대한 자세한 설명과 사람들이 빌드 할수 있는 몇가지 프로젝트를 포함합니다.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): 여러 예제를 통해 러스트의 문법을 보여주며 때때로 코드를 확장하는 약간의 연습문제들이 포함되어 있습니다.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): 러스트 표준 라이브러리 전체 문서입니다.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): 메모리 모델링과 러스트 문법을 설명하는 문서입니다.(아직 불완전하다함)"
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): 러스트에 대"
+"한 무료 표준 서적입니다. 언어에 대한 자세한 설명과 사람들이 빌드 할수 있는 몇"
+"가지 프로젝트를 포함합니다."
+
+#: src/other-resources.md:13
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): 여러 예제를 통"
+"해 러스트의 문법을 보여주며 때때로 코드를 확장하는 약간의 연습문제들이 포함되"
+"어 있습니다."
+
+#: src/other-resources.md:17
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): 러스트 표준 라이브러"
+"리 전체 문서입니다."
+
+#: src/other-resources.md:19
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
+msgstr ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): 메모리 모델링과 "
+"러스트 문법을 설명하는 문서입니다.(아직 불완전하다함)"
 
 #: src/other-resources.md:22
 msgid "More specialized guides hosted on the official Rust site:"
@@ -18304,22 +20964,34 @@ msgstr "좀 더 전문적인 공식 가이드입니다:"
 
 #: src/other-resources.md:24
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/):\n"
-"  covers the new asynchronous programming model which was introduced after the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
 msgstr ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): 안전하지 않은 러스트, FFI, raw포인터 작업을 다룹니다.\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): 러스트 북이 작성 된 이후 도입된 새로운 비동기 프로그래밍 모델을 다룹니다.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): 운영체제가 없는 임베디드 장치에서의 러스트 사용법을 소개합니다."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): 안전하지 않은 러스"
+"트, FFI, raw포인터 작업을 다룹니다."
+
+#: src/other-resources.md:27
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"러스트 북이 작성 된 이후 도입된 새로운 비동기 프로그래밍 모델을 다룹니다."
+
+#: src/other-resources.md:30
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
+msgstr ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): 운"
+"영체제가 없는 임베디드 장치에서의 러스트 사용법을 소개합니다."
 
 #: src/other-resources.md:33
-msgid "## Unofficial Learning Material"
-msgstr "## 비공식적 학습 자료"
+msgid "Unofficial Learning Material"
+msgstr "비공식적 학습 자료"
 
 #: src/other-resources.md:35
 msgid "A small selection of other guides and tutorial for Rust:"
@@ -18327,101 +20999,140 @@ msgstr "러스트에 대한 기타 안내서와 튜토리얼의 일부입니다:
 
 #: src/other-resources.md:37
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): a\n"
-"  series of small presentations covering both basic and advanced part of the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
 msgstr ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): C언어 프로그래머 관점에서 러스트를 다룹니다.\n"
-"* [Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): 임베디드 C개발자(펌웨어 개발자)를 위한 러스트 가이드입니다.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/): 다른 언어(C/C++, Java, Python, Javascript)와의 병렬비교를 사용하여 러스트 문법을 다룹니다.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 러스트를 배우는데 도움이 되는 100개 이상의 연습문제\n"
-"* [Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-material/index.html): 러스트 언어의 기본부터 고급을 전부 다루는 일련의 작은 프레젠테이션, 웹 어셈블리, async/await 같은 부분도 함께 다룹니다.\n"
-"* [Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/), [Take your first steps with Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): 첫번째는 35개의 시리즈 영상이며 두번째는 러스트의 문법과 구조를 다루는 11개의 모듈 세트입니다.\n"
-"* [Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists/): 몇가지 유형의 리스트 자료구조를 구현해보면서 러스트의 메모리 관리 규칙들을 깊이있게 탐색합니다."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): C언어 프로그"
+"래머 관점에서 러스트를 다룹니다."
+
+#: src/other-resources.md:39
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): 임베디드 C개발자(펌웨어 개발자)를 위한 러스트 가이드입니다."
+
+#: src/other-resources.md:42
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): 다"
+"른 언어(C/C++, Java, Python, Javascript)와의 병렬비교를 사용하여 러스트 문법"
+"을 다룹니다."
+
+#: src/other-resources.md:45
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 러스트를 배우는데 도움"
+"이 되는 100개 이상의 연습문제"
+
+#: src/other-resources.md:47
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): 러스트 언어의 기본부터 고급을 전부 다루는 일련의 작은 "
+"프레젠테이션, 웹 어셈블리, async/await 같은 부분도 함께 다룹니다."
+
+#: src/other-resources.md:52
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/), [Take your first steps with Rust](https://docs.microsoft."
+"com/en-us/learn/paths/rust-first-steps/): 첫번째는 35개의 시리즈 영상이며 두"
+"번째는 러스트의 문법과 구조를 다루는 11개의 모듈 세트입니다."
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
+msgstr ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): 몇가지 유형의 리스트 자료구조를 구현해보면서 러스"
+"트의 메모리 관리 규칙들을 깊이있게 탐색합니다."
 
 #: src/other-resources.md:63
 msgid ""
-"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) for\n"
-"even more Rust books."
-msgstr "[Little Book of Rust Books](https://lborb.github.io/book/)에서 더 많은 러스트 북을 확인해보세요."
-
-#: src/credits.md:1
-msgid "# Credits"
-msgstr "# Credits"
+"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
+"for even more Rust books."
+msgstr ""
+"[Little Book of Rust Books](https://lborb.github.io/book/)에서 더 많은 러스"
+"트 북을 확인해보세요."
 
 #: src/credits.md:3
 msgid ""
-"The material here builds on top of the many great sources of Rust documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of useful\n"
-"resources."
-msgstr "이 자료는 많은 훌륭한 러스트 문서들의 도움을 받아 작성되었습니다. 유용한 자료의 전체 목록은 [other resources](other-resources.md)에서 살펴보시기 바랍니다."
+"The material here builds on top of the many great sources of Rust "
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
+msgstr ""
+"이 자료는 많은 훌륭한 러스트 문서들의 도움을 받아 작성되었습니다. 유용한 자료"
+"의 전체 목록은 [other resources](other-resources.md)에서 살펴보시기 바랍니다."
 
 #: src/credits.md:7
 msgid ""
-"The material of Comprehensive Rust is licensed under the terms of the Apache 2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
-msgstr "Comprehensive Rust의 자료는 Apache 2.0 라이선스를 따릅니다. 자세한건 [`LICENSE`](../LICENSE) 확인해 보시기 바랍니다."
+"The material of Comprehensive Rust is licensed under the terms of the Apache "
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
+msgstr ""
+"Comprehensive Rust의 자료는 Apache 2.0 라이선스를 따릅니다. 자세한건 "
+"[`LICENSE`](../LICENSE) 확인해 보시기 바랍니다."
 
 #: src/credits.md:10
-msgid "## Rust by Example"
-msgstr "## Rust by Example"
+msgid "Rust by Example"
+msgstr "Rust by Example"
 
 #: src/credits.md:12
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
-msgstr "일부 예제와 연습문제는 [Rust by Example](https://doc.rust-lang.org/rust-by-example/)을 참조하였습니다. 라이선스 조항을 포함하여 저장소의 `third_party/rust-by-example/` 폴더를 참조하시기 바랍니다."
+msgstr ""
+"일부 예제와 연습문제는 [Rust by Example](https://doc.rust-lang.org/rust-by-"
+"example/)을 참조하였습니다. 라이선스 조항을 포함하여 저장소의 `third_party/"
+"rust-by-example/` 폴더를 참조하시기 바랍니다."
 
 #: src/credits.md:17
-msgid "## Rust on Exercism"
-msgstr "## Rust on Exercism"
+msgid "Rust on Exercism"
+msgstr "Rust on Exercism"
 
 #: src/credits.md:19
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the license\n"
-"terms."
-msgstr "일부 연습문제는 [Rust on Exercism](https://exercism.org/tracks/rust)을 참조하였습니다. 라이선스 조항을 포함하여 저장소의 `third_party/rust-on-exercism/`폴더를 참조하시기 바랍니다."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
+msgstr ""
+"일부 연습문제는 [Rust on Exercism](https://exercism.org/tracks/rust)을 참조하"
+"였습니다. 라이선스 조항을 포함하여 저장소의 `third_party/rust-on-exercism/`폴"
+"더를 참조하시기 바랍니다."
 
 #: src/credits.md:24
-msgid "## CXX"
-msgstr "## CXX"
+msgid "CXX"
+msgstr "CXX"
 
 #: src/credits.md:26
 msgid ""
-"The [Interoperability with C++](android/interoperability/cpp.md) section uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` directory\n"
-"for details, including the license terms."
-msgstr "4일차 오후 강의 중 [Interoperability with C++](android/interoperability/cpp.md)에서는 [CXX](https://cxx.rs/)의 이미지를 사용하였습니다. 라이선스 조항을 포함하여 저장소의 `third_party/cxx/`폴더를 참조하시기 바랍니다."
-
-#: src/exercises/solutions.md:1
-msgid "# Solutions"
-msgstr "# 해답"
+"The [Interoperability with C++](android/interoperability/cpp.md) section "
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
+msgstr ""
+"4일차 오후 강의 중 [Interoperability with C++](android/interoperability/cpp."
+"md)에서는 [CXX](https://cxx.rs/)의 이미지를 사용하였습니다. 라이선스 조항을 "
+"포함하여 저장소의 `third_party/cxx/`폴더를 참조하시기 바랍니다."
 
 #: src/exercises/solutions.md:3
 msgid "You will find solutions to the exercises on the following pages."
@@ -18429,25 +21140,25 @@ msgstr "연습문제의 해답은 다음 페이지에서 확인할 수 있습니
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us know\n"
-"if you have a different or better solution than what is presented here."
-msgstr "[깃허브](https://github.com/google/comprehensive-rust/discussions)에서 이에 대해 자유롭게 질문하시고 더 나은 솔루션이 있다면 알려주시기 바랍니다."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
+msgstr ""
+"[깃허브](https://github.com/google/comprehensive-rust/discussions)에서 이에 "
+"대해 자유롭게 질문하시고 더 나은 솔루션이 있다면 알려주시기 바랍니다."
 
 #: src/exercises/solutions.md:10
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
-msgstr "> **참고:** `// ANCHOR: label`과 `// ANCHOR_END: label` 주석은 문제를 구성하기 위한 메타 주석으로 무시하시면 됩니다."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
+msgstr ""
+"**참고:** `// ANCHOR: label`과 `// ANCHOR_END: label` 주석은 문제를 구성하기 "
+"위한 메타 주석으로 무시하시면 됩니다."
 
 #: src/exercises/day-1/solutions-morning.md:1
-msgid "# Day 1 Morning Exercises"
-msgstr "# 1일차 오전 연습문제"
-
-#: src/exercises/day-1/solutions-morning.md:3
-msgid "## Arrays and `for` Loops"
-msgstr "## 배열과 `for`반복문"
+msgid "Day 1 Morning Exercises"
+msgstr "1일차 오전 연습문제"
 
 #: src/exercises/day-1/solutions-morning.md:5
 msgid "([back to exercise](for-loops.md))"
@@ -18529,20 +21240,40 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
-msgid "### Bonus question"
-msgstr "### 보너스 문제"
+msgid "Bonus question"
+msgstr "보너스 문제"
 
 #: src/exercises/day-1/solutions-morning.md:80
-msgid "It requires more advanced concepts. It might seem that we could use a slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make our function handle any size of matrix. However, this quickly breaks down: the return type cannot be `&[&[i32]]` since it needs to own the data you return."
-msgstr "사실 이 문제는 고급 개념이 필요합니다. 슬라이스의 슬라이스(slice-of-slices, `&[&[i32]]`)를 입력 타입으로 사용하면 모든 크기의 행렬을 처리할 수 있을것 같습니다. 하지만 실제로 해보면 금방 안된다는 걸 알 수 있습니다. 반환값을 소유해야 하기때문에 `&[&[i32]]` 반환 타입으로 사용할 수 없습니다."
+msgid ""
+"It requires more advanced concepts. It might seem that we could use a slice-"
+"of-slices (`&[&[i32]]`) as the input type to transpose and thus make our "
+"function handle any size of matrix. However, this quickly breaks down: the "
+"return type cannot be `&[&[i32]]` since it needs to own the data you return."
+msgstr ""
+"사실 이 문제는 고급 개념이 필요합니다. 슬라이스의 슬라이스(slice-of-slices, "
+"`&[&[i32]]`)를 입력 타입으로 사용하면 모든 크기의 행렬을 처리할 수 있을것 같"
+"습니다. 하지만 실제로 해보면 금방 안된다는 걸 알 수 있습니다. 반환값을 소유해"
+"야 하기때문에 `&[&[i32]]` 반환 타입으로 사용할 수 없습니다."
 
 #: src/exercises/day-1/solutions-morning.md:82
-msgid "You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to `&[&[i32]]` so now you cannot easily use `pretty_print` either."
-msgstr "`Vec<Vec<i32>>`와 같은 타입을 사용하려고 시도할 수도 있지만 역시 쉽게 되진 않습니다. `Vec<Vec<i32>>` 타입을 `&[&[i32]]`로 변환하는 것이 어렵기 때문에 `pretty_print`을 사용하는데 어려움이 있습니다."
+msgid ""
+"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work "
+"out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to "
+"`&[&[i32]]` so now you cannot easily use `pretty_print` either."
+msgstr ""
+"`Vec<Vec<i32>>`와 같은 타입을 사용하려고 시도할 수도 있지만 역시 쉽게 되진 않"
+"습니다. `Vec<Vec<i32>>` 타입을 `&[&[i32]]`로 변환하는 것이 어렵기 때문에 "
+"`pretty_print`을 사용하는데 어려움이 있습니다."
 
 #: src/exercises/day-1/solutions-morning.md:84
-msgid "Once we get to traits and generics, we'll be able to use the [`std::convert::AsRef`][1] trait to abstract over anything that can be referenced as a slice."
-msgstr "트레잇나 제네릭을 다루고 나면 [`std::convert::AsRef`][1] 트레잇을 사용하여 슬라이스처럼 사용될 수 있는 타입을 추상화할 수 있습니다."
+msgid ""
+"Once we get to traits and generics, we'll be able to use the [`std::convert::"
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
+msgstr ""
+"트레잇나 제네릭을 다루고 나면 [`std::convert::AsRef`](https://doc.rust-lang."
+"org/std/convert/trait.AsRef.html) 트레잇을 사용하여 슬라이스처럼 사용될 수 있"
+"는 타입을 추상화할 수 있습니다."
 
 #: src/exercises/day-1/solutions-morning.md:86
 msgid ""
@@ -18575,16 +21306,17 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:113
-msgid "In addition, the type itself would not enforce that the child slices are of the same length, so such variable could contain an invalid matrix."
-msgstr "또한, 슬라이스 타입은 길이를 포함하지 않기 때문에 한 단계 아래의 슬라이스들이 같은 길이임을 보장할 수 없습니다. 때문에 슬라이스 타입의 변수에는 잘못된 행렬이 전달될 수 있습니다."
+msgid ""
+"In addition, the type itself would not enforce that the child slices are of "
+"the same length, so such variable could contain an invalid matrix."
+msgstr ""
+"또한, 슬라이스 타입은 길이를 포함하지 않기 때문에 한 단계 아래의 슬라이스들"
+"이 같은 길이임을 보장할 수 없습니다. 때문에 슬라이스 타입의 변수에는 잘못된 "
+"행렬이 전달될 수 있습니다."
 
 #: src/exercises/day-1/solutions-afternoon.md:1
-msgid "# Day 1 Afternoon Exercises"
-msgstr "# 1일차 오후 연습문제"
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-msgid "## Designing a Library"
-msgstr "## 도서관 설계"
+msgid "Day 1 Afternoon Exercises"
+msgstr "1일차 오후 연습문제"
 
 #: src/exercises/day-1/solutions-afternoon.md:5
 msgid "([back to exercise](book-library.md))"
@@ -18701,9 +21433,11 @@ msgid ""
 "    //println!(\"Our library is empty: {}\", library.is_empty());\n"
 "\n"
 "    let favorite_book = Book::new(\"Lord of the Rings\", 1954);\n"
-"    println!(\"Our favorite book {favorite_book} should go in the library\");\n"
+"    println!(\"Our favorite book {favorite_book} should go in the "
+"library\");\n"
 "    //library.add_book(favorite_book);\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    //\n"
 "    //library.print_books();\n"
 "    //\n"
@@ -18726,7 +21460,8 @@ msgid ""
 "    assert!(library.is_empty());\n"
 "\n"
 "    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    assert_eq!(library.len(), 2);\n"
 "    assert!(!library.is_empty());\n"
 "}\n"
@@ -18744,7 +21479,8 @@ msgid ""
 "fn test_library_print_books() {\n"
 "    let mut library = Library::new();\n"
 "    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    // We could try and capture stdout, but let us just call the\n"
 "    // method to start with.\n"
 "    library.print_books();\n"
@@ -18761,7 +21497,8 @@ msgid ""
 "        Some(\"Lord of the Rings\")\n"
 "    );\n"
 "\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    assert_eq!(\n"
 "        library.oldest_book().map(|b| b.title.as_str()),\n"
 "        Some(\"Alice's Adventures in Wonderland\")\n"
@@ -18771,12 +21508,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
-msgid "# Day 2 Morning Exercises"
-msgstr "# 2일차 오전 연습문제"
-
-#: src/exercises/day-2/solutions-morning.md:3
-msgid "## Points and Polygons"
-msgstr "## 점과 다각형"
+msgid "Day 2 Morning Exercises"
+msgstr "2일차 오전 연습문제"
 
 #: src/exercises/day-2/solutions-morning.md:5
 msgid "([back to exercise](points-polygons.md))"
@@ -19015,12 +21748,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
-msgid "# Day 2 Afternoon Exercises"
-msgstr "# 2일차 오후 연습문제"
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-msgid "## Luhn Algorithm"
-msgstr "## 룬 알고리즘"
+msgid "Day 2 Afternoon Exercises"
+msgstr "2일차 오후 연습문제"
 
 #: src/exercises/day-2/solutions-afternoon.md:5
 msgid "([back to exercise](luhn.md))"
@@ -19048,7 +21777,8 @@ msgid ""
 "    // ANCHOR_END: luhn\n"
 "    let mut digits_seen = 0;\n"
 "    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ').enumerate() {\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
 "        match ch.to_digit(10) {\n"
 "            Some(d) => {\n"
 "                sum += if i % 2 == 1 {\n"
@@ -19120,10 +21850,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:98
-msgid "## Strings and Iterators"
-msgstr "## 문자열과 반복자"
-
 #: src/exercises/day-2/solutions-afternoon.md:100
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
@@ -19171,12 +21897,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -19194,7 +21923,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -19207,12 +21937,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
-msgid "# Day 3 Morning Exercise"
-msgstr "# 3일차 오전 연습문제"
-
-#: src/exercises/day-3/solutions-morning.md:3
-msgid "## A Simple GUI Library"
-msgstr "## 간단한 GUI 라이브러리"
+msgid "Day 3 Morning Exercise"
+msgstr "3일차 오전 연습문제"
 
 #: src/exercises/day-3/solutions-morning.md:5
 msgid "([back to exercise](simple-gui.md))"
@@ -19373,7 +22099,8 @@ msgid ""
 "// ANCHOR: main\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\",\n"
 "        Box::new(|| println!(\"You clicked the button!\")),\n"
@@ -19385,12 +22112,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
-msgid "# Day 3 Afternoon Exercises"
-msgstr "# 3일차 오후 연습문제"
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-msgid "## Safe FFI Wrapper"
-msgstr "## FFI래퍼"
+msgid "Day 3 Afternoon Exercises"
+msgstr "3일차 오후 연습문제"
 
 #: src/exercises/day-3/solutions-afternoon.md:5
 msgid "([back to exercise](safe-ffi-wrapper.md))"
@@ -19421,10 +22144,12 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
-"    // Layout as per readdir(3) and definitions in /usr/include/x86_64-linux-gnu.\n"
+"    // Layout as per readdir(3) and definitions in /usr/include/x86_64-linux-"
+"gnu.\n"
 "    #[repr(C)]\n"
 "    pub struct dirent {\n"
 "        pub d_ino: c_long,\n"
@@ -19457,7 +22182,8 @@ msgid ""
 "        // Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
 "        // ANCHOR_END: DirectoryIterator\n"
-"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: {err}\"))?;\n"
+"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
+"{err}\"))?;\n"
 "        // SAFETY: path.as_ptr() cannot be NULL.\n"
 "        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
 "        if dir.is_null() {\n"
@@ -19513,12 +22239,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:1
-msgid "# Day 4 Morning Exercise"
-msgstr "# 4일차 오전 연습문제"
-
-#: src/exercises/day-4/solutions-morning.md:3
-msgid "## Dining Philosophers"
-msgstr "## 식사하는 철학자들"
+msgid "Day 4 Morning Exercise"
+msgstr "4일차 오전 연습문제"
 
 #: src/exercises/day-4/solutions-morning.md:5
 msgid "([back to exercise](dining-philosophers.md))"
@@ -19631,206 +22353,187 @@ msgstr "위에 표시되지 않은 몇 가지 문법이 있습니다."
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
-"- 원시 문자열을 사용하면 이스케이프되지 않는 `&str` 값을 만들 수 있습니"
-"다. `r\"\\n\"\n"
-"  == \"\\\\\\\\n\"` 따옴표의 양쪽에 같은 양의 `#`을\n"
-" 사용하여 큰따옴표를 삽입할 수 있습니다.\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"원시 문자열을 사용하면 이스케이프되지 않는 `&str` 값을 만들 수 있습니다. "
+"`r\"\\n\" == \"\\\\n\"` 따옴표의 양쪽에 같은 양의 `#`을 사용하여 큰따옴표를 "
+"삽입할 수 있습니다."
+
+#: src/basic-syntax/scalar-types.md:27
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr "Byte strings allow you to create a `&[u8]` value directly:"
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
 
 #: src/welcome.md:18
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, "
-"you're\n"
-"invited to dive into one or more specialized topics:"
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
-"처음 3일 동안은 Rust의 기본사항을 살펴봅니다. 그다음에는\n"
-"다음과 같은 하나 이상의 전문 주제를 자세히 알아봅니다."
+"처음 3일 동안은 Rust의 기본사항을 살펴봅니다. 그다음에는 다음과 같은 하나 이"
+"상의 전문 주제를 자세히 알아봅니다."
 
 #: src/welcome.md:21
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android "
-"platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a full day class on using Rust for bare-"
-"metal\n"
-"  (embedded) development. Both microcontrollers and application processors "
-"are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a full day class on concurrency in Rust. "
-"We\n"
-"  cover both classical concurrency (preemptively scheduling using threads "
-"and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"* [Android](android.md): Android 플랫폼 개발(AOSP) 시 Rust 사용에 관한\n"
-"반나절 과정입니다. 여기에는 C, C++, Java와의 상호 운용성이 포함됩니다.\n"
-"* [Bare-metal](bare-metal.md): bare-metal(임베디드) 개발 시 Rust 사용에 관"
-"한\n"
-"종일 과정입니다. 마이크로컨트롤러와 애플리케이션 프로세서를 모두\n"
-"다룹니다.\n"
-"* [동시성](concurrency.md): Rust의 동시성에 관한 종일 과정입니다. 여기"
-"서는\n"
-"고전적인 동시성(스레드와 뮤텍스를 사용하여 선점형 스케줄링을 하는 것)과\n"
-"async/await 동시성(future를 사용하는 협력적인 멀티태스킹)을 모두\n"
-"다룹니다."
+"[Android](android.md): Android 플랫폼 개발(AOSP) 시 Rust 사용에 관한 반나절 "
+"과정입니다. 여기에는 C, C++, Java와의 상호 운용성이 포함됩니다."
+
+#: src/welcome.md:23
+msgid ""
+"[Bare-metal](bare-metal.md): a full day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+"[Bare-metal](bare-metal.md): bare-metal(임베디드) 개발 시 Rust 사용에 관한 종"
+"일 과정입니다. 마이크로컨트롤러와 애플리케이션 프로세서를 모두 다룹니다."
+
+#: src/welcome.md:26
+msgid ""
+"[Concurrency](concurrency.md): a full day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
+msgstr ""
+"[동시성](concurrency.md): Rust의 동시성에 관한 종일 과정입니다. 여기서는 고전"
+"적인 동시성(스레드와 뮤텍스를 사용하여 선점형 스케줄링을 하는 것)과 async/"
+"await 동시성(future를 사용하는 협력적인 멀티태스킹)을 모두 다룹니다."
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
-"다른 언어의 `if` 문과 똑같이\n"
-"[`if` 표현식](https://doc.rust-lang.org/reference/expressions/if-expr."
-"html#if-expressions)을\n"
-"사용합니다."
+"다른 언어의 `if` 문과 똑같이 [`if` 표현식](https://doc.rust-lang.org/"
+"reference/expressions/if-expr.html#if-expressions)을 사용합니다."
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
 "[`if let` 표현식](https://doc.rust-lang.org/reference/expressions/if-expr."
-"html#if-let-expressions)을\n"
-"사용하면 값이 패턴과 일치하는지에 따라 다른 코드를\n"
-"실행할 수 있습니다."
+"html#if-let-expressions)을 사용하면 값이 패턴과 일치하는지에 따라 다른 코드"
+"를 실행할 수 있습니다."
 
-#: src/control-flow/if-let-expressions.md:23
+#: src/control-flow/if-let-expressions.md:26
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is "
-"interesting. In contrast, `match` requires all branches to be covered.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) construct allows to do a destructuring "
 "assignment, or if it fails, have a non-returning block branch (panic/return/"
-"break/continue):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"break/continue):"
 msgstr ""
-"* `if let`이 `match`보다 더 간결할 수 있습니다(예: 한가지 브랜치만 흥미로운 경"
-"우). 이와 달리 `match`에서는 모든 브랜치가 처리되어야 합니다.\n"
-"* 일반적 사용법은 `Option`을 사용할 때 `Some` 값을 처리하는 것입니다.\n"
-"* `match`와 달리 `if let`은 패턴 일치를 위한 보호 절을 지원하지 않습니다.\n"
-"* 1.65부터 유사한 [let-else](https://doc.rust-lang.org/rust-by-example/"
+"1.65부터 유사한 [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) 구성은 디스트럭처링 할당을 실행하거나 실패할 경"
 "우 반환되지 않는 블록 브랜치(panic/return/break/continue)를 보유하도록 허용합"
-"니다.\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"니다."
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 "[`while` 키워드](https://doc.rust-lang.org/reference/expressions/loop-expr."
-"html#predicate-loops)는 다른 언어와 매우 비슷하게\n"
-"작동합니다."
+"html#predicate-loops)는 다른 언어와 매우 비슷하게 작동합니다."
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
 "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 "마지막으로, 무한 루프를 만드는 [`loop` 키워드](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#infinite-loops)가\n"
-"있습니다."
+"reference/expressions/loop-expr.html#infinite-loops)가 있습니다."
 
-#: src/control-flow/loop-expressions.md:27
+#: src/control-flow/loop-expressions.md:28
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-"
-"trivial\n"
-"  value. This is because it's guaranteed to be entered at least once "
-"(unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
-"* `loop`를 값(예: `break 8`)으로 나누고 출력합니다.\n"
-"* `loop`는 non-trivial 값을 반환하는 유일한\n"
-"  반복문입니다. 이는 `while` 및 `for` 반복문과 달리 최소한 한 번은 루프문을 수행하는 것이\n"
-"  보장되기 때문입니다."
+"`loop`는 non-trivial 값을 반환하는 유일한 반복문입니다. 이는 `while` 및 "
+"`for` 반복문과 달리 최소한 한 번은 루프문을 수행하는 것이 보장되기 때문입니"
+"다."
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
 msgstr ""
-"- 루프를 조기에 종료하려면 [`break`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#break-expressions)를 사용합니다.\n"
-"- 다음 반복을 즉시 시작하려면\n"
-"[`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr."
-"html#continue-expressions)를 사용합니다."
+"루프를 조기에 종료하려면 [`break`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#break-expressions)를 사용합니다."
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+msgstr ""
+"다음 반복을 즉시 시작하려면 [`continue`](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#continue-expressions)를 사용합니다."
 
 #: src/SUMMARY.md:34
 msgid "Rustdoc"
@@ -19840,10 +22543,6 @@ msgstr "Rustdoc"
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr "클로저: Fn, FnMut, FnOnce"
 
-#: src/SUMMARY.md:168
-msgid "Useful crates"
-msgstr "유용한 크레이트"
-
 #: src/SUMMARY.md:212
 msgid "no_std"
 msgstr "no_std"
@@ -19851,14 +22550,6 @@ msgstr "no_std"
 #: src/SUMMARY.md:214
 msgid "alloc"
 msgstr "alloc"
-
-#: src/SUMMARY.md:215
-msgid "Microcontrollers"
-msgstr "마이크로컨트롤러"
-
-#: src/SUMMARY.md:216
-msgid "Raw MMIO"
-msgstr "원시 MMIO"
 
 #: src/SUMMARY.md:217
 msgid "PACs"
@@ -19940,10 +22631,6 @@ msgstr "tinyvec"
 msgid "spin"
 msgstr "회전"
 
-#: src/SUMMARY.md:250
-msgid "vmbase"
-msgstr "vmbase"
-
 #: src/SUMMARY.md:252
 msgid "RTC Driver"
 msgstr "RTC 드라이버"
@@ -19960,14 +22647,6 @@ msgstr "async/await"
 msgid "Futures"
 msgstr "Future"
 
-#: src/SUMMARY.md:283
-msgid "Tokio"
-msgstr "Tokio"
-
-#: src/SUMMARY.md:287
-msgid "Join"
-msgstr "Join"
-
 #: src/SUMMARY.md:288
 msgid "Select"
 msgstr "Select"
@@ -19979,10 +22658,6 @@ msgstr "함정"
 #: src/SUMMARY.md:290
 msgid "Blocking the Executor"
 msgstr "Executor 블로킹 하기"
-
-#: src/SUMMARY.md:291
-msgid "Pin"
-msgstr "Pin"
 
 #: src/SUMMARY.md:295
 msgid "Broadcast Chat Application"
@@ -20049,8 +22724,7 @@ msgstr ""
 #: src/basic-syntax/rustdoc.md:3
 msgid ""
 "All language items in Rust can be documented using special `///` syntax."
-msgstr ""
-"Rust의 아이템(item)은 `///` 문법을 사용하여 문서화할 수 있습니다."
+msgstr "Rust의 아이템(item)은 `///` 문법을 사용하여 문서화할 수 있습니다."
 
 #: src/basic-syntax/rustdoc.md:5
 msgid ""
@@ -20082,62 +22756,61 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
-"콘텐츠는 마크다운으로 처리됩니다. 게시된 모든 Rust 라이브러리 크레이트는\n"
+"콘텐츠는 마크다운으로 처리됩니다. 게시된 모든 Rust 라이브러리 크레이트는 "
 "[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) 도구를 사용"
-"하여 [`docs.rs`](https://docs.rs)에\n"
-"자동으로 문서화됩니다. 일반적으로 API의 모든 공개 항목은\n"
-"이 패턴을 사용하여 문서화됩니다."
+"하여 [`docs.rs`](https://docs.rs)에 자동으로 문서화됩니다. 일반적으로 API의 "
+"모든 공개 항목은 이 패턴을 사용하여 문서화됩니다."
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
-"* [`docs.rs/rand`](https://docs.rs/rand)에서 `rand` 크레이트용으로 생성된 문"
-"서를\n"
-"학생에게 보여줍니다.\n"
-"\n"
-"* 이 과정에서는 공간 절약을 위해 슬라이드에 rustdoc을 포함하지 않지만\n"
-"실제 코드에는 존재해야 합니다.\n"
-"\n"
-"* 내부 문서 주석은 모듈 페이지 뒷부분에서 다루며 여기서 다루지\n"
-"않아도 됩니다."
+"[`docs.rs/rand`](https://docs.rs/rand)에서 `rand` 크레이트용으로 생성된 문서"
+"를 학생에게 보여줍니다."
+
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+"이 과정에서는 공간 절약을 위해 슬라이드에 rustdoc을 포함하지 않지만 실제 코드"
+"에는 존재해야 합니다."
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr ""
+"내부 문서 주석은 모듈 페이지 뒷부분에서 다루며 여기서 다루지 않아도 됩니다."
 
 #: src/basic-syntax/methods.md:34
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
+msgstr "`Rectangle::new` 생성자를 추가하고 이를 `main`에서 호출합니다."
+
+#: src/basic-syntax/methods.md:36
 msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
 msgstr ""
-"- `Rectangle::new` 생성자를 추가하고 이를 `main`에서 호출합니다.\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- `Rectangle::new_square(width: u32)` 생성자를 추가하여 생성자가 임의의 매개"
-"변수를 사용할 수 있음을\n"
-"보여줍니다."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
+msgstr ""
+"`Rectangle::new_square(width: u32)` 생성자를 추가하여 생성자가 임의의 매개변"
+"수를 사용할 수 있음을 보여줍니다."


### PR DESCRIPTION
Before, po/ko.po had these statistics:

    1323 translated messages, 231 fuzzy translations, 227 untranslated messages.

Afterwards, the statistics for po/ko.po is:

    1898 translated messages, 259 fuzzy translations, 310 untranslated messages.

The number of translated messages changed from 74% to 77%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.