### PR TITLE
pl: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -12,27 +12,27 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Witamy w Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Prowadzenie kursu"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Struktura kursu"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Skróty klawiszowe"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Tłumaczenia"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Korzystanie z Cargo"
 
@@ -56,55 +56,55 @@ msgstr "Dzień 1: Rano"
 msgid "Welcome"
 msgstr "Witamy"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Co to jest Rust?"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Witaj świecie!"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "Mały przykład"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "Dlaczego Rust?"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "Gwarancje w czasie kompilacji"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "Gwarancje podczas działania"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "Nowoczesne funkcjonalności"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "Podstawowa składnia"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "Typy skalarne"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "Typy złożone"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "Referencje"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "Wiszące referencje"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "Wycinki"
 
@@ -112,11 +112,12 @@ msgstr "Wycinki"
 msgid "String vs str"
 msgstr "String a str"
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "Funkcje"
 
-#: src/SUMMARY.md:34 src/SUMMARY.md:81
+#: src/SUMMARY.md:34 src/SUMMARY.md:81 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "Metody"
 
@@ -124,12 +125,13 @@ msgstr "Metody"
 msgid "Overloading"
 msgstr "Przeciążenie"
 
-#: src/SUMMARY.md:36 src/SUMMARY.md:65 src/SUMMARY.md:89 src/SUMMARY.md:118 src/SUMMARY.md:147
-#: src/SUMMARY.md:175 src/SUMMARY.md:198 src/SUMMARY.md:225
+#: src/SUMMARY.md:36 src/SUMMARY.md:65 src/SUMMARY.md:89 src/SUMMARY.md:118
+#: src/SUMMARY.md:147 src/SUMMARY.md:175 src/SUMMARY.md:198 src/SUMMARY.md:225
+#: src/exercises/day-4/morning.md:1 src/exercises/day-4/afternoon.md:1
 msgid "Exercises"
 msgstr "Ćwiczenia"
 
-#: src/SUMMARY.md:37
+#: src/SUMMARY.md:37 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "Niejawne konwersje"
 
@@ -141,11 +143,11 @@ msgstr "Tablice i pętle for"
 msgid "Day 1: Afternoon"
 msgstr "Dzień 1: Popołudnie"
 
-#: src/SUMMARY.md:42
+#: src/SUMMARY.md:42 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "Zmienne"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "Wnioskowanie typów"
 
@@ -153,11 +155,11 @@ msgstr "Wnioskowanie typów"
 msgid "static & const"
 msgstr "static i const"
 
-#: src/SUMMARY.md:45
+#: src/SUMMARY.md:45 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "Zakresy i przesłanianie"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "Zarządzanie pamięcią"
 
@@ -165,15 +167,15 @@ msgstr "Zarządzanie pamięcią"
 msgid "Stack vs Heap"
 msgstr "Stos a sterta"
 
-#: src/SUMMARY.md:48
+#: src/SUMMARY.md:48 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "Pamięć stosu"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "Ręczne zarządzanie pamięcią"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "Zarządzanie pamięcią w oparciu o zakres"
 
@@ -185,61 +187,62 @@ msgstr "Odśmiecanie pamięci"
 msgid "Rust Memory Management"
 msgstr "Zarządzanie pamięcią w Ruście"
 
-#: src/SUMMARY.md:53
+#: src/SUMMARY.md:53 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "Porównanie"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/ownership.md:1
 msgid "Ownership"
 msgstr "Własność"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "Semantyka przenoszenia"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Przenoszenie String w Ruście"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "Podwójne zwalnianie pamięci w nowoczesnym C++"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "Przenoszenie w wywołaniach funkcji"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "Kopiowanie i klonowanie"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "Pożyczanie"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "Wspólne i unikalne pożyczenia"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "Czas życia"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes-function-calls.md:1
 #, fuzzy
 msgid "Lifetimes in Function Calls"
 msgstr "Czas życia w wywołaniach funkcji"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-data-structures.md:1
 #, fuzzy
 msgid "Lifetimes in Data Structures"
 msgstr "Czasy życia w strukturach danych"
 
-#: src/SUMMARY.md:66
+#: src/SUMMARY.md:66 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr "Projektowanie biblioteki"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "Iteratory a własność"
 
@@ -247,63 +250,64 @@ msgstr "Iteratory a własność"
 msgid "Day 2: Morning"
 msgstr "Dzień 2: Rano"
 
-#: src/SUMMARY.md:75
+#: src/SUMMARY.md:75 src/structs.md:1
 msgid "Structs"
 msgstr "Struktury"
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "Struktury krotkowe"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "Skrócona składnia pola"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/enums.md:1
 msgid "Enums"
 msgstr "Wyliczenia"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "Dane w wariantach"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "Rozmiary wyliczeń"
 
-#: src/SUMMARY.md:82
+#: src/SUMMARY.md:82 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "Składnia metody"
 
 #: src/SUMMARY.md:83 src/SUMMARY.md:158 src/SUMMARY.md:193
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "Przykład"
 
-#: src/SUMMARY.md:84
+#: src/SUMMARY.md:84 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "Dopasowywanie wzorców"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "Destrukturyzacja wyliczeń"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "Destrukturyzacja struktur"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "Destrukturyzacja tablic"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "Strażnicy w dopasowywaniu wzorców"
 
-#: src/SUMMARY.md:90
+#: src/SUMMARY.md:90 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "Statystyki zdrowia"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "Punkty i wielokąty"
 
@@ -311,11 +315,11 @@ msgstr "Punkty i wielokąty"
 msgid "Day 2: Afternoon"
 msgstr "Dzień 2: Popołudnie"
 
-#: src/SUMMARY.md:95
+#: src/SUMMARY.md:95 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "Kontrola przepływu"
 
-#: src/SUMMARY.md:96
+#: src/SUMMARY.md:96 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "Bloki"
 
@@ -351,7 +355,7 @@ msgstr "Wyrażenia match"
 msgid "break & continue"
 msgstr "break i continue"
 
-#: src/SUMMARY.md:105
+#: src/SUMMARY.md:105 src/std.md:1
 msgid "Standard Library"
 msgstr "Biblioteka standardowa"
 
@@ -359,7 +363,7 @@ msgstr "Biblioteka standardowa"
 msgid "Option and Result"
 msgstr "Option i Result"
 
-#: src/SUMMARY.md:107
+#: src/SUMMARY.md:107 src/std/string.md:1
 msgid "String"
 msgstr "String"
 
@@ -379,7 +383,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "Rekurencyjne typy danych"
 
-#: src/SUMMARY.md:112
+#: src/SUMMARY.md:112 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "Niszowa optymalizacja"
 
@@ -387,27 +391,29 @@ msgstr "Niszowa optymalizacja"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:114
+#: src/SUMMARY.md:114 src/modules.md:1
 msgid "Modules"
 msgstr "Moduły"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "Widoczność"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/paths.md:1
 msgid "Paths"
 msgstr "Ścieżki"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "Hierarchia systemu plików"
 
-#: src/SUMMARY.md:119
+#: src/SUMMARY.md:119 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Algorytm Luhna"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:98
 msgid "Strings and Iterators"
 msgstr "Łańcuchy i iteratory"
 
@@ -415,19 +421,19 @@ msgstr "Łańcuchy i iteratory"
 msgid "Day 3: Morning"
 msgstr "Dzień 3: Rano"
 
-#: src/SUMMARY.md:128
+#: src/SUMMARY.md:128 src/traits.md:1
 msgid "Traits"
 msgstr "Cechy"
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "Wyprowadzanie cech"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "Metody domyślne"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "Ważne cechy"
 
@@ -435,7 +441,7 @@ msgstr "Ważne cechy"
 msgid "Iterator"
 msgstr "Iterator"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -459,19 +465,19 @@ msgstr "Drop"
 msgid "Default"
 msgstr "Default"
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/generics.md:1
 msgid "Generics"
 msgstr "Generyki"
 
-#: src/SUMMARY.md:140
+#: src/SUMMARY.md:140 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "Generyczne typy danych"
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "Metody generyczne"
 
-#: src/SUMMARY.md:142
+#: src/SUMMARY.md:142 src/generics/trait-bounds.md:1
 #, fuzzy
 msgid "Trait Bounds"
 msgstr "Granice cech"
@@ -480,20 +486,21 @@ msgstr "Granice cech"
 msgid "impl Trait"
 msgstr "Składnia impl Cecha"
 
-#: src/SUMMARY.md:144
+#: src/SUMMARY.md:144 src/generics/closures.md:1
 msgid "Closures"
 msgstr "Domknięcia"
 
-#: src/SUMMARY.md:145
+#: src/SUMMARY.md:145 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "Monomorfizacja"
 
-#: src/SUMMARY.md:146
+#: src/SUMMARY.md:146 src/generics/trait-objects.md:1
 #, fuzzy
 msgid "Trait Objects"
 msgstr "Obiekty cech"
 
-#: src/SUMMARY.md:148
+#: src/SUMMARY.md:148 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "Prosta biblioteka GUI"
 
@@ -501,11 +508,11 @@ msgstr "Prosta biblioteka GUI"
 msgid "Day 3: Afternoon"
 msgstr "Dzień 3: Popołudnie"
 
-#: src/SUMMARY.md:152
+#: src/SUMMARY.md:152 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "Obsługa błędów"
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Panikowanie"
 
@@ -521,65 +528,66 @@ msgstr "Strukturalna obsługa błędów"
 msgid "Propagating Errors with ?"
 msgstr "Propagowanie błędów za pomocą ?"
 
-#: src/SUMMARY.md:157
+#: src/SUMMARY.md:157 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "Konwersja typów błędów"
 
-#: src/SUMMARY.md:159
+#: src/SUMMARY.md:159 src/error-handling/deriving-error-enums.md:1
 #, fuzzy
 msgid "Deriving Error Enums"
 msgstr "Wyprowadzanie wyliczeń błędów"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "Dynamiczne typy błędów"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "Dodawanie kontekstu do błędów"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/testing.md:1
 msgid "Testing"
 msgstr "Testowanie"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "Testy jednostkowe"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "Moduły testowe"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "Testy dokumentacyjne"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "Testy integracyjne"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Niebezpieczny Rust"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/unsafe/raw-pointers.md:1
 #, fuzzy
 msgid "Dereferencing Raw Pointers"
 msgstr "Dereferencja surowych wskaźników"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "Mutowalne zmienne statyczne"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "Unie"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "Wywoływanie niebezpiecznych funkcji"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "Pisanie niebezpiecznych funkcji"
 
@@ -587,12 +595,13 @@ msgstr "Pisanie niebezpiecznych funkcji"
 msgid "Extern Functions"
 msgstr "Funkcje zewnętrzne"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/unsafe-traits.md:1
 #, fuzzy
 msgid "Implementing Unsafe Traits"
 msgstr "Wdrażanie niebezpiecznych cech"
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "Bezpieczne opakowanie FFI"
 
@@ -604,27 +613,27 @@ msgstr "Dzień 4: Rano"
 msgid "Concurrency"
 msgstr "Współbieżność"
 
-#: src/SUMMARY.md:185
+#: src/SUMMARY.md:185 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "Wątki"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "Wątki z zakresem"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "Kanały"
 
-#: src/SUMMARY.md:188
+#: src/SUMMARY.md:188 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Nieograniczone kanały"
 
-#: src/SUMMARY.md:189
+#: src/SUMMARY.md:189 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Ograniczone kanały"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "Współdzielony stan"
 
@@ -648,15 +657,16 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:197
+#: src/SUMMARY.md:197 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "Przykłady"
 
-#: src/SUMMARY.md:199
+#: src/SUMMARY.md:199 src/exercises/day-4/dining-philosophers.md:1
+#: src/exercises/day-4/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "Ucztujący filozofowie"
 
-#: src/SUMMARY.md:200
+#: src/SUMMARY.md:200 src/exercises/day-4/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "Wielowątkowe narzędzie do sprawdzania linków"
 
@@ -664,15 +674,15 @@ msgstr "Wielowątkowe narzędzie do sprawdzania linków"
 msgid "Day 4: Afternoon"
 msgstr "Dzień 4: Popołudnie"
 
-#: src/SUMMARY.md:206
+#: src/SUMMARY.md:206 src/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:207
+#: src/SUMMARY.md:207 src/android/setup.md:1
 msgid "Setup"
 msgstr "Przygotowanie"
 
-#: src/SUMMARY.md:208
+#: src/SUMMARY.md:208 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "Reguły budowania"
 
@@ -684,7 +694,7 @@ msgstr "Pliki binarne"
 msgid "Library"
 msgstr "Biblioteka"
 
-#: src/SUMMARY.md:211
+#: src/SUMMARY.md:211 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -700,7 +710,7 @@ msgstr "Implementacja"
 msgid "Server"
 msgstr "Serwer"
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "Wdrażanie"
 
@@ -708,15 +718,15 @@ msgstr "Wdrażanie"
 msgid "Client"
 msgstr "Klient"
 
-#: src/SUMMARY.md:217
+#: src/SUMMARY.md:217 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "Zmiana API"
 
-#: src/SUMMARY.md:218
+#: src/SUMMARY.md:218 src/android/logging.md:1
 msgid "Logging"
 msgstr "Logowanie"
 
-#: src/SUMMARY.md:219
+#: src/SUMMARY.md:219 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "Interoperacyjność"
 
@@ -732,7 +742,7 @@ msgstr "Wywołanie C z Bindgenem"
 msgid "Calling Rust from C"
 msgstr "Wywołanie Rusta z C"
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "Z językiem C++"
 
@@ -744,7 +754,7 @@ msgstr "Z Javą"
 msgid "Final Words"
 msgstr "Ostatnie słowa"
 
-#: src/SUMMARY.md:229
+#: src/SUMMARY.md:229 src/thanks.md:1
 msgid "Thanks!"
 msgstr "Dzięki!"
 
@@ -752,11 +762,11 @@ msgstr "Dzięki!"
 msgid "Other Resources"
 msgstr "Inne zasoby"
 
-#: src/SUMMARY.md:231
+#: src/SUMMARY.md:231 src/credits.md:1
 msgid "Credits"
 msgstr "Uznania"
 
-#: src/SUMMARY.md:235
+#: src/SUMMARY.md:235 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "Rozwiązania"
 
@@ -788,237 +798,144 @@ msgstr "Dzień 3 Popołudnie"
 msgid "Day 4 Morning"
 msgstr "Dzień 4 Rano"
 
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Witamy w Comprehensive Rust 🦀"
-
 #: src/welcome.md:3
 msgid ""
 "This is a four day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 "To jest czterodniowy kurs Rust opracowany przez zespół Androida. Kurs "
-"obejmuje\n"
-"pełne spektrum Rusta, od podstawowej składni po zaawansowane tematy, takie "
-"jak programowanie uogólnione\n"
-"i obsługę błędów. Ostatni dzień obejmuje również treści specyficzne dla "
-"Androida."
+"obejmuje pełne spektrum Rusta, od podstawowej składni po zaawansowane "
+"tematy, takie jak programowanie uogólnione i obsługę błędów. Ostatni dzień "
+"obejmuje również treści specyficzne dla Androida."
 
 #: src/welcome.md:7
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
-"Celem kursu jest nauczenie Cię języka Rust. Zakładamy, że nic nie wiesz\n"
-"o Ruście i mamy nadzieję, że:"
+"Celem kursu jest nauczenie Cię języka Rust. Zakładamy, że nic nie wiesz o "
+"Ruście i mamy nadzieję, że:"
 
 #: src/welcome.md:10
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
+msgstr "Damy Ci kompleksowe zrozumienie składni i języka Rust."
+
+#: src/welcome.md:11
+msgid "Enable you to modify existing programs and write new programs in Rust."
 msgstr ""
-"* Damy Ci kompleksowe zrozumienie składni i języka Rust.\n"
-"* Umożliwimy modyfikowanie istniejących programów i pisanie nowych programów "
-"w Ruście.\n"
-"* Pokażemy powszechne idiomy Rusta."
+"Umożliwimy modyfikowanie istniejących programów i pisanie nowych programów w "
+"Ruście."
+
+#: src/welcome.md:12
+msgid "Show you common Rust idioms."
+msgstr "Pokażemy powszechne idiomy Rusta."
 
 #: src/welcome.md:14
 msgid "On Day 4, we will cover Android-specific things such as:"
 msgstr "W dniu 4 omówimy kwestie specyficzne dla Androida, takie jak:"
 
 #: src/welcome.md:16
-msgid ""
-"* Building Android components in Rust.\n"
-"* AIDL servers and clients.\n"
-"* Interoperability with C, C++, and Java."
-msgstr ""
-"* Budowanie komponentów Androida w Ruście.\n"
-"* Serwery i klienty AIDL.\n"
-"* Interoperacyjność z C, C++ i Javą."
+msgid "Building Android components in Rust."
+msgstr "Budowanie komponentów Androida w Ruście."
+
+#: src/welcome.md:17
+msgid "AIDL servers and clients."
+msgstr "Serwery i klienty AIDL."
+
+#: src/welcome.md:18
+msgid "Interoperability with C, C++, and Java."
+msgstr "Interoperacyjność z C, C++ i Javą."
 
 #: src/welcome.md:20
 msgid ""
 "It is important to note that this course does not cover Android "
-"**application** \n"
-"development in Rust, and that the Android-specific parts are specifically "
-"about\n"
-"writing code for Android itself, the operating system. "
+"**application**  development in Rust, and that the Android-specific parts "
+"are specifically about writing code for Android itself, the operating "
+"system. "
 msgstr ""
-"Należy zauważyć, że ten kurs nie obejmuje rozwoju **aplikacji** na Androida\n"
-"w Ruście i że części specyficzne dla Androida są o pisaniu kodu\n"
-"dla samego Androida, systemu operacyjnego. "
+"Należy zauważyć, że ten kurs nie obejmuje rozwoju **aplikacji** na Androida "
+"w Ruście i że części specyficzne dla Androida są o pisaniu kodu dla samego "
+"Androida, systemu operacyjnego. "
 
 #: src/welcome.md:24
-msgid "## Non-Goals"
-msgstr "## Poza zakresem"
+msgid "Non-Goals"
+msgstr "Poza zakresem"
 
 #: src/welcome.md:26
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 "Rust to duży język i nie będziemy w stanie omówić go w całości w ciągu kilku "
-"dni.\n"
-"Niektóre cele będące poza zakresem tego kursu to:"
+"dni. Niektóre cele będące poza zakresem tego kursu to:"
 
 #: src/welcome.md:29
 msgid ""
-"* Learn how to use async Rust --- we'll only mention async Rust when\n"
-"  covering traditional concurrency primitives. Please see [Asynchronous\n"
-"  Programming in Rust](https://rust-lang.github.io/async-book/) instead for\n"
-"  details on this topic.\n"
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to use async Rust --- we'll only mention async Rust when covering "
+"traditional concurrency primitives. Please see [Asynchronous Programming in "
+"Rust](https://rust-lang.github.io/async-book/) instead for details on this "
+"topic."
 msgstr ""
-"* Używanie asynchronicznego Rusta --- wspomnimy o asynchronicznym Ruście "
-"tylko wtedy, gdy\n"
-"  obejmujące tradycyjne prymitywy współbieżności. Po więcej szczegółów w tym "
-"temacie zobacz [Asynchronous\n"
-"  Programming in Rust](https://rust-lang.github.io/async-book/).\n"
-"* Tworzenie makr, zamiast tego zobacz [Rozdział 19.5 w Język Programowanie "
-"Rust](http://rust.w8.pl/book/ch19-06-macros.html) i [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
+"Używanie asynchronicznego Rusta --- wspomnimy o asynchronicznym Ruście tylko "
+"wtedy, gdy obejmujące tradycyjne prymitywy współbieżności. Po więcej "
+"szczegółów w tym temacie zobacz [Asynchronous Programming in Rust](https://"
+"rust-lang.github.io/async-book/)."
+
+#: src/welcome.md:33
+msgid ""
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+msgstr ""
+"Tworzenie makr, zamiast tego zobacz [Rozdział 19.5 w Język Programowanie "
+"Rust](http://rust.w8.pl/book/ch19-06-macros.html) i [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html)."
 
 #: src/welcome.md:37
-msgid "## Assumptions"
-msgstr "## Założenia"
+msgid "Assumptions"
+msgstr "Założenia"
 
 #: src/welcome.md:39
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
-"Kurs zakłada, że wiesz już, jak programować. Rust to statycznie\n"
-"typowany język i aby było lepiej wyjaśnić lub przeciwstawić podejście Rusta\n"
-"czasami będziemy dokonywać porównań z C i C++."
+"Kurs zakłada, że wiesz już, jak programować. Rust to statycznie typowany "
+"język i aby było lepiej wyjaśnić lub przeciwstawić podejście Rusta czasami "
+"będziemy dokonywać porównań z C i C++."
 
 #: src/welcome.md:43
 msgid ""
-"If you know how to program in a dynamically typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 "Jeśli wiesz, jak programować w języku o dynamicznym typowaniu, takim jak "
-"Python lub\n"
-"JavaScript, to też dasz sobie radę."
-
-#: src/welcome.md:46 src/cargo/rust-ecosystem.md:19 src/cargo/code-samples.md:22
-#: src/cargo/running-locally.md:68 src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8 src/why-rust/modern.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/slices.md:18
-#: src/basic-syntax/string-slices.md:25 src/basic-syntax/functions.md:33
-#: src/basic-syntax/functions-interlude.md:25 src/exercises/day-1/morning.md:9
-#: src/exercises/day-1/for-loops.md:90 src/basic-syntax/variables.md:15
-#: src/basic-syntax/type-inference.md:24 src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27 src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums/variant-payloads.md:33 src/methods.md:28
-#: src/pattern-matching/destructuring-enums.md:33 src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:29 src/control-flow/if-let-expressions.md:19
-#: src/control-flow/while-let-expressions.md:25 src/control-flow/match-expressions.md:25
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35 src/std/hashmap.md:36
-#: src/std/box.md:32 src/std/box-recursive.md:31 src/std/rc.md:29 src/modules.md:26
-#: src/modules/visibility.md:37 src/modules/filesystem.md:24 src/exercises/day-2/afternoon.md:5
-#: src/traits.md:39 src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/operators.md:24 src/traits/drop.md:32 src/traits/default.md:38
-#: src/generics/methods.md:23 src/generics/trait-bounds.md:33 src/generics/impl-trait.md:22
-#: src/generics/closures.md:23 src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:48 src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37 src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26 src/unsafe/raw-pointers.md:24
-#: src/unsafe/mutable-static-variables.md:30 src/unsafe/unions.md:19
-#: src/unsafe/writing-unsafe-functions.md:31 src/unsafe/extern-functions.md:19
-#: src/unsafe/unsafe-traits.md:28 src/exercises/day-3/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/channels.md:25 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/example.md:21 src/concurrency/send-sync.md:18
-#: src/concurrency/send-sync/sync.md:12 src/exercises/day-4/morning.md:10
-#: src/android/interoperability/with-c/rust.md:81 src/exercises/day-4/afternoon.md:10
-msgid "<details>"
-msgstr "<details>"
+"Python lub JavaScript, to też dasz sobie radę."
 
 #: src/welcome.md:48
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 "To jest przykład _notatki dla prowadzącego_. Użyjemy ich, aby dodać "
-"dodatkowe\n"
-"informacje do slajdów. Mogą to być kluczowe punkty, które prowadzący "
-"powinien\n"
-"omówić, a także odpowiedzi na typowe pytania, które pojawiają się na "
-"zajęciach."
-
-#: src/welcome.md:52 src/cargo/rust-ecosystem.md:67 src/cargo/code-samples.md:35
-#: src/cargo/running-locally.md:74 src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:36 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22 src/why-rust/modern.md:66
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:28
-#: src/basic-syntax/slices.md:36 src/basic-syntax/functions.md:54 src/exercises/day-1/morning.md:28
-#: src/exercises/day-1/for-loops.md:95 src/basic-syntax/variables.md:20
-#: src/basic-syntax/type-inference.md:48 src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/borrowing.md:51
-#: src/ownership/shared-unique-borrows.md:29 src/ownership/lifetimes-function-calls.md:60
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:103 src/structs.md:41
-#: src/structs/field-shorthand.md:41 src/enums/sizes.md:136 src/methods/example.md:53
-#: src/pattern-matching/destructuring-enums.md:39 src/pattern-matching/destructuring-arrays.md:46
-#: src/exercises/day-2/morning.md:15 src/exercises/day-2/points-polygons.md:125
-#: src/control-flow/if-let-expressions.md:26 src/control-flow/for-expressions.md:29
-#: src/control-flow/loop-expressions.md:27 src/std.md:31 src/std/option-result.md:25
-#: src/std/string.md:40 src/std/vec.md:49 src/std/hashmap.md:66 src/std/rc.md:66 src/modules.md:32
-#: src/modules/visibility.md:48 src/modules/filesystem.md:53 src/exercises/day-2/afternoon.md:11
-#: src/traits.md:54 src/traits/from-iterator.md:26 src/traits/operators.md:38 src/traits/drop.md:42
-#: src/traits/default.md:47 src/generics/methods.md:31 src/generics/closures.md:38
-#: src/exercises/day-3/morning.md:11 src/error-handling/try-operator.md:55
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45 src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32 src/unsafe/raw-pointers.md:42
-#: src/unsafe/mutable-static-variables.md:35 src/unsafe/unions.md:28
-#: src/unsafe/writing-unsafe-functions.md:38 src/unsafe/extern-functions.md:28
-#: src/unsafe/unsafe-traits.md:37 src/exercises/day-3/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/channels.md:32 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/example.md:60 src/concurrency/send-sync/sync.md:18
-#: src/exercises/day-4/morning.md:16 src/android/interoperability/with-c/rust.md:86
-#: src/exercises/day-4/afternoon.md:15
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# Prowadzenie kursu"
+"dodatkowe informacje do slajdów. Mogą to być kluczowe punkty, które "
+"prowadzący powinien omówić, a także odpowiedzi na typowe pytania, które "
+"pojawiają się na zajęciach."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> Ta strona jest dla prowadzącego kurs."
+msgid "This page is for the course instructor."
+msgstr "Ta strona jest dla prowadzącego kurs."
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
+"course internally at Google."
 msgstr ""
-"Oto trochę podstawowych informacji o tym, jak prowadziliśmy ten kurs\n"
+"Oto trochę podstawowych informacji o tym, jak prowadziliśmy ten kurs "
 "wewnętrznie w Google."
 
 #: src/running-the-course.md:8
@@ -1027,242 +944,229 @@ msgstr "Aby prowadzić kurs należy:"
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   on some of the pages to help highlight the key points (please help us by\n"
-"   contributing more speaker notes!). You should make sure to open the "
-"speaker\n"
-"   notes in a popup (click the link with a little arrow next to \"Speaker\n"
-"   Notes\"). This way you have a clean screen to present to the class."
+"Make yourself familiar with the course material. We've included speaker "
+"notes on some of the pages to help highlight the key points (please help us "
+"by contributing more speaker notes!). You should make sure to open the "
+"speaker notes in a popup (click the link with a little arrow next to "
+"\"Speaker Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. Zapoznaj się z materiałem kursu. Dołączyliśmy notatki prowadzącego\n"
-"   na niektórych stronach, aby podkreślić kluczowe punkty (pomóż nam "
-"dodając\n"
-"   więcej notatek dla prowadzącego!). Powinieneś upewnić się, że notatki są "
-"otwarte\n"
-"   w wyskakującym okienku (kliknij łącze z małą strzałką obok „Notatki\n"
-"   Prowadzącego\"). W ten sposób masz czysty ekran do zaprezentowania klasie."
+"Zapoznaj się z materiałem kursu. Dołączyliśmy notatki prowadzącego na "
+"niektórych stronach, aby podkreślić kluczowe punkty (pomóż nam dodając "
+"więcej notatek dla prowadzącego!). Powinieneś upewnić się, że notatki są "
+"otwarte w wyskakującym okienku (kliknij łącze z małą strzałką obok „Notatki "
+"Prowadzącego\"). W ten sposób masz czysty ekran do zaprezentowania klasie."
 
 #: src/running-the-course.md:16
 msgid ""
-"2. Decide on the dates. Since the course is large, we recommend that you\n"
-"   schedule the four days over two weeks. Course participants have said "
-"that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them."
+"Decide on the dates. Since the course is large, we recommend that you "
+"schedule the four days over two weeks. Course participants have said that "
+"they find it helpful to have a gap in the course since it helps them process "
+"all the information we give them."
 msgstr ""
-"2. Zdecyduj o datach. Ponieważ kurs jest duży, zalecamy\n"
-"   zaplanowanie czterech dni w przeciągu dwóch tygodni. Uczestnicy kursu\n"
-"   uważają, że luka w kursie jest pomocna, ponieważ pomaga im przetworzyć\n"
-"   wszystkie informacje, które im przekazujemy."
+"Zdecyduj o datach. Ponieważ kurs jest duży, zalecamy zaplanowanie czterech "
+"dni w przeciągu dwóch tygodni. Uczestnicy kursu uważają, że luka w kursie "
+"jest pomocna, ponieważ pomaga im przetworzyć wszystkie informacje, które im "
+"przekazujemy."
 
 #: src/running-the-course.md:21
 msgid ""
-"3. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-20 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions."
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-20 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions."
 msgstr ""
-"3. Znajdź pokój wystarczająco duży dla uczestników. Polecamy\n"
-"   grupy w wielkości 15-20 osób. To na tyle mało, że ludzie czują się "
-"komfortowo\n"
-"   w zadawaniu pytań --- jest również na tyle mało, że jeden prowadzący "
-"będzie miał\n"
-"   czas na odpowiedzenie na pytania."
+"Znajdź pokój wystarczająco duży dla uczestników. Polecamy grupy w wielkości "
+"15-20 osób. To na tyle mało, że ludzie czują się komfortowo w zadawaniu "
+"pytań --- jest również na tyle mało, że jeden prowadzący będzie miał czas na "
+"odpowiedzenie na pytania."
 
 #: src/running-the-course.md:26
 msgid ""
-"4. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][5]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them."
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
 msgstr ""
-"4. W dniu kursu przyjdź na salę nieco wcześniej, aby wszystko ustawić.\n"
-"   Zalecamy prezentację bezpośrednio przy użyciu `mdbook serve` "
-"uruchomionego na twoim\n"
-"   laptopie (zobacz [instrukcja instalacji][5]). Zapewnia to optymalną "
-"wydajność bez opóźnień podczas zmiany stron.\n"
-"   Korzystanie z laptopa pozwoli Ci również poprawiać literówki jak ty lub "
-"uczestnicy kursu\n"
-"   je dostrzegą."
+"W dniu kursu przyjdź na salę nieco wcześniej, aby wszystko ustawić. Zalecamy "
+"prezentację bezpośrednio przy użyciu `mdbook serve` uruchomionego na twoim "
+"laptopie (zobacz [instrukcja instalacji](https://github.com/google/"
+"comprehensive-rust#building)). Zapewnia to optymalną wydajność bez opóźnień "
+"podczas zmiany stron. Korzystanie z laptopa pozwoli Ci również poprawiać "
+"literówki jak ty lub uczestnicy kursu je dostrzegą."
 
 #: src/running-the-course.md:32
 msgid ""
-"5. Let people solve the exercises by themselves or in small groups. Make "
-"sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Let people solve the exercises by themselves or in small groups. Make sure "
+"to ask people if they're stuck or if there is anything you can help with. "
+"When you see that several people have the same problem, call it out to the "
+"class and offer a solution, e.g., by showing people where to find the "
+"relevant information in the standard library."
 msgstr ""
-"5. Pozwól uczestnikom rozwiązywać ćwiczenia samodzielnie lub w małych "
-"grupach. Upewnij się,\n"
-"   że pytasz uczestników, czy utknęli lub czy jest coś, w czym możesz pomóc. "
-"Gdy\n"
-"   widzisz, że kilka osób ma ten sam problem, powiedz o tym klasie\n"
-"   i zaoferuj rozwiązanie, np. pokazując gdzie znaleźć odpowiednie\n"
-"   informacje w bibliotece standardowej."
+"Pozwól uczestnikom rozwiązywać ćwiczenia samodzielnie lub w małych grupach. "
+"Upewnij się, że pytasz uczestników, czy utknęli lub czy jest coś, w czym "
+"możesz pomóc. Gdy widzisz, że kilka osób ma ten sam problem, powiedz o tym "
+"klasie i zaoferuj rozwiązanie, np. pokazując gdzie znaleźć odpowiednie "
+"informacje w bibliotece standardowej."
 
 #: src/running-the-course.md:38
 msgid ""
-"6. If you don't skip the Android specific parts on Day 4, you will need an "
-"[AOSP\n"
-"   checkout][1]. Make a checkout of the [course repository][2] on the same\n"
-"   machine and move the `src/android/` directory into the root of your AOSP\n"
-"   checkout. This will ensure that the Android build system sees the\n"
-"   `Android.bp` files in `src/android/`."
+"If you don't skip the Android specific parts on Day 4, you will need an "
+"[AOSP checkout](https://source.android.com/docs/setup/download/downloading). "
+"Make a checkout of the [course repository](https://github.com/google/"
+"comprehensive-rust) on the same machine and move the `src/android/` "
+"directory into the root of your AOSP checkout. This will ensure that the "
+"Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"6. Jeśli nie pomijasz części związanych z Androidem w dniu 4, będziesz "
-"potrzebować [AOSP][1].\n"
-"   Ściągnij [repozytorium kursu][2] na tym samym komputerze\n"
-"   i przenieś katalog `src/android/` do katalogu głównego AOSP.\n"
-"   Zapewni to, że system kompilacji Androida zobaczy pliki\n"
-"   `Android.bp` w `src/android/`."
+"Jeśli nie pomijasz części związanych z Androidem w dniu 4, będziesz "
+"potrzebować [AOSP](https://source.android.com/docs/setup/download/"
+"downloading). Ściągnij [repozytorium kursu](https://github.com/google/"
+"comprehensive-rust) na tym samym komputerze i przenieś katalog `src/android/"
+"` do katalogu głównego AOSP. Zapewni to, że system kompilacji Androida "
+"zobaczy pliki `Android.bp` w `src/android/`."
 
 #: src/running-the-course.md:44
 msgid ""
-"   Ensure that `adb sync` works with your emulator or real device and "
-"pre-build\n"
-"   all Android examples using `src/android/build_all.sh`. Read the script to "
-"see\n"
-"   the commands it runs and make sure they work when you run them by hand."
+"Ensure that `adb sync` works with your emulator or real device and pre-build "
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"   Upewnij się, że `adb sync` działa z twoim emulatorem lub prawdziwym "
-"urządzeniem i prekompiluj\n"
-"   wszystkie przykłady Androida używając `src/android/build_all.sh`. "
-"Przeczytaj skrypt, żeby zobaczyć\n"
-"   polecenia, które uruchamia, i upewnij się, że działają, gdy uruchamiasz "
-"je ręcznie."
+"Upewnij się, że `adb sync` działa z twoim emulatorem lub prawdziwym "
+"urządzeniem i prekompiluj wszystkie przykłady Androida używając `src/android/"
+"build_all.sh`. Przeczytaj skrypt, żeby zobaczyć polecenia, które uruchamia, "
+"i upewnij się, że działają, gdy uruchamiasz je ręcznie."
 
 #: src/running-the-course.md:48
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
+"for you as it has been for us!"
 msgstr ""
 "To wszystko, powodzenia w prowadzeniu kursu! Mamy nadzieję, że będzie to dla "
-"Ciebie równie zabawne\n"
-"jak dla nas!"
+"Ciebie równie zabawne jak dla nas!"
 
 #: src/running-the-course.md:51
 msgid ""
-"Please [provide feedback][3] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][4]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"Prosimy o późniejsze [przekazanie opinii][3], abyśmy mogli dalej ulepszać\n"
-"kurs. Chętnie dowiemy się, co sprawdziło się u Ciebie, a co można ulepszyć.\n"
-"Uczestników również zachęcamy do [przesłania nam swoich opinii][4]!"
-
-#: src/running-the-course.md:55
-msgid ""
-"[1]: https://source.android.com/docs/setup/download/downloading\n"
-"[2]: https://github.com/google/comprehensive-rust\n"
-"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
-"[4]: https://github.com/google/comprehensive-rust/discussions/100\n"
-"[5]: https://github.com/google/comprehensive-rust#building"
-msgstr ""
-"[1]: https://source.android.com/docs/setup/download/downloading\n"
-"[2]: https://github.com/google/comprehensive-rust\n"
-"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
-"[4]: https://github.com/google/comprehensive-rust/discussions/100\n"
-"[5]: https://github.com/google/comprehensive-rust#building"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# Struktura kursu"
+"Prosimy o późniejsze [przekazanie opinii](https://github.com/google/"
+"comprehensive-rust/discussions/86), abyśmy mogli dalej ulepszać kurs. "
+"Chętnie dowiemy się, co sprawdziło się u Ciebie, a co można ulepszyć. "
+"Uczestników również zachęcamy do [przesłania nam swoich opinii](https://"
+"github.com/google/comprehensive-rust/discussions/100)!"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "Kurs jest prowadzony w szybkim tempie i obejmuje dużo materiału:"
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust.\n"
-"* Day 4: Concurrency in Rust and interoperability with other languages"
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "Dzień 1: Podstawowy Rust, własność i nadzorca pożyczania."
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
 msgstr ""
-"* Dzień 1: Podstawowy Rust, własność i nadzorca pożyczania.\n"
-"* Dzień 2: Typy danych złożonych, dopasowywanie wzorców, biblioteka "
-"standardowa.\n"
-"* Dzień 3: Cechy i uogólnienia, obsługa błędów, testowanie, niebezpieczny "
-"Rust.\n"
-"* Dzień 4: Współbieżność w Ruście i interoperacyjność z innymi językami"
+"Dzień 2: Typy danych złożonych, dopasowywanie wzorców, biblioteka "
+"standardowa."
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr ""
+"Dzień 3: Cechy i uogólnienia, obsługa błędów, testowanie, niebezpieczny Rust."
+
+#: src/running-the-course/course-structure.md:10
+msgid "Day 4: Concurrency in Rust and interoperability with other languages"
+msgstr "Dzień 4: Współbieżność w Ruście i interoperacyjność z innymi językami"
 
 #: src/running-the-course/course-structure.md:12
 msgid ""
-"> **Exercise for Day 4:** Do you interface with some C/C++ code in your "
-"project\n"
-"> which we could attempt to move to Rust? The fewer dependencies the "
-"better.\n"
-"> Parsing code would be ideal."
+"**Exercise for Day 4:** Do you interface with some C/C++ code in your "
+"project which we could attempt to move to Rust? The fewer dependencies the "
+"better. Parsing code would be ideal."
 msgstr ""
-"> **Ćwiczenie na dzień 4:** Czy korzystasz z kodu C/C++ w swoim projekcie,\n"
-"> który moglibyśmy spróbować przenieść do Rusta? Im mniej zależności, tym "
-"lepiej.\n"
-"> Kod parsujący byłby idealny."
+"**Ćwiczenie na dzień 4:** Czy korzystasz z kodu C/C++ w swoim projekcie, "
+"który moglibyśmy spróbować przenieść do Rusta? Im mniej zależności, tym "
+"lepiej. Kod parsujący byłby idealny."
 
 #: src/running-the-course/course-structure.md:16
-msgid "## Format"
-msgstr "## Format"
+msgid "Format"
+msgstr "Format"
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
-"Kurs ma być bardzo interaktywny i zalecamy pozwalanie\n"
-"żeby pytania napędzały eksplorację Rusta!"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# Skróty klawiszowe"
+"Kurs ma być bardzo interaktywny i zalecamy pozwalanie żeby pytania napędzały "
+"eksplorację Rusta!"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Istnieje kilka przydatnych skrótów klawiaturowych w mdBook:"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Strzałka w lewo</kbd>: Przejdź do poprzedniej strony.\n"
-"* <kbd>Strzałka w prawo</kbd>: Przejdź do następnej strony.\n"
-"* <kbd>Ctrl + Enter</kbd>: Wykonaj przykładowy kod, który ma fokus.\n"
-"* <kbd>s</kbd>: Aktywuj pasek wyszukiwania."
+msgid "Arrow-Left"
+msgstr "Strzałka w lewo"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# Tłumaczenia"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr ": Przejdź do poprzedniej strony."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Strzałka w prawo"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr ": Przejdź do następnej strony."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr ": Wykonaj przykładowy kod, który ma fokus."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr ": Aktywuj pasek wyszukiwania."
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
 msgstr ""
-"Kurs został przetłumaczony na inne języki przez zespół cudownych\n"
+"Kurs został przetłumaczony na inne języki przez zespół cudownych "
 "wolontariuszy:"
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
 msgstr ""
-"* [brazylijski portugalski][pt-BR] autorstwa [@rastringer] i [@hugojacob].\n"
-"* [koreański][ko] autorstwa [@keispace], [@jiyongp] i [@jooyunghan]."
+"[brazylijski portugalski](https://google.github.io/comprehensive-rust/pt-"
+"BR/) autorstwa [@rastringer](https://github.com/rastringer) i [@hugojacob]"
+"(https://github.com/hugojacob)."
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
+msgstr ""
+"[koreański](https://google.github.io/comprehensive-rust/ko/) autorstwa "
+"[@keispace](https://github.com/keispace), [@jiyongp](https://github.com/"
+"jiyongp) i [@jooyunghan](https://github.com/jooyunghan)."
 
 #: src/running-the-course/translations.md:9
 msgid ""
@@ -1273,77 +1177,48 @@ msgstr ""
 
 #: src/running-the-course/translations.md:11
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"Jeśli chcesz w tym pomóc, zapoznaj się z [naszymi instrukcjami] aby "
-"dowiedzieć się, jak to zacząć.\n"
-"Tłumaczenia są koordynowane w [narzędziu do śledzenia problemów]."
-
-#: src/running-the-course/translations.md:14
-msgid ""
-"[pt-BR]: https://google.github.io/comprehensive-rust/pt-BR/\n"
-"[ko]: https://google.github.io/comprehensive-rust/ko/\n"
-"[@rastringer]: https://github.com/rastringer\n"
-"[@hugojacob]: https://github.com/hugojacob\n"
-"[@keispace]: https://github.com/keispace\n"
-"[@jiyongp]: https://github.com/jiyongp\n"
-"[@jooyunghan]: https://github.com/jooyunghan\n"
-"[our instructions]: "
-"https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md\n"
-"[issue tracker]: https://github.com/google/comprehensive-rust/issues/282"
-msgstr ""
-"[pt-BR]: https://google.github.io/comprehensive-rust/pt-BR/\n"
-"[ko]: https://google.github.io/comprehensive-rust/ko/\n"
-"[@rastringer]: https://github.com/rastringer\n"
-"[@hugojacob]: https://github.com/hugojacob\n"
-"[@keispace]: https://github.com/keispace\n"
-"[@jiyongp]: https://github.com/jiyongp\n"
-"[@jooyunghan]: https://github.com/jooyunghan\n"
-"[naszymi instrukcjami]: "
-"https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md\n"
-"[narzędziu do śledzenia problemów]: "
-"https://github.com/google/comprehensive-rust/issues/282"
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# Korzystanie z Cargo"
+"Jeśli chcesz w tym pomóc, zapoznaj się z [naszymi instrukcjami](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) aby "
+"dowiedzieć się, jak to zacząć. Tłumaczenia są koordynowane w [narzędziu do "
+"śledzenia problemów](https://github.com/google/comprehensive-rust/"
+"issues/282)."
 
 #: src/cargo.md:3
 msgid ""
-"When you start reading about Rust, you will soon meet "
-"[Cargo](https://doc.rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"When you start reading about Rust, you will soon meet [Cargo](https://doc."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
-"Kiedy zaczniesz czytać o Ruście, wkrótce poznasz "
-"[Cargo](https://doc.rust-lang.org/cargo/), jest to standardowe narzędzie\n"
-"używany w ekosystemie Rusta do tworzenia i uruchamiania aplikacji Rusta. "
-"Tutaj chcemy\n"
-"krótko opisać, czym jest Cargo i jak pasuje do szerszego ekosystemu\n"
-"i do tego szkolenia."
+"Kiedy zaczniesz czytać o Ruście, wkrótce poznasz [Cargo](https://doc.rust-"
+"lang.org/cargo/), jest to standardowe narzędzie używany w ekosystemie Rusta "
+"do tworzenia i uruchamiania aplikacji Rusta. Tutaj chcemy krótko opisać, "
+"czym jest Cargo i jak pasuje do szerszego ekosystemu i do tego szkolenia."
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## Instalacja"
+msgid "Installation"
+msgstr "Instalacja"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (zalecane)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (zalecane)"
 
 #: src/cargo.md:12
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rustup.rs/) tool, "
+"which is maintained by the Rust Foundation."
 msgstr ""
-"Możesz postępować zgodnie z instrukcjami narzędzia [rustup][3], aby "
-"zainstalować Cargo, kompilator Rusta oraz inne standardowe narzędzia "
-"ekosystemu Rusta. Narzędzie [rustup][3] jest utrzymywane przez Fundację Rust."
+"Możesz postępować zgodnie z instrukcjami narzędzia [rustup](https://rustup."
+"rs/), aby zainstalować Cargo, kompilator Rusta oraz inne standardowe "
+"narzędzia ekosystemu Rusta. Narzędzie [rustup](https://rustup.rs/) jest "
+"utrzymywane przez Fundację Rust."
 
 #: src/cargo.md:14
 msgid ""
@@ -1356,20 +1231,20 @@ msgstr ""
 "konfiguracji skrośnej kompilacji itp."
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### Menedżerowie pakietów"
+msgid "Package Managers"
+msgstr "Menedżerowie pakietów"
 
 #: src/cargo.md:18
-msgid "#### Debian"
-msgstr "#### Debian"
+msgid "Debian"
+msgstr "Debian"
 
 #: src/cargo.md:20
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
 "Na Debianie/Ubuntu możesz zainstalować Cargo, źródło Rusta i [narzędzie do "
-"formatowania Rusta][6] za pomocą"
+"formatowania Rusta](https://github.com/rust-lang/rustfmt) za pomocą"
 
 #: src/cargo.md:22
 msgid ""
@@ -1383,45 +1258,32 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow [rust-analyzer](https://rust-analyzer.github.io/) to jump to "
+"the definitions. We suggest using [VS Code](https://code.visualstudio.com/) "
+"to edit the code (but any LSP compatible editor works)."
 msgstr ""
-"Umożliwi to narzędziu [rust-analyzer][1] przechodzenie do definicji. "
-"Sugerujemy użycie\n"
-"[VS Code][2], aby edytować kod (ale działa każdy edytor kompatybilny z LSP)."
+"Umożliwi to narzędziu [rust-analyzer](https://rust-analyzer.github.io/) "
+"przechodzenie do definicji. Sugerujemy użycie [VS Code](https://code."
+"visualstudio.com/), aby edytować kod (ale działa każdy edytor kompatybilny z "
+"LSP)."
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"Niektórzy ludzie lubią również korzystać z rodziny IDE [JetBrains][4], które "
-"wykonują własne analizy, ale mają własne kompromisy. Jeśli wolisz je, możesz "
-"zainstalować [wtyczkę Rusta][5]. Należy pamiętać, że od stycznia 2023 r. "
-"debugowanie działa tylko w wersji CLion pakietu JetBrains IDEA."
-
-#: src/cargo.md:31
-msgid ""
-"[1]: https://rust-analyzer.github.io/\n"
-"[2]: https://code.visualstudio.com/\n"
-"[3]: https://rustup.rs/\n"
-"[4]: https://www.jetbrains.com/clion/\n"
-"[5]: https://www.jetbrains.com/rust/\n"
-"[6]: https://github.com/rust-lang/rustfmt"
-msgstr ""
-"[1]: https://rust-analyzer.github.io/\n"
-"[2]: https://code.visualstudio.com/\n"
-"[3]: https://rustup.rs/\n"
-"[4]: https://www.jetbrains.com/clion/\n"
-"[5]: https://www.jetbrains.com/rust/\n"
-"[6]: https://github.com/rust-lang/rustfmt"
+"Niektórzy ludzie lubią również korzystać z rodziny IDE [JetBrains](https://"
+"www.jetbrains.com/clion/), które wykonują własne analizy, ale mają własne "
+"kompromisy. Jeśli wolisz je, możesz zainstalować [wtyczkę Rusta](https://www."
+"jetbrains.com/rust/). Należy pamiętać, że od stycznia 2023 r. debugowanie "
+"działa tylko w wersji CLion pakietu JetBrains IDEA."
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# Ekosystem Rusta"
+msgid "The Rust Ecosystem"
+msgstr "Ekosystem Rusta"
 
 #: src/cargo/rust-ecosystem.md:3
 msgid ""
@@ -1430,205 +1292,187 @@ msgstr "Ekosystem Rusta składa się z wielu narzędzi, z których główne to:"
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc`: kompilator Rusta, który zmienia pliki `.rs` na pliki binarne i "
-"inne\n"
-"  formaty pośrednie."
+"`rustc`: kompilator Rusta, który zmienia pliki `.rs` na pliki binarne i inne "
+"formaty pośrednie."
 
 #: src/cargo/rust-ecosystem.md:8
 msgid ""
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests."
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
 msgstr ""
-"* `cargo`: menedżer zależności Rusta i narzędzie do budowania. Cargo wie, "
-"jak\n"
-"  pobrać zależności hostowane na <https://crates.io> i przekazać je do\n"
-"  `rustc` podczas budowania projektu. Cargo ma również wbudowane narzędzie "
-"do uruchamiania testów,\n"
-"  które jest używane do wykonywania testów jednostkowych."
+"`cargo`: menedżer zależności Rusta i narzędzie do budowania. Cargo wie, jak "
+"pobrać zależności hostowane na <https://crates.io> i przekazać je do `rustc` "
+"podczas budowania projektu. Cargo ma również wbudowane narzędzie do "
+"uruchamiania testów, które jest używane do wykonywania testów jednostkowych."
 
 #: src/cargo/rust-ecosystem.md:13
 msgid ""
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
 msgstr ""
-"* `rustup`: instalator i aktualizator pakietu narzędzi Rusta. To narzędzie "
-"służy do\n"
-"  instalowania i aktualizacji `rustc` i `cargo`, gdy zostaną wydane nowe "
-"wersje Rusta.\n"
-"  Ponadto `rustup` może również pobrać dokumentację biblioteki "
-"standardowej.\n"
-"  Możesz mieć jednocześnie zainstalowanych wiele wersji Rusta i `rustup`\n"
-"  pozwoli ci przełączać się między nimi w razie potrzeby."
+"`rustup`: instalator i aktualizator pakietu narzędzi Rusta. To narzędzie "
+"służy do instalowania i aktualizacji `rustc` i `cargo`, gdy zostaną wydane "
+"nowe wersje Rusta. Ponadto `rustup` może również pobrać dokumentację "
+"biblioteki standardowej. Możesz mieć jednocześnie zainstalowanych wiele "
+"wersji Rusta i `rustup` pozwoli ci przełączać się między nimi w razie "
+"potrzeby."
 
-#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25 src/hello-world/small-example.md:27
-#: src/why-rust/runtime.md:10 src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:30
-#: src/error-handling/try-operator.md:50 src/error-handling/converting-error-types-example.md:50
-#: src/concurrency/threads.md:30
+#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
+#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
+#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:30
+#: src/error-handling/try-operator.md:50
+#: src/error-handling/converting-error-types-example.md:50
+#: src/concurrency/threads.md:30 src/pattern-matching/destructuring-enums.md:35
 msgid "Key points:"
 msgstr "Kluczowe punkty:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality."
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust ma szybki harmonogram wydań z nową wersją\n"
-"  co sześć tygodni. Nowe wersje zachowują kompatybilność wsteczną z\n"
-"  starymi wersjami --- plus umożliwiają nowe funkcjonalności."
+"Rust ma szybki harmonogram wydań z nową wersją co sześć tygodni. Nowe wersje "
+"zachowują kompatybilność wsteczną z starymi wersjami --- plus umożliwiają "
+"nowe funkcjonalności."
 
 #: src/cargo/rust-ecosystem.md:27
 msgid ""
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
 msgstr ""
-"* Istnieją trzy kanały wydania: \"stable\" (\"stabilny\"), \"beta\" i "
+"Istnieją trzy kanały wydania: \"stable\" (\"stabilny\"), \"beta\" i "
 "\"nightly\" (\"nocny\")."
 
 #: src/cargo/rust-ecosystem.md:29
 msgid ""
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks."
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
 msgstr ""
-"* Nowe funkcje są testowane na \"nightly\", \"beta\" jest tym, co staje się\n"
-"  \"stable\" co sześć tygodni."
+"Nowe funkcje są testowane na \"nightly\", \"beta\" jest tym, co staje się "
+"\"stable\" co sześć tygodni."
 
 #: src/cargo/rust-ecosystem.md:32
 msgid ""
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018."
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
 msgstr ""
-"* Rust ma również [edycje]: obecna edycja to Rust 2021. Poprzednie\n"
-"  edycje to Rust 2015 i Rust 2018."
+"Rust ma również [edycje](https://doc.rust-lang.org/edition-guide/): obecna "
+"edycja to Rust 2021. Poprzednie edycje to Rust 2015 i Rust 2018."
 
 #: src/cargo/rust-ecosystem.md:35
 msgid ""
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language."
-msgstr "  * Edycje mogą wprowadzać do języka zmiany niekompatybilne wstecznie."
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "Edycje mogą wprowadzać do języka zmiany niekompatybilne wstecznie."
 
 #: src/cargo/rust-ecosystem.md:38
 msgid ""
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file."
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
 msgstr ""
-"  * Aby zapobiec niekompatybilności kodu, edycje są opcjonalne: wybierasz\n"
-"    edycję swojej skrzyni za pomocą pliku `Cargo.toml`."
+"Aby zapobiec niekompatybilności kodu, edycje są opcjonalne: wybierasz edycję "
+"swojej skrzyni za pomocą pliku `Cargo.toml`."
 
 #: src/cargo/rust-ecosystem.md:41
 msgid ""
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions."
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
 msgstr ""
-"  * Aby uniknąć podziału ekosystemu, kompilatory Rusta mogą mieszać kod\n"
-"    napisany dla różnych edycji."
+"Aby uniknąć podziału ekosystemu, kompilatory Rusta mogą mieszać kod napisany "
+"dla różnych edycji."
 
 #: src/cargo/rust-ecosystem.md:44
 msgid ""
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do)."
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
 msgstr ""
-"  * Wspomnij, że dość rzadko używa się kompilatora bezpośrednio, a nie przez "
+"Wspomnij, że dość rzadko używa się kompilatora bezpośrednio, a nie przez "
 "`cargo` (większość użytkowników nigdy tego nie robi)."
 
 #: src/cargo/rust-ecosystem.md:46
 msgid ""
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
 msgstr ""
-"  * Warto wspomnieć, że samo Cargo jest niezwykle potężnym i wszechstronnym "
-"narzędziem. Jest zdolne do wielu zaawansowanych funkcji, w tym między "
-"innymi:\n"
-"      * Struktura projektu/pakietu\n"
-"      * [obszary robocze]\n"
-"      * Zarządzanie/buforowanie zależności\n"
-"      * [tworzenie skryptów]\n"
-"      * [instalacja globalna]\n"
-"      * Jest również rozszerzalne za pomocą wtyczek poleceń podrzędnych "
-"(takich jak [cargo clippy]).\n"
-"  * Przeczytaj więcej w [oficjalnej księdze Cargo]"
+"Warto wspomnieć, że samo Cargo jest niezwykle potężnym i wszechstronnym "
+"narzędziem. Jest zdolne do wielu zaawansowanych funkcji, w tym między innymi:"
 
-#: src/cargo/rust-ecosystem.md:55
-msgid "[editions]: https://doc.rust-lang.org/edition-guide/"
-msgstr "[edycje]: https://doc.rust-lang.org/edition-guide/"
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "Struktura projektu/pakietu"
 
-#: src/cargo/rust-ecosystem.md:57
-msgid "[workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
 msgstr ""
-"[obszary robocze]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
+"[obszary robocze](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
 
-#: src/cargo/rust-ecosystem.md:59
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr "Zarządzanie/buforowanie zależności"
+
+#: src/cargo/rust-ecosystem.md:50
 msgid ""
-"[build scripting]: "
-"https://doc.rust-lang.org/cargo/reference/build-scripts.html"
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
 msgstr ""
-"[tworzenie skryptów]: "
-"https://doc.rust-lang.org/cargo/reference/build-scripts.html"
+"[tworzenie skryptów](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
 
-#: src/cargo/rust-ecosystem.md:61
+#: src/cargo/rust-ecosystem.md:51
 msgid ""
-"[global installation]: "
-"https://doc.rust-lang.org/cargo/commands/cargo-install.html"
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
 msgstr ""
-"[instalacja globalna]: "
-"https://doc.rust-lang.org/cargo/commands/cargo-install.html"
+"[instalacja globalna](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
 
-#: src/cargo/rust-ecosystem.md:63
-msgid "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
-msgstr "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"Jest również rozszerzalne za pomocą wtyczek poleceń podrzędnych (takich jak "
+"[cargo clippy](https://github.com/rust-lang/rust-clippy))."
 
-#: src/cargo/rust-ecosystem.md:65
-msgid "[official Cargo Book]: https://doc.rust-lang.org/cargo/"
-msgstr "[oficjalnej księdze Cargo]: https://doc.rust-lang.org/cargo/"
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr ""
+"Przeczytaj więcej w [oficjalnej księdze Cargo](https://doc.rust-lang.org/"
+"cargo/)"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# Próbki kodu"
+msgid "Code Samples in This Training"
+msgstr "Próbki kodu"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
-"Na tym szkoleniu będziemy głównie poznawać język Rust poprzez przykłady\n"
+"Na tym szkoleniu będziemy głównie poznawać język Rust poprzez przykłady "
 "które można wykonać za pośrednictwem przeglądarki. To znacznie ułatwia "
-"konfigurację i\n"
-"zapewnia spójne wrażenia dla wszystkich."
+"konfigurację i zapewnia spójne wrażenia dla wszystkich."
 
 #: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
-"Nadal zachęcamy do instalowania Cargo: ułatwi ci to wykonanie\n"
-"ćwiczeń. Ostatniego dnia wykonamy większe ćwiczenie, które pokaże ci, jak\n"
-"pracować z zależnościami i do tego potrzebujesz Cargo."
+"Nadal zachęcamy do instalowania Cargo: ułatwi ci to wykonanie ćwiczeń. "
+"Ostatniego dnia wykonamy większe ćwiczenie, które pokaże ci, jak pracować z "
+"zależnościami i do tego potrzebujesz Cargo."
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -1649,65 +1493,57 @@ msgstr ""
 "```"
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
-msgstr ""
-"Możesz użyć <kbd>Ctrl + Enter</kbd>, aby wykonać kod, gdy fokus znajduje się "
-"w\n"
-"polu tekstowym."
+msgid "You can use "
+msgstr "Możesz użyć "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr ", aby wykonać kod, gdy fokus znajduje się w polu tekstowym."
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
 "Większość przykładów kodu można edytować, jak pokazano powyżej. Kilku próbek "
-"kodu\n"
-"nie można edytować z różnych powodów:"
+"kodu nie można edytować z różnych powodów:"
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* Wbudowane playground nie mogą wykonywać testów jednostkowych. "
-"Kopiuj-wklej\n"
-"  kod i otwórz go na prawdziwym Playground, aby zademonstrować testy "
+"Wbudowane playground nie mogą wykonywać testów jednostkowych. Kopiuj-wklej "
+"kod i otwórz go na prawdziwym Playground, aby zademonstrować testy "
 "jednostkowe."
 
 #: src/cargo/code-samples.md:30
 msgid ""
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
 msgstr ""
-"* Wbudowane playground tracą swój stan w momencie nawigacji\n"
-"  z dala od strony! To jest powód, dla którego uczniowie powinni\n"
-"  rozwiązywać ćwiczenia korzystając z lokalnej instalacji Rusta lub za "
-"pośrednictwem\n"
-"  prawdziwego Playground."
+"Wbudowane playground tracą swój stan w momencie nawigacji z dala od strony! "
+"To jest powód, dla którego uczniowie powinni rozwiązywać ćwiczenia "
+"korzystając z lokalnej instalacji Rusta lub za pośrednictwem prawdziwego "
+"Playground."
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# Uruchamianie kodu lokalnie z Cargo"
+msgid "Running Code Locally with Cargo"
+msgstr "Uruchamianie kodu lokalnie z Cargo"
 
 #: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
-"Jeśli chcesz eksperymentować z kodem we własnym systemie, będziesz musieć\n"
+"Jeśli chcesz eksperymentować z kodem we własnym systemie, będziesz musieć "
 "najpierw zainstalować Rusta. Zrób to, postępując zgodnie z [instrukcjami w "
-"książce\n"
-"Język Programowania Rust][1]. To powinno dać działające `rustc` i `cargo`. "
-"Aktualnie\n"
+"książce Język Programowania Rust](http://rust.w8.pl/book/ch01-01-"
+"installation.html). To powinno dać działające `rustc` i `cargo`. Aktualnie "
 "najnowsza stabilna wersja Rusta ma następujące numery wersji:"
 
 #: src/cargo/running-locally.md:8
@@ -1729,194 +1565,188 @@ msgstr ""
 #: src/cargo/running-locally.md:15
 msgid ""
 "With this is in place, then follow these steps to build a Rust binary from "
-"one\n"
-"of the examples in this training:"
+"one of the examples in this training:"
 msgstr ""
-"Następnie wykonaj następujące kroki, aby zbudować plik binarny "
-"Rusta z jednego\n"
-"z przykładów w tym szkoleniu:"
+"Następnie wykonaj następujące kroki, aby zbudować plik binarny Rusta z "
+"jednego z przykładów w tym szkoleniu:"
 
 #: src/cargo/running-locally.md:18
-msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy."
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr ""
-"1. Kliknij przycisk „Kopiuj do schowka” na przykładzie, który chcesz "
-"skopiować."
+"Kliknij przycisk „Kopiuj do schowka” na przykładzie, który chcesz skopiować."
 
 #: src/cargo/running-locally.md:20
 msgid ""
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:"
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
 msgstr ""
-"2. Użyj polecenia `cargo new exercise`, aby utworzyć nowy katalog "
-"`exercise/` dla swojego kodu:"
+"Użyj polecenia `cargo new exercise`, aby utworzyć nowy katalog `exercise/` "
+"dla swojego kodu:"
 
 #: src/cargo/running-locally.md:22
 msgid ""
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```\n"
+"```"
 msgstr ""
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:27
 msgid ""
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:"
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
 msgstr ""
-"3. Przejdź do `exercise/` i użyj `cargo run`, aby zbudować i uruchomić plik "
+"Przejdź do `exercise/` i użyj `cargo run`, aby zbudować i uruchomić plik "
 "binarny:"
 
 #: src/cargo/running-locally.md:29
 msgid ""
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```\n"
+"```"
 msgstr ""
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:38
 msgid ""
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like"
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
 msgstr ""
-"4. Zastąp kod w `src/main.rs` własnym kodem. Na\n"
-"   przykład, korzystając z przykładu na poprzedniej stronie, spraw, aby "
-"`src/main.rs` wyglądał tak"
+"Zastąp kod w `src/main.rs` własnym kodem. Na przykład, korzystając z "
+"przykładu na poprzedniej stronie, spraw, aby `src/main.rs` wyglądał tak"
 
 #: src/cargo/running-locally.md:41
 msgid ""
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```"
+"```\n"
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```\n"
+"```"
 msgstr ""
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Zmień mnie!\");\n"
-"    }\n"
-"    ```"
+"```\n"
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Zmień mnie!\");\n"
+"}\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:47
-msgid "5. Use `cargo run` to build and run your updated binary:"
+msgid "Use `cargo run` to build and run your updated binary:"
 msgstr ""
-"5. Użyj polecenia `cargo run`, aby zbudować i uruchomić zaktualizowany plik "
+"Użyj polecenia `cargo run`, aby zbudować i uruchomić zaktualizowany plik "
 "binarny:"
 
 #: src/cargo/running-locally.md:49
 msgid ""
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```\n"
+"```"
 msgstr ""
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Zmień mnie!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Zmień mnie!\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:57
 msgid ""
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in "
-"`target/debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`."
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
 msgstr ""
-"6. Użyj `cargo check`, aby szybko sprawdzić swój projekt pod kątem błędów, "
-"użyj `cargo build`\n"
-"   aby skompilować go bez uruchamiania. Dane wyjściowe znajdziesz w "
-"`target/debug/`\n"
-"   dla normalnej kompilacji do debugowania. Użyj polecenia `cargo build "
-"--release`, aby utworzyć zoptymalizowany plik\n"
-"   do wydania w `target/release/`."
+"Użyj `cargo check`, aby szybko sprawdzić swój projekt pod kątem błędów, użyj "
+"`cargo build` aby skompilować go bez uruchamiania. Dane wyjściowe znajdziesz "
+"w `target/debug/` dla normalnej kompilacji do debugowania. Użyj polecenia "
+"`cargo build --release`, aby utworzyć zoptymalizowany plik do wydania w "
+"`target/release/`."
 
 #: src/cargo/running-locally.md:62
 msgid ""
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
 msgstr ""
-"7. Możesz dodać zależności dla swojego projektu, edytując `Cargo.toml`. "
-"Kiedy\n"
-"   uruchamiasz polecenia `cargo`, Cargo automatycznie pobierze i skompiluje "
-"brakujące\n"
-"   zależności dla Ciebie."
-
-#: src/cargo/running-locally.md:66
-msgid "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
-msgstr "[1]: http://rust.w8.pl/book/ch01-01-installation.html"
+"Możesz dodać zależności dla swojego projektu, edytując `Cargo.toml`. Kiedy "
+"uruchamiasz polecenia `cargo`, Cargo automatycznie pobierze i skompiluje "
+"brakujące zależności dla Ciebie."
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
-"Spróbuj zachęcić uczestników zajęć do zainstalowania Cargo i korzystania z\n"
-"edytora tekstu. Ułatwi im to życie, ponieważ będą mieli\n"
-"normalne środowisko programistyczne."
+"Spróbuj zachęcić uczestników zajęć do zainstalowania Cargo i korzystania z "
+"edytora tekstu. Ułatwi im to życie, ponieważ będą mieli normalne środowisko "
+"programistyczne."
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# Witamy w dniu 1"
+msgid "Welcome to Day 1"
+msgstr "Witamy w dniu 1"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr "To pierwszy dzień Comprehensive Rust. Przerobimy dziś dużo materiału:"
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* Podstawowa składnia Rusta: zmienne, typy skalarne i złożone, wyliczenia, "
-"struktury,\n"
-"  referencje, funkcje i metody."
+"Podstawowa składnia Rusta: zmienne, typy skalarne i złożone, wyliczenia, "
+"struktury, referencje, funkcje i metody."
 
 #: src/welcome-day-1.md:9
 msgid ""
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection."
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
 msgstr ""
-"* Zarządzanie pamięcią: stos a sterta, ręczne zarządzanie pamięcią, "
+"Zarządzanie pamięcią: stos a sterta, ręczne zarządzanie pamięcią, "
 "zarządzanie pamięcią oparte na zakresie i odśmiecanie pamięci."
 
 #: src/welcome-day-1.md:12
 msgid ""
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
 msgstr ""
-"* Własność: semantyka przenoszenia, kopiowanie i klonowanie, pożyczanie i "
+"Własność: semantyka przenoszenia, kopiowanie i klonowanie, pożyczanie i "
 "czasy życia."
 
 #: src/welcome-day-1.md:16
@@ -1925,148 +1755,168 @@ msgstr "Proszę przypomnieć uczniom, że:"
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, "
-"i.e.,\n"
-"    keep the related to how Rust does things vs some other language. It can "
-"be\n"
-"    hard to find the right balance, but err on the side of allowing "
-"discussions\n"
-"    since they engage people much more than one-way communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
 msgstr ""
-"* Powinni zadawać pytania, kiedy je dostaną, nich ich nie zachowują do "
-"końca.\n"
-"* Klasa ma być interaktywna, a dyskusje są bardzo mile widziane!\n"
-"  * Jako prowadzący powinieneś starać się, aby dyskusje były istotne, tj.\n"
-"    zachowaj związek z tym, jak Rust robi rzeczy w porównaniu z innym "
-"językiem. Może być\n"
-"    ciężko znaleźć właściwą równowagę, ale skłaniaj się do zezwalania na "
-"dyskusje\n"
-"    ponieważ angażują ludzi znacznie bardziej niż jednokierunkowa "
-"komunikacja.\n"
-"* Pytania prawdopodobnie oznaczają, że rozmawiamy o rzeczach przed "
-"slajdami.\n"
-"  * To jest całkowicie w porządku! Powtarzanie jest ważną częścią uczenia "
-"się. Pamiętaj,\n"
-"    że slajdy są tylko wsparciem i jeżeli chcesz to możesz je pominąć."
+"Powinni zadawać pytania, kiedy je dostaną, nich ich nie zachowują do końca."
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr "Klasa ma być interaktywna, a dyskusje są bardzo mile widziane!"
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the related to how Rust does things vs some other language. It can be "
+"hard to find the right balance, but err on the side of allowing discussions "
+"since they engage people much more than one-way communication."
+msgstr ""
+"Jako prowadzący powinieneś starać się, aby dyskusje były istotne, tj. "
+"zachowaj związek z tym, jak Rust robi rzeczy w porównaniu z innym językiem. "
+"Może być ciężko znaleźć właściwą równowagę, ale skłaniaj się do zezwalania "
+"na dyskusje ponieważ angażują ludzi znacznie bardziej niż jednokierunkowa "
+"komunikacja."
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+"Pytania prawdopodobnie oznaczają, że rozmawiamy o rzeczach przed slajdami."
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"To jest całkowicie w porządku! Powtarzanie jest ważną częścią uczenia się. "
+"Pamiętaj, że slajdy są tylko wsparciem i jeżeli chcesz to możesz je pominąć."
 
 #: src/welcome-day-1.md:29
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
-"Ideą pierwszego dnia jest pokazanie _tylko tyle_ Rusta, żeby móc mówić\n"
-"o słynnym nadzorcu pożyczania. Sposób, w jaki Rust obsługuje pamięć, jest "
-"jego główną cechą\n"
-"i powinniśmy od razu pokazać to uczniom."
+"Ideą pierwszego dnia jest pokazanie _tylko tyle_ Rusta, żeby móc mówić o "
+"słynnym nadzorcu pożyczania. Sposób, w jaki Rust obsługuje pamięć, jest jego "
+"główną cechą i powinniśmy od razu pokazać to uczniom."
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
-"Jeśli uczysz tego w klasie, jest to dobre miejsce do przejrzenia\n"
+"Jeśli uczysz tego w klasie, jest to dobre miejsce do przejrzenia "
 "harmonogramu. Proponujemy podzielić dzień na dwie części (według slajdów):"
 
 #: src/welcome-day-1.md:36
-msgid "* Morning: 9:00 to 12:00,\n* Afternoon: 13:00 to 16:00."
-msgstr "* Rano: od 9:00 do 12:00,\n* Po południu: od 13:00 do 16:00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "Rano: od 9:00 do 12:00,"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "Po południu: od 13:00 do 16:00."
 
 #: src/welcome-day-1.md:39
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
+"breaks, we recommend a break every hour!"
 msgstr ""
-"Można to oczywiście dostosować w razie potrzeby. Proszę uwzględnić przerwy,\n"
+"Można to oczywiście dostosować w razie potrzeby. Proszę uwzględnić przerwy, "
 "zalecamy przerwę co godzinę!"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# Co to jest Rust?"
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
-"Rust to nowy język programowania, który miał swoje [wydanie 1.0 w 2015 "
-"roku][1]:"
+"Rust to nowy język programowania, który miał swoje [wydanie 1.0 w 2015 roku]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 
 #: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "Rust to język kompilowany statycznie, pełniący podobną rolę jak C++"
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` używa LLVM jako backendu."
+
+#: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  "
-"architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"* Rust to język kompilowany statycznie, pełniący podobną rolę jak C++\n"
-"  * `rustc` używa LLVM jako backendu.\n"
-"* Rust obsługuje wiele [platform i\n"
-"  "
-"architektur](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows,...\n"
-"* Rust jest używany w szerokiej gamie urządzeń:\n"
-"  * firmware i bootloadery,\n"
-"  * inteligentne wyświetlacze,\n"
-"  * telefony komórkowe,\n"
-"  * komputery stacjonarne,\n"
-"  * serwery."
+"Rust obsługuje wiele [platform i architektur](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows,..."
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rust jest używany w szerokiej gamie urządzeń:"
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "firmware i bootloadery,"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "inteligentne wyświetlacze,"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "telefony komórkowe,"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "komputery stacjonarne,"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "serwery."
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust pasuje do tego samego obszaru co C++:"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
+msgid "High flexibility."
+msgstr "Wysoka elastyczność."
+
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "Wysoki poziom kontroli."
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
 msgstr ""
-"* Wysoka elastyczność.\n"
-"* Wysoki poziom kontroli.\n"
-"* Można skalować do bardzo ograniczonych urządzeń, takich jak telefony "
-"komórkowe.\n"
-"* Nie ma biblioteki uruchomieniowej ani odśmiecania pamięci.\n"
-"* Koncentruje się na niezawodności i bezpieczeństwie bez poświęcania "
+"Można skalować do bardzo ograniczonych urządzeń, takich jak telefony "
+"komórkowe."
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "Nie ma biblioteki uruchomieniowej ani odśmiecania pamięci."
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"Koncentruje się na niezawodności i bezpieczeństwie bez poświęcania "
 "wydajności."
-
-#: src/welcome-day-1/what-is-rust.md:31
-msgid "[1]: https://blog.rust-lang.org/2015/05/15/Rust-1.0.html"
-msgstr "[1]: https://blog.rust-lang.org/2015/05/15/Rust-1.0.html"
-
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr "# Witaj świecie!"
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
-"Przejdźmy do najprostszego możliwego programu Rust, klasycznego Hello World\n"
+"Przejdźmy do najprostszego możliwego programu Rust, klasycznego Hello World "
 "program:"
 
 #: src/hello-world.md:6
@@ -2088,58 +1938,57 @@ msgid "What you see:"
 msgstr "Co widać:"
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "Funkcje są wprowadzane za pomocą `fn`."
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "Bloki są oddzielone nawiasami klamrowymi, jak w C i C++."
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "Funkcja `main` jest punktem wejścia programu."
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr "Rust ma higieniczne makra, `println!` jest tego przykładem."
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
-"* Funkcje są wprowadzane za pomocą `fn`.\n"
-"* Bloki są oddzielone nawiasami klamrowymi, jak w C i C++.\n"
-"* Funkcja `main` jest punktem wejścia programu.\n"
-"* Rust ma higieniczne makra, `println!` jest tego przykładem.\n"
-"* Łańcuchy znaków w Ruście są zakodowane w UTF-8 i mogą zawierać dowolne "
-"znaki Unicode."
+"Łańcuchy znaków w Ruście są zakodowane w UTF-8 i mogą zawierać dowolne znaki "
+"Unicode."
 
 #: src/hello-world.md:22
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
-"Ten slajd ma na celu zapoznanie uczniów z kodem Rusta. Zobaczą\n"
-"tego dużo w ciągu następnych czterech dni, więc zaczniemy od czegoś "
-"znajomego."
+"Ten slajd ma na celu zapoznanie uczniów z kodem Rusta. Zobaczą tego dużo w "
+"ciągu następnych czterech dni, więc zaczniemy od czegoś znajomego."
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rust jest bardzo podobny do innych języków w tradycji C/C++/Java. Jest\n"
-"  imperatywny (nie funkcjonalny) i nie próbuje wymyślać rzeczy na nowo jeśli "
+"Rust jest bardzo podobny do innych języków w tradycji C/C++/Java. Jest "
+"imperatywny (nie funkcjonalny) i nie próbuje wymyślać rzeczy na nowo jeśli "
 "nie ma takiej potrzeby."
 
 #: src/hello-world.md:31
-msgid "* Rust is modern with full support for things like Unicode."
-msgstr "* Rust jest nowoczesny, ma pełne wsparcie dla rzeczy takich jak Unicode."
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "Rust jest nowoczesny, ma pełne wsparcie dla rzeczy takich jak Unicode."
 
 #: src/hello-world.md:33
 msgid ""
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
 msgstr ""
-"* Rust używa makr w sytuacjach, w których chcesz mieć zmienną liczbę\n"
-"  argumenty (brak [przeciążania "
-"funkcji](basic-syntax/functions-interlude.md))."
-
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# Mały przykład"
+"Rust używa makr w sytuacjach, w których chcesz mieć zmienną liczbę argumenty "
+"(brak [przeciążania funkcji](basic-syntax/functions-interlude.md))."
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2182,249 +2031,226 @@ msgstr ""
 #: src/hello-world/small-example.md:23
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
-"Kod implementuje hipotezę Collatza: uważa się, że pętla zawsze\n"
-"się kończy, ale nie zostało to jeszcze udowodnione. Edytuj kod i baw się "
-"różnymi\n"
-"danymi wejściowymi."
+"Kod implementuje hipotezę Collatza: uważa się, że pętla zawsze się kończy, "
+"ale nie zostało to jeszcze udowodnione. Edytuj kod i baw się różnymi danymi "
+"wejściowymi."
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
 "overflow."
 msgstr ""
-"* Wyjaśnij, że wszystkie zmienne są typowane statycznie. Spróbuj usunąć "
-"`i32`, aby uruchomić\n"
-"  wnioskowanie typu. Zamiast tego spróbuj z `i8` i wywołaj przepełnienie "
-"liczby całkowitej w czasie wykonywania."
+"Wyjaśnij, że wszystkie zmienne są typowane statycznie. Spróbuj usunąć `i32`, "
+"aby uruchomić wnioskowanie typu. Zamiast tego spróbuj z `i8` i wywołaj "
+"przepełnienie liczby całkowitej w czasie wykonywania."
 
 #: src/hello-world/small-example.md:32
-msgid "* Change `let mut x` to `let x`, discuss the compiler error."
-msgstr "* Zmień `let mut x` na `let x`, omów błąd kompilatora."
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "Zmień `let mut x` na `let x`, omów błąd kompilatora."
 
 #: src/hello-world/small-example.md:34
 msgid ""
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string."
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
 msgstr ""
-"* Pokaż, jak `print!` daje błąd kompilacji, jeśli argumenty nie pasują do\n"
-"  łańcucha formatującego."
+"Pokaż, jak `print!` daje błąd kompilacji, jeśli argumenty nie pasują do "
+"łańcucha formatującego."
 
 #: src/hello-world/small-example.md:37
 msgid ""
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable."
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
 msgstr ""
-"* Pokaż, że  musisz użyć `{}` jako symbolu zastępczego, jeśli chcesz "
-"wypisać\n"
-"  wyrażenie, które jest bardziej złożone niż tylko pojedyncza zmienna."
+"Pokaż, że  musisz użyć `{}` jako symbolu zastępczego, jeśli chcesz wypisać "
+"wyrażenie, które jest bardziej złożone niż tylko pojedyncza zmienna."
 
 #: src/hello-world/small-example.md:40
 msgid ""
-"* Show the students the standard library, show them how to search for "
-"`std::fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library."
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
 msgstr ""
-"* Pokaż uczniom standardową bibliotekę, pokaż im, jak szukać `std::fmt`\n"
-"  który ma zasady mini-języka formatowania. Ważne jest, aby\n"
-"  studenci zapoznają się z wyszukiwaniem w bibliotece standardowej."
-
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# Dlaczego Rust?"
+"Pokaż uczniom standardową bibliotekę, pokaż im, jak szukać `std::fmt` który "
+"ma zasady mini-języka formatowania. Ważne jest, aby studenci zapoznają się z "
+"wyszukiwaniem w bibliotece standardowej."
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Niektóre unikalne zalety Rusta:"
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* Bezpieczeństwo pamięci w czasie kompilacji.\n"
-"* Brak niezdefiniowanego zachowania w czasie wykonywania.\n"
-"* Nowoczesne funkcje językowe."
+msgid "Compile time memory safety."
+msgstr "Bezpieczeństwo pamięci w czasie kompilacji."
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "Brak niezdefiniowanego zachowania w czasie wykonywania."
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "Nowoczesne funkcje językowe."
 
 #: src/why-rust.md:11
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
 "Pamiętaj, aby zapytać klasę, z jakimi językami mają doświadczenie. W "
-"zależności\n"
-"od odpowiedzi możesz wyróżnić różne funkcje Rusta:"
+"zależności od odpowiedzi możesz wyróżnić różne funkcje Rusta:"
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management."
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* Doświadczenie z C lub C++: Rust eliminuje całą klasę błędów _w czasie "
-"działania_\n"
-"  za pośrednictwem nadzorcy pożyczania. Otrzymujesz wydajność jak w C i C++, "
-"ale bez\n"
-"  problemów z bezpieczeństwem pamięci. Ponadto otrzymujesz nowoczesny język "
-"z\n"
-"  konstrukcjami, jak dopasowywanie wzorców i wbudowane zarządzanie "
-"zależnościami."
+"Doświadczenie z C lub C++: Rust eliminuje całą klasę błędów _w czasie "
+"działania_ za pośrednictwem nadzorcy pożyczania. Otrzymujesz wydajność jak w "
+"C i C++, ale bez problemów z bezpieczeństwem pamięci. Ponadto otrzymujesz "
+"nowoczesny język z konstrukcjami, jak dopasowywanie wzorców i wbudowane "
+"zarządzanie zależnościami."
 
 #: src/why-rust.md:19
 msgid ""
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
 msgstr ""
-"* Doświadczenie z Javą, Go, Pythonem, JavaScript...: Otrzymujesz takie samo "
-"bezpieczeństwo pamięci\n"
-"  jak w tych językach, plus podobne uczucie języka wysokiego poziomu. "
-"Ponadto\n"
-"  otrzymujesz szybką i przewidywalną wydajność jak w C i C++ (bez Garbage "
-"Collectora)\n"
-"  a także dostęp do sprzętu na niskim poziomie (jeśli go potrzebujesz)"
-
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# Gwarancje w czasie kompilacji"
+"Doświadczenie z Javą, Go, Pythonem, JavaScript...: Otrzymujesz takie samo "
+"bezpieczeństwo pamięci jak w tych językach, plus podobne uczucie języka "
+"wysokiego poziomu. Ponadto otrzymujesz szybką i przewidywalną wydajność jak "
+"w C i C++ (bez Garbage Collectora) a także dostęp do sprzętu na niskim "
+"poziomie (jeśli go potrzebujesz)"
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "Statyczne zarządzanie pamięcią w czasie kompilacji:"
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* Brak niezainicjowanych zmiennych.\n"
-"* Brak wycieków pamięci (_głównie_, patrz uwagi).\n"
-"* Brak podwójnych zwolnień pamięci.\n"
-"* Brak użycia po zwolnieniu.\n"
-"* Brak wskaźników `NULL`.\n"
-"* Żadnych zapomnianych zablokowanych muteksów.\n"
-"* Brak wyścigów danych między wątkami.\n"
-"* Brak unieważniania iteratora."
+msgid "No uninitialized variables."
+msgstr "Brak niezainicjowanych zmiennych."
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "Brak wycieków pamięci (_głównie_, patrz uwagi)."
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "Brak podwójnych zwolnień pamięci."
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "Brak użycia po zwolnieniu."
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "Brak wskaźników `NULL`."
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "Żadnych zapomnianych zablokowanych muteksów."
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "Brak wyścigów danych między wątkami."
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "Brak unieważniania iteratora."
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr ""
 "Możliwe jest generowanie wycieków pamięci w (bezpiecznym) Ruście. Kilka "
 "przykładów:"
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can for use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can for use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* Możesz użyć [`Box::leak`] do wycieku wskaźnika. Można to wykorzystać,\n"
-"  aby uzyskać zmienne statyczne inicjowane w czasie wykonywania i o "
-"rozmiarze czasu wykonywania\n"
-"* Możesz użyć [`std::mem::forget`], aby kompilator „zapomniał” o\n"
-"  wartości (co oznacza, że destruktor nigdy nie jest uruchamiany).\n"
-"* Możesz także przypadkowo utworzyć [cykl referencyjny] za pomocą `Rc` lub\n"
-"  `Arc`.\n"
-"* W rzeczywistości niektórzy uznają zapełnianie kolekcji w nieskończoność "
-"za\n"
-"  wyciek pamięci, a Rust nie chroni przed nimi."
+"Możesz użyć [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) do wycieku wskaźnika. Można to wykorzystać, aby uzyskać "
+"zmienne statyczne inicjowane w czasie wykonywania i o rozmiarze czasu "
+"wykonywania"
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"Możesz użyć [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html), aby kompilator „zapomniał” o wartości (co oznacza, że destruktor "
+"nigdy nie jest uruchamiany)."
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"Możesz także przypadkowo utworzyć [cykl referencyjny](http://rust.w8.pl/book/"
+"ch15-06-reference-cycles.html) za pomocą `Rc` lub `Arc`."
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"W rzeczywistości niektórzy uznają zapełnianie kolekcji w nieskończoność za "
+"wyciek pamięci, a Rust nie chroni przed nimi."
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"Na potrzeby tego kursu należy rozumieć „Brak wycieków pamięci”.\n"
-"jako „Prawie nie ma *przypadkowych* wycieków pamięci”."
-
-#: src/why-rust/compile-time.md:31
-msgid ""
-"[`Box::leak`]: "
-"https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
-"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-"[reference cycle]: "
-"https://doc.rust-lang.org/book/ch15-06-reference-cycles.html"
-msgstr ""
-"[`Box::leak`]: "
-"https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
-"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-"[cykl referencyjny]: http://rust.w8.pl/book/ch15-06-reference-cycles.html"
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# Gwarancje podczas działania"
+"Na potrzeby tego kursu należy rozumieć „Brak wycieków pamięci”. jako „Prawie "
+"nie ma _przypadkowych_ wycieków pamięci”."
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "Brak niezdefiniowanego zachowania w czasie wykonywania:"
 
 #: src/why-rust/runtime.md:5
-msgid "* Array access is bounds checked.\n* Integer overflow is defined."
-msgstr ""
-"* Zakres dostępu do tablicy jest sprawdzany.\n"
-"* Zdefiniowano przepełnienie całkowitoliczbowe."
+msgid "Array access is bounds checked."
+msgstr "Zakres dostępu do tablicy jest sprawdzany."
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
+msgstr "Zdefiniowano przepełnienie całkowitoliczbowe."
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`)."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* Przepełnienie liczb całkowitych jest definiowane za pomocą flagi czasu "
-"kompilacji. Opcje to\n"
-"  panika (kontrolowana awaria programu) lub zawijanie.\n"
-"  Domyślnie to panika w trybie debugowania (`cargo build`)\n"
-"  i zawijanie w trybie produkcyjnym (`cargo build --release`)."
+"Przepełnienie liczb całkowitych jest definiowane za pomocą flagi czasu "
+"kompilacji. Opcje to panika (kontrolowana awaria programu) lub zawijanie. "
+"Domyślnie to panika w trybie debugowania (`cargo build`) i zawijanie w "
+"trybie produkcyjnym (`cargo build --release`)."
 
 #: src/why-rust/runtime.md:17
 msgid ""
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
 msgstr ""
-"* Sprawdzania granic nie można wyłączyć za pomocą flagi kompilatora. Nie "
-"może też\n"
-"  wyłączyć go bezpośrednio za pomocą słowa kluczowego `unsafe`. Jednakże,\n"
-"  `unsafe` pozwala na wywołanie funkcji takich jak `slice::get_unchecked`,\n"
-"  które nie sprawdzają granic."
-
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# Nowoczesne funkcjonalności"
+"Sprawdzania granic nie można wyłączyć za pomocą flagi kompilatora. Nie może "
+"też wyłączyć go bezpośrednio za pomocą słowa kluczowego `unsafe`. Jednakże, "
+"`unsafe` pozwala na wywołanie funkcji takich jak `slice::get_unchecked`, "
+"które nie sprawdzają granic."
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
@@ -2432,262 +2258,305 @@ msgstr ""
 "Rust jest zbudowany z całym doświadczeniem zdobytym w ciągu ostatnich 40 lat."
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## Funkcje języka"
+msgid "Language Features"
+msgstr "Funkcje języka"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* Wyliczenia i dopasowywanie wzorców.\n"
-"* Generyczne typy i funkcje.\n"
-"* Brak narzutu przy FFI.\n"
-"* Abstrakcje o zerowych kosztach."
+msgid "Enums and pattern matching."
+msgstr "Wyliczenia i dopasowywanie wzorców."
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "Generyczne typy i funkcje."
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "Brak narzutu przy FFI."
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "Abstrakcje o zerowych kosztach."
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
-msgstr "## Narzędzia"
+msgid "Tooling"
+msgstr "Narzędzia"
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* Świetne błędy kompilatora.\n"
-"* Wbudowany menedżer zależności.\n"
-"* Wbudowana obsługa testów.\n"
-"* Doskonała obsługa protokołu serwera językowego."
+msgid "Great compiler errors."
+msgstr "Świetne błędy kompilatora."
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "Wbudowany menedżer zależności."
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "Wbudowana obsługa testów."
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "Doskonała obsługa protokołu serwera językowego."
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* Abstrakcje o zerowych kosztach, podobne do C++, oznaczają, że nie musisz "
-"„płacić”\n"
-"  za konstrukcje programistyczne wyższego poziomu pamięcią lub procesorem. "
-"Na przykład,\n"
-"  pisanie pętli przy użyciu `for` powinno dać w przybliżeniu te same "
-"instrukcje niskiego poziomu\n"
-"  jak przy użyciu konstrukcji `.iter().fold()`."
+"Abstrakcje o zerowych kosztach, podobne do C++, oznaczają, że nie musisz "
+"„płacić” za konstrukcje programistyczne wyższego poziomu pamięcią lub "
+"procesorem. Na przykład, pisanie pętli przy użyciu `for` powinno dać w "
+"przybliżeniu te same instrukcje niskiego poziomu jak przy użyciu konstrukcji "
+"`.iter().fold()`."
 
 #: src/why-rust/modern.md:28
 msgid ""
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`."
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
 msgstr ""
-"* Warto wspomnieć, że wyliczenia w Rust również są „algebraicznymi typami "
-"danych”,\n"
-"  które pozwalają systemowi typów wyrażać takie rzeczy jak\n"
-"  `Option<T>` i `Result<T, E>`."
+"Warto wspomnieć, że wyliczenia w Rust również są „algebraicznymi typami "
+"danych”, które pozwalają systemowi typów wyrażać takie rzeczy jak "
+"`Option<T>` i `Result<T, E>`."
 
 #: src/why-rust/modern.md:32
 msgid ""
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code."
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
 msgstr ""
-"* Przypomnij ludziom, aby przeczytali błędy --- wielu programistów "
-"przyzwyczaiło się do\n"
-"  ignorowanie długich danych wyjściowych kompilatora. Kompilator Rusta jest "
-"znacznie bardziej\n"
-"  rozmowny niż inne kompilatory. Często da ci _użyteczne_ podpowiedzi,\n"
-"  gotowe do skopiowania i wklejenia do kodu."
+"Przypomnij ludziom, aby przeczytali błędy --- wielu programistów "
+"przyzwyczaiło się do ignorowanie długich danych wyjściowych kompilatora. "
+"Kompilator Rusta jest znacznie bardziej rozmowny niż inne kompilatory. "
+"Często da ci _użyteczne_ podpowiedzi, gotowe do skopiowania i wklejenia do "
+"kodu."
 
 #: src/why-rust/modern.md:37
 msgid ""
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:"
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
 msgstr ""
-"* Standardowa biblioteka Rusta jest niewielka w porównaniu z językami takimi "
-"jak Java, Python,\n"
-"  i Go. Rust nie zawiera kilku rzeczy, które można by uznać za standardowe "
-"i\n"
-"  niezbędne:"
+"Standardowa biblioteka Rusta jest niewielka w porównaniu z językami takimi "
+"jak Java, Python, i Go. Rust nie zawiera kilku rzeczy, które można by uznać "
+"za standardowe i niezbędne:"
 
 #: src/why-rust/modern.md:41
-msgid ""
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json]."
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr "generator liczb losowych, ale patrz [rand](https://docs.rs/rand/)."
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
 msgstr ""
-"  * generator liczb losowych, ale patrz [rand].\n"
-"  * wsparcie dla SSL lub TLS, ale zobacz [rusttls].\n"
-"  * wsparcie dla JSON, ale zobacz [serde_json]."
+"wsparcie dla SSL lub TLS, ale zobacz [rusttls](https://docs.rs/rustls/)."
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+"wsparcie dla JSON, ale zobacz [serde_json](https://docs.rs/serde_json/)."
 
 #: src/why-rust/modern.md:45
 msgid ""
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things."
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
 msgstr ""
-"  Powodem tego jest to, że funkcjonalność w bibliotece standardowej nie "
-"może\n"
-"  odejść, więc musi być bardzo stabilna. Dla powyższych przykładów "
-"społeczność Rusta\n"
-"  wciąż pracuje nad znalezieniem najlepszego rozwiązania --- i być może nie "
-"ma\n"
-"  jednego „najlepszego rozwiązania” dla niektórych z tych rzeczy."
+"Powodem tego jest to, że funkcjonalność w bibliotece standardowej nie może "
+"odejść, więc musi być bardzo stabilna. Dla powyższych przykładów społeczność "
+"Rusta wciąż pracuje nad znalezieniem najlepszego rozwiązania --- i być może "
+"nie ma jednego „najlepszego rozwiązania” dla niektórych z tych rzeczy."
 
 #: src/why-rust/modern.md:50
 msgid ""
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller."
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
 msgstr ""
-"  Rust ma wbudowanego menedżera pakietów w postaci Cargo i to sprawia, że\n"
-"  pobieranie i kompilowanie zewnętrznych pakietów jest trywialne. "
-"Konsekwencją tego\n"
-"  jest to, że standardowa biblioteka może być mniejsza."
+"Rust ma wbudowanego menedżera pakietów w postaci Cargo i to sprawia, że "
+"pobieranie i kompilowanie zewnętrznych pakietów jest trywialne. Konsekwencją "
+"tego jest to, że standardowa biblioteka może być mniejsza."
 
 #: src/why-rust/modern.md:54
 msgid ""
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
 msgstr ""
-"  Odkrywanie dobrych skrzynek może być problemem. Witryny takie jak\n"
-"  <https://lib.rs/> w tym pomagają, umożliwiając porównanie wskaźników "
-"kondycji\n"
-"  skrzynki, aby znaleźć te dobre i zaufane.\n"
-"  \n"
-"* [rust-analyzer] to dobrze obsługiwana implementacja LSP używana w "
-"głównych\n"
-"  IDE i edytorach tekstu."
+"Odkrywanie dobrych skrzynek może być problemem. Witryny takie jak <https://"
+"lib.rs/> w tym pomagają, umożliwiając porównanie wskaźników kondycji "
+"skrzynki, aby znaleźć te dobre i zaufane."
 
-#: src/why-rust/modern.md:61
+#: src/why-rust/modern.md:58
 msgid ""
-"[rand]: https://docs.rs/rand/\n"
-"[rusttls]: https://docs.rs/rustls/\n"
-"[serde_json]: https://docs.rs/serde_json/\n"
-"[rust-analyzer]: https://rust-analyzer.github.io/"
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
 msgstr ""
-"[rand]: https://docs.rs/rand/\n"
-"[rusttls]: https://docs.rs/rustls/\n"
-"[serde_json]: https://docs.rs/serde_json/\n"
-"[rust-analyzer]: https://rust-analyzer.github.io/"
-
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
-msgstr "# Podstawowa składnia"
+"[rust-analyzer](https://rust-analyzer.github.io/) to dobrze obsługiwana "
+"implementacja LSP używana w głównych IDE i edytorach tekstu."
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr "Większość składni Rusta będzie Ci znana z C, C++ lub Javy:"
 
 #: src/basic-syntax.md:5
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/* "
-"...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
-msgstr ""
-"* Bloki i zakresy są oddzielone nawiasami klamrowymi.\n"
-"* Komentarze wierszowe rozpoczynają się od `//`, komentarze blokowe są "
-"rozdzielane przez `/*...\n"
-"  */`.\n"
-"* Słowa kluczowe, takie jak `if` i `while`, działają tak samo.\n"
-"* Przypisanie zmiennej odbywa się za pomocą `=`, porównanie za pomocą `==`."
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "Bloki i zakresy są oddzielone nawiasami klamrowymi."
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
-msgstr "# Typy skalarne"
-
-#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax.md:6
 msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | "
-"`\"foo\"`, `r#\"\\\\\"#`            |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Byte strings           | `&[u8]`                                    | "
-"`b\"abc\"`, `br#\" \" \"#`         |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"| | Typy | Literały |\n"
-"|------------------------|--------- --------------------|-------------- --|\n"
-"| Liczby całkowite ze znakiem | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Liczby całkowite bez znaku | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | "
-"`0`, `123`, `10u16` |\n"
-"| Liczby zmiennoprzecinkowe | `f32`, `f64` | `3.14`, `-10.0e20`, `2f32` |\n"
-"| Łańcuchy znaków | `&str` | `\"foo\"`, `r#\"\\\\\"#` |\n"
-"| Wartości skalarne Unicode | `char` | `'a'`, `'α'`, `'∞'` |\n"
-"| Ciągi bajtów | `&[u8]` | `b\"abc\"`, `br#\" \"\"#` |\n"
-"| Logiczne | `bool` | `true`, `false` |"
+"Komentarze wierszowe rozpoczynają się od `//`, komentarze blokowe są "
+"rozdzielane przez `/*... */`."
+
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "Słowa kluczowe, takie jak `if` i `while`, działają tak samo."
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+"Przypisanie zmiennej odbywa się za pomocą `=`, porównanie za pomocą `==`."
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Types"
+msgstr "Typy"
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr "Literały"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr "Liczby całkowite ze znakiem"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr "Liczby całkowite bez znaku"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr "Liczby zmiennoprzecinkowe"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr "Łańcuchy znaków"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `r#\"\\\\\"#`"
+msgstr "`\"foo\"`, `r#\"\\\\\"#`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr "Wartości skalarne Unicode"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr "`char`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Byte strings"
+msgstr "Ciągi bajtów"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`&[u8]`"
+msgstr "`&[u8]`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`b\"abc\"`, `br#\" \" \"#`"
+msgstr "`b\"abc\"`, `br#\" \"\"#`"
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "Booleans"
+msgstr "Logiczne"
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`bool`"
+msgstr "`bool`"
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`true`, `false`"
+msgstr "`true`, `false`"
 
 #: src/basic-syntax/scalar-types.md:13
 msgid "The types have widths as follows:"
 msgstr "Typy mają następujące rozmiary:"
 
 #: src/basic-syntax/scalar-types.md:15
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
-msgstr ""
-"* `iN`, `uN` i `fN` mają wielkość _N_ bitów,\n"
-"* `isize` i `usize` mają wielkość wskaźnika,\n"
-"* `char` ma 32 bitów,\n"
-"* `bool` ma 8 bitów."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN` i `fN` mają wielkość _N_ bitów,"
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr "# Typy złożone"
+#: src/basic-syntax/scalar-types.md:16
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` i `usize` mają wielkość wskaźnika,"
 
-#: src/basic-syntax/compound-types.md:3
-msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
-msgstr ""
-"|        | Typy                         | Literały                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Tablice | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`         "
-" |\n"
-"| Krotki | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+#: src/basic-syntax/scalar-types.md:17
+msgid "`char` is 32 bit wide,"
+msgstr "`char` ma 32 bitów,"
+
+#: src/basic-syntax/scalar-types.md:18
+msgid "`bool` is 8 bit wide."
+msgstr "`bool` ma 8 bitów."
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr "Tablice"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr "`[T; N]`"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr "`[20, 30, 40]`, `[0; 3]`"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr "Krotki"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
 
 #: src/basic-syntax/compound-types.md:8
 msgid "Array assignment and access:"
@@ -2739,90 +2608,79 @@ msgstr "Tablice:"
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
-"compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
 msgstr ""
-"* Tablice mają elementy tego samego typu, `T`, i długość, `N`, która jest "
-"stałą czasu kompilacji.\n"
-"  Zauważ, że długość tablicy to *część jej typu*, to znaczy, że `[u8; 3]` i\n"
-"  `[u8; 4]` to dwa różne typy."
+"Tablice mają elementy tego samego typu, `T`, i długość, `N`, która jest "
+"stałą czasu kompilacji. Zauważ, że długość tablicy to _część jej typu_, to "
+"znaczy, że `[u8; 3]` i `[u8; 4]` to dwa różne typy."
 
 #: src/basic-syntax/compound-types.md:38
-msgid "* We can use literals to assign values to arrays."
-msgstr "* Możemy użyć literałów do przypisania wartości do tablic."
+msgid "We can use literals to assign values to arrays."
+msgstr "Możemy użyć literałów do przypisania wartości do tablic."
 
 #: src/basic-syntax/compound-types.md:40
 msgid ""
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string."
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
 msgstr ""
-"* W funkcji main instrukcja print pyta o implementację do debugowania za "
-"pomocą parametru formatowania `?`:\n"
-"  `{}` daje domyślne wyjście, `{:?}` daje wyjście do debugowania. Mogliśmy\n"
-"  również użyć `{a}` i `{a:?}` bez określania wartości po łańcuchu "
-"formatującym."
+"W funkcji main instrukcja print pyta o implementację do debugowania za "
+"pomocą parametru formatowania `?`: `{}` daje domyślne wyjście, `{:?}` daje "
+"wyjście do debugowania. Mogliśmy również użyć `{a}` i `{a:?}` bez określania "
+"wartości po łańcuchu formatującym."
 
 #: src/basic-syntax/compound-types.md:45
 msgid ""
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
 msgstr ""
-"* Dodanie `#`, np. `{a:#?}`, wywołuje format \"ładnego druku\", który może "
-"być łatwiejszy do odczytania."
+"Dodanie `#`, np. `{a:#?}`, wywołuje format \"ładnego druku\", który może być "
+"łatwiejszy do odczytania."
 
 #: src/basic-syntax/compound-types.md:47
 msgid "Tuples:"
 msgstr "Krotki:"
 
 #: src/basic-syntax/compound-types.md:49
-msgid "* Like arrays, tuples have a fixed length."
-msgstr "* Podobnie jak tablice, krotki mają stałą długość."
+msgid "Like arrays, tuples have a fixed length."
+msgstr "Podobnie jak tablice, krotki mają stałą długość."
 
 #: src/basic-syntax/compound-types.md:51
-msgid "* Tuples group together values of different types into a compound type."
-msgstr "* Krotki grupują wartości różnych typów w typ złożony."
+msgid "Tuples group together values of different types into a compound type."
+msgstr "Krotki grupują wartości różnych typów w typ złożony."
 
 #: src/basic-syntax/compound-types.md:53
 msgid ""
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`."
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
 msgstr ""
-"* Dostęp do pól krotki można uzyskać po kropce i indeksie wartości, np. "
-"`t.0`, `t.1`."
+"Dostęp do pól krotki można uzyskać po kropce i indeksie wartości, np. `t.0`, "
+"`t.1`."
 
 #: src/basic-syntax/compound-types.md:55
 msgid ""
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
 msgstr ""
-"* Pusta krotka `()` jest również znana jako \"typ jednostkowy\". Jest to "
-"zarówno typ, jak i\n"
-"  jedyna poprawna wartość tego typu — to znaczy zarówno typ, jak i jego "
-"wartość\n"
-"  są wyrażone jako `()`. Służy do wskazania, na przykład, że funkcja lub\n"
-"  wyrażenie nie zwraca żadnej wartości, co zobaczymy na kolejnym slajdzie.\n"
-"    * Możesz myśleć o tym jako o „pustce” (ang. `void`), która może być ci "
-"znana z innych\n"
-"      języków programowania."
+"Pusta krotka `()` jest również znana jako \"typ jednostkowy\". Jest to "
+"zarówno typ, jak i jedyna poprawna wartość tego typu — to znaczy zarówno "
+"typ, jak i jego wartość są wyrażone jako `()`. Służy do wskazania, na "
+"przykład, że funkcja lub wyrażenie nie zwraca żadnej wartości, co zobaczymy "
+"na kolejnym slajdzie."
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
-msgstr "# Referencje"
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr ""
+"Możesz myśleć o tym jako o „pustce” (ang. `void`), która może być ci znana z "
+"innych języków programowania."
 
 #: src/basic-syntax/references.md:3
 msgid "Like C++, Rust has references:"
@@ -2854,43 +2712,38 @@ msgstr "Niektóre uwagi:"
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* Podczas przypisywania musimy wyłuskać referencję `ref_x`, podobnie jak w "
-"przypadku wskaźników C i C++.\n"
-"* W niektórych przypadkach Rust dokona automatycznej dereferencji, w "
-"szczególności podczas wywoływania\n"
-"  metod (spróbuj `ref_x.count_ones()`).\n"
-"* Referencje zadeklarowane jako `mut` mogą być powiązane z różnymi "
-"wartościami w czasie ich istnienia."
+"Podczas przypisywania musimy wyłuskać referencję `ref_x`, podobnie jak w "
+"przypadku wskaźników C i C++."
 
-#: src/basic-syntax/references.md:21
-msgid "<details>\nKey points:"
-msgstr "<details>\nKluczowe punkty:"
+#: src/basic-syntax/references.md:17
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+"W niektórych przypadkach Rust dokona automatycznej dereferencji, w "
+"szczególności podczas wywoływania metod (spróbuj `ref_x.count_ones()`)."
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"Referencje zadeklarowane jako `mut` mogą być powiązane z różnymi wartościami "
+"w czasie ich istnienia."
 
 #: src/basic-syntax/references.md:24
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"* Pamiętaj o różnicy między `let mut ref_x: &i32` i `let ref_x:\n"
-"  &mut i32`. Pierwsza reprezentuje zmienną referencję, z którą można "
-"powiązać\n"
-"  różne wartości, podczas gdy druga reprezentuje odwołanie do zmiennej "
-"wartości."
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
-msgstr "# Wiszące referencje"
+"Pamiętaj o różnicy między `let mut ref_x: &i32` i `let ref_x: &mut i32`. "
+"Pierwsza reprezentuje zmienną referencję, z którą można powiązać różne "
+"wartości, podczas gdy druga reprezentuje odwołanie do zmiennej wartości."
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -2921,20 +2774,20 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
-msgstr ""
-"* Mówi się, że referencja „pożycza” wartość, do której się odnosi.\n"
-"* Rust śledzi czas życia wszystkich referencji, aby zapewnić, że mają "
-"wystarczająco długi czas życia.\n"
-"* Porozmawiamy więcej o pożyczaniu, kiedy przejdziemy do własności."
+msgid "A reference is said to \"borrow\" the value it refers to."
+msgstr "Mówi się, że referencja „pożycza” wartość, do której się odnosi."
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
-msgstr "# Wycinki"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"Rust śledzi czas życia wszystkich referencji, aby zapewnić, że mają "
+"wystarczająco długi czas życia."
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr "Porozmawiamy więcej o pożyczaniu, kiedy przejdziemy do własności."
 
 #: src/basic-syntax/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
@@ -2945,93 +2798,254 @@ msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];\n"
-"    println!(\"a: {a:?}\");"
+"    println!(\"a: {a:?}\");\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];\n"
-"    println!(\"a: {a:?}\");"
+"    println!(\"a: {a:?}\");\n"
+"```"
 
 #: src/basic-syntax/slices.md:10
 msgid ""
-"    let s: &[i32] = &a[2..4];\n"
-"    println!(\"s: {s:?}\");\n"
-"}\n"
+"```\n"
+"let s: &[i32] = &a[2..4];\n"
+"println!(\"s: {s:?}\");\n"
 "```"
 msgstr ""
-"    let s: &[i32] = &a[2..4];\n"
-"    println!(\"s: {s:?}\");\n"
-"}\n"
+"```\n"
+"let s: &[i32] = &a[2..4];\n"
+"println!(\"s: {s:?}\");\n"
+"```"
+
+#: src/basic-syntax/slices.md:12 src/basic-syntax/string-slices.md:17
+#: src/basic-syntax/methods.md:20
+#: src/exercises/day-1/implicit-conversions.md:16
+#: src/exercises/day-1/for-loops.md:35 src/exercises/day-1/for-loops.md:77
+#: src/basic-syntax/type-inference.md:21 src/basic-syntax/type-inference.md:43
+#: src/basic-syntax/scopes-shadowing.md:20
+#: src/ownership/shared-unique-borrows.md:20 src/std/rc.md:15
+#: src/exercises/day-1/book-library.md:74
+#: src/exercises/day-1/book-library.md:96
+#: src/exercises/day-1/iterators-and-ownership.md:31
+#: src/exercises/day-1/iterators-and-ownership.md:43
+#: src/exercises/day-1/iterators-and-ownership.md:80
+#: src/exercises/day-1/iterators-and-ownership.md:59
+#: src/exercises/day-1/iterators-and-ownership.md:100 src/structs.md:26
+#: src/enums/variant-payloads.md:30 src/enums/sizes.md:84
+#: src/enums/sizes.md:133 src/methods/example.md:30 src/pattern-matching.md:18
+#: src/exercises/day-2/health-statistics.md:47
+#: src/exercises/day-2/points-polygons.md:109
+#: src/control-flow/while-let-expressions.md:14
+#: src/control-flow/for-expressions.md:17 src/std/option-result.md:13
+#: src/std/string.md:19 src/std/vec.md:26 src/std/hashmap.md:33
+#: src/std/rc.md:63 src/modules/visibility.md:30
+#: src/exercises/day-2/strings-iterators.md:29
+#: src/exercises/day-2/solutions-afternoon.md:149
+#: src/exercises/day-2/strings-iterators.md:51 src/traits/iterator.md:20
+#: src/traits/read-write.md:20 src/traits/operators.md:15
+#: src/traits/default.md:34 src/generics/methods.md:15
+#: src/generics/trait-bounds.md:30 src/generics/closures.md:20
+#: src/exercises/day-3/simple-gui.md:35
+#: src/exercises/day-3/solutions-morning.md:36
+#: src/exercises/day-3/simple-gui.md:79
+#: src/exercises/day-3/solutions-morning.md:80
+#: src/exercises/day-3/simple-gui.md:90 src/exercises/day-3/simple-gui.md:100
+#: src/exercises/day-3/simple-gui.md:110 src/error-handling/try-operator.md:39
+#: src/testing/test-modules.md:23 src/unsafe/raw-pointers.md:21
+#: src/unsafe/mutable-static-variables.md:27
+#: src/unsafe/calling-unsafe-functions.md:23
+#: src/unsafe/writing-unsafe-functions.md:28
+#: src/exercises/day-3/safe-ffi-wrapper.md:54
+#: src/exercises/day-3/solutions-afternoon.md:48 src/concurrency/threads.md:21
+#: src/concurrency/scoped-threads.md:14 src/concurrency/scoped-threads.md:30
+#: src/concurrency/channels.md:22 src/concurrency/channels/unbounded.md:26
+#: src/concurrency/channels/bounded.md:26
+#: src/concurrency/shared_state/arc.md:22
+#: src/concurrency/shared_state/mutex.md:19
+#: src/concurrency/shared_state/example.md:18
+#: src/concurrency/shared_state/example.md:49
+#: src/exercises/day-4/dining-philosophers.md:44
+#: src/exercises/day-4/dining-philosophers.md:57
+#: src/exercises/day-4/link-checker.md:78 src/android/aidl/client.md:34
+#: src/android/interoperability/java.md:59
+#: src/exercises/day-1/solutions-morning.md:76
+#: src/exercises/day-1/solutions-afternoon.md:103
+#: src/exercises/day-1/solutions-afternoon.md:139
+#: src/exercises/day-1/solutions-afternoon.md:148
+#: src/exercises/day-1/solutions-afternoon.md:176
+#: src/exercises/day-2/solutions-morning.md:44
+#: src/exercises/day-2/solutions-morning.md:55
+#: src/exercises/day-2/solutions-morning.md:66
+#: src/exercises/day-2/solutions-morning.md:107
+#: src/exercises/day-2/solutions-morning.md:130
+#: src/exercises/day-2/solutions-afternoon.md:47
+#: src/exercises/day-2/solutions-afternoon.md:137
+#: src/exercises/day-3/solutions-morning.md:115
+#: src/exercises/day-3/solutions-morning.md:137
+#: src/exercises/day-3/solutions-morning.md:155
+#: src/exercises/day-4/solutions-morning.md:58
+#: src/exercises/day-4/solutions-morning.md:102
+msgid "}"
+msgstr "}"
+
+#: src/basic-syntax/slices.md:13 src/basic-syntax/string-slices.md:18
+#: src/basic-syntax/functions.md:31 src/basic-syntax/methods.md:28
+#: src/basic-syntax/functions-interlude.md:23
+#: src/exercises/day-1/implicit-conversions.md:17
+#: src/exercises/day-1/for-loops.md:36 src/exercises/day-1/for-loops.md:78
+#: src/basic-syntax/type-inference.md:22 src/basic-syntax/type-inference.md:44
+#: src/basic-syntax/static-and-const.md:25
+#: src/basic-syntax/static-and-const.md:39
+#: src/basic-syntax/scopes-shadowing.md:21 src/ownership.md:16
+#: src/ownership/moves-function-calls.md:16 src/ownership/copy-clone.md:28
+#: src/ownership/borrowing.md:20 src/ownership/shared-unique-borrows.md:21
+#: src/std/rc.md:16 src/ownership/lifetimes-function-calls.md:19
+#: src/exercises/day-1/book-library.md:97
+#: src/exercises/day-1/iterators-and-ownership.md:32
+#: src/exercises/day-1/iterators-and-ownership.md:44
+#: src/exercises/day-1/iterators-and-ownership.md:81
+#: src/exercises/day-1/iterators-and-ownership.md:60
+#: src/exercises/day-1/iterators-and-ownership.md:101 src/structs.md:27
+#: src/structs/tuple-structs.md:12 src/structs/tuple-structs.md:33
+#: src/traits/default.md:36 src/generics/trait-objects.md:86
+#: src/structs/field-shorthand.md:23 src/enums.md:29
+#: src/enums/variant-payloads.md:31 src/enums/sizes.md:35 src/enums/sizes.md:85
+#: src/enums/sizes.md:134 src/methods.md:26 src/methods/example.md:42
+#: src/pattern-matching.md:19 src/pattern-matching/destructuring-enums.md:27
+#: src/exercises/day-2/points-polygons.md:113 src/exercises/day-2/luhn.md:70
+#: src/control-flow/blocks.md:36 src/control-flow/while-let-expressions.md:15
+#: src/control-flow/for-expressions.md:18 src/std/option-result.md:14
+#: src/std/string.md:20 src/std/vec.md:27 src/std/hashmap.md:34
+#: src/std/box-recursive.md:16 src/std/box-niche.md:14 src/std/rc.md:64
+#: src/modules.md:24 src/modules/visibility.md:35
+#: src/exercises/day-2/strings-iterators.md:52 src/traits.md:37
+#: src/traits/deriving-traits.md:19 src/traits/default-methods.md:28
+#: src/traits/iterator.md:28 src/traits/read-write.md:21
+#: src/traits/read-write.md:40 src/traits/operators.md:22 src/traits/drop.md:30
+#: src/generics/data-types.md:17 src/generics/methods.md:21
+#: src/generics/trait-bounds.md:31 src/generics/impl-trait.md:17
+#: src/generics/closures.md:21 src/generics/monomorphization.md:29
+#: src/generics/trait-objects.md:16 src/generics/trait-objects.md:37
+#: src/exercises/day-3/simple-gui.md:121 src/exercises/day-3/simple-gui.md:133
+#: src/error-handling/panic-unwind.md:17 src/error-handling/result.md:23
+#: src/error-handling/try-operator.md:46
+#: src/error-handling/converting-error-types-example.md:46
+#: src/error-handling/deriving-error-enums.md:35
+#: src/error-handling/dynamic-errors.md:32
+#: src/error-handling/error-contexts.md:31 src/testing/test-modules.md:24
+#: src/unsafe/raw-pointers.md:22 src/unsafe/mutable-static-variables.md:11
+#: src/unsafe/mutable-static-variables.md:28 src/unsafe/unions.md:17
+#: src/unsafe/calling-unsafe-functions.md:28
+#: src/unsafe/writing-unsafe-functions.md:29 src/unsafe/extern-functions.md:17
+#: src/unsafe/unsafe-traits.md:26 src/exercises/day-3/safe-ffi-wrapper.md:93
+#: src/concurrency/threads.md:22 src/concurrency/scoped-threads.md:15
+#: src/concurrency/scoped-threads.md:31 src/concurrency/channels.md:23
+#: src/concurrency/channels/unbounded.md:27
+#: src/concurrency/channels/bounded.md:27
+#: src/concurrency/shared_state/arc.md:23
+#: src/concurrency/shared_state/mutex.md:20
+#: src/concurrency/shared_state/example.md:19
+#: src/exercises/day-4/dining-philosophers.md:58
+#: src/exercises/day-4/link-checker.md:88 src/android/build-rules/binary.md:25
+#: src/android/build-rules/library.md:46 src/android/build-rules/library.md:57
+#: src/android/aidl/interface.md:15 src/android/aidl/implementation.md:24
+#: src/android/aidl/server.md:26 src/android/aidl/client.md:35
+#: src/android/aidl/changing.md:14 src/android/logging.md:40
+#: src/android/interoperability/with-c.md:18
+#: src/android/interoperability/with-c/bindgen.md:17
+#: src/android/interoperability/with-c/bindgen.md:31
+#: src/android/interoperability/with-c/bindgen.md:96
+#: src/android/interoperability/with-c/rust.md:35
+#: src/android/interoperability/with-c/rust.md:60
+#: src/android/interoperability/java.md:60
+#: src/exercises/day-1/solutions-afternoon.md:177
+#: src/exercises/day-2/solutions-morning.md:234
+#: src/exercises/day-2/solutions-afternoon.md:175
+#: src/exercises/day-3/solutions-morning.md:168
+#: src/exercises/day-3/solutions-afternoon.md:118
+#: src/exercises/day-4/solutions-morning.md:103
+msgid ""
+"```\n"
+"```"
+msgstr ""
+"```\n"
 "```"
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
-msgstr ""
-"* Wycinki pożyczają dane od ciętego typu.\n"
-"* Pytanie: Co się stanie, jeśli zmodyfikujesz `a[3]`?"
+msgid "Slices borrow data from the sliced type."
+msgstr "Wycinki pożyczają dane od ciętego typu."
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "Pytanie: Co się stanie, jeśli zmodyfikujesz `a[3]`?"
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
+"We create a slice by borrowing `a` and specifying the starting and ending "
 "indexes in brackets."
 msgstr ""
-"* Tworzymy wycinek, pożyczając `a` i określając indeksy początkowe i końcowe "
-"w nawiasach."
+"Tworzymy wycinek, pożyczając `a` i określając indeksy początkowe i końcowe w "
+"nawiasach."
 
 #: src/basic-syntax/slices.md:22
 msgid ""
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
 "starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
 "identical."
 msgstr ""
-"* Jeśli wycinek zaczyna się od indeksu 0, składnia zakresu Rusta pozwala nam "
+"Jeśli wycinek zaczyna się od indeksu 0, składnia zakresu Rusta pozwala nam "
 "pominąć indeks początkowy, co oznacza, że `&a[0..a.len()]` i `&a[..a.len()]` "
-"są identyczne .\n"
-"    \n"
-"* To samo dotyczy ostatniego indeksu, więc `&a[2..a.len()]` i `&a[2..]` są "
+"są identyczne ."
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"To samo dotyczy ostatniego indeksu, więc `&a[2..a.len()]` i `&a[2..]` są "
 "identyczne."
 
 #: src/basic-syntax/slices.md:26
 msgid ""
-"* To easily create a slice of the full array, we can therefore use `&a[..]`."
-msgstr "* Aby łatwo utworzyć wycinek pełnej tablicy, możemy zatem użyć `&a[..]`."
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr "Aby łatwo utworzyć wycinek pełnej tablicy, możemy zatem użyć `&a[..]`."
 
 #: src/basic-syntax/slices.md:28
 msgid ""
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
 "(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"computation on slices of different sizes."
 msgstr ""
-"* `s` jest referencją do wycinka elementów `i32`. Zauważ, że typ `s` "
+"`s` jest referencją do wycinka elementów `i32`. Zauważ, że typ `s` "
 "(`&[i32]`) nie wspomina już o długości tablicy. To pozwala nam wykonywać "
-"obliczenia na wycinkach o różnych rozmiarach.\n"
-" \n"
-"* Wycinki zawsze pożyczają od innego obiektu. W tym przykładzie `a` musi "
-"pozostać 'żywe' (w zakresie) przynajmniej tak długo, jak nasz wycinek.\n"
-"    \n"
-"* Pytanie o modyfikację `a[3]` może wywołać interesującą dyskusję, ale "
-"odpowiedź jest taka, że ze względów bezpieczeństwa pamięci\n"
-"  nie możesz tego zrobić przez `a` po utworzeniu wycinka, ale możesz "
-"bezpiecznie odczytać dane zarówno z `a` jak i `s`.\n"
-"  Więcej szczegółów zostanie wyjaśnionych w sekcji o nadzorcy pożyczania."
+"obliczenia na wycinkach o różnych rozmiarach."
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"Wycinki zawsze pożyczają od innego obiektu. W tym przykładzie `a` musi "
+"pozostać 'żywe' (w zakresie) przynajmniej tak długo, jak nasz wycinek."
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
+"Pytanie o modyfikację `a[3]` może wywołać interesującą dyskusję, ale "
+"odpowiedź jest taka, że ze względów bezpieczeństwa pamięci nie możesz tego "
+"zrobić przez `a` po utworzeniu wycinka, ale możesz bezpiecznie odczytać dane "
+"zarówno z `a` jak i `s`. Więcej szczegółów zostanie wyjaśnionych w sekcji o "
+"nadzorcy pożyczania."
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
-msgstr "# `String` i `str`"
+msgid "`String` vs `str`"
+msgstr "`String` i `str`"
 
 #: src/basic-syntax/string-slices.md:3
 msgid "We can now understand the two string types in Rust:"
@@ -3042,33 +3056,35 @@ msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let s1: &str = \"World\";\n"
-"    println!(\"s1: {s1}\");"
+"    println!(\"s1: {s1}\");\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let s1: &str = \"Świecie\";\n"
-"    println!(\"s1: {s1}\");"
+"    println!(\"s1: {s1}\");\n"
+"```"
 
 #: src/basic-syntax/string-slices.md:10
 msgid ""
-"    let mut s2: String = String::from(\"Hello \");\n"
-"    println!(\"s2: {s2}\");\n"
-"    s2.push_str(s1);\n"
-"    println!(\"s2: {s2}\");\n"
-"    \n"
-"    let s3: &str = &s2[6..];\n"
-"    println!(\"s3: {s3}\");\n"
-"}\n"
+"```\n"
+"let mut s2: String = String::from(\"Hello \");\n"
+"println!(\"s2: {s2}\");\n"
+"s2.push_str(s1);\n"
+"println!(\"s2: {s2}\");\n"
+"\n"
+"let s3: &str = &s2[6..];\n"
+"println!(\"s3: {s3}\");\n"
 "```"
 msgstr ""
-"    let mut s2: String = String::from(\"Witaj \");\n"
-"    println!(\"s2: {s2}\");\n"
-"    s2.push_str(s1);\n"
-"    println!(\"s2: {s2}\");\n"
-"    \n"
-"    let s3: &str = &s2[6..];\n"
-"    println!(\"s3: {s3}\");\n"
-"}\n"
+"```\n"
+"let mut s2: String = String::from(\"Witaj \");\n"
+"println!(\"s2: {s2}\");\n"
+"s2.push_str(s1);\n"
+"println!(\"s2: {s2}\");\n"
+"\n"
+"let s3: &str = &s2[6..];\n"
+"println!(\"s3: {s3}\");\n"
 "```"
 
 #: src/basic-syntax/string-slices.md:20
@@ -3076,223 +3092,203 @@ msgid "Rust terminology:"
 msgstr "Terminologia Rusta:"
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* `&str` to niezmienna referencja do wycinka łańcucha.\n"
-"* `String` to zmienny bufor łańcucha znaków."
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str` to niezmienna referencja do wycinka łańcucha."
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String` to zmienny bufor łańcucha znaków."
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary."
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* `&str` wprowadza fragment łańcucha, który jest niezmiennym odniesieniem do "
-"danych łańcuchowych zakodowanych w UTF-8\n"
-"  przechowywanych w bloku pamięci. Literały łańcuchowe (`\"Witaj\"`) są "
-"przechowywane w pliku binarnym programu."
+"`&str` wprowadza fragment łańcucha, który jest niezmiennym odniesieniem do "
+"danych łańcuchowych zakodowanych w UTF-8 przechowywanych w bloku pamięci. "
+"Literały łańcuchowe (`\"Witaj\"`) są przechowywane w pliku binarnym programu."
 
 #: src/basic-syntax/string-slices.md:30
 msgid ""
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods."
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
 msgstr ""
-"* Typ `String` to opakowanie dla wektora bajtów. Tak jak `Vec<T>`, ma dane na "
-"własność.\n"
-"    \n"
-"* Tak jak z wieloma innymi typami `String::from()` tworzy łańcuch z literału "
-"znaków; `String::new()` \n"
-"  tworzy pusty łańcuch, do którego można dodać dane za pomocą metod `push()` "
-"i `push_str()`."
+"Typ `String` to opakowanie dla wektora bajtów. Tak jak `Vec<T>`, ma dane na "
+"własność."
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"Tak jak z wieloma innymi typami `String::from()` tworzy łańcuch z literału "
+"znaków; `String::new()`  tworzy pusty łańcuch, do którego można dodać dane "
+"za pomocą metod `push()` i `push_str()`."
 
 #: src/basic-syntax/string-slices.md:35
 msgid ""
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of "
-"`std::string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    \n"
-"</details>"
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
 msgstr ""
-"* Makro `format!()` jest wygodnym sposobem generowania posiadanego łańcucha "
-"z wartości dynamicznych.\n"
-"  Akceptuje tę samą specyfikację formatu co `println!()`.\n"
-"    \n"
-"* Możesz pożyczyć wycinki `&str` ze `String` za pomocą `&` i opcjonalnego "
-"wyboru zakresu.\n"
-"    \n"
-"* Dla programistów C++: myśl o `&str` jako o `const char*` z C++, ale tym, "
-"które zawsze wskazuje\n"
-"  do prawidłowego ciągu w pamięci. Rust `String` jest przybliżonym "
-"odpowiednikiem `std::string` z C++\n"
-"  (główna różnica: może zawierać tylko bajty zakodowane w UTF-8 i nigdy nie "
-"użyje optymalizacji małych ciągów).\n"
-"    \n"
-"</details>"
+"Makro `format!()` jest wygodnym sposobem generowania posiadanego łańcucha z "
+"wartości dynamicznych. Akceptuje tę samą specyfikację formatu co `println!"
+"()`."
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
-msgstr "# Funkcje"
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+"Możesz pożyczyć wycinki `&str` ze `String` za pomocą `&` i opcjonalnego "
+"wyboru zakresu."
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"Dla programistów C++: myśl o `&str` jako o `const char*` z C++, ale tym, "
+"które zawsze wskazuje do prawidłowego ciągu w pamięci. Rust `String` jest "
+"przybliżonym odpowiednikiem `std::string` z C++ (główna różnica: może "
+"zawierać tylko bajty zakodowane w UTF-8 i nigdy nie użyje optymalizacji "
+"małych ciągów)."
 
 #: src/basic-syntax/functions.md:3
 msgid ""
-"A Rust version of the famous "
-"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
+"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
+"Fizz_buzz) interview question:"
 msgstr ""
-"Rustowa wersja słynnego pytania z rozmów o pracę "
-"[FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz):"
+"Rustowa wersja słynnego pytania z rozmów o pracę [FizzBuzz](https://en."
+"wikipedia.org/wiki/Fizz_buzz):"
 
 #: src/basic-syntax/functions.md:5
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    fizzbuzz_to(20);   // Defined below, no forward declaration needed\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    fizzbuzz_to(20);   // Zdefiniowany poniżej, nie ma potrzeby na "
 "deklarowanie z góry\n"
-"}"
+"}\n"
+"```"
 
 #: src/basic-syntax/functions.md:10
 msgid ""
-"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
-"    if rhs == 0 {\n"
-"        return false;  // Corner case, early return\n"
-"    }\n"
-"    lhs % rhs == 0     // The last expression in a block is the return "
-"value\n"
-"}"
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool { if rhs == 0 { return "
+"false;  // Corner case, early return } lhs % rhs == 0     // The last "
+"expression in a block is the return value }"
 msgstr ""
-"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
-"    if rhs == 0 {\n"
-"        return false;  // Szczególny przypadek, wczesne wyjście\n"
-"    }\n"
-"    lhs % rhs == 0     // Ostatnie wyrażenie w bloku to zwracana wartość\n"
-"}"
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool { if rhs == 0 { return "
+"false;  // Szczególny przypadek, wczesne wyjście } lhs % rhs == 0     // "
+"Ostatnie wyrażenie w bloku to zwracana wartość }"
 
 #: src/basic-syntax/functions.md:17
 msgid ""
 "fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit "
-"type `()`\n"
-"    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
-"        (true,  true)  => println!(\"fizzbuzz\"),\n"
-"        (true,  false) => println!(\"fizz\"),\n"
-"        (false, true)  => println!(\"buzz\"),\n"
-"        (false, false) => println!(\"{n}\"),\n"
-"    }\n"
-"}"
+"type `()` match (is_divisible_by(n, 3), is_divisible_by(n, 5)) { (true,  "
+"true)  => println!(\"fizzbuzz\"), (true,  false) => println!(\"fizz\"), "
+"(false, true)  => println!(\"buzz\"), (false, false) => println!"
+"(\"{n}\"), } }"
 msgstr ""
 "fn fizzbuzz(n: u32) -> () { // Brak wartości zwracanej oznacza zwrócenie "
-"typu jednostkowego `()`\n"
-"    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
-"        (true, true) => println!(\"fizzbuzz\"),\n"
-"        (true, false) => println!(\"fizz\"),\n"
-"        (false, true) => println!(\"buzz\"),\n"
-"        (false, false) => println!(\"{n}\"),\n"
-"    }\n"
-"}"
+"typu jednostkowego `()` match (is_divisible_by(n, 3), is_divisible_by(n, 5)) "
+"{ (true, true) => println!(\"fizzbuzz\"), (true, false) => println!"
+"(\"fizz\"), (false, true) => println!(\"buzz\"), (false, false) => println!"
+"(\"{n}\"), } }"
 
 #: src/basic-syntax/functions.md:26
 msgid ""
-"fn fizzbuzz_to(n: u32) {  // `-> ()` is normally omitted\n"
-"    for i in 1..=n {\n"
-"        fizzbuzz(i);\n"
-"    }\n"
-"}\n"
-"```"
+"fn fizzbuzz_to(n: u32) {  // `-> ()` is normally omitted for i in 1..=n "
+"{ fizzbuzz(i); } }"
 msgstr ""
-"fn fizzbuzz_to(n: u32) {  // `-> ()` jest zwykle pomijany\n"
-"    for i in 1..=n {\n"
-"        fizzbuzz(i);\n"
-"    }\n"
-"}\n"
-"```"
+"fn fizzbuzz_to(n: u32) {  // `-> ()` jest zwykle pomijany for i in 1..=n "
+"{ fizzbuzz(i); } }"
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
-"which causes it to include the upper bound.\n"
-"* The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
+msgstr ""
+"W `main` odnosimy się do funkcji napisanej poniżej. Nie ma potrzeby na "
+"deklaracje z gory lub na nagłówki. "
+
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+"Deklarowane parametry są poprzedzają typ (na odwrót w porównaniu do "
+"niektórych języków programowania), potem zwracany typ."
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+"Ostatnie wyrażenie w ciele funkcji (lub bloku) staje się zwracaną wartością. "
+"Wystarczy pominąć `;` na końcu wyrażenia."
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+"Niektóre funkcje nie zwracają wartości, ich zwracany typ to 'typ "
+"jednostkowy', `()`. Kompilator to wywnioskuje jeżeli `-> ()` jest pominięte."
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
+"which causes it to include the upper bound."
+msgstr ""
+"Wyrażenie zakresu w pętli `for` w `fizzbuzz_to()` zawiera `=n`, powoduje to "
+"zawarcie górnego zakresu."
+
+#: src/basic-syntax/functions.md:40
+msgid ""
+"The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
 "expanded below to show what is happening."
 msgstr ""
-"* W `main` odnosimy się do funkcji napisanej poniżej. Nie ma potrzeby na "
-"deklaracje z gory lub na nagłówki. \n"
-"* Deklarowane parametry są poprzedzają typ (na odwrót w porównaniu do "
-"niektórych języków programowania), potem zwracany typ.\n"
-"* Ostatnie wyrażenie w ciele funkcji (lub bloku) staje się zwracaną "
-"wartością. Wystarczy pominąć `;` na końcu wyrażenia.\n"
-"* Niektóre funkcje nie zwracają wartości, ich zwracany typ to 'typ "
-"jednostkowy', `()`. Kompilator to wywnioskuje jeżeli `-> ()` jest "
-"pominięte.\n"
-"* Wyrażenie zakresu w pętli `for` w `fizzbuzz_to()` zawiera `=n`, powoduje "
-"to zawarcie górnego zakresu.\n"
-"* Wyrażenie `match` w `fizzbuzz()` wykonuje wiele pracy. Jest rozwinięte "
+"Wyrażenie `match` w `fizzbuzz()` wykonuje wiele pracy. Jest rozwinięte "
 "poniżej żeby pokazać co się dzieje."
 
 #: src/basic-syntax/functions.md:42
-msgid "  (Type annotations added for clarity, but they can be elided.)"
-msgstr "  (Adnotacje typów dodane dla przejrzystości, ale można je pominąć.)"
+msgid "(Type annotations added for clarity, but they can be elided.)"
+msgstr "(Adnotacje typów dodane dla przejrzystości, ale można je pominąć.)"
 
 #: src/basic-syntax/functions.md:44
 msgid ""
-"  ```rust,ignore\n"
-"  let by_3: bool = is_divisible_by(n, 3);\n"
-"  let by_5: bool = is_divisible_by(n, 5);\n"
-"  let by_35: (bool, bool) = (by_3, by_5);\n"
-"  match by_35 {\n"
-"    // ...\n"
-"  ```"
+"```rust,ignore\n"
+"let by_3: bool = is_divisible_by(n, 3);\n"
+"let by_5: bool = is_divisible_by(n, 5);\n"
+"let by_35: (bool, bool) = (by_3, by_5);\n"
+"match by_35 {\n"
+"  // ...\n"
+"```"
 msgstr ""
-"  ```rust,ignore\n"
-"  let by_3: bool = is_divisible_by(n, 3);\n"
-"  let by_5: bool = is_divisible_by(n, 5);\n"
-"  let by_35: (bool, bool) = (by_3, by_5);\n"
-"  match by_35 {\n"
-"    // ...\n"
-"  ```"
-
-#: src/basic-syntax/functions.md:52
-msgid "  "
-msgstr "  "
-
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
-msgstr "# Metody"
+"```rust,ignore\n"
+"let by_3: bool = is_divisible_by(n, 3);\n"
+"let by_5: bool = is_divisible_by(n, 5);\n"
+"let by_35: (bool, bool) = (by_3, by_5);\n"
+"match by_35 {\n"
+"  // ...\n"
+"```"
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Rust has methods, they are simply functions that are associated with a "
-"particular type. The\n"
-"first argument of a method is an instance of the type it is associated with:"
+"particular type. The first argument of a method is an instance of the type "
+"it is associated with:"
 msgstr ""
-"Rust ma metody, są to po prostu funkcje powiązane z określonym typem.\n"
+"Rust ma metody, są to po prostu funkcje powiązane z określonym typem. "
 "Pierwszy argument metody jest instancją typu, z którym jest powiązana:"
 
 #: src/basic-syntax/methods.md:6
@@ -3301,87 +3297,83 @@ msgid ""
 "struct Rectangle {\n"
 "    width: u32,\n"
 "    height: u32,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "struct Rectangle {\n"
 "    width: u32,\n"
 "    height: u32,\n"
-"}"
+"}\n"
+"```"
 
 #: src/basic-syntax/methods.md:12
-msgid ""
-"impl Rectangle {\n"
-"    fn area(&self) -> u32 {\n"
-"        self.width * self.height\n"
-"    }"
-msgstr ""
-"impl Rectangle {\n"
-"    fn area(&self) -> u32 {\n"
-"        self.width * self.height\n"
-"    }"
+msgid "impl Rectangle { fn area(&self) -> u32 { self.width * self.height }"
+msgstr "impl Rectangle { fn area(&self) -> u32 { self.width * self.height }"
 
 #: src/basic-syntax/methods.md:17
 msgid ""
-"    fn inc_width(&mut self, delta: u32) {\n"
-"        self.width += delta;\n"
-"    }\n"
-"}"
+"```\n"
+"fn inc_width(&mut self, delta: u32) {\n"
+"    self.width += delta;\n"
+"}\n"
+"```"
 msgstr ""
-"    fn inc_width(&mut self, delta: u32) {\n"
-"        self.width += delta;\n"
-"    }\n"
-"}"
+"```\n"
+"fn inc_width(&mut self, delta: u32) {\n"
+"    self.width += delta;\n"
+"}\n"
+"```"
 
 #: src/basic-syntax/methods.md:22
 msgid ""
-"fn main() {\n"
-"    let mut rect = Rectangle { width: 10, height: 5 };\n"
-"    println!(\"old area: {}\", rect.area());\n"
-"    rect.inc_width(5);\n"
-"    println!(\"new area: {}\", rect.area());\n"
-"}\n"
-"```"
+"fn main() { let mut rect = Rectangle { width: 10, height: 5 }; println!"
+"(\"old area: {}\", rect.area()); rect.inc_width(5); println!(\"new area: "
+"{}\", rect.area()); }"
 msgstr ""
-"fn main() {\n"
-"    let mut rect = Rectangle { width: 10, height: 5 };\n"
-"    println!(\"stare pole: {}\", rect.area());\n"
-"    rect.inc_width(5);\n"
-"    println!(\"nowe pole: {}\", rect.area());\n"
-"}\n"
-"```"
+"fn main() { let mut rect = Rectangle { width: 10, height: 5 }; println!"
+"(\"stare pole: {}\", rect.area()); rect.inc_width(5); println!(\"nowe pole: "
+"{}\", rect.area()); }"
 
 #: src/basic-syntax/methods.md:30
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
-"* W dzisiejszym ćwiczeniu i na jutrzejszych zajęciach przyjrzymy się metodom "
+"W dzisiejszym ćwiczeniu i na jutrzejszych zajęciach przyjrzymy się metodom "
 "znacznie dokładniej."
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
-msgstr "# Przeciążanie funkcji"
+msgid "Function Overloading"
+msgstr "Przeciążanie funkcji"
 
 #: src/basic-syntax/functions-interlude.md:3
 msgid "Overloading is not supported:"
 msgstr "Przeciążanie nie jest obsługiwane:"
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* Każda funkcja ma jedną implementację:\n"
-"  * Zawsze przyjmuje stałą liczbę parametrów.\n"
-"  * Zawsze przyjmuje jeden zestaw typów parametrów.\n"
-"* Wartości domyślne nie są obsługiwane:\n"
-"  * Wszystkie wywołania mają taką samą liczbę argumentów.\n"
-"  * Makra są czasami używane jako alternatywa."
+msgid "Each function has a single implementation:"
+msgstr "Każda funkcja ma jedną implementację:"
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "Zawsze przyjmuje stałą liczbę parametrów."
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "Zawsze przyjmuje jeden zestaw typów parametrów."
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "Wartości domyślne nie są obsługiwane:"
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr "Wszystkie wywołania mają taką samą liczbę argumentów."
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "Makra są czasami używane jako alternatywa."
 
 #: src/basic-syntax/functions-interlude.md:12
 msgid "However, function parameters can be generic:"
@@ -3392,57 +3384,48 @@ msgid ""
 "```rust,editable\n"
 "fn pick_one<T>(a: T, b: T) -> T {\n"
 "    if std::process::id() % 2 == 0 { a } else { b }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn pick_one<T>(a: T, b: T) -> T {\n"
 "    if std::process::id() % 2 == 0 { a } else { b }\n"
-"}"
+"}\n"
+"```"
 
 #: src/basic-syntax/functions-interlude.md:19
 msgid ""
-"fn main() {\n"
-"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
-"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
-"}\n"
-"```"
+"fn main() { println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\")); "
+"println!(\"cash prize: {}\", pick_one(500, 1000)); }"
 msgstr ""
-"fn main() {\n"
-"    println!(\"rzut monetą: {}\", pick_one(\"orzeł\", \"reszka\"));\n"
-"    println!(\"nagroda: {}\", pick_one(500, 1000));\n"
-"}\n"
-"```"
+"fn main() { println!(\"rzut monetą: {}\", pick_one(\"orzeł\", \"reszka\")); "
+"println!(\"nagroda: {}\", pick_one(500, 1000)); }"
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
-"* Podczas korzystania z typów generycznych, `Into<T>` z biblioteki "
-"standardowej może zapewnić pewnego rodzaju ograniczony\n"
-"  polimorfizm typów argumentów. Więcej szczegółów zobaczymy w dalszej części."
-
-#: src/basic-syntax/functions-interlude.md:30
-msgid "</defails>"
-msgstr "</defails>"
+"Podczas korzystania z typów generycznych, `Into<T>` z biblioteki "
+"standardowej może zapewnić pewnego rodzaju ograniczony polimorfizm typów "
+"argumentów. Więcej szczegółów zobaczymy w dalszej części."
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
-msgstr "# Dzień 1: Ćwiczenia poranne"
+msgid "Day 1: Morning Exercises"
+msgstr "Dzień 1: Ćwiczenia poranne"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
 msgstr "W tych ćwiczeniach przyjrzymy się dwóm częściom Rusta:"
 
 #: src/exercises/day-1/morning.md:5
-msgid "* Implicit conversions between types."
-msgstr "* Niejawne konwersje między typami."
+msgid "Implicit conversions between types."
+msgstr "Niejawne konwersje między typami."
 
 #: src/exercises/day-1/morning.md:7
-msgid "* Arrays and `for` loops."
-msgstr "* Tablice i pętle `for`."
+msgid "Arrays and `for` loops."
+msgstr "Tablice i pętle `for`."
 
 #: src/exercises/day-1/morning.md:11
 msgid "A few things to consider while solving the exercises:"
@@ -3451,175 +3434,139 @@ msgstr ""
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* Jeśli to możliwe, użyj lokalnej instalacji Rusta. W ten sposób możesz "
-"dostać\n"
-"  autouzupełnianie w twoim edytorze. Więcej informacji o instalowaniu Rusta "
-"znajdziesz na stronie o [Korzystaniu z Cargo]."
+"Jeśli to możliwe, użyj lokalnej instalacji Rusta. W ten sposób możesz dostać "
+"autouzupełnianie w twoim edytorze. Więcej informacji o instalowaniu Rusta "
+"znajdziesz na stronie o [Korzystaniu z Cargo](../../cargo.md)."
 
 #: src/exercises/day-1/morning.md:17
-msgid "* Alternatively, use the Rust Playground."
-msgstr "* Ewentualnie skorzystaj z Rust Playground."
+msgid "Alternatively, use the Rust Playground."
+msgstr "Ewentualnie skorzystaj z Rust Playground."
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
-"Fragmentów kodu celowo nie można edytować: wbudowane fragmenty kodu tracą\n"
+"Fragmentów kodu celowo nie można edytować: wbudowane fragmenty kodu tracą "
 "stan, jeśli opuścisz stronę."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
 #: src/exercises/day-3/morning.md:7 src/exercises/day-4/morning.md:12
-msgid "After looking at the exercises, you can look at the [solutions] provided."
-msgstr "Po obejrzeniu ćwiczeń możesz spojrzeć na dostarczone [rozwiązania]."
-
-#: src/exercises/day-1/morning.md:24 src/exercises/day-2/morning.md:13
-#: src/exercises/day-3/morning.md:9 src/exercises/day-4/morning.md:14
-msgid "[solutions]: solutions-morning.md"
-msgstr "[rozwiązania]: solutions-morning.md"
-
-#: src/exercises/day-1/morning.md:26
-msgid "[Using Cargo]: ../../cargo.md"
-msgstr "[Korzystaniu z Cargo]: ../../cargo.md"
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
-msgstr "# Niejawne konwersje"
+msgid ""
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
+msgstr ""
+"Po obejrzeniu ćwiczeń możesz spojrzeć na dostarczone \\[rozwiązania\\]."
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
 "Rust nie zastosuje automatycznie _niejawnych konwersji_ między typami ([w "
-"przeciwieństwie do\n"
-"C++][3]). Możesz to zobaczyć w takim programie:"
+"przeciwieństwie do C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). Możesz to zobaczyć w takim programie:"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn multiply(x: i16, y: i16) -> i16 {\n"
 "    x * y\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable,compile_fail\n"
 "fn multiply(x: i16, y: i16) -> i16 {\n"
 "    x * y\n"
-"}"
+"}\n"
+"```"
 
 #: src/exercises/day-1/implicit-conversions.md:11
-msgid ""
-"fn main() {\n"
-"    let x: i8 = 15;\n"
-"    let y: i16 = 1000;"
-msgstr ""
-"fn main() {\n"
-"    let x: i8 = 15;\n"
-"    let y: i16 = 1000;"
+msgid "fn main() { let x: i8 = 15; let y: i16 = 1000;"
+msgstr "fn main() { let x: i8 = 15; let y: i16 = 1000;"
 
 #: src/exercises/day-1/implicit-conversions.md:15
 msgid ""
-"    println!(\"{x} * {y} = {}\", multiply(x, y));\n"
-"}\n"
+"```\n"
+"println!(\"{x} * {y} = {}\", multiply(x, y));\n"
 "```"
 msgstr ""
-"    println!(\"{x} * {y} = {}\", multiply(x, y));\n"
-"}\n"
+"```\n"
+"println!(\"{x} * {y} = {}\", multiply(x, y));\n"
 "```"
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Wszystkie typy całkowite w Ruście implementują cechy [`From<T>`][1] i "
-"[`Into<T>`][2]\n"
-"aby umożliwić nam konwersję między nimi. Cecha `From<T>` ma jedną metodę "
-"`from()`\n"
-"i podobnie cecha `Into<T>` ma jedną metodę `into()`.\n"
-"Implementacja tych cech to wyrażenie, w jaki sposób można przekształcić dany "
-"typ\n"
-"w inny typ."
+"Wszystkie typy całkowite w Ruście implementują cechy [`From<T>`](https://doc."
+"rust-lang.org/std/convert/trait.From.html) i [`Into<T>`](https://doc.rust-"
+"lang.org/std/convert/trait.Into.html) aby umożliwić nam konwersję między "
+"nimi. Cecha `From<T>` ma jedną metodę `from()` i podobnie cecha `Into<T>` ma "
+"jedną metodę `into()`. Implementacja tych cech to wyrażenie, w jaki sposób "
+"można przekształcić dany typ w inny typ."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
-"Standardowa biblioteka ma implementację `From<i8>` dla `i16`, co oznacza\n"
-"że możemy zamienić zmienną `x` typu `i8` na `i16` przez wywołanie\n"
-"`i16::from(x)`. Lub, prościej, za pomocę `x.into()`, ponieważ implementacja "
-"`From<i8>` dla `i16`\n"
-"automatycznie tworzy implementację `Into<i16>` dla `i8`."
+"Standardowa biblioteka ma implementację `From<i8>` dla `i16`, co oznacza że "
+"możemy zamienić zmienną `x` typu `i8` na `i16` przez wywołanie `i16::"
+"from(x)`. Lub, prościej, za pomocę `x.into()`, ponieważ implementacja "
+"`From<i8>` dla `i16` automatycznie tworzy implementację `Into<i16>` dla `i8`."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
 "To samo dotyczy twoich własnych implementacji `From` dla twoich własnych "
-"typów, więc\n"
-"wystarczy zaimplementować tylko `From`, aby automatycznie uzyskać "
-"odpowiednią implementację `Into`."
+"typów, więc wystarczy zaimplementować tylko `From`, aby automatycznie "
+"uzyskać odpowiednią implementację `Into`."
 
 #: src/exercises/day-1/implicit-conversions.md:33
-msgid "1. Execute the above program and look at the compiler error."
-msgstr "1. Uruchom powyższy program i spójrz na błąd kompilatora."
+msgid "Execute the above program and look at the compiler error."
+msgstr "Uruchom powyższy program i spójrz na błąd kompilatora."
 
 #: src/exercises/day-1/implicit-conversions.md:35
-msgid "2. Update the code above to use `into()` to do the conversion."
+msgid "Update the code above to use `into()` to do the conversion."
 msgstr ""
-"2. Zaktualizuj powyższy kod, aby użyć funkcji `into()` do przeprowadzenia "
+"Zaktualizuj powyższy kod, aby użyć funkcji `into()` do przeprowadzenia "
 "konwersji."
 
 #: src/exercises/day-1/implicit-conversions.md:37
 msgid ""
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
-"3. Zmień typy `x` i `y` na inne (takie jak `f32`, `bool`,\n"
-"   `i128`), aby zobaczyć, które typy można przekonwertować na inne typy. "
-"Spróbuj\n"
-"   konwertować małe typy na duże i na odwrót. Sprawdź\n"
-"   [dokumentację biblioteki standardowej][1], aby zobaczyć, czy `From<T>` "
-"jest zaimplementowane\n"
-"   dla pary typów, które sprawdzasz."
-
-#: src/exercises/day-1/implicit-conversions.md:43
-msgid ""
-"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-"[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
-msgstr ""
-"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-"[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
+"Zmień typy `x` i `y` na inne (takie jak `f32`, `bool`, `i128`), aby "
+"zobaczyć, które typy można przekonwertować na inne typy. Spróbuj konwertować "
+"małe typy na duże i na odwrót. Sprawdź [dokumentację biblioteki standardowej]"
+"(https://doc.rust-lang.org/std/convert/trait.From.html), aby zobaczyć, czy "
+"`From<T>` jest zaimplementowane dla pary typów, które sprawdzasz."
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
-msgstr "# Tablice i pętle `for`"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "Tablice i pętle `for`"
 
 #: src/exercises/day-1/for-loops.md:3
 msgid "We saw that an array can be declared like this:"
@@ -3637,8 +3584,8 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:9
 msgid ""
-"You can print such an array by asking for its debug representation with "
-"`{:?}`:"
+"You can print such an array by asking for its debug representation with `{:?}"
+"`:"
 msgstr ""
 "Możesz wydrukować taką tablicę, prosząc o jej reprezentację debugowania za "
 "pomocą `{:?}`:"
@@ -3661,7 +3608,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr ""
 "Rust pozwala iterować po takich rzeczach, jak tablice i zakresy, używając "
@@ -3676,7 +3623,8 @@ msgid ""
 "    for n in array {\n"
 "        print!(\" {n}\");\n"
 "    }\n"
-"    println!();"
+"    println!();\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
@@ -3685,36 +3633,36 @@ msgstr ""
 "    for n in array {\n"
 "        print!(\" {n}\");\n"
 "    }\n"
-"    println!();"
+"    println!();\n"
+"```"
 
 #: src/exercises/day-1/for-loops.md:30
 msgid ""
-"    print!(\"Iterating over range:\");\n"
-"    for i in 0..3 {\n"
-"        print!(\" {}\", array[i]);\n"
-"    }\n"
-"    println!();\n"
+"```\n"
+"print!(\"Iterating over range:\");\n"
+"for i in 0..3 {\n"
+"    print!(\" {}\", array[i]);\n"
 "}\n"
+"println!();\n"
 "```"
 msgstr ""
-"    print!(\"Iterowanie po zakresie:\");\n"
-"    for i in 0..3 {\n"
-"        print!(\" {}\", array[i]);\n"
-"    }\n"
-"    println!();\n"
+"```\n"
+"print!(\"Iterowanie po zakresie:\");\n"
+"for i in 0..3 {\n"
+"    print!(\" {}\", array[i]);\n"
 "}\n"
+"println!();\n"
 "```"
 
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
 "Użyj powyższego, aby napisać funkcję `pretty_print`, która ładnie drukuje "
-"macierz i\n"
-"funkcję `transpose`, która transponuje macierz (zamienia wiersze na kolumny):"
+"macierz i funkcję `transpose`, która transponuje macierz (zamienia wiersze "
+"na kolumny):"
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3736,10 +3684,10 @@ msgstr "Zakoduj na stałe obie funkcje, aby działały na macierzach 3 × 3."
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
-"Skopiuj poniższy kod do <https://play.rust-lang.org/> i zaimplementuj\n"
+"Skopiuj poniższy kod do <https://play.rust-lang.org/> i zaimplementuj "
 "funkcje:"
 
 #: src/exercises/day-1/for-loops.md:52 src/exercises/day-1/book-library.md:20
@@ -3747,87 +3695,80 @@ msgstr ""
 msgid ""
 "```rust,should_panic\n"
 "// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]"
+"#![allow(unused_variables, dead_code)]\n"
+"```"
 msgstr ""
 "```rust,should_panic\n"
 "// TODO: usuń to jak skończysz implementację.\n"
-"#![allow(unused_variables, dead_code)]"
+"#![allow(unused_variables, dead_code)]\n"
+"```"
 
 #: src/exercises/day-1/for-loops.md:56
 msgid ""
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    unimplemented!()\n"
-"}"
+"fn transpose(matrix: \\[\\[i32; 3\\]; 3\\]) -> \\[\\[i32; 3\\]; 3\\] "
+"{ unimplemented!() }"
 msgstr ""
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    unimplemented!()\n"
-"}"
+"fn transpose(matrix: \\[\\[i32; 3\\]; 3\\]) -> \\[\\[i32; 3\\]; 3\\] "
+"{ unimplemented!() }"
 
 #: src/exercises/day-1/for-loops.md:60
-msgid ""
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    unimplemented!()\n"
-"}"
-msgstr ""
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    unimplemented!()\n"
-"}"
+msgid "fn pretty_print(matrix: &\\[\\[i32; 3\\]; 3\\]) { unimplemented!() }"
+msgstr "fn pretty_print(matrix: &\\[\\[i32; 3\\]; 3\\]) { unimplemented!() }"
 
 #: src/exercises/day-1/for-loops.md:64
 msgid ""
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];"
+"fn main() { let matrix = \\[ \\[101, 102, 103\\], // \\<\\-- the comment "
+"makes rustfmt add a newline \\[201, 202, 203\\], \\[301, 302, 303\\], \\];"
 msgstr ""
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- ten komentarz powoduje, że rustfmt dodaje "
-"nową linię\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];"
+"fn main() { let matrix = \\[ \\[101, 102, 103\\], // \\<\\-- ten komentarz "
+"powoduje, że rustfmt dodaje nową linię \\[201, 202, 203\\], \\[301, 302, "
+"303\\], \\];"
 
-#: src/exercises/day-1/for-loops.md:71 src/exercises/day-1/solutions-morning.md:70
-msgid "    println!(\"matrix:\");\n    pretty_print(&matrix);"
-msgstr "    println!(\"matrix:\");\n    pretty_print(&matrix);"
-
-#: src/exercises/day-1/for-loops.md:74
+#: src/exercises/day-1/for-loops.md:71
+#: src/exercises/day-1/solutions-morning.md:70
 msgid ""
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
+"```\n"
+"println!(\"matrix:\");\n"
+"pretty_print(&matrix);\n"
 "```"
 msgstr ""
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
+"```\n"
+"println!(\"matrix:\");\n"
+"pretty_print(&matrix);\n"
+"```"
+
+#: src/exercises/day-1/for-loops.md:74
+#: src/exercises/day-1/solutions-morning.md:73
+msgid ""
+"```\n"
+"let transposed = transpose(matrix);\n"
+"println!(\"transposed:\");\n"
+"pretty_print(&transposed);\n"
+"```"
+msgstr ""
+"```\n"
+"let transposed = transpose(matrix);\n"
+"println!(\"transposed:\");\n"
+"pretty_print(&transposed);\n"
 "```"
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
-msgstr "## Dodatkowe pytanie"
+msgid "Bonus Question"
+msgstr "Dodatkowe pytanie"
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
 "Czy mógłbyś użyć wycinków `&[i32]` zamiast zakodowanych na stałe macierzy 3 "
-"× 3 dla\n"
-"typów argumentów i typów zwracanych? Coś w stylu `&[&[i32]]` dla "
-"dwuwymiarowych\n"
-"wycinków-wycinków. Dlaczego tak lub dlaczego nie?"
+"× 3 dla typów argumentów i typów zwracanych? Coś w stylu `&[&[i32]]` dla "
+"dwuwymiarowych wycinków-wycinków. Dlaczego tak lub dlaczego nie?"
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
 "Zobacz [skrzynię `ndarray`](https://docs.rs/ndarray/) dla implementacji "
@@ -3835,21 +3776,16 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"Rozwiązanie i odpowiedź do sekcji bonusowej są dostępne w\n"
-"sekcji [Rozwiązanie](solutions-morning.md#arrays-and-for-loops)."
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
-msgstr "# Zmienne"
+"Rozwiązanie i odpowiedź do sekcji bonusowej są dostępne w sekcji "
+"[Rozwiązanie](solutions-morning.md#arrays-and-for-loops)."
 
 #: src/basic-syntax/variables.md:3
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
+"by default:"
 msgstr ""
 "Rust zapewnia bezpieczeństwo typów dzięki statycznemu typowaniu. Wiązania "
 "zmiennych są domyślnie niezmienne:"
@@ -3876,89 +3812,82 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
+msgstr ""
+"Ze względu na wnioskowanie o typie `i32` jest opcjonalne. Stopniowo będziemy "
+"pokazywać mniej typów w miarę postępów w kursie."
+
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
 "function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
-"* Ze względu na wnioskowanie o typie `i32` jest opcjonalne. Stopniowo "
-"będziemy pokazywać mniej typów w miarę postępów w kursie.\n"
-"* Zauważ, że ponieważ `println!` jest makrem, `x` nie jest przenoszone, "
-"nawet przy użyciu składni podobnej do funkcji `println!(\"x: {}\", x)`"
-
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
-msgstr "# Wnioskowanie typów"
+"Zauważ, że ponieważ `println!` jest makrem, `x` nie jest przenoszone, nawet "
+"przy użyciu składni podobnej do funkcji `println!(\"x: {}\", x)`"
 
 #: src/basic-syntax/type-inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
-msgstr "Rust sprawdzi, w jaki sposób zmienna jest _używana_ do określenia typu:"
+msgstr ""
+"Rust sprawdzi, w jaki sposób zmienna jest _używana_ do określenia typu:"
 
 #: src/basic-syntax/type-inference.md:5
 msgid ""
 "```rust,editable\n"
 "fn takes_u32(x: u32) {\n"
 "    println!(\"u32: {x}\");\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn takes_u32(x: u32) {\n"
 "    println!(\"u32: {x}\");\n"
-"}"
+"}\n"
+"```"
 
 #: src/basic-syntax/type-inference.md:10
-msgid ""
-"fn takes_i8(y: i8) {\n"
-"    println!(\"i8: {y}\");\n"
-"}"
-msgstr ""
-"fn takes_i8(y: i8) {\n"
-"    println!(\"i8: {y}\");\n"
-"}"
+msgid "fn takes_i8(y: i8) { println!(\"i8: {y}\"); }"
+msgstr "fn takes_i8(y: i8) { println!(\"i8: {y}\"); }"
 
 #: src/basic-syntax/type-inference.md:14
-msgid ""
-"fn main() {\n"
-"    let x = 10;\n"
-"    let y = 20;"
-msgstr ""
-"fn main() {\n"
-"    let x = 10;\n"
-"    let y = 20;"
+msgid "fn main() { let x = 10; let y = 20;"
+msgstr "fn main() { let x = 10; let y = 20;"
 
 #: src/basic-syntax/type-inference.md:18
 msgid ""
-"    takes_u32(x);\n"
-"    takes_i8(y);\n"
-"    // takes_u32(y);\n"
-"}\n"
+"```\n"
+"takes_u32(x);\n"
+"takes_i8(y);\n"
+"// takes_u32(y);\n"
 "```"
 msgstr ""
-"    takes_u32(x);\n"
-"    takes_i8(y);\n"
-"    // takes_u32(y);\n"
-"}\n"
+"```\n"
+"takes_u32(x);\n"
+"takes_i8(y);\n"
+"// takes_u32(y);\n"
 "```"
 
 #: src/basic-syntax/type-inference.md:26
 msgid ""
 "This slide demonstrates how the Rust compiler infers types based on "
-"constraints given by variable declarations and usages.\n"
-"    \n"
-"It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"constraints given by variable declarations and usages."
 msgstr ""
 "Ten slajd pokazuje, w jaki sposób kompilator Rusta wnioskuje o typach na "
-"podstawie ograniczeń nałożonych przez deklaracje i zastosowania zmiennych.\n"
-"    \n"
+"podstawie ograniczeń nałożonych przez deklaracje i zastosowania zmiennych."
+
+#: src/basic-syntax/type-inference.md:28
+msgid ""
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
+msgstr ""
 "Bardzo ważne jest podkreślenie, że zmienne zadeklarowane w ten sposób nie są "
-"jakimś dynamicznym „dowolnym typem”, który może\n"
-"przechowywać dowolne dane. Kod maszynowy generowany przez taką deklarację "
-"jest identyczny z jawną deklaracją typu.\n"
-"Kompilator wykonuje to za nas i pomaga nam pisać bardziej zwięzły kod."
+"jakimś dynamicznym „dowolnym typem”, który może przechowywać dowolne dane. "
+"Kod maszynowy generowany przez taką deklarację jest identyczny z jawną "
+"deklaracją typu. Kompilator wykonuje to za nas i pomaga nam pisać bardziej "
+"zwięzły kod."
 
 #: src/basic-syntax/type-inference.md:32
 msgid ""
@@ -3977,49 +3906,51 @@ msgid ""
 "    let mut v = Vec::new();\n"
 "    v.push((10, false));\n"
 "    v.push((20, true));\n"
-"    println!(\"v: {v:?}\");"
+"    println!(\"v: {v:?}\");\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let mut v = Vec::new();\n"
 "    v.push((10, false));\n"
 "    v.push((20, true));\n"
-"    println!(\"v: {v:?}\");"
+"    println!(\"v: {v:?}\");\n"
+"```"
 
 #: src/basic-syntax/type-inference.md:41
 msgid ""
-"    let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
-"    println!(\"vv: {vv:?}\");\n"
-"}\n"
+"```\n"
+"let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
+"println!(\"vv: {vv:?}\");\n"
 "```"
 msgstr ""
-"    let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
-"    println!(\"vv: {vv:?}\");\n"
-"}\n"
+"```\n"
+"let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
+"println!(\"vv: {vv:?}\");\n"
 "```"
 
 #: src/basic-syntax/type-inference.md:46
 msgid ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
-"relies on `FromIterator`, which "
-"[`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"implements."
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) relies on `FromIterator`, which [`HashSet`](https://doc."
+"rust-lang.org/std/iter/trait.FromIterator.html) implements."
 msgstr ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) "
-"polega na `FromIterator`, który [`HashSet`](https:/ "
-"/doc.rust-lang.org/std/iter/trait.FromIterator.html) implementuje."
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) polega na `FromIterator`, który \\[`HashSet`\\]"
+"(https:/ /doc.rust-lang.org/std/iter/trait.FromIterator.html) implementuje."
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
-msgstr "# Zmienne statyczne i stałe"
+msgid "Static and Constant Variables"
+msgstr "Zmienne statyczne i stałe"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid "Global state is managed with static and constant variables."
-msgstr "Stan globalny jest zarządzany za pomocą zmiennych statycznych i stałych."
+msgstr ""
+"Stan globalny jest zarządzany za pomocą zmiennych statycznych i stałych."
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
-msgstr "## `const`"
+msgid "`const`"
+msgstr "`const`"
 
 #: src/basic-syntax/static-and-const.md:7
 msgid "You can declare compile-time constants:"
@@ -4029,191 +3960,198 @@ msgstr "Możesz zadeklarować stałe czasu kompilacji:"
 msgid ""
 "```rust,editable\n"
 "const DIGEST_SIZE: usize = 3;\n"
-"const ZERO: Option<u8> = Some(42);"
+"const ZERO: Option<u8> = Some(42);\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "const DIGEST_SIZE: usize = 3;\n"
-"const ZERO: Option<u8> = Some(42);"
+"const ZERO: Option<u8> = Some(42);\n"
+"```"
 
 #: src/basic-syntax/static-and-const.md:13
 msgid ""
-"fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
-"    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
-"    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
-"        digest[idx % DIGEST_SIZE] = digest[idx % "
-"DIGEST_SIZE].wrapping_add(b);\n"
-"    }\n"
-"    digest\n"
-"}"
+"fn compute_digest(text: &str) -> \\[u8; DIGEST_SIZE\\] { let mut digest = "
+"\\[ZERO.unwrap_or(0); DIGEST_SIZE\\]; for (idx, &b) in text.as_bytes()."
+"iter().enumerate() { digest\\[idx % DIGEST_SIZE\\] = digest\\[idx % "
+"DIGEST_SIZE\\].wrapping_add(b); } digest }"
 msgstr ""
-"fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
-"    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
-"    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
-"        digest[idx % DIGEST_SIZE] = digest[idx % "
-"DIGEST_SIZE].wrapping_add(b);\n"
-"    }\n"
-"    digest\n"
-"}"
+"fn compute_digest(text: &str) -> \\[u8; DIGEST_SIZE\\] { let mut digest = "
+"\\[ZERO.unwrap_or(0); DIGEST_SIZE\\]; for (idx, &b) in text.as_bytes()."
+"iter().enumerate() { digest\\[idx % DIGEST_SIZE\\] = digest\\[idx % "
+"DIGEST_SIZE\\].wrapping_add(b); } digest }"
 
 #: src/basic-syntax/static-and-const.md:21
 msgid ""
-"fn main() {\n"
-"    let digest = compute_digest(\"Hello\");\n"
-"    println!(\"Digest: {digest:?}\");\n"
-"}\n"
-"```"
+"fn main() { let digest = compute_digest(\"Hello\"); println!(\"Digest: "
+"{digest:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    let digest = compute_digest(\"Hello\");\n"
-"    println!(\"Digest: {digest:?}\");\n"
-"}\n"
-"```"
+"fn main() { let digest = compute_digest(\"Hello\"); println!(\"Digest: "
+"{digest:?}\"); }"
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According the the [Rust RFC Book][1] these are inlined upon use."
-msgstr "Zgodnie z [książką Rust RFC][1] są one wstawiane podczas użycia."
+msgid ""
+"According the the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-"
+"const-vs-static.html) these are inlined upon use."
+msgstr ""
+"Zgodnie z [książką Rust RFC](https://rust-lang.github.io/rfcs/0246-const-vs-"
+"static.html) są one wstawiane podczas użycia."
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
-msgstr "## `static`"
+msgid "`static`"
+msgstr "`static`"
 
 #: src/basic-syntax/static-and-const.md:31
 msgid "You can also declare static variables:"
 msgstr "Możesz także zadeklarować zmienne statyczne:"
 
 #: src/basic-syntax/static-and-const.md:33
-msgid "```rust,editable\nstatic BANNER: &str = \"Welcome to RustOS 3.14\";"
-msgstr "```rust,editable\nstatic BANNER: &str = \"Witamy w RustOS 3.14\";"
-
-#: src/basic-syntax/static-and-const.md:36
 msgid ""
-"fn main() {\n"
-"    println!(\"{BANNER}\");\n"
-"}\n"
+"```rust,editable\n"
+"static BANNER: &str = \"Welcome to RustOS 3.14\";\n"
 "```"
 msgstr ""
-"fn main() {\n"
-"    println!(\"{BANNER}\");\n"
-"}\n"
+"```rust,editable\n"
+"static BANNER: &str = \"Witamy w RustOS 3.14\";\n"
 "```"
+
+#: src/basic-syntax/static-and-const.md:36
+msgid "fn main() { println!(\"{BANNER}\"); }"
+msgstr "fn main() { println!(\"{BANNER}\"); }"
 
 #: src/basic-syntax/static-and-const.md:41
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
-"Jak zauważono w [książce Rust RFC][1], nie są one wstawiane podczas użycia i "
-"mają rzeczywistą powiązaną lokalizację pamięci. Jest to przydatne w "
-"przypadku niebezpiecznego i osadzonego kodu, a zmienna żyje przez całe "
-"wykonanie programu."
+"Jak zauważono w [książce Rust RFC](https://rust-lang.github.io/rfcs/0246-"
+"const-vs-static.html), nie są one wstawiane podczas użycia i mają "
+"rzeczywistą powiązaną lokalizację pamięci. Jest to przydatne w przypadku "
+"niebezpiecznego i osadzonego kodu, a zmienna żyje przez całe wykonanie "
+"programu."
 
 #: src/basic-syntax/static-and-const.md:44
 msgid ""
-"We will look at mutating static data in the [chapter on Unsafe "
-"Rust](../unsafe.md)."
+"We will look at mutating static data in the [chapter on Unsafe Rust](../"
+"unsafe.md)."
 msgstr ""
 "Przyjrzymy się zmienianiu danych statycznych w [rozdziale dotyczącym "
 "niebezpiecznego Rusta](../unsafe.md)."
 
 #: src/basic-syntax/static-and-const.md:48
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
-"* Wspomnij, że `const` zachowuje się semantycznie podobnie do `constexpr` "
-"C++.\n"
-"* Z drugiej strony `static` jest znacznie bardziej podobny do `const` lub "
-"mutowalnej zmiennej globalnej w C++.\n"
-"* Nie jest bardzo powszechne, że ktoś potrzebowałby stałej wyliczanej w "
-"czasie wykonywania, ale jest to pomocne i bezpieczniejsze niż używanie "
-"zmiennej statycznej."
+"Wspomnij, że `const` zachowuje się semantycznie podobnie do `constexpr` C++."
 
-#: src/basic-syntax/static-and-const.md:54
-msgid "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
-msgstr "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
+#: src/basic-syntax/static-and-const.md:49
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+"Z drugiej strony `static` jest znacznie bardziej podobny do `const` lub "
+"mutowalnej zmiennej globalnej w C++."
 
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
-msgstr "# Zakresy i przesłanianie"
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+"Nie jest bardzo powszechne, że ktoś potrzebowałby stałej wyliczanej w czasie "
+"wykonywania, ale jest to pomocne i bezpieczniejsze niż używanie zmiennej "
+"statycznej."
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
+"the same scope:"
 msgstr ""
 "Możesz przesłaniać zmienne, zarówno te z zakresów zewnętrznych, jak i "
-"zmienne z\n"
-"tego samego zakresu:"
+"zmienne z tego samego zakresu:"
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let a = 10;\n"
-"    println!(\"before: {a}\");"
+"    println!(\"before: {a}\");\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let a = 10;\n"
-"    println!(\"przedtem: {a}\");"
+"    println!(\"przedtem: {a}\");\n"
+"```"
 
 #: src/basic-syntax/scopes-shadowing.md:11
 msgid ""
-"    {\n"
-"        let a = \"hello\";\n"
-"        println!(\"inner scope: {a}\");"
+"```\n"
+"{\n"
+"    let a = \"hello\";\n"
+"    println!(\"inner scope: {a}\");\n"
+"```"
 msgstr ""
-"    {\n"
-"        let a = \"cześć\";\n"
-"        println!(\"wewnętrzny zakres: {a}\");"
+"```\n"
+"{\n"
+"    let a = \"cześć\";\n"
+"    println!(\"wewnętrzny zakres: {a}\");\n"
+"```"
 
 #: src/basic-syntax/scopes-shadowing.md:15
 msgid ""
-"        let a = true;\n"
-"        println!(\"shadowed in inner scope: {a}\");\n"
-"    }"
-msgstr ""
-"        let a = true;\n"
-"        println!(\"przesłonięta w wewnętrznym zakresie: {a}\");\n"
-"    }"
-
-#: src/basic-syntax/scopes-shadowing.md:19
-msgid ""
-"    println!(\"after: {a}\");\n"
+"```\n"
+"    let a = true;\n"
+"    println!(\"shadowed in inner scope: {a}\");\n"
 "}\n"
 "```"
 msgstr ""
-"    println!(\"potem: {a}\");\n"
+"```\n"
+"    let a = true;\n"
+"    println!(\"przesłonięta w wewnętrznym zakresie: {a}\");\n"
 "}\n"
+"```"
+
+#: src/basic-syntax/scopes-shadowing.md:19
+msgid ""
+"```\n"
+"println!(\"after: {a}\");\n"
+"```"
+msgstr ""
+"```\n"
+"println!(\"potem: {a}\");\n"
 "```"
 
 #: src/basic-syntax/scopes-shadowing.md:25
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"Definicja: Przesłanianie różni się od mutacji, ponieważ po przesłanianiu "
+"obie lokalizacje pamięci istnieją w tym samym czasie. Obie są dostępne pod "
+"tą samą nazwą, w zależności od tego, gdzie używasz ich w kodzie."
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr "Zmienna przesłaniająca może mieć inny typ."
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+"Przesłanianie na pierwszy rzut oka wygląda niejasno, ale jest wygodne do "
+"trzymania wartości po `.unwrap()`."
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
-"* Definicja: Przesłanianie różni się od mutacji, ponieważ po przesłanianiu "
-"obie lokalizacje pamięci istnieją w tym samym czasie. Obie są dostępne pod "
-"tą samą nazwą, w zależności od tego, gdzie używasz ich w kodzie.\n"
-"* Zmienna przesłaniająca może mieć inny typ.\n"
-"* Przesłanianie na pierwszy rzut oka wygląda niejasno, ale jest wygodne do "
-"trzymania wartości po `.unwrap()`.\n"
-"* Poniższy kod ilustruje, dlaczego kompilator nie może po prostu ponownie "
-"użyć lokalizacji pamięci podczas przesłaniania niemutowalnej zmiennej w "
-"zakresie, nawet jeśli typ się nie zmienia."
+"Poniższy kod ilustruje, dlaczego kompilator nie może po prostu ponownie użyć "
+"lokalizacji pamięci podczas przesłaniania niemutowalnej zmiennej w zakresie, "
+"nawet jeśli typ się nie zmienia."
 
 #: src/basic-syntax/scopes-shadowing.md:30
 msgid ""
@@ -4235,22 +4173,21 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr "# Zarządzanie pamięcią"
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr "Tradycyjnie języki dzieliły się na dwie szerokie kategorie:"
 
 #: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr ""
+"Pełna kontrola poprzez ręczne zarządzanie pamięcią: C, C++, Pascal, ..."
+
+#: src/memory-management.md:6
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
-"* Pełna kontrola poprzez ręczne zarządzanie pamięcią: C, C++, Pascal, ...\n"
-"* Pełne bezpieczeństwo dzięki automatycznemu zarządzaniu pamięcią w czasie "
+"Pełne bezpieczeństwo dzięki automatycznemu zarządzaniu pamięcią w czasie "
 "wykonywania: Java, Python, Go, Haskell, ..."
 
 #: src/memory-management.md:8
@@ -4259,10 +4196,10 @@ msgstr "Rust oferuje nową mieszankę:"
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
-"> Pełna kontrola *i* bezpieczeństwo poprzez egzekwowanie poprawnego "
+"Pełna kontrola _i_ bezpieczeństwo poprzez egzekwowanie poprawnego "
 "zarządzania pamięcią w czasie kompilacji."
 
 #: src/memory-management.md:13
@@ -4274,48 +4211,52 @@ msgid "First, let's refresh how memory management works."
 msgstr "Najpierw odświeżmy, jak działa zarządzanie pamięcią."
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
-msgstr "# Stos a sterta"
+msgid "The Stack vs The Heap"
+msgstr "Stos a sterta"
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality."
-msgstr ""
-"* Stos: ciągły obszar pamięci dla zmiennych lokalnych.\n"
-"  * Wartości mają stałe rozmiary znane w czasie kompilacji.\n"
-"  * Niezwykle szybki: wystarczy przesunąć wskaźnik stosu.\n"
-"  * Łatwy w zarządzaniu: podąża za wywołaniami funkcji.\n"
-"  * Świetna lokalność pamięci."
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "Stos: ciągły obszar pamięci dla zmiennych lokalnych."
+
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr "Wartości mają stałe rozmiary znane w czasie kompilacji."
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr "Niezwykle szybki: wystarczy przesunąć wskaźnik stosu."
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr "Łatwy w zarządzaniu: podąża za wywołaniami funkcji."
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr "Świetna lokalność pamięci."
 
 #: src/memory-management/stack-vs-heap.md:9
-msgid ""
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* Sterta: Przechowywanie wartości poza wywołaniami funkcji.\n"
-"  * Wartości mają dynamiczne rozmiary określone w czasie wykonywania.\n"
-"  * Nieco wolniejsza niż stos: potrzebne trochę księgowości.\n"
-"  * Brak gwarancji lokalności pamięci."
+msgid "Heap: Storage of values outside of function calls."
+msgstr "Sterta: Przechowywanie wartości poza wywołaniami funkcji."
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
-msgstr "# Pamięć stosu"
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr "Wartości mają dynamiczne rozmiary określone w czasie wykonywania."
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "Nieco wolniejsza niż stos: potrzebne trochę księgowości."
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr "Brak gwarancji lokalności pamięci."
 
 #: src/memory-management/stack.md:3
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 "Utworzenie `String` powoduje umieszczenie danych o stałym rozmiarze na "
-"stosie i danych o dynamicznym rozmiarze\n"
-"na stercie:"
+"stosie i danych o dynamicznym rozmiarze na stercie:"
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -4363,28 +4304,30 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
 "length and can grow if mutable via reallocation on the heap."
 msgstr ""
-"* Wspomnij, że `String` jest oparty o `Vec`, więc ma pojemność i długość, i "
+"Wspomnij, że `String` jest oparty o `Vec`, więc ma pojemność i długość, i "
 "jeżeli jest mutowalny to może rosnąć poprzez realokację na stercie."
 
 #: src/memory-management/stack.md:30
 msgid ""
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]"
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
-"* Jeżeli uczniowie o to zapytają to możesz wspomnieć, że pamięć na stercie "
-"jest alokowana za pomocą [alokatora systemowego] I własny alokator może być "
-"zaimplementowany używając [API alokatora]"
+"Jeżeli uczniowie o to zapytają to możesz wspomnieć, że pamięć na stercie "
+"jest alokowana za pomocą [alokatora systemowego](https://doc.rust-lang.org/"
+"std/alloc/struct.System.html) I własny alokator może być zaimplementowany "
+"używając [API alokatora](https://doc.rust-lang.org/std/alloc/index.html)"
 
 #: src/memory-management/stack.md:32
 msgid ""
-"* We can inspect the memory layout with `unsafe` code. However, you should "
+"We can inspect the memory layout with `unsafe` code. However, you should "
 "point out that this is rightfully unsafe!"
 msgstr ""
-"* Możemy zrobić inspekcję rozłożenia pamięci w niebezpiecznym (`unsafe`) "
+"Możemy zrobić inspekcję rozłożenia pamięci w niebezpiecznym (`unsafe`) "
 "kodzie. Jednak należy zauważyć, że jest to niebezpieczne!"
 
 #: src/memory-management/stack.md:34
@@ -4399,8 +4342,8 @@ msgid ""
 "to\n"
 "    // undefined behavior.\n"
 "    unsafe {\n"
-"        let (capacity, ptr, len): (usize, usize, usize) = "
-"std::mem::transmute(s1);\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
@@ -4415,25 +4358,12 @@ msgstr ""
 "    // String nie gwarantuje rozłożenia pamięci więc to może prowadzić do\n"
 "    // niezdefiniowanego zachowania.\n"
 "    unsafe {\n"
-"        let (capacity, ptr, len): (usize, usize, usize) = "
-"std::mem::transmute(s1);\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
 "```"
-
-#: src/memory-management/stack.md:51
-msgid ""
-"[System Allocator]: https://doc.rust-lang.org/std/alloc/struct.System.html\n"
-"[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
-msgstr ""
-"[alokatora systemowego]: "
-"https://doc.rust-lang.org/std/alloc/struct.System.html\n"
-"[API alokatora]: https://doc.rust-lang.org/std/alloc/index.html"
-
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
-msgstr "# Ręczne zarządzanie pamięcią"
 
 #: src/memory-management/manual.md:3
 msgid "You allocate and deallocate heap memory yourself."
@@ -4448,8 +4378,8 @@ msgstr ""
 "(\"crash\"), błędów, problemów bezpieczeństwa i wycieków pamięci."
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
-msgstr "## Przykład C"
+msgid "C Example"
+msgstr "Przykład C"
 
 #: src/memory-management/manual.md:9
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
@@ -4482,44 +4412,37 @@ msgstr ""
 #: src/memory-management/manual.md:21
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
-"Pamięć wycieka jeżeli funkcja zwróci pomiędzy `malloc` i `free`:\n"
-"wskaźnik jest stracony i nie możemy zwolnić pamięci."
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
-msgstr "# Zarządzanie pamięcią w oparciu o zakres"
+"Pamięć wycieka jeżeli funkcja zwróci pomiędzy `malloc` i `free`: wskaźnik "
+"jest stracony i nie możemy zwolnić pamięci."
 
 #: src/memory-management/scope-based.md:3
-msgid "Constructors and destructors let you hook into the lifetime of an object."
+msgid ""
+"Constructors and destructors let you hook into the lifetime of an object."
 msgstr "Konstruktory i destruktory pozwalają wpiąć się do czasu życia obiektu."
 
 #: src/memory-management/scope-based.md:5
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
 "Przez opakowania wskaźnika w obiekt, możesz zwolnić pamięć jeżeli obiekt "
-"jest\n"
-"zniszczony. Kompilator to gwarantuje, nawet jeżeli rzucony jest wyjątek."
+"jest zniszczony. Kompilator to gwarantuje, nawet jeżeli rzucony jest wyjątek."
 
 #: src/memory-management/scope-based.md:9
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr ""
 "Często jest to nazywane inicjowaniem przy pozyskaniu zasobu (ang. _resource "
 "acquisition is initialization_ (RAII)) i pozwala nam na inteligentne "
 "wskaźniki."
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
-msgstr "## Przykład C++"
+msgid "C++ Example"
+msgstr "Przykład C++"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -4537,18 +4460,23 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:20
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
 msgstr ""
-"* Obiekt `std::unique_ptr` jest alokowany na stosie i wskazuje na pamięć "
-"zaalokowaną na stercie.\n"
-"* Na końcu `say_hello` jest wywoływany destruktor `std::unique_ptr`.\n"
-"* Destruktor zwalnia pamięć obiektu `Person` na który wskazuje."
+"Obiekt `std::unique_ptr` jest alokowany na stosie i wskazuje na pamięć "
+"zaalokowaną na stercie."
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr "Na końcu `say_hello` jest wywoływany destruktor `std::unique_ptr`."
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
+msgstr "Destruktor zwalnia pamięć obiektu `Person` na który wskazuje."
 
 #: src/memory-management/scope-based.md:25
-msgid "Special move constructors are used when passing ownership to a function:"
+msgid ""
+"Special move constructors are used when passing ownership to a function:"
 msgstr ""
 "Specjalne konstruktory przenoszenia są używane kiedy własność jest "
 "przekazywana do funkcji:"
@@ -4566,30 +4494,31 @@ msgstr ""
 "```"
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
-msgstr "## Automatyczne zarządzanie pamięcią"
+msgid "Automatic Memory Management"
+msgstr "Automatyczne zarządzanie pamięcią"
 
 #: src/memory-management/garbage-collection.md:3
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
+"memory management:"
 msgstr ""
 "Alternatywą do ręcznego zarządzania pamięcią i zarządzania opartego o zasięg "
 "jest automatyczne zarządzanie pamięcią:"
 
 #: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "Programista nigdy wyraźnie nie alokuje i nie zwalnia pamięci."
+
+#: src/memory-management/garbage-collection.md:7
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
 msgstr ""
-"* Programista nigdy wyraźnie nie alokuje i nie zwalnia pamięci.\n"
-"* Odśmiecacz pamięci znajduje nieużywaną pamięć i zwalnia ją dla programisty."
+"Odśmiecacz pamięci znajduje nieużywaną pamięć i zwalnia ją dla programisty."
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
-msgstr "## Przykład Javy"
+msgid "Java Example"
+msgstr "Przykład Javy"
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
@@ -4610,29 +4539,38 @@ msgstr ""
 "```"
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
-msgstr "# Zarządzanie pamięcią w Ruście"
+msgid "Memory Management in Rust"
+msgstr "Zarządzanie pamięcią w Ruście"
 
 #: src/memory-management/rust.md:3
 msgid "Memory management in Rust is a mix:"
 msgstr "Zarządzanie pamięcią w Ruście to mieszanka:"
 
 #: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "Bezpieczne i prawidłowe jak w Javie, ale bez odśmiecania pamięci."
+
+#: src/memory-management/rust.md:6
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+"W zależności którą abstrakcję (lub kombinację abstrakcji) wybierzesz to może "
+"być pojedynczy unikalny wskażnik, zliczanie referencji lub atomiczne "
+"zliczanie referencji."
+
+#: src/memory-management/rust.md:7
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+"Oparte o zakres jak w C++, ale kompilator egzekwuje pełne przestrzeganie."
+
+#: src/memory-management/rust.md:8
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
-"* Bezpieczne i prawidłowe jak w Javie, ale bez odśmiecania pamięci.\n"
-"* W zależności którą abstrakcję (lub kombinację abstrakcji) wybierzesz to "
-"może być pojedynczy unikalny wskażnik, zliczanie referencji lub atomiczne "
-"zliczanie referencji.\n"
-"* Oparte o zakres jak w C++, ale kompilator egzekwuje pełne przestrzeganie.\n"
-"* Użytkownika Rusta wybiera właściwą abstrakcję w zależności od sytuacji, "
+"Użytkownika Rusta wybiera właściwą abstrakcję w zależności od sytuacji, "
 "niektóre nie mają nawet kosztu w czasie uruchomienia jak w C."
 
 #: src/memory-management/rust.md:10
@@ -4641,161 +4579,159 @@ msgstr "Osiąga to przez wyraźne modelowanie _własności_."
 
 #: src/memory-management/rust.md:14
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* Jeżeli uczniowie zapytają w tym momencie jak, to wspomnij, że w Ruście to "
-"przeważnie jest zrobione za pomocą opakowań takich jak [Box], [Vec], [Rc], "
-"czy [Arc]. Typy te zapewniają własność i alokację pamięci różnymi metodami i "
-"zapobiegają potencjalnym problemom w C."
+"Jeżeli uczniowie zapytają w tym momencie jak, to wspomnij, że w Ruście to "
+"przeważnie jest zrobione za pomocą opakowań takich jak [Box](https://doc."
+"rust-lang.org/std/boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/"
+"std/vec/struct.Vec.html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc."
+"html), czy [Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html). Typy "
+"te zapewniają własność i alokację pamięci różnymi metodami i zapobiegają "
+"potencjalnym problemom w C."
 
 #: src/memory-management/rust.md:16
 msgid ""
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
 msgstr ""
-"* Możesz dostać pytanie o destruktory, cecha [Drop] to Rustowy odpowiednik."
-
-#: src/memory-management/rust.md:20
-msgid ""
-"[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-"[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-"[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-"[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-"[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-msgstr ""
-"[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-"[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-"[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-"[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-"[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
-msgstr "# Porównanie"
+"Możesz dostać pytanie o destruktory, cecha [Drop](https://doc.rust-lang.org/"
+"std/ops/trait.Drop.html) to Rustowy odpowiednik."
 
 #: src/memory-management/comparison.md:3
 msgid "Here is a rough comparison of the memory management techniques."
 msgstr "Tutaj z grubsza porównujemy techniki zarządzania pamięcią."
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## Zalety różnych technik zarządzania pamięcią"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "Zalety różnych technik zarządzania pamięcią"
 
-#: src/memory-management/comparison.md:7
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* Ręczne jak w C:\n"
-"  * Brak kosztu w czasie działania.\n"
-"* Automatyczne jak w Javie:\n"
-"  * W pełnie automatyczne.\n"
-"  * Bezpieczne i prawidłowe.\n"
-"* Oparte o zakres jak w C++:\n"
-"  * Częściowo automatyczne.\n"
-"  * Brak kosztu w czasie działania.\n"
-"* Egzekwowane przez kompilator oparte o zakres jak w Ruście:\n"
-"  * Egzekwowane przez kompilator.\n"
-"  * Brak kosztu w czasie działania.\n"
-"  * Bezpiecznie i prawidłowe."
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
+msgid "Manual like C:"
+msgstr "Ręczne jak w C:"
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+msgid "No runtime overhead."
+msgstr "Brak kosztu w czasie działania."
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+msgid "Automatic like Java:"
+msgstr "Automatyczne jak w Javie:"
+
+#: src/memory-management/comparison.md:10
+msgid "Fully automatic."
+msgstr "W pełnie automatyczne."
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+msgid "Safe and correct."
+msgstr "Bezpieczne i prawidłowe."
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+msgid "Scope-based like C++:"
+msgstr "Oparte o zakres jak w C++:"
+
+#: src/memory-management/comparison.md:13
+msgid "Partially automatic."
+msgstr "Częściowo automatyczne."
+
+#: src/memory-management/comparison.md:15
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "Egzekwowane przez kompilator oparte o zakres jak w Ruście:"
+
+#: src/memory-management/comparison.md:16
+msgid "Enforced by compiler."
+msgstr "Egzekwowane przez kompilator."
 
 #: src/memory-management/comparison.md:20
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## Wady różnych technik zarządzania pamięcią"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "Wady różnych technik zarządzania pamięcią"
 
-#: src/memory-management/comparison.md:22
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* Ręczne jak w C:\n"
-"  * Użycie po zwolnieniu.\n"
-"  * Podwójne zwolnienie.\n"
-"  * Wycieki pamięci.\n"
-"* Automatyczne jak w Javie:\n"
-"  * Pauzy na odśmiecanie pamięci.\n"
-"  * Opóźnienie destruktorów.\n"
-"* Oparte o zakres jak w C++:\n"
-"  * Skomplikowane, dobrowolnie używane przez programistę.\n"
-"  * Potencjalne użycie po zwolnieniu.\n"
-"* Egzekwowane przez kompilator oparte o zakres jak w Ruście:\n"
-"  * Pewna złożoność z góry.\n"
-"  * Może odrzucić prawidłowe programy."
+#: src/memory-management/comparison.md:23
+msgid "Use-after-free."
+msgstr "Użycie po zwolnieniu."
 
-#: src/ownership.md:1
-msgid "# Ownership"
-msgstr "# Własność"
+#: src/memory-management/comparison.md:24
+msgid "Double-frees."
+msgstr "Podwójne zwolnienie."
+
+#: src/memory-management/comparison.md:25
+msgid "Memory leaks."
+msgstr "Wycieki pamięci."
+
+#: src/memory-management/comparison.md:27
+msgid "Garbage collection pauses."
+msgstr "Pauzy na odśmiecanie pamięci."
+
+#: src/memory-management/comparison.md:28
+msgid "Destructor delays."
+msgstr "Opóźnienie destruktorów."
+
+#: src/memory-management/comparison.md:30
+msgid "Complex, opt-in by programmer."
+msgstr "Skomplikowane, dobrowolnie używane przez programistę."
+
+#: src/memory-management/comparison.md:31
+msgid "Potential for use-after-free."
+msgstr "Potencjalne użycie po zwolnieniu."
+
+#: src/memory-management/comparison.md:32
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "Egzekwowane przez kompilator oparte o zakres jak w Ruście:"
+
+#: src/memory-management/comparison.md:33
+msgid "Some upfront complexity."
+msgstr "Pewna złożoność z góry."
+
+#: src/memory-management/comparison.md:34
+msgid "Can reject valid programs."
+msgstr "Może odrzucić prawidłowe programy."
 
 #: src/ownership.md:3
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
+"to use a variable outside its scope:"
 msgstr ""
 "Wszystkie przywiązania zmiennych mają _zakres_, w którym są prawidłowe. "
 "Użycie zmiennej poza jej zakresem jest błędem:"
 
 #: src/ownership.md:6
-msgid "```rust,editable,compile_fail\nstruct Point(i32, i32);"
-msgstr "```rust,editable,compile_fail\nstruct Point(i32, i32);"
+msgid ""
+"```rust,editable,compile_fail\n"
+"struct Point(i32, i32);\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"struct Point(i32, i32);\n"
+"```"
 
 #: src/ownership.md:9
 msgid ""
-"fn main() {\n"
-"    {\n"
-"        let p = Point(3, 4);\n"
-"        println!(\"x: {}\", p.0);\n"
-"    }\n"
-"    println!(\"y: {}\", p.1);\n"
-"}\n"
-"```"
+"fn main() { { let p = Point(3, 4); println!(\"x: {}\", p.0); } println!(\"y: "
+"{}\", p.1); }"
 msgstr ""
-"fn main() {\n"
-"    {\n"
-"        let p = Point(3, 4);\n"
-"        println!(\"x: {}\", p.0);\n"
-"    }\n"
-"    println!(\"y: {}\", p.1);\n"
-"}\n"
-"```"
+"fn main() { { let p = Point(3, 4); println!(\"x: {}\", p.0); } println!(\"y: "
+"{}\", p.1); }"
 
 #: src/ownership.md:18
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
-msgstr ""
-"* Na końcu zakresu, zmienna jest _upuszczana_ i dane są zwalniane.\n"
-"* Destruktor może być uruchomiony żeby zwolnić zasoby.\n"
-"* Mówi się, że zmienna _posiada_ wartość."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
+msgstr "Na końcu zakresu, zmienna jest _upuszczana_ i dane są zwalniane."
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
-msgstr "# Semantyka przenoszenia"
+#: src/ownership.md:19
+msgid "A destructor can run here to free up resources."
+msgstr "Destruktor może być uruchomiony żeby zwolnić zasoby."
+
+#: src/ownership.md:20
+msgid "We say that the variable _owns_ the value."
+msgstr "Mówi się, że zmienna _posiada_ wartość."
 
 #: src/ownership/move-semantics.md:3
 msgid "An assignment will transfer ownership between variables:"
@@ -4822,37 +4758,41 @@ msgstr ""
 "```"
 
 #: src/ownership/move-semantics.md:14
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "Przypisanie `s1` do `s2` przenosi własność."
+
+#: src/ownership/move-semantics.md:15
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr "Dane są _przeniesione_ z `s1` i zmienna `s1` nie jest już dostępna."
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
 msgstr ""
-"* Przypisanie `s1` do `s2` przenosi własność.\n"
-"* Dane są _przeniesione_ z `s1` i zmienna `s1` nie jest już dostępna.\n"
-"* Kiedy zmienna `s1` wychodzi poza zakres, nic się nie dzieje: nie ma "
-"własności.\n"
-"* Kiedy zmienna `s2` wychodzi poza zakres, dane łańcucha znaków są "
-"zwalniane.\n"
-"* Zawsze jest _dokładnie_ jedno przypisanie do zmiennej, które ma dane na "
+"Kiedy zmienna `s1` wychodzi poza zakres, nic się nie dzieje: nie ma "
+"własności."
+
+#: src/ownership/move-semantics.md:17
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr ""
+"Kiedy zmienna `s2` wychodzi poza zakres, dane łańcucha znaków są zwalniane."
+
+#: src/ownership/move-semantics.md:18
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr ""
+"Zawsze jest _dokładnie_ jedno przypisanie do zmiennej, które ma dane na "
 "własność."
 
 #: src/ownership/move-semantics.md:22
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
+"Mention that this is the opposite of the defaults in C++, which copies by "
 "value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* Wspomnij, że jest to na odwrót niż w C++, który domyślnie kopiuje wartości "
+"Wspomnij, że jest to na odwrót niż w C++, który domyślnie kopiuje wartości "
 "chyba, że jest użyte `std::move` (i zdefiniowany konstruktor przenoszenia!)."
 
 #: src/ownership/move-semantics.md:24
-msgid "* In Rust, clones are explicit (by using `clone`)."
-msgstr "* W Ruście, klonowanie jest jawne (za pomocą `clone`)."
-
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
-msgstr "# Przenoszenie String w Ruście"
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "W Ruście, klonowanie jest jawne (za pomocą `clone`)."
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4871,12 +4811,13 @@ msgstr ""
 "```"
 
 #: src/ownership/moved-strings-rust.md:10
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "Dane sterty z `s1` są użyte ponownie dla `s2`."
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
 msgstr ""
-"* Dane sterty z `s1` są użyte ponownie dla `s2`.\n"
-"* Kiedy `s1` wychodzi poza zakres, nic się nie dzieje (dane zostały z niej "
+"Kiedy `s1` wychodzi poza zakres, nic się nie dzieje (dane zostały z niej "
 "przeniesione)."
 
 #: src/ownership/moved-strings-rust.md:13
@@ -4963,10 +4904,6 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr "# Podwójne zwalnianie w nowoczesnym C++"
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr "Nowoczesny C++ rozwiązuje to inaczej:"
@@ -4985,12 +4922,14 @@ msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
-"* Dane sterty z `s1` są zduplikowane i `s2` dostaje swoją niezależną kopię.\n"
-"* Kiedy `s1` i `s2` wychodzą poza zakres, obydwie zmienne zwalniają swoją "
+"Dane sterty z `s1` są zduplikowane i `s2` dostaje swoją niezależną kopię."
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"Kiedy `s1` i `s2` wychodzą poza zakres, obydwie zmienne zwalniają swoją "
 "pamięć."
 
 #: src/ownership/double-free-modern-cpp.md:13
@@ -5075,13 +5014,9 @@ msgstr ""
 "`- - - - - - - - - - - - - -'\n"
 "```"
 
-#: src/ownership/moves-function-calls.md:1
-msgid "# Moves in Function Calls"
-msgstr "# Przenoszenie w wywołaniach funkcji"
-
 #: src/ownership/moves-function-calls.md:3
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 "Kiedy przekazujesz wartość do funkcji, wartość jest przypisywana do "
@@ -5092,58 +5027,63 @@ msgid ""
 "```rust,editable\n"
 "fn say_hello(name: String) {\n"
 "    println!(\"Hello {name}\")\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn say_hello(name: String) {\n"
 "    println!(\"Cześć {name}\")\n"
-"}"
+"}\n"
+"```"
 
 #: src/ownership/moves-function-calls.md:11
 msgid ""
-"fn main() {\n"
-"    let name = String::from(\"Alice\");\n"
-"    say_hello(name);\n"
-"    // say_hello(name);\n"
-"}\n"
-"```"
+"fn main() { let name = String::from(\"Alice\"); say_hello(name); // "
+"say_hello(name); }"
 msgstr ""
-"fn main() {\n"
-"    let name = String::from(\"Alice\");\n"
-"    say_hello(name);\n"
-"    // say_hello(name);\n"
-"}\n"
-"```"
+"fn main() { let name = String::from(\"Alice\"); say_hello(name); // "
+"say_hello(name); }"
 
 #: src/ownership/moves-function-calls.md:20
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call "
-"(`name.clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* Przy pierwszym wywołaniu `say_hello`, `main` oddaje własność `name`. Potem "
-"`name` nie może być już użyte wewnątrz `main`.\n"
-"* Dane zaalokowane na stercie dla `name` będą zwolnione na końcu wywołania "
-"funkcji `say_hello`.\n"
-"* `main` może zachować własność jeżeli przekaże `name` jako referencję "
-"(`&name`) i jeżeli `say_hello` akceptuje referencję jako parameter.\n"
-"* Alternatywnie, `main` może przekazać klona `name` w pierwszym wywołaniu "
-"(`name.clone()`).\n"
-"* Przez używanie semantyki przenoszenia domyślnie i przez zmuszanie "
+"Przy pierwszym wywołaniu `say_hello`, `main` oddaje własność `name`. Potem "
+"`name` nie może być już użyte wewnątrz `main`."
+
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+"Dane zaalokowane na stercie dla `name` będą zwolnione na końcu wywołania "
+"funkcji `say_hello`."
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"`main` może zachować własność jeżeli przekaże `name` jako referencję "
+"(`&name`) i jeżeli `say_hello` akceptuje referencję jako parameter."
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+"Alternatywnie, `main` może przekazać klona `name` w pierwszym wywołaniu "
+"(`name.clone()`)."
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"Przez używanie semantyki przenoszenia domyślnie i przez zmuszanie "
 "programistów do jawnego tworzenia klonów, Rust powoduje, że przypadkowe "
 "tworzenie kopii jest trudniejsze niż w C++."
-
-#: src/ownership/copy-clone.md:1
-msgid "# Copying and Cloning"
-msgstr "# Kopiowanie i klonowanie"
 
 #: src/ownership/copy-clone.md:3
 msgid ""
@@ -5186,37 +5126,30 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "#[derive(Copy, Clone, Debug)]\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "#[derive(Copy, Clone, Debug)]\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 
 #: src/ownership/copy-clone.md:22
 msgid ""
-"fn main() {\n"
-"    let p1 = Point(3, 4);\n"
-"    let p2 = p1;\n"
-"    println!(\"p1: {p1:?}\");\n"
-"    println!(\"p2: {p2:?}\");\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point(3, 4); let p2 = p1; println!(\"p1: {p1:?}\"); "
+"println!(\"p2: {p2:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    let p1 = Point(3, 4);\n"
-"    let p2 = p1;\n"
-"    println!(\"p1: {p1:?}\");\n"
-"    println!(\"p2: {p2:?}\");\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point(3, 4); let p2 = p1; println!(\"p1: {p1:?}\"); "
+"println!(\"p2: {p2:?}\"); }"
 
 #: src/ownership/copy-clone.md:30
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
+msgid "After the assignment, both `p1` and `p2` own their own data."
 msgstr ""
-"* Po przypisaniu, obydwie zmienne `p1` i `p2` mają swoje dane na własność.\n"
-"* Możemy też użyć `p1.clone()` żeby jawnie skopiować dane."
+"Po przypisaniu, obydwie zmienne `p1` i `p2` mają swoje dane na własność."
+
+#: src/ownership/copy-clone.md:31
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr "Możemy też użyć `p1.clone()` żeby jawnie skopiować dane."
 
 #: src/ownership/copy-clone.md:35
 msgid "Copying and cloning are not the same thing:"
@@ -5224,21 +5157,29 @@ msgstr "Kopiowanie i klonowanie to nie to samo:"
 
 #: src/ownership/copy-clone.md:37
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in "
-"C++).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
 msgstr ""
-"* Kopiowanie odnosi się do bezpośredniego kopiowania pamięci i nie działa "
-"dla wszystkich obiektów.\n"
-"* Kopiowanie nie pozwala na własną logikę (jak konstruktory kopiowania w "
-"C++).\n"
-"* Klonowanie jest ogólniejszą operacją i pozwala na własne zachowanie "
-"poprzez implementację cechy `Clone`.\n"
-"* Kopiowanie nie działa na typach, które implementują cechę `Drop`."
+"Kopiowanie odnosi się do bezpośredniego kopiowania pamięci i nie działa dla "
+"wszystkich obiektów."
+
+#: src/ownership/copy-clone.md:38
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+"Kopiowanie nie pozwala na własną logikę (jak konstruktory kopiowania w C++)."
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+"Klonowanie jest ogólniejszą operacją i pozwala na własne zachowanie poprzez "
+"implementację cechy `Clone`."
+
+#: src/ownership/copy-clone.md:40
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr "Kopiowanie nie działa na typach, które implementują cechę `Drop`."
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 msgid "In the above example, try the following:"
@@ -5246,270 +5187,248 @@ msgstr "W powyższym przykładzie spróbuj następującego:"
 
 #: src/ownership/copy-clone.md:44
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* Dodaj pole `String` do `struct Point`. Nie skompiluje się bo `String` nie "
-"jest typem `Copy`.\n"
-"* Usuń `Copy` z atrybutu `derive`. Kompilator teraz zwróci błąd w `println!` "
-"dla `p1`.\n"
-"* Pokaż, że zadziała jeżeli zamiast tego sklonujesz `p1`."
+"Dodaj pole `String` do `struct Point`. Nie skompiluje się bo `String` nie "
+"jest typem `Copy`."
+
+#: src/ownership/copy-clone.md:45
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"Usuń `Copy` z atrybutu `derive`. Kompilator teraz zwróci błąd w `println!` "
+"dla `p1`."
+
+#: src/ownership/copy-clone.md:46
+msgid "Show that it works if you clone `p1` instead."
+msgstr "Pokaż, że zadziała jeżeli zamiast tego sklonujesz `p1`."
 
 #: src/ownership/copy-clone.md:48
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated.\n"
-"    \n"
-"</details>"
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 "Jeżeli studenci zapytają o `derive`, to wystarczy powiedzieć, że to sposób "
-"na generowanie kodu Rusta w czasie kompilacji.\n"
-"W tym przypadku będą wygenerowane domyślne implementacje cech `Copy` i "
-"`Clone`.\n"
-"    \n"
-"</details>"
-
-#: src/ownership/borrowing.md:1
-msgid "# Borrowing"
-msgstr "# Pożyczanie"
+"na generowanie kodu Rusta w czasie kompilacji. W tym przypadku będą "
+"wygenerowane domyślne implementacje cech `Copy` i `Clone`."
 
 #: src/ownership/borrowing.md:3
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
 "Zamiast przekazywania własności w momencie wywołania funkcji, możesz "
 "_pożyczyć_ funkcji wartość:"
 
 #: src/ownership/borrowing.md:6 src/ownership/lifetimes-function-calls.md:5
+#: src/ownership/borrowing.md:30
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 
 #: src/ownership/borrowing.md:10
 msgid ""
-"fn add(p1: &Point, p2: &Point) -> Point {\n"
-"    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
-"}"
+"fn add(p1: &Point, p2: &Point) -> Point { Point(p1.0 + p2.0, p1.1 + p2.1) }"
 msgstr ""
-"fn add(p1: &Point, p2: &Point) -> Point {\n"
-"    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
-"}"
+"fn add(p1: &Point, p2: &Point) -> Point { Point(p1.0 + p2.0, p1.1 + p2.1) }"
 
 #: src/ownership/borrowing.md:14
 msgid ""
-"fn main() {\n"
-"    let p1 = Point(3, 4);\n"
-"    let p2 = Point(10, 20);\n"
-"    let p3 = add(&p1, &p2);\n"
-"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point(3, 4); let p2 = Point(10, 20); let p3 = add(&p1, "
+"&p2); println!(\"{p1:?} + {p2:?} = {p3:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    let p1 = Point(3, 4);\n"
-"    let p2 = Point(10, 20);\n"
-"    let p3 = add(&p1, &p2);\n"
-"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point(3, 4); let p2 = Point(10, 20); let p3 = add(&p1, "
+"&p2); println!(\"{p1:?} + {p2:?} = {p3:?}\"); }"
 
 #: src/ownership/borrowing.md:22
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
-msgstr ""
-"* Funkcja `add` _pożycza_ dwa punkty i zwraca nowy punkt.\n"
-"* Wywołujący funkcję zachowuje własność."
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr "Funkcja `add` _pożycza_ dwa punkty i zwraca nowy punkt."
+
+#: src/ownership/borrowing.md:23
+msgid "The caller retains ownership of the inputs."
+msgstr "Wywołujący funkcję zachowuje własność."
 
 #: src/ownership/borrowing.md:27
-msgid ""
-"Notes on stack returns:\n"
-"* Demonstrate that the return from `add` is cheap because the compiler can "
-"eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while the stay the same when changing to the "
-"\"RELEASE\" setting:"
-msgstr ""
-"Kilka notatek na temat zwracania przez stos:\n"
-"* Pokaż, że zwracanie z `add` jest tanie bo kompilator eliminuje kopiowanie. "
-"Zmień powyższy kod żeby pokazać adresy na stosie i uruchom w [Playground]. W "
-"optymalizacji \"DEBUG\" adresy powinny się zmienić, ale przy użyciu "
-"ustawienia \"RELEASE\" powinny pozostać te same:"
+msgid "Notes on stack returns:"
+msgstr "Kilka notatek na temat zwracania przez stos:"
 
-#: src/ownership/borrowing.md:30
+#: src/ownership/borrowing.md:28
 msgid ""
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);"
+"Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while the stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);"
+"Pokaż, że zwracanie z `add` jest tanie bo kompilator eliminuje kopiowanie. "
+"Zmień powyższy kod żeby pokazać adresy na stosie i uruchom w [Playground]"
+"(https://play.rust-lang.org/). W optymalizacji \"DEBUG\" adresy powinny się "
+"zmienić, ale przy użyciu ustawienia \"RELEASE\" powinny pozostać te same:"
 
 #: src/ownership/borrowing.md:34
 msgid ""
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }"
+"fn add(p1: &Point, p2: &Point) -> Point { let p = Point(p1.0 + p2.0, p1.1 + "
+"p2.1); println!(\"&p.0: {:p}\", &p.0); p }"
 msgstr ""
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }"
+"fn add(p1: &Point, p2: &Point) -> Point { let p = Point(p1.0 + p2.0, p1.1 + "
+"p2.1); println!(\"&p.0: {:p}\", &p.0); p }"
 
 #: src/ownership/borrowing.md:40
 msgid ""
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
+"fn main() { let p1 = Point(3, 4); let p2 = Point(10, 20); let p3 = add(&p1, "
+"&p2); println!(\"&p3.0: {:p}\", &p3.0); println!(\"{p1:?} + {p2:?} = "
+"{p3:?}\"); }"
+msgstr ""
+"fn main() { let p1 = Point(3, 4); let p2 = Point(10, 20); let p3 = add(&p1, "
+"&p2); println!(\"&p3.0: {:p}\", &p3.0); println!(\"{p1:?} + {p2:?} = "
+"{p3:?}\"); }"
+
+#: src/ownership/borrowing.md:47
+msgid ""
+"```\n"
 "* The Rust compiler can do return value optimization (RVO).\n"
 "* In C++, copy elision has to be defined in the language specification "
 "because constructors can have side effects. In Rust, this is not an issue at "
 "all. If RVO did not happen, Rust will always performs a simple and efficient "
-"`memcpy` copy."
+"`memcpy` copy.\n"
+"```"
 msgstr ""
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
+"```\n"
 "* Kompilator Rusta może zoptymalizować zwracanie przez wartość (ang. _return "
 "value optimization_ (RVO)).\n"
 "* W C++, usuwanie kopii musi być zdefiniowane w specyfikacji języka bo "
 "konstruktory mogą mieć skutki uboczne. W Ruście nie stanowi to problemu. "
 "Jeżeli RVO nie było zastosowane, to Rust użyje prostej i wydajnej kopii "
-"`memcpy`."
-
-#: src/ownership/borrowing.md:53
-msgid "[Playground]: https://play.rust-lang.org/"
-msgstr "[Playground]: https://play.rust-lang.org/"
-
-#: src/ownership/shared-unique-borrows.md:1
-msgid "# Shared and Unique Borrows"
-msgstr "# Wspólne i unikalne pożyczenia"
+"`memcpy`.\n"
+"```"
 
 #: src/ownership/shared-unique-borrows.md:3
 msgid "Rust puts constraints on the ways you can borrow values:"
 msgstr "Rust narzuca ograniczenia na sposób w jaki można pożyczać wartości:"
 
 #: src/ownership/shared-unique-borrows.md:5
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
+msgid "You can have one or more `&T` values at any given time, _or_"
 msgstr ""
-"* Możesz mieć jedno lub więcej pożyczeń wartości `&T` w tym samym czasie, "
-"_albo_\n"
-"* Możesz mieć dokładnie jedno pożyczenie wartości `&mut T`."
+"Możesz mieć jedno lub więcej pożyczeń wartości `&T` w tym samym czasie, "
+"_albo_"
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
+msgstr "Możesz mieć dokładnie jedno pożyczenie wartości `&mut T`."
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
 "    let mut a: i32 = 10;\n"
-"    let b: &i32 = &a;"
+"    let b: &i32 = &a;\n"
+"```"
 msgstr ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
 "    let mut a: i32 = 10;\n"
-"    let b: &i32 = &a;"
+"    let b: &i32 = &a;\n"
+"```"
 
 #: src/ownership/shared-unique-borrows.md:13
 msgid ""
-"    {\n"
-"        let c: &mut i32 = &mut a;\n"
-"        *c = 20;\n"
-"    }"
-msgstr ""
-"    {\n"
-"        let c: &mut i32 = &mut a;\n"
-"        *c = 20;\n"
-"    }"
-
-#: src/ownership/shared-unique-borrows.md:18 src/std/rc.md:13
-msgid ""
-"    println!(\"a: {a}\");\n"
-"    println!(\"b: {b}\");\n"
+"```\n"
+"{\n"
+"    let c: &mut i32 = &mut a;\n"
+"    *c = 20;\n"
 "}\n"
 "```"
 msgstr ""
-"    println!(\"a: {a}\");\n"
-"    println!(\"b: {b}\");\n"
+"```\n"
+"{\n"
+"    let c: &mut i32 = &mut a;\n"
+"    *c = 20;\n"
 "}\n"
+"```"
+
+#: src/ownership/shared-unique-borrows.md:18 src/std/rc.md:13
+msgid ""
+"```\n"
+"println!(\"a: {a}\");\n"
+"println!(\"b: {b}\");\n"
+"```"
+msgstr ""
+"```\n"
+"println!(\"a: {a}\");\n"
+"println!(\"b: {b}\");\n"
 "```"
 
 #: src/ownership/shared-unique-borrows.md:25
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+"Powyższy kod się nie kompiluje ponieważ `a` jest pożyczone jako mutowalne "
+"(przez `c`) i jako niemutowalne (przez `b`) w tym samym czasie."
+
+#: src/ownership/shared-unique-borrows.md:26
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"Przenieś instrukcję `println!` dla `b` przed zakres, który wprowadza `c`, "
+"żeby kod się kompilował."
+
+#: src/ownership/shared-unique-borrows.md:27
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"* Powyższy kod się nie kompiluje ponieważ `a` jest pożyczone jako mutowalne "
-"(przez `c`) i jako niemutowalne (przez `b`) w tym samym czasie.\n"
-"* Przenieś instrukcję `println!` dla `b` przed zakres, który wprowadza `c`, "
-"żeby kod się kompilował.\n"
-"* Po zmianie, kompilator uświadomi sobie, że `b` jest tylko używane przed "
+"Po zmianie, kompilator uświadomi sobie, że `b` jest tylko używane przed "
 "mutowalnym pożyczeniem `a` przez `c`. Ta funkcja nadzorcy pożyczania nazywa "
 "się \"nieleksykalne czasy życia\" (ang. _non-lexical lifetimes_)."
-
-#: src/ownership/lifetimes.md:1
-msgid "# Lifetimes"
-msgstr "# Czasy życia"
 
 #: src/ownership/lifetimes.md:3
 msgid "A borrowed value has a _lifetime_:"
 msgstr "Pożyczona wartość ma _czas życia_:"
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution."
-msgstr ""
-"* Czas życia może być pominięty: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Czasy życia mogą też być jawne: `&'a Point`, `&'document str`.\n"
-"* Czytaj `&'a Point` jako \"pożyczony `Point` który jest ważny co najmniej w "
-"czasie życia `a`\".\n"
-"* Czasy życia zawsze są wyliczane przez kompilator: nie można samemu "
-"przypisać czasu życia.\n"
-"* Adnotacje czasu życia tworzą ograniczenia; kompilator weryfikuje, że "
-"istnieje prawidłowe rozwiązanie."
+msgid "The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`."
+msgstr "Czas życia może być pominięty: `add(p1: &Point, p2: &Point) -> Point`."
 
-#: src/ownership/lifetimes-function-calls.md:1
-msgid "# Lifetimes in Function Calls"
-msgstr "# Czasy życia w wywołaniach funkcji"
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr "Czasy życia mogą też być jawne: `&'a Point`, `&'document str`."
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+"Czytaj `&'a Point` jako \"pożyczony `Point` który jest ważny co najmniej w "
+"czasie życia `a`\"."
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+"Czasy życia zawsze są wyliczane przez kompilator: nie można samemu przypisać "
+"czasu życia."
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+"Adnotacje czasu życia tworzą ograniczenia; kompilator weryfikuje, że "
+"istnieje prawidłowe rozwiązanie."
 
 #: src/ownership/lifetimes-function-calls.md:3
 msgid ""
@@ -5520,127 +5439,115 @@ msgstr ""
 "wartość:"
 
 #: src/ownership/lifetimes-function-calls.md:9
+#: src/ownership/lifetimes-function-calls.md:36
 msgid ""
-"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"    if p1.0 < p2.0 { p1 } else { p2 }\n"
-"}"
+"fn left_most\\<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point { if p1.0 \\< "
+"p2.0 { p1 } else { p2 } }"
 msgstr ""
-"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"    if p1.0 < p2.0 { p1 } else { p2 }\n"
-"}"
+"fn left_most\\<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point { if p1.0 \\< "
+"p2.0 { p1 } else { p2 } }"
 
 #: src/ownership/lifetimes-function-calls.md:13
 msgid ""
-"fn main() {\n"
-"    let p1: Point = Point(10, 10);\n"
-"    let p2: Point = Point(20, 20);\n"
-"    let p3: &Point = left_most(&p1, &p2);\n"
-"    println!(\"left-most point: {:?}\", p3);\n"
-"}\n"
-"```"
+"fn main() { let p1: Point = Point(10, 10); let p2: Point = Point(20, 20); "
+"let p3: &Point = left_most(&p1, &p2); println!(\"left-most point: {:?}\", "
+"p3); }"
 msgstr ""
-"fn main() {\n"
-"    let p1: Point = Point(10, 10);\n"
-"    let p2: Point = Point(20, 20);\n"
-"    let p3: &Point = left_most(&p1, &p2);\n"
-"    println!(\"left-most point: {:?}\", p3);\n"
-"}\n"
-"```"
+"fn main() { let p1: Point = Point(10, 10); let p2: Point = Point(20, 20); "
+"let p3: &Point = left_most(&p1, &p2); println!(\"left-most point: {:?}\", "
+"p3); }"
 
 #: src/ownership/lifetimes-function-calls.md:21
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`'a` to parameter generyczny, jest wyliczany przez kompilator."
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr "Czas życia zaczyna się `'` i `'a` to typowa domyślna nazwa."
+
+#: src/ownership/lifetimes-function-calls.md:25
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
-msgstr ""
-"* `'a` to parameter generyczny, jest wyliczany przez kompilator.\n"
-"* Czas życia zaczyna się `'` i `'a` to typowa domyślna nazwa.\n"
-"* Czytaj `&'a Point` jako \"pożyczony `Point` który jest ważny co najmniej w "
-"czasie życia `a`\".\n"
-"* To _co najmniej_ jest ważne jeżeli parametry są w różnych zakresach."
+"The _at least_ part is important when parameters are in different scopes."
+msgstr "To _co najmniej_ jest ważne jeżeli parametry są w różnych zakresach."
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);"
+"Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
-"* Przenieś deklarację `p2` i `p3` do nowego zakresu (`{ ... }`), powinieneś "
-"otrzymać poniższy kod:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);"
+"Przenieś deklarację `p2` i `p3` do nowego zakresu (`{ ... }`), powinieneś "
+"otrzymać poniższy kod:"
 
-#: src/ownership/lifetimes-function-calls.md:36
+#: src/ownership/lifetimes-function-calls.md:32
 msgid ""
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }"
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }"
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"```"
 
 #: src/ownership/lifetimes-function-calls.md:40
 msgid ""
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`."
+"fn main() { let p1: Point = Point(10, 10); let p3: &Point; { let p2: Point = "
+"Point(20, 20); p3 = left_most(&p1, &p2); } println!(\"left-most point: "
+"{:?}\", p3); }"
 msgstr ""
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Zauważ, że teraz kod się nie kompiluje bo `p3` przeżywa `p2`."
+"fn main() { let p1: Point = Point(10, 10); let p3: &Point; { let p2: Point = "
+"Point(20, 20); p3 = left_most(&p1, &p2); } println!(\"left-most point: "
+"{:?}\", p3); }"
+
+#: src/ownership/lifetimes-function-calls.md:49
+msgid ""
+"```\n"
+"Note how this does not compile since `p3` outlives `p2`.\n"
+"```"
+msgstr ""
+"```\n"
+"Zauważ, że teraz kod się nie kompiluje bo `p3` przeżywa `p2`.\n"
+"```"
 
 #: src/ownership/lifetimes-function-calls.md:52
 msgid ""
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
+"Reset the workspace and change the function signature to `fn left_most<'a, "
 "'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
 msgstr ""
-"* Zresetuj edytor i zmień sygnaturę funkcji na `fn left_most<'a, 'b>(p1: &'a "
+"Zresetuj edytor i zmień sygnaturę funkcji na `fn left_most<'a, 'b>(p1: &'a "
 "Point, p2: &'a Point) -> &'b Point`. To się nie skompiluje bo zależność "
-"pomiędzy czasami życia `'a` i `'b` jest niejasna.\n"
-"* Inny sposób żeby to wytłumaczyć:\n"
-"  * Dwie referencje do dwóch wartości są pożyczone przez funkcję i funkcja "
-"musi zwrócić inną referencję.\n"
-"  * Ta referencja musi pochodzić z jednego z dwóch wejść(lub ze zmiennej "
-"globalnej).\n"
-"  * Która to? Kompilator musi wiedzieć, żeby w czasie wywołania zwracana "
+"pomiędzy czasami życia `'a` i `'b` jest niejasna."
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr "Inny sposób żeby to wytłumaczyć:"
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+"Dwie referencje do dwóch wartości są pożyczone przez funkcję i funkcja musi "
+"zwrócić inną referencję."
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+"Ta referencja musi pochodzić z jednego z dwóch wejść(lub ze zmiennej "
+"globalnej)."
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
+"Która to? Kompilator musi wiedzieć, żeby w czasie wywołania zwracana "
 "referencja nie jest używana dłużej niż zmienna z której pochodzi ta "
 "referencja."
-
-#: src/ownership/lifetimes-data-structures.md:1
-msgid "# Lifetimes in Data Structures"
-msgstr "# Czasy życia w strukturach danych"
 
 #: src/ownership/lifetimes-data-structures.md:3
 msgid ""
@@ -5653,48 +5560,48 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Highlight<'doc>(&'doc str);"
+"struct Highlight<'doc>(&'doc str);\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Highlight<'doc>(&'doc str);"
+"struct Highlight<'doc>(&'doc str);\n"
+"```"
 
 #: src/ownership/lifetimes-data-structures.md:9
-msgid ""
-"fn erase(text: String) {\n"
-"    println!(\"Bye {text}!\");\n"
-"}"
-msgstr ""
-"fn erase(text: String) {\n"
-"    println!(\"Bye {text}!\");\n"
-"}"
+msgid "fn erase(text: String) { println!(\"Bye {text}!\"); }"
+msgstr "fn erase(text: String) { println!(\"Bye {text}!\"); }"
 
 #: src/ownership/lifetimes-data-structures.md:13
 msgid ""
-"fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy "
-"dog.\");\n"
-"    let fox = Highlight(&text[4..19]);\n"
-"    let dog = Highlight(&text[35..43]);\n"
-"    // erase(text);\n"
-"    println!(\"{fox:?}\");\n"
-"    println!(\"{dog:?}\");\n"
-"}\n"
-"```"
+"fn main() { let text = String::from(\"The quick brown fox jumps over the "
+"lazy dog.\"); let fox = Highlight(&text\\[4..19\\]); let dog = "
+"Highlight(&text\\[35..43\\]); // erase(text); println!(\"{fox:?}\"); println!"
+"(\"{dog:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy "
-"dog.\");\n"
-"    let fox = Highlight(&text[4..19]);\n"
-"    let dog = Highlight(&text[35..43]);\n"
-"    // erase(text);\n"
-"    println!(\"{fox:?}\");\n"
-"    println!(\"{dog:?}\");\n"
-"}\n"
-"```"
+"fn main() { let text = String::from(\"The quick brown fox jumps over the "
+"lazy dog.\"); let fox = Highlight(&text\\[4..19\\]); let dog = "
+"Highlight(&text\\[35..43\\]); // erase(text); println!(\"{fox:?}\"); println!"
+"(\"{dog:?}\"); }"
 
-#: src/ownership/lifetimes-data-structures.md:25
+#: src/ownership/lifetimes-data-structures.md:21
 msgid ""
+"```\n"
+"\n"
+"# Lifetimes in Data Structures\n"
+"\n"
+"If a data type stores borrowed data, it must be annotated with a lifetime:\n"
+"\n"
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"<details>\n"
+"\n"
 "* In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
 "`Highlight` that uses that data.\n"
@@ -5708,8 +5615,48 @@ msgid ""
 "lifetime annotation. This can be necessary if there is a need to describe "
 "lifetime relationships between the references themselves, in addition to the "
 "lifetime of the struct itself. Those are very advanced use cases.\n"
-"</details>"
+"</details>\n"
+"\n"
+"# Lifetimes in Data Structures\n"
+"\n"
+"If a data type stores borrowed data, it must be annotated with a lifetime:\n"
+"\n"
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(text);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
 msgstr ""
+"```\n"
+"\n"
+"# Czasy życia w strukturach danych\n"
+"\n"
+"Jeżeli typ danych przechowuje pożyczone dane, to muszą one mieć adnotcję "
+"czasu życia:\n"
+"\n"
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"<details>\n"
+"\n"
 "* W powyższym przykładzie, adnotacja na `Highlight` wymaga żeby dane w "
 "zawartym `&str` żyły co najmniej tak długo jak instancja `Highlight`, która "
 "używa tych danych.\n"
@@ -5724,12 +5671,81 @@ msgstr ""
 "adnotację cyklu życia. To może być potrzebne jeżeli potrzebujesz opisać "
 "relację cyklu życia pomiędzy referencjami w dodatku do cyklu życia samej "
 "struktury. Są to bardzo zaawansowane przypadki użycia.\n"
-"</details>"
+"</details>\n"
+"\n"
+"# Lifetimes in Data Structures\n"
+"\n"
+"If a data type stores borrowed data, it must be annotated with a lifetime:\n"
+"\n"
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
+"    let fox = Highlight(&text[4..19]);\n"
+"    let dog = Highlight(&text[35..43]);\n"
+"    // erase(text);\n"
+"    println!(\"{fox:?}\");\n"
+"    println!(\"{dog:?}\");\n"
+"}\n"
+"```"
+
+#: src/ownership/lifetimes-data-structures.md:25
+msgid ""
+"In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data."
+msgstr ""
+"W powyższym przykładzie, adnotacja na `Highlight` wymaga żeby dane w "
+"zawartym `&str` żyły co najmniej tak długo jak instancja `Highlight`, która "
+"używa tych danych."
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"Jeżeli `text` jest skonsumowany przed końcem życia `fox` (lub `dog`), to "
+"nadzorca pożyczania pokaże błąd."
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"Typy z pożyczonymi danymi wymagają od użytkowników utrzymywania oryginalnych "
+"danych. Jest to przydatne przy tworzeniu lekkich widoków, ale generalnie "
+"powoduje, że są trudniejsze w użyciu."
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+"Jeżeli możliwe twórz struktury danych, które bezpośrednio są właścicielami "
+"swoich danych."
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"Niektóre struktury z wieloma referencjami mogą mieć więcej niż jedną "
+"adnotację cyklu życia. To może być potrzebne jeżeli potrzebujesz opisać "
+"relację cyklu życia pomiędzy referencjami w dodatku do cyklu życia samej "
+"struktury. Są to bardzo zaawansowane przypadki użycia."
 
 #: src/exercises/day-1/afternoon.md:1
 #, fuzzy
-msgid "# Day 1: Afternoon Exercises"
-msgstr "# Dzień 1: Ćwiczenia popołudniowe"
+msgid "Day 1: Afternoon Exercises"
+msgstr "Dzień 1: Ćwiczenia popołudniowe"
 
 #: src/exercises/day-1/afternoon.md:3
 #, fuzzy
@@ -5738,32 +5754,21 @@ msgstr "Przyjrzymy się dwóm rzeczom:"
 
 #: src/exercises/day-1/afternoon.md:5
 #, fuzzy
-msgid "* A small book library,"
-msgstr "* Mała biblioteczka,"
+msgid "A small book library,"
+msgstr "Mała biblioteczka,"
 
 #: src/exercises/day-1/afternoon.md:7
 #, fuzzy
-msgid "* Iterators and ownership (hard)."
-msgstr "* Iteratory i własność (trudne)."
-
-#: src/exercises/day-1/afternoon.md:13 src/exercises/day-2/afternoon.md:9
-#, fuzzy
-msgid "[solutions]: solutions-afternoon.md"
-msgstr "[rozwiązania]: rozwiązania-po południu.md"
-
-#: src/exercises/day-1/book-library.md:1
-#, fuzzy
-msgid "# Designing a Library"
-msgstr "# Projektowanie biblioteki"
+msgid "Iterators and ownership (hard)."
+msgstr "Iteratory i własność (trudne)."
 
 #: src/exercises/day-1/book-library.md:3
 #, fuzzy
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
-"Jutro dowiemy się znacznie więcej o strukturach i typie `Vec<T>`. Na razie,\n"
+"Jutro dowiemy się znacznie więcej o strukturach i typie `Vec<T>`. Na razie, "
 "wystarczy znać część jego API:"
 
 #: src/exercises/day-1/book-library.md:6
@@ -5793,210 +5798,180 @@ msgstr ""
 #: src/exercises/day-1/book-library.md:17
 #, fuzzy
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
-"Użyj tego, aby utworzyć aplikację biblioteczną. Skopiuj poniższy kod do\n"
+"Użyj tego, aby utworzyć aplikację biblioteczną. Skopiuj poniższy kod do "
 "<https://play.rust-lang.org/> i zaktualizuj typy, aby skompilować:"
 
 #: src/exercises/day-1/book-library.md:24
-msgid ""
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}"
-msgstr ""
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}"
+msgid "struct Library { books: Vec"
+msgstr "struct Library { books: Vec"
 
-#: src/exercises/day-1/book-library.md:28 src/exercises/day-1/solutions-afternoon.md:27
-msgid ""
-"struct Book {\n"
-"    title: String,\n"
-"    year: u16,\n"
-"}"
-msgstr ""
-"struct Book {\n"
-"    title: String,\n"
-"    year: u16,\n"
-"}"
+#: src/exercises/day-1/book-library.md:25
+#: src/exercises/day-1/solutions-afternoon.md:24
+#: src/exercises/day-2/solutions-morning.md:71
+#: src/exercises/day-4/solutions-morning.md:35
+msgid ", }"
+msgstr ", }"
 
-#: src/exercises/day-1/book-library.md:33 src/exercises/day-1/solutions-afternoon.md:32
+#: src/exercises/day-1/book-library.md:28
+#: src/exercises/day-1/solutions-afternoon.md:27
+msgid "struct Book { title: String, year: u16, }"
+msgstr "struct Book { title: String, year: u16, }"
+
+#: src/exercises/day-1/book-library.md:33
+#: src/exercises/day-1/solutions-afternoon.md:32
 msgid ""
-"impl Book {\n"
-"    // This is a constructor, used below.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Book { // This is a constructor, used below. fn new(title: &str, year: "
+"u16) -> Book { Book { title: String::from(title), year, } } }"
 msgstr ""
-"impl Book {\n"
-"    // To jest konstruktor używany poniżej.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Book { // To jest konstruktor używany poniżej. fn new(title: &str, "
+"year: u16) -> Book { Book { title: String::from(title), year, } } }"
 
 #: src/exercises/day-1/book-library.md:43
 msgid ""
-"// This makes it possible to print Book values with {}.\n"
-"impl std::fmt::Display for Book {\n"
-"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-"        write!(f, \"{} ({})\", self.title, self.year)\n"
-"    }\n"
-"}"
+"// This makes it possible to print Book values with {}. impl std::fmt::"
+"Display for Book { fn fmt(&self, f: &mut std::fmt::Formatter\\<'\\_\\>) -> "
+"std::fmt::Result { write!(f, \"{} ({})\", self.title, self.year) } }"
 msgstr ""
-"// Umożliwia to drukowanie wartości Book za pomocą {}.\n"
-"impl std::fmt::Display for Book {\n"
-"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-"        write!(f, \"{} ({})\", self.title, self.year)\n"
-"    }\n"
-"}"
+"// Umożliwia to drukowanie wartości Book za pomocą {}. impl std::fmt::"
+"Display for Book { fn fmt(&self, f: &mut std::fmt::Formatter\\<'\\_\\>) -> "
+"std::fmt::Result { write!(f, \"{} ({})\", self.title, self.year) } }"
 
 #: src/exercises/day-1/book-library.md:50
-msgid ""
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        unimplemented!()\n"
-"    }"
-msgstr ""
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Library { fn new() -> Library { unimplemented!() }"
+msgstr "impl Library { fn new() -> Library { unimplemented!() }"
 
 #: src/exercises/day-1/book-library.md:55
 msgid ""
-"    //fn len(self) -> usize {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn len(self) -> usize {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
-"    //fn len(self) -> usize {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn len(self) -> usize {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 
 #: src/exercises/day-1/book-library.md:59
 msgid ""
-"    //fn is_empty(self) -> bool {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn is_empty(self) -> bool {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
-"    //fn is_empty(self) -> bool {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn is_empty(self) -> bool {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 
 #: src/exercises/day-1/book-library.md:63
 msgid ""
-"    //fn add_book(self, book: Book) {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn add_book(self, book: Book) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
-"    //fn add_book(self, book: Book) {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn add_book(self, book: Book) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 
 #: src/exercises/day-1/book-library.md:67
 msgid ""
-"    //fn print_books(self) {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn print_books(self) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
-"    //fn print_books(self) {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn print_books(self) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 
 #: src/exercises/day-1/book-library.md:71
 msgid ""
-"    //fn oldest_book(self) -> Option<&Book> {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"}"
+"```\n"
+"//fn oldest_book(self) -> Option<&Book> {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
-"    //fn oldest_book(self) -> Option<&Book> {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"}"
+"```\n"
+"//fn oldest_book(self) -> Option<&Book> {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 
 #: src/exercises/day-1/book-library.md:76
 msgid ""
-"// This shows the desired behavior. Uncomment the code below and\n"
-"// implement the missing methods. You will need to update the\n"
-"// method signatures, including the \"self\" parameter! You may\n"
-"// also need to update the variable bindings within main.\n"
-"fn main() {\n"
-"    let library = Library::new();"
+"// This shows the desired behavior. Uncomment the code below and // "
+"implement the missing methods. You will need to update the // method "
+"signatures, including the \"self\" parameter! You may // also need to update "
+"the variable bindings within main. fn main() { let library = Library::new();"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:83
+#: src/exercises/day-1/solutions-afternoon.md:113
 msgid ""
-"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
-"    //\n"
-"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    //\n"
-"    //library.print_books();\n"
-"    //\n"
-"    //match library.oldest_book() {\n"
-"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
-"    //    None => println!(\"My library is empty!\"),\n"
-"    //}\n"
-"    //\n"
-"    //println!(\"Our library has {} books\", library.len());\n"
-"}\n"
+"```\n"
+"//println!(\"Our library is empty: {}\", library.is_empty());\n"
+"//\n"
+"//library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"//library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"//\n"
+"//library.print_books();\n"
+"//\n"
+"//match library.oldest_book() {\n"
+"//    Some(book) => println!(\"My oldest book is {book}\"),\n"
+"//    None => println!(\"My library is empty!\"),\n"
+"//}\n"
+"//\n"
+"//println!(\"Our library has {} books\", library.len());\n"
 "```"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:99
-msgid ""
-"<details>\n"
-"    \n"
-"[Solution](solutions-afternoon.md#designing-a-library)"
-msgstr ""
-"<details>\n"
-"    \n"
-"[Rozwiązanie](solutions-afternoon.md#designing-a-library)"
-
-#: src/exercises/day-1/iterators-and-ownership.md:1
-#, fuzzy
-msgid "# Iterators and Ownership"
-msgstr "# Iteratory i własność"
+#: src/exercises/day-1/book-library.md:101
+msgid "[Solution](solutions-afternoon.md#designing-a-library)"
+msgstr "[Rozwiązanie](solutions-afternoon.md#designing-a-library)"
 
 #: src/exercises/day-1/iterators-and-ownership.md:3
 #, fuzzy
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 "Model własności Rust wpływa na wiele interfejsów API. Przykładem tego jest "
-"tzw\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) i\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"tzw [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) i "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "cechy."
 
 #: src/exercises/day-1/iterators-and-ownership.md:8
-msgid "## `Iterator`"
-msgstr "## `Iterator`"
+msgid "`Iterator`"
+msgstr "`Iterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 #, fuzzy
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
-"Cechy są jak interfejsy: opisują zachowanie (metody) dla typu. The\n"
-"Cecha `Iterator` mówi po prostu, że możesz wywoływać `next`, dopóki nie "
-"otrzymasz z powrotem `None`:"
+"Cechy są jak interfejsy: opisują zachowanie (metody) dla typu. The Cecha "
+"`Iterator` mówi po prostu, że możesz wywoływać `next`, dopóki nie otrzymasz "
+"z powrotem `None`:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
 msgid ""
@@ -6024,27 +5999,29 @@ msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();"
+"    let mut iter = v.iter();\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();"
+"    let mut iter = v.iter();\n"
+"```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:27
 msgid ""
-"    println!(\"v[0]: {:?}\", iter.next());\n"
-"    println!(\"v[1]: {:?}\", iter.next());\n"
-"    println!(\"v[2]: {:?}\", iter.next());\n"
-"    println!(\"No more items: {:?}\", iter.next());\n"
-"}\n"
+"```\n"
+"println!(\"v[0]: {:?}\", iter.next());\n"
+"println!(\"v[1]: {:?}\", iter.next());\n"
+"println!(\"v[2]: {:?}\", iter.next());\n"
+"println!(\"No more items: {:?}\", iter.next());\n"
 "```"
 msgstr ""
-"    println!(\"v[0]: {:?}\", iter.next());\n"
-"    println!(\"v[1]: {:?}\", iter.next());\n"
-"    println!(\"v[2]: {:?}\", iter.next());\n"
-"    println!(\"Nie ma więcej elementów: {:?}\", iter.next());\n"
-"}\n"
+"```\n"
+"println!(\"v[0]: {:?}\", iter.next());\n"
+"println!(\"v[1]: {:?}\", iter.next());\n"
+"println!(\"v[2]: {:?}\", iter.next());\n"
+"println!(\"Nie ma więcej elementów: {:?}\", iter.next());\n"
 "```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:34
@@ -6057,24 +6034,26 @@ msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
 "    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();"
+"    let mut iter = v.iter();\n"
+"```"
 msgstr ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
 "    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();"
+"    let mut iter = v.iter();\n"
+"```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:41
 #: src/exercises/day-1/iterators-and-ownership.md:78
 msgid ""
-"    let v0: Option<..> = iter.next();\n"
-"    println!(\"v0: {v0:?}\");\n"
-"}\n"
+"```\n"
+"let v0: Option<..> = iter.next();\n"
+"println!(\"v0: {v0:?}\");\n"
 "```"
 msgstr ""
-"    let v0: Option<..> = iter.next();\n"
-"    println!(\"v0: {v0:?}\");\n"
-"}\n"
+"```\n"
+"let v0: Option<..> = iter.next();\n"
+"println!(\"v0: {v0:?}\");\n"
 "```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:46
@@ -6083,67 +6062,70 @@ msgid "Why is this type used?"
 msgstr "Dlaczego ten typ jest używany?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
-msgid "## `IntoIterator`"
-msgstr "## `IntoIterator`"
+msgid "`IntoIterator`"
+msgstr "`IntoIterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 #, fuzzy
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
-"Cecha `Iterator` mówi ci, jak _iterować_ po utworzeniu\n"
-"iterator. Powiązana cecha `IntoIterator` mówi ci, jak stworzyć iterator:"
+"Cecha `Iterator` mówi ci, jak _iterować_ po utworzeniu iterator. Powiązana "
+"cecha `IntoIterator` mówi ci, jak stworzyć iterator:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:53
 msgid ""
 "```rust\n"
 "pub trait IntoIterator {\n"
 "    type Item;\n"
-"    type IntoIter: Iterator<Item = Self::Item>;"
+"    type IntoIter: Iterator<Item = Self::Item>;\n"
+"```"
 msgstr ""
 "```rust\n"
 "pub trait IntoIterator {\n"
 "    type Item;\n"
-"    type IntoIter: Iterator<Item = Self::Item>;"
+"    type IntoIter: Iterator<Item = Self::Item>;\n"
+"```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:58
 msgid ""
-"    fn into_iter(self) -> Self::IntoIter;\n"
-"}\n"
+"```\n"
+"fn into_iter(self) -> Self::IntoIter;\n"
 "```"
 msgstr ""
-"    fn into_iter(self) -> Self::IntoIter;\n"
-"}\n"
+"```\n"
+"fn into_iter(self) -> Self::IntoIter;\n"
 "```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:62
 #, fuzzy
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
-"Składnia tutaj oznacza, że każda implementacja `IntoIterator` musi\n"
+"Składnia tutaj oznacza, że każda implementacja `IntoIterator` musi "
 "zadeklarować dwa typy:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
 #, fuzzy
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
-msgstr ""
-"* `Item`: typ, który iterujemy, na przykład `i8`,\n"
-"* `IntoIter`: typ `Iterator` zwracany przez metodę `into_iter`."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr "`Item`: typ, który iterujemy, na przykład `i8`,"
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+#, fuzzy
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr "`IntoIter`: typ `Iterator` zwracany przez metodę `into_iter`."
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 #, fuzzy
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
-"Zauważ, że `IntoIter` i `Item` są połączone: iterator musi mieć to samo\n"
-"Typ `Item`, co oznacza, że zwraca `Option<Item>`"
+"Zauważ, że `IntoIter` i `Item` są połączone: iterator musi mieć to samo Typ "
+"`Item`, co oznacza, że zwraca `Option<Item>`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:71
 #, fuzzy
@@ -6154,64 +6136,71 @@ msgstr "Tak jak poprzednio, jaki typ jest zwracany przez iterator?"
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), "
-"String::from(\"bar\")];\n"
-"    let mut iter = v.into_iter();"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"    let mut iter = v.into_iter();\n"
+"```"
 msgstr ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), "
-"String::from(\"bar\")];\n"
-"    let mut iter = v.into_iter();"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"    let mut iter = v.into_iter();\n"
+"```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
-msgid "## `for` Loops"
-msgstr "## Pętle `for`"
+msgid "`for` Loops"
+msgstr "Pętle `for`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 #, fuzzy
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 "Teraz, gdy znamy zarówno `Iterator`, jak i `IntoIterator`, możemy budować "
-"pętle `for`.\n"
-"Wywołują `into_iter()` na wyrażeniu i iterują wynik\n"
-"iterator:"
+"pętle `for`. Wywołują `into_iter()` na wyrażeniu i iterują wynik iterator:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"```"
 
 #: src/exercises/day-1/iterators-and-ownership.md:93
 msgid ""
-"    for word in &v {\n"
-"        println!(\"word: {word}\");\n"
-"    }"
-msgstr ""
-"    for word in &v {\n"
-"        println!(\"word: {word}\");\n"
-"    }"
-
-#: src/exercises/day-1/iterators-and-ownership.md:97
-msgid ""
-"    for word in v {\n"
-"        println!(\"word: {word}\");\n"
-"    }\n"
+"```\n"
+"for word in &v {\n"
+"    println!(\"word: {word}\");\n"
 "}\n"
 "```"
 msgstr ""
-"    for word in v {\n"
-"        println!(\"word: {word}\");\n"
-"    }\n"
+"```\n"
+"for word in &v {\n"
+"    println!(\"word: {word}\");\n"
+"}\n"
+"```"
+
+#: src/exercises/day-1/iterators-and-ownership.md:97
+msgid ""
+"```\n"
+"for word in v {\n"
+"    println!(\"word: {word}\");\n"
+"}\n"
+"```"
+msgstr ""
+"```\n"
+"for word in v {\n"
+"    println!(\"word: {word}\");\n"
 "}\n"
 "```"
 
@@ -6223,25 +6212,21 @@ msgstr "Jaki jest typ słowa w każdej pętli?"
 #: src/exercises/day-1/iterators-and-ownership.md:105
 #, fuzzy
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 "Eksperymentuj z powyższym kodem, a następnie zapoznaj się z dokumentacją dla "
-"[`impl\n"
-"IntoIterator dla\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"i [`impl IntoIterator dla\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
-"aby sprawdzić swoje odpowiedzi."
+"[`impl IntoIterator dla &Vec<T>`](https://doc.rust-lang.org/std/vec/struct."
+"Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) i [`impl "
+"IntoIterator dla Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) aby sprawdzić swoje odpowiedzi."
 
 #: src/welcome-day-2.md:1
-msgid "# Welcome to Day 2"
-msgstr "# Witamy w dniu 2"
+msgid "Welcome to Day 2"
+msgstr "Witamy w dniu 2"
 
 #: src/welcome-day-2.md:3
 #, fuzzy
@@ -6250,45 +6235,36 @@ msgstr "Teraz, gdy widzieliśmy już sporo Rust, będziemy kontynuować:"
 
 #: src/welcome-day-2.md:5
 #, fuzzy
-msgid "* Structs, enums, methods."
-msgstr "* Struktury, wyliczenia, metody."
+msgid "Structs, enums, methods."
+msgstr "Struktury, wyliczenia, metody."
 
 #: src/welcome-day-2.md:7
 #, fuzzy
-msgid "* Pattern matching: destructuring enums, structs, and arrays."
-msgstr "* Dopasowywanie wzorców: destrukturyzacja wyliczeń, struktur i tablic."
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr "Dopasowywanie wzorców: destrukturyzacja wyliczeń, struktur i tablic."
 
 #: src/welcome-day-2.md:9
 #, fuzzy
 msgid ""
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`."
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
 msgstr ""
-"* Konstrukcje przepływu sterowania: `if`, `if let`, `while`, `while let`, "
-"`break` i\n"
-"  `kontynuuj`."
+"Konstrukcje przepływu sterowania: `if`, `if let`, `while`, `while let`, "
+"`break` i `kontynuuj`."
 
 #: src/welcome-day-2.md:12
 #, fuzzy
 msgid ""
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`."
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
 msgstr ""
-"* Biblioteka standardowa: `String`, `Option` i `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  i `Łuk`."
+"Biblioteka standardowa: `String`, `Option` i `Result`, `Vec`, `HashMap`, "
+"`Rc` i `Łuk`."
 
 #: src/welcome-day-2.md:15
 #, fuzzy
-msgid "* Modules: visibility, paths, and filesystem hierarchy."
-msgstr "* Moduły: widoczność, ścieżki i hierarchia systemów plików."
-
-#: src/structs.md:1
-#, fuzzy
-msgid "# Structs"
-msgstr "# Struktury"
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr "Moduły: widoczność, ścieżki i hierarchia systemów plików."
 
 #: src/structs.md:3
 #, fuzzy
@@ -6301,80 +6277,91 @@ msgid ""
 "struct Person {\n"
 "    name: String,\n"
 "    age: u8,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "struct Person {\n"
 "    name: String,\n"
 "    age: u8,\n"
-"}"
+"}\n"
+"```"
 
 #: src/structs.md:11
 msgid ""
-"fn main() {\n"
-"    let mut peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    peter.age = 28;\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    let jackie = Person {\n"
-"        name: String::from(\"Jackie\"),\n"
-"        ..peter\n"
-"    };\n"
-"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
-"}\n"
+"fn main() { let mut peter = Person { name: String::from(\"Peter\"), age: "
+"27, }; println!(\"{} is {} years old\", peter.name, peter.age);"
+msgstr ""
+"fn main() { let mut peter = Person { name: String::from(\"Peter\"), age: "
+"27, }; println!(\"{} ma {} lat\", peter.name, peter.age);"
+
+#: src/structs.md:18
+msgid ""
+"```\n"
+"peter.age = 28;\n"
+"println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"\n"
+"let jackie = Person {\n"
+"    name: String::from(\"Jackie\"),\n"
+"    ..peter\n"
+"};\n"
+"println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
 "```"
 msgstr ""
-"fn main() {\n"
-"    let mut peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    println!(\"{} ma {} lat\", peter.name, peter.age);\n"
-"    \n"
-"    peter.age = 28;\n"
-"    println!(\"{} ma {} lat\", peter.name, peter.age);\n"
-"    \n"
-"    let jackie = Person {\n"
-"        name: String::from(\"Jackie\"),\n"
-"        ..peter\n"
-"    };\n"
-"    println!(\"{} ma {} lat\", jackie.name, jackie.age);\n"
-"}\n"
+"```\n"
+"peter.age = 28;\n"
+"println!(\"{} ma {} lat\", peter.name, peter.age);\n"
+"\n"
+"let jackie = Person {\n"
+"    name: String::from(\"Jackie\"),\n"
+"    ..peter\n"
+"};\n"
+"println!(\"{} ma {} lat\", jackie.name, jackie.age);\n"
 "```"
 
-#: src/structs.md:29
-#, fuzzy
-msgid "<details>\nKey Points: "
-msgstr "<details>\nKluczowe punkty:"
-
 #: src/structs.md:32
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:33
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:35
 msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:36
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
-
-#: src/structs/tuple-structs.md:1
-#, fuzzy
-msgid "# Tuple Structs"
-msgstr "# Struktury krotkowe"
 
 #: src/structs/tuple-structs.md:3
 #, fuzzy
@@ -6382,22 +6369,18 @@ msgid "If the field names are unimportant, you can use a tuple struct:"
 msgstr "Jeśli nazwy pól są nieistotne, możesz użyć struktury krotki:"
 
 #: src/structs/tuple-structs.md:5
-msgid "```rust,editable\nstruct Point(i32, i32);"
-msgstr "```rust,editable\nstruct Point(i32, i32);"
-
-#: src/structs/tuple-structs.md:8
 msgid ""
-"fn main() {\n"
-"    let p = Point(17, 23);\n"
-"    println!(\"({}, {})\", p.0, p.1);\n"
-"}\n"
+"```rust,editable\n"
+"struct Point(i32, i32);\n"
 "```"
 msgstr ""
-"fn main() {\n"
-"    let p = Point(17, 23);\n"
-"    println!(\"({}, {})\", p.0, p.1);\n"
-"}\n"
+"```rust,editable\n"
+"struct Point(i32, i32);\n"
 "```"
+
+#: src/structs/tuple-structs.md:8
+msgid "fn main() { let p = Point(17, 23); println!(\"({}, {})\", p.0, p.1); }"
+msgstr "fn main() { let p = Point(17, 23); println!(\"({}, {})\", p.0, p.1); }"
 
 #: src/structs/tuple-structs.md:14
 #, fuzzy
@@ -6410,92 +6393,92 @@ msgstr ""
 msgid ""
 "```rust,editable,compile_fail\n"
 "struct PoundOfForce(f64);\n"
-"struct Newtons(f64);"
+"struct Newtons(f64);\n"
+"```"
 msgstr ""
 "```rust,editable,compile_fail\n"
 "struct PoundOfForce(f64);\n"
-"struct Newtons(f64);"
+"struct Newtons(f64);\n"
+"```"
 
 #: src/structs/tuple-structs.md:20
 msgid ""
-"fn compute_thruster_force() -> PoundOfForce {\n"
-"    todo!(\"Ask a rocket scientist at NASA\")\n"
-"}"
+"fn compute_thruster_force() -> PoundOfForce { todo!(\"Ask a rocket scientist "
+"at NASA\") }"
 msgstr ""
-"fn compute_thruster_force() -> PoundOfForce {\n"
-"    todo!(\"Zapytaj naukowca rakietowego z NASA\")\n"
-"}"
+"fn compute_thruster_force() -> PoundOfForce { todo!(\"Zapytaj naukowca "
+"rakietowego z NASA\") }"
 
 #: src/structs/tuple-structs.md:24
-msgid ""
-"fn set_thruster_force(force: Newtons) {\n"
-"    // ...\n"
-"}"
-msgstr ""
-"fn set_thruster_force(force: Newtons) {\n"
-"    // ...\n"
-"}"
+msgid "fn set_thruster_force(force: Newtons) { // ... }"
+msgstr "fn set_thruster_force(force: Newtons) { // ... }"
 
 #: src/structs/tuple-structs.md:28
 msgid ""
-"fn main() {\n"
-"    let force = compute_thruster_force();\n"
-"    set_thruster_force(force);\n"
-"}"
+"fn main() { let force = compute_thruster_force(); "
+"set_thruster_force(force); }"
 msgstr ""
-"fn main() {\n"
-"    let force = compute_thruster_force();\n"
-"    set_thruster_force(force);\n"
-"}"
-
-#: src/structs/tuple-structs.md:33 src/traits/default.md:36 src/generics/trait-objects.md:86
-msgid "```"
-msgstr "```"
+"fn main() { let force = compute_thruster_force(); "
+"set_thruster_force(force); }"
 
 #: src/structs/tuple-structs.md:37
 #, fuzzy
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). \n"
-"</details>"
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
-"* Nowe typy to świetny sposób na zakodowanie dodatkowych informacji o "
-"wartości w typie pierwotnym, na przykład:\n"
-"  * Liczba jest mierzona w niektórych jednostkach: „Newtons” w powyższym "
-"przykładzie.\n"
-"  * Wartość przeszła walidację podczas tworzenia, więc nie musisz już "
-"weryfikować jej ponownie przy każdym użyciu: „PhoneNumber(String)” lub "
-"„OddNumber(u32)”.\n"
-"* Zademonstruj, jak dodać wartość `f64` do typu `Newtons`, uzyskując dostęp "
-"do pojedynczego pola w newtype.\n"
-"  * Rust generalnie nie lubi niejasnych rzeczy, takich jak automatyczne "
-"rozpakowywanie lub na przykład używanie wartości boolowskich jako liczb "
-"całkowitych.\n"
-"  * Przeciążenie operatora jest omówione w dniu 3 (leki generyczne).\n"
-"</details>"
+"Nowe typy to świetny sposób na zakodowanie dodatkowych informacji o wartości "
+"w typie pierwotnym, na przykład:"
 
-#: src/structs/field-shorthand.md:1
+#: src/structs/tuple-structs.md:38
 #, fuzzy
-msgid "# Field Shorthand Syntax"
-msgstr "# Skrócona składnia pola"
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+"Liczba jest mierzona w niektórych jednostkach: „Newtons” w powyższym "
+"przykładzie."
+
+#: src/structs/tuple-structs.md:39
+#, fuzzy
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"Wartość przeszła walidację podczas tworzenia, więc nie musisz już "
+"weryfikować jej ponownie przy każdym użyciu: „PhoneNumber(String)” lub "
+"„OddNumber(u32)”."
+
+#: src/structs/tuple-structs.md:40
+#, fuzzy
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+"Zademonstruj, jak dodać wartość `f64` do typu `Newtons`, uzyskując dostęp do "
+"pojedynczego pola w newtype."
+
+#: src/structs/tuple-structs.md:41
+#, fuzzy
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+"Rust generalnie nie lubi niejasnych rzeczy, takich jak automatyczne "
+"rozpakowywanie lub na przykład używanie wartości boolowskich jako liczb "
+"całkowitych."
+
+#: src/structs/tuple-structs.md:42
+#, fuzzy
+msgid "Operator overloading is discussed on Day 3 (generics). "
+msgstr "Przeciążenie operatora jest omówione w dniu 3 (leki generyczne)."
 
 #: src/structs/field-shorthand.md:3
 #, fuzzy
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
-"Jeśli masz już zmienne o odpowiednich nazwach, możesz je utworzyć\n"
-"struct za pomocą skrótu:"
+"Jeśli masz już zmienne o odpowiednich nazwach, możesz je utworzyć struct za "
+"pomocą skrótu:"
 
 #: src/structs/field-shorthand.md:6 src/methods.md:6
 msgid ""
@@ -6504,51 +6487,41 @@ msgid ""
 "struct Person {\n"
 "    name: String,\n"
 "    age: u8,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
 "struct Person {\n"
 "    name: String,\n"
 "    age: u8,\n"
-"}"
+"}\n"
+"```"
 
 #: src/structs/field-shorthand.md:13
 msgid ""
-"impl Person {\n"
-"    fn new(name: String, age: u8) -> Person {\n"
-"        Person { name, age }\n"
-"    }\n"
-"}"
+"impl Person { fn new(name: String, age: u8) -> Person { Person { name, "
+"age } } }"
 msgstr ""
-"impl Person {\n"
-"    fn new(name: String, age: u8) -> Person {\n"
-"        Person { name, age }\n"
-"    }\n"
-"}"
+"impl Person { fn new(name: String, age: u8) -> Person { Person { name, "
+"age } } }"
 
 #: src/structs/field-shorthand.md:19
 msgid ""
-"fn main() {\n"
-"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
-"    println!(\"{peter:?}\");\n"
-"}\n"
-"```"
+"fn main() { let peter = Person::new(String::from(\"Peter\"), 27); println!"
+"(\"{peter:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
-"    println!(\"{peter:?}\");\n"
-"}\n"
-"```"
+"fn main() { let peter = Person::new(String::from(\"Peter\"), 27); println!"
+"(\"{peter:?}\"); }"
 
 #: src/structs/field-shorthand.md:27
 #, fuzzy
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
+"The `new` function could be written using `Self` as a type, as it is "
 "interchangeable with the struct type name"
 msgstr ""
-"* Funkcja `new` może być napisana przy użyciu `Self` jako typu, ponieważ "
-"jest wymienna z nazwą typu struct"
+"Funkcja `new` może być napisana przy użyciu `Self` jako typu, ponieważ jest "
+"wymienna z nazwą typu struct"
 
 #: src/structs/field-shorthand.md:29
 msgid ""
@@ -6570,143 +6543,126 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:37
 #, fuzzy
-msgid ""
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
-msgstr ""
-"* Metody są zdefiniowane w bloku `impl`.\n"
-"* Użyj składni aktualizacji struktury, aby zdefiniować nową strukturę za "
-"pomocą `peter`. Zauważ, że później zmienna `peter` nie będzie już dostępna.\n"
-"* Użyj `{:#?}` podczas drukowania struktur, aby zażądać reprezentacji "
-"`Debug`."
+msgid "Methods are defined in the `impl` block."
+msgstr "Metody są zdefiniowane w bloku `impl`."
 
-#: src/enums.md:1
+#: src/structs/field-shorthand.md:38
 #, fuzzy
-msgid "# Enums"
-msgstr "# Wyliczenia"
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+"Użyj składni aktualizacji struktury, aby zdefiniować nową strukturę za "
+"pomocą `peter`. Zauważ, że później zmienna `peter` nie będzie już dostępna."
+
+#: src/structs/field-shorthand.md:39
+#, fuzzy
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
+"Użyj `{:#?}` podczas drukowania struktur, aby zażądać reprezentacji `Debug`."
 
 #: src/enums.md:3
 #, fuzzy
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
-"Słowo kluczowe `enum` pozwala na utworzenie typu, który ma kilka\n"
-"różne warianty:"
+"Słowo kluczowe `enum` pozwala na utworzenie typu, który ma kilka różne "
+"warianty:"
 
 #: src/enums.md:6
 msgid ""
 "```rust,editable\n"
 "fn generate_random_number() -> i32 {\n"
 "    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn generate_random_number() -> i32 {\n"
 "    4  // Wyznaczone rzutem kości. Gwarantowana losowość.\n"
-"}"
+"}\n"
+"```"
 
 #: src/enums.md:11
-msgid ""
-"#[derive(Debug)]\n"
-"enum CoinFlip {\n"
-"    Heads,\n"
-"    Tails,\n"
-"}"
-msgstr ""
-"#[derive(Debug)]\n"
-"enum CoinFlip {\n"
-"    Heads,\n"
-"    Tails,\n"
-"}"
+msgid "\\#\\[derive(Debug)\\] enum CoinFlip { Heads, Tails, }"
+msgstr "\\#\\[derive(Debug)\\] enum CoinFlip { Heads, Tails, }"
 
 #: src/enums.md:17
 msgid ""
-"fn flip_coin() -> CoinFlip {\n"
-"    let random_number = generate_random_number();\n"
-"    if random_number % 2 == 0 {\n"
-"        return CoinFlip::Heads;\n"
-"    } else {\n"
-"        return CoinFlip::Tails;\n"
-"    }\n"
-"}"
+"fn flip_coin() -> CoinFlip { let random_number = generate_random_number(); "
+"if random_number % 2 == 0 { return CoinFlip::Heads; } else { return "
+"CoinFlip::Tails; } }"
 msgstr ""
-"fn flip_coin() -> CoinFlip {\n"
-"    let random_number = generate_random_number();\n"
-"    if random_number % 2 == 0 {\n"
-"        return CoinFlip::Heads;\n"
-"    } else {\n"
-"        return CoinFlip::Tails;\n"
-"    }\n"
-"}"
+"fn flip_coin() -> CoinFlip { let random_number = generate_random_number(); "
+"if random_number % 2 == 0 { return CoinFlip::Heads; } else { return "
+"CoinFlip::Tails; } }"
 
 #: src/enums.md:26
-msgid ""
-"fn main() {\n"
-"    println!(\"You got: {:?}\", flip_coin());\n"
-"}\n"
-"```"
-msgstr ""
-"fn main() {\n"
-"    println!(\"Wynik: {:?}\", flip_coin());\n"
-"}\n"
-"```"
+msgid "fn main() { println!(\"You got: {:?}\", flip_coin()); }"
+msgstr "fn main() { println!(\"Wynik: {:?}\", flip_coin()); }"
 
-#: src/enums.md:31
+#: src/enums.md:33 src/methods.md:30 src/methods/example.md:46
+#: src/pattern-matching.md:25 src/pattern-matching/match-guards.md:22
+#: src/control-flow/blocks.md:42
 #, fuzzy
-msgid ""
-"<details>\n"
-"    \n"
-"Key Points:"
-msgstr ""
-"<details>\n"
-"    \n"
-"Kluczowe punkty:"
+msgid "Key Points:"
+msgstr "Kluczowe punkty:"
 
 #: src/enums.md:35
 #, fuzzy
-msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
-"structs but then they wouldn’t be the same type as they would if they were "
-"all defined in an enum. \n"
-"</details>"
-msgstr ""
-"* Wyliczenia umożliwiają zebranie zestawu wartości w ramach jednego typu\n"
-"* Ta strona oferuje typ wyliczeniowy `CoinFlip` z dwoma wariantami `Heads` i "
-"`Tail`. Podczas używania wariantów możesz zwrócić uwagę na przestrzeń nazw.\n"
-"* To może być dobry moment na porównanie Structs i Enums:\n"
-"  * W obu przypadkach możesz mieć prostą wersję bez pól (struktura "
-"jednostek) lub wersję z różnymi typami pól (wariantowe ładunki).\n"
-"  * W obu przypadkach powiązane funkcje są zdefiniowane w bloku `impl`.\n"
-"  * Można nawet zaimplementować różne warianty wyliczenia z osobnymi "
-"strukturami, ale wtedy nie byłyby one tego samego typu, co gdyby wszystkie "
-"były zdefiniowane w wyliczeniu.\n"
-"</details>"
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr "Wyliczenia umożliwiają zebranie zestawu wartości w ramach jednego typu"
 
-#: src/enums/variant-payloads.md:1
+#: src/enums.md:36
 #, fuzzy
-msgid "# Variant Payloads"
-msgstr "# Wariant Ładunki"
+msgid ""
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+"Ta strona oferuje typ wyliczeniowy `CoinFlip` z dwoma wariantami `Heads` i "
+"`Tail`. Podczas używania wariantów możesz zwrócić uwagę na przestrzeń nazw."
+
+#: src/enums.md:37
+#, fuzzy
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr "To może być dobry moment na porównanie Structs i Enums:"
+
+#: src/enums.md:38
+#, fuzzy
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"W obu przypadkach możesz mieć prostą wersję bez pól (struktura jednostek) "
+"lub wersję z różnymi typami pól (wariantowe ładunki)."
+
+#: src/enums.md:39
+#, fuzzy
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr "W obu przypadkach powiązane funkcje są zdefiniowane w bloku `impl`."
+
+#: src/enums.md:40
+#, fuzzy
+msgid ""
+"You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. "
+msgstr ""
+"Można nawet zaimplementować różne warianty wyliczenia z osobnymi "
+"strukturami, ale wtedy nie byłyby one tego samego typu, co gdyby wszystkie "
+"były zdefiniowane w wyliczeniu."
 
 #: src/enums/variant-payloads.md:3
 #, fuzzy
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 "Możesz zdefiniować bogatsze wyliczenia, w których warianty zawierają dane. "
-"Możesz wtedy użyć tzw\n"
-"Instrukcja `match` w celu wyodrębnienia danych z każdego wariantu:"
+"Możesz wtedy użyć tzw Instrukcja `match` w celu wyodrębnienia danych z "
+"każdego wariantu:"
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -6715,108 +6671,124 @@ msgid ""
 "    PageLoad,                 // Variant without payload\n"
 "    KeyPress(char),           // Tuple struct variant\n"
 "    Click { x: i64, y: i64 }, // Full struct variant\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/enums/variant-payloads.md:13
 msgid ""
-"#[rustfmt::skip]\n"
-"fn inspect(event: WebEvent) {\n"
-"    match event {\n"
-"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
-"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
-"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
-"    }\n"
-"}"
+"\\#\\[rustfmt::skip\\] fn inspect(event: WebEvent) { match event { WebEvent::"
+"PageLoad       => println!(\"page loaded\"), WebEvent::KeyPress(c)    => "
+"println!(\"pressed '{c}'\"), WebEvent::Click { x, y } => println!(\"clicked "
+"at x={x}, y={y}\"), } }"
 msgstr ""
-"#[rustfmt::skip]\n"
-"fn inspect(event: WebEvent) {\n"
-"    match event {\n"
-"        WebEvent::PageLoad       => println!(\"strona załadowana\"),\n"
-"        WebEvent::KeyPress(c)    => println!(\"przyciśnięto '{c}'\"),\n"
-"        WebEvent::Click { x, y } => println!(\"kliknięto w x={x}, y={y}\"),\n"
-"    }\n"
-"}"
+"\\#\\[rustfmt::skip\\] fn inspect(event: WebEvent) { match event { WebEvent::"
+"PageLoad       => println!(\"strona załadowana\"), WebEvent::KeyPress(c)    "
+"=> println!(\"przyciśnięto '{c}'\"), WebEvent::Click { x, y } => println!"
+"(\"kliknięto w x={x}, y={y}\"), } }"
 
 #: src/enums/variant-payloads.md:22
 msgid ""
-"fn main() {\n"
-"    let load = WebEvent::PageLoad;\n"
-"    let press = WebEvent::KeyPress('x');\n"
-"    let click = WebEvent::Click { x: 20, y: 80 };"
+"fn main() { let load = WebEvent::PageLoad; let press = WebEvent::"
+"KeyPress('x'); let click = WebEvent::Click { x: 20, y: 80 };"
 msgstr ""
-"fn main() {\n"
-"    let load = WebEvent::PageLoad;\n"
-"    let press = WebEvent::KeyPress('x');\n"
-"    let click = WebEvent::Click { x: 20, y: 80 };"
+"fn main() { let load = WebEvent::PageLoad; let press = WebEvent::"
+"KeyPress('x'); let click = WebEvent::Click { x: 20, y: 80 };"
 
 #: src/enums/variant-payloads.md:27
 msgid ""
-"    inspect(load);\n"
-"    inspect(press);\n"
-"    inspect(click);\n"
-"}\n"
+"```\n"
+"inspect(load);\n"
+"inspect(press);\n"
+"inspect(click);\n"
 "```"
 msgstr ""
-"    inspect(load);\n"
-"    inspect(press);\n"
-"    inspect(click);\n"
-"}\n"
+"```\n"
+"inspect(load);\n"
+"inspect(press);\n"
+"inspect(click);\n"
 "```"
 
 #: src/enums/variant-payloads.md:35
 #, fuzzy
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expressions is matched against the patterns from top to bottom. "
-"There is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling "
-"`std::mem::discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as "
-"`WebEvent::Click(Click)` with a top level `struct Click { ... }`. The "
-"inlined version cannot implement traits, for example.  \n"
-"  \n"
-"</details>"
+"after the `=>`."
 msgstr ""
-"* Dostęp do wartości w wariantach enum można uzyskać dopiero po dopasowaniu "
-"do wzorca. Wzorzec wiąże odniesienia do pól w „ramię dopasowania” po `=>`.\n"
-"  * Wyrażenia są dopasowywane do wzorców od góry do dołu. Nie ma spadku, jak "
-"w C lub C++.\n"
-"  * Wyrażenie dopasowania ma wartość. Wartość to ostatnie wyrażenie w "
-"ramieniu dopasowania, które zostało wykonane.\n"
-"  * Zaczynając od góry, szukamy wzoru pasującego do wartości, a następnie "
-"uruchamiamy kod podążający za strzałką. Gdy znajdziemy dopasowanie, "
-"zatrzymujemy się.\n"
-"* Zademonstruj, co się dzieje, gdy wyszukiwanie jest niewyczerpujące. Zwróć "
-"uwagę na zalety kompilatora Rusta, który potwierdza, kiedy wszystkie "
-"przypadki są obsługiwane.\n"
-"* `match` sprawdza ukryte pole dyskryminujące w `enum`.\n"
-"* Możliwe jest odzyskanie wyróżnika przez wywołanie "
-"`std::mem::discriminant()`\n"
-"  * Jest to przydatne na przykład przy implementacji `PartialEq` dla "
-"struktur, w których porównywanie wartości pól nie wpływa na równość.\n"
-"* `WebEvent::Click { ... }` nie jest dokładnie tym samym co "
-"`WebEvent::Click(Click)` z najwyższym poziomem `struct Click { ... }`. "
-"Wbudowana wersja nie może na przykład implementować cech.\n"
-"  \n"
-"</details>"
+"Dostęp do wartości w wariantach enum można uzyskać dopiero po dopasowaniu do "
+"wzorca. Wzorzec wiąże odniesienia do pól w „ramię dopasowania” po `=>`."
 
-#: src/enums/sizes.md:1
+#: src/enums/variant-payloads.md:36
 #, fuzzy
-msgid "# Enum Sizes"
-msgstr "# Wylicz rozmiary"
+msgid ""
+"The expressions is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+"Wyrażenia są dopasowywane do wzorców od góry do dołu. Nie ma spadku, jak w C "
+"lub C++."
+
+#: src/enums/variant-payloads.md:37
+#, fuzzy
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+"Wyrażenie dopasowania ma wartość. Wartość to ostatnie wyrażenie w ramieniu "
+"dopasowania, które zostało wykonane."
+
+#: src/enums/variant-payloads.md:38
+#, fuzzy
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+"Zaczynając od góry, szukamy wzoru pasującego do wartości, a następnie "
+"uruchamiamy kod podążający za strzałką. Gdy znajdziemy dopasowanie, "
+"zatrzymujemy się."
+
+#: src/enums/variant-payloads.md:39
+#, fuzzy
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+"Zademonstruj, co się dzieje, gdy wyszukiwanie jest niewyczerpujące. Zwróć "
+"uwagę na zalety kompilatora Rusta, który potwierdza, kiedy wszystkie "
+"przypadki są obsługiwane."
+
+#: src/enums/variant-payloads.md:40
+#, fuzzy
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr "`match` sprawdza ukryte pole dyskryminujące w `enum`."
+
+#: src/enums/variant-payloads.md:41
+#, fuzzy
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+"Możliwe jest odzyskanie wyróżnika przez wywołanie `std::mem::discriminant()`"
+
+#: src/enums/variant-payloads.md:42
+#, fuzzy
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+"Jest to przydatne na przykład przy implementacji `PartialEq` dla struktur, w "
+"których porównywanie wartości pól nie wpływa na równość."
+
+#: src/enums/variant-payloads.md:43
+#, fuzzy
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
+"`WebEvent::Click { ... }` nie jest dokładnie tym samym co `WebEvent::"
+"Click(Click)` z najwyższym poziomem `struct Click { ... }`. Wbudowana wersja "
+"nie może na przykład implementować cech."
 
 #: src/enums/sizes.md:3
 #, fuzzy
@@ -6828,209 +6800,195 @@ msgstr ""
 "wynikające z wyrównania:"
 
 #: src/enums/sizes.md:5
-msgid "```rust,editable\nuse std::mem::{align_of, size_of};"
-msgstr "```rust,editable\nuse std::mem::{align_of, size_of};"
+msgid ""
+"```rust,editable\n"
+"use std::mem::{align_of, size_of};\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::mem::{align_of, size_of};\n"
+"```"
 
 #: src/enums/sizes.md:8
 msgid ""
-"macro_rules! dbg_size {\n"
-"    ($t:ty) => {\n"
-"        println!(\"{}: size {} bytes, align: {} bytes\",\n"
-"                 stringify!($t), size_of::<$t>(), align_of::<$t>());\n"
-"    };\n"
-"}"
+"macro_rules! dbg_size { ($t:ty) => { println!(\"{}: size {} bytes, align: {} "
+"bytes\", stringify!($t), size_of::\\<$t>(), align_of::\\<$t>()); }; }"
 msgstr ""
-"macro_rules! dbg_size {\n"
-"    ($t:ty) => {\n"
-"        println!(\"{}: rozmiar {} bajtów, wyrównanie: {} bytes\",\n"
-"                 stringify!($t), size_of::<$t>(), align_of::<$t>());\n"
-"    };\n"
-"}"
+"macro_rules! dbg_size { ($t:ty) => { println!(\"{}: rozmiar {} bajtów, "
+"wyrównanie: {} bytes\", stringify!($t), size_of::\\<$t>(), align_of::"
+"\\<$t>()); }; }"
 
 #: src/enums/sizes.md:15
-msgid ""
-"enum Foo {\n"
-"    A,\n"
-"    B,\n"
-"}"
-msgstr ""
-"enum Foo {\n"
-"    A,\n"
-"    B,\n"
-"}"
+msgid "enum Foo { A, B, }"
+msgstr "enum Foo { A, B, }"
 
 #: src/enums/sizes.md:20
-msgid ""
-"#[repr(u32)]\n"
-"enum Bar {\n"
-"    A,  // 0\n"
-"    B = 10000,\n"
-"    C,  // 10001\n"
-"}"
-msgstr ""
-"#[repr(u32)]\n"
-"enum Bar {\n"
-"    A,  // 0\n"
-"    B = 10000,\n"
-"    C,  // 10001\n"
-"}"
+msgid "\\#\\[repr(u32)\\] enum Bar { A,  // 0 B = 10000, C,  // 10001 }"
+msgstr "\\#\\[repr(u32)\\] enum Bar { A,  // 0 B = 10000, C,  // 10001 }"
 
 #: src/enums/sizes.md:27
 msgid ""
-"fn main() {\n"
-"    dbg_size!(Foo);\n"
-"    dbg_size!(Bar);\n"
-"    dbg_size!(bool);\n"
-"    dbg_size!(Option<bool>);\n"
-"    dbg_size!(&i32);\n"
-"    dbg_size!(Option<&i32>);\n"
-"}\n"
-"```"
+"fn main() { dbg_size!(Foo); dbg_size!(Bar); dbg_size!(bool); dbg_size!(Option"
 msgstr ""
-"fn main() {\n"
-"    dbg_size!(Foo);\n"
-"    dbg_size!(Bar);\n"
-"    dbg_size!(bool);\n"
-"    dbg_size!(Option<bool>);\n"
-"    dbg_size!(&i32);\n"
-"    dbg_size!(Option<&i32>);\n"
-"}\n"
-"```"
+"fn main() { dbg_size!(Foo); dbg_size!(Bar); dbg_size!(bool); dbg_size!(Option"
+
+#: src/enums/sizes.md:31
+msgid "); dbg_size!(&i32); dbg_size!(Option\\<&i32>); }"
+msgstr "); dbg_size!(&i32); dbg_size!(Option\\<&i32>); }"
 
 #: src/enums/sizes.md:37
 #, fuzzy
 msgid ""
-"* See the [Rust "
-"Reference](https://doc.rust-lang.org/reference/type-layout.html)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"html)."
 msgstr ""
-"* Zobacz [Odniesienie do "
-"Rust](https://doc.rust-lang.org/reference/type-layout.html)."
+"Zobacz [Odniesienie do Rust](https://doc.rust-lang.org/reference/type-layout."
+"html)."
 
-#: src/enums/sizes.md:39
+#: src/enums/sizes.md:41
+#, fuzzy
+msgid "Key Points: "
+msgstr "Kluczowe punkty:"
+
+#: src/enums/sizes.md:42
 #, fuzzy
 msgid ""
-"<details>\n"
-"    \n"
-"Key Points: \n"
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
-" * `Bar` enum demonstrates that there is a way to control the discriminant "
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+"Wewnętrznie Rust używa pola (dyskryminacyjnego) do śledzenia wariantu enum."
+
+#: src/enums/sizes.md:43
+#, fuzzy
+msgid ""
+"`Bar` enum demonstrates that there is a way to control the discriminant "
 "value and type. If `repr` is removed, the discriminant type takes 2 bytes, "
-"becuase 10001 fits 2 bytes.\n"
-" * As a niche optimization an enum discriminant is merged with the pointer "
-"so that `Option<&Foo>` is the same size as `&Foo`.\n"
-" * `Option<bool>` is another example of tight packing.\n"
-" * For [some types](https://doc.rust-lang.org/std/option/#representation), "
-"Rust guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-" * Zero-sized types allow for efficient implementation of `HashSet` using "
+"becuase 10001 fits 2 bytes."
+msgstr ""
+"Wyliczenie `Bar` pokazuje, że istnieje sposób kontrolowania wartości i typu "
+"wyróżnika. Jeśli usunie się `repr`, typ dyskryminacyjny zajmuje 2 bajty, "
+"ponieważ 10001 mieści 2 bajty."
+
+#: src/enums/sizes.md:44
+#, fuzzy
+msgid ""
+"As a niche optimization an enum discriminant is merged with the pointer so "
+"that `Option<&Foo>` is the same size as `&Foo`."
+msgstr ""
+"Jako optymalizacja niszowa dyskryminator wyliczeniowy jest łączony ze "
+"wskaźnikiem, dzięki czemu `Option<&Foo>` ma taki sam rozmiar jak `&Foo`."
+
+#: src/enums/sizes.md:45
+#, fuzzy
+msgid "`Option<bool>` is another example of tight packing."
+msgstr "`Option<bool>` to kolejny przykład ciasnego upakowania."
+
+#: src/enums/sizes.md:46
+#, fuzzy
+msgid ""
+"For [some types](https://doc.rust-lang.org/std/option/#representation), Rust "
+"guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`."
+msgstr ""
+"Dla [niektórych typów](https://doc.rust-lang.org/std/option/"
+"#representation), Rust gwarantuje, że `size_of::<T>()` równa się `size_of::"
+"<Option<T> >()`."
+
+#: src/enums/sizes.md:47
+#, fuzzy
+msgid ""
+"Zero-sized types allow for efficient implementation of `HashSet` using "
 "`HashMap` with `()` as the value."
 msgstr ""
-"<details>\n"
-"    \n"
-"Kluczowe punkty:\n"
-" * Wewnętrznie Rust używa pola (dyskryminacyjnego) do śledzenia wariantu "
-"enum.\n"
-" * Wyliczenie `Bar` pokazuje, że istnieje sposób kontrolowania wartości i "
-"typu wyróżnika. Jeśli usunie się `repr`, typ dyskryminacyjny zajmuje 2 "
-"bajty, ponieważ 10001 mieści 2 bajty.\n"
-" * Jako optymalizacja niszowa dyskryminator wyliczeniowy jest łączony ze "
-"wskaźnikiem, dzięki czemu `Option<&Foo>` ma taki sam rozmiar jak `&Foo`.\n"
-" * `Option<bool>` to kolejny przykład ciasnego upakowania.\n"
-" * Dla [niektórych "
-"typów](https://doc.rust-lang.org/std/option/#representation), Rust "
-"gwarantuje, że `size_of::<T>()` równa się `size_of::<Option<T> >()`.\n"
-" * Typy o zerowym rozmiarze pozwalają na wydajną implementację `HashSet` "
-"przy użyciu `HashMap` z `()` jako wartością."
+"Typy o zerowym rozmiarze pozwalają na wydajną implementację `HashSet` przy "
+"użyciu `HashMap` z `()` jako wartością."
 
 #: src/enums/sizes.md:49
 #, fuzzy
 msgid ""
-"Example code if you want to show how the bitwise representation *may* look "
-"like in practice.\n"
-"It's important to note that the compiler provides no guarantees regarding "
-"this representation, therefore this is totally unsafe."
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
 msgstr ""
-"Przykładowy kod, jeśli chcesz pokazać, jak reprezentacja bitowa *może* "
-"wyglądać w praktyce.\n"
-"Należy zauważyć, że kompilator nie zapewnia żadnych gwarancji dotyczących "
-"tej reprezentacji, dlatego jest to całkowicie niebezpieczne."
+"Przykładowy kod, jeśli chcesz pokazać, jak reprezentacja bitowa _może_ "
+"wyglądać w praktyce. Należy zauważyć, że kompilator nie zapewnia żadnych "
+"gwarancji dotyczących tej reprezentacji, dlatego jest to całkowicie "
+"niebezpieczne."
 
 #: src/enums/sizes.md:52
-msgid "```rust,editable\nuse std::mem::transmute;"
-msgstr "```rust,editable\nuse std::mem::transmute;"
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
+"```"
 
 #: src/enums/sizes.md:55 src/enums/sizes.md:94
 msgid ""
-"macro_rules! dbg_bits {\n"
-"    ($e:expr, $bit_type:ty) => {\n"
-"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
-"$bit_type>($e));\n"
-"    };\n"
-"}"
+"macro_rules! dbg_bits { ($e:expr, $bit_type:ty) => { println!(\"- {}: {:"
+"#x}\", stringify!($e), transmute::\\<\\_, $bit_type>($e)); }; }"
 msgstr ""
-"macro_rules! dbg_bits {\n"
-"    ($e:expr, $bit_type:ty) => {\n"
-"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
-"$bit_type>($e));\n"
-"    };\n"
-"}"
+"macro_rules! dbg_bits { ($e:expr, $bit_type:ty) => { println!(\"- {}: {:"
+"#x}\", stringify!($e), transmute::\\<\\_, $bit_type>($e)); }; }"
 
 #: src/enums/sizes.md:61
 msgid ""
-"fn main() {\n"
-"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"    // representation of types.\n"
-"    unsafe {\n"
-"        println!(\"Bitwise representation of bool\");\n"
-"        dbg_bits!(false, u8);\n"
-"        dbg_bits!(true, u8);"
+"fn main() { // TOTALLY UNSAFE. Rust provides no guarantees about the "
+"bitwise // representation of types. unsafe { println!(\"Bitwise "
+"representation of bool\"); dbg_bits!(false, u8); dbg_bits!(true, u8);"
 msgstr ""
-"fn main() {\n"
-"    // NIEBEZPIECZNE. Rust nie daje gwarancji jak dany typ jest przedstawiony w pamięci.\n"
-"    unsafe {\n"
-"        println!(\"Bitowa reprezentacja typu bool\");\n"
-"        dbg_bits!(false, u8);\n"
-"        dbg_bits!(true, u8);"
+"fn main() { // NIEBEZPIECZNE. Rust nie daje gwarancji jak dany typ jest "
+"przedstawiony w pamięci. unsafe { println!(\"Bitowa reprezentacja typu "
+"bool\"); dbg_bits!(false, u8); dbg_bits!(true, u8);"
 
 #: src/enums/sizes.md:69
 msgid ""
-"        println!(\"Bitwise representation of Option<bool>\");\n"
-"        dbg_bits!(None::<bool>, u8);\n"
-"        dbg_bits!(Some(false), u8);\n"
-"        dbg_bits!(Some(true), u8);"
+"```\n"
+"    println!(\"Bitwise representation of Option<bool>\");\n"
+"    dbg_bits!(None::<bool>, u8);\n"
+"    dbg_bits!(Some(false), u8);\n"
+"    dbg_bits!(Some(true), u8);\n"
+"```"
 msgstr ""
-"        println!(\"Bitowa reprezentacja Option<bool>\");\n"
-"        dbg_bits!(None::<bool>, u8);\n"
-"        dbg_bits!(Some(false), u8);\n"
-"        dbg_bits!(Some(true), u8);"
+"```\n"
+"    println!(\"Bitowa reprezentacja Option<bool>\");\n"
+"    dbg_bits!(None::<bool>, u8);\n"
+"    dbg_bits!(Some(false), u8);\n"
+"    dbg_bits!(Some(true), u8);\n"
+"```"
 
 #: src/enums/sizes.md:74
 msgid ""
-"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"        dbg_bits!(Some(Some(false)), u8);\n"
-"        dbg_bits!(Some(Some(true)), u8);\n"
-"        dbg_bits!(Some(None::<bool>), u8);\n"
-"        dbg_bits!(None::<Option<bool>>, u8);"
+"```\n"
+"    println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"    dbg_bits!(Some(Some(false)), u8);\n"
+"    dbg_bits!(Some(Some(true)), u8);\n"
+"    dbg_bits!(Some(None::<bool>), u8);\n"
+"    dbg_bits!(None::<Option<bool>>, u8);\n"
+"```"
 msgstr ""
-"        println!(\"Bitowa reprezentacja Option<Option<bool>>\");\n"
-"        dbg_bits!(Some(Some(false)), u8);\n"
-"        dbg_bits!(Some(Some(true)), u8);\n"
-"        dbg_bits!(Some(None::<bool>), u8);\n"
-"        dbg_bits!(None::<Option<bool>>, u8);"
+"```\n"
+"    println!(\"Bitowa reprezentacja Option<Option<bool>>\");\n"
+"    dbg_bits!(Some(Some(false)), u8);\n"
+"    dbg_bits!(Some(Some(true)), u8);\n"
+"    dbg_bits!(Some(None::<bool>), u8);\n"
+"    dbg_bits!(None::<Option<bool>>, u8);\n"
+"```"
 
 #: src/enums/sizes.md:80
 msgid ""
-"        println!(\"Bitwise representation of Option<&i32>\");\n"
-"        dbg_bits!(None::<&i32>, usize);\n"
-"        dbg_bits!(Some(&0i32), usize);\n"
-"    }\n"
+"```\n"
+"    println!(\"Bitwise representation of Option<&i32>\");\n"
+"    dbg_bits!(None::<&i32>, usize);\n"
+"    dbg_bits!(Some(&0i32), usize);\n"
 "}\n"
 "```"
 msgstr ""
-"        println!(\"Bitowa reprezentacja Option<&i32>\");\n"
-"        dbg_bits!(None::<&i32>, usize);\n"
-"        dbg_bits!(Some(&0i32), usize);\n"
-"    }\n"
+"```\n"
+"    println!(\"Bitowa reprezentacja Option<&i32>\");\n"
+"    dbg_bits!(None::<&i32>, usize);\n"
+"    dbg_bits!(Some(&0i32), usize);\n"
 "}\n"
 "```"
 
@@ -7044,8 +7002,14 @@ msgstr ""
 "razem więcej niż 256 opcji."
 
 #: src/enums/sizes.md:89
-msgid "```rust,editable\n#![recursion_limit = \"1000\"]"
-msgstr "```rust,editable\n#![recursion_limit = \"1000\"]"
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
+"```"
 
 #: src/enums/sizes.md:92
 msgid "use std::mem::transmute;"
@@ -7054,82 +7018,73 @@ msgstr "use std::mem::transmute;"
 #: src/enums/sizes.md:100
 msgid ""
 "// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
-"signs.\n"
-"// Increasing the recursion limit is required to evaluate this macro.\n"
-"macro_rules! many_options {\n"
-"    ($value:expr) => { Some($value) };\n"
-"    ($value:expr, @) => {\n"
-"        Some(Some($value))\n"
-"    };\n"
-"    ($value:expr, @ $($more:tt)+) => {\n"
-"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"    };\n"
-"}"
+"signs. // Increasing the recursion limit is required to evaluate this macro. "
+"macro_rules! many_options { ($value:expr) => { Some($value) }; ($value:expr, "
+"@) => { Some(Some($value)) }; ($value:expr, @ $($more:tt)+) => "
+"{ many_options!(many_options!($value, $($more)+), $($more)+) }; }"
 msgstr ""
-"// Makro pakujące wartość w 2^n Some() gdzie n to liczba znaków \"@\".\n"
-"// Zwiększnie limitu rekurencji jest wymagane żeby wywołać to makro.\n"
-"macro_rules! many_options {\n"
-"    ($value:expr) => { Some($value) };\n"
-"    ($value:expr, @) => {\n"
-"        Some(Some($value))\n"
-"    };\n"
-"    ($value:expr, @ $($more:tt)+) => {\n"
-"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"    };\n"
-"}"
+"// Makro pakujące wartość w 2^n Some() gdzie n to liczba znaków \"@\". // "
+"Zwiększnie limitu rekurencji jest wymagane żeby wywołać to makro. "
+"macro_rules! many_options { ($value:expr) => { Some($value) }; ($value:expr, "
+"@) => { Some(Some($value)) }; ($value:expr, @ $($more:tt)+) => "
+"{ many_options!(many_options!($value, $($more)+), $($more)+) }; }"
 
 #: src/enums/sizes.md:112
 msgid ""
-"fn main() {\n"
-"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"    // representation of types.\n"
-"    unsafe {\n"
-"        assert_eq!(many_options!(false), Some(false));\n"
-"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"        assert_eq!(many_options!(false, @@), Some(Some(Some(Some(false)))));"
+"fn main() { // TOTALLY UNSAFE. Rust provides no guarantees about the "
+"bitwise // representation of types. unsafe { assert_eq!(many_options!"
+"(false), Some(false)); assert_eq!(many_options!(false, @), "
+"Some(Some(false))); assert_eq!(many_options!(false, @@), "
+"Some(Some(Some(Some(false)))));"
 msgstr ""
-"fn main() {\n"
-"    // NIEBEZPIECZNE. Rust nie daje gwarancji jak dany typ jest przedstawiony w pamięci.\n"
-"    unsafe {\n"
-"        assert_eq!(many_options!(false), Some(false));\n"
-"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"        assert_eq!(many_options!(false, @@), Some(Some(Some(Some(false)))));"
+"fn main() { // NIEBEZPIECZNE. Rust nie daje gwarancji jak dany typ jest "
+"przedstawiony w pamięci. unsafe { assert_eq!(many_options!(false), "
+"Some(false)); assert_eq!(many_options!(false, @), Some(Some(false))); "
+"assert_eq!(many_options!(false, @@), Some(Some(Some(Some(false)))));"
 
 #: src/enums/sizes.md:120
 msgid ""
-"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
-"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"        dbg_bits!(many_options!(true, @@@@@@@), u8);"
+"```\n"
+"    println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"    dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"    dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"```"
 msgstr ""
-"        println!(\"Bitowa reprezentacja łańcucha 128 Option.\");\n"
-"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"        dbg_bits!(many_options!(true, @@@@@@@), u8);"
+"```\n"
+"    println!(\"Bitowa reprezentacja łańcucha 128 Option.\");\n"
+"    dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"    dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"```"
 
 #: src/enums/sizes.md:124
 msgid ""
-"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
-"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(true, @@@@@@@@), u16);"
+"```\n"
+"    println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"    dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"```"
 msgstr ""
-"        println!(\"Bitowa reprezentacja łańcucha 256 Option.\");\n"
-"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(true, @@@@@@@@), u16);"
+"```\n"
+"    println!(\"Bitowa reprezentacja łańcucha 256 Option.\");\n"
+"    dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"```"
 
 #: src/enums/sizes.md:128
 msgid ""
-"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
-"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"    }\n"
+"```\n"
+"    println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"    dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
 "}\n"
 "```"
 msgstr ""
-"        println!(\"Bitowa reprezentacja łańcucha 257 Option.\");\n"
-"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"    }\n"
+"```\n"
+"    println!(\"Bitowa reprezentacja łańcucha 257 Option.\");\n"
+"    dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
 "}\n"
 "```"
 
@@ -7137,183 +7092,181 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
-"Rust umożliwia powiązanie funkcji z nowymi typami. Robisz to z\n"
-"blok `impl`:"
+"Rust umożliwia powiązanie funkcji z nowymi typami. Robisz to z blok `impl`:"
 
 #: src/methods.md:13
 msgid ""
-"impl Person {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Hello, my name is {}\", self.name);\n"
-"    }\n"
-"}"
+"impl Person { fn say_hello(&self) { println!(\"Hello, my name is {}\", self."
+"name); } }"
 msgstr ""
-"impl Person {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Cześć, mam na imię {}\", self.name);\n"
-"    }\n"
-"}"
+"impl Person { fn say_hello(&self) { println!(\"Cześć, mam na imię {}\", self."
+"name); } }"
 
 #: src/methods.md:19
 msgid ""
-"fn main() {\n"
-"    let peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    peter.say_hello();\n"
-"}\n"
-"```"
+"fn main() { let peter = Person { name: String::from(\"Peter\"), age: 27, }; "
+"peter.say_hello(); }"
 msgstr ""
-"fn main() {\n"
-"    let peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    peter.say_hello();\n"
-"}\n"
-"```"
+"fn main() { let peter = Person { name: String::from(\"Peter\"), age: 27, }; "
+"peter.say_hello(); }"
 
-#: src/methods.md:30
+#: src/methods.md:31
+#, fuzzy
+msgid "It can be helpful to introduce methods by comparing them to functions."
+msgstr ""
+"Pomocne może być wprowadzenie metod poprzez porównanie ich z funkcjami."
+
+#: src/methods.md:32
 #, fuzzy
 msgid ""
-"Key Points:\n"
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   \n"
-"</details>"
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
 msgstr ""
-"Kluczowe punkty:\n"
-"* Pomocne może być wprowadzenie metod poprzez porównanie ich z funkcjami.\n"
-"  * Metody są wywoływane na instancji typu (takiej jak struct lub enum), "
-"pierwszy parametr reprezentuje instancję jako `self`.\n"
-"  * Deweloperzy mogą zdecydować się na użycie metod, aby skorzystać ze "
-"składni odbiornika metod i pomóc w ich lepszej organizacji. Dzięki metodom "
-"możemy przechowywać cały kod implementacji w jednym przewidywalnym miejscu.\n"
-"* Zwróć uwagę na użycie słowa kluczowego `self`, odbiornika metody.\n"
-"  * Pokaż, że jest to skrócony termin dla `self:&Self` i być może pokaż, jak "
-"można również użyć nazwy struktury.\n"
-"  * Wyjaśnij, że `Self` jest aliasem typu dla typu, w którym znajduje się "
-"blok `impl` i może być użyty w innym miejscu bloku.\n"
-"  * Zwróć uwagę, jak `self` jest używane jak inne struktury, a notacja "
-"kropkowa może być używana do odwoływania się do poszczególnych pól.\n"
-"  * To może być dobry moment, aby zademonstrować, czym `&self` różni się od "
-"`self` poprzez modyfikację kodu i próbę dwukrotnego uruchomienia say_hello.\n"
-"* Następnie opiszemy rozróżnienie między odbiornikami metod.\n"
-"   \n"
-"</details>"
+"Metody są wywoływane na instancji typu (takiej jak struct lub enum), "
+"pierwszy parametr reprezentuje instancję jako `self`."
 
-#: src/methods/receiver.md:1
+#: src/methods.md:33
 #, fuzzy
-msgid "# Method Receiver"
-msgstr "# Odbiornik metody"
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+"Deweloperzy mogą zdecydować się na użycie metod, aby skorzystać ze składni "
+"odbiornika metod i pomóc w ich lepszej organizacji. Dzięki metodom możemy "
+"przechowywać cały kod implementacji w jednym przewidywalnym miejscu."
+
+#: src/methods.md:34
+#, fuzzy
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr "Zwróć uwagę na użycie słowa kluczowego `self`, odbiornika metody."
+
+#: src/methods.md:35
+#, fuzzy
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+"Pokaż, że jest to skrócony termin dla `self:&Self` i być może pokaż, jak "
+"można również użyć nazwy struktury."
+
+#: src/methods.md:36
+#, fuzzy
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+"Wyjaśnij, że `Self` jest aliasem typu dla typu, w którym znajduje się blok "
+"`impl` i może być użyty w innym miejscu bloku."
+
+#: src/methods.md:37
+#, fuzzy
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+"Zwróć uwagę, jak `self` jest używane jak inne struktury, a notacja kropkowa "
+"może być używana do odwoływania się do poszczególnych pól."
+
+#: src/methods.md:38
+#, fuzzy
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+"To może być dobry moment, aby zademonstrować, czym `&self` różni się od "
+"`self` poprzez modyfikację kodu i próbę dwukrotnego uruchomienia say_hello."
+
+#: src/methods.md:39
+#, fuzzy
+msgid "We describe the distinction between method receivers next."
+msgstr "Następnie opiszemy rozróżnienie między odbiornikami metod."
 
 #: src/methods/receiver.md:3
 #, fuzzy
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
-"„&self” powyżej wskazuje, że metoda niezmiennie pożycza obiekt. Tam\n"
-"są innymi możliwymi odbiorcami metody:"
+"„&self” powyżej wskazuje, że metoda niezmiennie pożycza obiekt. Tam są "
+"innymi możliwymi odbiorcami metody:"
 
 #: src/methods/receiver.md:6
 #, fuzzy
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted.\n"
-"* `mut self`: same as above, but while the method owns the object, it can\n"
-"  mutate it too. Complete ownership does not automatically mean mutability.\n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
 msgstr ""
-"* `&self`: pożycza obiekt od dzwoniącego za pomocą współdzielonego i "
-"niezmiennego\n"
-"  odniesienie. Obiekt może być później ponownie użyty.\n"
-"* `&mut self`: pożycza obiekt od wywołującego używając unikalnego i "
-"zmiennego\n"
-"  odniesienie. Obiekt może być później ponownie użyty.\n"
-"* `self`: przejmuje obiekt na własność i oddala go od dzwoniącego. The\n"
-"  metoda staje się właścicielem obiektu. Obiekt zostanie usunięty (cofnięty "
-"przydział)\n"
-"  gdy metoda zwraca, chyba że jej własność jest wyraźnie określona\n"
-"  przekazywane.\n"
-"* `mut self`: to samo co powyżej, ale gdy metoda jest właścicielem obiektu, "
-"może\n"
-"  też mutuj. Pełna własność nie oznacza automatycznie zmienności.\n"
-"* Brak odbiornika: staje się to metodą statyczną w strukturze. Zwykle "
-"przyzwyczajony\n"
-"  tworzyć konstruktory, które zgodnie z konwencją nazywane są „nowymi”."
+"`&self`: pożycza obiekt od dzwoniącego za pomocą współdzielonego i "
+"niezmiennego odniesienie. Obiekt może być później ponownie użyty."
+
+#: src/methods/receiver.md:8
+#, fuzzy
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+"`&mut self`: pożycza obiekt od wywołującego używając unikalnego i zmiennego "
+"odniesienie. Obiekt może być później ponownie użyty."
+
+#: src/methods/receiver.md:10
+#, fuzzy
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted."
+msgstr ""
+"`self`: przejmuje obiekt na własność i oddala go od dzwoniącego. The metoda "
+"staje się właścicielem obiektu. Obiekt zostanie usunięty (cofnięty "
+"przydział) gdy metoda zwraca, chyba że jej własność jest wyraźnie określona "
+"przekazywane."
+
+#: src/methods/receiver.md:14
+#, fuzzy
+msgid ""
+"`mut self`: same as above, but while the method owns the object, it can "
+"mutate it too. Complete ownership does not automatically mean mutability."
+msgstr ""
+"`mut self`: to samo co powyżej, ale gdy metoda jest właścicielem obiektu, "
+"może też mutuj. Pełna własność nie oznacza automatycznie zmienności."
+
+#: src/methods/receiver.md:16
+#, fuzzy
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
+msgstr ""
+"Brak odbiornika: staje się to metodą statyczną w strukturze. Zwykle "
+"przyzwyczajony tworzyć konstruktory, które zgodnie z konwencją nazywane są "
+"„nowymi”."
 
 #: src/methods/receiver.md:19
 #, fuzzy
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper "
-"types](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
-"Oprócz wariantów na „ja”, istnieją również\n"
-"[specjalne typy "
-"opakowań](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
-"mogą być typami odbiorników, takimi jak `Box<Self>`."
+"Oprócz wariantów na „ja”, istnieją również [specjalne typy opakowań](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) mogą być typami "
+"odbiorników, takimi jak `Box<Self>`."
 
-#: src/methods/receiver.md:23
+#: src/methods/receiver.md:25
 #, fuzzy
 msgid ""
-"<details>\n"
-"  \n"
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it.\n"
-"  \n"
-"</details>"
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
-"<details>\n"
-"  \n"
 "Rozważ podkreślenie słów „wspólny i niezmienny” oraz „unikatowy i zmienny”. "
-"Te ograniczenia pojawiają się zawsze\n"
-"razem w Rust ze względu na zasady pożyczania sprawdzania, a `self` nie jest "
-"wyjątkiem. Nie można\n"
-"odwołać się do struktury z wielu lokalizacji i wywołać na niej metodę "
-"mutacji (`&mut self`).\n"
-"  \n"
-"</details>"
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "# Example"
-msgstr "# Przykład"
+"Te ograniczenia pojawiają się zawsze razem w Rust ze względu na zasady "
+"pożyczania sprawdzania, a `self` nie jest wyjątkiem. Nie można odwołać się "
+"do struktury z wielu lokalizacji i wywołać na niej metodę mutacji (`&mut "
+"self`)."
 
 #: src/methods/example.md:3
 msgid ""
@@ -7322,131 +7275,123 @@ msgid ""
 "struct Race {\n"
 "    name: String,\n"
 "    laps: Vec<i32>,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
 "struct Race {\n"
 "    name: String,\n"
 "    laps: Vec<i32>,\n"
-"}"
+"}\n"
+"```"
 
 #: src/methods/example.md:10
 #, fuzzy
 msgid ""
-"impl Race {\n"
-"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
-"        Race { name: String::from(name), laps: Vec::new() }\n"
-"    }"
+"impl Race { fn new(name: &str) -> Race {  // No receiver, a static method "
+"Race { name: String::from(name), laps: Vec::new() } }"
 msgstr ""
-"impl Wyścig {\n"
-"    fn new(name: &str) -> Race { // Brak odbiornika, metoda statyczna\n"
-"        Wyścig { nazwa: String::from(name), okrążenia: Vec::new() }\n"
-"    }"
+"impl Wyścig { fn new(name: &str) -> Race { // Brak odbiornika, metoda "
+"statyczna Wyścig { nazwa: String::from(name), okrążenia: Vec::new() } }"
 
 #: src/methods/example.md:15
 msgid ""
-"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
-"access to self\n"
-"        self.laps.push(lap);\n"
-"    }"
+"```\n"
+"fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write access "
+"to self\n"
+"    self.laps.push(lap);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods/example.md:19
 msgid ""
-"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
-"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
-"        for (idx, lap) in self.laps.iter().enumerate() {\n"
-"            println!(\"Lap {idx}: {lap} sec\");\n"
-"        }\n"
-"    }"
+"```\n"
+"fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
+"    println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
+"    for (idx, lap) in self.laps.iter().enumerate() {\n"
+"        println!(\"Lap {idx}: {lap} sec\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods/example.md:26
 msgid ""
-"    fn finish(self) {  // Exclusive ownership of self\n"
-"        let total = self.laps.iter().sum::<i32>();\n"
-"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"```\n"
+"fn finish(self) {  // Exclusive ownership of self\n"
+"    let total = self.laps.iter().sum::<i32>();\n"
+"    println!(\"Race {} is finished, total lap time: {}\", self.name, "
 "total);\n"
-"    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods/example.md:32
 msgid ""
-"fn main() {\n"
-"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
-"    race.add_lap(70);\n"
-"    race.add_lap(68);\n"
-"    race.print_laps();\n"
-"    race.add_lap(71);\n"
-"    race.print_laps();\n"
-"    race.finish();\n"
-"    // race.add_lap(42);\n"
-"}\n"
-"```"
+"fn main() { let mut race = Race::new(\"Monaco Grand Prix\"); race."
+"add_lap(70); race.add_lap(68); race.print_laps(); race.add_lap(71); race."
+"print_laps(); race.finish(); // race.add_lap(42); }"
 msgstr ""
-"fn main() {\n"
-"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
-"    race.add_lap(70);\n"
-"    race.add_lap(68);\n"
-"    race.print_laps();\n"
-"    race.add_lap(71);\n"
-"    race.print_laps();\n"
-"    race.finish();\n"
-"    // race.add_lap(42);\n"
-"}\n"
-"```"
+"fn main() { let mut race = Race::new(\"Monaco Grand Prix\"); race."
+"add_lap(70); race.add_lap(68); race.print_laps(); race.add_lap(71); race."
+"print_laps(); race.finish(); // race.add_lap(42); }"
 
-#: src/methods/example.md:44
+#: src/methods/example.md:47
+#, fuzzy
+msgid "All four methods here use a different method receiver."
+msgstr "Wszystkie cztery metody tutaj wykorzystują inny odbiornik metody."
+
+#: src/methods/example.md:48
 #, fuzzy
 msgid ""
-"<details>\n"
-"    \n"
-"Key Points:\n"
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+"Możesz wskazać, jak to zmienia to, co funkcja może zrobić z wartościami "
+"zmiennych i czy/jak można jej ponownie użyć w `main`."
+
+#: src/methods/example.md:49
+#, fuzzy
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+"Możesz pokazać błąd, który pojawia się podczas próby dwukrotnego wywołania "
+"`finish`."
+
+#: src/methods/example.md:50
+#, fuzzy
+msgid ""
+"Note that although the method receivers are different, the non-static "
 "functions are called the same way in the main body. Rust enables automatic "
 "referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+"Należy zauważyć, że chociaż odbiorniki metod są różne, funkcje niestatyczne "
+"są wywoływane w ten sam sposób w głównej części. Rust umożliwia automatyczne "
+"odwoływanie się i usuwanie odwołań podczas wywoływania metod. Rust "
+"automatycznie dodaje `&`, `*`, `muts`, aby ten obiekt pasował do sygnatury "
+"metody."
+
+#: src/methods/example.md:51
+#, fuzzy
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
 "over. We describe vectors in more detail in the afternoon. "
 msgstr ""
-"<details>\n"
-"    \n"
-"Kluczowe punkty:\n"
-"* Wszystkie cztery metody tutaj wykorzystują inny odbiornik metody.\n"
-"  * Możesz wskazać, jak to zmienia to, co funkcja może zrobić z wartościami "
-"zmiennych i czy/jak można jej ponownie użyć w `main`.\n"
-"  * Możesz pokazać błąd, który pojawia się podczas próby dwukrotnego "
-"wywołania `finish`.\n"
-"* Należy zauważyć, że chociaż odbiorniki metod są różne, funkcje "
-"niestatyczne są wywoływane w ten sam sposób w głównej części. Rust umożliwia "
-"automatyczne odwoływanie się i usuwanie odwołań podczas wywoływania metod. "
-"Rust automatycznie dodaje `&`, `*`, `muts`, aby ten obiekt pasował do "
-"sygnatury metody.\n"
-"* Możesz zauważyć, że `print_laps` używa wektora, który jest iterowany. "
+"Możesz zauważyć, że `print_laps` używa wektora, który jest iterowany. "
 "Wektory opiszemy bardziej szczegółowo po południu."
-
-#: src/pattern-matching.md:1
-#, fuzzy
-msgid "# Pattern Matching"
-msgstr "# Dopasowanie wzorca"
 
 #: src/pattern-matching.md:3
 #, fuzzy
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 "Słowo kluczowe `match` pozwala dopasować wartość do jednego lub więcej "
-"_wzorców_. The\n"
-"porównania są wykonywane od góry do dołu, a pierwszy mecz wygrywa."
+"_wzorców_. The porównania są wykonywane od góry do dołu, a pierwszy mecz "
+"wygrywa."
 
 #: src/pattern-matching.md:6
 #, fuzzy
@@ -7457,17 +7402,18 @@ msgstr "Wzorce mogą być prostymi wartościami, podobnie jak `switch` w C i C++
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let input = 'x';"
+"    let input = 'x';\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching.md:12
 msgid ""
-"    match input {\n"
-"        'q'                   => println!(\"Quitting\"),\n"
-"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
-"        '0'..='9'             => println!(\"Number input\"),\n"
-"        _                     => println!(\"Something else\"),\n"
-"    }\n"
+"```\n"
+"match input {\n"
+"    'q'                   => println!(\"Quitting\"),\n"
+"    'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
+"    '0'..='9'             => println!(\"Number input\"),\n"
+"    _                     => println!(\"Something else\"),\n"
 "}\n"
 "```"
 msgstr ""
@@ -7478,59 +7424,66 @@ msgid "The `_` pattern is a wildcard pattern which matches any value."
 msgstr ""
 "Wzorzec `_` jest wzorcem wieloznacznym, który pasuje do dowolnej wartości."
 
-#: src/pattern-matching.md:23
+#: src/pattern-matching.md:26
 #, fuzzy
 msgid ""
-"<details>\n"
-"    \n"
-"Key Points:\n"
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   \n"
-"</details>"
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
-"<details>\n"
-"    \n"
-"Kluczowe punkty:\n"
-"* Możesz wskazać, w jaki sposób niektóre określone znaki są używane we "
-"wzorcu\n"
-"  * `|` jako `lub`\n"
-"  * `..` może rozwinąć się tak bardzo, jak to konieczne\n"
-"  * `1..=5` reprezentuje zakres włącznie\n"
-"  * `_` to symbol wieloznaczny\n"
-"* Przydatne może być pokazanie, jak działa wiązanie, na przykład zastępując "
-"symbol wieloznaczny zmienną lub usuwając cudzysłowy wokół `q`.\n"
-"* Możesz zademonstrować dopasowanie na podstawie referencji.\n"
-"* To może być dobry moment, aby przywołać koncepcję niepodważalnych wzorców, "
-"ponieważ termin ten może pojawiać się w komunikatach o błędach.\n"
-"   \n"
-"</details>"
+"Możesz wskazać, w jaki sposób niektóre określone znaki są używane we wzorcu"
 
-#: src/pattern-matching/destructuring-enums.md:1
+#: src/pattern-matching.md:27
 #, fuzzy
-msgid "# Destructuring Enums"
-msgstr "# Niszczenie wyliczeń"
+msgid "`|` as an `or`"
+msgstr "`|` jako `lub`"
+
+#: src/pattern-matching.md:28
+#, fuzzy
+msgid "`..` can expand as much as it needs to be"
+msgstr "`..` może rozwinąć się tak bardzo, jak to konieczne"
+
+#: src/pattern-matching.md:29
+#, fuzzy
+msgid "`1..=5` represents an inclusive range"
+msgstr "`1..=5` reprezentuje zakres włącznie"
+
+#: src/pattern-matching.md:30
+#, fuzzy
+msgid "`_` is a wild card"
+msgstr "`_` to symbol wieloznaczny"
+
+#: src/pattern-matching.md:31
+#, fuzzy
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+"Przydatne może być pokazanie, jak działa wiązanie, na przykład zastępując "
+"symbol wieloznaczny zmienną lub usuwając cudzysłowy wokół `q`."
+
+#: src/pattern-matching.md:32
+#, fuzzy
+msgid "You can demonstrate matching on a reference."
+msgstr "Możesz zademonstrować dopasowanie na podstawie referencji."
+
+#: src/pattern-matching.md:33
+#, fuzzy
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
+msgstr ""
+"To może być dobry moment, aby przywołać koncepcję niepodważalnych wzorców, "
+"ponieważ termin ten może pojawiać się w komunikatach o błędach."
 
 #: src/pattern-matching/destructuring-enums.md:3
 #, fuzzy
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 "Wzorców można również używać do wiązania zmiennych z częściami wartości. Oto "
-"jak\n"
-"sprawdzasz strukturę swoich typów. Zacznijmy od prostego typu `enum`:"
+"jak sprawdzasz strukturę swoich typów. Zacznijmy od prostego typu `enum`:"
 
 #: src/pattern-matching/destructuring-enums.md:6
 msgid ""
@@ -7538,76 +7491,57 @@ msgid ""
 "enum Result {\n"
 "    Ok(i32),\n"
 "    Err(String),\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:12
 #, fuzzy
 msgid ""
-"fn divide_in_two(n: i32) -> Result {\n"
-"    if n % 2 == 0 {\n"
-"        Result::Ok(n / 2)\n"
-"    } else {\n"
-"        Result::Err(format!(\"cannot divide {n} into two equal parts\"))\n"
-"    }\n"
-"}"
+"fn divide_in_two(n: i32) -> Result { if n % 2 == 0 { Result::Ok(n / 2) } "
+"else { Result::Err(format!(\"cannot divide {n} into two equal parts\")) } }"
 msgstr ""
-"fn dzielenie_na_dwa(n: i32) -> Wynik {\n"
-"    jeśli n % 2 == 0 {\n"
-"        Wynik::OK(n / 2)\n"
-"    } w przeciwnym razie {\n"
-"        Result::Err(format!(\"nie można podzielić {n} na dwie równe "
-"części\"))\n"
-"    }\n"
-"}"
+"fn dzielenie_na_dwa(n: i32) -> Wynik { jeśli n % 2 == 0 { Wynik::OK(n / 2) } "
+"w przeciwnym razie { Result::Err(format!(\"nie można podzielić {n} na dwie "
+"równe części\")) } }"
 
 #: src/pattern-matching/destructuring-enums.md:20
 msgid ""
-"fn main() {\n"
-"    let n = 100;\n"
-"    match divide_in_two(n) {\n"
-"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
-"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let n = 100; match divide_in_two(n) { Result::Ok(half) => "
+"println!(\"{n} divided in two is {half}\"), Result::Err(msg) => println!"
+"(\"sorry, an error happened: {msg}\"), } }"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
 #, fuzzy
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
-"Tutaj użyliśmy ramion do _destrukturyzacji_ wartości `Result`. Na początku\n"
+"Tutaj użyliśmy ramion do _destrukturyzacji_ wartości `Result`. Na początku "
 "arm, `half` jest powiązany z wartością wewnątrz wariantu `Ok`. W drugim "
-"ramieniu\n"
-"`msg` jest powiązany z komunikatem o błędzie."
+"ramieniu `msg` jest powiązany z komunikatem o błędzie."
 
-#: src/pattern-matching/destructuring-enums.md:35
+#: src/pattern-matching/destructuring-enums.md:36
 #, fuzzy
 msgid ""
-"Key points:\n"
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
-"Kluczowe punkty:\n"
-"* Wyrażenie `if`/`else` zwraca wyliczenie, które jest później rozpakowywane "
-"z `match`.\n"
-"* Możesz spróbować dodać trzeci wariant do definicji enum i wyświetlić błędy "
+"Wyrażenie `if`/`else` zwraca wyliczenie, które jest później rozpakowywane z "
+"`match`."
+
+#: src/pattern-matching/destructuring-enums.md:37
+#, fuzzy
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
+msgstr ""
+"Możesz spróbować dodać trzeci wariant do definicji enum i wyświetlić błędy "
 "podczas uruchamiania kodu. Wskaż miejsca, w których Twój kod jest teraz "
 "niewyczerpany i jak kompilator próbuje udzielić Ci wskazówek."
-
-#: src/pattern-matching/destructuring-structs.md:1
-#, fuzzy
-msgid "# Destructuring Structs"
-msgstr "# Destrukcja struktur"
 
 #: src/pattern-matching/destructuring-structs.md:3
 #, fuzzy
@@ -7620,40 +7554,55 @@ msgid ""
 "struct Foo {\n"
 "    x: (u32, u32),\n"
 "    y: u32,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:11
 msgid ""
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let foo = Foo { x: (1, 2), y: 3 };\n"
-"    match foo {\n"
-"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
-"        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
-"ignored\"),\n"
-"    }\n"
-"}\n"
+"\\#\\[rustfmt::skip\\] fn main() { let foo = Foo { x: (1, 2), y: 3 }; match "
+"foo { Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"), Foo "
+"{ y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"), Foo { y, .. }        => "
+"println!(\"y = {y}, other fields were ignored\"), } }"
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:20
+msgid ""
 "```\n"
-"<details>"
+"<details>\n"
+"\n"
+"# Destructuring Structs\n"
+"\n"
+"You can also destructure `structs`:\n"
+"\n"
+"```rust,editable\n"
+"struct Foo {\n"
+"    x: (u32, u32),\n"
+"    y: u32,\n"
+"}\n"
+"\n"
+"* Change the literal values in `foo` to match with the other patterns.\n"
+"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
+"</details>\n"
+"\n"
+"# Destructuring Structs\n"
+"\n"
+"You can also destructure `structs`:\n"
+"\n"
+"```rust,editable\n"
+"{{#include ../../third_party/rust-by-example/destructuring-structs.rs}}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
 #, fuzzy
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"</details>"
-msgstr ""
-"* Zmień wartości literalne w `foo`, aby dopasować je do innych wzorców.\n"
-"* Dodaj nowe pole do `Foo` i w razie potrzeby wprowadź zmiany we wzorcu.\n"
-"</details>"
+msgid "Change the literal values in `foo` to match with the other patterns."
+msgstr "Zmień wartości literalne w `foo`, aby dopasować je do innych wzorców."
 
-#: src/pattern-matching/destructuring-arrays.md:1
+#: src/pattern-matching/destructuring-structs.md:24
 #, fuzzy
-msgid "# Destructuring Arrays"
-msgstr "# Destrukturyzacja tablic"
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr "Dodaj nowe pole do `Foo` i w razie potrzeby wprowadź zmiany we wzorcu."
 
 #: src/pattern-matching/destructuring-arrays.md:3
 #, fuzzy
@@ -7680,11 +7629,11 @@ msgstr ""
 #: src/pattern-matching/destructuring-arrays.md:21
 #, fuzzy
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length."
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
-"* Destrukturyzacja plasterków o nieznanej długości działa również z wzorami "
-"o stałej długości."
+"Destrukturyzacja plasterków o nieznanej długości działa również z wzorami o "
+"stałej długości."
 
 #: src/pattern-matching/destructuring-arrays.md:24
 msgid ""
@@ -7692,43 +7641,55 @@ msgid ""
 "fn main() {\n"
 "    inspect(&[0, -2, 3]);\n"
 "    inspect(&[0, -2, 3, 4]);\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:30
 msgid ""
-"#[rustfmt::skip]\n"
-"fn inspect(slice: &[i32]) {\n"
-"    println!(\"Tell me about {slice:?}\");\n"
-"    match slice {\n"
-"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"        _          => println!(\"All elements were ignored\"),\n"
-"    }\n"
-"}\n"
+"\\#\\[rustfmt::skip\\] fn inspect(slice: &\\[i32\\]) { println!(\"Tell me "
+"about {slice:?}\"); match slice { &\\[0, y, z\\] => println!(\"First is 0, y "
+"= {y}, and z = {z}\"), &\\[1, ..\\]   => println!(\"First is 1 and the rest "
+"were ignored\"), \\_          => println!(\"All elements were ignored\"), } }"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:39
+msgid ""
 "```\n"
 "  \n"
 "* Create a new pattern using `_` to represent an element. \n"
 "* Add more values to the array.\n"
 "* Point out that how `..` will expand to account for different number of "
 "elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`\n"
+"\n"
+"# Destructuring Arrays\n"
+"\n"
+"You can destructure arrays, tuples, and slices by matching on their "
+"elements:\n"
+"\n"
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let triple = [0, -2, 3];\n"
+"    println!(\"Tell me about {triple:?}\");\n"
+"    match triple {\n"
+"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _         => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
-
-#: src/pattern-matching/match-guards.md:1
-msgid "# Match Guards"
-msgstr "# Strażnicy w dopasowywaniu wzorców"
 
 #: src/pattern-matching/match-guards.md:3
 #, fuzzy
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 "Podczas dopasowywania możesz dodać _guard_ do wzoru. To jest dowolna wartość "
-"logiczna\n"
-"wyrażenie, które zostanie wykonane, jeśli wzorzec pasuje:"
+"logiczna wyrażenie, które zostanie wykonane, jeśli wzorzec pasuje:"
 
 #: src/pattern-matching/match-guards.md:6
 msgid ""
@@ -7747,41 +7708,49 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:22
+#: src/pattern-matching/match-guards.md:23
 #, fuzzy
 msgid ""
-"Key Points:\n"
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr ""
+"Osłony dopasowujące jako oddzielna funkcja składni są ważne i konieczne, gdy "
+"chcemy zwięźle wyrazić bardziej złożone idee, niż pozwalają na to same "
+"wzorce."
+
+#: src/pattern-matching/match-guards.md:24
+#, fuzzy
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`.\n"
-"</details>"
+"result in other arms of the original `match` expression being considered."
 msgstr ""
-"Kluczowe punkty:\n"
-"* Osłony dopasowujące jako oddzielna funkcja składni są ważne i konieczne, "
-"gdy chcemy zwięźle wyrazić bardziej złożone idee, niż pozwalają na to same "
-"wzorce.\n"
-"* Nie są tym samym, co osobne wyrażenie `if` wewnątrz ramienia dopasowania. "
+"Nie są tym samym, co osobne wyrażenie `if` wewnątrz ramienia dopasowania. "
 "Wyrażenie `if` wewnątrz bloku rozgałęzienia (po `=>`) następuje po wybraniu "
 "ramienia dopasowania. Niepowodzenie warunku `if` wewnątrz tego bloku nie "
-"spowoduje powstania innych ramion\n"
-"oryginalnego wyrażenia „dopasuj”, które jest brane pod uwagę.\n"
-"* Możesz użyć zmiennych zdefiniowanych we wzorcu w swoim wyrażeniu if.\n"
-"* Warunek zdefiniowany w strażniku dotyczy każdego wyrażenia we wzorcu ze "
-"znakiem `|`.\n"
-"</details>"
+"spowoduje powstania innych ramion oryginalnego wyrażenia „dopasuj”, które "
+"jest brane pod uwagę."
+
+#: src/pattern-matching/match-guards.md:26
+#, fuzzy
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr "Możesz użyć zmiennych zdefiniowanych we wzorcu w swoim wyrażeniu if."
+
+#: src/pattern-matching/match-guards.md:27
+#, fuzzy
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr ""
+"Warunek zdefiniowany w strażniku dotyczy każdego wyrażenia we wzorcu ze "
+"znakiem `|`."
 
 #: src/exercises/day-2/morning.md:1
 #, fuzzy
-msgid "# Day 2: Morning Exercises"
-msgstr "# Dzień 2: Ćwiczenia poranne"
+msgid "Day 2: Morning Exercises"
+msgstr "Dzień 2: Ćwiczenia poranne"
 
 #: src/exercises/day-2/morning.md:3
 #, fuzzy
@@ -7790,159 +7759,242 @@ msgstr "Przyjrzymy się metodom implementacji w dwóch kontekstach:"
 
 #: src/exercises/day-2/morning.md:5
 #, fuzzy
-msgid "* Simple struct which tracks health statistics."
-msgstr "* Prosta struktura, która śledzi statystyki zdrowotne."
+msgid "Simple struct which tracks health statistics."
+msgstr "Prosta struktura, która śledzi statystyki zdrowotne."
 
 #: src/exercises/day-2/morning.md:7
 #, fuzzy
-msgid "* Multiple structs and enums for a drawing library."
-msgstr "* Wiele struktur i wyliczeń dla biblioteki rysunków."
-
-#: src/exercises/day-2/health-statistics.md:1
-#, fuzzy
-msgid "# Health Statistics"
-msgstr "# Statystyki zdrowia"
+msgid "Multiple structs and enums for a drawing library."
+msgstr "Wiele struktur i wyliczeń dla biblioteki rysunków."
 
 #: src/exercises/day-2/health-statistics.md:3
 #, fuzzy
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
-"Pracujesz nad wdrożeniem systemu monitorowania stanu. W ramach tego ty\n"
-"muszą śledzić statystyki dotyczące zdrowia użytkowników."
+"Pracujesz nad wdrożeniem systemu monitorowania stanu. W ramach tego ty muszą "
+"śledzić statystyki dotyczące zdrowia użytkowników."
 
 #: src/exercises/day-2/health-statistics.md:6
 #, fuzzy
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 "Zaczniesz od niektórych funkcji skrótowych w bloku `impl`, jak również "
-"`Użytkownika`\n"
-"definicja struktury. Twoim celem jest zaimplementowanie wygaszonych metod "
-"na\n"
-"`User` `struct` zdefiniowana w bloku `impl`."
+"`Użytkownika` definicja struktury. Twoim celem jest zaimplementowanie "
+"wygaszonych metod na `User` `struct` zdefiniowana w bloku `impl`."
 
 #: src/exercises/day-2/health-statistics.md:10
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
-"Skopiuj poniższy kod na <https://play.rust-lang.org/> i uzupełnij brakujące\n"
+"Skopiuj poniższy kod na <https://play.rust-lang.org/> i uzupełnij brakujące "
 "metody:"
 
 #: src/exercises/day-2/health-statistics.md:17
-msgid ""
-"struct User {\n"
-"    name: String,\n"
-"    age: u32,\n"
-"    weight: f32,\n"
-"}"
-msgstr ""
-"struct User {\n"
-"    name: String,\n"
-"    age: u32,\n"
-"    weight: f32,\n"
-"}"
+msgid "struct User { name: String, age: u32, weight: f32, }"
+msgstr "struct User { name: String, age: u32, weight: f32, }"
 
 #: src/exercises/day-2/health-statistics.md:23
 msgid ""
-"impl User {\n"
-"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
-"        unimplemented!()\n"
-"    }"
+"impl User { pub fn new(name: String, age: u32, weight: f32) -> Self "
+"{ unimplemented!() }"
 msgstr ""
-"impl User {\n"
-"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
-"        unimplemented!()\n"
-"    }"
+"impl User { pub fn new(name: String, age: u32, weight: f32) -> Self "
+"{ unimplemented!() }"
 
 #: src/exercises/day-2/health-statistics.md:28
 msgid ""
-"    pub fn name(&self) -> &str {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn name(&self) -> &str {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn name(&self) -> &str {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn name(&self) -> &str {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/health-statistics.md:32
 msgid ""
-"    pub fn age(&self) -> u32 {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn age(&self) -> u32 {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn age(&self) -> u32 {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn age(&self) -> u32 {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/health-statistics.md:36
 msgid ""
-"    pub fn weight(&self) -> f32 {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn weight(&self) -> f32 {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn weight(&self) -> f32 {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn weight(&self) -> f32 {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/health-statistics.md:40
 msgid ""
-"    pub fn set_age(&mut self, new_age: u32) {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn set_age(&mut self, new_age: u32) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn set_age(&mut self, new_age: u32) {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn set_age(&mut self, new_age: u32) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/health-statistics.md:44
 msgid ""
-"    pub fn set_weight(&mut self, new_weight: f32) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn set_weight(&mut self, new_weight: f32) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn set_weight(&mut self, new_weight: f32) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn set_weight(&mut self, new_weight: f32) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/health-statistics.md:49
 msgid ""
-"fn main() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
-"}"
+"fn main() { let bob = User::new(String::from(\"Bob\"), 32, 155.2); println!"
+"(\"I'm {} and my age is {}\", bob.name(), bob.age()); }"
 msgstr ""
-"fn main() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    println!(\"Jestem {} i mam {} lat\", bob.name(), bob.age());\n"
-"}"
+"fn main() { let bob = User::new(String::from(\"Bob\"), 32, 155.2); println!"
+"(\"Jestem {} i mam {} lat\", bob.name(), bob.age()); }"
 
 #: src/exercises/day-2/health-statistics.md:54
 msgid ""
-"#[test]\n"
-"fn test_weight() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.weight(), 155.2);\n"
-"}"
+"\\#\\[test\\] fn test_weight() { let bob = User::new(String::from(\"Bob\"), "
+"32, 155.2); assert_eq!(bob.weight(), 155.2); }"
 msgstr ""
-"#[test]\n"
-"fn test_weight() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.weight(), 155.2);\n"
-"}"
+"\\#\\[test\\] fn test_weight() { let bob = User::new(String::from(\"Bob\"), "
+"32, 155.2); assert_eq!(bob.weight(), 155.2); }"
 
 #: src/exercises/day-2/health-statistics.md:60
 msgid ""
+"\\#\\[test\\] fn test_set_age() { let mut bob = User::new(String::"
+"from(\"Bob\"), 32, 155.2); assert_eq!(bob.age(), 32); bob.set_age(33); "
+"assert_eq!(bob.age(), 33); }"
+msgstr ""
+"\\#\\[test\\] fn test_set_age() { let mut bob = User::new(String::"
+"from(\"Bob\"), 32, 155.2); assert_eq!(bob.age(), 32); bob.set_age(33); "
+"assert_eq!(bob.age(), 33); }"
+
+#: src/exercises/day-2/health-statistics.md:67
+msgid ""
+"```\n"
+"\n"
+"# Health Statistics\n"
+"\n"
+"You're working on implementing a health-monitoring system. As part of that, "
+"you\n"
+"need to keep track of users' health statistics.\n"
+"\n"
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User`\n"
+"struct definition. Your goal is to implement the stubbed out methods on the\n"
+"`User` `struct` defined in the `impl` block.\n"
+"\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"methods:\n"
+"\n"
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    weight: f32,\n"
+"}\n"
+"\n"
+"impl User {\n"
+"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn name(&self) -> &str {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn age(&self) -> u32 {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn weight(&self) -> f32 {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn set_weight(&mut self, new_weight: f32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_weight() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.weight(), 155.2);\n"
+"}\n"
+"\n"
+"# Health Statistics\n"
+"\n"
+"{{#include ../../../third_party/rust-on-exercism/health-statistics.md}}\n"
+"\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"methods:\n"
+"\n"
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"{{#include ../../../third_party/rust-on-exercism/health-statistics.rs}}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_height() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.height(), 155.2);\n"
+"}\n"
+"\n"
 "#[test]\n"
 "fn test_set_age() {\n"
 "    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
@@ -7950,358 +8002,468 @@ msgid ""
 "    bob.set_age(33);\n"
 "    assert_eq!(bob.age(), 33);\n"
 "}\n"
+"\n"
+"#[test]\n"
+"fn test_visit() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.doctor_visits(), 0);\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (120, 80),\n"
+"    });\n"
+"    assert_eq!(report.patient_name, \"Bob\");\n"
+"    assert_eq!(report.visit_count, 1);\n"
+"    assert_eq!(report.blood_pressure_change, None);\n"
+"\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (115, 76),\n"
+"    });\n"
+"\n"
+"    assert_eq!(report.visit_count, 2);\n"
+"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
+"}\n"
 "```"
 msgstr ""
+"```\n"
+"\n"
+"# Statystyki zdrowia\n"
+"\n"
+"Pracujesz nad wdrożeniem systemu monitorowania stanu. W ramach tego ty\n"
+"muszą śledzić statystyki dotyczące zdrowia użytkowników.\n"
+"\n"
+"Zaczniesz od niektórych funkcji skrótowych w bloku `impl`, jak również "
+"`Użytkownika`\n"
+"definicja struktury. Twoim celem jest zaimplementowanie wygaszonych metod "
+"na\n"
+"`User` `struct` zdefiniowana w bloku `impl`.\n"
+"\n"
+"Skopiuj poniższy kod na <https://play.rust-lang.org/> i uzupełnij brakujące\n"
+"metody:\n"
+"\n"
+"```rust,should_panic\n"
+"// TODO: usuń to jak skończysz implementację.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    weight: f32,\n"
+"}\n"
+"\n"
+"impl User {\n"
+"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn name(&self) -> &str {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn age(&self) -> u32 {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn weight(&self) -> f32 {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn set_weight(&mut self, new_weight: f32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"Jestem {} i mam {} lat\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_weight() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.weight(), 155.2);\n"
+"}\n"
+"\n"
+"# Health Statistics\n"
+"\n"
+"{{#include ../../../third_party/rust-on-exercism/health-statistics.md}}\n"
+"\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"methods:\n"
+"\n"
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"{{#include ../../../third_party/rust-on-exercism/health-statistics.rs}}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_height() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.height(), 155.2);\n"
+"}\n"
+"\n"
 "#[test]\n"
 "fn test_set_age() {\n"
 "    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
 "    assert_eq!(bob.age(), 32);\n"
 "    bob.set_age(33);\n"
 "    assert_eq!(bob.age(), 33);\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_visit() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.doctor_visits(), 0);\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (120, 80),\n"
+"    });\n"
+"    assert_eq!(report.patient_name, \"Bob\");\n"
+"    assert_eq!(report.visit_count, 1);\n"
+"    assert_eq!(report.blood_pressure_change, None);\n"
+"\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (115, 76),\n"
+"    });\n"
+"\n"
+"    assert_eq!(report.visit_count, 2);\n"
+"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
 "}\n"
 "```"
 
 #: src/exercises/day-2/points-polygons.md:1
 #, fuzzy
-msgid "# Polygon Struct"
-msgstr "# Struktura wielokąta"
+msgid "Polygon Struct"
+msgstr "Struktura wielokąta"
 
 #: src/exercises/day-2/points-polygons.md:3
 #, fuzzy
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 "Stworzymy strukturę `Polygon` zawierającą kilka punktów. Skopiuj poniższy "
-"kod\n"
-"na <https://play.rust-lang.org/> i uzupełnij brakujące metody, aby utworzyć "
-"plik\n"
-"testy przechodzą:"
+"kod na <https://play.rust-lang.org/> i uzupełnij brakujące metody, aby "
+"utworzyć plik testy przechodzą:"
 
 #: src/exercises/day-2/points-polygons.md:7 src/exercises/day-2/luhn.md:23
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
 "```rust\n"
 "// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]"
+"#![allow(unused_variables, dead_code)]\n"
+"```"
 msgstr ""
 "```rust\n"
 "// TODO: usuń to jak skończysz implementację.\n"
-"#![allow(unused_variables, dead_code)]"
+"#![allow(unused_variables, dead_code)]\n"
+"```"
 
 #: src/exercises/day-2/points-polygons.md:11
-msgid ""
-"pub struct Point {\n"
-"    // add fields\n"
-"}"
-msgstr ""
-"pub struct Point {\n"
-"    // dodaj pola\n"
-"}"
+msgid "pub struct Point { // add fields }"
+msgstr "pub struct Point { // dodaj pola }"
 
 #: src/exercises/day-2/points-polygons.md:15
-msgid ""
-"impl Point {\n"
-"    // add methods\n"
-"}"
-msgstr ""
-"impl Point {\n"
-"    // dodaj metody\n"
-"}"
+msgid "impl Point { // add methods }"
+msgstr "impl Point { // dodaj metody }"
 
 #: src/exercises/day-2/points-polygons.md:19
-msgid ""
-"pub struct Polygon {\n"
-"    // add fields\n"
-"}"
-msgstr ""
-"pub struct Polygon {\n"
-"    // dodaj pola\n"
-"}"
+msgid "pub struct Polygon { // add fields }"
+msgstr "pub struct Polygon { // dodaj pola }"
 
 #: src/exercises/day-2/points-polygons.md:23
-msgid ""
-"impl Polygon {\n"
-"    // add methods\n"
-"}"
-msgstr ""
-"impl Polygon {\n"
-"    // dodaj metody\n"
-"}"
+msgid "impl Polygon { // add methods }"
+msgstr "impl Polygon { // dodaj metody }"
 
 #: src/exercises/day-2/points-polygons.md:27
-msgid ""
-"pub struct Circle {\n"
-"    // add fields\n"
-"}"
-msgstr ""
-"pub struct Circle {\n"
-"    // dodaj pola\n"
-"}"
+msgid "pub struct Circle { // add fields }"
+msgstr "pub struct Circle { // dodaj pola }"
 
 #: src/exercises/day-2/points-polygons.md:31
-msgid ""
-"impl Circle {\n"
-"    // add methods\n"
-"}"
-msgstr ""
-"impl Circle {\n"
-"    // dodaj metody\n"
-"}"
+msgid "impl Circle { // add methods }"
+msgstr "impl Circle { // dodaj metody }"
 
 #: src/exercises/day-2/points-polygons.md:35
-msgid ""
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}"
-msgstr ""
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}"
+msgid "pub enum Shape { Polygon(Polygon), Circle(Circle), }"
+msgstr "pub enum Shape { Polygon(Polygon), Circle(Circle), }"
 
 #: src/exercises/day-2/points-polygons.md:40 src/testing/test-modules.md:15
-msgid ""
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;"
-msgstr ""
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;"
+msgid "\\#\\[cfg(test)\\] mod tests { use super::\\*;"
+msgstr "\\#\\[cfg(test)\\] mod tests { use super::\\*;"
 
-#: src/exercises/day-2/points-polygons.md:44 src/exercises/day-2/solutions-morning.md:165
+#: src/exercises/day-2/points-polygons.md:44
+#: src/exercises/day-2/solutions-morning.md:165
 msgid ""
-"    fn round_two_digits(x: f64) -> f64 {\n"
-"        (x * 100.0).round() / 100.0\n"
-"    }"
+"```\n"
+"fn round_two_digits(x: f64) -> f64 {\n"
+"    (x * 100.0).round() / 100.0\n"
+"}\n"
+"```"
 msgstr ""
-"    fn round_two_digits(x: f64) -> f64 {\n"
-"        (x * 100.0).round() / 100.0\n"
-"    }"
+"```\n"
+"fn round_two_digits(x: f64) -> f64 {\n"
+"    (x * 100.0).round() / 100.0\n"
+"}\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:48 src/exercises/day-2/solutions-morning.md:169
+#: src/exercises/day-2/points-polygons.md:48
+#: src/exercises/day-2/solutions-morning.md:169
 msgid ""
-"    #[test]\n"
-"    fn test_point_magnitude() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_magnitude() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"}\n"
+"```"
 msgstr ""
-"    #[test]\n"
-"    fn test_point_magnitude() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_magnitude() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"}\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:54 src/exercises/day-2/solutions-morning.md:175
+#: src/exercises/day-2/points-polygons.md:54
+#: src/exercises/day-2/solutions-morning.md:175
 msgid ""
-"    #[test]\n"
-"    fn test_point_dist() {\n"
-"        let p1 = Point::new(10, 10);\n"
-"        let p2 = Point::new(14, 13);\n"
-"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_dist() {\n"
+"    let p1 = Point::new(10, 10);\n"
+"    let p2 = Point::new(14, 13);\n"
+"    assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"}\n"
+"```"
 msgstr ""
-"    #[test]\n"
-"    fn test_point_dist() {\n"
-"        let p1 = Point::new(10, 10);\n"
-"        let p2 = Point::new(14, 13);\n"
-"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_dist() {\n"
+"    let p1 = Point::new(10, 10);\n"
+"    let p2 = Point::new(14, 13);\n"
+"    assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"}\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:61 src/exercises/day-2/solutions-morning.md:182
+#: src/exercises/day-2/points-polygons.md:61
+#: src/exercises/day-2/solutions-morning.md:182
 msgid ""
-"    #[test]\n"
-"    fn test_point_add() {\n"
-"        let p1 = Point::new(16, 16);\n"
-"        let p2 = p1 + Point::new(-4, 3);\n"
-"        assert_eq!(p2, Point::new(12, 19));\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_add() {\n"
+"    let p1 = Point::new(16, 16);\n"
+"    let p2 = p1 + Point::new(-4, 3);\n"
+"    assert_eq!(p2, Point::new(12, 19));\n"
+"}\n"
+"```"
 msgstr ""
-"    #[test]\n"
-"    fn test_point_add() {\n"
-"        let p1 = Point::new(16, 16);\n"
-"        let p2 = p1 + Point::new(-4, 3);\n"
-"        assert_eq!(p2, Point::new(12, 19));\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_add() {\n"
+"    let p1 = Point::new(16, 16);\n"
+"    let p2 = p1 + Point::new(-4, 3);\n"
+"    assert_eq!(p2, Point::new(12, 19));\n"
+"}\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:68 src/exercises/day-2/solutions-morning.md:189
+#: src/exercises/day-2/points-polygons.md:68
+#: src/exercises/day-2/solutions-morning.md:189
 msgid ""
-"    #[test]\n"
-"    fn test_polygon_left_most_point() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);"
+"```\n"
+"#[test]\n"
+"fn test_polygon_left_most_point() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    let p2 = Point::new(16, 16);\n"
+"```"
 msgstr ""
-"    #[test]\n"
-"    fn test_polygon_left_most_point() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);"
+"```\n"
+"#[test]\n"
+"fn test_polygon_left_most_point() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    let p2 = Point::new(16, 16);\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:73 src/exercises/day-2/solutions-morning.md:194
+#: src/exercises/day-2/points-polygons.md:73
+#: src/exercises/day-2/solutions-morning.md:194
 msgid ""
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"        assert_eq!(poly.left_most_point(), Some(p1));\n"
-"    }"
+"```\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(p1);\n"
+"    poly.add_point(p2);\n"
+"    assert_eq!(poly.left_most_point(), Some(p1));\n"
+"}\n"
+"```"
 msgstr ""
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"        assert_eq!(poly.left_most_point(), Some(p1));\n"
-"    }"
+"```\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(p1);\n"
+"    poly.add_point(p2);\n"
+"    assert_eq!(poly.left_most_point(), Some(p1));\n"
+"}\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:79 src/exercises/day-2/solutions-morning.md:200
+#: src/exercises/day-2/points-polygons.md:79
+#: src/exercises/day-2/solutions-morning.md:200
 msgid ""
-"    #[test]\n"
-"    fn test_polygon_iter() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);"
+"```\n"
+"#[test]\n"
+"fn test_polygon_iter() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    let p2 = Point::new(16, 16);\n"
+"```"
 msgstr ""
-"    #[test]\n"
-"    fn test_polygon_iter() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);"
+"```\n"
+"#[test]\n"
+"fn test_polygon_iter() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    let p2 = Point::new(16, 16);\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:84 src/exercises/day-2/solutions-morning.md:205
+#: src/exercises/day-2/points-polygons.md:84
+#: src/exercises/day-2/solutions-morning.md:205
 msgid ""
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);"
+"```\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(p1);\n"
+"    poly.add_point(p2);\n"
+"```"
 msgstr ""
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);"
+"```\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(p1);\n"
+"    poly.add_point(p2);\n"
+"```"
 
-#: src/exercises/day-2/points-polygons.md:88 src/exercises/day-2/solutions-morning.md:209
+#: src/exercises/day-2/points-polygons.md:88
+#: src/exercises/day-2/solutions-morning.md:209
 msgid ""
-"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
-"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
-"    }"
+"```\n"
+"    let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"    assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"}\n"
+"```"
 msgstr ""
-"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
-"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
-"    }"
+"```\n"
+"    let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"    assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/points-polygons.md:92
+#: src/exercises/day-2/solutions-morning.md:213
 msgid ""
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}"
+"```\n"
+"#[test]\n"
+"fn test_shape_perimeters() {\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(Point::new(12, 13));\n"
+"    poly.add_point(Point::new(17, 11));\n"
+"    poly.add_point(Point::new(16, 16));\n"
+"    let shapes = vec![\n"
+"        Shape::from(poly),\n"
+"        Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"    ];\n"
+"    let perimeters = shapes\n"
+"        .iter()\n"
+"        .map(Shape::perimeter)\n"
+"        .map(round_two_digits)\n"
+"        .collect::<Vec<_>>();\n"
+"    assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"}\n"
+"```"
 msgstr ""
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}"
+"```\n"
+"#[test]\n"
+"fn test_shape_perimeters() {\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(Point::new(12, 13));\n"
+"    poly.add_point(Point::new(17, 11));\n"
+"    poly.add_point(Point::new(16, 16));\n"
+"    let shapes = vec![\n"
+"        Shape::from(poly),\n"
+"        Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"    ];\n"
+"    let perimeters = shapes\n"
+"        .iter()\n"
+"        .map(Shape::perimeter)\n"
+"        .map(round_two_digits)\n"
+"        .collect::<Vec<_>>();\n"
+"    assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/points-polygons.md:111 src/exercises/day-2/luhn.md:68
-msgid ""
-"#[allow(dead_code)]\n"
-"fn main() {}\n"
-"```"
-msgstr ""
-"#[allow(dead_code)]\n"
-"fn main() {}\n"
-"```"
+msgid "\\#\\[allow(dead_code)\\] fn main() {}"
+msgstr "\\#\\[allow(dead_code)\\] fn main() {}"
 
 #: src/exercises/day-2/points-polygons.md:117
 #, fuzzy
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
-"Ponieważ w opisach problemów brakuje sygnatur metod, kluczowa część\n"
+"Ponieważ w opisach problemów brakuje sygnatur metod, kluczowa część "
 "ćwiczenia polega na ich prawidłowym określeniu. Nie musisz modyfikować "
 "testów."
 
 #: src/exercises/day-2/points-polygons.md:120
 #, fuzzy
-msgid ""
-"Other interesting parts of the exercise:\n"
-"    \n"
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
-msgstr ""
-"Inne ciekawe części ćwiczenia:\n"
-"    \n"
-"* Wyprowadź cechę `Kopiuj` dla niektórych struktur, ponieważ w testach "
-"metody czasami nie pożyczają swoich argumentów.\n"
-"* Odkryj, że cecha `Dodaj` musi zostać zaimplementowana, aby dwa obiekty "
-"można było dodawać za pomocą „+”. Pamiętaj, że nie omawiamy leków "
-"generycznych aż do dnia 3."
+msgid "Other interesting parts of the exercise:"
+msgstr "Inne ciekawe części ćwiczenia:"
 
-#: src/control-flow.md:1
+#: src/exercises/day-2/points-polygons.md:122
 #, fuzzy
-msgid "# Control Flow"
-msgstr "# Kontrola przepływu"
+msgid ""
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
+msgstr ""
+"Wyprowadź cechę `Kopiuj` dla niektórych struktur, ponieważ w testach metody "
+"czasami nie pożyczają swoich argumentów."
+
+#: src/exercises/day-2/points-polygons.md:123
+#, fuzzy
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
+"Odkryj, że cecha `Dodaj` musi zostać zaimplementowana, aby dwa obiekty można "
+"było dodawać za pomocą „+”. Pamiętaj, że nie omawiamy leków generycznych aż "
+"do dnia 3."
 
 #: src/control-flow.md:3
 #, fuzzy
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
-"Jak widzieliśmy, `if` jest wyrażeniem w Rust. Służy do warunkowego\n"
-"ocenić jeden z dwóch bloków, ale bloki mogą mieć wartość, która następnie "
-"staje się\n"
+"Jak widzieliśmy, `if` jest wyrażeniem w Rust. Służy do warunkowego ocenić "
+"jeden z dwóch bloków, ale bloki mogą mieć wartość, która następnie staje się "
 "wartość wyrażenia `if`. Inne wyrażenia przepływu sterowania działają "
-"podobnie\n"
-"w Ruście."
-
-#: src/control-flow/blocks.md:1
-#, fuzzy
-msgid "# Blocks"
-msgstr "# Bloki"
+"podobnie w Ruście."
 
 #: src/control-flow/blocks.md:3
 #, fuzzy
 msgid ""
 "A block in Rust has a value and a type: the value is the last expression of "
-"the\n"
-"block:"
-msgstr "Blok w Rust ma wartość i typ: wartość jest ostatnim wyrażeniem\nblok:"
+"the block:"
+msgstr "Blok w Rust ma wartość i typ: wartość jest ostatnim wyrażeniem blok:"
 
 #: src/control-flow/blocks.md:6
 msgid ""
@@ -8328,10 +8490,10 @@ msgstr ""
 #: src/control-flow/blocks.md:25
 #, fuzzy
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
-"Ta sama reguła jest używana dla funkcji: wartością ciała funkcji jest\n"
+"Ta sama reguła jest używana dla funkcji: wartością ciała funkcji jest "
 "zwracana wartość:"
 
 #: src/control-flow/blocks.md:28
@@ -8339,15 +8501,12 @@ msgid ""
 "```rust,editable\n"
 "fn double(x: i32) -> i32 {\n"
 "    x + x\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/control-flow/blocks.md:33
-msgid ""
-"fn main() {\n"
-"    println!(\"doubled: {}\", double(7));\n"
-"}\n"
-"```"
+msgid "fn main() { println!(\"doubled: {}\", double(7)); }"
 msgstr ""
 
 #: src/control-flow/blocks.md:38
@@ -8356,29 +8515,26 @@ msgid ""
 "type is `()`."
 msgstr ""
 
-#: src/control-flow/blocks.md:42
+#: src/control-flow/blocks.md:43
 #, fuzzy
 msgid ""
-"Key Points:\n"
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   \n"
-"</details>"
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr "Celem tego slajdu jest pokazanie, że bloki mają typ i wartość w Rust."
+
+#: src/control-flow/blocks.md:44
+#, fuzzy
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
-"Kluczowe punkty:\n"
-"* Celem tego slajdu jest pokazanie, że bloki mają typ i wartość w Rust.\n"
-"* Możesz pokazać, jak zmienia się wartość bloku, zmieniając ostatnią linię w "
-"bloku. Na przykład dodanie/usunięcie średnika lub użycie zwrotu.\n"
-"   \n"
-"</details>"
+"Możesz pokazać, jak zmienia się wartość bloku, zmieniając ostatnią linię w "
+"bloku. Na przykład dodanie/usunięcie średnika lub użycie zwrotu."
 
 #: src/control-flow/if-expressions.md:1
 #, fuzzy
-msgid "# `if` expressions"
-msgstr "# wyrażenia `jeśli`"
+msgid "`if` expressions"
+msgstr "wyrażenia `jeśli`"
 
 #: src/control-flow/if-expressions.md:3
 #, fuzzy
@@ -8423,15 +8579,13 @@ msgstr ""
 msgid ""
 "Because `if` is an expression and must have a particular type, both of its "
 "branch blocks must have the same type. Consider showing what happens if you "
-"add `;` after `x / 2` in the second example.\n"
-"    \n"
-"</details>"
+"add `;` after `x / 2` in the second example."
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:1
 #, fuzzy
-msgid "# `if let` expressions"
-msgstr "# wyrażenia `if let`"
+msgid "`if let` expressions"
+msgstr "wyrażenia `if let`"
 
 #: src/control-flow/if-let-expressions.md:3
 #, fuzzy
@@ -8452,44 +8606,54 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:16 src/control-flow/while-let-expressions.md:21
+#: src/control-flow/if-let-expressions.md:16
+#: src/control-flow/while-let-expressions.md:21
 #: src/control-flow/match-expressions.md:22
 #, fuzzy
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
 "Zobacz [dopasowywanie wzorców](../pattern-matching.md), aby uzyskać więcej "
-"informacji na temat wzorców w\n"
-"Rdza."
+"informacji na temat wzorców w Rdza."
 
 #: src/control-flow/if-let-expressions.md:21
 #, fuzzy
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is "
-"interesting. In contrast, `match` requires all branches to be covered.\n"
-"    * For the similar use case consider demonstrating a newly stabilized "
-"[`let else`](https://github.com/rust-lang/rust/pull/93628) feature.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching."
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
 msgstr ""
-"* `if let` może być bardziej zwięzłe niż `dopasuj`, np. gdy interesujący "
-"jest tylko jeden przypadek. Natomiast „dopasowanie” wymaga pokrycia "
-"wszystkich gałęzi.\n"
-"    * W przypadku podobnego przypadku rozważ zademonstrowanie nowo "
-"ustabilizowanej funkcji [`let "
-"else`](https://github.com/rust-lang/rust/pull/93628).\n"
-"* Typowym zastosowaniem jest obsługa wartości `Some` podczas pracy z "
-"`Option`.\n"
-"* W przeciwieństwie do `match`, `if let` nie obsługuje klauzul ochronnych "
-"dla dopasowywania wzorców."
+"`if let` może być bardziej zwięzłe niż `dopasuj`, np. gdy interesujący jest "
+"tylko jeden przypadek. Natomiast „dopasowanie” wymaga pokrycia wszystkich "
+"gałęzi."
+
+#: src/control-flow/if-let-expressions.md:22
+#, fuzzy
+msgid ""
+"For the similar use case consider demonstrating a newly stabilized [`let "
+"else`](https://github.com/rust-lang/rust/pull/93628) feature."
+msgstr ""
+"W przypadku podobnego przypadku rozważ zademonstrowanie nowo ustabilizowanej "
+"funkcji [`let else`](https://github.com/rust-lang/rust/pull/93628)."
+
+#: src/control-flow/if-let-expressions.md:23
+#, fuzzy
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+"Typowym zastosowaniem jest obsługa wartości `Some` podczas pracy z `Option`."
+
+#: src/control-flow/if-let-expressions.md:24
+#, fuzzy
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr ""
+"W przeciwieństwie do `match`, `if let` nie obsługuje klauzul ochronnych dla "
+"dopasowywania wzorców."
 
 #: src/control-flow/while-expressions.md:1
 #, fuzzy
-msgid "# `while` expressions"
-msgstr "# Wyrażenia `while`"
+msgid "`while` expressions"
+msgstr "Wyrażenia `while`"
 
 #: src/control-flow/while-expressions.md:3
 #, fuzzy
@@ -8515,33 +8679,32 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
 #, fuzzy
-msgid "# `while let` expressions"
-msgstr "# wyrażenia `while let`"
+msgid "`while let` expressions"
+msgstr "wyrażenia `while let`"
 
 #: src/control-flow/while-let-expressions.md:3
 #, fuzzy
 msgid ""
 "Like with `if`, there is a `while let` variant which repeatedly tests a "
-"value\n"
-"against a pattern:"
+"value against a pattern:"
 msgstr ""
 "Podobnie jak w przypadku `if`, istnieje wariant `while let`, który "
-"wielokrotnie sprawdza wartość\n"
-"wbrew wzorowi:"
+"wielokrotnie sprawdza wartość wbrew wzorowi:"
 
 #: src/control-flow/while-let-expressions.md:6
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let v = vec![10, 20, 30];\n"
-"    let mut iter = v.into_iter();"
+"    let mut iter = v.into_iter();\n"
+"```"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:11
 msgid ""
-"    while let Some(x) = iter.next() {\n"
-"        println!(\"x: {x}\");\n"
-"    }\n"
+"```\n"
+"while let Some(x) = iter.next() {\n"
+"    println!(\"x: {x}\");\n"
 "}\n"
 "```"
 msgstr ""
@@ -8550,51 +8713,49 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
-"Tutaj iterator zwrócony przez `v.iter()` zwróci `Option<i32>` przy każdym\n"
+"Tutaj iterator zwrócony przez `v.iter()` zwróci `Option<i32>` przy każdym "
 "wywołanie funkcji „następny()”. Zwraca `Some(x)` dopóki nie skończy, po czym "
-"to zrobi\n"
-"zwróć „Brak”. Polecenie „while let” pozwala nam przeglądać wszystkie "
-"elementy."
+"to zrobi zwróć „Brak”. Polecenie „while let” pozwala nam przeglądać "
+"wszystkie elementy."
 
 #: src/control-flow/while-let-expressions.md:27
 #, fuzzy
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
-"statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    \n"
-"</details>"
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
 msgstr ""
-"* Zwróć uwagę, że pętla „while let” będzie działać tak długo, jak długo "
-"wartość będzie pasować do wzorca.\n"
-"* Możesz przepisać pętlę `while let` jako pętlę nieskończoną z instrukcją "
-"if, która przerywa działanie, gdy nie ma wartości do rozpakowania dla "
-"`iter.next()`. Opcja `while let` zapewnia cukier składniowy dla powyższego "
-"scenariusza.\n"
-"    \n"
-"</details>"
+"Zwróć uwagę, że pętla „while let” będzie działać tak długo, jak długo "
+"wartość będzie pasować do wzorca."
+
+#: src/control-flow/while-let-expressions.md:28
+#, fuzzy
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
+msgstr ""
+"Możesz przepisać pętlę `while let` jako pętlę nieskończoną z instrukcją if, "
+"która przerywa działanie, gdy nie ma wartości do rozpakowania dla `iter."
+"next()`. Opcja `while let` zapewnia cukier składniowy dla powyższego "
+"scenariusza."
 
 #: src/control-flow/for-expressions.md:1
 #, fuzzy
-msgid "# `for` expressions"
-msgstr "# wyrażenia `for`"
+msgid "`for` expressions"
+msgstr "wyrażenia `for`"
 
 #: src/control-flow/for-expressions.md:3
 #, fuzzy
 msgid ""
 "The `for` expression is closely related to the `while let` expression. It "
-"will\n"
-"automatically call `into_iter()` on the expression and then iterate over it:"
+"will automatically call `into_iter()` on the expression and then iterate "
+"over it:"
 msgstr ""
-"Wyrażenie `for` jest blisko spokrewnione z wyrażeniem `while let`. To "
-"będzie\n"
+"Wyrażenie `for` jest blisko spokrewnione z wyrażeniem `while let`. To będzie "
 "automatycznie wywołaj `into_iter()` na wyrażeniu, a następnie wykonaj "
 "iterację:"
 
@@ -8602,18 +8763,19 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v = vec![10, 20, 30];"
+"    let v = vec![10, 20, 30];\n"
+"```"
 msgstr ""
 
 #: src/control-flow/for-expressions.md:10
 msgid ""
-"    for x in v {\n"
-"        println!(\"x: {x}\");\n"
-"    }\n"
-"    \n"
-"    for i in (0..10).step_by(2) {\n"
-"        println!(\"i: {i}\");\n"
-"    }\n"
+"```\n"
+"for x in v {\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"\n"
+"for i in (0..10).step_by(2) {\n"
+"    println!(\"i: {i}\");\n"
 "}\n"
 "```"
 msgstr ""
@@ -8623,43 +8785,48 @@ msgstr ""
 msgid "You can use `break` and `continue` here as usual."
 msgstr "Możesz użyć `break` i `continue` tutaj jak zwykle."
 
-#: src/control-flow/for-expressions.md:22
+#: src/control-flow/for-expressions.md:24
+#, fuzzy
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr ""
+"Iteracja indeksu nie jest specjalną składnią w Rust tylko w tym przypadku."
+
+#: src/control-flow/for-expressions.md:25
+#, fuzzy
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "`(0..10)` to zakres implementujący cechę `Iterator`."
+
+#: src/control-flow/for-expressions.md:26
 #, fuzzy
 msgid ""
-"<details>\n"
-"    \n"
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+"`step_by` to metoda, która zwraca kolejny `Iterator`, który pomija każdy "
+"inny element."
+
+#: src/control-flow/for-expressions.md:27
+#, fuzzy
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
-"<details>\n"
-"    \n"
-"* Iteracja indeksu nie jest specjalną składnią w Rust tylko w tym "
-"przypadku.\n"
-"* `(0..10)` to zakres implementujący cechę `Iterator`.\n"
-"* `step_by` to metoda, która zwraca kolejny `Iterator`, który pomija każdy "
-"inny element.\n"
-"* Zmodyfikuj elementy wektora i wyjaśnij błędy kompilatora. Zmień wektor `v` "
+"Zmodyfikuj elementy wektora i wyjaśnij błędy kompilatora. Zmień wektor `v` "
 "na zmienny, a pętlę for na `for x w v.iter_mut()`."
 
 #: src/control-flow/loop-expressions.md:1
 #, fuzzy
-msgid "# `loop` expressions"
-msgstr "# wyrażenia `pętli`"
+msgid "`loop` expressions"
+msgstr "wyrażenia `pętli`"
 
 #: src/control-flow/loop-expressions.md:3
 #, fuzzy
 msgid ""
 "Finally, there is a `loop` keyword which creates an endless loop. Here you "
-"must\n"
-"either `break` or `return` to stop the loop:"
+"must either `break` or `return` to stop the loop:"
 msgstr ""
 "Wreszcie istnieje słowo kluczowe `loop`, które tworzy nieskończoną pętlę. "
-"Tutaj musisz\n"
-"albo `break` albo `return`, aby zatrzymać pętlę:"
+"Tutaj musisz albo `break` albo `return`, aby zatrzymać pętlę:"
 
 #: src/control-flow/loop-expressions.md:6
 msgid ""
@@ -8681,32 +8848,24 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/control-flow/loop-expressions.md:23
+#: src/control-flow/loop-expressions.md:25
 #, fuzzy
-msgid ""
-"<details>\n"
-"    \n"
-"* Break the `loop` with a value (e.g. `break 8`) and print it out."
-msgstr ""
-"<details>\n"
-"    \n"
-"* Przerwij `pętlę` wartością (np. `break 8`) i wypisz ją."
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr "Przerwij `pętlę` wartością (np. `break 8`) i wypisz ją."
 
 #: src/control-flow/match-expressions.md:1
 #, fuzzy
-msgid "# `match` expressions"
-msgstr "# `dopasuj` wyrażenia"
+msgid "`match` expressions"
+msgstr "`dopasuj` wyrażenia"
 
 #: src/control-flow/match-expressions.md:3
 #, fuzzy
 msgid ""
 "The `match` keyword is used to match a value against one or more patterns. "
-"In\n"
-"that sense, it works like a series of `if let` expressions:"
+"In that sense, it works like a series of `if let` expressions:"
 msgstr ""
 "Słowo kluczowe `match` służy do dopasowania wartości do jednego lub więcej "
-"wzorców. W\n"
-"w tym sensie działa jak seria wyrażeń „if let”:"
+"wzorców. W w tym sensie działa jak seria wyrażeń „if let”:"
 
 #: src/control-flow/match-expressions.md:6
 msgid ""
@@ -8727,55 +8886,65 @@ msgstr ""
 #: src/control-flow/match-expressions.md:19
 #, fuzzy
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 "Podobnie jak `if let`, każde ramię dopasowania musi być tego samego typu. "
-"Typ jest ostatni\n"
-"wyrażenie bloku, jeśli istnieje. W powyższym przykładzie typem jest `()`."
+"Typ jest ostatni wyrażenie bloku, jeśli istnieje. W powyższym przykładzie "
+"typem jest `()`."
 
 #: src/control-flow/match-expressions.md:27
 #, fuzzy
+msgid "Save the match expression to a variable and print it out."
+msgstr "Zapisz wyrażenie dopasowania do zmiennej i wydrukuj je."
+
+#: src/control-flow/match-expressions.md:28
+#, fuzzy
+msgid "Remove `.as_deref()` and explain the error."
+msgstr "Usuń `.as_deref()` i wyjaśnij błąd."
+
+#: src/control-flow/match-expressions.md:29
+#, fuzzy
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`.\n"
-"</details>"
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
 msgstr ""
-"* Zapisz wyrażenie dopasowania do zmiennej i wydrukuj je.\n"
-"* Usuń `.as_deref()` i wyjaśnij błąd.\n"
-"    * `std::env::args().next()` zwraca `Option<String>`, ale nie możemy "
-"dopasować do `String`.\n"
-"    * `as_deref()` przekształca `Option<T>` w `Option<&T::Target>`. W naszym "
-"przypadku zmienia to `Option<String>` w `Option<&str>`.\n"
-"    * Możemy teraz użyć dopasowywania wzorców, aby dopasować się do `&str` "
-"wewnątrz `Option`.\n"
-"</details>"
+"`std::env::args().next()` zwraca `Option<String>`, ale nie możemy dopasować "
+"do `String`."
+
+#: src/control-flow/match-expressions.md:30
+#, fuzzy
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+"`as_deref()` przekształca `Option<T>` w `Option<&T::Target>`. W naszym "
+"przypadku zmienia to `Option<String>` w `Option<&str>`."
+
+#: src/control-flow/match-expressions.md:31
+#, fuzzy
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
+msgstr ""
+"Możemy teraz użyć dopasowywania wzorców, aby dopasować się do `&str` "
+"wewnątrz `Option`."
 
 #: src/control-flow/break-continue.md:1
 #, fuzzy
-msgid "# `break` and `continue`"
-msgstr "# `przerwij` i `kontynuuj`"
+msgid "`break` and `continue`"
+msgstr "`przerwij` i `kontynuuj`"
 
 #: src/control-flow/break-continue.md:3
 #, fuzzy
 msgid ""
 "If you want to exit a loop early, use `break`, if you want to immediately "
-"start\n"
-"the next iteration use `continue`. Both `continue` and `break` can "
-"optionally\n"
-"take a label argument which is used to break out of nested loops:"
+"start the next iteration use `continue`. Both `continue` and `break` can "
+"optionally take a label argument which is used to break out of nested loops:"
 msgstr ""
 "Jeśli chcesz wyjść z pętli wcześniej, użyj `break`, jeśli chcesz natychmiast "
-"rozpocząć\n"
-"w następnej iteracji użyj polecenia „kontynuuj”. Zarówno `continue`, jak i "
-"`break` mogą opcjonalnie\n"
-"weź argument etykiety, który służy do wyrwania się z zagnieżdżonych pętli:"
+"rozpocząć w następnej iteracji użyj polecenia „kontynuuj”. Zarówno "
+"`continue`, jak i `break` mogą opcjonalnie weź argument etykiety, który "
+"służy do wyrwania się z zagnieżdżonych pętli:"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
@@ -8806,25 +8975,17 @@ msgstr ""
 "W tym przypadku przerywamy zewnętrzną pętlę po 3 iteracjach wewnętrznej "
 "pętli."
 
-#: src/std.md:1
-#, fuzzy
-msgid "# Standard Library"
-msgstr "# Biblioteka standardowa"
-
 #: src/std.md:3
 #, fuzzy
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 "Rust jest dostarczany ze standardową biblioteką, która pomaga ustalić zestaw "
-"typowych typów\n"
-"używany przez bibliotekę i programy Rusta. W ten sposób dwie biblioteki mogą "
-"ze sobą współpracować\n"
-"płynnie, ponieważ oba używają tego samego typu `String`."
+"typowych typów używany przez bibliotekę i programy Rusta. W ten sposób dwie "
+"biblioteki mogą ze sobą współpracować płynnie, ponieważ oba używają tego "
+"samego typu `String`."
 
 #: src/std.md:7
 #, fuzzy
@@ -8833,79 +8994,84 @@ msgstr "Typowe typy słownictwa obejmują:"
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md)."
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
 msgstr ""
-"* Typy [`Option` i `Result`](std/option-result.md): używane dla wartości "
-"opcjonalnych\n"
-"  i [obsługi błędów](error-handling.md)."
+"Typy [`Option` i `Result`](std/option-result.md): używane dla wartości "
+"opcjonalnych i [obsługi błędów](error-handling.md)."
 
 #: src/std.md:12
 #, fuzzy
-msgid "* [`String`](std/string.md): the default string type used for owned data."
+msgid "[`String`](std/string.md): the default string type used for owned data."
 msgstr ""
-"* [`String`](std/string.md): domyślny typ ciągu używany dla posiadanych "
-"danych."
+"[`String`](std/string.md): domyślny typ ciągu używany dla posiadanych danych."
 
 #: src/std.md:14
 #, fuzzy
-msgid "* [`Vec`](std/vec.md): a standard extensible vector."
-msgstr "* [`Vec`](std/vec.md): standardowy rozszerzalny wektor."
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr "[`Vec`](std/vec.md): standardowy rozszerzalny wektor."
 
 #: src/std.md:16
 #, fuzzy
 msgid ""
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm."
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
 msgstr ""
-"* [`HashMap`](std/hashmap.md): typ mapy mieszającej z konfigurowalnym "
-"haszowaniem\n"
-"  algorytm."
+"[`HashMap`](std/hashmap.md): typ mapy mieszającej z konfigurowalnym "
+"haszowaniem algorytm."
 
 #: src/std.md:19
 #, fuzzy
-msgid "* [`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
 msgstr ""
-"* [`Box`](std/box.md): własny wskaźnik dla danych przydzielonych na stercie."
+"[`Box`](std/box.md): własny wskaźnik dla danych przydzielonych na stercie."
 
 #: src/std.md:21
 #, fuzzy
 msgid ""
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
 "data."
 msgstr ""
-"* [`Rc`](std/rc.md): współdzielony wskaźnik zliczania odwołań dla danych "
+"[`Rc`](std/rc.md): współdzielony wskaźnik zliczania odwołań dla danych "
 "alokowanych na stercie."
 
-#: src/std.md:23
+#: src/std.md:25
 #, fuzzy
 msgid ""
-"<details>\n"
-"  \n"
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
 msgstr ""
-"<details>\n"
-"  \n"
-"  * W rzeczywistości Rust zawiera kilka warstw Biblioteki Standardowej: "
-"`core`, `alloc` i `std`.\n"
-"  * `core` zawiera najbardziej podstawowe typy i funkcje, które nie zależą "
-"od `libc`, alokatora lub\n"
-"    nawet obecność systemu operacyjnego.\n"
-"  * `alloc` obejmuje typy, które wymagają globalnego alokatora sterty, takie "
-"jak `Vec`, `Box` i `Arc`.\n"
-"  * Aplikacje Embedded Rust często używają tylko `core`, a czasami `alloc`."
+"W rzeczywistości Rust zawiera kilka warstw Biblioteki Standardowej: `core`, "
+"`alloc` i `std`."
+
+#: src/std.md:26
+#, fuzzy
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+"`core` zawiera najbardziej podstawowe typy i funkcje, które nie zależą od "
+"`libc`, alokatora lub nawet obecność systemu operacyjnego."
+
+#: src/std.md:28
+#, fuzzy
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+"`alloc` obejmuje typy, które wymagają globalnego alokatora sterty, takie jak "
+"`Vec`, `Box` i `Arc`."
+
+#: src/std.md:29
+#, fuzzy
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"Aplikacje Embedded Rust często używają tylko `core`, a czasami `alloc`."
 
 #: src/std/option-result.md:1
-msgid "# `Option` and `Result`"
-msgstr "# `Option` i `Result`"
+msgid "`Option` and `Result`"
+msgstr "`Option` i `Result`"
 
 #: src/std/option-result.md:3
 #, fuzzy
@@ -8918,52 +9084,67 @@ msgid ""
 "fn main() {\n"
 "    let numbers = vec![10, 20, 30];\n"
 "    let first: Option<&i8> = numbers.first();\n"
-"    println!(\"first: {first:?}\");"
+"    println!(\"first: {first:?}\");\n"
+"```"
 msgstr ""
 
 #: src/std/option-result.md:11
 msgid ""
-"    let idx: Result<usize, usize> = numbers.binary_search(&10);\n"
-"    println!(\"idx: {idx:?}\");\n"
-"}\n"
+"```\n"
+"let idx: Result<usize, usize> = numbers.binary_search(&10);\n"
+"println!(\"idx: {idx:?}\");\n"
 "```"
 msgstr ""
 
 #: src/std/option-result.md:18
 #, fuzzy
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
-"* `Opcja` i `Wynik` są szeroko stosowane nie tylko w standardowej "
-"bibliotece.\n"
-"* `Option<&T>` ma zerowy narzut przestrzeni w porównaniu z `&T`.\n"
-"* `Result` to standardowy typ implementacji obsługi błędów, jak zobaczymy w "
-"dniu 3.\n"
-"* `binary_search` zwraca `Result<usize, use>`.\n"
-"  * Jeśli zostanie znaleziony, `Result::Ok` zawiera indeks, w którym element "
-"został znaleziony.\n"
-"  * W przeciwnym razie `Result::Err` zawiera indeks, w którym taki element "
-"powinien zostać wstawiony."
+"`Opcja` i `Wynik` są szeroko stosowane nie tylko w standardowej bibliotece."
 
-#: src/std/string.md:1
+#: src/std/option-result.md:19
 #, fuzzy
-msgid "# String"
-msgstr "# Strunowy"
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "`Option<&T>` ma zerowy narzut przestrzeni w porównaniu z `&T`."
+
+#: src/std/option-result.md:20
+#, fuzzy
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+"`Result` to standardowy typ implementacji obsługi błędów, jak zobaczymy w "
+"dniu 3."
+
+#: src/std/option-result.md:21
+#, fuzzy
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "`binary_search` zwraca `Result<usize, use>`."
+
+#: src/std/option-result.md:22
+#, fuzzy
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr ""
+"Jeśli zostanie znaleziony, `Result::Ok` zawiera indeks, w którym element "
+"został znaleziony."
+
+#: src/std/option-result.md:23
+#, fuzzy
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr ""
+"W przeciwnym razie `Result::Err` zawiera indeks, w którym taki element "
+"powinien zostać wstawiony."
 
 #: src/std/string.md:3
 #, fuzzy
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
-"[`String`][1] to standardowy bufor ciągów znaków UTF-8 przydzielony na "
-"stercie:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) to "
+"standardowy bufor ciągów znaków UTF-8 przydzielony na stercie:"
 
 #: src/std/string.md:5
 msgid ""
@@ -8971,83 +9152,109 @@ msgid ""
 "fn main() {\n"
 "    let mut s1 = String::new();\n"
 "    s1.push_str(\"Hello\");\n"
-"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());"
+"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/string.md:11
 msgid ""
-"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
-"    s2.push_str(&s1);\n"
-"    s2.push('!');\n"
-"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());"
+"```\n"
+"let mut s2 = String::with_capacity(s1.len() + 1);\n"
+"s2.push_str(&s1);\n"
+"s2.push('!');\n"
+"println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/string.md:16
 msgid ""
-"    let s3 = String::from(\"🇨🇭\");\n"
-"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
-"             s3.chars().count());\n"
-"}\n"
+"```\n"
+"let s3 = String::from(\"🇨🇭\");\n"
+"println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
+"         s3.chars().count());\n"
 "```"
 msgstr ""
 
 #: src/std/string.md:22
 #, fuzzy
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` implementuje [`Deref<Target = str>`][2], co oznacza, że możesz "
-"wywołać wszystkie\n"
-"Metody `str` na `Stringu`."
-
-#: src/std/string.md:25
-#, fuzzy
-msgid ""
-"[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
-"[2]: "
-"https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str"
-msgstr ""
-"[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
-"[2]: "
-"https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str"
+"`String` implementuje [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), co oznacza, że możesz wywołać "
+"wszystkie Metody `str` na `Stringu`."
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme "
-"clusters](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to inde a Strings by using `s3[i]` and "
-"`s3.chars.nth(i).unwrap()` where `i` is in-bound, out-of-bounds, and \"on\" "
-"the flag unicode character."
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid ""
+"Compare the different ways to inde a Strings by using `s3[i]` and `s3.chars."
+"nth(i).unwrap()` where `i` is in-bound, out-of-bounds, and \"on\" the flag "
+"unicode character."
 msgstr ""
 
 #: src/std/vec.md:1
 #, fuzzy
-msgid "# `Vec`"
-msgstr "# `Vec`"
+msgid "`Vec`"
+msgstr "`Vec`"
 
 #: src/std/vec.md:3
 #, fuzzy
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
 msgstr ""
-"[`Vec`][1] to standardowy bufor alokowany na stercie o zmiennym rozmiarze:"
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) to standardowy "
+"bufor alokowany na stercie o zmiennym rozmiarze:"
 
 #: src/std/vec.md:5
 msgid ""
@@ -9055,85 +9262,94 @@ msgid ""
 "fn main() {\n"
 "    let mut v1 = Vec::new();\n"
 "    v1.push(42);\n"
-"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());"
+"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:11
 msgid ""
-"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
-"    v2.extend(v1.iter());\n"
-"    v2.push(9999);\n"
-"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());"
+"```\n"
+"let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
+"v2.extend(v1.iter());\n"
+"v2.push(9999);\n"
+"println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:16
 msgid ""
-"    // Canonical macro to initialize a vector with elements.\n"
-"    let mut v3 = vec![0, 0, 1, 2, 3, 4];"
+"```\n"
+"// Canonical macro to initialize a vector with elements.\n"
+"let mut v3 = vec![0, 0, 1, 2, 3, 4];\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:19
 msgid ""
-"    // Retain only the even elements.\n"
-"    v3.retain(|x| x % 2 == 0);\n"
-"    println!(\"{v3:?}\");"
+"```\n"
+"// Retain only the even elements.\n"
+"v3.retain(|x| x % 2 == 0);\n"
+"println!(\"{v3:?}\");\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:23
 msgid ""
-"    // Remove consecutive duplicates.\n"
-"    v3.dedup();\n"
-"    println!(\"{v3:?}\");\n"
-"}\n"
+"```\n"
+"// Remove consecutive duplicates.\n"
+"v3.dedup();\n"
+"println!(\"{v3:?}\");\n"
 "```"
 msgstr ""
 
 #: src/std/vec.md:29
 #, fuzzy
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-[T]), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
-"`Vec` implementuje [`Deref<Target = [T]>`][2], co oznacza, że możesz wywołać "
-"slice\n"
+"`Vec` implementuje [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-[T]), co oznacza, że możesz wywołać slice "
 "metody na `Vec`."
-
-#: src/std/vec.md:32
-#, fuzzy
-msgid ""
-"[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-"[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
-msgstr ""
-"[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-"[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
+msgstr ""
+
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
 msgstr ""
 
 #: src/std/hashmap.md:1
 #, fuzzy
-msgid "# `HashMap`"
-msgstr "# `HashMap`"
+msgid "`HashMap`"
+msgstr "`HashMap`"
 
 #: src/std/hashmap.md:3
 #, fuzzy
@@ -9141,144 +9357,169 @@ msgid "Standard hash map with protection against HashDoS attacks:"
 msgstr "Standardowa mapa haszująca z ochroną przed atakami HashDoS:"
 
 #: src/std/hashmap.md:5
-msgid "```rust,editable\nuse std::collections::HashMap;"
+msgid ""
+"```rust,editable\n"
+"use std::collections::HashMap;\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:8
 msgid ""
-"fn main() {\n"
-"    let mut page_counts = HashMap::new();\n"
-"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
-"207);\n"
-"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
-"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);"
+"fn main() { let mut page_counts = HashMap::new(); page_counts."
+"insert(\"Adventures of Huckleberry Finn\".to_string(), 207); page_counts."
+"insert(\"Grimms' Fairy Tales\".to_string(), 751); page_counts.insert(\"Pride "
+"and Prejudice\".to_string(), 303);"
 msgstr ""
 
 #: src/std/hashmap.md:14
 msgid ""
-"    if !page_counts.contains_key(\"Les Misérables\") {\n"
-"        println!(\"We know about {} books, but not Les Misérables.\",\n"
-"                 page_counts.len());\n"
-"    }"
+"```\n"
+"if !page_counts.contains_key(\"Les Misérables\") {\n"
+"    println!(\"We know about {} books, but not Les Misérables.\",\n"
+"             page_counts.len());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:19
 #, fuzzy
 msgid ""
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
-"Wonderland\"] {\n"
-"        match page_counts.get(book) {\n"
-"            Some(count) => println!(\"{book}: {count} pages\"),\n"
-"            None => println!(\"{book} is unknown.\")\n"
-"        }\n"
-"    }"
+"```\n"
+"for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] "
+"{\n"
+"    match page_counts.get(book) {\n"
+"        Some(count) => println!(\"{book}: {count} pages\"),\n"
+"        None => println!(\"{book} is unknown.\")\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
-"    za książkę w [\"Duma i uprzedzenie\", \"Alicja w Krainie Czarów\"] {\n"
-"        dopasuj page_counts.get(book) {\n"
-"            Some(count) => println!(\"{książka}: {count} stron\"),\n"
-"            Brak => println!(\"{książka} jest nieznana.\")\n"
-"        }\n"
-"    }"
+"```\n"
+"za książkę w [\"Duma i uprzedzenie\", \"Alicja w Krainie Czarów\"] {\n"
+"    dopasuj page_counts.get(book) {\n"
+"        Some(count) => println!(\"{książka}: {count} stron\"),\n"
+"        Brak => println!(\"{książka} jest nieznana.\")\n"
+"    }\n"
+"}\n"
+"```"
 
 #: src/std/hashmap.md:26
 msgid ""
-"    // Use the .entry() method to insert a value if nothing is found.\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
-"Wonderland\"] {\n"
-"        let page_count: &mut i32 = "
-"page_counts.entry(book.to_string()).or_insert(0);\n"
-"        *page_count += 1;\n"
-"    }"
+"```\n"
+"// Use the .entry() method to insert a value if nothing is found.\n"
+"for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] "
+"{\n"
+"    let page_count: &mut i32 = page_counts.entry(book.to_string())."
+"or_insert(0);\n"
+"    *page_count += 1;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:32
 msgid ""
-"    println!(\"{page_counts:#?}\");\n"
-"}\n"
+"```\n"
+"println!(\"{page_counts:#?}\");\n"
 "```"
 msgstr ""
 
 #: src/std/hashmap.md:38
 #, fuzzy
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found."
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
 msgstr ""
-"* `HashMap` nie jest zdefiniowany we wstępie i musi zostać uwzględniony w "
-"zakresie.\n"
-"* Wypróbuj następujące wiersze kodu. Pierwsza linia pokaże, czy książka "
+"`HashMap` nie jest zdefiniowany we wstępie i musi zostać uwzględniony w "
+"zakresie."
+
+#: src/std/hashmap.md:39
+#, fuzzy
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+"Wypróbuj następujące wiersze kodu. Pierwsza linia pokaże, czy książka "
 "znajduje się w mapie skrótów, a jeśli nie, zwróci wartość alternatywną. "
 "Drugi wiersz wstawi alternatywną wartość do mapy skrótów, jeśli książka nie "
 "zostanie znaleziona."
 
 #: src/std/hashmap.md:41
 msgid ""
-"  ```rust,ignore\n"
-"  let pc1 = page_counts\n"
-"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"      .unwrap_or(&336);\n"
-"  let pc2 = page_counts\n"
-"      .entry(\"The Hunger Games\".to_string())\n"
-"      .or_insert(374);\n"
-"  ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:"
+"```rust,ignore\n"
+"let pc1 = page_counts\n"
+"    .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"    .unwrap_or(&336);\n"
+"let pc2 = page_counts\n"
+"    .entry(\"The Hunger Games\".to_string())\n"
+"    .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K%2C%20V)%3B%20N%5D%3E-for-"
+"HashMap%3CK%2C%20V%2C%20RandomState%3E), which allows us to easily "
+"initialize a hash map from a literal array:"
 msgstr ""
 
 #: src/std/hashmap.md:52
 msgid ""
-"  ```rust,ignore\n"
-"  let page_counts = HashMap::from([\n"
-"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"    (\"The Hunger Games\".to_string(), 374),\n"
-"  ]);\n"
-"  ```"
+"```rust,ignore\n"
+"let page_counts = HashMap::from([\n"
+"  (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"  (\"The Hunger Games\".to_string(), 374),\n"
+"]);\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:59
 #, fuzzy
 msgid ""
-" * Alternatively HashMap can be built from any `Iterator` which yields "
-"key-value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
-"compiles. Where do you think we might run into issues?"
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
 msgstr ""
-" * Alternatywnie HashMap można zbudować z dowolnego `Iteratora`, który daje "
-"krotki klucz-wartość.\n"
-"* Pokazujemy `HashMap<String, i32>` i unikamy używania `&str` jako klucza, "
-"aby ułatwić przykłady. Korzystanie z referencji w kolekcjach jest oczywiście "
-"możliwe,\n"
-"  ale może to prowadzić do komplikacji z sprawdzaniem pożyczek.\n"
-"  * Spróbuj usunąć `to_string()` z powyższego przykładu i sprawdź, czy nadal "
-"się kompiluje. Jak myślisz, gdzie możemy napotkać problemy?"
+"Alternatywnie HashMap można zbudować z dowolnego `Iteratora`, który daje "
+"krotki klucz-wartość."
 
-#: src/std/hashmap.md:64
+#: src/std/hashmap.md:60
 #, fuzzy
 msgid ""
-"[1]: "
-"https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K%2C%20V)%3B%20N%5D%3E-for-HashMap%3CK%2C%20V%2C%20RandomState%3E"
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
 msgstr ""
-"[1]: "
-"https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-From%3C%5B(K%2C%20V)%3B%20N%5D%3E "
-"-for-HashMap% 3CK% 2C% 20V% 2C% 20Losowy stan% 3E"
+"Pokazujemy `HashMap<String, i32>` i unikamy używania `&str` jako klucza, aby "
+"ułatwić przykłady. Korzystanie z referencji w kolekcjach jest oczywiście "
+"możliwe, ale może to prowadzić do komplikacji z sprawdzaniem pożyczek."
+
+#: src/std/hashmap.md:62
+#, fuzzy
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
+"compiles. Where do you think we might run into issues?"
+msgstr ""
+"Spróbuj usunąć `to_string()` z powyższego przykładu i sprawdź, czy nadal się "
+"kompiluje. Jak myślisz, gdzie możemy napotkać problemy?"
 
 #: src/std/box.md:1
 #, fuzzy
-msgid "# `Box`"
-msgstr "# `Pudełko`"
+msgid "`Box`"
+msgstr "`Pudełko`"
 
 #: src/std/box.md:3
 #, fuzzy
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "[`Box`][1] jest posiadanym wskaźnikiem do danych na stercie:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) jest posiadanym "
+"wskaźnikiem do danych na stercie:"
 
 #: src/std/box.md:5
 msgid ""
@@ -9310,54 +9551,59 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 "`Box<T>` implementuje `Deref<Target = T>`, co oznacza, że możesz [wywoływać "
-"metody\n"
-"z `T` bezpośrednio na `Box<T>`][2]."
-
-#: src/std/box.md:29
-#, fuzzy
-msgid ""
-"[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-"[2]: "
-"https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion"
-msgstr ""
-"[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-"[2]: "
-"https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion"
+"metody z `T` bezpośrednio na `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 
 #: src/std/box.md:34
 #, fuzzy
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved.\n"
-"</details>"
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
 msgstr ""
-"* `Box` jest jak `std::unique_ptr` w C++, z tą różnicą, że nie jest puste.\n"
-"* W powyższym przykładzie możesz nawet pominąć `*` w instrukcji `println!` "
-"dzięki `Deref`.\n"
-"* Pudełko może być przydatne, gdy:\n"
-"   * mieć typ, którego rozmiar nie może być znany w czasie kompilacji, ale "
-"kompilator Rust chce znać dokładny rozmiar.\n"
-"   * chcesz przenieść własność dużej ilości danych. Aby uniknąć kopiowania "
-"dużych ilości danych na stosie, zamiast tego przechowuj dane na stercie w "
-"`Box`, tak aby przesuwany był tylko wskaźnik.\n"
-"</details>"
+"`Box` jest jak `std::unique_ptr` w C++, z tą różnicą, że nie jest puste."
+
+#: src/std/box.md:35
+#, fuzzy
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+"W powyższym przykładzie możesz nawet pominąć `*` w instrukcji `println!` "
+"dzięki `Deref`."
+
+#: src/std/box.md:36
+#, fuzzy
+msgid "A `Box` can be useful when you:"
+msgstr "Pudełko może być przydatne, gdy:"
+
+#: src/std/box.md:37
+#, fuzzy
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+"mieć typ, którego rozmiar nie może być znany w czasie kompilacji, ale "
+"kompilator Rust chce znać dokładny rozmiar."
+
+#: src/std/box.md:38
+#, fuzzy
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr ""
+"chcesz przenieść własność dużej ilości danych. Aby uniknąć kopiowania dużych "
+"ilości danych na stosie, zamiast tego przechowuj dane na stercie w `Box`, "
+"tak aby przesuwany był tylko wskaźnik."
 
 #: src/std/box-recursive.md:1
 #, fuzzy
-msgid "# Box with Recursive Data Structures"
-msgstr "# Pudełko z rekurencyjnymi strukturami danych"
+msgid "Box with Recursive Data Structures"
+msgstr "Pudełko z rekurencyjnymi strukturami danych"
 
 #: src/std/box-recursive.md:3
 #, fuzzy
@@ -9374,17 +9620,18 @@ msgid ""
 "enum List<T> {\n"
 "    Cons(T, Box<List<T>>),\n"
 "    Nil,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/box-recursive.md:12 src/std/box-niche.md:10
+msgid "fn main() { let list: List"
+msgstr ""
+
+#: src/std/box-recursive.md:13 src/std/box-niche.md:11
 msgid ""
-"fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, "
-"Box::new(List::Nil))));\n"
-"    println!(\"{list:?}\");\n"
-"}\n"
-"```"
+" = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil)))); println!"
+"(\"{list:?}\"); }"
 msgstr ""
 
 #: src/std/box-recursive.md:18
@@ -9393,20 +9640,17 @@ msgid ""
 " Stack                           Heap\n"
 ".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
 "- -.\n"
-":                         :     :                                            "
-"   :\n"
-":    list                 :     :                                            "
-"   :\n"
-":   +------+----+----+    :     :    +------+----+----+    "
-"+------+----+----+   :\n"
+":                         :     :                                               :\n"
+":    "
+"list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
 ":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
 "|   :\n"
-":   +------+----+----+    :     :    +------+----+----+    "
-"+------+----+----+   :\n"
-":                         :     :                                            "
-"   :\n"
-":                         :     :                                            "
-"   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
+":                         :     :                                               :\n"
+":                         :     :                                               :\n"
 "'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
 "- -'\n"
 "```"
@@ -9415,57 +9659,42 @@ msgstr ""
 #: src/std/box-recursive.md:33
 #, fuzzy
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly "
-"into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it "
-"would look infinite."
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
-"* Jeśli `Box` nie został tutaj użyty i próbowaliśmy osadzić `List` "
-"bezpośrednio w `List`,\n"
-"kompilator nie obliczyłby stałego rozmiaru struktury w pamięci, wyglądałby "
-"na nieskończony."
+"Jeśli `Box` nie został tutaj użyty i próbowaliśmy osadzić `List` "
+"bezpośrednio w `List`, kompilator nie obliczyłby stałego rozmiaru struktury "
+"w pamięci, wyglądałby na nieskończony."
 
 #: src/std/box-recursive.md:36
 #, fuzzy
 msgid ""
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap."
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
 msgstr ""
-"* `Box` rozwiązuje ten problem, ponieważ ma taki sam rozmiar jak zwykły "
-"wskaźnik i po prostu wskazuje następny\n"
-"element „Listy” w stercie."
+"`Box` rozwiązuje ten problem, ponieważ ma taki sam rozmiar jak zwykły "
+"wskaźnik i po prostu wskazuje następny element „Listy” w stercie."
 
 #: src/std/box-recursive.md:39
 #, fuzzy
 msgid ""
-"* Remove the `Box` in the List definition and show the compiler error. "
+"Remove the `Box` in the List definition and show the compiler error. "
 "\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    \n"
-"</details>"
+"reference of some kind, instead of storing a value directly."
 msgstr ""
-"* Usuń `Box` w definicji listy i pokaż błąd kompilatora. „Rekurencyjne z "
+"Usuń `Box` w definicji listy i pokaż błąd kompilatora. „Rekurencyjne z "
 "kierunkiem” to wskazówka, że możesz chcieć użyć pewnego rodzaju pudełka lub "
-"odniesienia, zamiast bezpośrednio przechowywać wartość.\n"
-"    \n"
-"</details>"
-
-#: src/std/box-niche.md:1
-#, fuzzy
-msgid "# Niche Optimization"
-msgstr "# Optymalizacja niszy"
+"odniesienia, zamiast bezpośrednio przechowywać wartość."
 
 #: src/std/box-niche.md:16
 #, fuzzy
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 "`Box` nie może być pusty, więc wskaźnik jest zawsze ważny i nie ma wartości "
-"`null`. Ten\n"
-"pozwala kompilatorowi zoptymalizować układ pamięci:"
+"`null`. Ten pozwala kompilatorowi zoptymalizować układ pamięci:"
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -9473,20 +9702,17 @@ msgid ""
 " Stack                           Heap\n"
 ".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
 "-.\n"
-":                         :     :                                            "
-" :\n"
-":    list                 :     :                                            "
-" :\n"
-":   +----+----+           :     :    +----+----+    +----+------+            "
-" :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |            "
-" :\n"
-":   +----+----+           :     :    +----+----+    +----+------+            "
-" :\n"
-":                         :     :                                            "
-" :\n"
-":                         :     :                                            "
-" :\n"
+":                         :     :                                             :\n"
+":    "
+"list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
+"|             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":                         :     :                                             :\n"
+":                         :     :                                             :\n"
 "`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
 "-'\n"
 "```"
@@ -9494,134 +9720,132 @@ msgstr ""
 
 #: src/std/rc.md:1
 #, fuzzy
-msgid "# `Rc`"
-msgstr "# `Rc`"
+msgid "`Rc`"
+msgstr "`Rc`"
 
 #: src/std/rc.md:3
 #, fuzzy
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`][1] jest współdzielonym wskaźnikiem zliczanym przez referencje. Użyj "
-"tego, gdy potrzebujesz się odnieść\n"
-"do tych samych danych z wielu miejsc:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) jest współdzielonym "
+"wskaźnikiem zliczanym przez referencje. Użyj tego, gdy potrzebujesz się "
+"odnieść do tych samych danych z wielu miejsc:"
 
 #: src/std/rc.md:6
-msgid "```rust,editable\nuse std::rc::Rc;"
+msgid ""
+"```rust,editable\n"
+"use std::rc::Rc;\n"
+"```"
 msgstr ""
 
 #: src/std/rc.md:9
-msgid ""
-"fn main() {\n"
-"    let mut a = Rc::new(10);\n"
-"    let mut b = a.clone();"
+msgid "fn main() { let mut a = Rc::new(10); let mut b = a.clone();"
 msgstr ""
 
 #: src/std/rc.md:18
 #, fuzzy
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](https://doc.rust-lang.org/std/"
+"cell/index.html)."
 msgstr ""
-"* Jeśli musisz zmutować dane wewnątrz `Rc`, będziesz musiał zawinąć dane\n"
-"  typu takiego jak [`Cell` lub `RefCell`][2].\n"
-"* Zobacz [`Arc`][3], jeśli pracujesz w kontekście wielowątkowym.\n"
-"* Możesz *zmniejszyć* współdzielony wskaźnik do wskaźnika [`Weak`][4], aby "
-"tworzyć cykle\n"
-"  że zostanie upuszczony."
+"Jeśli musisz zmutować dane wewnątrz `Rc`, będziesz musiał zawinąć dane typu "
+"takiego jak [`Cell` lub `RefCell`](../concurrency/shared_state/arc.md)."
 
-#: src/std/rc.md:24
+#: src/std/rc.md:20
 #, fuzzy
 msgid ""
-"[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-"[2]: https://doc.rust-lang.org/std/cell/index.html\n"
-"[3]: ../concurrency/shared_state/arc.md\n"
-"[4]: https://doc.rust-lang.org/std/rc/struct.Weak.html"
+"See [`Arc`](../concurrency/shared_state/arc.md) if you are in a multi-"
+"threaded context."
 msgstr ""
-"[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-"[2]: https://doc.rust-lang.org/std/cell/index.html\n"
-"[3]: ../concurrency/shared_state/arc.md\n"
-"[4]: https://doc.rust-lang.org/std/rc/struct.Weak.html"
+"Zobacz [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html), jeśli "
+"pracujesz w kontekście wielowątkowym."
+
+#: src/std/rc.md:21
+#, fuzzy
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
+"Możesz _zmniejszyć_ współdzielony wskaźnik do wskaźnika [`Weak`](https://doc."
+"rust-lang.org/std/rc/struct.Weak.html), aby tworzyć cykle że zostanie "
+"upuszczony."
 
 #: src/std/rc.md:31
 #, fuzzy
+msgid "Like C++'s `std::shared_ptr`."
+msgstr "Podobnie jak `std::shared_ptr` C++."
+
+#: src/std/rc.md:32
+#, fuzzy
 msgid ""
-"* Like C++'s `std::shared_ptr`.\n"
-"* `clone` is cheap: creates a pointer to the same allocation and increases "
-"the reference count.\n"
-"* `make_mut` actually clones the inner value if necessary "
-"(\"clone-on-write\") and returns a mutable reference.\n"
-"* You can `downgrade()` a `Rc` into a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"`clone` is cheap: creates a pointer to the same allocation and increases the "
+"reference count."
 msgstr ""
-"* Podobnie jak `std::shared_ptr` C++.\n"
-"* `clone` jest tanie: tworzy wskaźnik do tej samej alokacji i zwiększa "
-"liczbę odwołań.\n"
-"* `make_mut` faktycznie klonuje wewnętrzną wartość, jeśli to konieczne "
-"(„clone-on-write”) i zwraca mutowalną referencję.\n"
-"* Możesz `downgrade()` `Rc` do obiektu *słabo zliczanego*, aby\n"
-"  tworzyć cykle, które zostaną poprawnie upuszczone (prawdopodobnie w "
-"połączeniu z\n"
-"  `Komórka Ref`)."
+"`clone` jest tanie: tworzy wskaźnik do tej samej alokacji i zwiększa liczbę "
+"odwołań."
+
+#: src/std/rc.md:33
+#, fuzzy
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+"`make_mut` faktycznie klonuje wewnętrzną wartość, jeśli to konieczne („clone-"
+"on-write”) i zwraca mutowalną referencję."
+
+#: src/std/rc.md:34
+#, fuzzy
+msgid ""
+"You can `downgrade()` a `Rc` into a _weakly reference-counted_ object to "
+"create cycles that will be dropped properly (likely in combination with "
+"`RefCell`)."
+msgstr ""
+"Możesz `downgrade()` `Rc` do obiektu _słabo zliczanego_, aby tworzyć cykle, "
+"które zostaną poprawnie upuszczone (prawdopodobnie w połączeniu z `Komórka "
+"Ref`)."
 
 #: src/std/rc.md:38
 msgid ""
 "```rust,editable\n"
 "use std::rc::{Rc, Weak};\n"
-"use std::cell::RefCell;"
+"use std::cell::RefCell;\n"
+"```"
 msgstr ""
 
 #: src/std/rc.md:42
 msgid ""
-"#[derive(Debug)]\n"
-"struct Node {\n"
-"    value: i64,\n"
-"    parent: Option<Weak<RefCell<Node>>>,\n"
-"    children: Vec<Rc<RefCell<Node>>>,\n"
-"}"
+"\\#\\[derive(Debug)\\] struct Node { value: i64, parent: "
+"Option\\<Weak\\<RefCell"
 msgstr ""
-"#[derive(Debug)]\n"
-"struct Node {\n"
-"    value: i64,\n"
-"    parent: Option<Weak<RefCell<Node>>>,\n"
-"    children: Vec<Rc<RefCell<Node>>>,\n"
-"}"
+"\\#\\[derive(Debug)\\] struct Node { value: i64, parent: "
+"Option\\<Weak\\<RefCell"
+
+#: src/std/rc.md:45
+msgid "\\>>, children: Vec\\<Rc\\<RefCell"
+msgstr "\\>>, children: Vec\\<Rc\\<RefCell"
+
+#: src/std/rc.md:46
+msgid "\\>>, }"
+msgstr "\\>>, }"
 
 #: src/std/rc.md:49
 msgid ""
-"fn main() {\n"
-"    let mut root = Rc::new(RefCell::new(Node {\n"
-"        value: 42,\n"
-"        parent: None,\n"
-"        children: vec![],\n"
-"    }));\n"
-"    let child = Rc::new(RefCell::new(Node {\n"
-"        value: 43,\n"
-"        children: vec![],\n"
-"        parent: Some(Rc::downgrade(&root))\n"
-"    }));\n"
-"    root.borrow_mut().children.push(child);"
+"fn main() { let mut root = Rc::new(RefCell::new(Node { value: 42, parent: "
+"None, children: vec![\\], })); let child = Rc::new(RefCell::new(Node "
+"{ value: 43, children: vec![\\], parent: Some(Rc::downgrade(&root)) })); "
+"root.borrow_mut().children.push(child);"
 msgstr ""
 
 #: src/std/rc.md:62
 msgid ""
-"    println!(\"graph: {root:#?}\");\n"
-"}\n"
+"```\n"
+"println!(\"graph: {root:#?}\");\n"
 "```"
 msgstr ""
-
-#: src/modules.md:1
-#, fuzzy
-msgid "# Modules"
-msgstr "# Moduły"
 
 #: src/modules.md:3
 #, fuzzy
@@ -9642,46 +9866,40 @@ msgid ""
 "    pub fn do_something() {\n"
 "        println!(\"In the foo module\");\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/modules.md:14
-msgid ""
-"mod bar {\n"
-"    pub fn do_something() {\n"
-"        println!(\"In the bar module\");\n"
-"    }\n"
-"}"
+msgid "mod bar { pub fn do_something() { println!(\"In the bar module\"); } }"
 msgstr ""
 
 #: src/modules.md:20
-msgid ""
-"fn main() {\n"
-"    foo::do_something();\n"
-"    bar::do_something();\n"
-"}\n"
-"```"
+msgid "fn main() { foo::do_something(); bar::do_something(); }"
 msgstr ""
 
 #: src/modules.md:28
 #, fuzzy
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
-"* Pakiety zapewniają funkcjonalność i zawierają plik `Cargo.toml`, który "
-"opisuje, jak zbudować pakiet 1+ skrzynek.\n"
-"* Skrzynki to drzewo modułów, w którym binarna skrzynia tworzy plik "
-"wykonywalny, a skrzynka biblioteczna kompiluje się do biblioteki.\n"
-"* Moduły określają organizację, zakres i są tematem tej sekcji."
+"Pakiety zapewniają funkcjonalność i zawierają plik `Cargo.toml`, który "
+"opisuje, jak zbudować pakiet 1+ skrzynek."
 
-#: src/modules/visibility.md:1
+#: src/modules.md:29
 #, fuzzy
-msgid "# Visibility"
-msgstr "# Widoczność"
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+"Skrzynki to drzewo modułów, w którym binarna skrzynia tworzy plik "
+"wykonywalny, a skrzynka biblioteczna kompiluje się do biblioteki."
+
+#: src/modules.md:30
+#, fuzzy
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr "Moduły określają organizację, zakres i są tematem tej sekcji."
 
 #: src/modules/visibility.md:3
 #, fuzzy
@@ -9690,18 +9908,23 @@ msgstr "Moduły stanowią granicę prywatności:"
 
 #: src/modules/visibility.md:5
 #, fuzzy
-msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+msgid "Module items are private by default (hides implementation details)."
 msgstr ""
-"* Elementy modułu są domyślnie prywatne (ukrywa szczegóły implementacji).\n"
-"* Elementy nadrzędne i rodzeństwo są zawsze widoczne.\n"
-"* Innymi słowy, jeśli element jest widoczny w module `foo`, jest widoczny we "
-"wszystkich modułach\n"
-"  potomkowie `foo`."
+"Elementy modułu są domyślnie prywatne (ukrywa szczegóły implementacji)."
+
+#: src/modules/visibility.md:6
+#, fuzzy
+msgid "Parent and sibling items are always visible."
+msgstr "Elementy nadrzędne i rodzeństwo są zawsze widoczne."
+
+#: src/modules/visibility.md:7
+#, fuzzy
+msgid ""
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
+msgstr ""
+"Innymi słowy, jeśli element jest widoczny w module `foo`, jest widoczny we "
+"wszystkich modułach potomkowie `foo`."
 
 #: src/modules/visibility.md:10
 msgid ""
@@ -9709,46 +9932,48 @@ msgid ""
 "mod outer {\n"
 "    fn private() {\n"
 "        println!(\"outer::private\");\n"
-"    }"
+"    }\n"
+"```"
 msgstr ""
 
 #: src/modules/visibility.md:16
 msgid ""
-"    pub fn public() {\n"
-"        println!(\"outer::public\");\n"
-"    }"
-msgstr ""
-
-#: src/modules/visibility.md:20
-msgid ""
-"    mod inner {\n"
-"        fn private() {\n"
-"            println!(\"outer::inner::private\");\n"
-"        }"
-msgstr ""
-
-#: src/modules/visibility.md:25
-msgid ""
-"        pub fn public() {\n"
-"            println!(\"outer::inner::public\");\n"
-"            super::private();\n"
-"        }\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/modules/visibility.md:32
-msgid ""
-"fn main() {\n"
-"    outer::public();\n"
+"```\n"
+"pub fn public() {\n"
+"    println!(\"outer::public\");\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/modules/visibility.md:20
+msgid ""
+"```\n"
+"mod inner {\n"
+"    fn private() {\n"
+"        println!(\"outer::inner::private\");\n"
+"    }\n"
+"```"
+msgstr ""
+
+#: src/modules/visibility.md:25
+msgid ""
+"```\n"
+"    pub fn public() {\n"
+"        println!(\"outer::inner::public\");\n"
+"        super::private();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/modules/visibility.md:32
+msgid "fn main() { outer::public(); }"
+msgstr ""
+
 #: src/modules/visibility.md:39
 #, fuzzy
-msgid "* Use the `pub` keyword to make modules public."
-msgstr "* Użyj słowa kluczowego `pub`, aby upublicznić moduły."
+msgid "Use the `pub` keyword to make modules public."
+msgstr "Użyj słowa kluczowego `pub`, aby upublicznić moduły."
 
 #: src/modules/visibility.md:41
 #, fuzzy
@@ -9762,24 +9987,30 @@ msgstr ""
 #: src/modules/visibility.md:43
 #, fuzzy
 msgid ""
-"* See the [Rust "
-"Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself))."
+msgstr ""
+"Zobacz [Odniesienie do Rust](https://doc.rust-lang.org/reference/visibility-"
+"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself))."
+
+#: src/modules/visibility.md:44
+#, fuzzy
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr "Konfigurowanie widoczności `pub(crate)` jest powszechnym wzorcem."
+
+#: src/modules/visibility.md:45
+#, fuzzy
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr "Rzadziej można zapewnić widoczność określonej ścieżce."
+
+#: src/modules/visibility.md:46
+#, fuzzy
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
 "its descendants)."
 msgstr ""
-"* Zobacz [Odniesienie do "
-"Rust](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)).\n"
-"* Konfigurowanie widoczności `pub(crate)` jest powszechnym wzorcem.\n"
-"* Rzadziej można zapewnić widoczność określonej ścieżce.\n"
-"* W każdym przypadku widoczność musi być przyznana modułowi przodka (i "
+"W każdym przypadku widoczność musi być przyznana modułowi przodka (i "
 "wszystkim jego potomkom)."
-
-#: src/modules/paths.md:1
-#, fuzzy
-msgid "# Paths"
-msgstr "# Ścieżki"
 
 #: src/modules/paths.md:3
 #, fuzzy
@@ -9788,30 +10019,33 @@ msgstr "Ścieżki są rozstrzygane w następujący sposób:"
 
 #: src/modules/paths.md:5
 #, fuzzy
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module."
-msgstr ""
-"1. Jako ścieżka względna:\n"
-"   * `foo` lub `self::foo` odnosi się do `foo` w bieżącym module,\n"
-"   * `super::foo` odnosi się do `foo` w module nadrzędnym."
+msgid "As a relative path:"
+msgstr "Jako ścieżka względna:"
+
+#: src/modules/paths.md:6
+#, fuzzy
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr "`foo` lub `self::foo` odnosi się do `foo` w bieżącym module,"
+
+#: src/modules/paths.md:7
+#, fuzzy
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr "`super::foo` odnosi się do `foo` w module nadrzędnym."
 
 #: src/modules/paths.md:9
 #, fuzzy
-msgid ""
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
-msgstr ""
-"2. Jako ścieżka bezwzględna:\n"
-"   * `crate::foo` odnosi się do `foo` w katalogu głównym bieżącej skrzynki,\n"
-"   * `bar::foo` odnosi się do `foo` w skrzynce `bar`."
+msgid "As an absolute path:"
+msgstr "Jako ścieżka bezwzględna:"
 
-#: src/modules/filesystem.md:1
+#: src/modules/paths.md:10
 #, fuzzy
-msgid "# Filesystem Hierarchy"
-msgstr "# Hierarchia systemu plików"
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr "`crate::foo` odnosi się do `foo` w katalogu głównym bieżącej skrzynki,"
+
+#: src/modules/paths.md:11
+#, fuzzy
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr "`bar::foo` odnosi się do `foo` w skrzynce `bar`."
 
 #: src/modules/filesystem.md:3
 #, fuzzy
@@ -9832,12 +10066,13 @@ msgstr "Zawartość modułu `garden` znajduje się pod adresem:"
 
 #: src/modules/filesystem.md:11
 #, fuzzy
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden.rs` (nowoczesny styl Rust 2018)\n"
-"* `src/garden/mod.rs` (starszy styl Rust 2015)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr "`src/garden.rs` (nowoczesny styl Rust 2018)"
+
+#: src/modules/filesystem.md:12
+#, fuzzy
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/mod.rs` (starszy styl Rust 2015)"
 
 #: src/modules/filesystem.md:14
 #, fuzzy
@@ -9846,12 +10081,13 @@ msgstr "Podobnie moduł `garden::vegetables` można znaleźć pod adresem:"
 
 #: src/modules/filesystem.md:16
 #, fuzzy
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden/vegetables.rs` (nowoczesny styl Rust 2018)\n"
-"* `src/garden/vegetables/mod.rs` (starszy styl Rust 2015)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr "`src/garden/vegetables.rs` (nowoczesny styl Rust 2018)"
+
+#: src/modules/filesystem.md:17
+#, fuzzy
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/vegetables/mod.rs` (starszy styl Rust 2015)"
 
 #: src/modules/filesystem.md:19
 #, fuzzy
@@ -9860,349 +10096,271 @@ msgstr "Korzeń `crate` znajduje się w:"
 
 #: src/modules/filesystem.md:21
 #, fuzzy
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
-msgstr ""
-"* `src/lib.rs` (dla skrzynki bibliotecznej)\n"
-"* `src/main.rs` (dla skrzynki binarnej)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr "`src/lib.rs` (dla skrzynki bibliotecznej)"
+
+#: src/modules/filesystem.md:22
+#, fuzzy
+msgid "`src/main.rs` (for a binary crate)"
+msgstr "`src/main.rs` (dla skrzynki binarnej)"
 
 #: src/modules/filesystem.md:26
 #, fuzzy
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)"
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
 msgstr ""
-"* Zmiana z `module/mod.rs` na `module.rs` nie wyklucza użycia submodułów w "
-"Rust 2018.\n"
-"  (Było to obowiązkowe w Rust 2015.)"
+"Zmiana z `module/mod.rs` na `module.rs` nie wyklucza użycia submodułów w "
+"Rust 2018. (Było to obowiązkowe w Rust 2015.)"
 
 #: src/modules/filesystem.md:29
 #, fuzzy
-msgid "  The following is valid:"
-msgstr "  Poniższe jest ważne:"
+msgid "The following is valid:"
+msgstr "Poniższe jest ważne:"
 
 #: src/modules/filesystem.md:31
 msgid ""
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```"
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
 msgstr ""
 
 #: src/modules/filesystem.md:39
 #, fuzzy
 msgid ""
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs."
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
 msgstr ""
-"* Głównym powodem zmiany jest uniemożliwienie wielu plików o nazwie "
-"`mod.rs`, co może być trudne\n"
-"  rozróżniać w IDE."
+"Głównym powodem zmiany jest uniemożliwienie wielu plików o nazwie `mod.rs`, "
+"co może być trudne rozróżniać w IDE."
 
 #: src/modules/filesystem.md:42
 #, fuzzy
 msgid ""
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:"
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
 msgstr ""
-"* Rust będzie szukał modułów w `modulename/mod.rs` i `modulename.rs`, ale "
-"można to zmienić\n"
-"  z dyrektywą kompilatora:"
+"Rust będzie szukał modułów w `modulename/mod.rs` i `modulename.rs`, ale "
+"można to zmienić z dyrektywą kompilatora:"
 
 #: src/modules/filesystem.md:45
 msgid ""
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```"
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
 msgstr ""
 
 #: src/modules/filesystem.md:50
 #, fuzzy
 msgid ""
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
-"  Jest to przydatne na przykład, jeśli chcesz umieścić testy modułu w pliku "
-"o nazwie\n"
-"  `some_module_test.rs`, podobnie do konwencji w Go."
+"Jest to przydatne na przykład, jeśli chcesz umieścić testy modułu w pliku o "
+"nazwie `some_module_test.rs`, podobnie do konwencji w Go."
 
 #: src/exercises/day-2/afternoon.md:1
 #, fuzzy
-msgid "# Day 2: Afternoon Exercises"
-msgstr "# Dzień 2: Ćwiczenia popołudniowe"
+msgid "Day 2: Afternoon Exercises"
+msgstr "Dzień 2: Ćwiczenia popołudniowe"
 
 #: src/exercises/day-2/afternoon.md:3
 #, fuzzy
 msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr "Ćwiczenia na to popołudnie skupią się na ciągach znaków i iteratorach."
 
-#: src/exercises/day-2/luhn.md:1
-#, fuzzy
-msgid "# Luhn Algorithm"
-msgstr "# Algorytm Luhna"
-
 #: src/exercises/day-2/luhn.md:3
 #, fuzzy
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
-"[Algorytm Luhna](https://en.wikipedia.org/wiki/Luhn_algorithm) służy do\n"
+"[Algorytm Luhna](https://en.wikipedia.org/wiki/Luhn_algorithm) służy do "
 "zweryfikować numery kart kredytowych. Algorytm pobiera ciąg jako dane "
-"wejściowe i wykonuje\n"
-"aby zweryfikować numer karty kredytowej:"
+"wejściowe i wykonuje aby zweryfikować numer karty kredytowej:"
 
 #: src/exercises/day-2/luhn.md:7
 #, fuzzy
-msgid "* Ignore all spaces. Reject number with less than two digits."
+msgid "Ignore all spaces. Reject number with less than two digits."
 msgstr ""
-"* Zignoruj wszystkie spacje. Odrzuć numer zawierający mniej niż dwie cyfry."
+"Zignoruj wszystkie spacje. Odrzuć numer zawierający mniej niż dwie cyfry."
 
 #: src/exercises/day-2/luhn.md:9
 #, fuzzy
 msgid ""
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
 msgstr ""
-"* Przechodząc od prawej do lewej, podwajaj co drugą cyfrę: dla liczby "
-"`1234`,\n"
-"  podwajamy „3” i „1”."
+"Przechodząc od prawej do lewej, podwajaj co drugą cyfrę: dla liczby `1234`, "
+"podwajamy „3” i „1”."
 
 #: src/exercises/day-2/luhn.md:12
 #, fuzzy
 msgid ""
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`."
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
 msgstr ""
-"* Po podwojeniu cyfry zsumuj cyfry. Więc podwojenie „7” daje „14”, co\n"
-"  staje się „5”."
+"Po podwojeniu cyfry zsumuj cyfry. Więc podwojenie „7” daje „14”, co staje "
+"się „5”."
 
 #: src/exercises/day-2/luhn.md:15
 #, fuzzy
-msgid "* Sum all the undoubled and doubled digits."
-msgstr "* Zsumuj wszystkie niepodwojone i podwojone cyfry."
+msgid "Sum all the undoubled and doubled digits."
+msgstr "Zsumuj wszystkie niepodwojone i podwojone cyfry."
 
 #: src/exercises/day-2/luhn.md:17
 #, fuzzy
-msgid "* The credit card number is valid if the sum ends with `0`."
-msgstr "* Numer karty kredytowej jest ważny, jeśli suma kończy się na `0`."
+msgid "The credit card number is valid if the sum ends with `0`."
+msgstr "Numer karty kredytowej jest ważny, jeśli suma kończy się na `0`."
 
 #: src/exercises/day-2/luhn.md:19
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
-"Skopiuj poniższy kod do <https://play.rust-lang.org/> i zaimplementuj\n"
+"Skopiuj poniższy kod do <https://play.rust-lang.org/> i zaimplementuj "
 "funkcjonować:"
 
 #: src/exercises/day-2/luhn.md:27
-msgid ""
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}"
-msgstr ""
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}"
+msgid "pub fn luhn(cc_number: &str) -> bool { unimplemented!() }"
+msgstr "pub fn luhn(cc_number: &str) -> bool { unimplemented!() }"
 
 #: src/exercises/day-2/luhn.md:31
 msgid ""
-"#[test]\n"
-"fn test_non_digit_cc_number() {\n"
-"    assert!(!luhn(\"foo\"));\n"
-"}"
+"\\#\\[test\\] fn test_non_digit_cc_number() { assert!(!luhn(\"foo\")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:36 src/exercises/day-2/solutions-afternoon.md:64
 msgid ""
-"#[test]\n"
-"fn test_empty_cc_number() {\n"
-"    assert!(!luhn(\"\"));\n"
-"    assert!(!luhn(\" \"));\n"
-"    assert!(!luhn(\"  \"));\n"
-"    assert!(!luhn(\"    \"));\n"
-"}"
+"\\#\\[test\\] fn test_empty_cc_number() { assert!(!luhn(\"\")); assert!(!"
+"luhn(\" \")); assert!(!luhn(\"  \")); assert!(!luhn(\"    \")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:44 src/exercises/day-2/solutions-afternoon.md:72
 msgid ""
-"#[test]\n"
-"fn test_single_digit_cc_number() {\n"
-"    assert!(!luhn(\"0\"));\n"
-"}"
+"\\#\\[test\\] fn test_single_digit_cc_number() { assert!(!luhn(\"0\")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:49 src/exercises/day-2/solutions-afternoon.md:77
 msgid ""
-"#[test]\n"
-"fn test_two_digit_cc_number() {\n"
-"    assert!(luhn(\" 0 0 \"));\n"
-"}"
+"\\#\\[test\\] fn test_two_digit_cc_number() { assert!(luhn(\" 0 0 \")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:54 src/exercises/day-2/solutions-afternoon.md:82
 msgid ""
-"#[test]\n"
-"fn test_valid_cc_number() {\n"
-"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
-"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
-"    assert!(luhn(\"7992 7398 713\"));\n"
-"}"
+"\\#\\[test\\] fn test_valid_cc_number() { assert!(luhn(\"4263 9826 4026 "
+"9299\")); assert!(luhn(\"4539 3195 0343 6467\")); assert!(luhn(\"7992 7398 "
+"713\")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:61
 msgid ""
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
-"}"
+"\\#\\[test\\] fn test_invalid_cc_number() { assert!(!luhn(\"4223 9826 4026 "
+"9299\")); assert!(!luhn(\"4539 3195 0343 6476\")); assert!(!luhn(\"8273 1232 "
+"7352 0569\")); }"
 msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:1
-#, fuzzy
-msgid "# Strings and Iterators"
-msgstr "# Łańcuchy i iteratory"
 
 #: src/exercises/day-2/strings-iterators.md:3
 #, fuzzy
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
-"W tym ćwiczeniu implementujesz komponent routingu serwera WWW. The\n"
-"serwer jest skonfigurowany z liczbą _prefiksów ścieżki_, z którymi są "
-"dopasowywane\n"
-"_zażądaj ścieżek_. Prefiksy ścieżki mogą zawierać symbol wieloznaczny, "
-"który\n"
+"W tym ćwiczeniu implementujesz komponent routingu serwera WWW. The serwer "
+"jest skonfigurowany z liczbą _prefiksów ścieżki_, z którymi są dopasowywane "
+"_zażądaj ścieżek_. Prefiksy ścieżki mogą zawierać symbol wieloznaczny, który "
 "pasuje do pełnego segmentu. Zobacz testy jednostkowe poniżej."
 
 #: src/exercises/day-2/strings-iterators.md:8
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
-"Skopiuj poniższy kod do <https://play.rust-lang.org/> i wykonaj testy\n"
+"Skopiuj poniższy kod do <https://play.rust-lang.org/> i wykonaj testy "
 "przechodzić. Staraj się unikać przydzielania `Vec` dla wyników pośrednich:"
 
 #: src/exercises/day-2/strings-iterators.md:16
 msgid ""
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool "
+"{ unimplemented!() }"
 msgstr ""
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool "
+"{ unimplemented!() }"
 
 #: src/exercises/day-2/strings-iterators.md:20
 msgid ""
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));"
+"\\#\\[test\\] fn test_matches_without_wildcard() { assert!(prefix_matches(\"/"
+"v1/publishers\", \"/v1/publishers\")); assert!(prefix_matches(\"/v1/"
+"publishers\", \"/v1/publishers/abc-123\")); assert!(prefix_matches(\"/v1/"
+"publishers\", \"/v1/publishers/abc/books\"));"
 msgstr ""
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));"
+"\\#\\[test\\] fn test_matches_without_wildcard() { assert!(prefix_matches(\"/"
+"v1/publishers\", \"/v1/publishers\")); assert!(prefix_matches(\"/v1/"
+"publishers\", \"/v1/publishers/abc-123\")); assert!(prefix_matches(\"/v1/"
+"publishers\", \"/v1/publishers/abc/books\"));"
 
-#: src/exercises/day-2/strings-iterators.md:26 src/exercises/day-2/solutions-afternoon.md:146
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/solutions-afternoon.md:146
 msgid ""
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", "
-"\"/v1/parent/publishers\"));\n"
-"}"
-msgstr ""
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", "
-"\"/v1/parent/publishers\"));\n"
-"}"
-
-#: src/exercises/day-2/strings-iterators.md:31 src/exercises/day-2/solutions-afternoon.md:151
-msgid ""
-"#[test]\n"
-"fn test_matches_with_wildcard() {\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/bar/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books/book1\"\n"
-"    ));"
-msgstr ""
-"#[test]\n"
-"fn test_matches_with_wildcard() {\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/bar/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books/book1\"\n"
-"    ));"
-
-#: src/exercises/day-2/strings-iterators.md:46
-msgid ""
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
+"```\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
 "```"
 msgstr ""
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
+"```\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
+"```"
+
+#: src/exercises/day-2/strings-iterators.md:31
+#: src/exercises/day-2/solutions-afternoon.md:151
+msgid ""
+"\\#\\[test\\] fn test_matches_with_wildcard() { assert!(prefix_matches( \"/"
+"v1/publishers/_/books\", \"/v1/publishers/foo/books\" )); assert!"
+"(prefix_matches( \"/v1/publishers/_/books\", \"/v1/publishers/bar/"
+"books\" )); assert!(prefix_matches( \"/v1/publishers/\\*/books\", \"/v1/"
+"publishers/foo/books/book1\" ));"
+msgstr ""
+"\\#\\[test\\] fn test_matches_with_wildcard() { assert!(prefix_matches( \"/"
+"v1/publishers/_/books\", \"/v1/publishers/foo/books\" )); assert!"
+"(prefix_matches( \"/v1/publishers/_/books\", \"/v1/publishers/bar/"
+"books\" )); assert!(prefix_matches( \"/v1/publishers/\\*/books\", \"/v1/"
+"publishers/foo/books/book1\" ));"
+
+#: src/exercises/day-2/strings-iterators.md:46
+#: src/exercises/day-2/solutions-afternoon.md:166
+msgid ""
+"```\n"
+"assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"assert!(!prefix_matches(\n"
+"    \"/v1/publishers/*/books\",\n"
+"    \"/v1/publishers/foo/booksByAuthor\"\n"
+"));\n"
+"```"
+msgstr ""
+"```\n"
+"assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"assert!(!prefix_matches(\n"
+"    \"/v1/publishers/*/books\",\n"
+"    \"/v1/publishers/foo/booksByAuthor\"\n"
+"));\n"
 "```"
 
 #: src/welcome-day-3.md:1
-msgid "# Welcome to Day 3"
-msgstr "# Witamy w dniu 3"
+msgid "Welcome to Day 3"
+msgstr "Witamy w dniu 3"
 
 #: src/welcome-day-3.md:3
 #, fuzzy
@@ -10213,47 +10371,39 @@ msgstr ""
 #: src/welcome-day-3.md:5
 #, fuzzy
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
-"* Cechy: wyprowadzanie cech, metody domyślne i ważna biblioteka standardowa\n"
-"  cechy."
+"Cechy: wyprowadzanie cech, metody domyślne i ważna biblioteka standardowa "
+"cechy."
 
 #: src/welcome-day-3.md:8
 #, fuzzy
 msgid ""
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects."
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
 msgstr ""
-"* Rodzaje: ogólne typy danych, metody ogólne, monomorfizacja i cecha\n"
-"  obiekty."
+"Rodzaje: ogólne typy danych, metody ogólne, monomorfizacja i cecha obiekty."
 
 #: src/welcome-day-3.md:11
 #, fuzzy
-msgid "* Error handling: panics, `Result`, and the try operator `?`."
-msgstr "* Obsługa błędów: paniki, `Result` i operator try `?`."
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr "Obsługa błędów: paniki, `Result` i operator try `?`."
 
 #: src/welcome-day-3.md:13
 #, fuzzy
-msgid "* Testing: unit tests, documentation tests, and integration tests."
+msgid "Testing: unit tests, documentation tests, and integration tests."
 msgstr ""
-"* Testowanie: testy jednostkowe, testy dokumentacji i testy integracyjne."
+"Testowanie: testy jednostkowe, testy dokumentacji i testy integracyjne."
 
 #: src/welcome-day-3.md:15
 #, fuzzy
 msgid ""
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
 msgstr ""
-"* Niebezpieczny Rust: surowe wskaźniki, zmienne statyczne, niebezpieczne "
-"funkcje i extern\n"
-"  Funkcje."
-
-#: src/traits.md:1
-#, fuzzy
-msgid "# Traits"
-msgstr "# Cechy"
+"Niebezpieczny Rust: surowe wskaźniki, zmienne statyczne, niebezpieczne "
+"funkcje i extern Funkcje."
 
 #: src/traits.md:3
 #, fuzzy
@@ -10267,19 +10417,14 @@ msgid ""
 "```rust,editable\n"
 "trait Greet {\n"
 "    fn say_hello(&self);\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits.md:10
 #, fuzzy
-msgid ""
-"struct Dog {\n"
-"    name: String,\n"
-"}"
-msgstr ""
-"pies konstrukcyjny {\n"
-"    imię: Ciąg,\n"
-"}"
+msgid "struct Dog { name: String, }"
+msgstr "pies konstrukcyjny { imię: Ciąg, }"
 
 #: src/traits.md:14
 msgid "struct Cat;  // No name, cats won't respond to it anyway."
@@ -10287,81 +10432,82 @@ msgstr ""
 
 #: src/traits.md:16
 msgid ""
-"impl Greet for Dog {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Wuf, my name is {}!\", self.name);\n"
-"    }\n"
-"}"
+"impl Greet for Dog { fn say_hello(&self) { println!(\"Wuf, my name is {}!\", "
+"self.name); } }"
 msgstr ""
 
 #: src/traits.md:22
-msgid ""
-"impl Greet for Cat {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Miau!\");\n"
-"    }\n"
-"}"
+msgid "impl Greet for Cat { fn say_hello(&self) { println!(\"Miau!\"); } }"
 msgstr ""
 
 #: src/traits.md:28
+msgid "fn main() { let pets: Vec\\<Box"
+msgstr ""
+
+#: src/traits.md:29
 msgid ""
-"fn main() {\n"
-"    let pets: Vec<Box<dyn Greet>> = vec![\n"
-"        Box::new(Dog { name: String::from(\"Fido\") }),\n"
-"        Box::new(Cat),\n"
-"    ];\n"
-"    for pet in pets {\n"
-"        pet.say_hello();\n"
-"    }\n"
-"}\n"
-"```"
+"\\> = vec![ Box::new(Dog { name: String::from(\"Fido\") }), Box::new(Cat), "
+"\\]; for pet in pets { pet.say_hello(); } }"
 msgstr ""
 
 #: src/traits.md:41
 #, fuzzy
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to implement themselves. Methods with default "
-"implementations can rely on required methods.\n"
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Greet>` in the example above.\n"
-"* `dyn Greet` is a way to tell the compiler about a dynamically sized type "
-"that implements `Greet`.\n"
-"* In the example, `pets` holds Fat Pointers to objects that implement "
-"`Greet`. The Fat Pointer consists of two components, a pointer to the actual "
-"object and a pointer to the virtual method table for the `Greet` "
-"implementation of that particular object."
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
-"* Cechy mogą określać wstępnie zaimplementowane (domyślne) metody i metody, "
+"Cechy mogą określać wstępnie zaimplementowane (domyślne) metody i metody, "
 "które użytkownicy muszą sami zaimplementować. Metody z domyślnymi "
-"implementacjami mogą polegać na metodach wymaganych.\n"
-"* Typy realizujące daną cechę mogą mieć różne rozmiary. To sprawia, że "
+"implementacjami mogą polegać na metodach wymaganych."
+
+#: src/traits.md:42
+#, fuzzy
+msgid ""
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Greet>` in the example above."
+msgstr ""
+"Typy realizujące daną cechę mogą mieć różne rozmiary. To sprawia, że "
 "niemożliwe jest posiadanie rzeczy takich jak `Vec<Greet>` w powyższym "
-"przykładzie.\n"
-"* `dyn Greet` to sposób poinformowania kompilatora o typie o dynamicznym "
-"rozmiarze, który implementuje `Greet`.\n"
-"* W przykładzie `pets` przechowuje Fat Pointers do obiektów, które "
+"przykładzie."
+
+#: src/traits.md:43
+#, fuzzy
+msgid ""
+"`dyn Greet` is a way to tell the compiler about a dynamically sized type "
+"that implements `Greet`."
+msgstr ""
+"`dyn Greet` to sposób poinformowania kompilatora o typie o dynamicznym "
+"rozmiarze, który implementuje `Greet`."
+
+#: src/traits.md:44
+#, fuzzy
+msgid ""
+"In the example, `pets` holds Fat Pointers to objects that implement `Greet`. "
+"The Fat Pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Greet` implementation of "
+"that particular object."
+msgstr ""
+"W przykładzie `pets` przechowuje Fat Pointers do obiektów, które "
 "implementują `Greet`. Fat Pointer składa się z dwóch komponentów, wskaźnika "
 "do rzeczywistego obiektu i wskaźnika do wirtualnej tabeli metod dla "
 "implementacji `Greet` tego konkretnego obiektu."
 
 #: src/traits.md:46
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits.md:47
 msgid ""
-"Compare these outputs in the above example:\n"
 "```rust,ignore\n"
-"    println!(\"{} {}\", std::mem::size_of::<Dog>(), "
-"std::mem::size_of::<Cat>());\n"
-"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), "
-"std::mem::size_of::<&Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
 "    println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
 "    println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
 "```"
 msgstr ""
-
-#: src/traits/deriving-traits.md:1
-#, fuzzy
-msgid "# Deriving Traits"
-msgstr "# Wyprowadzanie cech"
 
 #: src/traits/deriving-traits.md:3
 #, fuzzy
@@ -10376,26 +10522,16 @@ msgid ""
 "    name: String,\n"
 "    strength: u8,\n"
 "    hit_points: u8,\n"
-"}"
-msgstr ""
-
-#: src/traits/deriving-traits.md:13
-msgid ""
-"fn main() {\n"
-"    let p1 = Player::default();\n"
-"    let p2 = p1.clone();\n"
-"    println!(\"Is {:?}\\n"
-"equal to {:?}?\\n"
-"The answer is {}!\", &p1, &p2,\n"
-"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/traits/default-methods.md:1
-#, fuzzy
-msgid "# Default Methods"
-msgstr "# Metody domyślne"
+#: src/traits/deriving-traits.md:13
+msgid ""
+"fn main() { let p1 = Player::default(); let p2 = p1.clone(); println!(\"Is "
+"{:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2, if p1 == p2 "
+"{ \"yes\" } else { \"no\" }); }"
+msgstr ""
 
 #: src/traits/default-methods.md:3
 #, fuzzy
@@ -10410,43 +10546,29 @@ msgid ""
 "    fn not_equal(&self, other: &Self) -> bool {\n"
 "        !self.equal(other)\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/default-methods.md:13
-msgid "#[derive(Debug)]\nstruct Centimeter(i16);"
+msgid "\\#\\[derive(Debug)\\] struct Centimeter(i16);"
 msgstr ""
 
 #: src/traits/default-methods.md:16
 #, fuzzy
 msgid ""
-"impl Equals for Centimeter {\n"
-"    fn equal(&self, other: &Centimeter) -> bool {\n"
-"        self.0 == other.0\n"
-"    }\n"
-"}"
+"impl Equals for Centimeter { fn equal(&self, other: &Centimeter) -> bool "
+"{ self.0 == other.0 } }"
 msgstr ""
-"impl Równa się dla centymetra {\n"
-"    fn równy(&ja; inny: &Centymetr) -> bool {\n"
-"        sam.0 == inny.0\n"
-"    }\n"
-"}"
+"impl Równa się dla centymetra { fn równy(&ja; inny: &Centymetr) -> bool "
+"{ sam.0 == inny.0 } }"
 
 #: src/traits/default-methods.md:22
 msgid ""
-"fn main() {\n"
-"    let a = Centimeter(10);\n"
-"    let b = Centimeter(20);\n"
-"    println!(\"{a:?} equals {b:?}: {}\", a.equal(&b));\n"
-"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equal(&b));\n"
-"}\n"
-"```"
+"fn main() { let a = Centimeter(10); let b = Centimeter(20); println!(\"{a:?} "
+"equals {b:?}: {}\", a.equal(&b)); println!(\"{a:?} not_equals {b:?}: {}\", a."
+"not_equal(&b)); }"
 msgstr ""
-
-#: src/traits/important-traits.md:1
-#, fuzzy
-msgid "# Important Traits"
-msgstr "# Ważne cechy"
 
 #: src/traits/important-traits.md:3
 #, fuzzy
@@ -10460,54 +10582,76 @@ msgstr ""
 #: src/traits/important-traits.md:5
 #, fuzzy
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
 msgstr ""
-"* [`Iterator`][1] i [`IntoIterator`][2] używane w pętlach `for`,\n"
-"* [`From`][3] i [`Into`][4] używane do konwersji wartości,\n"
-"* [`Read`][5] i [`Write`][6] używane do IO,\n"
-"* [`Add`][7], [`Mul`][8], ... używane do przeciążania operatora i\n"
-"* [`Drop`][9] używane do definiowania destruktorów.\n"
-"* [`Default`][10] używane do konstruowania domyślnej instancji typu."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) i "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"używane w pętlach `for`,"
 
-#: src/traits/important-traits.md:12
+#: src/traits/important-traits.md:6
 #, fuzzy
 msgid ""
-"[1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html\n"
-"[2]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html\n"
-"[3]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[4]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-"[5]: https://doc.rust-lang.org/std/io/trait.Read.html\n"
-"[6]: https://doc.rust-lang.org/std/io/trait.Write.html\n"
-"[7]: https://doc.rust-lang.org/std/ops/trait.Add.html\n"
-"[8]: https://doc.rust-lang.org/std/ops/trait.Mul.html\n"
-"[9]: https://doc.rust-lang.org/std/ops/trait.Drop.html\n"
-"[10]: https://doc.rust-lang.org/std/default/trait.Default.html"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
 msgstr ""
-"[1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html\n"
-"[2]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html\n"
-"[3]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[4]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-"[5]: https://doc.rust-lang.org/std/io/trait.Read.html\n"
-"[6]: https://doc.rust-lang.org/std/io/trait.Write.html\n"
-"[7]: https://doc.rust-lang.org/std/ops/trait.Add.html\n"
-"[8]: https://doc.rust-lang.org/std/ops/trait.Mul.html\n"
-"[9]: https://doc.rust-lang.org/std/ops/trait.Drop.html\n"
-"[10]: https://doc.rust-lang.org/std/default/trait.Default.html"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) i [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) używane do konwersji "
+"wartości,"
+
+#: src/traits/important-traits.md:7
+#, fuzzy
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) i [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) używane do IO,"
+
+#: src/traits/important-traits.md:8
+#, fuzzy
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... używane do przeciążania "
+"operatora i"
+
+#: src/traits/important-traits.md:9
+#, fuzzy
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) używane do "
+"definiowania destruktorów."
+
+#: src/traits/important-traits.md:10
+#, fuzzy
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
+"używane do konstruowania domyślnej instancji typu."
 
 #: src/traits/iterator.md:1
 #, fuzzy
-msgid "# Iterators"
-msgstr "# Iteratory"
+msgid "Iterators"
+msgstr "Iteratory"
 
 #: src/traits/iterator.md:3
 #, fuzzy
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
-msgstr "Możesz zaimplementować cechę [`Iterator`][1] na swoich własnych typach:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
+msgstr ""
+"Możesz zaimplementować cechę [`Iterator`](https://doc.rust-lang.org/std/iter/"
+"trait.Iterator.html) na swoich własnych typach:"
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -10515,80 +10659,67 @@ msgid ""
 "struct Fibonacci {\n"
 "    curr: u32,\n"
 "    next: u32,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/iterator.md:11
-msgid "impl Iterator for Fibonacci {\n    type Item = u32;"
+msgid "impl Iterator for Fibonacci { type Item = u32;"
 msgstr ""
 
 #: src/traits/iterator.md:14
 msgid ""
-"    fn next(&mut self) -> Option<Self::Item> {\n"
-"        let new_next = self.curr + self.next;\n"
-"        self.curr = self.next;\n"
-"        self.next = new_next;\n"
-"        Some(self.curr)\n"
-"    }\n"
-"}"
+"```\n"
+"fn next(&mut self) -> Option<Self::Item> {\n"
+"    let new_next = self.curr + self.next;\n"
+"    self.curr = self.next;\n"
+"    self.next = new_next;\n"
+"    Some(self.curr)\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/iterator.md:22
 msgid ""
-"fn main() {\n"
-"    let fib = Fibonacci { curr: 0, next: 1 };\n"
-"    for (i, n) in fib.enumerate().take(5) {\n"
-"        println!(\"fib({i}): {n}\");\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let fib = Fibonacci { curr: 0, next: 1 }; for (i, n) in fib."
+"enumerate().take(5) { println!(\"fib({i}): {n}\"); } }"
 msgstr ""
 
 #: src/traits/iterator.md:32
 #, fuzzy
 msgid ""
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it.\n"
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"</details>"
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it."
 msgstr ""
-"* `IntoIterator` to cecha, która sprawia, że pętle for działają. Jest "
-"implementowany przez typy kolekcji, takie jak\n"
-"  `Vec<T>` i odniesienia do nich, takie jak `&Vec<T>` i `&[T]`. Realizują to "
-"również zakresy.\n"
-"* Cecha `Iterator` implementuje wiele typowych operacji programowania "
-"funkcyjnego na kolekcjach\n"
-"  (np. `mapa`, `filtr`, `zmniejsz` itp.). Jest to cecha, w której można "
-"znaleźć całą dokumentację\n"
-"  o nich. W Rust te funkcje powinny generować kod tak wydajny, jak "
-"równoważny imperatyw\n"
-"  wdrożenia.\n"
-"    \n"
-"</details>"
+"`IntoIterator` to cecha, która sprawia, że pętle for działają. Jest "
+"implementowany przez typy kolekcji, takie jak `Vec<T>` i odniesienia do "
+"nich, takie jak `&Vec<T>` i `&[T]`. Realizują to również zakresy."
 
-#: src/traits/iterator.md:41
+#: src/traits/iterator.md:34
 #, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
-msgstr "[1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
-
-#: src/traits/from-iterator.md:1
-#, fuzzy
-msgid "# FromIterator"
-msgstr "# Z Iteratora"
+msgid ""
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
+msgstr ""
+"Cecha `Iterator` implementuje wiele typowych operacji programowania "
+"funkcyjnego na kolekcjach (np. `mapa`, `filtr`, `zmniejsz` itp.). Jest to "
+"cecha, w której można znaleźć całą dokumentację o nich. W Rust te funkcje "
+"powinny generować kod tak wydajny, jak równoważny imperatyw wdrożenia."
 
 #: src/traits/from-iterator.md:3
 #, fuzzy
-msgid "[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
-msgstr "[`FromIterator`][1] pozwala zbudować kolekcję z [`Iterator`][2]."
+msgid ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
+msgstr ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"pozwala zbudować kolekcję z [`Iterator`](https://doc.rust-lang.org/std/iter/"
+"trait.Iterator.html)."
 
 #: src/traits/from-iterator.md:5
 msgid ""
@@ -10606,49 +10737,36 @@ msgstr ""
 #: src/traits/from-iterator.md:17
 #, fuzzy
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"Implementy `Iteratora`\n"
-"`fn zbieraj<B>(ja) -> B\n"
-"Gdzie\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Własny: Wielkości`"
+"Implementy `Iteratora` `fn zbieraj<B>(ja) -> B Gdzie B: FromIterator<Self::"
+"Item>, Własny: Wielkości`"
 
 #: src/traits/from-iterator.md:23
 #, fuzzy
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 "Istnieją również implementacje, które pozwalają robić fajne rzeczy, takie "
-"jak konwersja pliku\n"
-"`Iterator<Pozycja = Wynik<V, E>>` w `Wynik<Vec<V>, E>`."
-
-#: src/traits/from-iterator.md:28
-#, fuzzy
-msgid ""
-"[1]: https://doc.rust-lang.org/std/iter/trait.FromIterator.html\n"
-"[2]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
-msgstr ""
-"[1]: https://doc.rust-lang.org/std/iter/trait.FromIterator.html\n"
-"[2]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
+"jak konwersja pliku `Iterator<Pozycja = Wynik<V, E>>` w `Wynik<Vec<V>, E>`."
 
 #: src/traits/from-into.md:1
 #, fuzzy
-msgid "# `From` and `Into`"
-msgstr "# `Od` i `do`"
+msgid "`From` and `Into`"
+msgstr "`Od` i `do`"
 
 #: src/traits/from-into.md:3
 #, fuzzy
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
-"Typy implementują [`From`][1] i [`Into`][2] w celu ułatwienia konwersji "
-"typów:"
+"Typy implementują [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) i [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) w "
+"celu ułatwienia konwersji typów:"
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -10665,10 +10783,14 @@ msgstr ""
 
 #: src/traits/from-into.md:15
 #, fuzzy
-msgid "[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+msgid ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
-"[`Into`][2] jest automatycznie implementowane po zaimplementowaniu "
-"[`From`][1]:"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) jest "
+"automatycznie implementowane po zaimplementowaniu [`From`](https://doc.rust-"
+"lang.org/std/convert/trait.From.html):"
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -10683,164 +10805,146 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/traits/from-into.md:27
+#: src/traits/from-into.md:29
 #, fuzzy
 msgid ""
-"<details>\n"
-"  \n"
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    \n"
-"</details>"
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
 msgstr ""
-"<details>\n"
-"  \n"
-"* Dlatego często implementuje się tylko `From`, ponieważ twój typ również "
-"otrzyma implementację `Into`.\n"
-"* Deklarując typ wejściowy argumentu funkcji, taki jak „wszystko, co można "
-"przekonwertować na `String`”, zasada jest odwrotna, należy użyć `Into`.\n"
-"  Twoja funkcja akceptuje typy, które implementują `From` i te, które "
-"_tylko_ implementują `Into`.\n"
-"    \n"
-"</details>"
+"Dlatego często implementuje się tylko `From`, ponieważ twój typ również "
+"otrzyma implementację `Into`."
 
-#: src/traits/from-into.md:35
+#: src/traits/from-into.md:30
 #, fuzzy
 msgid ""
-"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html"
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
 msgstr ""
-"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html"
+"Deklarując typ wejściowy argumentu funkcji, taki jak „wszystko, co można "
+"przekonwertować na `String`”, zasada jest odwrotna, należy użyć `Into`. "
+"Twoja funkcja akceptuje typy, które implementują `From` i te, które _tylko_ "
+"implementują `Into`."
 
 #: src/traits/read-write.md:1
 #, fuzzy
-msgid "# `Read` and `Write`"
-msgstr "# `Odczyt` i `Zapis`"
+msgid "`Read` and `Write`"
+msgstr "`Odczyt` i `Zapis`"
 
 #: src/traits/read-write.md:3
 #, fuzzy
-msgid "Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
-msgstr "Używając [`Read`][1] i [`BufRead`][2], możesz wyodrębnić źródła `u8`:"
+msgid ""
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr ""
+"Używając [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) i "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), możesz "
+"wyodrębnić źródła `u8`:"
 
 #: src/traits/read-write.md:5
-msgid "```rust,editable\nuse std::io::{BufRead, BufReader, Read, Result};"
+msgid ""
+"```rust,editable\n"
+"use std::io::{BufRead, BufReader, Read, Result};\n"
+"```"
 msgstr ""
 
 #: src/traits/read-write.md:8
 msgid ""
-"fn count_lines<R: Read>(reader: R) -> usize {\n"
-"    let buf_reader = BufReader::new(reader);\n"
-"    buf_reader.lines().count()\n"
-"}"
+"fn count_lines\\<R: Read>(reader: R) -> usize { let buf_reader = BufReader::"
+"new(reader); buf_reader.lines().count() }"
 msgstr ""
 
 #: src/traits/read-write.md:13
 msgid ""
-"fn main() -> Result<()> {\n"
-"    let slice: &[u8] = b\"foo\\n"
-"bar\\n"
-"baz\\n"
-"\";\n"
-"    println!(\"lines in slice: {}\", count_lines(slice));"
+"fn main() -> Result\\<()> { let slice: &\\[u8\\] = b\"foo\\nbar\\nbaz\\n\"; "
+"println!(\"lines in slice: {}\", count_lines(slice));"
 msgstr ""
 
 #: src/traits/read-write.md:17
 msgid ""
-"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
-"    println!(\"lines in file: {}\", count_lines(file));\n"
-"    Ok(())\n"
-"}\n"
+"```\n"
+"let file = std::fs::File::open(std::env::current_exe()?)?;\n"
+"println!(\"lines in file: {}\", count_lines(file));\n"
+"Ok(())\n"
 "```"
 msgstr ""
 
 #: src/traits/read-write.md:23
 #, fuzzy
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
-msgstr "Podobnie, [`Write`][3] pozwala na abstrakcję nad ujściami `u8`:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
+msgstr ""
+"Podobnie, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) "
+"pozwala na abstrakcję nad ujściami `u8`:"
 
 #: src/traits/read-write.md:25
-msgid "```rust,editable\nuse std::io::{Result, Write};"
+msgid ""
+"```rust,editable\n"
+"use std::io::{Result, Write};\n"
+"```"
 msgstr ""
 
 #: src/traits/read-write.md:28
 msgid ""
-"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
-"    writer.write_all(msg.as_bytes())?;\n"
-"    writer.write_all(\"\\n"
-"\".as_bytes())\n"
-"}"
+"fn log\\<W: Write>(writer: &mut W, msg: &str) -> Result\\<()> { writer."
+"write_all(msg.as_bytes())?; writer.write_all(\"\\n\".as_bytes()) }"
 msgstr ""
 
 #: src/traits/read-write.md:33
 msgid ""
-"fn main() -> Result<()> {\n"
-"    let mut buffer = Vec::new();\n"
-"    log(&mut buffer, \"Hello\")?;\n"
-"    log(&mut buffer, \"World\")?;\n"
-"    println!(\"Logged: {:?}\", buffer);\n"
-"    Ok(())\n"
-"}\n"
-"```"
+"fn main() -> Result\\<()> { let mut buffer = Vec::new(); log(&mut buffer, "
+"\"Hello\")?; log(&mut buffer, \"World\")?; println!(\"Logged: {:?}\", "
+"buffer); Ok(()) }"
 msgstr ""
-
-#: src/traits/read-write.md:42
-#, fuzzy
-msgid ""
-"[1]: https://doc.rust-lang.org/std/io/trait.Read.html\n"
-"[2]: https://doc.rust-lang.org/std/io/trait.BufRead.html\n"
-"[3]: https://doc.rust-lang.org/std/io/trait.Write.html"
-msgstr ""
-"[1]: https://doc.rust-lang.org/std/io/trait.Read.html\n"
-"[2]: https://doc.rust-lang.org/std/io/trait.BufRead.html\n"
-"[3]: https://doc.rust-lang.org/std/io/trait.Write.html"
 
 #: src/traits/operators.md:1
 #, fuzzy
-msgid "# `Add`, `Mul`, ..."
-msgstr "# `Dodaj`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
+msgstr "`Dodaj`, `Mul`, ..."
 
 #: src/traits/operators.md:3
 #, fuzzy
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
-msgstr "Przeciążanie operatora jest realizowane poprzez cechy w [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
+msgstr ""
+"Przeciążanie operatora jest realizowane poprzez cechy w [`std::ops`](https://"
+"doc.rust-lang.org/std/ops/index.html):"
 
 #: src/traits/operators.md:5
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug, Copy, Clone)]\n"
-"struct Point { x: i32, y: i32 }"
+"struct Point { x: i32, y: i32 }\n"
+"```"
 msgstr ""
 
 #: src/traits/operators.md:9 src/exercises/day-2/solutions-morning.md:46
-msgid "impl std::ops::Add for Point {\n    type Output = Self;"
+msgid "impl std::ops::Add for Point { type Output = Self;"
 msgstr ""
 
 #: src/traits/operators.md:12
 #, fuzzy
 msgid ""
-"    fn add(self, other: Self) -> Self {\n"
-"        Self {x: self.x + other.x, y: self.y + other.y}\n"
-"    }\n"
-"}"
+"```\n"
+"fn add(self, other: Self) -> Self {\n"
+"    Self {x: self.x + other.x, y: self.y + other.y}\n"
+"}\n"
+"```"
 msgstr ""
-"    fn add(sam, inny: Własny) -> Własny {\n"
-"        Ja {x: ja.x + inny.x, y: ja.y + inny.y}\n"
-"    }\n"
-"}"
+"```\n"
+"fn add(sam, inny: Własny) -> Własny {\n"
+"    Ja {x: ja.x + inny.x, y: ja.y + inny.y}\n"
+"}\n"
+"```"
 
 #: src/traits/operators.md:17
 msgid ""
-"fn main() {\n"
-"    let p1 = Point { x: 10, y: 20 };\n"
-"    let p2 = Point { x: 100, y: 200 };\n"
-"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point { x: 10, y: 20 }; let p2 = Point { x: 100, y: "
+"200 }; println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2); }"
 msgstr ""
 
 #: src/traits/operators.md:26 src/traits/drop.md:34
@@ -10851,122 +10955,109 @@ msgstr "Punkty dyskusji:"
 #: src/traits/operators.md:28
 #, fuzzy
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter?\n"
-"    * Short answer: Type parameters are controlled by the caller, but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
 msgstr ""
-"* Możesz zaimplementować `Add` dla `&Point`. W jakich sytuacjach jest to "
-"przydatne?\n"
-"    * Odpowiedź: `Add:add` zużywa `self`. Jeśli wpisz `T` za którym jesteś\n"
-"        przeciążanie operatora nie jest `Kopiuj`, powinieneś rozważyć "
-"przeciążanie\n"
-"        operator dla `&T` również. Pozwala to uniknąć niepotrzebnego "
-"klonowania w pliku\n"
-"        Zadzwoń do serwisu.\n"
-"* Dlaczego `Output` jest powiązanym typem? Czy można go ustawić jako "
-"parametr typu?\n"
-"    * Krótka odpowiedź: Parametry typu są kontrolowane przez dzwoniącego, "
-"ale\n"
-"        powiązane typy (takie jak `Output`) są kontrolowane przez "
-"implementatora a\n"
-"        cecha."
+"Możesz zaimplementować `Add` dla `&Point`. W jakich sytuacjach jest to "
+"przydatne?"
 
-#: src/traits/operators.md:40
+#: src/traits/operators.md:29
 #, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/ops/index.html"
-msgstr "[1]: https://doc.rust-lang.org/std/ops/index.html"
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"Odpowiedź: `Add:add` zużywa `self`. Jeśli wpisz `T` za którym jesteś "
+"przeciążanie operatora nie jest `Kopiuj`, powinieneś rozważyć przeciążanie "
+"operator dla `&T` również. Pozwala to uniknąć niepotrzebnego klonowania w "
+"pliku Zadzwoń do serwisu."
+
+#: src/traits/operators.md:33
+#, fuzzy
+msgid "Why is `Output` an associated type? Could it be made a type parameter?"
+msgstr ""
+"Dlaczego `Output` jest powiązanym typem? Czy można go ustawić jako parametr "
+"typu?"
+
+#: src/traits/operators.md:34
+#, fuzzy
+msgid ""
+"Short answer: Type parameters are controlled by the caller, but associated "
+"types (like `Output`) are controlled by the implementor of a trait."
+msgstr ""
+"Krótka odpowiedź: Parametry typu są kontrolowane przez dzwoniącego, ale "
+"powiązane typy (takie jak `Output`) są kontrolowane przez implementatora a "
+"cecha."
 
 #: src/traits/drop.md:1
 #, fuzzy
-msgid "# The `Drop` Trait"
-msgstr "# Cecha „Upuść”."
+msgid "The `Drop` Trait"
+msgstr "Cecha „Upuść”."
 
 #: src/traits/drop.md:3
 #, fuzzy
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
-"Wartości, które implementują [`Drop`][1], mogą określać kod do wykonania, "
-"gdy wykraczają poza zakres:"
+"Wartości, które implementują [`Drop`](https://doc.rust-lang.org/std/ops/"
+"trait.Drop.html), mogą określać kod do wykonania, gdy wykraczają poza zakres:"
 
 #: src/traits/drop.md:5
 msgid ""
 "```rust,editable\n"
 "struct Droppable {\n"
 "    name: &'static str,\n"
-"}"
-msgstr ""
-
-#: src/traits/drop.md:10
-msgid ""
-"impl Drop for Droppable {\n"
-"    fn drop(&mut self) {\n"
-"        println!(\"Dropping {}\", self.name);\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/traits/drop.md:16
-msgid ""
-"fn main() {\n"
-"    let a = Droppable { name: \"a\" };\n"
-"    {\n"
-"        let b = Droppable { name: \"b\" };\n"
-"        {\n"
-"            let c = Droppable { name: \"c\" };\n"
-"            let d = Droppable { name: \"d\" };\n"
-"            println!(\"Exiting block B\");\n"
-"        }\n"
-"        println!(\"Exiting block A\");\n"
-"    }\n"
-"    drop(a);\n"
-"    println!(\"Exiting main\");\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/traits/drop.md:10
+msgid ""
+"impl Drop for Droppable { fn drop(&mut self) { println!(\"Dropping {}\", "
+"self.name); } }"
+msgstr ""
+
+#: src/traits/drop.md:16
+msgid ""
+"fn main() { let a = Droppable { name: \"a\" }; { let b = Droppable { name: "
+"\"b\" }; { let c = Droppable { name: \"c\" }; let d = Droppable { name: "
+"\"d\" }; println!(\"Exiting block B\"); } println!(\"Exiting block A\"); } "
+"drop(a); println!(\"Exiting main\"); }"
+msgstr ""
+
 #: src/traits/drop.md:36
 #, fuzzy
-msgid ""
-"* Why does not `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
-msgstr ""
-"* Dlaczego `Drop::drop` nie przyjmuje `self`?\n"
-"    * Krótka odpowiedź: gdyby tak było, `std::mem::drop` zostałoby wywołane "
-"na końcu\n"
-"        blok, co skutkuje kolejnym wywołaniem `Drop::drop` i stosem\n"
-"        przelewowy!\n"
-"* Spróbuj zamienić `drop(a)` na `a.drop()`."
+msgid "Why does not `Drop::drop` take `self`?"
+msgstr "Dlaczego `Drop::drop` nie przyjmuje `self`?"
 
-#: src/traits/drop.md:44
+#: src/traits/drop.md:37
 #, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-msgstr "[1]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
+msgid ""
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
+msgstr ""
+"Krótka odpowiedź: gdyby tak było, `std::mem::drop` zostałoby wywołane na "
+"końcu blok, co skutkuje kolejnym wywołaniem `Drop::drop` i stosem przelewowy!"
+
+#: src/traits/drop.md:40
+#, fuzzy
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "Spróbuj zamienić `drop(a)` na `a.drop()`."
 
 #: src/traits/default.md:1
 #, fuzzy
-msgid "# The `Default` Trait"
-msgstr "# Cecha „Domyślna”."
+msgid "The `Default` Trait"
+msgstr "Cecha „Domyślna”."
 
 #: src/traits/default.md:3
 #, fuzzy
-msgid "[`Default`][1] trait provides a default implementation of a trait."
-msgstr "Cecha [`Default`][1] zapewnia domyślną implementację cechy."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"provides a default implementation of a trait."
+msgstr ""
+"Cecha [`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
+"zapewnia domyślną implementację cechy."
 
 #: src/traits/default.md:5
 msgid ""
@@ -10976,102 +11067,103 @@ msgid ""
 "    x: u32,\n"
 "    y: String,\n"
 "    z: Implemented,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/default.md:13
-msgid "#[derive(Debug)]\nstruct Implemented(String);"
+msgid "\\#\\[derive(Debug)\\] struct Implemented(String);"
 msgstr ""
 
 #: src/traits/default.md:16
 #, fuzzy
 msgid ""
-"impl Default for Implemented {\n"
-"    fn default() -> Self {\n"
-"        Self(\"John Smith\".into())\n"
-"    }\n"
-"}"
+"impl Default for Implemented { fn default() -> Self { Self(\"John Smith\"."
+"into()) } }"
 msgstr ""
-"impl Domyślnie dla zaimplementowanych {\n"
-"    fn default() -> Własny {\n"
-"        Self(\"Jan Kowalski\".do())\n"
-"    }\n"
-"}"
+"impl Domyślnie dla zaimplementowanych { fn default() -> Własny { Self(\"Jan "
+"Kowalski\".do()) } }"
 
 #: src/traits/default.md:22
 msgid ""
-"fn main() {\n"
-"    let default_struct: Derived = Default::default();\n"
-"    println!(\"{default_struct:#?}\");"
+"fn main() { let default_struct: Derived = Default::default(); println!"
+"(\"{default_struct:#?}\");"
 msgstr ""
 
 #: src/traits/default.md:26
 msgid ""
-"    let almost_default_struct = Derived {\n"
-"        y: \"Y is set!\".into(),\n"
-"        ..Default::default()\n"
-"    };\n"
-"    println!(\"{almost_default_struct:#?}\");"
+"```\n"
+"let almost_default_struct = Derived {\n"
+"    y: \"Y is set!\".into(),\n"
+"    ..Default::default()\n"
+"};\n"
+"println!(\"{almost_default_struct:#?}\");\n"
+"```"
 msgstr ""
 
 #: src/traits/default.md:32
 msgid ""
-"    let nothing: Option<Derived> = None;\n"
-"    println!(\"{:#?}\", nothing.unwrap_or_default());\n"
-"}"
+"```\n"
+"let nothing: Option<Derived> = None;\n"
+"println!(\"{:#?}\", nothing.unwrap_or_default());\n"
+"```"
 msgstr ""
 
 #: src/traits/default.md:40
 #, fuzzy
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values "
-"(e.g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr ""
+"Może być zaimplementowany bezpośrednio lub wyprowadzony przez "
+"`#[derive(Default)]`."
+
+#: src/traits/default.md:41
+#, fuzzy
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr ""
+"Implementacja pochodna utworzy instancję, w której wszystkie pola zostaną "
+"ustawione na wartości domyślne."
+
+#: src/traits/default.md:42
+#, fuzzy
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+"Oznacza to, że wszystkie typy w strukturze muszą również implementować "
+"`Default`."
+
+#: src/traits/default.md:43
+#, fuzzy
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+"Standardowe typy Rust często implementują `Default` z rozsądnymi wartościami "
+"(np. `0`, `\"\"` itp.)."
+
+#: src/traits/default.md:44
+#, fuzzy
+msgid "The partial struct copy works nicely with default."
+msgstr "Częściowa kopia struktury dobrze działa z ustawieniami domyślnymi."
+
+#: src/traits/default.md:45
+#, fuzzy
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
-"  * Może być zaimplementowany bezpośrednio lub wyprowadzony przez "
-"`#[derive(Default)]`.\n"
-"  * Implementacja pochodna utworzy instancję, w której wszystkie pola "
-"zostaną ustawione na wartości domyślne.\n"
-"    * Oznacza to, że wszystkie typy w strukturze muszą również implementować "
-"`Default`.\n"
-"  * Standardowe typy Rust często implementują `Default` z rozsądnymi "
-"wartościami (np. `0`, `\"\"` itp.).\n"
-"  * Częściowa kopia struktury dobrze działa z ustawieniami domyślnymi.\n"
-"  * Standardowa biblioteka Rust jest świadoma, że typy mogą implementować "
+"Standardowa biblioteka Rust jest świadoma, że typy mogą implementować "
 "`Default` i zapewnia wygodne metody, które z niej korzystają."
-
-#: src/traits/default.md:49
-#, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/default/trait.Default.html"
-msgstr "[1]: https://doc.rust-lang.org/std/default/trait.Default.html"
-
-#: src/generics.md:1
-#, fuzzy
-msgid "# Generics"
-msgstr "# Generyki"
 
 #: src/generics.md:3
 #, fuzzy
 msgid ""
 "Rust support generics, which lets you abstract an algorithm (such as "
-"sorting)\n"
-"over the types used in the algorithm."
+"sorting) over the types used in the algorithm."
 msgstr ""
 "Rust obsługuje typy ogólne, które pozwalają wyodrębnić algorytm (taki jak "
-"sortowanie)\n"
-"nad typami używanymi w algorytmie."
-
-#: src/generics/data-types.md:1
-#, fuzzy
-msgid "# Generic Data Types"
-msgstr "# Ogólne typy danych"
+"sortowanie) nad typami używanymi w algorytmie."
 
 #: src/generics/data-types.md:3
 #, fuzzy
@@ -11085,23 +11177,15 @@ msgid ""
 "struct Point<T> {\n"
 "    x: T,\n"
 "    y: T,\n"
-"}"
-msgstr ""
-
-#: src/generics/data-types.md:12
-msgid ""
-"fn main() {\n"
-"    let integer = Point { x: 5, y: 10 };\n"
-"    let float = Point { x: 1.0, y: 4.0 };\n"
-"    println!(\"{integer:?} and {float:?}\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/generics/methods.md:1
-#, fuzzy
-msgid "# Generic Methods"
-msgstr "# Ogólne metody"
+#: src/generics/data-types.md:12
+msgid ""
+"fn main() { let integer = Point { x: 5, y: 10 }; let float = Point { x: 1.0, "
+"y: 4.0 }; println!(\"{integer:?} and {float:?}\"); }"
+msgstr ""
 
 #: src/generics/methods.md:3
 #, fuzzy
@@ -11112,70 +11196,84 @@ msgstr "Możesz zadeklarować typ ogólny w swoim bloku `impl`:"
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Point<T>(T, T);"
+"struct Point<T>(T, T);\n"
+"```"
 msgstr ""
 
 #: src/generics/methods.md:9
 #, fuzzy
-msgid ""
-"impl<T> Point<T> {\n"
-"    fn x(&self) -> &T {\n"
-"        &self.0  // + 10\n"
-"    }"
-msgstr ""
-"impl<T> Punkt<T> {\n"
-"    fn x(&ja) -> &T {\n"
-"        &sobie.0 // + 10\n"
-"    }"
+msgid "impl"
+msgstr "impl"
+
+#: src/generics/methods.md:9
+#, fuzzy
+msgid " Point"
+msgstr " Punkt"
+
+#: src/generics/methods.md:9
+#, fuzzy
+msgid " { fn x(&self) -> &T { &self.0  // + 10 }"
+msgstr " { fn x(&ja) -> &T { &sobie.0 // + 10 }"
 
 #: src/generics/methods.md:14
 #, fuzzy
-msgid "    // fn set_x(&mut self, x: T)\n}"
-msgstr "    // fn set_x(&mut self, x: T)\n}"
+msgid ""
+"```\n"
+"// fn set_x(&mut self, x: T)\n"
+"```"
+msgstr ""
+"```\n"
+"// fn set_x(&mut self, x: T)\n"
+"```"
 
 #: src/generics/methods.md:17
-msgid ""
-"fn main() {\n"
-"    let p = Point(5, 10);\n"
-"    println!(\"p.x = {}\", p.x());\n"
-"}\n"
-"```"
+msgid "fn main() { let p = Point(5, 10); println!(\"p.x = {}\", p.x()); }"
 msgstr ""
 
 #: src/generics/methods.md:25
 #, fuzzy
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
-"* *P:* Dlaczego `T` jest określone dwukrotnie w `impl<T> Point<T> {}`? Czy "
-"to nie jest zbędne?\n"
-"    * Dzieje się tak, ponieważ jest to ogólna sekcja implementacji dla typu "
-"ogólnego. Są niezależnie ogólne.\n"
-"    * Oznacza to, że te metody są zdefiniowane dla dowolnego `T`.\n"
-"    * Można napisać `impl Point<u32> { .. }`.\n"
-"      * `Point` jest nadal ogólny i możesz użyć `Point<f64>`, ale metody w "
-"tym bloku będą dostępne tylko dla `Point<u32>`."
+"_P:_ Dlaczego `T` jest określone dwukrotnie w `impl<T> Point<T> {}`? Czy to "
+"nie jest zbędne?"
 
-#: src/generics/trait-bounds.md:1
+#: src/generics/methods.md:26
 #, fuzzy
-msgid "# Trait Bounds"
-msgstr "# Granice cech"
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"Dzieje się tak, ponieważ jest to ogólna sekcja implementacji dla typu "
+"ogólnego. Są niezależnie ogólne."
+
+#: src/generics/methods.md:27
+#, fuzzy
+msgid "It means these methods are defined for any `T`."
+msgstr "Oznacza to, że te metody są zdefiniowane dla dowolnego `T`."
+
+#: src/generics/methods.md:28
+#, fuzzy
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "Można napisać `impl Point<u32> { .. }`."
+
+#: src/generics/methods.md:29
+#, fuzzy
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"`Point` jest nadal ogólny i możesz użyć `Point<f64>`, ale metody w tym bloku "
+"będą dostępne tylko dla `Point<u32>`."
 
 #: src/generics/trait-bounds.md:3
 #, fuzzy
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
-"Podczas pracy z typami ogólnymi często chcesz wymagać implementacji typów\n"
+"Podczas pracy z typami ogólnymi często chcesz wymagać implementacji typów "
 "jakąś cechę, aby można było wywołać metody tej cechy."
 
 #: src/generics/trait-bounds.md:6
@@ -11188,23 +11286,24 @@ msgid ""
 "```rust,editable\n"
 "fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
 "    (a.clone(), a.clone())\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/trait-bounds.md:13
 #, fuzzy
-msgid ""
-"// Syntactic sugar for:\n"
-"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
-"fn add_42_millions(x: impl Into<i32>) -> i32 {\n"
-"    x.into() + 42_000_000\n"
-"}"
-msgstr ""
-"// Cukier syntaktyczny do:\n"
-"// fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
-"fn add_42_milions(x: impl Into<i32>) -> i32 {\n"
-"    x.do() + 42_000_000\n"
-"}"
+msgid "// Syntactic sugar for: //   fn add_42_millions\\<T: Into"
+msgstr "// Cukier syntaktyczny do: // fn add_42_millions\\<T: Into"
+
+#: src/generics/trait-bounds.md:14
+#, fuzzy
+msgid "\\>(x: T) -> i32 { fn add_42_millions(x: impl Into"
+msgstr "\\>(x: T) -> i32 { fn add_42_milions(x: impl Into"
+
+#: src/generics/trait-bounds.md:15
+#, fuzzy
+msgid ") -> i32 { x.into() + 42_000_000 }"
+msgstr ") -> i32 { x.do() + 42_000_000 }"
 
 #: src/generics/trait-bounds.md:19
 msgid "// struct NotClonable;"
@@ -11212,26 +11311,26 @@ msgstr ""
 
 #: src/generics/trait-bounds.md:21
 msgid ""
-"fn main() {\n"
-"    let foo = String::from(\"foo\");\n"
-"    let pair = duplicate(foo);\n"
-"    println!(\"{pair:?}\");"
+"fn main() { let foo = String::from(\"foo\"); let pair = duplicate(foo); "
+"println!(\"{pair:?}\");"
 msgstr ""
 
 #: src/generics/trait-bounds.md:26
 msgid ""
-"    let many = add_42_millions(42_i8);\n"
-"    println!(\"{many}\");\n"
-"    let many_more = add_42_millions(10_000_000);\n"
-"    println!(\"{many_more}\");\n"
-"}\n"
+"```\n"
+"let many = add_42_millions(42_i8);\n"
+"println!(\"{many}\");\n"
+"let many_more = add_42_millions(10_000_000);\n"
+"println!(\"{many_more}\");\n"
 "```"
 msgstr ""
 
 #: src/generics/trait-bounds.md:35
+msgid "Show a `where` clause, students will encounter it when reading code."
+msgstr ""
+
+#: src/generics/trait-bounds.md:37
 msgid ""
-"Show a `where` clause, students will encounter it when reading code.\n"
-"    \n"
 "```rust,ignore\n"
 "fn duplicate<T>(a: T) -> (T, T)\n"
 "where\n"
@@ -11244,68 +11343,65 @@ msgstr ""
 
 #: src/generics/trait-bounds.md:46
 #, fuzzy
+msgid "It declutters the function signature if you have many parameters."
+msgstr "Odczytuje sygnaturę funkcji, jeśli masz wiele parametrów."
+
+#: src/generics/trait-bounds.md:47
+#, fuzzy
+msgid "It has additional features making it more powerful."
+msgstr "Posiada dodatkowe funkcje, dzięki którym jest potężniejszy."
+
+#: src/generics/trait-bounds.md:48
+#, fuzzy
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of "
-"\":\" can be arbitrary, like `Option<T>`.\n"
-"    \n"
-"</details>"
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
-"* Odczytuje sygnaturę funkcji, jeśli masz wiele parametrów.\n"
-"* Posiada dodatkowe funkcje, dzięki którym jest potężniejszy.\n"
-"    * Jeśli ktoś zapyta, dodatkową cechą jest to, że typ po lewej stronie "
-"„:” może być dowolny, na przykład `Option<T>`.\n"
-"    \n"
-"</details>"
+"Jeśli ktoś zapyta, dodatkową cechą jest to, że typ po lewej stronie „:” może "
+"być dowolny, na przykład `Option<T>`."
 
 #: src/generics/impl-trait.md:1
 #, fuzzy
-msgid "# `impl Trait`"
-msgstr "# `impl Cecha`"
+msgid "`impl Trait`"
+msgstr "`impl Cecha`"
 
 #: src/generics/impl-trait.md:3
 #, fuzzy
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 "Podobnie jak w przypadku granic cech, składnia `impl Trait` może być używana "
-"w funkcji\n"
-"argumenty i zwracane wartości:"
+"w funkcji argumenty i zwracane wartości:"
 
-#: src/generics/impl-trait.md:6 src/generics/trait-objects.md:5 src/generics/trait-objects.md:28
-msgid "```rust,editable\nuse std::fmt::Display;"
+#: src/generics/impl-trait.md:6 src/generics/trait-objects.md:5
+#: src/generics/trait-objects.md:28
+msgid ""
+"```rust,editable\n"
+"use std::fmt::Display;\n"
+"```"
 msgstr ""
 
 #: src/generics/impl-trait.md:9
 #, fuzzy
 msgid ""
-"fn get_x(name: impl Display) -> impl Display {\n"
-"    format!(\"Hello {name}\")\n"
-"}"
+"fn get_x(name: impl Display) -> impl Display { format!(\"Hello {name}\") }"
 msgstr ""
-"fn get_x(nazwa: impl Wyświetl) -> impl Wyświetl {\n"
-"    format!(\"Witaj {imię}\")\n"
-"}"
+"fn get_x(nazwa: impl Wyświetl) -> impl Wyświetl { format!(\"Witaj {imię}\") }"
 
 #: src/generics/impl-trait.md:13
-msgid ""
-"fn main() {\n"
-"    let x = get_x(\"foo\");\n"
-"    println!(\"{x}\");\n"
-"}\n"
-"```"
+msgid "fn main() { let x = get_x(\"foo\"); println!(\"{x}\"); }"
 msgstr ""
 
 #: src/generics/impl-trait.md:19
 #, fuzzy
-msgid ""
-"* `impl Trait` cannot be used with the `::<>` turbo fish syntax.\n"
-"* `impl Trait` allows you to work with types which you cannot name."
-msgstr ""
-"* `impl Trait` nie może być używany ze składnią `::<>` turbofish.\n"
-"* `impl Trait` umożliwia pracę z typami, których nie można nazwać."
+msgid "`impl Trait` cannot be used with the `::<>` turbo fish syntax."
+msgstr "`impl Trait` nie może być używany ze składnią `::<>` turbofish."
+
+#: src/generics/impl-trait.md:20
+#, fuzzy
+msgid "`impl Trait` allows you to work with types which you cannot name."
+msgstr "`impl Trait` umożliwia pracę z typami, których nie można nazwać."
 
 #: src/generics/impl-trait.md:24
 #, fuzzy
@@ -11316,72 +11412,55 @@ msgstr "Znaczenie „impl Cecha” jest nieco inne w różnych pozycjach."
 #: src/generics/impl-trait.md:26
 #, fuzzy
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
 msgstr ""
-"* W przypadku parametru „impl Trait” jest jak anonimowy parametr ogólny z "
-"powiązaniem z cechą.\n"
-"* W przypadku typu zwracanego oznacza to, że typ zwracany jest jakimś "
-"konkretnym typem, który implementuje cechę,\n"
-"  bez określania rodzaju. Może to być przydatne, gdy nie chcesz ujawniać "
-"konkretnego typu w pliku\n"
-"  publiczne API."
+"W przypadku parametru „impl Trait” jest jak anonimowy parametr ogólny z "
+"powiązaniem z cechą."
+
+#: src/generics/impl-trait.md:27
+#, fuzzy
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+"W przypadku typu zwracanego oznacza to, że typ zwracany jest jakimś "
+"konkretnym typem, który implementuje cechę, bez określania rodzaju. Może to "
+"być przydatne, gdy nie chcesz ujawniać konkretnego typu w pliku publiczne "
+"API."
 
 #: src/generics/impl-trait.md:31
 #, fuzzy
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters.\n"
-"    \n"
-"</details>"
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 "Ten przykład jest świetny, ponieważ dwukrotnie używa `impl Display`. Pomaga "
-"to wyjaśnić\n"
-"nic tutaj nie wymusza, że jest to _ten sam_ typ `impl Display`. Gdybyśmy "
-"użyli jednego\n"
-"`T: Display`, wymuszałoby ograniczenie, że wejście `T` i zwracany typ `T` są "
-"tego samego typu.\n"
-"Nie zadziałałoby to dla tej konkretnej funkcji, ponieważ typ, którego "
-"oczekujemy jako dane wejściowe, prawdopodobnie nie\n"
-"co zwraca `format!`. Gdybyśmy chcieli zrobić to samo za pomocą składni `: "
-"Display`, potrzebowalibyśmy dwóch\n"
-"niezależne parametry ogólne.\n"
-"    \n"
-"</details>"
-
-#: src/generics/closures.md:1
-#, fuzzy
-msgid "# Closures"
-msgstr "# Domknięcia"
+"to wyjaśnić nic tutaj nie wymusza, że jest to _ten sam_ typ `impl Display`. "
+"Gdybyśmy użyli jednego `T: Display`, wymuszałoby ograniczenie, że wejście "
+"`T` i zwracany typ `T` są tego samego typu. Nie zadziałałoby to dla tej "
+"konkretnej funkcji, ponieważ typ, którego oczekujemy jako dane wejściowe, "
+"prawdopodobnie nie co zwraca `format!`. Gdybyśmy chcieli zrobić to samo za "
+"pomocą składni `: Display`, potrzebowalibyśmy dwóch niezależne parametry "
+"ogólne."
 
 #: src/generics/closures.md:3
 #, fuzzy
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 "Domknięcia lub wyrażenia lambda mają typy, których nie można nazwać. Jednak "
-"oni\n"
-"zaimplementować specjalne "
-"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) oraz\n"
+"oni zaimplementować specjalne [`Fn`](https://doc.rust-lang.org/std/ops/trait."
+"Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) oraz "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) cechy:"
 
 #: src/generics/closures.md:8
@@ -11390,21 +11469,19 @@ msgid ""
 "fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
 "    println!(\"Calling function on {input}\");\n"
 "    func(input)\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/closures.md:14
-msgid ""
-"fn main() {\n"
-"    let add_3 = |x| x + 3;\n"
-"    let mul_5 = |x| x * 5;"
+msgid "fn main() { let add_3 = |x| x + 3; let mul_5 = |x| x * 5;"
 msgstr ""
 
 #: src/generics/closures.md:18
 msgid ""
-"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
-"    println!(\"mul_5: {}\", apply_with_log(mul_5, 20));\n"
-"}\n"
+"```\n"
+"println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
+"println!(\"mul_5: {}\", apply_with_log(mul_5, 20));\n"
 "```"
 msgstr ""
 
@@ -11430,37 +11507,27 @@ msgstr ""
 #, fuzzy
 msgid ""
 "An `Fn` neither consumes nor mutates captured values, or perhaps captures "
-"nothing at all, so it can\n"
-"be called multiple times concurrently."
+"nothing at all, so it can be called multiple times concurrently."
 msgstr ""
 "`Fn` ani nie konsumuje, ani nie mutuje przechwyconych wartości, a być może w "
-"ogóle nie przechwytuje niczego, więc może\n"
-"być wywoływane wiele razy jednocześnie."
+"ogóle nie przechwytuje niczego, więc może być wywoływane wiele razy "
+"jednocześnie."
 
 #: src/generics/closures.md:32
 #, fuzzy
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 "`FnMut` jest podtypem `FnOnce`. `Fn` jest podtypem `FnMut` i `FnOnce`. Tj. "
-"możesz użyć\n"
-"`FnMut` wszędzie tam, gdzie wymagane jest `FnOnce`, a `Fn` można użyć "
-"wszędzie tam, gdzie `FnMut` lub `FnOnce`\n"
-"jest wezwany."
+"możesz użyć `FnMut` wszędzie tam, gdzie wymagane jest `FnOnce`, a `Fn` można "
+"użyć wszędzie tam, gdzie `FnMut` lub `FnOnce` jest wezwany."
 
 #: src/generics/closures.md:36
 #, fuzzy
 msgid "`move` closures only implement `FnOnce`."
 msgstr "Zamknięcia `move` implementują tylko `FnOnce`."
-
-#: src/generics/monomorphization.md:1
-#, fuzzy
-msgid "# Monomorphization"
-msgstr "# Monomorfizacja"
 
 #: src/generics/monomorphization.md:3
 #, fuzzy
@@ -11490,46 +11557,29 @@ msgid ""
 "enum Option_i32 {\n"
 "    Some(i32),\n"
 "    None,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/monomorphization.md:20
 #, fuzzy
-msgid ""
-"enum Option_f64 {\n"
-"    Some(f64),\n"
-"    None,\n"
-"}"
-msgstr ""
-"wyliczenie Option_f64 {\n"
-"    Niektóre (f64),\n"
-"    Nic,\n"
-"}"
+msgid "enum Option_f64 { Some(f64), None, }"
+msgstr "wyliczenie Option_f64 { Niektóre (f64), Nic, }"
 
 #: src/generics/monomorphization.md:25
 msgid ""
-"fn main() {\n"
-"    let integer = Option_i32::Some(5);\n"
-"    let float = Option_f64::Some(5.0);\n"
-"}\n"
-"```"
+"fn main() { let integer = Option_i32::Some(5); let float = Option_f64::"
+"Some(5.0); }"
 msgstr ""
 
 #: src/generics/monomorphization.md:31
 #, fuzzy
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 "Jest to abstrakcja o zerowych kosztach: otrzymujesz dokładnie taki sam "
-"wynik, jakbyś miał\n"
-"ręcznie zakodował struktury danych bez abstrakcji."
-
-#: src/generics/trait-objects.md:1
-#, fuzzy
-msgid "# Trait Objects"
-msgstr "# Obiekty cech"
+"wynik, jakbyś miał ręcznie zakodował struktury danych bez abstrakcji."
 
 #: src/generics/trait-objects.md:3
 #, fuzzy
@@ -11538,19 +11588,11 @@ msgstr ""
 "Widzieliśmy, jak funkcja może przyjmować argumenty, które implementują cechę:"
 
 #: src/generics/trait-objects.md:8
-msgid ""
-"fn print<T: Display>(x: T) {\n"
-"    println!(\"Your value: {x}\");\n"
-"}"
+msgid "fn print\\<T: Display>(x: T) { println!(\"Your value: {x}\"); }"
 msgstr ""
 
 #: src/generics/trait-objects.md:12
-msgid ""
-"fn main() {\n"
-"    print(123);\n"
-"    print(\"Hello\");\n"
-"}\n"
-"```"
+msgid "fn main() { print(123); print(\"Hello\"); }"
 msgstr ""
 
 #: src/generics/trait-objects.md:18
@@ -11577,15 +11619,13 @@ msgid "For this, we need _trait objects_:"
 msgstr "W tym celu potrzebujemy _obiektów cech_:"
 
 #: src/generics/trait-objects.md:31
+msgid "fn main() { let xs: Vec\\<Box"
+msgstr ""
+
+#: src/generics/trait-objects.md:32
 msgid ""
-"fn main() {\n"
-"    let xs: Vec<Box<dyn Display>> = vec![Box::new(123), "
-"Box::new(\"Hello\")];\n"
-"    for x in xs {\n"
-"        println!(\"x: {x}\");\n"
-"    }\n"
-"}\n"
-"```"
+"\\> = vec![Box::new(123), Box::new(\"Hello\")\\]; for x in xs { println!"
+"(\"x: {x}\"); } }"
 msgstr ""
 
 #: src/generics/trait-objects.md:39
@@ -11599,50 +11639,47 @@ msgid ""
 " Stack                             Heap\n"
 ".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
 "- - -.\n"
-":                           :     :                                          "
-"     :\n"
-":    xs                     :     :                                          "
-"     :\n"
-":   +-----------+-------+   :     :   +-----+-----+                          "
-"     :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |                          "
-"     :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+                          "
-"     :\n"
-":   | capacity  |     2 |   :     :     | |   | |   "
-"+----+----+----+----+----+    :\n"
+":                           :     :                                               :\n"
+":    "
+"xs                     :     :                                               :\n"
+":   +-----------+-------+   :     :   +-----+-----"
+"+                               :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o "
+"|                               :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-"
+"+                               :\n"
+":   | capacity  |     2 |   :     :     | |   | |   +----+----+----+----+----"
+"+    :\n"
 ":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  "
 "|    :\n"
-":                           :     :     | |   |     "
-"+----+----+----+----+----+    :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |                              "
-"     :\n"
+":                           :     :     | |   |     +----+----+----+----+----"
+"+    :\n"
+"`- - - - - - - - - - - - - -'     :     | |   "
+"|                                   :\n"
 "                                  :     | |   |     "
 "+-------------------------+   :\n"
-"                                  :     | |   '---->| \"<str as "
-"Display>::fmt\" |   :\n"
+"                                  :     | |   '---->| \"<str as Display>::"
+"fmt\" |   :\n"
 "                                  :     | |         "
 "+-------------------------+   :\n"
-"                                  :     | |                                  "
-"     :\n"
-"                                  :     | |   +----+----+----+----+          "
-"     :\n"
-"                                  :     | '-->| 7b | 00 | 00 | 00 |          "
-"     :\n"
-"                                  :     |     +----+----+----+----+          "
-"     :\n"
-"                                  :     |                                    "
-"     :\n"
-"                                  :     |     +-------------------------+    "
-"     :\n"
-"                                  :     '---->| \"<i32 as Display>::fmt\" |  "
-"       :\n"
-"                                  :           +-------------------------+    "
-"     :\n"
-"                                  :                                          "
-"     :\n"
-"                                  :                                          "
-"     :\n"
+"                                  :     | "
+"|                                       :\n"
+"                                  :     | |   +----+----+----+----"
+"+               :\n"
+"                                  :     | '-->| 7b | 00 | 00 | 00 "
+"|               :\n"
+"                                  :     |     +----+----+----+----"
+"+               :\n"
+"                                  :     "
+"|                                         :\n"
+"                                  :     |     +-------------------------"
+"+         :\n"
+"                                  :     '---->| \"<i32 as Display>::fmt\" "
+"|         :\n"
+"                                  :           +-------------------------"
+"+         :\n"
+"                                  :                                               :\n"
+"                                  :                                               :\n"
 "                                  '- - - - - - - - - - - - - - - - - - - - - "
 "- - -'\n"
 "```"
@@ -11651,10 +11688,10 @@ msgstr ""
 #: src/generics/trait-objects.md:69
 #, fuzzy
 msgid ""
-"Similarly, you need a trait object if you want to return different types\n"
+"Similarly, you need a trait object if you want to return different types "
 "implementing a trait:"
 msgstr ""
-"Podobnie potrzebujesz obiektu cechy, jeśli chcesz zwrócić różne typy\n"
+"Podobnie potrzebujesz obiektu cechy, jeśli chcesz zwrócić różne typy "
 "wdrożenie cechy:"
 
 #: src/generics/trait-objects.md:72
@@ -11666,41 +11703,34 @@ msgid ""
 "    } else {\n"
 "        Box::new((n..0).rev())\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/trait-objects.md:81
 msgid ""
-"fn main() {\n"
-"    println!(\"{:?}\", numbers(-5).collect::<Vec<_>>());\n"
-"    println!(\"{:?}\", numbers(5).collect::<Vec<_>>());\n"
-"}"
+"fn main() { println!(\"{:?}\", numbers(-5).collect::\\<Vec\\<_\\>>()); "
+"println!(\"{:?}\", numbers(5).collect::\\<Vec\\<_\\>>()); }"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
 #, fuzzy
-msgid "# Day 3: Morning Exercises"
-msgstr "# Dzień 3: Ćwiczenia poranne"
+msgid "Day 3: Morning Exercises"
+msgstr "Dzień 3: Ćwiczenia poranne"
 
 #: src/exercises/day-3/morning.md:3
 #, fuzzy
 msgid "We will design a classical GUI library traits and trait objects."
 msgstr "Zaprojektujemy klasyczną bibliotekę GUI cech i obiektów cech."
 
-#: src/exercises/day-3/simple-gui.md:1
-#, fuzzy
-msgid "# A Simple GUI Library"
-msgstr "# Prosta biblioteka GUI"
-
 #: src/exercises/day-3/simple-gui.md:3
 #, fuzzy
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 "Zaprojektujmy klasyczną bibliotekę GUI, korzystając z naszej nowej wiedzy na "
-"temat cech i\n"
-"obiekty cech."
+"temat cech i obiekty cech."
 
 #: src/exercises/day-3/simple-gui.md:6
 #, fuzzy
@@ -11709,17 +11739,22 @@ msgstr "W naszej bibliotece będziemy mieć kilka widżetów:"
 
 #: src/exercises/day-3/simple-gui.md:8
 #, fuzzy
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr "`Okno`: ma `tytuł` i zawiera inne widżety."
+
+#: src/exercises/day-3/simple-gui.md:9
+#, fuzzy
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
 msgstr ""
-"* `Okno`: ma `tytuł` i zawiera inne widżety.\n"
-"* `Button`: ma `etykietę` i funkcję wywołania zwrotnego, która jest "
-"wywoływana, gdy\n"
-"  przycisk jest wciśnięty.\n"
-"* `Etykieta`: ma `etykietę`."
+"`Button`: ma `etykietę` i funkcję wywołania zwrotnego, która jest "
+"wywoływana, gdy przycisk jest wciśnięty."
+
+#: src/exercises/day-3/simple-gui.md:11
+#, fuzzy
+msgid "`Label`: has a `label`."
+msgstr "`Etykieta`: ma `etykietę`."
 
 #: src/exercises/day-3/simple-gui.md:13
 #, fuzzy
@@ -11729,222 +11764,160 @@ msgstr "Widżety zaimplementują cechę `Widget`, patrz poniżej."
 #: src/exercises/day-3/simple-gui.md:15
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
-"Skopiuj poniższy kod na <https://play.rust-lang.org/>, uzupełnij brakujące\n"
+"Skopiuj poniższy kod na <https://play.rust-lang.org/>, uzupełnij brakujące "
 "metody `draw_into`, aby zaimplementować cechę `Widget`:"
 
-#: src/exercises/day-3/simple-gui.md:18 src/exercises/day-3/safe-ffi-wrapper.md:25
+#: src/exercises/day-3/simple-gui.md:18
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
 "```rust,should_panic\n"
 "// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]"
+"#![allow(unused_imports, unused_variables, dead_code)]\n"
+"```"
 msgstr ""
 "```rust,should_panic\n"
 "// TODO: usuń to jak skończysz implementację.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]"
+"#![allow(unused_imports, unused_variables, dead_code)]\n"
+"```"
 
 #: src/exercises/day-3/simple-gui.md:22
 msgid ""
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;"
+"pub trait Widget { /// Natural width of `self`. fn width(&self) -> usize;"
 msgstr ""
-"pub trait Widget {\n"
-"    /// Naturalna szerokość `self`.\n"
-"    fn width(&self) -> usize;"
+"pub trait Widget { /// Naturalna szerokość `self`. fn width(&self) -> usize;"
 
-#: src/exercises/day-3/simple-gui.md:26 src/exercises/day-3/solutions-morning.md:27
+#: src/exercises/day-3/simple-gui.md:26
+#: src/exercises/day-3/solutions-morning.md:27
 msgid ""
-"    /// Draw the widget into a buffer.\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);"
+"```\n"
+"/// Draw the widget into a buffer.\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
+"```"
 msgstr ""
-"    /// Narysuj widget w buforze.\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);"
+"```\n"
+"/// Narysuj widget w buforze.\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
+"```"
 
-#: src/exercises/day-3/simple-gui.md:29 src/exercises/day-3/solutions-morning.md:30
+#: src/exercises/day-3/simple-gui.md:29
+#: src/exercises/day-3/solutions-morning.md:30
 msgid ""
-"    /// Draw the widget on standard output.\n"
-"    fn draw(&self) {\n"
-"        let mut buffer = String::new();\n"
-"        self.draw_into(&mut buffer);\n"
-"        println!(\"{buffer}\");\n"
-"    }\n"
-"}"
+"```\n"
+"/// Draw the widget on standard output.\n"
+"fn draw(&self) {\n"
+"    let mut buffer = String::new();\n"
+"    self.draw_into(&mut buffer);\n"
+"    println!(\"{buffer}\");\n"
+"}\n"
+"```"
 msgstr ""
-"    /// Narysuj widget na standardowym wyjściu.\n"
-"    fn draw(&self) {\n"
-"        let mut buffer = String::new();\n"
-"        self.draw_into(&mut buffer);\n"
-"        println!(\"{buffer}\");\n"
-"    }\n"
-"}"
+"```\n"
+"/// Narysuj widget na standardowym wyjściu.\n"
+"fn draw(&self) {\n"
+"    let mut buffer = String::new();\n"
+"    self.draw_into(&mut buffer);\n"
+"    println!(\"{buffer}\");\n"
+"}\n"
+"```"
 
-#: src/exercises/day-3/simple-gui.md:37 src/exercises/day-3/solutions-morning.md:38
-msgid ""
-"pub struct Label {\n"
-"    label: String,\n"
-"}"
-msgstr ""
-"pub struct Label {\n"
-"    label: String,\n"
-"}"
+#: src/exercises/day-3/simple-gui.md:37
+#: src/exercises/day-3/solutions-morning.md:38
+msgid "pub struct Label { label: String, }"
+msgstr "pub struct Label { label: String, }"
 
-#: src/exercises/day-3/simple-gui.md:41 src/exercises/day-3/solutions-morning.md:42
+#: src/exercises/day-3/simple-gui.md:41
+#: src/exercises/day-3/solutions-morning.md:42
 msgid ""
-"impl Label {\n"
-"    fn new(label: &str) -> Label {\n"
-"        Label {\n"
-"            label: label.to_owned(),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Label { fn new(label: &str) -> Label { Label { label: label."
+"to_owned(), } } }"
 msgstr ""
-"impl Label {\n"
-"    fn new(label: &str) -> Label {\n"
-"        Label {\n"
-"            label: label.to_owned(),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Label { fn new(label: &str) -> Label { Label { label: label."
+"to_owned(), } } }"
 
-#: src/exercises/day-3/simple-gui.md:49 src/exercises/day-3/solutions-morning.md:50
-msgid ""
-"pub struct Button {\n"
-"    label: Label,\n"
-"    callback: Box<dyn FnMut()>,\n"
-"}"
-msgstr ""
-"pub struct Button {\n"
-"    label: Label,\n"
-"    callback: Box<dyn FnMut()>,\n"
-"}"
+#: src/exercises/day-3/simple-gui.md:49
+#: src/exercises/day-3/solutions-morning.md:50
+msgid "pub struct Button { label: Label, callback: Box\\<dyn FnMut()>, }"
+msgstr "pub struct Button { label: Label, callback: Box\\<dyn FnMut()>, }"
 
-#: src/exercises/day-3/simple-gui.md:54 src/exercises/day-3/solutions-morning.md:55
+#: src/exercises/day-3/simple-gui.md:54
+#: src/exercises/day-3/solutions-morning.md:55
 msgid ""
-"impl Button {\n"
-"    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
-"        Button {\n"
-"            label: Label::new(label),\n"
-"            callback,\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Button { fn new(label: &str, callback: Box\\<dyn FnMut()>) -> Button "
+"{ Button { label: Label::new(label), callback, } } }"
 msgstr ""
-"impl Button {\n"
-"    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
-"        Button {\n"
-"            label: Label::new(label),\n"
-"            callback,\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Button { fn new(label: &str, callback: Box\\<dyn FnMut()>) -> Button "
+"{ Button { label: Label::new(label), callback, } } }"
 
-#: src/exercises/day-3/simple-gui.md:63 src/exercises/day-3/solutions-morning.md:64
-msgid ""
-"pub struct Window {\n"
-"    title: String,\n"
-"    widgets: Vec<Box<dyn Widget>>,\n"
-"}"
-msgstr ""
-"pub struct Window {\n"
-"    title: String,\n"
-"    widgets: Vec<Box<dyn Widget>>,\n"
-"}"
+#: src/exercises/day-3/simple-gui.md:63
+#: src/exercises/day-3/solutions-morning.md:64
+msgid "pub struct Window { title: String, widgets: Vec\\<Box"
+msgstr "pub struct Window { title: String, widgets: Vec\\<Box"
 
-#: src/exercises/day-3/simple-gui.md:68 src/exercises/day-3/solutions-morning.md:69
-msgid ""
-"impl Window {\n"
-"    fn new(title: &str) -> Window {\n"
-"        Window {\n"
-"            title: title.to_owned(),\n"
-"            widgets: Vec::new(),\n"
-"        }\n"
-"    }"
-msgstr ""
-"impl Window {\n"
-"    fn new(title: &str) -> Window {\n"
-"        Window {\n"
-"            title: title.to_owned(),\n"
-"            widgets: Vec::new(),\n"
-"        }\n"
-"    }"
+#: src/exercises/day-3/simple-gui.md:65
+#: src/exercises/day-3/solutions-morning.md:66
+msgid "\\>, }"
+msgstr "\\>, }"
 
-#: src/exercises/day-3/simple-gui.md:76 src/exercises/day-3/solutions-morning.md:77
+#: src/exercises/day-3/simple-gui.md:68
+#: src/exercises/day-3/solutions-morning.md:69
 msgid ""
-"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
-"        self.widgets.push(widget);\n"
-"    }\n"
-"}"
+"impl Window { fn new(title: &str) -> Window { Window { title: title."
+"to_owned(), widgets: Vec::new(), } }"
 msgstr ""
-"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
-"        self.widgets.push(widget);\n"
-"    }\n"
-"}"
+"impl Window { fn new(title: &str) -> Window { Window { title: title."
+"to_owned(), widgets: Vec::new(), } }"
+
+#: src/exercises/day-3/simple-gui.md:76
+#: src/exercises/day-3/solutions-morning.md:77
+msgid ""
+"```\n"
+"fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"    self.widgets.push(widget);\n"
+"}\n"
+"```"
+msgstr ""
+"```\n"
+"fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"    self.widgets.push(widget);\n"
+"}\n"
+"```"
 
 #: src/exercises/day-3/simple-gui.md:82
-msgid ""
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
-msgstr ""
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Widget for Label { fn width(&self) -> usize { unimplemented!() }"
+msgstr "impl Widget for Label { fn width(&self) -> usize { unimplemented!() }"
 
 #: src/exercises/day-3/simple-gui.md:87 src/exercises/day-3/simple-gui.md:97
 #: src/exercises/day-3/simple-gui.md:107
 msgid ""
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"```\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"```\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-3/simple-gui.md:92
-msgid ""
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
-msgstr ""
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Widget for Button { fn width(&self) -> usize { unimplemented!() }"
+msgstr "impl Widget for Button { fn width(&self) -> usize { unimplemented!() }"
 
 #: src/exercises/day-3/simple-gui.md:102
-msgid ""
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
-msgstr ""
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Widget for Window { fn width(&self) -> usize { unimplemented!() }"
+msgstr "impl Widget for Window { fn width(&self) -> usize { unimplemented!() }"
 
 #: src/exercises/day-3/simple-gui.md:112
 msgid ""
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
-"demo.\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\",\n"
-"        Box::new(|| println!(\"You clicked the button!\")),\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"```"
+"fn main() { let mut window = Window::new(\"Rust GUI Demo 1.23\"); window."
+"add_widget(Box::new(Label::new(\"This is a small text GUI demo.\"))); window."
+"add_widget(Box::new(Button::new( \"Click me!\", Box::new(|| println!(\"You "
+"clicked the button!\")), ))); window.draw(); }"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:123
@@ -11957,7 +11930,8 @@ msgid ""
 "```text\n"
 "========\n"
 "Rust GUI Demo 1.23\n"
-"========"
+"========\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:130
@@ -11966,22 +11940,21 @@ msgid "This is a small text GUI demo."
 msgstr "To jest mała tekstowa demonstracja GUI."
 
 #: src/exercises/day-3/simple-gui.md:132
-msgid "| Click me! |\n```"
+msgid "\\| Click me! |"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:135
 #, fuzzy
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
-"Jeśli chcesz narysować wyrównany tekst, możesz użyć\n"
-"[wypełnienie/wyrównanie](https://doc.rust-lang.org/std/fmt/index.html#wyrównanie)\n"
-"operatory formatowania. W szczególności zwróć uwagę, jak możesz wypełnić "
-"różne\n"
-"znaki (tutaj `'/'`) i jak możesz kontrolować wyrównanie:"
+"Jeśli chcesz narysować wyrównany tekst, możesz użyć [wypełnienie/wyrównanie]"
+"(https://doc.rust-lang.org/std/fmt/index.html#wyrównanie) operatory "
+"formatowania. W szczególności zwróć uwagę, jak możesz wypełnić różne znaki "
+"(tutaj `'/'`) i jak możesz kontrolować wyrównanie:"
 
 #: src/exercises/day-3/simple-gui.md:140
 msgid ""
@@ -12017,28 +11990,21 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-msgid "# Error Handling"
-msgstr "# Obsługa błędów"
-
 #: src/error-handling.md:3
 #, fuzzy
 msgid "Error handling in Rust is done using explicit control flow:"
-msgstr "Obsługa błędów w Rust odbywa się za pomocą jawnego przepływu sterowania:"
+msgstr ""
+"Obsługa błędów w Rust odbywa się za pomocą jawnego przepływu sterowania:"
 
 #: src/error-handling.md:5
 #, fuzzy
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
-msgstr ""
-"* Funkcje, które mogą mieć błędy, wymieniają to w zwracanym typie,\n"
-"* Nie ma wyjątków."
+msgid "Functions that can have errors list this in their return type,"
+msgstr "Funkcje, które mogą mieć błędy, wymieniają to w zwracanym typie,"
 
-#: src/error-handling/panics.md:1
+#: src/error-handling.md:6
 #, fuzzy
-msgid "# Panics"
-msgstr "# Paniki"
+msgid "There are no exceptions."
+msgstr "Nie ma wyjątków."
 
 #: src/error-handling/panics.md:3
 #, fuzzy
@@ -12063,20 +12029,26 @@ msgstr ""
 
 #: src/error-handling/panics.md:12
 #, fuzzy
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "Paniki dotyczą nieodwracalnych i nieoczekiwanych błędów."
+
+#: src/error-handling/panics.md:13
+#, fuzzy
+msgid "Panics are symptoms of bugs in the program."
+msgstr "Paniki to objawy błędów w programie."
+
+#: src/error-handling/panics.md:14
+#, fuzzy
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
-"* Paniki dotyczą nieodwracalnych i nieoczekiwanych błędów.\n"
-"  * Paniki to objawy błędów w programie.\n"
-"* Używaj niepanikujących interfejsów API (takich jak `Vec::get`), jeśli "
-"awaria jest nie do zaakceptowania."
+"Używaj niepanikujących interfejsów API (takich jak `Vec::get`), jeśli awaria "
+"jest nie do zaakceptowania."
 
 #: src/error-handling/panic-unwind.md:1
 #, fuzzy
-msgid "# Catching the Stack Unwinding"
-msgstr "# Łapanie rozwijającego się stosu"
+msgid "Catching the Stack Unwinding"
+msgstr "Łapanie rozwijającego się stosu"
 
 #: src/error-handling/panic-unwind.md:3
 #, fuzzy
@@ -12086,135 +12058,114 @@ msgid ""
 msgstr "Domyślnie panika spowoduje wycofanie stosu. Odwijanie można złapać:"
 
 #: src/error-handling/panic-unwind.md:5
-msgid "```rust\nuse std::panic;"
+msgid ""
+"```rust\n"
+"use std::panic;\n"
+"```"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:8
 msgid ""
-"let result = panic::catch_unwind(|| {\n"
-"    println!(\"hello!\");\n"
-"});\n"
-"assert!(result.is_ok());"
+"let result = panic::catch_unwind(|| { println!(\"hello!\"); }); assert!"
+"(result.is_ok());"
 msgstr ""
-"let result = panic::catch_unwind(|| {\n"
-"    println!(\"cześć!\");\n"
-"});\n"
-"assert!(result.is_ok());"
+"let result = panic::catch_unwind(|| { println!(\"cześć!\"); }); assert!"
+"(result.is_ok());"
 
 #: src/error-handling/panic-unwind.md:13
 msgid ""
-"let result = panic::catch_unwind(|| {\n"
-"    panic!(\"oh no!\");\n"
-"});\n"
-"assert!(result.is_err());\n"
-"```"
+"let result = panic::catch_unwind(|| { panic!(\"oh no!\"); }); assert!(result."
+"is_err());"
 msgstr ""
-"let result = panic::catch_unwind(|| {\n"
-"    panic!(\"o nie!\");\n"
-"});\n"
-"assert!(result.is_err());\n"
-"```"
+"let result = panic::catch_unwind(|| { panic!(\"o nie!\"); }); assert!(result."
+"is_err());"
 
 #: src/error-handling/panic-unwind.md:19
 #, fuzzy
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* Może to być przydatne na serwerach, które powinny działać, nawet jeśli są "
-"pojedyncze\n"
-"  żądania awarii.\n"
-"* To nie działa, jeśli w twoim `Cargo.toml` ustawiono `panic = 'abort'`."
+"Może to być przydatne na serwerach, które powinny działać, nawet jeśli są "
+"pojedyncze żądania awarii."
+
+#: src/error-handling/panic-unwind.md:21
+#, fuzzy
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr "To nie działa, jeśli w twoim `Cargo.toml` ustawiono `panic = 'abort'`."
 
 #: src/error-handling/result.md:1
 #, fuzzy
-msgid "# Structured Error Handling with `Result`"
-msgstr "# Strukturalna obsługa błędów za pomocą `Result`"
+msgid "Structured Error Handling with `Result`"
+msgstr "Strukturalna obsługa błędów za pomocą `Result`"
 
 #: src/error-handling/result.md:3
 #, fuzzy
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
 "Widzieliśmy już enum `Result`. Jest to powszechnie stosowane, gdy występują "
-"błędy\n"
-"spodziewane w ramach normalnej eksploatacji:"
+"błędy spodziewane w ramach normalnej eksploatacji:"
 
 #: src/error-handling/result.md:6
 msgid ""
 "```rust\n"
 "use std::fs::File;\n"
-"use std::io::Read;"
+"use std::io::Read;\n"
+"```"
 msgstr ""
 "```rust\n"
 "use std::fs::File;\n"
-"use std::io::Read;"
+"use std::io::Read;\n"
+"```"
 
 #: src/error-handling/result.md:10
 msgid ""
-"fn main() {\n"
-"    let file = File::open(\"diary.txt\");\n"
-"    match file {\n"
-"        Ok(mut file) => {\n"
-"            let mut contents = String::new();\n"
-"            file.read_to_string(&mut contents);\n"
-"            println!(\"Dear diary: {contents}\");\n"
-"        },\n"
-"        Err(err) => {\n"
-"            println!(\"The diary could not be opened: {err}\");\n"
-"        }\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let file = File::open(\"diary.txt\"); match file { Ok(mut file) "
+"=> { let mut contents = String::new(); file.read_to_string(&mut contents); "
+"println!(\"Dear diary: {contents}\"); }, Err(err) => { println!(\"The diary "
+"could not be opened: {err}\"); } } }"
 msgstr ""
 
 #: src/error-handling/result.md:27
 #, fuzzy
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
-"    \n"
-"</details>"
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
 msgstr ""
-"  * Podobnie jak w przypadku `Opcji`, pomyślna wartość znajduje się wewnątrz "
-"`Result`, zmuszając programistę do tego\n"
-"    wyraźnie go wyodrębnić. To zachęca do sprawdzania błędów. W przypadku, "
-"gdy błąd nigdy nie powinien się wydarzyć,\n"
-"    Można wywołać `unwrap()` lub `expect()`, co również jest sygnałem "
-"intencji programisty.\n"
-"  * Dokumentacja `Result` jest zalecaną lekturą. Nie w trakcie kursu, ale "
-"warto o tym wspomnieć.\n"
-"    Zawiera wiele wygodnych metod i funkcji, które pomagają programować w "
-"stylu funkcjonalnym.\n"
-"    \n"
-"</details>"
+"Podobnie jak w przypadku `Opcji`, pomyślna wartość znajduje się wewnątrz "
+"`Result`, zmuszając programistę do tego wyraźnie go wyodrębnić. To zachęca "
+"do sprawdzania błędów. W przypadku, gdy błąd nigdy nie powinien się "
+"wydarzyć, Można wywołać `unwrap()` lub `expect()`, co również jest sygnałem "
+"intencji programisty."
+
+#: src/error-handling/result.md:30
+#, fuzzy
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr ""
+"Dokumentacja `Result` jest zalecaną lekturą. Nie w trakcie kursu, ale warto "
+"o tym wspomnieć. Zawiera wiele wygodnych metod i funkcji, które pomagają "
+"programować w stylu funkcjonalnym."
 
 #: src/error-handling/try-operator.md:1
 #, fuzzy
-msgid "# Propagating Errors with `?`"
-msgstr "# Propagowanie błędów za pomocą `?`"
+msgid "Propagating Errors with `?`"
+msgstr "Propagowanie błędów za pomocą `?`"
 
 #: src/error-handling/try-operator.md:3
 #, fuzzy
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
+"turn the common"
 msgstr ""
 "Operator try `?` służy do zwracania błędów do obiektu wywołującego. Pozwala "
-"się obrócić\n"
-"wspólne"
+"się obrócić wspólne"
 
 #: src/error-handling/try-operator.md:6
 msgid ""
@@ -12256,82 +12207,89 @@ msgstr "Możemy użyć tego, aby uprościć nasz kod przekazywania błędów:"
 msgid ""
 "```rust,editable\n"
 "use std::fs;\n"
-"use std::io::{self, Read};"
+"use std::io::{self, Read};\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "use std::fs;\n"
-"use std::io::{self, Read};"
+"use std::io::{self, Read};\n"
+"```"
 
 #: src/error-handling/try-operator.md:25
 msgid ""
-"fn read_username(path: &str) -> Result<String, io::Error> {\n"
-"    let username_file_result = fs::File::open(path);"
+"fn read_username(path: &str) -> Result\\<String, io::Error> { let "
+"username_file_result = fs::File::open(path);"
 msgstr ""
-"fn read_username(path: &str) -> Result<String, io::Error> {\n"
-"    let username_file_result = fs::File::open(path);"
+"fn read_username(path: &str) -> Result\\<String, io::Error> { let "
+"username_file_result = fs::File::open(path);"
 
 #: src/error-handling/try-operator.md:28
 msgid ""
-"    let mut username_file = match username_file_result {\n"
-"        Ok(file) => file,\n"
-"        Err(e) => return Err(e),\n"
-"    };"
+"```\n"
+"let mut username_file = match username_file_result {\n"
+"    Ok(file) => file,\n"
+"    Err(e) => return Err(e),\n"
+"};\n"
+"```"
 msgstr ""
-"    let mut username_file = match username_file_result {\n"
-"        Ok(file) => file,\n"
-"        Err(e) => return Err(e),\n"
-"    };"
+"```\n"
+"let mut username_file = match username_file_result {\n"
+"    Ok(file) => file,\n"
+"    Err(e) => return Err(e),\n"
+"};\n"
+"```"
 
 #: src/error-handling/try-operator.md:33
-msgid "    let mut username = String::new();"
-msgstr "    let mut username = String::new();"
+msgid ""
+"```\n"
+"let mut username = String::new();\n"
+"```"
+msgstr ""
+"```\n"
+"let mut username = String::new();\n"
+"```"
 
 #: src/error-handling/try-operator.md:35
 msgid ""
-"    match username_file.read_to_string(&mut username) {\n"
-"        Ok(_) => Ok(username),\n"
-"        Err(e) => Err(e),\n"
-"    }\n"
-"}"
+"```\n"
+"match username_file.read_to_string(&mut username) {\n"
+"    Ok(_) => Ok(username),\n"
+"    Err(e) => Err(e),\n"
+"}\n"
+"```"
 msgstr ""
-"    match username_file.read_to_string(&mut username) {\n"
-"        Ok(_) => Ok(username),\n"
-"        Err(e) => Err(e),\n"
-"    }\n"
-"}"
+"```\n"
+"match username_file.read_to_string(&mut username) {\n"
+"    Ok(_) => Ok(username),\n"
+"    Err(e) => Err(e),\n"
+"}\n"
+"```"
 
 #: src/error-handling/try-operator.md:41
 msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"alice\").unwrap(); let username = "
+"read_username(\"config.dat\"); println!(\"username or error: "
+"{username:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"nazwa użytkownika lub błąd: {username:?}\");\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"alice\").unwrap(); let username = "
+"read_username(\"config.dat\"); println!(\"nazwa użytkownika lub błąd: "
+"{username:?}\"); }"
 
-#: src/error-handling/try-operator.md:52 src/error-handling/converting-error-types-example.md:52
+#: src/error-handling/try-operator.md:52
+#: src/error-handling/converting-error-types-example.md:52
+#, fuzzy
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr "Zmienna `username` może mieć postać `Ok(string)` lub `Err(error)`."
+
+#: src/error-handling/try-operator.md:53
+#: src/error-handling/converting-error-types-example.md:53
 #, fuzzy
 msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
 msgstr ""
-"* Zmienna `username` może mieć postać `Ok(string)` lub `Err(error)`.\n"
-"* Użyj wywołania `fs::write`, aby przetestować różne scenariusze: brak "
-"pliku, pusty plik, plik z nazwą użytkownika."
-
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-#, fuzzy
-msgid "# Converting Error Types"
-msgstr "# Konwersja typów błędów"
+"Użyj wywołania `fs::write`, aby przetestować różne scenariusze: brak pliku, "
+"pusty plik, plik z nazwą użytkownika."
 
 #: src/error-handling/converting-error-types.md:3
 #, fuzzy
@@ -12376,11 +12334,10 @@ msgstr ""
 #: src/error-handling/converting-error-types.md:18
 #, fuzzy
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
-"Wywołanie `From::from` oznacza, że próbujemy przekonwertować typ błędu na\n"
+"Wywołanie `From::from` oznacza, że próbujemy przekonwertować typ błędu na "
 "typ zwracany przez funkcję:"
 
 #: src/error-handling/converting-error-types-example.md:3
@@ -12389,27 +12346,23 @@ msgid ""
 "use std::error::Error;\n"
 "use std::fmt::{self, Display, Formatter};\n"
 "use std::fs::{self, File};\n"
-"use std::io::{self, Read};"
+"use std::io::{self, Read};\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "use std::error::Error;\n"
 "use std::fmt::{self, Display, Formatter};\n"
 "use std::fs::{self, File};\n"
-"use std::io::{self, Read};"
+"use std::io::{self, Read};\n"
+"```"
 
 #: src/error-handling/converting-error-types-example.md:9
 msgid ""
-"#[derive(Debug)]\n"
-"enum ReadUsernameError {\n"
-"    IoError(io::Error),\n"
-"    EmptyUsername(String),\n"
-"}"
+"\\#\\[derive(Debug)\\] enum ReadUsernameError { IoError(io::Error), "
+"EmptyUsername(String), }"
 msgstr ""
-"#[derive(Debug)]\n"
-"enum ReadUsernameError {\n"
-"    IoError(io::Error),\n"
-"    EmptyUsername(String),\n"
-"}"
+"\\#\\[derive(Debug)\\] enum ReadUsernameError { IoError(io::Error), "
+"EmptyUsername(String), }"
 
 #: src/error-handling/converting-error-types-example.md:15
 msgid "impl Error for ReadUsernameError {}"
@@ -12417,175 +12370,115 @@ msgstr "impl Error for ReadUsernameError {}"
 
 #: src/error-handling/converting-error-types-example.md:17
 msgid ""
-"impl Display for ReadUsernameError {\n"
-"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-"        match self {\n"
-"            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
-"in {}\", filename),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Display for ReadUsernameError { fn fmt(&self, f: &mut Formatter) -> "
+"fmt::Result { match self { Self::IoError(e) => write!(f, \"IO error: {}\", "
+"e), Self::EmptyUsername(filename) => write!(f, \"Found no username in {}\", "
+"filename), } } }"
 msgstr ""
-"impl Display for ReadUsernameError {\n"
-"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-"        match self {\n"
-"            Self::IoError(e) => write!(f, \"Błąd wejścia/wyjścia: {}\", e),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Nie znaleziono nazwy użytkownika "
-"w {}\", filename),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Display for ReadUsernameError { fn fmt(&self, f: &mut Formatter) -> "
+"fmt::Result { match self { Self::IoError(e) => write!(f, \"Błąd wejścia/"
+"wyjścia: {}\", e), Self::EmptyUsername(filename) => write!(f, \"Nie "
+"znaleziono nazwy użytkownika w {}\", filename), } } }"
 
 #: src/error-handling/converting-error-types-example.md:26
 msgid ""
-"impl From<io::Error> for ReadUsernameError {\n"
-"    fn from(err: io::Error) -> ReadUsernameError {\n"
-"        ReadUsernameError::IoError(err)\n"
-"    }\n"
-"}"
+"impl From<io::Error> for ReadUsernameError { fn from(err: io::Error) -> "
+"ReadUsernameError { ReadUsernameError::IoError(err) } }"
 msgstr ""
-"impl From<io::Error> for ReadUsernameError {\n"
-"    fn from(err: io::Error) -> ReadUsernameError {\n"
-"        ReadUsernameError::IoError(err)\n"
-"    }\n"
-"}"
+"impl From<io::Error> for ReadUsernameError { fn from(err: io::Error) -> "
+"ReadUsernameError { ReadUsernameError::IoError(err) } }"
 
 #: src/error-handling/converting-error-types-example.md:32
 msgid ""
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+"fn read_username(path: &str) -> Result\\<String, ReadUsernameError> { let "
+"mut username = String::with_capacity(100); File::open(path)?."
+"read_to_string(&mut username)?; if username.is_empty() { return "
+"Err(ReadUsernameError::EmptyUsername(String::from(path))); } Ok(username) }"
 msgstr ""
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+"fn read_username(path: &str) -> Result\\<String, ReadUsernameError> { let "
+"mut username = String::with_capacity(100); File::open(path)?."
+"read_to_string(&mut username)?; if username.is_empty() { return "
+"Err(ReadUsernameError::EmptyUsername(String::from(path))); } Ok(username) }"
 
 #: src/error-handling/converting-error-types-example.md:41
 msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"\").unwrap(); let username = "
+"read_username(\"config.dat\"); println!(\"username or error: "
+"{username:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"nazwa użytkownika lub błąd: {username:?}\");\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"\").unwrap(); let username = "
+"read_username(\"config.dat\"); println!(\"nazwa użytkownika lub błąd: "
+"{username:?}\"); }"
 
 #: src/error-handling/converting-error-types-example.md:55
 #, fuzzy
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
 msgstr ""
-"Dobrą praktyką dla wszystkich typów błędów jest implementacja "
-"`std::error::Error`, która wymaga `Debugowania` i\n"
-"`Wyświetlanie`. Generalnie pomocne jest dla nich zaimplementowanie `Clone` i "
-"`Eq` tam, gdzie to możliwe\n"
-"ułatwi życie testerom i konsumentom Twojej biblioteki. W tym przypadku nie "
-"możemy tego łatwo zrobić, ponieważ\n"
-"`io::Error` nie implementuje ich."
-
-#: src/error-handling/deriving-error-enums.md:1
-#, fuzzy
-msgid "# Deriving Error Enums"
-msgstr "# Wyprowadzanie wyliczeń błędów"
+"Dobrą praktyką dla wszystkich typów błędów jest implementacja `std::error::"
+"Error`, która wymaga `Debugowania` i `Wyświetlanie`. Generalnie pomocne jest "
+"dla nich zaimplementowanie `Clone` i `Eq` tam, gdzie to możliwe ułatwi życie "
+"testerom i konsumentom Twojej biblioteki. W tym przypadku nie możemy tego "
+"łatwo zrobić, ponieważ `io::Error` nie implementuje ich."
 
 #: src/error-handling/deriving-error-enums.md:3
 #, fuzzy
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
 "Skrzynka [thiserror](https://docs.rs/thiserror/) to popularny sposób "
-"tworzenia\n"
-"enum błędu, tak jak zrobiliśmy to na poprzedniej stronie:"
+"tworzenia enum błędu, tak jak zrobiliśmy to na poprzedniej stronie:"
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
 "```rust,editable,compile_fail\n"
 "use std::{fs, io};\n"
 "use std::io::Read;\n"
-"use thiserror::Error;"
+"use thiserror::Error;\n"
+"```"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:11
 msgid ""
-"#[derive(Debug, Error)]\n"
-"enum ReadUsernameError {\n"
-"    #[error(\"Could not read: {0}\")]\n"
-"    IoError(#[from] io::Error),\n"
-"    #[error(\"Found no username in {0}\")]\n"
-"    EmptyUsername(String),\n"
-"}"
+"\\#\\[derive(Debug, Error)\\] enum ReadUsernameError { \\#\\[error(\"Could "
+"not read: {0}\")\\] IoError(#\\[from\\] io::Error), \\#\\[error(\"Found no "
+"username in {0}\")\\] EmptyUsername(String), }"
 msgstr ""
-"#[derive(Debug, Error)]\n"
-"enum ReadUsernameError {\n"
-"    #[error(\"Nie można odczytać: {0}\")]\n"
-"    IoError(#[from] io::Error),\n"
-"    #[error(\"Nie znaleziono nazwy użytkownika w {0}\")]\n"
-"    EmptyUsername(String),\n"
-"}"
+"\\#\\[derive(Debug, Error)\\] enum ReadUsernameError { \\#\\[error(\"Nie "
+"można odczytać: {0}\")\\] IoError(#\\[from\\] io::Error), \\#\\[error(\"Nie "
+"znaleziono nazwy użytkownika w {0}\")\\] EmptyUsername(String), }"
 
 #: src/error-handling/deriving-error-enums.md:19
 msgid ""
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+"fn read_username(path: &str) -> Result\\<String, ReadUsernameError> { let "
+"mut username = String::with_capacity(100); fs::File::open(path)?."
+"read_to_string(&mut username)?; if username.is_empty() { return "
+"Err(ReadUsernameError::EmptyUsername(String::from(path))); } Ok(username) }"
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:28 src/error-handling/dynamic-errors.md:25
+#: src/error-handling/deriving-error-enums.md:28
+#: src/error-handling/dynamic-errors.md:25
 msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err}\"),\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"\").unwrap(); match "
+"read_username(\"config.dat\") { Ok(username) => println!(\"Username: "
+"{username}\"), Err(err)     => println!(\"Error: {err}\"), } }"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:39
 #, fuzzy
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 "Makro pochodne `thiserror` automatycznie implementuje `std::error::Error` i "
-"opcjonalnie `Display`\n"
-"(jeśli podano atrybuty `#[error(...)]`) i `From` (jeśli dodano atrybut "
-"`#[from]`).\n"
-"Działa również dla struktur."
+"opcjonalnie `Display` (jeśli podano atrybuty `#[error(...)]`) i `From` "
+"(jeśli dodano atrybut `#[from]`). Działa również dla struktur."
 
 #: src/error-handling/deriving-error-enums.md:43
 #, fuzzy
@@ -12593,21 +12486,16 @@ msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr ""
 "Nie wpływa na twój publiczny interfejs API, co czyni go dobrym dla bibliotek."
 
-#: src/error-handling/dynamic-errors.md:1
-#, fuzzy
-msgid "# Dynamic Error Types"
-msgstr "# Typy błędów dynamicznych"
-
 #: src/error-handling/dynamic-errors.md:3
 #, fuzzy
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 "Czasami chcemy zezwolić na zwrócenie dowolnego rodzaju błędu bez pisania "
-"własnego pokrycia wyliczeniowego\n"
-"wszystkie różne możliwości. `std::error::Error` ułatwia to zadanie."
+"własnego pokrycia wyliczeniowego wszystkie różne możliwości. `std::error::"
+"Error` ułatwia to zadanie."
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -12615,132 +12503,120 @@ msgid ""
 "use std::fs::{self, File};\n"
 "use std::io::Read;\n"
 "use thiserror::Error;\n"
-"use std::error::Error;"
+"use std::error::Error;\n"
+"```"
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:12
 msgid ""
-"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
-"#[error(\"Found no username in {0}\")]\n"
-"struct EmptyUsernameError(String);"
+"\\#\\[derive(Clone, Debug, Eq, Error, PartialEq)\\] \\#\\[error(\"Found no "
+"username in {0}\")\\] struct EmptyUsernameError(String);"
+msgstr ""
+
+#: src/error-handling/dynamic-errors.md:16
+msgid "fn read_username(path: &str) -> Result\\<String, Box"
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:16
 msgid ""
-"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(EmptyUsernameError(String::from(path)).into());\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+"\\> { let mut username = String::with_capacity(100); File::open(path)?."
+"read_to_string(&mut username)?; if username.is_empty() { return "
+"Err(EmptyUsernameError(String::from(path)).into()); } Ok(username) }"
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:36
 #, fuzzy
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
 "Oszczędza to kod, ale rezygnuje z możliwości czystego radzenia sobie z "
-"różnymi przypadkami błędów w inny sposób\n"
-"program. W związku z tym generalnie nie jest dobrym pomysłem używanie "
-"`Box<dyn Error>` w publicznym API aplikacji a\n"
-"Library, ale może to być dobra opcja w programie, w którym chcesz tylko "
-"wyświetlić komunikat o błędzie\n"
-"gdzieś."
-
-#: src/error-handling/error-contexts.md:1
-#, fuzzy
-msgid "# Adding Context to Errors"
-msgstr "# Dodawanie kontekstu do błędów"
+"różnymi przypadkami błędów w inny sposób program. W związku z tym generalnie "
+"nie jest dobrym pomysłem używanie `Box<dyn Error>` w publicznym API "
+"aplikacji a Library, ale może to być dobra opcja w programie, w którym "
+"chcesz tylko wyświetlić komunikat o błędzie gdzieś."
 
 #: src/error-handling/error-contexts.md:3
 #, fuzzy
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 "Powszechnie używana [mimo wszystko](https://docs.rs/anyhow/) skrzynka może "
-"pomóc w dodaniu\n"
-"informacje kontekstowe do twoich błędów i pozwala mieć ich mniej\n"
-"niestandardowe typy błędów:"
+"pomóc w dodaniu informacje kontekstowe do twoich błędów i pozwala mieć ich "
+"mniej niestandardowe typy błędów:"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
 "```rust,editable,compile_fail\n"
 "use std::{fs, io};\n"
 "use std::io::Read;\n"
-"use anyhow::{Context, Result, bail};"
+"use anyhow::{Context, Result, bail};\n"
+"```"
 msgstr ""
 "```rust,editable,compile_fail\n"
 "use std::{fs, io};\n"
 "use std::io::Read;\n"
-"use anyhow::{Context, Result, bail};"
+"use anyhow::{Context, Result, bail};\n"
+"```"
+
+#: src/error-handling/error-contexts.md:12
+msgid "fn read_username(path: &str) -> Result"
+msgstr ""
 
 #: src/error-handling/error-contexts.md:12
 msgid ""
-"fn read_username(path: &str) -> Result<String> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    fs::File::open(path)\n"
-"        .context(format!(\"Failed to open {path}\"))?\n"
-"        .read_to_string(&mut username)\n"
-"        .context(\"Failed to read\")?;\n"
-"    if username.is_empty() {\n"
-"        bail!(\"Found no username in {path}\");\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+" { let mut username = String::with_capacity(100); fs::File::open(path) ."
+"context(format!(\"Failed to open {path}\"))? .read_to_string(&mut username) ."
+"context(\"Failed to read\")?; if username.is_empty() { bail!(\"Found no "
+"username in {path}\"); } Ok(username) }"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:24
 msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err:?}\"),\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"\").unwrap(); match "
+"read_username(\"config.dat\") { Ok(username) => println!(\"Username: "
+"{username}\"), Err(err)     => println!(\"Error: {err:?}\"), } }"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
 #, fuzzy
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
-msgstr ""
-"* `anyhow::Result<V>` jest aliasem typu dla `Result<V, anyhow::Error>`.\n"
-"* `w każdym razie::Błąd` jest zasadniczo opakowaniem wokół `Box<dyn Error>`. "
-"Jako taki to znowu generalnie nie\n"
-"  dobry wybór dla publicznego interfejsu API biblioteki, ale jest szeroko "
-"stosowany w aplikacjach.\n"
-"* Rzeczywisty typ błędu w nim można wyodrębnić w celu zbadania, jeśli to "
-"konieczne.\n"
-"* Funkcjonalność zapewniana przez `anyhow::Result<T>` może być znana "
-"programistom Go, ponieważ zapewnia\n"
-"  podobne wzorce użytkowania i ergonomia do `(T, error)` z Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
+msgstr "`anyhow::Result<V>` jest aliasem typu dla `Result<V, anyhow::Error>`."
 
-#: src/testing.md:1
+#: src/error-handling/error-contexts.md:36
 #, fuzzy
-msgid "# Testing"
-msgstr "# Testowanie"
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+"`w każdym razie::Błąd` jest zasadniczo opakowaniem wokół `Box<dyn Error>`. "
+"Jako taki to znowu generalnie nie dobry wybór dla publicznego interfejsu API "
+"biblioteki, ale jest szeroko stosowany w aplikacjach."
+
+#: src/error-handling/error-contexts.md:38
+#, fuzzy
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+"Rzeczywisty typ błędu w nim można wyodrębnić w celu zbadania, jeśli to "
+"konieczne."
+
+#: src/error-handling/error-contexts.md:39
+#, fuzzy
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"Funkcjonalność zapewniana przez `anyhow::Result<T>` może być znana "
+"programistom Go, ponieważ zapewnia podobne wzorce użytkowania i ergonomia do "
+"`(T, error)` z Go."
 
 #: src/testing.md:3
 #, fuzzy
@@ -12750,18 +12626,13 @@ msgstr ""
 
 #: src/testing.md:5
 #, fuzzy
-msgid "* Unit tests are supported throughout your code."
-msgstr "* Testy jednostkowe są obsługiwane w całym kodzie."
+msgid "Unit tests are supported throughout your code."
+msgstr "Testy jednostkowe są obsługiwane w całym kodzie."
 
 #: src/testing.md:7
 #, fuzzy
-msgid "* Integration tests are supported via the `tests/` directory."
-msgstr "* Testy integracyjne są obsługiwane przez katalog `tests/`."
-
-#: src/testing/unit-tests.md:1
-#, fuzzy
-msgid "# Unit Tests"
-msgstr "# Testy jednostkowe"
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr "Testy integracyjne są obsługiwane przez katalog `tests/`."
 
 #: src/testing/unit-tests.md:3
 #, fuzzy
@@ -12776,27 +12647,76 @@ msgid ""
 "        Some(idx) => &text[..idx],\n"
 "        None => &text,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/testing/unit-tests.md:13
-msgid ""
-"#[test]\n"
-"fn test_empty() {\n"
-"    assert_eq!(first_word(\"\"), \"\");\n"
-"}"
+msgid "\\#\\[test\\] fn test_empty() { assert_eq!(first_word(\"\"), \"\"); }"
 msgstr ""
 
 #: src/testing/unit-tests.md:18
 msgid ""
-"#[test]\n"
-"fn test_single_word() {\n"
-"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
-"}"
+"\\#\\[test\\] fn test_single_word() { assert_eq!(first_word(\"Hello\"), "
+"\"Hello\"); }"
 msgstr ""
 
 #: src/testing/unit-tests.md:23
 msgid ""
+"\\#\\[test\\] fn test_multiple_words() { assert_eq!(first_word(\"Hello "
+"World\"), \"Hello\"); }"
+msgstr ""
+
+#: src/testing/unit-tests.md:27
+msgid ""
+"```\n"
+"\n"
+"# Unit Tests\n"
+"\n"
+"Mark unit tests with `#[test]`:\n"
+"\n"
+"```rust,editable\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}\n"
+"\n"
+"Use `cargo test` to find and run the unit tests.\n"
+"\n"
+"# Unit Tests\n"
+"\n"
+"Mark unit tests with `#[test]`:\n"
+"\n"
+"```rust,editable,ignore\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}\n"
+"\n"
 "#[test]\n"
 "fn test_multiple_words() {\n"
 "    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
@@ -12809,59 +12729,48 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr "Użyj testu ładunku, aby znaleźć i uruchomić testy jednostkowe."
 
-#: src/testing/test-modules.md:1
-#, fuzzy
-msgid "# Test Modules"
-msgstr "# Moduły testowe"
-
 #: src/testing/test-modules.md:3
 #, fuzzy
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 "Testy jednostkowe są często umieszczane w zagnieżdżonym module (uruchamiaj "
-"testy na\n"
-"[Plac zabaw](https://play.rust-lang.org/)):"
+"testy na [Plac zabaw](https://play.rust-lang.org/)):"
 
 #: src/testing/test-modules.md:6
 msgid ""
 "```rust,editable\n"
 "fn helper(a: &str, b: &str) -> String {\n"
 "    format!(\"{a} {b}\")\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/testing/test-modules.md:11
-msgid ""
-"pub fn main() {\n"
-"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
-"}"
+msgid "pub fn main() { println!(\"{}\", helper(\"Hello\", \"World\")); }"
 msgstr ""
 
 #: src/testing/test-modules.md:19
 msgid ""
-"    #[test]\n"
-"    fn test_helper() {\n"
-"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
-"    }\n"
+"```\n"
+"#[test]\n"
+"fn test_helper() {\n"
+"    assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/testing/test-modules.md:26
 #, fuzzy
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
-msgstr ""
-"* To pozwala testować prywatnych pomocników jednostkowych.\n"
-"* Atrybut `#[cfg(test)]` jest aktywny tylko po uruchomieniu `cargo test`."
+msgid "This lets you unit test private helpers."
+msgstr "To pozwala testować prywatnych pomocników jednostkowych."
 
-#: src/testing/doc-tests.md:1
+#: src/testing/test-modules.md:27
 #, fuzzy
-msgid "# Documentation Tests"
-msgstr "# Testy dokumentacji"
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr ""
+"Atrybut `#[cfg(test)]` jest aktywny tylko po uruchomieniu `cargo test`."
 
 #: src/testing/doc-tests.md:3
 #, fuzzy
@@ -12886,22 +12795,23 @@ msgstr ""
 
 #: src/testing/doc-tests.md:18
 #, fuzzy
-msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust "
-"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
-"* Bloki kodu w komentarzach `///` są automatycznie postrzegane jako kod "
-"Rusta.\n"
-"* Kod zostanie skompilowany i wykonany w ramach testu ładunku.\n"
-"* Przetestuj powyższy kod na [Rust "
-"Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+"Bloki kodu w komentarzach `///` są automatycznie postrzegane jako kod Rusta."
 
-#: src/testing/integration-tests.md:1
+#: src/testing/doc-tests.md:19
 #, fuzzy
-msgid "# Integration Tests"
-msgstr "# Testy integracyjne"
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "Kod zostanie skompilowany i wykonany w ramach testu ładunku."
+
+#: src/testing/doc-tests.md:20
+#, fuzzy
+msgid ""
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgstr ""
+"Przetestuj powyższy kod na [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 
 #: src/testing/integration-tests.md:3
 #, fuzzy
@@ -12916,11 +12826,40 @@ msgid "Create a `.rs` file under `tests/`:"
 msgstr "Utwórz plik `.rs` w `tests/`:"
 
 #: src/testing/integration-tests.md:7
-msgid "```rust,ignore\nuse my_library::init;"
+msgid ""
+"```rust,ignore\n"
+"use my_library::init;\n"
+"```"
 msgstr ""
 
 #: src/testing/integration-tests.md:10
+msgid "\\#\\[test\\] fn test_init() { assert!(init().is_ok()); }"
+msgstr ""
+
+#: src/testing/integration-tests.md:14
 msgid ""
+"```\n"
+"\n"
+"# Integration Tests\n"
+"\n"
+"If you want to test your library as a client, use an integration test.\n"
+"\n"
+"Create a `.rs` file under `tests/`:\n"
+"\n"
+"```rust,ignore\n"
+"use my_library::init;\n"
+"\n"
+"These tests only have access to the public API of your crate.\n"
+"\n"
+"# Integration Tests\n"
+"\n"
+"If you want to test your library as a client, use an integration test.\n"
+"\n"
+"Create a `.rs` file under `tests/`:\n"
+"\n"
+"```rust,ignore\n"
+"use my_library::init;\n"
+"\n"
 "#[test]\n"
 "fn test_init() {\n"
 "    assert!(init().is_ok());\n"
@@ -12933,11 +12872,6 @@ msgstr ""
 msgid "These tests only have access to the public API of your crate."
 msgstr "Te testy mają dostęp tylko do publicznego API Twojej skrzynki."
 
-#: src/unsafe.md:1
-#, fuzzy
-msgid "# Unsafe Rust"
-msgstr "Co to jest Rust?"
-
 #: src/unsafe.md:3
 #, fuzzy
 msgid "The Rust language has two parts:"
@@ -12945,37 +12879,38 @@ msgstr "Język Rust składa się z dwóch części:"
 
 #: src/unsafe.md:5
 #, fuzzy
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr ""
+"**Bezpieczna rdza:** bezpieczna pamięć, niemożliwe niezdefiniowane "
+"zachowanie."
+
+#: src/unsafe.md:6
+#, fuzzy
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
-"* **Bezpieczna rdza:** bezpieczna pamięć, niemożliwe niezdefiniowane "
-"zachowanie.\n"
-"* **Niebezpieczna rdza:** może wywołać niezdefiniowane zachowanie, jeśli "
+"**Niebezpieczna rdza:** może wywołać niezdefiniowane zachowanie, jeśli "
 "zostaną naruszone warunki wstępne."
 
 #: src/unsafe.md:8
 #, fuzzy
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr ""
-"W tym kursie zobaczymy głównie bezpieczną Rust, ale ważne jest, aby "
-"wiedzieć\n"
+"W tym kursie zobaczymy głównie bezpieczną Rust, ale ważne jest, aby wiedzieć "
 "czym jest niebezpieczna rdza."
 
 #: src/unsafe.md:11
 #, fuzzy
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 "Niebezpieczny kod jest zwykle mały i izolowany, a jego poprawność powinna "
-"być ostrożna\n"
-"udokumentowane. Zwykle jest opakowany w bezpieczną warstwę abstrakcji."
+"być ostrożna udokumentowane. Zwykle jest opakowany w bezpieczną warstwę "
+"abstrakcji."
 
 #: src/unsafe.md:14
 #, fuzzy
@@ -12984,54 +12919,53 @@ msgstr "Unsafe Rust zapewnia dostęp do pięciu nowych możliwości:"
 
 #: src/unsafe.md:16
 #, fuzzy
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
-msgstr ""
-"* Wyłuskaj surowe wskaźniki.\n"
-"* Uzyskaj dostęp lub modyfikuj zmienne zmienne statyczne.\n"
-"* Dostęp do pól „unii”.\n"
-"* Wywołaj funkcje `niebezpieczne`, w tym funkcje `extern`.\n"
-"* Implementuj „niebezpieczne” cechy."
+msgid "Dereference raw pointers."
+msgstr "Wyłuskaj surowe wskaźniki."
+
+#: src/unsafe.md:17
+#, fuzzy
+msgid "Access or modify mutable static variables."
+msgstr "Uzyskaj dostęp lub modyfikuj zmienne zmienne statyczne."
+
+#: src/unsafe.md:18
+#, fuzzy
+msgid "Access `union` fields."
+msgstr "Dostęp do pól „unii”."
+
+#: src/unsafe.md:19
+#, fuzzy
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr "Wywołaj funkcje `niebezpieczne`, w tym funkcje `extern`."
+
+#: src/unsafe.md:20
+#, fuzzy
+msgid "Implement `unsafe` traits."
+msgstr "Implementuj „niebezpieczne” cechy."
 
 #: src/unsafe.md:22
 #, fuzzy
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
-"[Chapter 19.1 in the Rust "
-"Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"We will briefly cover unsafe capabilities next. For full details, please see "
+"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 "W dalszej części krótko omówimy niebezpieczne możliwości. Aby uzyskać "
-"szczegółowe informacje, zobacz\n"
-"[Rozdział 19.1 w Księdze "
-"Rusta](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
-"oraz [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"szczegółowe informacje, zobacz [Rozdział 19.1 w Księdze Rusta](https://doc."
+"rust-lang.org/book/ch19-01-unsafe-rust.html) oraz [Rustonomicon](https://doc."
+"rust-lang.org/nomicon/)."
 
 #: src/unsafe.md:28
 #, fuzzy
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
 "Niebezpieczny Rust nie oznacza, że kod jest nieprawidłowy. Oznacza to, że "
-"deweloperzy mają\n"
-"wyłączył funkcje bezpieczeństwa kompilatora i musiał napisać poprawny kod "
-"wg\n"
-"sobie. Oznacza to, że kompilator nie egzekwuje już zasad bezpieczeństwa "
-"pamięci Rusta."
-
-#: src/unsafe/raw-pointers.md:1
-#, fuzzy
-msgid "# Dereferencing Raw Pointers"
-msgstr "# Dereferencja surowych wskaźników"
+"deweloperzy mają wyłączył funkcje bezpieczeństwa kompilatora i musiał "
+"napisać poprawny kod wg sobie. Oznacza to, że kompilator nie egzekwuje już "
+"zasad bezpieczeństwa pamięci Rusta."
 
 #: src/unsafe/raw-pointers.md:3
 #, fuzzy
@@ -13044,27 +12978,32 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let mut num = 5;"
+"    let mut num = 5;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:9
-msgid "    let r1 = &mut num as *mut i32;\n    let r2 = &num as *const i32;"
+msgid ""
+"```\n"
+"let r1 = &mut num as *mut i32;\n"
+"let r2 = &num as *const i32;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:12
 msgid ""
-"    // Safe because r1 and r2 were obtained from references and so are "
+"```\n"
+"// Safe because r1 and r2 were obtained from references and so are "
 "guaranteed to be non-null and\n"
-"    // properly aligned, the objects underlying the references from which "
-"they were obtained are\n"
-"    // live throughout the whole unsafe block, and they are not accessed "
-"either through the\n"
-"    // references or concurrently through any other pointers.\n"
-"    unsafe {\n"
-"        println!(\"r1 is: {}\", *r1);\n"
-"        *r1 = 10;\n"
-"        println!(\"r2 is: {}\", *r2);\n"
-"    }\n"
+"// properly aligned, the objects underlying the references from which they "
+"were obtained are\n"
+"// live throughout the whole unsafe block, and they are not accessed either "
+"through the\n"
+"// references or concurrently through any other pointers.\n"
+"unsafe {\n"
+"    println!(\"r1 is: {}\", *r1);\n"
+"    *r1 = 10;\n"
+"    println!(\"r2 is: {}\", *r2);\n"
 "}\n"
 "```"
 msgstr ""
@@ -13073,56 +13012,62 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 "Dobrą praktyką (i wymaganą przez przewodnik stylistyczny Android Rust) jest "
-"napisanie komentarza dla każdego\n"
-"Blok `niebezpieczny` wyjaśniający, w jaki sposób znajdujący się w nim kod "
-"spełnia wymagania bezpieczeństwa niebezpiecznego\n"
-"operacje, które wykonuje."
+"napisanie komentarza dla każdego Blok `niebezpieczny` wyjaśniający, w jaki "
+"sposób znajdujący się w nim kod spełnia wymagania bezpieczeństwa "
+"niebezpiecznego operacje, które wykonuje."
 
 #: src/unsafe/raw-pointers.md:30
 #, fuzzy
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
-"W przypadku dereferencji wskaźników oznacza to, że wskaźniki muszą być\n"
+"W przypadku dereferencji wskaźników oznacza to, że wskaźniki muszą być "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), czyli:"
 
 #: src/unsafe/raw-pointers.md:33
 #, fuzzy
+msgid "The pointer must be non-null."
+msgstr "Wskaźnik musi być inny niż null."
+
+#: src/unsafe/raw-pointers.md:34
+#, fuzzy
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
 msgstr ""
-" * Wskaźnik musi być inny niż null.\n"
-" * Wskaźnik musi być _dereferenceable_ (w granicach pojedynczego "
-"przydzielonego obiektu).\n"
-" * Obiekt nie może być cofnięty.\n"
-" * Nie może być jednoczesnych dostępów do tej samej lokalizacji.\n"
-" * Jeśli wskaźnik został uzyskany przez rzutowanie odniesienia, obiekt "
-"leżący pod spodem musi być żywy i nie\n"
-"   odwołanie może być użyte do uzyskania dostępu do pamięci."
+"Wskaźnik musi być _dereferenceable_ (w granicach pojedynczego przydzielonego "
+"obiektu)."
+
+#: src/unsafe/raw-pointers.md:35
+#, fuzzy
+msgid "The object must not have been deallocated."
+msgstr "Obiekt nie może być cofnięty."
+
+#: src/unsafe/raw-pointers.md:36
+#, fuzzy
+msgid "There must not be concurrent accesses to the same location."
+msgstr "Nie może być jednoczesnych dostępów do tej samej lokalizacji."
+
+#: src/unsafe/raw-pointers.md:37
+#, fuzzy
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr ""
+"Jeśli wskaźnik został uzyskany przez rzutowanie odniesienia, obiekt leżący "
+"pod spodem musi być żywy i nie odwołanie może być użyte do uzyskania dostępu "
+"do pamięci."
 
 #: src/unsafe/raw-pointers.md:40
 #, fuzzy
 msgid "In most cases the pointer must also be properly aligned."
-msgstr "W większości przypadków wskaźnik musi być również odpowiednio wyrównany."
-
-#: src/unsafe/mutable-static-variables.md:1
-#, fuzzy
-msgid "# Mutable Static Variables"
-msgstr "# Zmienne zmienne statyczne"
+msgstr ""
+"W większości przypadków wskaźnik musi być również odpowiednio wyrównany."
 
 #: src/unsafe/mutable-static-variables.md:3
 #, fuzzy
@@ -13130,46 +13075,46 @@ msgid "It is safe to read an immutable static variable:"
 msgstr "Odczyt niezmiennej zmiennej statycznej jest bezpieczny:"
 
 #: src/unsafe/mutable-static-variables.md:5
-msgid "```rust,editable\nstatic HELLO_WORLD: &str = \"Hello, world!\";"
+msgid ""
+"```rust,editable\n"
+"static HELLO_WORLD: &str = \"Hello, world!\";\n"
+"```"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:8
-msgid ""
-"fn main() {\n"
-"    println!(\"HELLO_WORLD: {HELLO_WORLD}\");\n"
-"}\n"
-"```"
+msgid "fn main() { println!(\"HELLO_WORLD: {HELLO_WORLD}\"); }"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
 #, fuzzy
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 "Ponieważ jednak mogą wystąpić wyścigi danych, odczytywanie i zapisywanie "
-"zmiennych jest niebezpieczne\n"
-"zmienne statyczne:"
+"zmiennych jest niebezpieczne zmienne statyczne:"
 
 #: src/unsafe/mutable-static-variables.md:16
-msgid "```rust,editable\nstatic mut COUNTER: u32 = 0;"
+msgid ""
+"```rust,editable\n"
+"static mut COUNTER: u32 = 0;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:19
 msgid ""
-"fn add_to_counter(inc: u32) {\n"
-"    unsafe { COUNTER += inc; }  // Potential data race!\n"
-"}"
+"fn add_to_counter(inc: u32) { unsafe { COUNTER += inc; }  // Potential data "
+"race! }"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:23
-msgid "fn main() {\n    add_to_counter(42);"
+msgid "fn main() { add_to_counter(42);"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:26
 msgid ""
-"    unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
-"}\n"
+"```\n"
+"unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
 "```"
 msgstr ""
 
@@ -13177,19 +13122,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 "Używanie zmiennej statyki jest generalnie złym pomysłem, ale są przypadki, w "
-"których może to mieć sens\n"
-"w kodzie niskiego poziomu `no_std`, takim jak implementacja alokatora sterty "
-"lub praca z niektórymi interfejsami API C."
-
-#: src/unsafe/unions.md:1
-#, fuzzy
-msgid "# Unions"
-msgstr "# Związki"
+"których może to mieć sens w kodzie niskiego poziomu `no_std`, takim jak "
+"implementacja alokatora sterty lub praca z niektórymi interfejsami API C."
 
 #: src/unsafe/unions.md:3
 #, fuzzy
@@ -13203,119 +13141,100 @@ msgid ""
 "union MyUnion {\n"
 "    i: u8,\n"
 "    b: bool,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/unions.md:12
 msgid ""
-"fn main() {\n"
-"    let u = MyUnion { i: 42 };\n"
-"    println!(\"int: {}\", unsafe { u.i });\n"
-"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
-"}\n"
-"```"
+"fn main() { let u = MyUnion { i: 42 }; println!(\"int: {}\", unsafe { u."
+"i }); println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior! }"
 msgstr ""
 
 #: src/unsafe/unions.md:21
 #, fuzzy
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 "Unie są bardzo rzadko potrzebne w Rust, ponieważ zwykle można użyć "
-"wyliczenia. Czasami są potrzebne\n"
-"do interakcji z interfejsami API biblioteki C."
+"wyliczenia. Czasami są potrzebne do interakcji z interfejsami API biblioteki "
+"C."
 
 #: src/unsafe/unions.md:24
 #, fuzzy
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
-"or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"If you just want to reinterpret bytes as a different type, you probably want "
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 "Jeśli chcesz po prostu ponownie zinterpretować bajty jako inny typ, "
-"prawdopodobnie chcesz\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) "
-"lub sejf\n"
-"opakowanie, takie jak skrzynka "
+"prawdopodobnie chcesz [`std::mem::transmute`](https://doc.rust-lang.org/"
+"stable/std/mem/fn.transmute.html) lub sejf opakowanie, takie jak skrzynka "
 "[`zerocopy`](https://crates.io/crates/zerocopy)."
-
-#: src/unsafe/calling-unsafe-functions.md:1
-#, fuzzy
-msgid "# Calling Unsafe Functions"
-msgstr "# Wywoływanie niebezpiecznych funkcji"
 
 #: src/unsafe/calling-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 "Funkcja lub metoda może zostać oznaczona jako „niebezpieczna”, jeśli ma "
-"dodatkowe warunki wstępne\n"
-"których należy przestrzegać, aby uniknąć niezdefiniowanych zachowań:"
+"dodatkowe warunki wstępne których należy przestrzegać, aby uniknąć "
+"niezdefiniowanych zachowań:"
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let emojis = \"🗻∈🌏\";"
+"    let emojis = \"🗻∈🌏\";\n"
+"```"
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:10
 msgid ""
-"    // Safe because the indices are in the correct order, within the bounds "
-"of\n"
-"    // the string slice, and lie on UTF-8 sequence boundaries.\n"
-"    unsafe {\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
-"    }"
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:18
-msgid ""
-"    println!(\"char count: {}\", count_chars(unsafe { "
-"emojis.get_unchecked(0..7) }));"
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:20
-msgid ""
-"    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
-"    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe { "
-"emojis.get_unchecked(0..3) }));\n"
-"}"
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:25
-msgid ""
-"fn count_chars(s: &str) -> usize {\n"
-"    s.chars().map(|_| 1).sum()\n"
+"```\n"
+"// Safe because the indices are in the correct order, within the bounds of\n"
+"// the string slice, and lie on UTF-8 sequence boundaries.\n"
+"unsafe {\n"
+"    println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
+"    println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
+"    println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-#, fuzzy
-msgid "# Writing Unsafe Functions"
-msgstr "# Pisanie niebezpiecznych funkcji"
+#: src/unsafe/calling-unsafe-functions.md:18
+msgid ""
+"```\n"
+"println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..7) }));\n"
+"```"
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:20
+msgid ""
+"```\n"
+"// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
+"// println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
+"// println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..3) }));\n"
+"```"
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:25
+msgid "fn count_chars(s: &str) -> usize { s.chars().map(|\\_\\| 1).sum() }"
+msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
 "Możesz oznaczyć własne funkcje jako „niebezpieczne”, jeśli wymagają "
-"określonych warunków, aby uniknąć niezdefiniowanych\n"
-"zachowanie."
+"określonych warunków, aby uniknąć niezdefiniowanych zachowanie."
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -13329,28 +13248,28 @@ msgid ""
 "    let temp = *a;\n"
 "    *a = *b;\n"
 "    *b = temp;\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:18
-msgid ""
-"fn main() {\n"
-"    let mut a = 42;\n"
-"    let mut b = 66;"
+msgid "fn main() { let mut a = 42; let mut b = 66;"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:22
 msgid ""
-"    // Safe because ...\n"
-"    unsafe {\n"
-"        swap(&mut a, &mut b);\n"
-"    }"
+"```\n"
+"// Safe because ...\n"
+"unsafe {\n"
+"    swap(&mut a, &mut b);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:27
 msgid ""
-"    println!(\"a = {}, b = {}\", a, b);\n"
-"}\n"
+"```\n"
+"println!(\"a = {}, b = {}\", a, b);\n"
 "```"
 msgstr ""
 
@@ -13367,148 +13286,114 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 "Należy zauważyć, że niebezpieczny kod jest dozwolony w niebezpiecznej "
-"funkcji bez bloku `unsafe`. Możemy\n"
-"zabronić tego za pomocą `#[deny(unsafe_op_in_unsafe_fn)]`. Spróbuj go dodać "
-"i zobacz, co się stanie."
+"funkcji bez bloku `unsafe`. Możemy zabronić tego za pomocą "
+"`#[deny(unsafe_op_in_unsafe_fn)]`. Spróbuj go dodać i zobacz, co się stanie."
 
 #: src/unsafe/extern-functions.md:1
 #, fuzzy
-msgid "# Calling External Code"
+msgid "Calling External Code"
 msgstr "Próbki kodu"
 
 #: src/unsafe/extern-functions.md:3
 #, fuzzy
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
-"Funkcje z innych języków mogą naruszać gwarancje Rusta. Powołanie\n"
-"są więc niebezpieczne:"
+"Funkcje z innych języków mogą naruszać gwarancje Rusta. Powołanie są więc "
+"niebezpieczne:"
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
 "```rust,editable\n"
 "extern \"C\" {\n"
 "    fn abs(input: i32) -> i32;\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/unsafe/extern-functions.md:11
 msgid ""
-"fn main() {\n"
-"    unsafe {\n"
-"        // Undefined behavior if abs misbehaves.\n"
-"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { unsafe { // Undefined behavior if abs misbehaves. println!"
+"(\"Absolute value of -3 according to C: {}\", abs(-3)); } }"
 msgstr ""
 
 #: src/unsafe/extern-functions.md:21
 #, fuzzy
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 "Zwykle jest to problem tylko w przypadku funkcji extern, które robią rzeczy "
-"ze wskaźnikami, które mogą\n"
-"naruszają model pamięci Rusta, ale ogólnie każda funkcja C może mieć "
-"niezdefiniowane zachowanie pod dowolnym\n"
-"arbitralne okoliczności."
+"ze wskaźnikami, które mogą naruszają model pamięci Rusta, ale ogólnie każda "
+"funkcja C może mieć niezdefiniowane zachowanie pod dowolnym arbitralne "
+"okoliczności."
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available "
-"too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-#, fuzzy
-msgid "# Implementing Unsafe Traits"
-msgstr "# Wdrażanie niebezpiecznych cech"
 
 #: src/unsafe/unsafe-traits.md:3
 #, fuzzy
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 "Podobnie jak w przypadku funkcji, możesz oznaczyć cechę jako "
-"„niebezpieczną”, jeśli implementacja musi gwarantować\n"
-"szczególne warunki, aby uniknąć nieokreślonego zachowania."
+"„niebezpieczną”, jeśli implementacja musi gwarantować szczególne warunki, "
+"aby uniknąć nieokreślonego zachowania."
 
 #: src/unsafe/unsafe-traits.md:6
 #, fuzzy
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like "
-"this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
-"Na przykład skrzynka „zerocopy” ma niebezpieczną cechę, która wygląda\n"
-"[coś takiego](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+"Na przykład skrzynka „zerocopy” ma niebezpieczną cechę, która wygląda [coś "
+"takiego](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 
 #: src/unsafe/unsafe-traits.md:9
 msgid ""
 "```rust,editable\n"
 "use std::mem::size_of_val;\n"
-"use std::slice;"
+"use std::slice;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:13
 #, fuzzy
 msgid ""
-"/// ...\n"
-"/// # Safety\n"
-"/// The type must have a defined representation and no padding.\n"
-"pub unsafe trait AsBytes {\n"
-"    fn as_bytes(&self) -> &[u8] {\n"
-"        unsafe {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, "
-"size_of_val(self))\n"
-"        }\n"
-"    }\n"
-"}"
+"/// ... /// # Safety /// The type must have a defined representation and no "
+"padding. pub unsafe trait AsBytes { fn as_bytes(&self) -> &\\[u8\\] { unsafe "
+"{ slice::from_raw_parts(self as \\*const Self as \\*const u8, "
+"size_of_val(self)) } } }"
 msgstr ""
-"/// ...\n"
-"/// # Bezpieczeństwo\n"
-"/// Typ musi mieć zdefiniowaną reprezentację i brak dopełnienia.\n"
-"niebezpieczna cecha publikacji AsBytes {\n"
-"    fn as_bytes(&self) -> &[u8] {\n"
-"        niebezpieczny {\n"
-"            slice::from_raw_parts(self jako *const Self as *const u8, "
-"size_of_val(self))\n"
-"        }\n"
-"    }\n"
-"}"
+"/// ... /// # Bezpieczeństwo /// Typ musi mieć zdefiniowaną reprezentację i "
+"brak dopełnienia. niebezpieczna cecha publikacji AsBytes { fn "
+"as_bytes(&self) -> &\\[u8\\] { niebezpieczny { slice::from_raw_parts(self "
+"jako \\*const Self as \\*const u8, size_of_val(self)) } } }"
 
 #: src/unsafe/unsafe-traits.md:24
 msgid ""
-"// Safe because u32 has a defined representation and no padding.\n"
-"unsafe impl AsBytes for u32 {}\n"
-"```"
+"// Safe because u32 has a defined representation and no padding. unsafe impl "
+"AsBytes for u32 {}"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:30
 #, fuzzy
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
 "Powinna istnieć sekcja `# Safety` w Rustdoc dla cechy wyjaśniającej "
-"wymagania dla\n"
-"cecha, którą należy bezpiecznie wdrożyć."
+"wymagania dla cecha, którą należy bezpiecznie wdrożyć."
 
 #: src/unsafe/unsafe-traits.md:33
 #, fuzzy
@@ -13526,8 +13411,8 @@ msgstr "Wbudowane cechy „Wyślij” i „Synchronizacja” są niebezpieczne."
 
 #: src/exercises/day-3/afternoon.md:1
 #, fuzzy
-msgid "# Day 3: Afternoon Exercises"
-msgstr "# Dzień 3: Ćwiczenia popołudniowe"
+msgid "Day 3: Afternoon Exercises"
+msgstr "Dzień 3: Ćwiczenia popołudniowe"
 
 #: src/exercises/day-3/afternoon.md:3
 #, fuzzy
@@ -13536,29 +13421,23 @@ msgstr "Zbudujmy bezpieczne opakowanie do odczytu zawartości katalogu!"
 
 #: src/exercises/day-3/afternoon.md:7
 #, fuzzy
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr "Po obejrzeniu ćwiczenia możesz spojrzeć na podane [rozwiązanie]."
-
-#: src/exercises/day-3/afternoon.md:9
-msgid "[solution]: solutions-afternoon.md"
-msgstr "[rozwiązanie]: solutions-afternoon.md"
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-#, fuzzy
-msgid "# Safe FFI Wrapper"
-msgstr "# Bezpieczne opakowanie FFI"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
+msgstr ""
+"Po obejrzeniu ćwiczenia możesz spojrzeć na podane [rozwiązanie](solutions-"
+"afternoon.md)."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 #, fuzzy
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
-"Rust ma świetne wsparcie dla wywoływania funkcji poprzez funkcję _foreign\n"
+"Rust ma świetne wsparcie dla wywoływania funkcji poprzez funkcję _foreign "
 "interfejs_ (FFI). Użyjemy tego do zbudowania bezpiecznego opakowania dla "
-"`libc`\n"
-"funkcje, których użyłbyś z C do odczytania nazw plików z katalogu."
+"`libc` funkcje, których użyłbyś z C do odczytania nazw plików z katalogu."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:7
 #, fuzzy
@@ -13566,185 +13445,149 @@ msgid "You will want to consult the manual pages:"
 msgstr "Będziesz chciał zapoznać się ze stronami podręcznika:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
-msgstr ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 #, fuzzy
 msgid ""
-"You will also want to browse the [`std::ffi`] module, particular for "
-"[`CStr`]\n"
-"and [`CString`] types which are used to hold NUL-terminated strings coming "
-"from\n"
-"C. The [Nomicon] also has a very useful chapter about FFI."
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module, particular for [`CStr`](https://doc.rust-lang.org/std/ffi/"
+"struct.CStr.html) and [`CString`](https://doc.rust-lang.org/std/ffi/struct."
+"CString.html) types which are used to hold NUL-terminated strings coming "
+"from C. The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a "
+"very useful chapter about FFI."
 msgstr ""
-"Będziesz także chciał przejrzeć moduł [`std::ffi`], w szczególności dla "
-"[`CStr`]\n"
-"i [`CString`], które są używane do przechowywania ciągów znaków zakończonych "
-"znakiem NUL pochodzących z\n"
-"C. [Nomicon] zawiera również bardzo przydatny rozdział o FFI."
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:17
-#, fuzzy
-msgid ""
-"[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
-"[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
-"[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
-"[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
-msgstr ""
-"[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
-"[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
-"[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
-"[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
+"Będziesz także chciał przejrzeć moduł [`std::ffi`](https://doc.rust-lang.org/"
+"std/ffi/), w szczególności dla [`CStr`](https://doc.rust-lang.org/std/ffi/"
+"struct.CStr.html) i [`CString`](https://doc.rust-lang.org/std/ffi/struct."
+"CString.html), które są używane do przechowywania ciągów znaków zakończonych "
+"znakiem NUL pochodzących z C. [Nomicon](https://doc.rust-lang.org/nomicon/"
+"ffi.html) zawiera również bardzo przydatny rozdział o FFI."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
-"Skopiuj poniższy kod na <https://play.rust-lang.org/> i uzupełnij brakujące\n"
+"Skopiuj poniższy kod na <https://play.rust-lang.org/> i uzupełnij brakujące "
 "funkcje i metody:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:29
-msgid ""
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+msgid "mod ffi { use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:32 src/exercises/day-3/solutions-afternoon.md:26
+#: src/exercises/day-3/safe-ffi-wrapper.md:32
+#: src/exercises/day-3/solutions-afternoon.md:26
 msgid ""
-"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-"    #[repr(C)]\n"
-"    pub struct DIR {\n"
-"        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, "
-"core::marker::PhantomPinned)>,\n"
-"    }"
+"```\n"
+"// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"#[repr(C)]\n"
+"pub struct DIR {\n"
+"    _data: [u8; 0],\n"
+"    _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:39 src/exercises/day-3/solutions-afternoon.md:33
+#: src/exercises/day-3/safe-ffi-wrapper.md:39
+#: src/exercises/day-3/solutions-afternoon.md:33
 msgid ""
-"    // Layout as per readdir(3) and definitions in "
-"/usr/include/x86_64-linux-gnu.\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_ino: c_long,\n"
-"        pub d_off: c_ulong,\n"
-"        pub d_reclen: c_ushort,\n"
-"        pub d_type: c_char,\n"
-"        pub d_name: [c_char; 256],\n"
-"    }"
+"```\n"
+"// Layout as per readdir(3) and definitions in /usr/include/x86_64-linux-"
+"gnu.\n"
+"#[repr(C)]\n"
+"pub struct dirent {\n"
+"    pub d_ino: c_long,\n"
+"    pub d_off: c_ulong,\n"
+"    pub d_reclen: c_ushort,\n"
+"    pub d_type: c_char,\n"
+"    pub d_name: [c_char; 256],\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:49 src/exercises/day-3/solutions-afternoon.md:43
+#: src/exercises/day-3/safe-ffi-wrapper.md:49
+#: src/exercises/day-3/solutions-afternoon.md:43
 msgid ""
-"    extern \"C\" {\n"
-"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"        pub fn closedir(s: *mut DIR) -> c_int;\n"
-"    }\n"
-"}"
+"```\n"
+"extern \"C\" {\n"
+"    pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"    pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"    pub fn closedir(s: *mut DIR) -> c_int;\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:56 src/exercises/day-3/solutions-afternoon.md:50
+#: src/exercises/day-3/safe-ffi-wrapper.md:56
+#: src/exercises/day-3/solutions-afternoon.md:50
 msgid ""
-"use std::ffi::{CStr, CString, OsStr, OsString};\n"
-"use std::os::unix::ffi::OsStrExt;"
+"use std::ffi::{CStr, CString, OsStr, OsString}; use std::os::unix::ffi::"
+"OsStrExt;"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:59
 msgid ""
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}"
+"\\#\\[derive(Debug)\\] struct DirectoryIterator { path: CString, dir: \\*mut "
+"ffi::DIR, }"
 msgstr ""
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}"
+"\\#\\[derive(Debug)\\] struct DirectoryIterator { path: CString, dir: \\*mut "
+"ffi::DIR, }"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:65
 msgid ""
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"impl DirectoryIterator { fn new(path: &str) -> Result\\<DirectoryIterator, "
+"String> { // Call opendir and return a Ok value if that worked, // otherwise "
+"return Err with a message. unimplemented!() } }"
 msgstr ""
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"impl DirectoryIterator { fn new(path: &str) -> Result\\<DirectoryIterator, "
+"String> { // Call opendir and return a Ok value if that worked, // otherwise "
+"return Err with a message. unimplemented!() } }"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:73
 msgid ""
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"impl Iterator for DirectoryIterator { type Item = OsString; fn next(&mut "
+"self) -> Option"
 msgstr ""
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Wywołuj readdir do uzyskania wskaźnika NULL.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"impl Iterator for DirectoryIterator { type Item = OsString; fn next(&mut "
+"self) -> Option"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:75
+msgid ""
+" { // Keep calling readdir until we get a NULL pointer back. unimplemented!"
+"() } }"
+msgstr ""
+" { // Wywołuj readdir do uzyskania wskaźnika NULL. unimplemented!() } }"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:81
 msgid ""
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"impl Drop for DirectoryIterator { fn drop(&mut self) { // Call closedir as "
+"needed. unimplemented!() } }"
 msgstr ""
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Wywołaj closedir.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"impl Drop for DirectoryIterator { fn drop(&mut self) { // Wywołaj closedir. "
+"unimplemented!() } }"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:88
 msgid ""
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"```"
+"fn main() -> Result\\<(), String> { let iter = DirectoryIterator::new(\"."
+"\")?; println!(\"files: {:#?}\", iter.collect::\\<Vec\\<\\_\\>>()); Ok(()) }"
 msgstr ""
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"pliki: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"```"
+"fn main() -> Result\\<(), String> { let iter = DirectoryIterator::new(\"."
+"\")?; println!(\"pliki: {:#?}\", iter.collect::\\<Vec\\<\\_\\>>()); Ok(()) }"
 
 #: src/welcome-day-4.md:1
-msgid "# Welcome to Day 4"
-msgstr "# Witamy w dniu 4"
+msgid "Welcome to Day 4"
+msgstr "Witamy w dniu 4"
 
 #: src/welcome-day-4.md:3
 #, fuzzy
@@ -13753,72 +13596,58 @@ msgstr "Dzisiaj przyjrzymy się dwóm głównym tematom:"
 
 #: src/welcome-day-4.md:5
 #, fuzzy
-msgid "* Concurrency: threads, channels, shared state, `Send` and `Sync`."
+msgid "Concurrency: threads, channels, shared state, `Send` and `Sync`."
 msgstr ""
-"* Współbieżność: wątki, kanały, współdzielony stan, `Wyślij` i "
+"Współbieżność: wątki, kanały, współdzielony stan, `Wyślij` i "
 "`Synchronizacja`."
 
 #: src/welcome-day-4.md:7
 #, fuzzy
 msgid ""
-"* Android: building binaries and libraries, using AIDL, logging, and\n"
-"  interoperability with C, C++, and Java."
+"Android: building binaries and libraries, using AIDL, logging, and "
+"interoperability with C, C++, and Java."
 msgstr ""
-"* Android: tworzenie plików binarnych i bibliotek przy użyciu AIDL, "
-"logowanie i\n"
-"  współdziałanie z C, C++ i Javą."
+"Android: tworzenie plików binarnych i bibliotek przy użyciu AIDL, logowanie "
+"i współdziałanie z C, C++ i Javą."
 
 #: src/welcome-day-4.md:10
 #, fuzzy
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try "
-"to\n"
-"> find a little corner of your code base where we can move some lines of "
-"code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
-"that\n"
-"> parses some raw bytes would be ideal."
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
-"> Spróbujemy dzisiaj wywołać Rusta z jednego z twoich własnych projektów. "
-"Więc spróbuj\n"
-"> znajdź mały zakątek swojej bazy kodu, do którego możemy przenieść kilka "
-"linii kodu\n"
-"> Rdza. Im mniej zależności i typów „egzotycznych”, tym lepiej. Coś takiego\n"
-"> analizuje kilka nieprzetworzonych bajtów byłoby idealnie."
+"Spróbujemy dzisiaj wywołać Rusta z jednego z twoich własnych projektów. Więc "
+"spróbuj znajdź mały zakątek swojej bazy kodu, do którego możemy przenieść "
+"kilka linii kodu Rdza. Im mniej zależności i typów „egzotycznych”, tym "
+"lepiej. Coś takiego analizuje kilka nieprzetworzonych bajtów byłoby idealnie."
 
 #: src/concurrency.md:1
 #, fuzzy
-msgid "# Fearless Concurrency"
-msgstr "# Nieustraszona współbieżność"
+msgid "Fearless Concurrency"
+msgstr "Nieustraszona współbieżność"
 
 #: src/concurrency.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 "Rust ma pełne wsparcie dla współbieżności przy użyciu wątków systemu "
-"operacyjnego z muteksami i\n"
-"kanały."
+"operacyjnego z muteksami i kanały."
 
 #: src/concurrency.md:6
 #, fuzzy
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
-"System typu Rust odgrywa ważną rolę w tworzeniu wielu błędów współbieżności\n"
+"System typu Rust odgrywa ważną rolę w tworzeniu wielu błędów współbieżności "
 "skompilować błędy czasowe. Od tego czasu jest to często określane jako "
-"_nieustraszona współbieżność_\n"
-"może polegać na kompilatorze, aby zapewnić poprawność w czasie wykonywania."
-
-#: src/concurrency/threads.md:1
-#, fuzzy
-msgid "# Threads"
-msgstr "# Wątki"
+"_nieustraszona współbieżność_ może polegać na kompilatorze, aby zapewnić "
+"poprawność w czasie wykonywania."
 
 #: src/concurrency/threads.md:3
 #, fuzzy
@@ -13829,88 +13658,76 @@ msgstr "Wątki Rust działają podobnie do wątków w innych językach:"
 msgid ""
 "```rust,editable\n"
 "use std::thread;\n"
-"use std::time::Duration;"
+"use std::time::Duration;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/threads.md:9
 msgid ""
-"fn main() {\n"
-"    thread::spawn(|| {\n"
-"        for i in 1..10 {\n"
-"            println!(\"Count in thread: {i}!\");\n"
-"            thread::sleep(Duration::from_millis(5));\n"
-"        }\n"
-"    });"
+"fn main() { thread::spawn(|| { for i in 1..10 { println!(\"Count in thread: "
+"{i}!\"); thread::sleep(Duration::from_millis(5)); } });"
 msgstr ""
 
 #: src/concurrency/threads.md:17
 msgid ""
-"    for i in 1..5 {\n"
-"        println!(\"Main thread: {i}\");\n"
-"        thread::sleep(Duration::from_millis(5));\n"
-"    }\n"
+"```\n"
+"for i in 1..5 {\n"
+"    println!(\"Main thread: {i}\");\n"
+"    thread::sleep(Duration::from_millis(5));\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/concurrency/threads.md:24
 #, fuzzy
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
+msgstr "Wątki to wszystkie wątki demonów, główny wątek na nie nie czeka."
+
+#: src/concurrency/threads.md:25
+#, fuzzy
+msgid "Thread panics are independent of each other."
+msgstr "Paniki wątków są od siebie niezależne."
+
+#: src/concurrency/threads.md:26
+#, fuzzy
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
 msgstr ""
-"* Wątki to wszystkie wątki demonów, główny wątek na nie nie czeka.\n"
-"* Paniki wątków są od siebie niezależne.\n"
-"  * Paniki mogą przenosić ładunek, który można rozpakować za pomocą "
+"Paniki mogą przenosić ładunek, który można rozpakować za pomocą "
 "`downcast_ref`."
 
 #: src/concurrency/threads.md:32
 #, fuzzy
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
-"* Zauważ, że wątek jest zatrzymywany, zanim osiągnie 10 — główny wątek jest\n"
-"  nie czekać."
+"Zauważ, że wątek jest zatrzymywany, zanim osiągnie 10 — główny wątek jest "
+"nie czekać."
 
 #: src/concurrency/threads.md:35
 #, fuzzy
 msgid ""
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish."
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
 msgstr ""
-"* Użyj `let handle = thread::spawn(...)` a później `handle.join()` aby "
-"czekać\n"
-"  wątek do końca."
+"Użyj `let handle = thread::spawn(...)` a później `handle.join()` aby czekać "
+"wątek do końca."
 
 #: src/concurrency/threads.md:38
 #, fuzzy
-msgid "* Trigger a panic in the thread, notice how this doesn't affect `main`."
-msgstr "* Wywołaj panikę w wątku, zauważ, że nie wpływa to na `main`."
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr "Wywołaj panikę w wątku, zauważ, że nie wpływa to na `main`."
 
 #: src/concurrency/threads.md:40
 #, fuzzy
 msgid ""
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
 msgstr ""
-"* Użyj wartości zwracanej przez `Result` z `handle.join()`, aby uzyskać "
-"dostęp do paniki\n"
-"  ładunek. To dobry moment, aby porozmawiać o [`Dowolny`]."
-
-#: src/concurrency/threads.md:43
-#, fuzzy
-msgid "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
-msgstr "[`Dowolny`]: https://doc.rust-lang.org/std/any/index.html"
-
-#: src/concurrency/scoped-threads.md:1
-#, fuzzy
-msgid "# Scoped Threads"
-msgstr "# Wątki o ograniczonym zakresie"
+"Użyj wartości zwracanej przez `Result` z `handle.join()`, aby uzyskać dostęp "
+"do paniki ładunek. To dobry moment, aby porozmawiać o [`Dowolny`](https://"
+"doc.rust-lang.org/std/any/index.html)."
 
 #: src/concurrency/scoped-threads.md:3
 #, fuzzy
@@ -13918,175 +13735,175 @@ msgid "Normal threads cannot borrow from their environment:"
 msgstr "Normalne wątki nie mogą pożyczać ze swojego środowiska:"
 
 #: src/concurrency/scoped-threads.md:5
-msgid "```rust,editable,compile_fail\nuse std::thread;"
+msgid ""
+"```rust,editable,compile_fail\n"
+"use std::thread;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:8 src/concurrency/scoped-threads.md:22
-msgid "fn main() {\n    let s = String::from(\"Hello\");"
+msgid "fn main() { let s = String::from(\"Hello\");"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:11
 msgid ""
-"    thread::spawn(|| {\n"
-"        println!(\"Length: {}\", s.len());\n"
-"    });\n"
-"}\n"
+"```\n"
+"thread::spawn(|| {\n"
+"    println!(\"Length: {}\", s.len());\n"
+"});\n"
 "```"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
 #, fuzzy
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "W tym celu możesz jednak użyć [wątku z zakresem] [1]:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"W tym celu możesz jednak użyć \\[wątku z zakresem\\] [1](https://doc.rust-"
+"lang.org/std/thread/fn.scope.html):"
 
 #: src/concurrency/scoped-threads.md:19
-msgid "```rust,editable\nuse std::thread;"
+msgid ""
+"```rust,editable\n"
+"use std::thread;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:25
 msgid ""
-"    thread::scope(|scope| {\n"
-"        scope.spawn(|| {\n"
-"            println!(\"Length: {}\", s.len());\n"
-"        });\n"
+"```\n"
+"thread::scope(|scope| {\n"
+"    scope.spawn(|| {\n"
+"        println!(\"Length: {}\", s.len());\n"
 "    });\n"
-"}\n"
+"});\n"
 "```"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md:33
-#, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
-msgstr "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
-
-#: src/concurrency/scoped-threads.md:35
+#: src/concurrency/scoped-threads.md:37
 #, fuzzy
 msgid ""
-"<details>\n"
-"    \n"
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    \n"
-"</details>"
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"<details>\n"
-"    \n"
-"* Powodem tego jest to, że gdy funkcja `thread::scope` zakończy działanie, "
-"wszystkie wątki zostaną połączone, więc będą mogły zwrócić pożyczone dane.\n"
-"* Obowiązują normalne zasady pożyczania Rusta: możesz pożyczać zmiennie o "
-"jeden wątek lub niezmiennie o dowolną liczbę wątków.\n"
-"    \n"
-"</details>"
+"Powodem tego jest to, że gdy funkcja `thread::scope` zakończy działanie, "
+"wszystkie wątki zostaną połączone, więc będą mogły zwrócić pożyczone dane."
 
-#: src/concurrency/channels.md:1
+#: src/concurrency/scoped-threads.md:38
 #, fuzzy
-msgid "# Channels"
-msgstr "# Kanały"
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"Obowiązują normalne zasady pożyczania Rusta: możesz pożyczać zmiennie o "
+"jeden wątek lub niezmiennie o dowolną liczbę wątków."
 
 #: src/concurrency/channels.md:3
 #, fuzzy
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
-"Kanały Rusta mają dwie części: `Sender<T>` i `Receiver<T>`. Dwie części\n"
-"są połączone kanałem, ale widzisz tylko punkty końcowe."
+"Kanały Rusta mają dwie części: `Sender<T>` i `Receiver<T>`. Dwie części są "
+"połączone kanałem, ale widzisz tylko punkty końcowe."
 
 #: src/concurrency/channels.md:6
 msgid ""
 "```rust,editable\n"
 "use std::sync::mpsc;\n"
-"use std::thread;"
+"use std::thread;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels.md:10 src/concurrency/channels/unbounded.md:10
-msgid "fn main() {\n    let (tx, rx) = mpsc::channel();"
+msgid "fn main() { let (tx, rx) = mpsc::channel();"
 msgstr ""
 
 #: src/concurrency/channels.md:13
-msgid "    tx.send(10).unwrap();\n    tx.send(20).unwrap();"
+msgid ""
+"```\n"
+"tx.send(10).unwrap();\n"
+"tx.send(20).unwrap();\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels.md:16
 msgid ""
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"    println!(\"Received: {:?}\", rx.recv());"
+"```\n"
+"println!(\"Received: {:?}\", rx.recv());\n"
+"println!(\"Received: {:?}\", rx.recv());\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels.md:19
 msgid ""
-"    let tx2 = tx.clone();\n"
-"    tx2.send(30).unwrap();\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"}\n"
+"```\n"
+"let tx2 = tx.clone();\n"
+"tx2.send(30).unwrap();\n"
+"println!(\"Received: {:?}\", rx.recv());\n"
 "```"
 msgstr ""
 
 #: src/concurrency/channels.md:27
 #, fuzzy
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* `mpsc` oznacza Multi-Producer, Single-Consumer. `Sender` i `SyncSender` "
-"implementują `Clone` (tzw\n"
-"  możesz stworzyć wielu producentów), ale `Receiver` nie.\n"
-"* `send()` i `recv()` zwracają `Result`. Jeśli zwracają `Błąd`, oznacza to "
-"odpowiednik `Nadawca` lub\n"
-"  `Odbiornik` jest odrzucany i kanał jest zamykany."
+"`mpsc` oznacza Multi-Producer, Single-Consumer. `Sender` i `SyncSender` "
+"implementują `Clone` (tzw możesz stworzyć wielu producentów), ale `Receiver` "
+"nie."
 
-#: src/concurrency/channels/unbounded.md:1
+#: src/concurrency/channels.md:29
 #, fuzzy
-msgid "# Unbounded Channels"
-msgstr "# Nieograniczone kanały"
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()` i `recv()` zwracają `Result`. Jeśli zwracają `Błąd`, oznacza to "
+"odpowiednik `Nadawca` lub `Odbiornik` jest odrzucany i kanał jest zamykany."
 
 #: src/concurrency/channels/unbounded.md:3
 #, fuzzy
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr "Otrzymujesz nieograniczony i asynchroniczny kanał z `mpsc::channel()`:"
 
-#: src/concurrency/channels/unbounded.md:5 src/concurrency/channels/bounded.md:5
+#: src/concurrency/channels/unbounded.md:5
+#: src/concurrency/channels/bounded.md:5
 msgid ""
 "```rust,editable\n"
 "use std::sync::mpsc;\n"
 "use std::thread;\n"
-"use std::time::Duration;"
+"use std::time::Duration;\n"
+"```"
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:13 src/concurrency/channels/bounded.md:13
+#: src/concurrency/channels/unbounded.md:13
+#: src/concurrency/channels/bounded.md:13
 msgid ""
-"    thread::spawn(move || {\n"
-"        let thread_id = thread::current().id();\n"
-"        for i in 1..10 {\n"
-"            tx.send(format!(\"Message {i}\")).unwrap();\n"
-"            println!(\"{thread_id:?}: sent Message {i}\");\n"
-"        }\n"
-"        println!(\"{thread_id:?}: done\");\n"
-"    });\n"
-"    thread::sleep(Duration::from_millis(100));"
+"```\n"
+"thread::spawn(move || {\n"
+"    let thread_id = thread::current().id();\n"
+"    for i in 1..10 {\n"
+"        tx.send(format!(\"Message {i}\")).unwrap();\n"
+"        println!(\"{thread_id:?}: sent Message {i}\");\n"
+"    }\n"
+"    println!(\"{thread_id:?}: done\");\n"
+"});\n"
+"thread::sleep(Duration::from_millis(100));\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels/unbounded.md:23
 msgid ""
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {}\", msg);\n"
-"    }\n"
+"```\n"
+"for msg in rx.iter() {\n"
+"    println!(\"Main: got {}\", msg);\n"
 "}\n"
 "```"
 msgstr ""
-
-#: src/concurrency/channels/bounded.md:1
-#, fuzzy
-msgid "# Bounded Channels"
-msgstr "# Ograniczone kanały"
 
 #: src/concurrency/channels/bounded.md:3
 #, fuzzy
@@ -14096,247 +13913,241 @@ msgstr ""
 "wątek:"
 
 #: src/concurrency/channels/bounded.md:10
-msgid "fn main() {\n    let (tx, rx) = mpsc::sync_channel(3);"
+msgid "fn main() { let (tx, rx) = mpsc::sync_channel(3);"
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:23
 msgid ""
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {msg}\");\n"
-"    }\n"
+"```\n"
+"for msg in rx.iter() {\n"
+"    println!(\"Main: got {msg}\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/concurrency/shared_state.md:1
-#, fuzzy
-msgid "# Shared State"
-msgstr "# stan udostępniony"
-
 #: src/concurrency/shared_state.md:3
 #, fuzzy
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 "Rust używa systemu typów do wymuszania synchronizacji współdzielonych "
-"danych. To jest\n"
-"odbywa się głównie za pomocą dwóch typów:"
+"danych. To jest odbywa się głównie za pomocą dwóch typów:"
 
 #: src/concurrency/shared_state.md:6
 #, fuzzy
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1], referencja atomowa liczona `T`: obsługuje udostępnianie "
-"między wątkami i\n"
-"  dba o zwolnienie `T`, gdy ostatnie odwołanie zostanie usunięte,\n"
-"* [`Mutex<T>`][2]: zapewnia wzajemnie wykluczający się dostęp do wartości "
-"`T`."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), referencja "
+"atomowa liczona `T`: obsługuje udostępnianie między wątkami i dba o "
+"zwolnienie `T`, gdy ostatnie odwołanie zostanie usunięte,"
 
-#: src/concurrency/shared_state.md:10
+#: src/concurrency/shared_state.md:8
 #, fuzzy
 msgid ""
-"[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
 msgstr ""
-"[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): zapewnia "
+"wzajemnie wykluczający się dostęp do wartości `T`."
 
 #: src/concurrency/shared_state/arc.md:1
 #, fuzzy
-msgid "# `Arc`"
-msgstr "# `Łuk`"
+msgid "`Arc`"
+msgstr "`Łuk`"
 
 #: src/concurrency/shared_state/arc.md:3
 #, fuzzy
-msgid "[`Arc<T>`][1] allows shared read-only access via its `clone` method:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via its `clone` method:"
 msgstr ""
-"[`Arc<T>`][1] umożliwia współdzielony dostęp tylko do odczytu poprzez swoją "
-"metodę `clone`:"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) umożliwia "
+"współdzielony dostęp tylko do odczytu poprzez swoją metodę `clone`:"
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
 "```rust,editable\n"
 "use std::thread;\n"
-"use std::sync::Arc;"
+"use std::sync::Arc;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:9
 msgid ""
-"fn main() {\n"
-"    let v = Arc::new(vec![10, 20, 30]);\n"
-"    let mut handles = Vec::new();\n"
-"    for _ in 1..5 {\n"
-"        let v = v.clone();\n"
-"        handles.push(thread::spawn(move || {\n"
-"            let thread_id = thread::current().id();\n"
-"            println!(\"{thread_id:?}: {v:?}\");\n"
-"        }));\n"
-"    }"
+"fn main() { let v = Arc::new(vec![10, 20, 30\\]); let mut handles = Vec::"
+"new(); for _ in 1..5 { let v = v.clone(); handles.push(thread::spawn(move || "
+"{ let thread_id = thread::current().id(); println!(\"{thread_id:?}: "
+"{v:?}\"); })); }"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:20
 msgid ""
-"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
+"```\n"
+"handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"println!(\"v: {v:?}\");\n"
 "```"
 msgstr ""
-
-#: src/concurrency/shared_state/arc.md:25
-#, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-msgstr "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
 
 #: src/concurrency/shared_state/arc.md:29
 #, fuzzy
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
 msgstr ""
-"* `Arc` oznacza \"Atomic Reference Counted\", bezpieczną dla wątków wersję "
-"`Rc`, która wykorzystuje\n"
-"  operacje.\n"
-"* `Arc<T>` implementuje `Clone` niezależnie od tego, czy `T` to robi. "
-"Implementuje `Wyślij` i `Sync` iff `T`\n"
-"  realizuje je obie.\n"
-"* `Arc::clone()` ma koszt wykonania operacji atomowych, ale później użycie\n"
-"  `T` jest darmowe.\n"
-"* Uważaj na cykle referencyjne, `Arc` nie używa modułu wyrzucania elementów "
-"bezużytecznych do ich wykrywania.\n"
-"    * `std::sync::Weak` może pomóc."
+"`Arc` oznacza \"Atomic Reference Counted\", bezpieczną dla wątków wersję "
+"`Rc`, która wykorzystuje operacje."
+
+#: src/concurrency/shared_state/arc.md:31
+#, fuzzy
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+"`Arc<T>` implementuje `Clone` niezależnie od tego, czy `T` to robi. "
+"Implementuje `Wyślij` i `Sync` iff `T` realizuje je obie."
+
+#: src/concurrency/shared_state/arc.md:33
+#, fuzzy
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"`Arc::clone()` ma koszt wykonania operacji atomowych, ale później użycie `T` "
+"jest darmowe."
+
+#: src/concurrency/shared_state/arc.md:35
+#, fuzzy
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+"Uważaj na cykle referencyjne, `Arc` nie używa modułu wyrzucania elementów "
+"bezużytecznych do ich wykrywania."
+
+#: src/concurrency/shared_state/arc.md:36
+#, fuzzy
+msgid "`std::sync::Weak` can help."
+msgstr "`std::sync::Weak` może pomóc."
 
 #: src/concurrency/shared_state/mutex.md:1
 #, fuzzy
-msgid "# `Mutex`"
-msgstr "# `Mutex`"
+msgid "`Mutex`"
+msgstr "`Mutex`"
 
 #: src/concurrency/shared_state/mutex.md:3
 #, fuzzy
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
-"[`Mutex<T>`][1] zapewnia wzajemne wykluczanie _i_ umożliwia zmienny dostęp "
-"do `T`\n"
-"za interfejsem tylko do odczytu:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) zapewnia "
+"wzajemne wykluczanie _i_ umożliwia zmienny dostęp do `T` za interfejsem "
+"tylko do odczytu:"
 
 #: src/concurrency/shared_state/mutex.md:6
-msgid "```rust,editable\nuse std::sync::Mutex;"
+msgid ""
+"```rust,editable\n"
+"use std::sync::Mutex;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:9
 msgid ""
-"fn main() {\n"
-"    let v = Mutex::new(vec![10, 20, 30]);\n"
-"    println!(\"v: {:?}\", v.lock().unwrap());"
+"fn main() { let v = Mutex::new(vec![10, 20, 30\\]); println!(\"v: {:?}\", v."
+"lock().unwrap());"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:13
 msgid ""
-"    {\n"
-"        let mut guard = v.lock().unwrap();\n"
-"        guard.push(40);\n"
-"    }"
+"```\n"
+"{\n"
+"    let mut guard = v.lock().unwrap();\n"
+"    guard.push(40);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:18
 msgid ""
-"    println!(\"v: {:?}\", v.lock().unwrap());\n"
-"}\n"
+"```\n"
+"println!(\"v: {:?}\", v.lock().unwrap());\n"
 "```"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 #, fuzzy
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
-msgstr "Zauważ, że mamy koc [`impl<T:Send> Sync for Mutex<T>`][2].\nrealizacja."
+msgstr ""
+"Zauważ, że mamy koc [`impl<T:Send> Sync for Mutex<T>`](https://doc.rust-lang."
+"org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E). realizacja."
 
-#: src/concurrency/shared_state/mutex.md:25
+#: src/concurrency/shared_state/mutex.md:31
 #, fuzzy
 msgid ""
-"[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-"[2]: "
-"https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E\n"
-"[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
 msgstr ""
-"[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-"[2]: "
-"https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E\n"
-"[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+"`Mutex` w Rust wygląda jak kolekcja z tylko jednym elementem - chronionymi "
+"danymi."
 
-#: src/concurrency/shared_state/mutex.md:29
+#: src/concurrency/shared_state/mutex.md:32
 #, fuzzy
 msgid ""
-"<details>\n"
-"    \n"
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
 msgstr ""
-"<details>\n"
-"    \n"
-"* `Mutex` w Rust wygląda jak kolekcja z tylko jednym elementem - chronionymi "
-"danymi.\n"
-"    * Nie można zapomnieć o zdobyciu muteksu przed uzyskaniem dostępu do "
-"chronionych danych.\n"
-"* Możesz uzyskać `&mut T` z `&Mutex<T>`, biorąc blokadę. `MutexGuard` "
-"zapewnia, że\n"
-"  `&mut T` nie przetrwa utrzymywanej blokady.\n"
-"* `Mutex<T>` implementuje zarówno `Send`, jak i `Sync`, jeśli `T` "
-"implementuje `Send`.\n"
-"* Odpowiednik blokady odczytu i zapisu - `RwLock`.\n"
-"* Dlaczego `lock()` zwraca `Result`?\n"
-"    * Jeśli wątek, który zawierał `Mutex` wpadł w panikę, `Mutex` zostaje "
-"„zatruty”, aby zasygnalizować, że\n"
-"      chronione dane mogą być w niespójnym stanie. Wywołanie `lock()` na "
-"zatrutym muteksie\n"
-"      kończy się niepowodzeniem z błędem [`PoisonError`]. Możesz wywołać "
-"`into_inner()` w przypadku błędu, aby odzyskać dane\n"
-"      mimo wszystko."
+"Nie można zapomnieć o zdobyciu muteksu przed uzyskaniem dostępu do "
+"chronionych danych."
 
-#: src/concurrency/shared_state/mutex.md:43
+#: src/concurrency/shared_state/mutex.md:33
 #, fuzzy
 msgid ""
-"[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html  "
-"\n"
-"    \n"
-"</details>"
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
 msgstr ""
-"[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html\n"
-"    \n"
-"</details>"
+"Możesz uzyskać `&mut T` z `&Mutex<T>`, biorąc blokadę. `MutexGuard` "
+"zapewnia, że `&mut T` nie przetrwa utrzymywanej blokady."
+
+#: src/concurrency/shared_state/mutex.md:35
+#, fuzzy
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr ""
+"`Mutex<T>` implementuje zarówno `Send`, jak i `Sync`, jeśli `T` implementuje "
+"`Send`."
+
+#: src/concurrency/shared_state/mutex.md:36
+#, fuzzy
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "Odpowiednik blokady odczytu i zapisu - `RwLock`."
+
+#: src/concurrency/shared_state/mutex.md:37
+#, fuzzy
+msgid "Why does `lock()` return a `Result`? "
+msgstr "Dlaczego `lock()` zwraca `Result`?"
+
+#: src/concurrency/shared_state/mutex.md:38
+#, fuzzy
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"Jeśli wątek, który zawierał `Mutex` wpadł w panikę, `Mutex` zostaje "
+"„zatruty”, aby zasygnalizować, że chronione dane mogą być w niespójnym "
+"stanie. Wywołanie `lock()` na zatrutym muteksie kończy się niepowodzeniem z "
+"błędem [`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError."
+"html). Możesz wywołać `into_inner()` w przypadku błędu, aby odzyskać dane "
+"mimo wszystko."
 
 #: src/concurrency/shared_state/example.md:3
 #, fuzzy
@@ -14347,99 +14158,130 @@ msgstr "Zobaczmy `Arc` i `Mutex` w akcji:"
 msgid ""
 "```rust,editable,compile_fail\n"
 "use std::thread;\n"
-"// use std::sync::{Arc, Mutex};"
+"// use std::sync::{Arc, Mutex};\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:9
 msgid ""
-"fn main() {\n"
-"    let mut v = vec![10, 20, 30];\n"
-"    let handle = thread::spawn(|| {\n"
-"        v.push(10);\n"
-"    });\n"
-"    v.push(1000);"
+"fn main() { let mut v = vec![10, 20, 30\\]; let handle = thread::spawn(|| "
+"{ v.push(10); }); v.push(1000);"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:16
 msgid ""
-"    handle.join().unwrap();\n"
+"```\n"
+"handle.join().unwrap();\n"
+"println!(\"v: {v:?}\");\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:23
+msgid "Possible solution:"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:25
+msgid ""
+"```rust,editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:29
+msgid "fn main() { let v = Arc::new(Mutex::new(vec![10, 20, 30\\]));"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:32
+msgid ""
+"```\n"
+"let v2 = v.clone();\n"
+"let handle = thread::spawn(move || {\n"
+"    let mut v2 = v2.lock().unwrap();\n"
+"    v2.push(10);\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:38
+msgid ""
+"```\n"
+"{\n"
+"    let mut v = v.lock().unwrap();\n"
+"    v.push(1000);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:43
+msgid ""
+"```\n"
+"handle.join().unwrap();\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:45
+msgid ""
+"```\n"
+"{\n"
+"    let v = v.lock().unwrap();\n"
 "    println!(\"v: {v:?}\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:23
+#: src/concurrency/shared_state/example.md:50
 msgid ""
-"Possible solution:\n"
-"    \n"
-"```rust,editable\n"
-"use std::sync::{Arc, Mutex};\n"
-"use std::thread;"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:29
-msgid "fn main() {\n    let v = Arc::new(Mutex::new(vec![10, 20, 30]));"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:32
-msgid ""
-"    let v2 = v.clone();\n"
-"    let handle = thread::spawn(move || {\n"
-"        let mut v2 = v2.lock().unwrap();\n"
-"        v2.push(10);\n"
-"    });"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:38
-msgid ""
-"    {\n"
-"        let mut v = v.lock().unwrap();\n"
-"        v.push(1000);\n"
-"    }"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:43
-msgid "    handle.join().unwrap();"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:45
-msgid ""
-"    {\n"
-"        let v = v.lock().unwrap();\n"
-"        println!(\"v: {v:?}\");\n"
-"    }\n"
-"}\n"
 "```\n"
 "    \n"
-"Notable parts:"
+"Notable parts:\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:54
 #, fuzzy
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
-"possible.\n"
-"* We still need to acquire the `Mutex` to print our `Vec`."
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
 msgstr ""
-"* `v` jest opakowane zarówno w `Arc`, jak i `Mutex`, ponieważ ich "
-"zainteresowania są ortogonalne.\n"
-"  * Zawijanie `Mutex` w `Arc` to powszechny wzorzec udostępniania zmiennego "
-"stanu między wątkami.\n"
-"* `v: Arc<_>` musi zostać sklonowany jako `v2` zanim będzie można go "
-"przenieść do innego wątku. Uwaga: do sygnatury lambda dodano słowo „move”.\n"
-"* Blokady są wprowadzane w celu maksymalnego zawężenia zakresu `LockGuard`.\n"
-"* Nadal musimy zdobyć `Mutex`, aby wydrukować nasz `Vec`."
+"`v` jest opakowane zarówno w `Arc`, jak i `Mutex`, ponieważ ich "
+"zainteresowania są ortogonalne."
+
+#: src/concurrency/shared_state/example.md:55
+#, fuzzy
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+"Zawijanie `Mutex` w `Arc` to powszechny wzorzec udostępniania zmiennego "
+"stanu między wątkami."
+
+#: src/concurrency/shared_state/example.md:56
+#, fuzzy
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+"`v: Arc<_>` musi zostać sklonowany jako `v2` zanim będzie można go przenieść "
+"do innego wątku. Uwaga: do sygnatury lambda dodano słowo „move”."
+
+#: src/concurrency/shared_state/example.md:57
+#, fuzzy
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible."
+msgstr ""
+"Blokady są wprowadzane w celu maksymalnego zawężenia zakresu `LockGuard`."
+
+#: src/concurrency/shared_state/example.md:58
+#, fuzzy
+msgid "We still need to acquire the `Mutex` to print our `Vec`."
+msgstr "Nadal musimy zdobyć `Mutex`, aby wydrukować nasz `Vec`."
 
 #: src/concurrency/send-sync.md:1
 #, fuzzy
-msgid "# `Send` and `Sync`"
-msgstr "# `Wyślij` i `Synchronizacja`"
+msgid "`Send` and `Sync`"
+msgstr "`Wyślij` i `Synchronizacja`"
 
 #: src/concurrency/send-sync.md:3
 #, fuzzy
@@ -14453,108 +14295,86 @@ msgstr ""
 #: src/concurrency/send-sync.md:5
 #, fuzzy
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [`Wyślij`][1]: typ `T` to `Wyślij`, jeśli bezpieczne jest przeniesienie "
-"`T` w wątku\n"
-"  granica.\n"
-"* [`Sync`][2]: typ `T` to `Sync`, jeśli bezpieczne jest przeniesienie `&T` w "
-"wątku\n"
-"  granica."
+"[`Wyślij`](https://doc.rust-lang.org/std/marker/trait.Send.html): typ `T` to "
+"`Wyślij`, jeśli bezpieczne jest przeniesienie `T` w wątku granica."
+
+#: src/concurrency/send-sync.md:7
+#, fuzzy
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): typ `T` to "
+"`Sync`, jeśli bezpieczne jest przeniesienie `&T` w wątku granica."
 
 #: src/concurrency/send-sync.md:10
 #, fuzzy
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
-"`Wyślij` i `Synchronizacja` to [niebezpieczne cechy][3]. Kompilator "
-"automatycznie wyprowadzi je dla twoich typów\n"
-"o ile zawierają tylko typy `Send` i `Sync`. Możesz także zaimplementować je "
-"ręcznie, gdy ty\n"
+"`Wyślij` i `Synchronizacja` to [niebezpieczne cechy](../unsafe/unsafe-traits."
+"md). Kompilator automatycznie wyprowadzi je dla twoich typów o ile zawierają "
+"tylko typy `Send` i `Sync`. Możesz także zaimplementować je ręcznie, gdy ty "
 "wiedzieć, że jest ważny."
-
-#: src/concurrency/send-sync.md:14
-#, fuzzy
-msgid ""
-"[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
-"[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
-"[3]: ../unsafe/unsafe-traits.md"
-msgstr ""
-"[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
-"[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
-"[3]: ../unsafe/unsafe-traits.md"
 
 #: src/concurrency/send-sync.md:20
 #, fuzzy
 msgid ""
-"* One can think of these traits as markers that the type has certain "
-"thread-safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  \n"
-"</details>"
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr ""
-"* Można myśleć o tych cechach jako o znacznikach, że typ ma pewne "
-"właściwości bezpieczeństwa wątków.\n"
-"* Mogą być używane w ogólnych ograniczeniach jako normalne cechy.\n"
-"  \n"
-"</details>"
+"Można myśleć o tych cechach jako o znacznikach, że typ ma pewne właściwości "
+"bezpieczeństwa wątków."
+
+#: src/concurrency/send-sync.md:21
+#, fuzzy
+msgid "They can be used in the generic constraints as normal traits."
+msgstr "Mogą być używane w ogólnych ograniczeniach jako normalne cechy."
 
 #: src/concurrency/send-sync/send.md:1
 #, fuzzy
-msgid "# `Send`"
-msgstr "# `Wyślij`"
+msgid "`Send`"
+msgstr "`Wyślij`"
 
 #: src/concurrency/send-sync/send.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
-"> Typ `T` to [`Send`][1], jeśli przeniesienie wartości `T` do innego wątku "
-"jest bezpieczne."
+"Typ `T` to [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html), "
+"jeśli przeniesienie wartości `T` do innego wątku jest bezpieczne."
 
 #: src/concurrency/send-sync/send.md:5
 #, fuzzy
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 "Efektem przeniesienia własności do innego wątku jest uruchomienie "
-"_destruktorów_\n"
-"w tym wątku. Pytanie brzmi, kiedy można przydzielić wartość w jednym wątku\n"
-"i zwolnij go w innym."
-
-#: src/concurrency/send-sync/send.md:9
-#, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
+"_destruktorów_ w tym wątku. Pytanie brzmi, kiedy można przydzielić wartość w "
+"jednym wątku i zwolnij go w innym."
 
 #: src/concurrency/send-sync/sync.md:1
 #, fuzzy
-msgid "# `Sync`"
-msgstr "# `Synchronizacja`"
+msgid "`Sync`"
+msgstr "`Synchronizacja`"
 
 #: src/concurrency/send-sync/sync.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"> Typ `T` to [`Sync`][1], jeśli dostęp do wartości `T` z wielu\n"
-"> wątków jednocześnie."
+"Typ `T` to [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html), "
+"jeśli dostęp do wartości `T` z wielu wątków jednocześnie."
 
 #: src/concurrency/send-sync/sync.md:6
 #, fuzzy
@@ -14563,13 +14383,8 @@ msgstr "Dokładniej, definicja brzmi:"
 
 #: src/concurrency/send-sync/sync.md:8
 #, fuzzy
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
-msgstr "> `T` to `Sync` wtedy i tylko wtedy, gdy `&T` to `Wyślij`"
-
-#: src/concurrency/send-sync/sync.md:10
-#, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
-msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
+msgstr "`T` to `Sync` wtedy i tylko wtedy, gdy `&T` to `Wyślij`"
 
 #: src/concurrency/send-sync/sync.md:14
 #, fuzzy
@@ -14598,15 +14413,10 @@ msgstr ""
 "wątku, ponieważ do danych, do których się odwołuje, można bezpiecznie "
 "uzyskać dostęp z dowolnego wątku."
 
-#: src/concurrency/send-sync/examples.md:1
-#, fuzzy
-msgid "# Examples"
-msgstr "# Przykłady"
-
 #: src/concurrency/send-sync/examples.md:3
 #, fuzzy
-msgid "## `Send + Sync`"
-msgstr "## `Wyślij + synchronizuj`"
+msgid "`Send + Sync`"
+msgstr "`Wyślij + synchronizuj`"
 
 #: src/concurrency/send-sync/examples.md:5
 #, fuzzy
@@ -14614,61 +14424,81 @@ msgid "Most types you come across are `Send + Sync`:"
 msgstr "Większość spotykanych typów to `Wyślij + synchronizuj`:"
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 #, fuzzy
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
-"Typy ogólne to zazwyczaj `Wyślij + synchronizacja`, gdy są to parametry "
-"typu\n"
+"Typy ogólne to zazwyczaj `Wyślij + synchronizacja`, gdy są to parametry typu "
 "`Wyślij + synchronizuj`."
 
 #: src/concurrency/send-sync/examples.md:17
 #, fuzzy
-msgid "## `Send + !Sync`"
-msgstr "## `Wyślij +!Synchronizacja`"
+msgid "`Send + !Sync`"
+msgstr "`Wyślij +!Synchronizacja`"
 
 #: src/concurrency/send-sync/examples.md:19
 #, fuzzy
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 "Te typy można przenosić do innych wątków, ale nie są one bezpieczne dla "
-"wątków.\n"
-"Zazwyczaj z powodu wewnętrznej zmienności:"
+"wątków. Zazwyczaj z powodu wewnętrznej zmienności:"
 
 #: src/concurrency/send-sync/examples.md:22
 #, fuzzy
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Nadawca<T>`\n"
-"* `mpsc::Odbiornik<T>`\n"
-"* `Komórka<T>`\n"
-"* `RefKomórka<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Nadawca<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+#, fuzzy
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Odbiornik<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+#, fuzzy
+msgid "`Cell<T>`"
+msgstr "`Komórka<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+#, fuzzy
+msgid "`RefCell<T>`"
+msgstr "`RefKomórka<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
 #, fuzzy
-msgid "## `!Send + Sync`"
-msgstr "## `!Wyślij + synchronizuj`"
+msgid "`!Send + Sync`"
+msgstr "`!Wyślij + synchronizuj`"
 
 #: src/concurrency/send-sync/examples.md:29
 #, fuzzy
-msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgid ""
+"These types are thread-safe, but they cannot be moved to another thread:"
 msgstr ""
 "Te typy są bezpieczne dla wątków, ale nie można ich przenieść do innego "
 "wątku:"
@@ -14676,18 +14506,16 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:31
 #, fuzzy
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
-"* `MutexGuard<T>`: Używa prymitywów na poziomie systemu operacyjnego, które "
-"muszą zostać zwolnione na\n"
-"  wątek, który je stworzył."
+"`MutexGuard<T>`: Używa prymitywów na poziomie systemu operacyjnego, które "
+"muszą zostać zwolnione na wątek, który je stworzył."
 
 #: src/concurrency/send-sync/examples.md:34
 #, fuzzy
-msgid "## `!Send + !Sync`"
-msgstr "## `!Wyślij + !Sync`"
+msgid "`!Send + !Sync`"
+msgstr "`!Wyślij + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:36
 #, fuzzy
@@ -14699,21 +14527,20 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:38
 #, fuzzy
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
-"* `Rc<T>`: każdy `Rc<T>` ma odniesienie do `RcBox<T>`, który zawiera\n"
-"  nieatomowa liczba referencji.\n"
-"* `*const T`, `*mut T`: Rust zakłada, że surowe wskaźniki mogą mieć "
-"specjalne\n"
-"  względy współbieżności."
+"`Rc<T>`: każdy `Rc<T>` ma odniesienie do `RcBox<T>`, który zawiera "
+"nieatomowa liczba referencji."
 
-#: src/exercises/day-4/morning.md:1 src/exercises/day-4/afternoon.md:1
+#: src/concurrency/send-sync/examples.md:40
 #, fuzzy
-msgid "# Exercises"
-msgstr "# Ćwiczenia"
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr ""
+"`*const T`, `*mut T`: Rust zakłada, że surowe wskaźniki mogą mieć specjalne "
+"względy współbieżności."
 
 #: src/exercises/day-4/morning.md:3
 #, fuzzy
@@ -14722,23 +14549,17 @@ msgstr "Przećwiczmy nasze nowe umiejętności współbieżności z"
 
 #: src/exercises/day-4/morning.md:5
 #, fuzzy
-msgid "* Dining philosophers: a classic problem in concurrency."
-msgstr "* Filozofowie jadalni: klasyczny problem współbieżności."
+msgid "Dining philosophers: a classic problem in concurrency."
+msgstr "Filozofowie jadalni: klasyczny problem współbieżności."
 
 #: src/exercises/day-4/morning.md:7
 #, fuzzy
 msgid ""
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
 msgstr ""
-"* Wielowątkowe narzędzie do sprawdzania linków: większy projekt, do którego "
-"użyjesz Cargo\n"
-"  pobierz zależności, a następnie sprawdź linki równolegle."
-
-#: src/exercises/day-4/dining-philosophers.md:1
-#, fuzzy
-msgid "# Dining Philosophers"
-msgstr "# Filozofowie jedzenia"
+"Wielowątkowe narzędzie do sprawdzania linków: większy projekt, do którego "
+"użyjesz Cargo pobierz zależności, a następnie sprawdź linki równolegle."
 
 #: src/exercises/day-4/dining-philosophers.md:3
 #, fuzzy
@@ -14748,43 +14569,33 @@ msgstr "Problem filozofów jadalni jest klasycznym problemem współbieżności:
 #: src/exercises/day-4/dining-philosophers.md:5
 #, fuzzy
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
-"> Pięciu filozofów je razem przy jednym stole. Każdy filozof ma swoje\n"
-"> własne miejsce przy stole. Pomiędzy każdym talerzem znajduje się widelec. "
-"Serwowane danie to\n"
-"> rodzaj spaghetti, które trzeba jeść dwoma widelcami. Każdy filozof może\n"
-"> tylko na przemian myśleć i jeść. Co więcej, filozof może jeść tylko ich\n"
-"> spaghetti, gdy mają lewy i prawy widelec. Tak więc tylko dwa widelce\n"
-"> być dostępnym, gdy dwaj najbliżsi sąsiedzi myślą, a nie jedzą. Po\n"
-"> pojedynczy filozof skończy jeść, odłoży oba widelce."
+"Pięciu filozofów je razem przy jednym stole. Każdy filozof ma swoje własne "
+"miejsce przy stole. Pomiędzy każdym talerzem znajduje się widelec. Serwowane "
+"danie to rodzaj spaghetti, które trzeba jeść dwoma widelcami. Każdy filozof "
+"może tylko na przemian myśleć i jeść. Co więcej, filozof może jeść tylko ich "
+"spaghetti, gdy mają lewy i prawy widelec. Tak więc tylko dwa widelce być "
+"dostępnym, gdy dwaj najbliżsi sąsiedzi myślą, a nie jedzą. Po pojedynczy "
+"filozof skończy jeść, odłoży oba widelce."
 
 #: src/exercises/day-4/dining-philosophers.md:13
 #, fuzzy
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to `src/main.rs` file, fill out the "
-"blanks,\n"
-"and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to `src/main.rs` file, fill out the "
+"blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
-"Będziesz potrzebować lokalnej [instalacji "
-"Cargo](../../cargo/running-locally.md) dla\n"
-"to ćwiczenie. Skopiuj poniższy kod do pliku `src/main.rs`, wypełnij puste "
-"pola,\n"
-"i sprawdź, czy `cargo run` nie powoduje impasu:"
+"Będziesz potrzebować lokalnej [instalacji Cargo](../../cargo/running-locally."
+"md) dla to ćwiczenie. Skopiuj poniższy kod do pliku `src/main.rs`, wypełnij "
+"puste pola, i sprawdź, czy `cargo run` nie powoduje impasu:"
 
 #: src/exercises/day-4/dining-philosophers.md:17
 msgid ""
@@ -14792,109 +14603,103 @@ msgid ""
 "use std::sync::mpsc;\n"
 "use std::sync::{Arc, Mutex};\n"
 "use std::thread;\n"
-"use std::time::Duration;"
+"use std::time::Duration;\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-4/dining-philosophers.md:23 src/exercises/day-4/solutions-morning.md:28
+#: src/exercises/day-4/dining-philosophers.md:23
+#: src/exercises/day-4/solutions-morning.md:28
 msgid "struct Fork;"
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:25
 #, fuzzy
 msgid ""
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // left_fork: ...\n"
-"    // right_fork: ...\n"
-"    // thoughts: ...\n"
-"}"
+"struct Philosopher { name: String, // left_fork: ... // right_fork: ... // "
+"thoughts: ... }"
 msgstr ""
-"struktura Filozof {\n"
-"    imię: Ciąg,\n"
-"    // lewy_fork: ...\n"
-"    // widelec_w prawo: ...\n"
-"    // myśli: ...\n"
-"}"
+"struktura Filozof { imię: Ciąg, // lewy_fork: ... // widelec_w prawo: ... // "
+"myśli: ... }"
 
 #: src/exercises/day-4/dining-philosophers.md:32
 msgid ""
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }"
+"impl Philosopher { fn think(&self) { self.thoughts .send(format!(\"Eureka! "
+"{} has a new idea!\", &self.name)) .unwrap(); }"
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:39
 msgid ""
-"    fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:46 src/exercises/day-4/solutions-morning.md:60
-msgid ""
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];"
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:49
-#, fuzzy
-msgid "fn main() {\n    // Create forks"
-msgstr "fn main() {\n    // Utwórz rozwidlenia"
-
-#: src/exercises/day-4/dining-philosophers.md:52
-#, fuzzy
-msgid "    // Create philosophers"
-msgstr "    // Twórz filozofów"
-
-#: src/exercises/day-4/dining-philosophers.md:54
-#, fuzzy
-msgid "    // Make them think and eat"
-msgstr "    // Niech myślą i jedzą"
-
-#: src/exercises/day-4/dining-philosophers.md:56
-msgid ""
-"    // Output their thoughts\n"
+"```\n"
+"fn eat(&self) {\n"
+"    // Pick up forks...\n"
+"    println!(\"{} is eating...\", &self.name);\n"
+"    thread::sleep(Duration::from_millis(10));\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/exercises/day-4/link-checker.md:1
+#: src/exercises/day-4/dining-philosophers.md:46
+#: src/exercises/day-4/solutions-morning.md:60
+msgid ""
+"static PHILOSOPHERS: &\\[&str\\] = &\\[\"Socrates\", \"Plato\", "
+"\"Aristotle\", \"Thales\", \"Pythagoras\"\\];"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:49
 #, fuzzy
-msgid "# Multi-threaded Link Checker"
-msgstr "# Wielowątkowe narzędzie do sprawdzania linków"
+msgid "fn main() { // Create forks"
+msgstr "fn main() { // Utwórz rozwidlenia"
+
+#: src/exercises/day-4/dining-philosophers.md:52
+#, fuzzy
+msgid ""
+"```\n"
+"// Create philosophers\n"
+"```"
+msgstr ""
+"```\n"
+"// Twórz filozofów\n"
+"```"
+
+#: src/exercises/day-4/dining-philosophers.md:54
+#, fuzzy
+msgid ""
+"```\n"
+"// Make them think and eat\n"
+"```"
+msgstr ""
+"```\n"
+"// Niech myślą i jedzą\n"
+"```"
+
+#: src/exercises/day-4/dining-philosophers.md:56
+msgid ""
+"```\n"
+"// Output their thoughts\n"
+"```"
+msgstr ""
 
 #: src/exercises/day-4/link-checker.md:3
 #, fuzzy
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 "Wykorzystajmy naszą nową wiedzę do stworzenia wielowątkowego narzędzia do "
-"sprawdzania linków. Powinno\n"
-"zacznij od strony internetowej i sprawdź, czy linki na stronie są "
-"prawidłowe. Powinno\n"
-"rekurencyjnie sprawdzaj inne strony w tej samej domenie i rób to, aż "
-"wszystkie\n"
-"strony zostały zweryfikowane."
+"sprawdzania linków. Powinno zacznij od strony internetowej i sprawdź, czy "
+"linki na stronie są prawidłowe. Powinno rekurencyjnie sprawdzaj inne strony "
+"w tej samej domenie i rób to, aż wszystkie strony zostały zweryfikowane."
 
 #: src/exercises/day-4/link-checker.md:8
 #, fuzzy
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
-"Do tego potrzebny będzie klient HTTP, taki jak [`reqwest`][1]. Stwórz nowy\n"
-"Projekt Cargo i `reqwest` jako zależność z:"
+"Do tego potrzebny będzie klient HTTP, taki jak [`reqwest`](https://docs.rs/"
+"reqwest/). Stwórz nowy Projekt Cargo i `reqwest` jako zależność z:"
 
 #: src/exercises/day-4/link-checker.md:11
 msgid ""
@@ -14908,21 +14713,21 @@ msgstr ""
 #: src/exercises/day-4/link-checker.md:17
 #, fuzzy
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
-"> Jeśli polecenie `cargo add` nie powiedzie się z komunikatem `error: no "
-"such subcommand`, edytuj\n"
-"> Plik `Cargo.toml` ręcznie. Dodaj zależności wymienione poniżej."
+"Jeśli polecenie `cargo add` nie powiedzie się z komunikatem `error: no such "
+"subcommand`, edytuj Plik `Cargo.toml` ręcznie. Dodaj zależności wymienione "
+"poniżej."
 
 #: src/exercises/day-4/link-checker.md:20
 #, fuzzy
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 "Będziesz także potrzebował sposobu na znalezienie linków. Możemy do tego "
-"użyć [`scraper`][2]:"
+"użyć [`scraper`](https://docs.rs/scraper/):"
 
 #: src/exercises/day-4/link-checker.md:22
 msgid ""
@@ -14934,13 +14739,11 @@ msgstr ""
 #: src/exercises/day-4/link-checker.md:26
 #, fuzzy
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 "Na koniec będziemy potrzebować jakiegoś sposobu obsługi błędów. Używamy "
-"[`thiserror`][3] dla\n"
-"To:"
+"[`thiserror`](https://docs.rs/thiserror/) dla To:"
 
 #: src/exercises/day-4/link-checker.md:29
 msgid ""
@@ -14961,8 +14764,8 @@ msgstr ""
 msgid ""
 "```toml\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] "
-"}\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -14971,10 +14774,10 @@ msgstr ""
 #: src/exercises/day-4/link-checker.md:42
 #, fuzzy
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
-"Możesz teraz pobrać stronę startową. Spróbuj z małą witryną, taką jak\n"
+"Możesz teraz pobrać stronę startową. Spróbuj z małą witryną, taką jak "
 "`https://www.google.org/`."
 
 #: src/exercises/day-4/link-checker.md:45
@@ -14988,64 +14791,64 @@ msgid ""
 "use reqwest::blocking::{get, Response};\n"
 "use reqwest::Url;\n"
 "use scraper::{Html, Selector};\n"
-"use thiserror::Error;"
+"use thiserror::Error;\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:53
 msgid ""
-"#[derive(Error, Debug)]\n"
-"enum Error {\n"
-"    #[error(\"request error: {0}\")]\n"
-"    ReqwestError(#[from] reqwest::Error),\n"
-"}"
+"\\#\\[derive(Error, Debug)\\] enum Error { \\#\\[error(\"request error: "
+"{0}\")\\] ReqwestError(#\\[from\\] reqwest::Error), }"
 msgstr ""
-"#[derive(Error, Debug)]\n"
-"enum Error {\n"
-"    #[error(\"błąd zapytania: {0}\")]\n"
-"    ReqwestError(#[from] reqwest::Error),\n"
-"}"
+"\\#\\[derive(Error, Debug)\\] enum Error { \\#\\[error(\"błąd zapytania: "
+"{0}\")\\] ReqwestError(#\\[from\\] reqwest::Error), }"
+
+#: src/exercises/day-4/link-checker.md:59
+msgid "fn extract_links(response: Response) -> Result\\<Vec"
+msgstr ""
 
 #: src/exercises/day-4/link-checker.md:59
 msgid ""
-"fn extract_links(response: Response) -> Result<Vec<Url>, Error> {\n"
-"    let base_url = response.url().to_owned();\n"
-"    let document = response.text()?;\n"
-"    let html = Html::parse_document(&document);\n"
-"    let selector = Selector::parse(\"a\").unwrap();"
+", Error> { let base_url = response.url().to_owned(); let document = response."
+"text()?; let html = Html::parse_document(&document); let selector = "
+"Selector::parse(\"a\").unwrap();"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:65
 msgid ""
-"    let mut valid_urls = Vec::new();\n"
-"    for element in html.select(&selector) {\n"
-"        if let Some(href) = element.value().attr(\"href\") {\n"
-"            match base_url.join(href) {\n"
-"                Ok(url) => valid_urls.push(url),\n"
-"                Err(err) => {\n"
-"                    println!(\"On {base_url}: could not parse {href:?}: "
-"{err} (ignored)\",);\n"
-"                }\n"
+"```\n"
+"let mut valid_urls = Vec::new();\n"
+"for element in html.select(&selector) {\n"
+"    if let Some(href) = element.value().attr(\"href\") {\n"
+"        match base_url.join(href) {\n"
+"            Ok(url) => valid_urls.push(url),\n"
+"            Err(err) => {\n"
+"                println!(\"On {base_url}: could not parse {href:?}: {err} "
+"(ignored)\",);\n"
 "            }\n"
 "        }\n"
-"    }"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:77
 #, fuzzy
-msgid "    Ok(valid_urls)\n}"
-msgstr "    OK (prawidłowe_adresy URL)\n}"
+msgid ""
+"```\n"
+"Ok(valid_urls)\n"
+"```"
+msgstr ""
+"```\n"
+"OK (prawidłowe_adresy URL)\n"
+"```"
 
 #: src/exercises/day-4/link-checker.md:80
 msgid ""
-"fn main() {\n"
-"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
-"    let response = get(start_url).unwrap();\n"
-"    match extract_links(response) {\n"
-"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
-"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let start_url = Url::parse(\"https://www.google.org\").unwrap(); "
+"let response = get(start_url).unwrap(); match extract_links(response) "
+"{ Ok(links) => println!(\"Links: {links:#?}\"), Err(err) => println!(\"Could "
+"not extract links: {err:#}\"), } }"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:90
@@ -15063,72 +14866,49 @@ msgstr "Korzystanie z Cargo"
 
 #: src/exercises/day-4/link-checker.md:96
 #, fuzzy
-msgid "## Tasks"
-msgstr "## Zadania"
+msgid "Tasks"
+msgstr "Zadania"
 
 #: src/exercises/day-4/link-checker.md:98
 #, fuzzy
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
 msgstr ""
-"* Używaj wątków do równoległego sprawdzania linków: wyślij adresy URL do "
-"sprawdzenia do a\n"
-"  channel i pozwól kilku wątkom równolegle sprawdzać adresy URL.\n"
-"* Rozszerz to, aby rekurencyjnie wyodrębnić linki ze wszystkich stron w "
-"witrynie\n"
-"  domena `www.google.org`. Ustaw górny limit 100 stron lub tak, abyś mógł\n"
-"  nie zostań zablokowany przez witrynę."
+"Używaj wątków do równoległego sprawdzania linków: wyślij adresy URL do "
+"sprawdzenia do a channel i pozwól kilku wątkom równolegle sprawdzać adresy "
+"URL."
 
-#: src/exercises/day-4/link-checker.md:104
+#: src/exercises/day-4/link-checker.md:100
 #, fuzzy
 msgid ""
-"[1]: https://docs.rs/reqwest/\n"
-"[2]: https://docs.rs/scraper/\n"
-"[3]: https://docs.rs/thiserror/"
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
-"[1]: https://docs.rs/reqwest/\n"
-"[2]: https://docs.rs/scraper/\n"
-"[3]: https://docs.rs/thiserror/"
-
-#: src/android.md:1
-#, fuzzy
-msgid "# Android"
-msgstr "# Androida"
+"Rozszerz to, aby rekurencyjnie wyodrębnić linki ze wszystkich stron w "
+"witrynie domena `www.google.org`. Ustaw górny limit 100 stron lub tak, abyś "
+"mógł nie zostań zablokowany przez witrynę."
 
 #: src/android.md:3
 #, fuzzy
 msgid ""
 "Rust is supported for native platform development on Android. This means "
-"that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 "Rust jest obsługiwany w przypadku tworzenia natywnych platform na Androida. "
-"To znaczy że\n"
-"możesz pisać nowe usługi systemu operacyjnego w Rust, a także rozszerzać\n"
-"istniejące usługi."
-
-#: src/android/setup.md:1
-#, fuzzy
-msgid "# Setup"
-msgstr "# Organizować coś"
+"To znaczy że możesz pisać nowe usługi systemu operacyjnego w Rust, a także "
+"rozszerzać istniejące usługi."
 
 #: src/android/setup.md:3
 #, fuzzy
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
-"have\n"
-"access to one or create a new one with:"
+"have access to one or create a new one with:"
 msgstr ""
 "Będziemy używać urządzenia wirtualnego z Androidem do testowania naszego "
-"kodu. Upewnij się że masz\n"
-"dostęp do jednego lub utwórz nowy z:"
+"kodu. Upewnij się że masz dostęp do jednego lub utwórz nowy z:"
 
 #: src/android/setup.md:6
 msgid ""
@@ -15142,17 +14922,11 @@ msgstr ""
 #: src/android/setup.md:12
 #, fuzzy
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-"Zobacz [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start), aby uzyskać "
-"szczegółowe informacje."
-
-#: src/android/build-rules.md:1
-#, fuzzy
-msgid "# Build Rules"
-msgstr "# Reguły budowania"
+"Zobacz [Android Developer Codelab](https://source.android.com/docs/setup/"
+"start), aby uzyskać szczegółowe informacje."
 
 #: src/android/build-rules.md:3
 #, fuzzy
@@ -15163,44 +14937,112 @@ msgstr ""
 
 #: src/android/build-rules.md:5
 #, fuzzy
-msgid ""
-"| Module Type       | Description                                            "
-"                                            |\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust binary.                                "
-"                                            |\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
-"`dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
-"provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
-"analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard "
-"Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging `libfuzzer`.    "
-"                                            |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that "
-"provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library "
-"containing Rust bindings to C libraries.              |"
+msgid "Module Type"
+msgstr "Typ modułu"
+
+#: src/android/build-rules.md:5
+#, fuzzy
+msgid "Description"
+msgstr "Opis"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "`rust_binary`"
+msgstr "`rust_binary`"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "Produces a Rust binary."
+msgstr "Tworzy plik binarny Rust."
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "`rust_library`"
+msgstr "`rust_biblioteka`"
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
 msgstr ""
-"| Typ modułu | Opis |\n"
-"|-------------------|-------------- "
-"-------------------------------------------------- ---------------------|\n"
-"| `rust_binary` | Tworzy plik binarny Rust. |\n"
-"| `rust_biblioteka` | Tworzy bibliotekę Rust i udostępnia zarówno warianty "
-"`rlib`, jak i `dylib`. |\n"
-"| `rust_ffi` | Tworzy bibliotekę Rust C używaną przez moduły `cc` i zapewnia "
-"zarówno statyczne, jak i współdzielone warianty. |\n"
-"| `rust_proc_macro` | Tworzy bibliotekę `proc-macro` Rusta. Są one "
-"analogiczne do wtyczek kompilatora. |\n"
-"| `test_rdzy` | Tworzy plik binarny testu Rust, który używa standardowej "
-"wiązki testowej Rust. |\n"
-"| `rust_fuzz` | Tworzy plik binarny Rust fuzz wykorzystujący `libfuzzer`. |\n"
-"| `rust_protobuf` | Generuje źródło i tworzy bibliotekę Rust, która zapewnia "
-"interfejs dla określonego protobuf. |\n"
-"| `rdza_powiązanie` | Generuje źródło i tworzy bibliotekę Rust zawierającą "
-"powiązania Rusta z bibliotekami C. |"
+"Tworzy bibliotekę Rust i udostępnia zarówno warianty `rlib`, jak i `dylib`."
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid "`rust_ffi`"
+msgstr "`rust_ffi`"
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid ""
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+"Tworzy bibliotekę Rust C używaną przez moduły `cc` i zapewnia zarówno "
+"statyczne, jak i współdzielone warianty."
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid "`rust_proc_macro`"
+msgstr "`rust_proc_macro`"
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+"Tworzy bibliotekę `proc-macro` Rusta. Są one analogiczne do wtyczek "
+"kompilatora."
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "`rust_test`"
+msgstr "`test_rdzy`"
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+"Tworzy plik binarny testu Rust, który używa standardowej wiązki testowej "
+"Rust."
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "`rust_fuzz`"
+msgstr "`rust_fuzz`"
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr "Tworzy plik binarny Rust fuzz wykorzystujący `libfuzzer`."
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid "`rust_protobuf`"
+msgstr "`rust_protobuf`"
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+"Generuje źródło i tworzy bibliotekę Rust, która zapewnia interfejs dla "
+"określonego protobuf."
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid "`rust_bindgen`"
+msgstr "`rdza_powiązanie`"
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr ""
+"Generuje źródło i tworzy bibliotekę Rust zawierającą powiązania Rusta z "
+"bibliotekami C."
 
 #: src/android/build-rules.md:16
 #, fuzzy
@@ -15208,17 +15050,16 @@ msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr "Następnie przyjrzymy się `rust_binary` i `rust_library`."
 
 #: src/android/build-rules/binary.md:1
-msgid "# Rust Binaries"
-msgstr "# Binaria Rusta"
+msgid "Rust Binaries"
+msgstr "Binaria Rusta"
 
 #: src/android/build-rules/binary.md:3
 #, fuzzy
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr ""
-"Zacznijmy od prostej aplikacji. W katalogu głównym kasy AOSP utwórz\n"
+"Zacznijmy od prostej aplikacji. W katalogu głównym kasy AOSP utwórz "
 "następujące pliki:"
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
@@ -15242,16 +15083,19 @@ msgid "_hello_rust/src/main.rs_:"
 msgstr "_hello_rust/src/main.rs_:"
 
 #: src/android/build-rules/binary.md:18
-msgid "```rust\n//! Rust demo."
-msgstr "```rust\n//! Rust demo."
+msgid ""
+"```rust\n"
+"//! Rust demo.\n"
+"```"
+msgstr ""
+"```rust\n"
+"//! Rust demo.\n"
+"```"
 
 #: src/android/build-rules/binary.md:21
 msgid ""
-"/// Prints a greeting to standard output.\n"
-"fn main() {\n"
-"    println!(\"Hello from Rust!\");\n"
-"}\n"
-"```"
+"/// Prints a greeting to standard output. fn main() { println!(\"Hello from "
+"Rust!\"); }"
 msgstr ""
 
 #: src/android/build-rules/binary.md:27
@@ -15270,13 +15114,14 @@ msgid ""
 msgstr ""
 
 #: src/android/build-rules/library.md:1
-msgid "# Rust Libraries"
-msgstr "# Biblioteki Rusta"
+msgid "Rust Libraries"
+msgstr "Biblioteki Rusta"
 
 #: src/android/build-rules/library.md:3
 #, fuzzy
 msgid "You use `rust_library` to create a new Rust library for Android."
-msgstr "Używasz `rust_library` do tworzenia nowej biblioteki Rust dla Androida."
+msgstr ""
+"Używasz `rust_library` do tworzenia nowej biblioteki Rust dla Androida."
 
 #: src/android/build-rules/library.md:5
 #, fuzzy
@@ -15285,23 +15130,19 @@ msgstr "Tutaj deklarujemy zależność od dwóch bibliotek:"
 
 #: src/android/build-rules/library.md:7
 #, fuzzy
-msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
-msgstr ""
-"* `libgreeting`, które definiujemy poniżej,\n"
-"* `libtextwrap`, która jest już sprzedawaną skrzynką\n"
-"  [`zewnętrzne/rdza/skrzynie/`][skrzynie]."
+msgid "`libgreeting`, which we define below,"
+msgstr "`libgreeting`, które definiujemy poniżej,"
 
-#: src/android/build-rules/library.md:11
+#: src/android/build-rules/library.md:8
 #, fuzzy
 msgid ""
-"[crates]: "
-"https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/"
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"[skrzynie]: "
-"https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/"
+"`libtextwrap`, która jest już sprzedawaną skrzynką [`zewnętrzne/rdza/"
+"skrzynie/`](https://cs.android.com/android/platform/superproject/+/master:"
+"external/rust/crates/)."
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -15315,34 +15156,80 @@ msgid ""
 "        \"libtextwrap\",\n"
 "    ],\n"
 "    prefer_rlib: true,\n"
-"}"
-msgstr ""
-
-#: src/android/build-rules/library.md:27
-msgid ""
-"rust_library {\n"
-"    name: \"libgreetings\",\n"
-"    crate_name: \"greetings\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/android/build-rules/library.md:36
-msgid "```rust,ignore\n//! Rust demo."
-msgstr "```rust,ignore\n//! Rust demo."
-
-#: src/android/build-rules/library.md:39
-msgid "use greetings::greeting;\nuse textwrap::fill;"
+#: src/android/build-rules/library.md:27
+msgid ""
+"rust_library { name: \"libgreetings\", crate_name: \"greetings\", srcs: "
+"\\[\"src/lib.rs\"\\], }"
 msgstr ""
 
-#: src/android/build-rules/library.md:42
+#: src/android/build-rules/library.md:32
 msgid ""
+"```\n"
+"\n"
+"# Rust Libraries\n"
+"\n"
+"You use `rust_library` to create a new Rust library for Android.\n"
+"\n"
+"Here we declare a dependency on two libraries:\n"
+"\n"
+"* `libgreeting`, which we define below,\n"
+"* `libtextwrap`, which is a crate already vendored in\n"
+"  [`external/rust/crates/`][crates].\n"
+"\n"
+"[crates]: https://cs.android.com/android/platform/superproject/+/master:"
+"external/rust/crates/\n"
+"\n"
+"_hello_rust/Android.bp_:\n"
+"\n"
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"\n"
+"_hello_rust/src/main.rs_:\n"
+"\n"
+"```rust,ignore\n"
+"//! Rust demo.\n"
+"\n"
+"use greetings::greeting;\n"
+"use textwrap::fill;\n"
+"\n"
 "/// Prints a greeting to standard output.\n"
 "fn main() {\n"
 "    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
 "}\n"
 "```"
+msgstr ""
+
+#: src/android/build-rules/library.md:36
+msgid ""
+"```rust,ignore\n"
+"//! Rust demo.\n"
+"```"
+msgstr ""
+"```rust,ignore\n"
+"//! Rust demo.\n"
+"```"
+
+#: src/android/build-rules/library.md:39
+msgid "use greetings::greeting; use textwrap::fill;"
+msgstr ""
+
+#: src/android/build-rules/library.md:42
+msgid ""
+"/// Prints a greeting to standard output. fn main() { println!(\"{}\", "
+"fill(&greeting(\"Bob\"), 24)); }"
 msgstr ""
 
 #: src/android/build-rules/library.md:48
@@ -15351,16 +15238,16 @@ msgid "_hello_rust/src/lib.rs_:"
 msgstr "_hello_rust/src/lib.rs_:"
 
 #: src/android/build-rules/library.md:50
-msgid "```rust,ignore\n//! Greeting library."
+msgid ""
+"```rust,ignore\n"
+"//! Greeting library.\n"
+"```"
 msgstr ""
 
 #: src/android/build-rules/library.md:53
 msgid ""
-"/// Greet `name`.\n"
-"pub fn greeting(name: &str) -> String {\n"
-"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
-"}\n"
-"```"
+"/// Greet `name`. pub fn greeting(name: &str) -> String { format!(\"Hello "
+"{name}, it is very nice to meet you!\") }"
 msgstr ""
 
 #: src/android/build-rules/library.md:59
@@ -15372,43 +15259,37 @@ msgstr "Budujesz, wypychasz i uruchamiasz plik binarny tak jak poprzednio:"
 msgid ""
 "```shell\n"
 "$ m hello_rust_with_dep\n"
-"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep "
-"/data/local/tmp\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
+"tmp\n"
 "$ adb shell /data/local/tmp/hello_rust_with_dep\n"
 "Hello Bob, it is very\n"
 "nice to meet you!\n"
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-#, fuzzy
-msgid "# AIDL"
-msgstr "# AIDL"
-
 #: src/android/aidl.md:3
 #, fuzzy
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
-"[Język definicji interfejsu Androida\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) jest "
-"obsługiwany w Rust:"
+"[Język definicji interfejsu Androida (AIDL)](https://developer.android.com/"
+"guide/components/aidl) jest obsługiwany w Rust:"
 
 #: src/android/aidl.md:6
 #, fuzzy
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
-msgstr ""
-"* Kod Rusta może wywoływać istniejące serwery AIDL,\n"
-"* Możesz tworzyć nowe serwery AIDL w Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr "Kod Rusta może wywoływać istniejące serwery AIDL,"
+
+#: src/android/aidl.md:7
+#, fuzzy
+msgid "You can create new AIDL servers in Rust."
+msgstr "Możesz tworzyć nowe serwery AIDL w Rust."
 
 #: src/android/aidl/interface.md:1
 #, fuzzy
-msgid "# AIDL Interfaces"
-msgstr "# Interfejsy AIDL"
+msgid "AIDL Interfaces"
+msgstr "Interfejsy AIDL"
 
 #: src/android/aidl/interface.md:3
 #, fuzzy
@@ -15418,28 +15299,28 @@ msgstr "Deklarujesz API swojej usługi za pomocą interfejsu AIDL:"
 #: src/android/aidl/interface.md:5
 #, fuzzy
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
-"*urodziny_serwis/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_urodziny_serwis/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 
 #: src/android/aidl/interface.md:7 src/android/aidl/changing.md:6
-msgid "```java\npackage com.example.birthdayservice;"
+msgid ""
+"```java\n"
+"package com.example.birthdayservice;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/interface.md:10
 msgid ""
-"/** Birthday service interface. */\n"
-"interface IBirthdayService {\n"
-"    /** Generate a Happy Birthday message. */\n"
-"    String wishHappyBirthday(String name, int years);\n"
-"}\n"
-"```"
+"/\\*\\* Birthday service interface. _/ interface IBirthdayService { /_\\* "
+"Generate a Happy Birthday message. \\*/ String wishHappyBirthday(String "
+"name, int years); }"
 msgstr ""
 
 #: src/android/aidl/interface.md:17
 #, fuzzy
-msgid "*birthday_service/aidl/Android.bp*:"
-msgstr "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_birthday_service/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md:19
 msgid ""
@@ -15461,17 +15342,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 "Dodaj „vendor_available: true”, jeśli plik AIDL jest używany przez plik "
-"binarny dostawcy\n"
-"przegroda."
+"binarny dostawcy przegroda."
 
 #: src/android/aidl/implementation.md:1
 #, fuzzy
-msgid "# Service Implementation"
-msgstr "# Implementacja usługi"
+msgid "Service Implementation"
+msgstr "Implementacja usługi"
 
 #: src/android/aidl/implementation.md:3
 #, fuzzy
@@ -15480,20 +15359,21 @@ msgstr "Możemy teraz wdrożyć usługę AIDL:"
 
 #: src/android/aidl/implementation.md:5
 #, fuzzy
-msgid "*birthday_service/src/lib.rs*:"
-msgstr "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
+msgstr "_birthday_service/src/lib.rs_:"
 
 #: src/android/aidl/implementation.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
-"use com_example_birthdayservice::binder;"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/implementation.md:12
-msgid "/// The `IBirthdayService` implementation.\npub struct BirthdayService;"
+msgid "/// The `IBirthdayService` implementation. pub struct BirthdayService;"
 msgstr ""
 
 #: src/android/aidl/implementation.md:15
@@ -15503,22 +15383,21 @@ msgstr "impl binder::Interfejs dla BirthdayService {}"
 
 #: src/android/aidl/implementation.md:17
 msgid ""
-"impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> "
-"binder::Result<String> {\n"
-"        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} "
-"years!\"\n"
-"        ))\n"
-"    }\n"
-"}\n"
-"```"
+"impl IBirthdayService for BirthdayService { fn wishHappyBirthday(&self, "
+"name: &str, years: i32) -> binder::Result"
 msgstr ""
 
-#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28 src/android/aidl/client.md:37
+#: src/android/aidl/implementation.md:18
+msgid ""
+" { Ok(format!( \"Happy Birthday {name}, congratulations with the {years} "
+"years!\" )) } }"
+msgstr ""
+
+#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
+#: src/android/aidl/client.md:37
 #, fuzzy
-msgid "*birthday_service/Android.bp*:"
-msgstr "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
+msgstr "_birthday_service/Android.bp_:"
 
 #: src/android/aidl/implementation.md:28
 msgid ""
@@ -15537,8 +15416,8 @@ msgstr ""
 
 #: src/android/aidl/server.md:1
 #, fuzzy
-msgid "# AIDL Server"
-msgstr "# Serwer AIDL"
+msgid "AIDL Server"
+msgstr "Serwer AIDL"
 
 #: src/android/aidl/server.md:3
 #, fuzzy
@@ -15547,17 +15426,18 @@ msgstr "Na koniec możemy stworzyć serwer, który eksponuje usługę:"
 
 #: src/android/aidl/server.md:5
 #, fuzzy
-msgid "*birthday_service/src/server.rs*:"
-msgstr "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_birthday_service/src/server.rs_:"
 
 #: src/android/aidl/server.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
 "use birthdayservice::BirthdayService;\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
-"use com_example_birthdayservice::binder;"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/server.md:13 src/android/aidl/client.md:12
@@ -15566,19 +15446,12 @@ msgstr ""
 
 #: src/android/aidl/server.md:15
 msgid ""
-"/// Entry point for birthday service.\n"
-"fn main() {\n"
-"    let birthday_service = BirthdayService;\n"
-"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
-"        birthday_service,\n"
-"        binder::BinderFeatures::default(),\n"
-"    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, "
-"birthday_service_binder.as_binder())\n"
-"        .expect(\"Failed to register service\");\n"
-"    binder::ProcessState::join_thread_pool()\n"
-"}\n"
-"```"
+"/// Entry point for birthday service. fn main() { let birthday_service = "
+"BirthdayService; let birthday_service_binder = BnBirthdayService::"
+"new_binder( birthday_service, binder::BinderFeatures::default(), ); binder::"
+"add_service(SERVICE_IDENTIFIER, birthday_service_binder.as_binder()) ."
+"expect(\"Failed to register service\"); binder::ProcessState::"
+"join_thread_pool() }"
 msgstr ""
 
 #: src/android/aidl/server.md:30
@@ -15597,11 +15470,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/android/aidl/deploy.md:1
-#, fuzzy
-msgid "# Deploy"
-msgstr "# Wdrożyć"
 
 #: src/android/aidl/deploy.md:3
 #, fuzzy
@@ -15653,8 +15521,8 @@ msgstr ""
 
 #: src/android/aidl/client.md:1
 #, fuzzy
-msgid "# AIDL Client"
-msgstr "# Klient AIDL"
+msgid "AIDL Client"
+msgstr "Klient AIDL"
 
 #: src/android/aidl/client.md:3
 #, fuzzy
@@ -15663,55 +15531,53 @@ msgstr "Wreszcie możemy stworzyć klienta Rust dla naszej nowej usługi."
 
 #: src/android/aidl/client.md:5
 #, fuzzy
-msgid "*birthday_service/src/client.rs*:"
-msgstr "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
+msgstr "_birthday_service/src/client.rs_:"
 
 #: src/android/aidl/client.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
-"use "
-"com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
-"use com_example_birthdayservice::binder;"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/client.md:14
 #, fuzzy
 msgid ""
-"/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, "
-"binder::StatusCode> {\n"
-"    binder::get_interface(SERVICE_IDENTIFIER)\n"
-"}"
+"/// Connect to the BirthdayService. pub fn connect() -> Result\\<binder::"
+"Strong"
 msgstr ""
-"/// Połącz się z usługą BirthdayService.\n"
-"pub fn connect() -> Wynik<binder::Strong<dyn IBirthdayService>, "
-"binder::StatusCode> {\n"
-"    binder::get_interface(SERVICE_IDENTIFIER)\n"
-"}"
+"/// Połącz się z usługą BirthdayService. pub fn connect() -> Wynik\\<binder::"
+"Strong"
+
+#: src/android/aidl/client.md:15
+#, fuzzy
+msgid ", binder::StatusCode> { binder::get_interface(SERVICE_IDENTIFIER) }"
+msgstr ", binder::StatusCode> { binder::get_interface(SERVICE_IDENTIFIER) }"
 
 #: src/android/aidl/client.md:19
 msgid ""
-"/// Call the birthday service.\n"
-"fn main() -> Result<(), binder::Status> {\n"
-"    let name = std::env::args()\n"
-"        .nth(1)\n"
-"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
-"    let years = std::env::args()\n"
-"        .nth(2)\n"
-"        .and_then(|arg| arg.parse::<i32>().ok())\n"
-"        .unwrap_or(42);"
+"/// Call the birthday service. fn main() -> Result\\<(), binder::Status> "
+"{ let name = std::env::args() .nth(1) .unwrap_or_else(|| String::"
+"from(\"Bob\")); let years = std::env::args() .nth(2) .and_then(|arg| arg."
+"parse::"
+msgstr ""
+
+#: src/android/aidl/client.md:26
+msgid "().ok()) .unwrap_or(42);"
 msgstr ""
 
 #: src/android/aidl/client.md:29
 msgid ""
-"    binder::ProcessState::start_thread_pool();\n"
-"    let service = connect().expect(\"Failed to connect to "
-"BirthdayService\");\n"
-"    let msg = service.wishHappyBirthday(&name, years)?;\n"
-"    println!(\"{msg}\");\n"
-"    Ok(())\n"
-"}\n"
+"```\n"
+"binder::ProcessState::start_thread_pool();\n"
+"let service = connect().expect(\"Failed to connect to BirthdayService\");\n"
+"let msg = service.wishHappyBirthday(&name, years)?;\n"
+"println!(\"{msg}\");\n"
+"Ok(())\n"
 "```"
 msgstr ""
 
@@ -15751,46 +15617,30 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-#, fuzzy
-msgid "# Changing API"
-msgstr "# Zmiana API"
-
 #: src/android/aidl/changing.md:3
 #, fuzzy
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr ""
-"Rozszerzmy API o więcej funkcji: chcemy pozwolić klientom określić\n"
-"lista wierszy na kartkę urodzinową:"
+"Rozszerzmy API o więcej funkcji: chcemy pozwolić klientom określić lista "
+"wierszy na kartkę urodzinową:"
 
 #: src/android/aidl/changing.md:9
 msgid ""
-"/** Birthday service interface. */\n"
-"interface IBirthdayService {\n"
-"    /** Generate a Happy Birthday message. */\n"
-"    String wishHappyBirthday(String name, int years, in String[] text);\n"
-"}\n"
-"```"
+"/\\*\\* Birthday service interface. _/ interface IBirthdayService { /_\\* "
+"Generate a Happy Birthday message. \\*/ String wishHappyBirthday(String "
+"name, int years, in String\\[\\] text); }"
 msgstr ""
-
-#: src/android/logging.md:1
-#, fuzzy
-msgid "# Logging"
-msgstr "# Logowanie"
 
 #: src/android/logging.md:3
 #, fuzzy
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
 "Powinieneś użyć skrzynki `log`, aby automatycznie zalogować się do `logcat` "
-"(na urządzeniu) lub\n"
-"`stdout` (na hoście):"
+"(na urządzeniu) lub `stdout` (na hoście):"
 
 #: src/android/logging.md:6
 #, fuzzy
@@ -15820,7 +15670,10 @@ msgid "_hello_rust_logs/src/main.rs_:"
 msgstr "_hello_rust_logs/src/main.rs_:"
 
 #: src/android/logging.md:24
-msgid "```rust,ignore\n//! Rust logging demo."
+msgid ""
+"```rust,ignore\n"
+"//! Rust logging demo.\n"
+"```"
 msgstr ""
 
 #: src/android/logging.md:27
@@ -15829,18 +15682,10 @@ msgstr ""
 
 #: src/android/logging.md:29
 msgid ""
-"/// Logs a greeting.\n"
-"fn main() {\n"
-"    logger::init(\n"
-"        logger::Config::default()\n"
-"            .with_tag_on_device(\"rust\")\n"
-"            .with_min_level(log::Level::Trace),\n"
-"    );\n"
-"    debug!(\"Starting program.\");\n"
-"    info!(\"Things are going fine.\");\n"
-"    error!(\"Something went wrong!\");\n"
-"}\n"
-"```"
+"/// Logs a greeting. fn main() { logger::init( logger::Config::default() ."
+"with_tag_on_device(\"rust\") .with_min_level(log::Level::Trace), ); debug!"
+"(\"Starting program.\"); info!(\"Things are going fine.\"); error!"
+"(\"Something went wrong!\"); }"
 msgstr ""
 
 #: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
@@ -15875,54 +15720,47 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-#, fuzzy
-msgid "# Interoperability"
-msgstr "# Interoperacyjność"
-
 #: src/android/interoperability.md:3
 #, fuzzy
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 "Rust ma doskonałe wsparcie dla interoperacyjności z innymi językami. To "
-"znaczy\n"
-"że możesz:"
+"znaczy że możesz:"
 
 #: src/android/interoperability.md:6
 #, fuzzy
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
-msgstr ""
-"* Wywołaj funkcje Rust z innych języków.\n"
-"* Funkcje wywołania napisane w innych językach z Rust."
+msgid "Call Rust functions from other languages."
+msgstr "Wywołaj funkcje Rust z innych języków."
+
+#: src/android/interoperability.md:7
+#, fuzzy
+msgid "Call functions written in other languages from Rust."
+msgstr "Funkcje wywołania napisane w innych językach z Rust."
 
 #: src/android/interoperability.md:9
 #, fuzzy
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
-"Kiedy wywołujesz funkcje w języku obcym, mówimy, że używasz a\n"
-"_interfejs funkcji obcych_, znany również jako FFI."
+"Kiedy wywołujesz funkcje w języku obcym, mówimy, że używasz a _interfejs "
+"funkcji obcych_, znany również jako FFI."
 
 #: src/android/interoperability/with-c.md:1
 #, fuzzy
-msgid "# Interoperability with C"
-msgstr "# Interoperacyjność z C"
+msgid "Interoperability with C"
+msgstr "Interoperacyjność z C"
 
 #: src/android/interoperability/with-c.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 "Rust ma pełne wsparcie dla łączenia plików obiektowych z konwencją "
-"wywoływania C.\n"
-"Podobnie możesz eksportować funkcje Rust i wywoływać je z C."
+"wywoływania C. Podobnie możesz eksportować funkcje Rust i wywoływać je z C."
 
 #: src/android/interoperability/with-c.md:6
 #, fuzzy
@@ -15934,36 +15772,32 @@ msgid ""
 "```rust\n"
 "extern \"C\" {\n"
 "    fn abs(x: i32) -> i32;\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:13
 msgid ""
-"fn main() {\n"
-"    let x = -42;\n"
-"    let abs_x = unsafe { abs(x) };\n"
-"    println!(\"{x}, {abs_x}\");\n"
-"}\n"
-"```"
+"fn main() { let x = -42; let abs_x = unsafe { abs(x) }; println!(\"{x}, "
+"{abs_x}\"); }"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 #, fuzzy
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
-"Widzieliśmy to już w [Safe FFI Wrapper\n"
-"ćwiczenie](../../ćwiczenia/dzień-3/safe-ffi-wrapper.md)."
+"Widzieliśmy to już w [Safe FFI Wrapper ćwiczenie](../../ćwiczenia/dzień-3/"
+"safe-ffi-wrapper.md)."
 
 #: src/android/interoperability/with-c.md:23
 #, fuzzy
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
-"> Zakłada to pełną znajomość platformy docelowej. Nie zalecane dla\n"
-"> produkcja."
+"Zakłada to pełną znajomość platformy docelowej. Nie zalecane dla produkcja."
 
 #: src/android/interoperability/with-c.md:26
 #, fuzzy
@@ -15972,19 +15806,17 @@ msgstr "W następnej kolejności przyjrzymy się lepszym opcjom."
 
 #: src/android/interoperability/with-c/bindgen.md:1
 #, fuzzy
-msgid "# Using Bindgen"
+msgid "Using Bindgen"
 msgstr "Korzystanie z Cargo"
 
 #: src/android/interoperability/with-c/bindgen.md:3
 #, fuzzy
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
-"Narzędzie "
-"[bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html)\n"
-"może automatycznie generować powiązania z pliku nagłówkowego C."
+"Narzędzie [bindgen](https://rust-lang.github.io/rust-bindgen/introduction."
+"html) może automatycznie generować powiązania z pliku nagłówkowego C."
 
 #: src/android/interoperability/with-c/bindgen.md:6
 #, fuzzy
@@ -16002,11 +15834,12 @@ msgid ""
 "typedef struct card {\n"
 "  const char* name;\n"
 "  int years;\n"
-"} card;"
+"} card;\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:16
-msgid "void print_card(const card* card);\n```"
+msgid "void print_card(const card\\* card);"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:19
@@ -16018,22 +15851,15 @@ msgstr "_interoperability/bindgen/libbirthday.c_:"
 msgid ""
 "```c\n"
 "#include <stdio.h>\n"
-"#include \"libbirthday.h\""
+"#include \"libbirthday.h\"\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:25
 msgid ""
-"void print_card(const card* card) {\n"
-"  printf(\"+--------------\\n"
-"\");\n"
-"  printf(\"| Happy Birthday %s!\\n"
-"\", card->name);\n"
-"  printf(\"| Congratulations with the %i years!\\n"
-"\", card->years);\n"
-"  printf(\"+--------------\\n"
-"\");\n"
-"}\n"
-"```"
+"void print_card(const card\\* card) { printf(\"+--------------\\n\"); "
+"printf(\"| Happy Birthday %s!\\n\", card->name); printf(\"| Congratulations "
+"with the %i years!\\n\", card->years); printf(\"+--------------\\n\"); }"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:33
@@ -16062,12 +15888,11 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:44
 #, fuzzy
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 "Utwórz plik nagłówkowy opakowania dla biblioteki (nie jest to bezwzględnie "
-"potrzebne w tym przypadku\n"
-"przykład):"
+"potrzebne w tym przypadku przykład):"
 
 #: src/android/interoperability/with-c/bindgen.md:47
 #, fuzzy
@@ -16121,7 +15946,10 @@ msgid "_interoperability/bindgen/main.rs_:"
 msgstr "_interoperacyjność/bindgen/main.rs_:"
 
 #: src/android/interoperability/with-c/bindgen.md:81
-msgid "```rust,compile_fail\n//! Bindgen demo."
+msgid ""
+"```rust,compile_fail\n"
+"//! Bindgen demo.\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:84
@@ -16130,25 +15958,17 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:86
 msgid ""
-"fn main() {\n"
-"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
-"    let card = card {\n"
-"        name: name.as_ptr(),\n"
-"        years: 42,\n"
-"    };\n"
-"    unsafe {\n"
-"        print_card(&card as *const card);\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let name = std::ffi::CString::new(\"Peter\").unwrap(); let card "
+"= card { name: name.as_ptr(), years: 42, }; unsafe { print_card(&card as "
+"\\*const card); } }"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:100
 msgid ""
 "```shell\n"
 "$ m print_birthday_card\n"
-"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card "
-"/data/local/tmp\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/"
+"tmp\n"
 "$ adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
@@ -16184,7 +16004,7 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
 #, fuzzy
-msgid "# Calling Rust"
+msgid "Calling Rust"
 msgstr "Ekosystem Rust"
 
 #: src/android/interoperability/with-c/rust.md:3
@@ -16201,7 +16021,8 @@ msgstr "_interoperability/rust/libanalyze/analyze.rs_"
 msgid ""
 "```rust,editable\n"
 "//! Rust FFI demo.\n"
-"#![deny(improper_ctypes_definitions)]"
+"#![deny(improper_ctypes_definitions)]\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:11
@@ -16210,15 +16031,39 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:13
 msgid ""
-"/// Analyze the numbers.\n"
-"#[no_mangle]\n"
-"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
-"    if x < y {\n"
-"        println!(\"x ({x}) is smallest!\");\n"
-"    } else {\n"
-"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
-"    }\n"
+"/// Analyze the numbers. \\#\\[no_mangle\\] pub extern \"C\" fn "
+"analyze_numbers(x: c_int, y: c_int) { if x \\< y { println!(\"x ({x}) is "
+"smallest!\"); } else { println!(\"y ({y}) is probably larger than x "
+"({x})\"); } }"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:22
+msgid ""
+"```\n"
+"\n"
+"# Calling Rust\n"
+"\n"
+"Exporting Rust functions and types to C is easy:\n"
+"\n"
+"_interoperability/rust/libanalyze/analyze.rs_\n"
+"\n"
+"```rust,editable\n"
+"//! Rust FFI demo.\n"
+"#![deny(improper_ctypes_definitions)]\n"
+"\n"
+"use std::os::raw::c_int;\n"
+"\n"
+"_interoperability/rust/libanalyze/analyze.h_\n"
+"\n"
+"```c\n"
+"#ifndef ANALYSE_H\n"
+"#define ANALYSE_H\n"
+"\n"
+"extern \"C\" {\n"
+"void analyze_numbers(int x, int y);\n"
 "}\n"
+"\n"
+"#endif\n"
 "```"
 msgstr ""
 
@@ -16231,18 +16076,16 @@ msgstr "_interoperability/rust/libanalyze/analyze.h_"
 msgid ""
 "```c\n"
 "#ifndef ANALYSE_H\n"
-"#define ANALYSE_H"
+"#define ANALYSE_H\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:30
-msgid ""
-"extern \"C\" {\n"
-"void analyze_numbers(int x, int y);\n"
-"}"
+msgid "extern \"C\" { void analyze_numbers(int x, int y); }"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:34
-msgid "#endif\n```"
+msgid "\\#endif"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:37
@@ -16273,17 +16116,15 @@ msgid "_interoperability/rust/analyze/main.c_"
 msgstr "_interoperacyjność/rust/analiza/main.c_"
 
 #: src/android/interoperability/with-c/rust.md:52
-msgid "```c\n#include \"analyze.h\""
+msgid ""
+"```c\n"
+"#include \"analyze.h\"\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:55
 msgid ""
-"int main() {\n"
-"  analyze_numbers(10, 20);\n"
-"  analyze_numbers(123, 123);\n"
-"  return 0;\n"
-"}\n"
-"```"
+"int main() { analyze_numbers(10, 20); analyze_numbers(123, 123); return 0; }"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:62
@@ -16315,67 +16156,52 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 "`#[no_mangle]` wyłącza zwykłe zniekształcanie nazw Rusta, więc eksportowany "
-"symbol będzie po prostu nazwą\n"
-"funkcja. Możesz także użyć `#[nazwa_eksportu = \"jakaś_nazwa\"]`, aby "
-"określić dowolną nazwę."
-
-#: src/android/interoperability/cpp.md:1
-#, fuzzy
-msgid "# With C++"
-msgstr "# Z C++"
+"symbol będzie po prostu nazwą funkcja. Możesz także użyć `#[nazwa_eksportu = "
+"\"jakaś_nazwa\"]`, aby określić dowolną nazwę."
 
 #: src/android/interoperability/cpp.md:3
 #, fuzzy
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
-"[Skrzynia CXX][1] umożliwia bezpieczną interoperacyjność między Rust\n"
-"i C++."
+"[Skrzynia CXX](https://cxx.rs/) umożliwia bezpieczną interoperacyjność "
+"między Rust i C++."
 
 #: src/android/interoperability/cpp.md:6
 #, fuzzy
 msgid "The overall approach looks like this:"
 msgstr "Ogólne podejście wygląda następująco:"
 
-#: src/android/interoperability/cpp.md:8
-#, fuzzy
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr "<img src=\"cpp/overview.svg\">"
-
 #: src/android/interoperability/cpp.md:10
 #, fuzzy
-msgid "See the [CXX tutorial][2] for an full example of using this."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
-"Zobacz [samouczek CXX][2], aby zapoznać się z pełnym przykładem użycia tego."
-
-#: src/android/interoperability/cpp.md:12
-#, fuzzy
-msgid "[1]: https://cxx.rs/\n[2]: https://cxx.rs/tutorial.html"
-msgstr "[1]: https://cxx.rs/\n[2]: https://cxx.rs/tutorial.html"
+"Zobacz [samouczek CXX](https://cxx.rs/tutorial.html), aby zapoznać się z "
+"pełnym przykładem użycia tego."
 
 #: src/android/interoperability/java.md:1
 #, fuzzy
-msgid "# Interoperability with Java"
-msgstr "# Współpraca z Javą"
+msgid "Interoperability with Java"
+msgstr "Współpraca z Javą"
 
 #: src/android/interoperability/java.md:3
 #, fuzzy
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 "Java może ładować udostępnione obiekty za pośrednictwem [Java Native "
-"Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). [`jni`\n"
-"crate](https://docs.rs/jni/) umożliwia utworzenie kompatybilnej biblioteki."
+"Interface (JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). "
+"[`jni` crate](https://docs.rs/jni/) umożliwia utworzenie kompatybilnej "
+"biblioteki."
 
 #: src/android/interoperability/java.md:7
 #, fuzzy
@@ -16388,34 +16214,61 @@ msgid "_interoperability/java/src/lib.rs_:"
 msgstr "_interoperacyjność/java/src/lib.rs_:"
 
 #: src/android/interoperability/java.md:11
-msgid "```rust,compile_fail\n//! Rust <-> Java FFI demo."
+msgid ""
+"```rust,compile_fail\n"
+"//! Rust <-> Java FFI demo.\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:14
 msgid ""
-"use jni::objects::{JClass, JString};\n"
-"use jni::sys::jstring;\n"
-"use jni::JNIEnv;"
+"use jni::objects::{JClass, JString}; use jni::sys::jstring; use jni::JNIEnv;"
 msgstr ""
 
 #: src/android/interoperability/java.md:18
 msgid ""
-"/// HelloWorld::hello method implementation.\n"
-"#[no_mangle]\n"
-"pub extern \"system\" fn Java_HelloWorld_hello(\n"
-"    env: JNIEnv,\n"
-"    _class: JClass,\n"
-"    name: JString,\n"
-") -> jstring {\n"
-"    let input: String = env.get_string(name).unwrap().into();\n"
-"    let greeting = format!(\"Hello, {input}!\");\n"
-"    let output = env.new_string(greeting).unwrap();\n"
-"    output.into_inner()\n"
+"/// HelloWorld::hello method implementation. \\#\\[no_mangle\\] pub extern "
+"\"system\" fn Java_HelloWorld_hello( env: JNIEnv, \\_class: JClass, name: "
+"JString, ) -> jstring { let input: String = env.get_string(name).unwrap()."
+"into(); let greeting = format!(\"Hello, {input}!\"); let output = env."
+"new_string(greeting).unwrap(); output.into_inner() }"
+msgstr ""
+
+#: src/android/interoperability/java.md:30
+msgid ""
+"```\n"
+"\n"
+"# Interoperability with Java\n"
+"\n"
+"Java can load shared objects via [Java Native Interface\n"
+"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
+"crate](https://docs.rs/jni/) allows you to create a compatible library.\n"
+"\n"
+"First, we create a Rust function to export to Java:\n"
+"\n"
+"_interoperability/java/src/lib.rs_:\n"
+"\n"
+"```rust,compile_fail\n"
+"//! Rust <-> Java FFI demo.\n"
+"\n"
+"use jni::objects::{JClass, JString};\n"
+"use jni::sys::jstring;\n"
+"use jni::JNIEnv;\n"
+"\n"
+"_interoperability/java/Android.bp_:\n"
+"\n"
+"```javascript\n"
+"rust_ffi_shared {\n"
+"    name: \"libhello_jni\",\n"
+"    crate_name: \"hello_jni\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    rustlibs: [\"libjni\"],\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/android/interoperability/java.md:32 src/android/interoperability/java.md:62
+#: src/android/interoperability/java.md:32
+#: src/android/interoperability/java.md:62
 #, fuzzy
 msgid "_interoperability/java/Android.bp_:"
 msgstr "_interoperacyjność/java/Android.bp_:"
@@ -16446,22 +16299,25 @@ msgstr "_interoperacyjność/java/HelloWorld.java_:"
 msgid ""
 "```java\n"
 "class HelloWorld {\n"
-"    private static native String hello(String name);"
+"    private static native String hello(String name);\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:51
 msgid ""
-"    static {\n"
-"        System.loadLibrary(\"hello_jni\");\n"
-"    }"
+"```\n"
+"static {\n"
+"    System.loadLibrary(\"hello_jni\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:55
 msgid ""
-"    public static void main(String[] args) {\n"
-"        String output = HelloWorld.hello(\"Alice\");\n"
-"        System.out.println(output);\n"
-"    }\n"
+"```\n"
+"public static void main(String[] args) {\n"
+"    String output = HelloWorld.hello(\"Alice\");\n"
+"    System.out.println(output);\n"
 "}\n"
 "```"
 msgstr ""
@@ -16496,86 +16352,70 @@ msgstr ""
 #, fuzzy
 msgid ""
 "For the last exercise, we will look at one of the projects you work with. "
-"Let us\n"
-"group up and do this together. Some suggestions:"
+"Let us group up and do this together. Some suggestions:"
 msgstr ""
 "W ostatnim ćwiczeniu przyjrzymy się jednemu z projektów, nad którymi "
-"pracujesz. Pozwól nam\n"
-"zbierzcie się i zróbcie to razem. Jakieś sugestie:"
+"pracujesz. Pozwól nam zbierzcie się i zróbcie to razem. Jakieś sugestie:"
 
 #: src/exercises/day-4/afternoon.md:6
 #, fuzzy
-msgid "* Call your AIDL service with a client written in Rust."
-msgstr "* Zadzwoń do swojego serwisu AIDL z klientem napisanym w Rust."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr "Zadzwoń do swojego serwisu AIDL z klientem napisanym w Rust."
 
 #: src/exercises/day-4/afternoon.md:8
 #, fuzzy
-msgid "* Move a function from your project to Rust and call it."
-msgstr "* Przenieś funkcję z projektu do Rusta i wywołaj ją."
+msgid "Move a function from your project to Rust and call it."
+msgstr "Przenieś funkcję z projektu do Rusta i wywołaj ją."
 
 #: src/exercises/day-4/afternoon.md:12
 #, fuzzy
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 "Nie podano tutaj żadnego rozwiązania, ponieważ jest ono otwarte: polega na "
-"kimś w\n"
-"klasa posiadająca fragment kodu, który można przekazać Rustowi w locie."
-
-#: src/thanks.md:1
-#, fuzzy
-msgid "# Thanks!"
-msgstr "# Dzięki!"
+"kimś w klasa posiadająca fragment kodu, który można przekazać Rustowi w "
+"locie."
 
 #: src/thanks.md:3
 #, fuzzy
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that "
-"it\n"
-"was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
 msgstr ""
 "_Dziękujemy za skorzystanie z Comprehensive Rust 🦀!_ Mamy nadzieję, że Ci "
-"się podobało i że tak\n"
-"było przydatne."
+"się podobało i że tak było przydatne."
 
 #: src/thanks.md:6
 #, fuzzy
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
-"Świetnie się bawiliśmy przygotowując kurs. Kurs nie jest doskonały,\n"
-"więc jeśli zauważyłeś jakieś błędy lub masz pomysły na ulepszenia, wejdź\n"
-"[kontakt z nami na\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). "
-"Kochalibyśmy się\n"
-"usłyszeć od ciebie."
+"Świetnie się bawiliśmy przygotowując kurs. Kurs nie jest doskonały, więc "
+"jeśli zauważyłeś jakieś błędy lub masz pomysły na ulepszenia, wejdź [kontakt "
+"z nami na GitHub](https://github.com/google/comprehensive-rust/discussions). "
+"Kochalibyśmy się usłyszeć od ciebie."
 
 #: src/other-resources.md:1
-msgid "# Other Rust Resources"
-msgstr "# Inne źródła o Ruście"
+msgid "Other Rust Resources"
+msgstr "Inne źródła o Ruście"
 
 #: src/other-resources.md:3
 #, fuzzy
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
-"Społeczność Rust stworzyła bogactwo wysokiej jakości i bezpłatnych zasobów\n"
+"Społeczność Rust stworzyła bogactwo wysokiej jakości i bezpłatnych zasobów "
 "online."
 
 #: src/other-resources.md:6
 #, fuzzy
-msgid "## Official Documentation"
-msgstr "## Oficjalna dokumentacja"
+msgid "Official Documentation"
+msgstr "Oficjalna dokumentacja"
 
 #: src/other-resources.md:8
 #, fuzzy
@@ -16585,39 +16425,44 @@ msgstr "Projekt Rust zawiera wiele zasobów. Obejmują one ogólnie Rusta:"
 #: src/other-resources.md:10
 #, fuzzy
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
 msgstr ""
-"* [Język programowania Rust](https://doc.rust-lang.org/book/): the\n"
-"  kanoniczna darmowa książka o Rust. Szczegółowo omawia język i zawiera "
-"m.in\n"
-"  kilka projektów dla ludzi do zbudowania.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): obejmuje "
-"Rust\n"
-"  składni za pomocą serii przykładów prezentujących różne konstrukcje. "
-"Czasami\n"
-"  zawiera małe ćwiczenia, w których jesteś proszony o rozwinięcie kodu w\n"
-"  przykłady.\n"
-"* [Biblioteka standardowa Rust](https://doc.rust-lang.org/std/): pełna "
-"dokumentacja\n"
-"  standardowa biblioteka dla Rusta.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): niekompletna "
-"książka\n"
-"  który opisuje gramatykę i model pamięci Rusta."
+"[Język programowania Rust](https://doc.rust-lang.org/book/): the kanoniczna "
+"darmowa książka o Rust. Szczegółowo omawia język i zawiera m.in kilka "
+"projektów dla ludzi do zbudowania."
+
+#: src/other-resources.md:13
+#, fuzzy
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): obejmuje Rust "
+"składni za pomocą serii przykładów prezentujących różne konstrukcje. Czasami "
+"zawiera małe ćwiczenia, w których jesteś proszony o rozwinięcie kodu w "
+"przykłady."
+
+#: src/other-resources.md:17
+#, fuzzy
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+"[Biblioteka standardowa Rust](https://doc.rust-lang.org/std/): pełna "
+"dokumentacja standardowa biblioteka dla Rusta."
+
+#: src/other-resources.md:19
+#, fuzzy
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
+msgstr ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): niekompletna "
+"książka który opisuje gramatykę i model pamięci Rusta."
 
 #: src/other-resources.md:22
 #, fuzzy
@@ -16628,37 +16473,40 @@ msgstr ""
 #: src/other-resources.md:24
 #, fuzzy
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in "
-"Rust](https://rust-lang.github.io/async-book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
 msgstr ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): obejmuje "
-"niebezpieczną Rust,\n"
-"  w tym praca z surowymi wskaźnikami i łączenie z innymi językami\n"
-"  (FFI).\n"
-"* [Programowanie asynchroniczne w "
-"Rust](https://rust-lang.github.io/async-book/):\n"
-"  obejmuje nowy model programowania asynchronicznego, który został "
-"wprowadzony po\n"
-"  Księga rdzy została napisana.\n"
-"* [The Embedded Rust "
-"Book](https://doc.rust-lang.org/stable/embedded-book/):\n"
-"  wprowadzenie do używania Rusta na urządzeniach wbudowanych bez systemu "
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): obejmuje "
+"niebezpieczną Rust, w tym praca z surowymi wskaźnikami i łączenie z innymi "
+"językami (FFI)."
+
+#: src/other-resources.md:27
+#, fuzzy
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+"[Programowanie asynchroniczne w Rust](https://rust-lang.github.io/async-"
+"book/): obejmuje nowy model programowania asynchronicznego, który został "
+"wprowadzony po Księga rdzy została napisana."
+
+#: src/other-resources.md:30
+#, fuzzy
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
+msgstr ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"wprowadzenie do używania Rusta na urządzeniach wbudowanych bez systemu "
 "operacyjnego."
 
 #: src/other-resources.md:33
 #, fuzzy
-msgid "## Unofficial Learning Material"
-msgstr "## Nieoficjalny materiał do nauki"
+msgid "Unofficial Learning Material"
+msgstr "Nieoficjalny materiał do nauki"
 
 #: src/other-resources.md:35
 #, fuzzy
@@ -16668,183 +16516,163 @@ msgstr "Niewielki wybór innych przewodników i samouczków dotyczących Rusta:"
 #: src/other-resources.md:37
 #, fuzzy
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
 msgstr ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): obejmuje "
-"Rust\n"
-"  z perspektywy niskopoziomowych programistów C.\n"
-"* [Rdza dla wbudowanego C\n"
-"  Programiści](https://docs.opentitan.org/doc/ug/rust_for_c/): obejmuje "
-"Rusta z\n"
-"  perspektywa programistów, którzy piszą firmware w C.\n"
-"* [Rdza dla "
-"profesjonalistów](https://overexact.com/rust-for-professionals/):\n"
-"  obejmuje składnię języka Rust przy użyciu porównań side-by-side z innymi "
-"językami\n"
-"  takich jak C, C++, Java, JavaScript i Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): ponad 100 ćwiczeń, "
-"które pomogą\n"
-"  uczysz się Rusta.\n"
-"* [Żelazne nauczanie\n"
-"  Materiał](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  seria małych prezentacji obejmujących zarówno podstawową, jak i "
-"zaawansowaną część\n"
-"  Język rdzy. Inne tematy, takie jak WebAssembly i "
-"asynchronizacja/oczekiwanie, również są\n"
-"  pokryty.\n"
-"* [Seria dla początkujących do\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) i\n"
-"  [Zrób swoje pierwsze kroki z\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"dwa\n"
-"  Przewodniki Rust skierowane do nowych programistów. Pierwszy to zestaw 35 "
-"filmów i\n"
-"  drugi to zestaw 11 modułów, który obejmuje składnię i podstawowe "
-"konstrukcje Rusta.\n"
-"* [Naucz się Rust z całkowicie zbyt wieloma linkami\n"
-"  Listy](https://rust-unofficial.github.io/too-many-lists/): szczegółowe\n"
-"  eksploracja reguł zarządzania pamięcią Rust, poprzez implementację kilku\n"
-"  różne rodzaje struktur list."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): obejmuje "
+"Rust z perspektywy niskopoziomowych programistów C."
+
+#: src/other-resources.md:39
+#, fuzzy
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+"[Rdza dla wbudowanego C Programiści](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): obejmuje Rusta z perspektywa programistów, którzy piszą "
+"firmware w C."
+
+#: src/other-resources.md:42
+#, fuzzy
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+"[Rdza dla profesjonalistów](https://overexact.com/rust-for-professionals/): "
+"obejmuje składnię języka Rust przy użyciu porównań side-by-side z innymi "
+"językami takich jak C, C++, Java, JavaScript i Python."
+
+#: src/other-resources.md:45
+#, fuzzy
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): ponad 100 ćwiczeń, "
+"które pomogą uczysz się Rusta."
+
+#: src/other-resources.md:47
+#, fuzzy
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+"[Żelazne nauczanie Materiał](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a seria małych prezentacji obejmujących zarówno "
+"podstawową, jak i zaawansowaną część Język rdzy. Inne tematy, takie jak "
+"WebAssembly i asynchronizacja/oczekiwanie, również są pokryty."
+
+#: src/other-resources.md:52
+#, fuzzy
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+"[Seria dla początkujących do Rust](https://docs.microsoft.com/en-us/shows/"
+"beginners-series-to-rust/) i [Zrób swoje pierwsze kroki z Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): dwa Przewodniki Rust "
+"skierowane do nowych programistów. Pierwszy to zestaw 35 filmów i drugi to "
+"zestaw 11 modułów, który obejmuje składnię i podstawowe konstrukcje Rusta."
+
+#: src/other-resources.md:58
+#, fuzzy
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
+msgstr ""
+"[Naucz się Rust z całkowicie zbyt wieloma linkami Listy](https://rust-"
+"unofficial.github.io/too-many-lists/): szczegółowe eksploracja reguł "
+"zarządzania pamięcią Rust, poprzez implementację kilku różne rodzaje "
+"struktur list."
 
 #: src/other-resources.md:63
 #, fuzzy
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
+"for even more Rust books."
 msgstr ""
-"Proszę zapoznać się z [Little Book of Rust "
-"Books](https://lborb.github.io/book/)\n"
-"jeszcze więcej książek Rust."
-
-#: src/credits.md:1
-#, fuzzy
-msgid "# Credits"
-msgstr "# Kredyty"
+"Proszę zapoznać się z [Little Book of Rust Books](https://lborb.github.io/"
+"book/) jeszcze więcej książek Rust."
 
 #: src/credits.md:3
 #, fuzzy
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
-"Materiał tutaj opiera się na wielu wspaniałych źródłach dokumentacji Rusta.\n"
+"Materiał tutaj opiera się na wielu wspaniałych źródłach dokumentacji Rusta. "
 "Zobacz stronę [inne zasoby](other-resources.md), aby uzyskać pełną listę "
-"przydatnych\n"
-"zasoby."
+"przydatnych zasoby."
 
 #: src/credits.md:7
 #, fuzzy
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
 msgstr ""
-"Materiał Comprehensive Rust jest objęty licencją na warunkach Apache 2.0\n"
+"Materiał Comprehensive Rust jest objęty licencją na warunkach Apache 2.0 "
 "licencji, zobacz [`LICENCJA`](../LICENCJA), aby uzyskać szczegółowe "
 "informacje."
 
 #: src/credits.md:10
 #, fuzzy
-msgid "## Rust by Example"
-msgstr "## Rust by Example"
+msgid "Rust by Example"
+msgstr "Rust by Example"
 
 #: src/credits.md:12
 #, fuzzy
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
-"Niektóre przykłady i ćwiczenia zostały skopiowane i zaadaptowane z [Rust by\n"
-"Przykład](https://doc.rust-lang.org/rust-by-example/). Proszę zobaczyć\n"
+"Niektóre przykłady i ćwiczenia zostały skopiowane i zaadaptowane z [Rust by "
+"Przykład](https://doc.rust-lang.org/rust-by-example/). Proszę zobaczyć "
 "Katalog `third_party/rust-by-example/` zawiera szczegółowe informacje, w tym "
-"licencję\n"
-"warunki."
+"licencję warunki."
 
 #: src/credits.md:17
 #, fuzzy
-msgid "## Rust on Exercism"
-msgstr "## Rust on Exercism"
+msgid "Rust on Exercism"
+msgstr "Rust on Exercism"
 
 #: src/credits.md:19
 #, fuzzy
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"Niektóre ćwiczenia zostały skopiowane i zaadaptowane z [Rust on\n"
-"ćwiczenia](https://exercism.org/tracks/rust). Proszę zobaczyć\n"
-"`third_party/rust-on-exercism/`, aby uzyskać szczegółowe informacje, w tym "
-"licencję\n"
-"warunki."
+"Niektóre ćwiczenia zostały skopiowane i zaadaptowane z [Rust on ćwiczenia]"
+"(https://exercism.org/tracks/rust). Proszę zobaczyć `third_party/rust-on-"
+"exercism/`, aby uzyskać szczegółowe informacje, w tym licencję warunki."
 
 #: src/credits.md:24
 #, fuzzy
-msgid "## CXX"
-msgstr "## CXX"
+msgid "CXX"
+msgstr "CXX"
 
 #: src/credits.md:26
 #, fuzzy
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 "Sekcja [Interoperability with C++](android/interoperability/cpp.md) "
-"wykorzystuje plik\n"
-"obraz z [CXX](https://cxx.rs/). Zapoznaj się z katalogiem "
-"`third_party/cxx/`\n"
-"aby uzyskać szczegółowe informacje, w tym warunki licencji."
-
-#: src/exercises/solutions.md:1
-#, fuzzy
-msgid "# Solutions"
-msgstr "# Rozwiązania"
+"wykorzystuje plik obraz z [CXX](https://cxx.rs/). Zapoznaj się z katalogiem "
+"`third_party/cxx/` aby uzyskać szczegółowe informacje, w tym warunki "
+"licencji."
 
 #: src/exercises/solutions.md:3
 #, fuzzy
@@ -16854,46 +16682,42 @@ msgstr "Na kolejnych stronach znajdziesz rozwiązania ćwiczeń."
 #: src/exercises/solutions.md:5
 #, fuzzy
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
-"Zachęcamy do zadawania pytań dotyczących rozwiązań [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Daj nam "
-"znać\n"
-"jeśli masz inne lub lepsze rozwiązanie niż przedstawione tutaj."
+"Zachęcamy do zadawania pytań dotyczących rozwiązań [on GitHub](https://"
+"github.com/google/comprehensive-rust/discussions). Daj nam znać jeśli masz "
+"inne lub lepsze rozwiązanie niż przedstawione tutaj."
 
 #: src/exercises/solutions.md:10
 #, fuzzy
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
-"> **Uwaga:** proszę zignorować `// ANCHOR: etykieta` i `// ANCHOR_END: "
-"etykieta`\n"
-"> komentarze, które widzisz w rozwiązaniach. Są po to, aby to umożliwić\n"
-"> ponownie wykorzystaj części rozwiązań jako ćwiczenia."
+"**Uwaga:** proszę zignorować `// ANCHOR: etykieta` i `// ANCHOR_END: "
+"etykieta` komentarze, które widzisz w rozwiązaniach. Są po to, aby to "
+"umożliwić ponownie wykorzystaj części rozwiązań jako ćwiczenia."
 
 #: src/exercises/day-1/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 1 Morning Exercises"
-msgstr "# Dzień 1 Ćwiczenia poranne"
-
-#: src/exercises/day-1/solutions-morning.md:3
-#, fuzzy
-msgid "## Arrays and `for` Loops"
-msgstr "## Tablice i pętle `for`"
+msgid "Day 1 Morning Exercises"
+msgstr "Dzień 1 Ćwiczenia poranne"
 
 #: src/exercises/day-1/solutions-morning.md:5
 msgid "([back to exercise](for-loops.md))"
 msgstr "([powrót do ćwiczenia](for-loops.md))"
 
-#: src/exercises/day-1/solutions-morning.md:7 src/exercises/day-1/solutions-afternoon.md:7
-#: src/exercises/day-2/solutions-morning.md:7 src/exercises/day-2/solutions-afternoon.md:7
-#: src/exercises/day-2/solutions-afternoon.md:102 src/exercises/day-3/solutions-morning.md:7
-#: src/exercises/day-3/solutions-afternoon.md:7 src/exercises/day-4/solutions-morning.md:7
+#: src/exercises/day-1/solutions-morning.md:7
+#: src/exercises/day-1/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-morning.md:7
+#: src/exercises/day-2/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-afternoon.md:102
+#: src/exercises/day-3/solutions-morning.md:7
+#: src/exercises/day-3/solutions-afternoon.md:7
+#: src/exercises/day-4/solutions-morning.md:7
 msgid ""
 "```rust\n"
 "// Copyright 2022 Google LLC\n"
@@ -16908,87 +16732,54 @@ msgid ""
 "// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
 "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
 "// See the License for the specific language governing permissions and\n"
-"// limitations under the License."
+"// limitations under the License.\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:22
 msgid ""
-"// ANCHOR: transpose\n"
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    // ANCHOR_END: transpose\n"
-"    let mut result = [[0; 3]; 3];\n"
-"    for i in 0..3 {\n"
-"        for j in 0..3 {\n"
-"            result[j][i] = matrix[i][j];\n"
-"        }\n"
-"    }\n"
-"    return result;\n"
-"}"
+"// ANCHOR: transpose fn transpose(matrix: \\[\\[i32; 3\\]; 3\\]) -> "
+"\\[\\[i32; 3\\]; 3\\] { // ANCHOR_END: transpose let mut result = \\[\\[0; "
+"3\\]; 3\\]; for i in 0..3 { for j in 0..3 { result\\[j\\]\\[i\\] = "
+"matrix\\[i\\]\\[j\\]; } } return result; }"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:34
 msgid ""
-"// ANCHOR: pretty_print\n"
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    // ANCHOR_END: pretty_print\n"
-"    for row in matrix {\n"
-"        println!(\"{row:?}\");\n"
-"    }\n"
-"}"
+"// ANCHOR: pretty_print fn pretty_print(matrix: &\\[\\[i32; 3\\]; 3\\]) { // "
+"ANCHOR_END: pretty_print for row in matrix { println!(\"{row:?}\"); } }"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:42
 msgid ""
-"// ANCHOR: tests\n"
-"#[test]\n"
-"fn test_transpose() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], //\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];\n"
-"    let transposed = transpose(matrix);\n"
-"    assert_eq!(\n"
-"        transposed,\n"
-"        [\n"
-"            [101, 201, 301], //\n"
-"            [102, 202, 302],\n"
-"            [103, 203, 303],\n"
-"        ]\n"
-"    );\n"
-"}\n"
-"// ANCHOR_END: tests"
+"// ANCHOR: tests \\#\\[test\\] fn test_transpose() { let matrix = "
+"\\[ \\[101, 102, 103\\], // \\[201, 202, 203\\], \\[301, 302, 303\\], \\]; "
+"let transposed = transpose(matrix); assert_eq!( transposed, \\[ \\[101, 201, "
+"301\\], // \\[102, 202, 302\\], \\[103, 203, 303\\], \\] ); } // ANCHOR_END: "
+"tests"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:62
 msgid ""
-"// ANCHOR: main\n"
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];"
+"// ANCHOR: main fn main() { let matrix = \\[ \\[101, 102, 103\\], // \\<\\-- "
+"the comment makes rustfmt add a newline \\[201, 202, 203\\], \\[301, 302, "
+"303\\], \\];"
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:73
+#: src/exercises/day-1/solutions-morning.md:77
 msgid ""
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
 "```\n"
-"### Bonus question"
+"### Bonus question\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:80
 #, fuzzy
 msgid ""
-"It requires more advanced concepts. It might seem that we could use a "
-"slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make "
-"our function handle any size of matrix. However, this quickly breaks down: "
-"the return type cannot be `&[&[i32]]` since it needs to own the data you "
-"return."
+"It requires more advanced concepts. It might seem that we could use a slice-"
+"of-slices (`&[&[i32]]`) as the input type to transpose and thus make our "
+"function handle any size of matrix. However, this quickly breaks down: the "
+"return type cannot be `&[&[i32]]` since it needs to own the data you return."
 msgstr ""
 "Wymaga bardziej zaawansowanych koncepcji. Mogłoby się wydawać, że moglibyśmy "
 "użyć wycinka plasterków (`&[&[i32]]`) jako typu wejściowego do transpozycji, "
@@ -17011,46 +16802,120 @@ msgstr ""
 #: src/exercises/day-1/solutions-morning.md:84
 #, fuzzy
 msgid ""
-"Once we get to traits and generics, we'll be able to use the "
-"[`std::convert::AsRef`][1] trait to abstract over anything that can be "
-"referenced as a slice."
+"Once we get to traits and generics, we'll be able to use the [`std::convert::"
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
-"Gdy przejdziemy do cech i typów ogólnych, będziemy mogli użyć cechy "
-"[`std::convert::AsRef`][1] do abstrakcji na wszystkim, co można nazwać "
-"plasterkiem."
+"Gdy przejdziemy do cech i typów ogólnych, będziemy mogli użyć cechy [`std::"
+"convert::AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) do "
+"abstrakcji na wszystkim, co można nazwać plasterkiem."
 
 #: src/exercises/day-1/solutions-morning.md:86
 msgid ""
 "```rust\n"
 "use std::convert::AsRef;\n"
-"use std::fmt::Debug;"
+"use std::fmt::Debug;\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:90
 msgid ""
-"fn pretty_print<T, Line, Matrix>(matrix: Matrix)\n"
-"where\n"
-"    T: Debug,\n"
-"    // A line references a slice of items\n"
-"    Line: AsRef<[T]>,\n"
-"    // A matrix references a slice of lines\n"
-"    Matrix: AsRef<[Line]>\n"
-"{\n"
-"    for row in matrix.as_ref() {\n"
-"        println!(\"{:?}\", row.as_ref());\n"
-"    }\n"
-"}"
+"fn pretty_print\\<T, Line, Matrix>(matrix: Matrix) where T: Debug, // A line "
+"references a slice of items Line: AsRef\\<\\[T\\]\\>, // A matrix references "
+"a slice of lines Matrix: AsRef\\<\\[Line\\]\\> { for row in matrix.as_ref() "
+"{ println!(\"{:?}\", row.as_ref()); } }"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:103
 msgid ""
+"fn main() { // &\\[&\\[i32\\]\\] pretty_print(&\\[&\\[1, 2, 3\\], &\\[4, 5, "
+"6\\], &\\[7, 8, 9\\]\\]); // \\[\\[&str; 2\\]; 2\\] "
+"pretty_print(\\[\\[\"a\", \"b\"\\], \\[\"c\", \"d\"\\]\\]); // Vec\\<Vec"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:108
+msgid "\\> pretty_print(vec![vec![1, 2\\], vec![3, 4\\]\\]); }"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:111
+msgid ""
+"```\n"
+"\n"
+"# Day 1 Morning Exercises\n"
+"\n"
+"## Arrays and `for` Loops\n"
+"\n"
+"([back to exercise](for-loops.md))\n"
+"\n"
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"// ANCHOR: transpose\n"
+"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
+"    // ANCHOR_END: transpose\n"
+"    let mut result = [[0; 3]; 3];\n"
+"    for i in 0..3 {\n"
+"        for j in 0..3 {\n"
+"            result[j][i] = matrix[i][j];\n"
+"        }\n"
+"    }\n"
+"    return result;\n"
+"}\n"
+"\n"
+"// ANCHOR: pretty_print\n"
+"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
+"    // ANCHOR_END: pretty_print\n"
+"    for row in matrix {\n"
+"        println!(\"{row:?}\");\n"
+"    }\n"
+"}\n"
+"\n"
+"// ANCHOR: tests\n"
+"#[test]\n"
+"fn test_transpose() {\n"
+"    let matrix = [\n"
+"        [101, 102, 103], //\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"    let transposed = transpose(matrix);\n"
+"    assert_eq!(\n"
+"        transposed,\n"
+"        [\n"
+"            [101, 201, 301], //\n"
+"            [102, 202, 302],\n"
+"            [103, 203, 303],\n"
+"        ]\n"
+"    );\n"
+"}\n"
+"// ANCHOR_END: tests\n"
+"\n"
+"// ANCHOR: main\n"
 "fn main() {\n"
-"    // &[&[i32]]\n"
-"    pretty_print(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);\n"
-"    // [[&str; 2]; 2]\n"
-"    pretty_print([[\"a\", \"b\"], [\"c\", \"d\"]]);\n"
-"    // Vec<Vec<i32>>\n"
-"    pretty_print(vec![vec![1, 2], vec![3, 4]]);\n"
+"    let matrix = [\n"
+"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
+"        [201, 202, 203],\n"
+"        [301, 302, 303],\n"
+"    ];\n"
+"\n"
+"    println!(\"matrix:\");\n"
+"    pretty_print(&matrix);\n"
+"\n"
+"    let transposed = transpose(matrix);\n"
+"    println!(\"transposed:\");\n"
+"    pretty_print(&transposed);\n"
 "}\n"
 "```"
 msgstr ""
@@ -17064,294 +16929,246 @@ msgstr ""
 "Ponadto sam typ nie wymuszałby, aby wycinki potomne były tej samej długości, "
 "więc taka zmienna mogłaby zawierać nieprawidłową macierz."
 
-#: src/exercises/day-1/solutions-morning.md:115
-#, fuzzy
-msgid "[1]: https://doc.rust-lang.org/std/convert/trait.AsRef.html"
-msgstr "[1]: https://doc.rust-lang.org/std/convert/trait.AsRef.html"
-
 #: src/exercises/day-1/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 1 Afternoon Exercises"
-msgstr "# Dzień 1 Ćwiczenia popołudniowe"
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Designing a Library"
-msgstr "## Projektowanie biblioteki"
+msgid "Day 1 Afternoon Exercises"
+msgstr "Dzień 1 Ćwiczenia popołudniowe"
 
 #: src/exercises/day-1/solutions-afternoon.md:5
 msgid "([back to exercise](book-library.md))"
 msgstr "([powrót do ćwiczenia](book-library.md))"
 
 #: src/exercises/day-1/solutions-afternoon.md:22
-msgid ""
-"// ANCHOR: setup\n"
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}"
-msgstr ""
-"// ANCHOR: setup\n"
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}"
+msgid "// ANCHOR: setup struct Library { books: Vec"
+msgstr "// ANCHOR: setup struct Library { books: Vec"
 
 #: src/exercises/day-1/solutions-afternoon.md:42
 msgid ""
-"// This makes it possible to print Book values with {}.\n"
-"impl std::fmt::Display for Book {\n"
-"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-"        write!(f, \"{} ({})\", self.title, self.year)\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: setup"
+"// This makes it possible to print Book values with {}. impl std::fmt::"
+"Display for Book { fn fmt(&self, f: &mut std::fmt::Formatter\\<'\\_\\>) -> "
+"std::fmt::Result { write!(f, \"{} ({})\", self.title, self.year) } } // "
+"ANCHOR_END: setup"
 msgstr ""
-"// Umożliwia to drukowanie wartości Book za pomocą {}.\n"
-"impl std::fmt::Display for Book {\n"
-"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-"        write!(f, \"{} ({})\", self.title, self.year)\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: setup"
+"// Umożliwia to drukowanie wartości Book za pomocą {}. impl std::fmt::"
+"Display for Book { fn fmt(&self, f: &mut std::fmt::Formatter\\<'\\_\\>) -> "
+"std::fmt::Result { write!(f, \"{} ({})\", self.title, self.year) } } // "
+"ANCHOR_END: setup"
 
 #: src/exercises/day-1/solutions-afternoon.md:50
 msgid ""
-"// ANCHOR: Library_new\n"
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        // ANCHOR_END: Library_new\n"
-"        Library { books: Vec::new() }\n"
-"    }"
+"// ANCHOR: Library_new impl Library { fn new() -> Library { // ANCHOR_END: "
+"Library_new Library { books: Vec::new() } }"
 msgstr ""
-"// ANCHOR: Library_new\n"
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        // ANCHOR_END: Library_new\n"
-"        Library { books: Vec::new() }\n"
-"    }"
+"// ANCHOR: Library_new impl Library { fn new() -> Library { // ANCHOR_END: "
+"Library_new Library { books: Vec::new() } }"
 
 #: src/exercises/day-1/solutions-afternoon.md:57
 msgid ""
-"    // ANCHOR: Library_len\n"
-"    //fn len(self) -> usize {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_len\n"
-"    fn len(&self) -> usize {\n"
-"        self.books.len()\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_len\n"
+"//fn len(self) -> usize {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_len\n"
+"fn len(&self) -> usize {\n"
+"    self.books.len()\n"
+"}\n"
+"```"
 msgstr ""
-"    // ANCHOR: Library_len\n"
-"    //fn len(self) -> usize {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_len\n"
-"    fn len(&self) -> usize {\n"
-"        self.books.len()\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_len\n"
+"//fn len(self) -> usize {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_len\n"
+"fn len(&self) -> usize {\n"
+"    self.books.len()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-1/solutions-afternoon.md:66
 msgid ""
-"    // ANCHOR: Library_is_empty\n"
-"    //fn is_empty(self) -> bool {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_is_empty\n"
-"    fn is_empty(&self) -> bool {\n"
-"        self.books.is_empty()\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_is_empty\n"
+"//fn is_empty(self) -> bool {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_is_empty\n"
+"fn is_empty(&self) -> bool {\n"
+"    self.books.is_empty()\n"
+"}\n"
+"```"
 msgstr ""
-"    // ANCHOR: Library_is_empty\n"
-"    //fn is_empty(self) -> bool {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_is_empty\n"
-"    fn is_empty(&self) -> bool {\n"
-"        self.books.is_empty()\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_is_empty\n"
+"//fn is_empty(self) -> bool {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_is_empty\n"
+"fn is_empty(&self) -> bool {\n"
+"    self.books.is_empty()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-1/solutions-afternoon.md:75
 msgid ""
-"    // ANCHOR: Library_add_book\n"
-"    //fn add_book(self, book: Book) {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_add_book\n"
-"    fn add_book(&mut self, book: Book) {\n"
-"        self.books.push(book)\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_add_book\n"
+"//fn add_book(self, book: Book) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_add_book\n"
+"fn add_book(&mut self, book: Book) {\n"
+"    self.books.push(book)\n"
+"}\n"
+"```"
 msgstr ""
-"    // ANCHOR: Library_add_book\n"
-"    //fn add_book(self, book: Book) {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_add_book\n"
-"    fn add_book(&mut self, book: Book) {\n"
-"        self.books.push(book)\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_add_book\n"
+"//fn add_book(self, book: Book) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_add_book\n"
+"fn add_book(&mut self, book: Book) {\n"
+"    self.books.push(book)\n"
+"}\n"
+"```"
 
 #: src/exercises/day-1/solutions-afternoon.md:84
 msgid ""
-"    // ANCHOR: Library_print_books\n"
-"    //fn print_books(self) {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_print_books\n"
-"    fn print_books(&self) {\n"
-"        for book in &self.books {\n"
-"            println!(\"{}\", book);\n"
-"        }\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_print_books\n"
+"//fn print_books(self) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_print_books\n"
+"fn print_books(&self) {\n"
+"    for book in &self.books {\n"
+"        println!(\"{}\", book);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
-"    // ANCHOR: Library_print_books\n"
-"    //fn print_books(self) {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_print_books\n"
-"    fn print_books(&self) {\n"
-"        for book in &self.books {\n"
-"            println!(\"{}\", book);\n"
-"        }\n"
-"    }"
+"```\n"
+"// ANCHOR: Library_print_books\n"
+"//fn print_books(self) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_print_books\n"
+"fn print_books(&self) {\n"
+"    for book in &self.books {\n"
+"        println!(\"{}\", book);\n"
+"    }\n"
+"}\n"
+"```"
 
 #: src/exercises/day-1/solutions-afternoon.md:95
 msgid ""
-"    // ANCHOR: Library_oldest_book\n"
-"    //fn oldest_book(self) -> Option<&Book> {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_oldest_book\n"
-"    fn oldest_book(&self) -> Option<&Book> {\n"
-"        self.books.iter().min_by_key(|book| book.year)\n"
-"    }\n"
-"}"
+"```\n"
+"// ANCHOR: Library_oldest_book\n"
+"//fn oldest_book(self) -> Option<&Book> {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_oldest_book\n"
+"fn oldest_book(&self) -> Option<&Book> {\n"
+"    self.books.iter().min_by_key(|book| book.year)\n"
+"}\n"
+"```"
 msgstr ""
-"    // ANCHOR: Library_oldest_book\n"
-"    //fn oldest_book(self) -> Option<&Book> {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_oldest_book\n"
-"    fn oldest_book(&self) -> Option<&Book> {\n"
-"        self.books.iter().min_by_key(|book| book.year)\n"
-"    }\n"
-"}"
+"```\n"
+"// ANCHOR: Library_oldest_book\n"
+"//fn oldest_book(self) -> Option<&Book> {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_oldest_book\n"
+"fn oldest_book(&self) -> Option<&Book> {\n"
+"    self.books.iter().min_by_key(|book| book.year)\n"
+"}\n"
+"```"
 
 #: src/exercises/day-1/solutions-afternoon.md:105
 msgid ""
-"// ANCHOR: main\n"
-"// This shows the desired behavior. Uncomment the code below and\n"
-"// implement the missing methods. You will need to update the\n"
-"// method signatures, including the \"self\" parameter! You may\n"
-"// also need to update the variable bindings within main.\n"
-"fn main() {\n"
-"    let library = Library::new();"
+"// ANCHOR: main // This shows the desired behavior. Uncomment the code below "
+"and // implement the missing methods. You will need to update the // method "
+"signatures, including the \"self\" parameter! You may // also need to update "
+"the variable bindings within main. fn main() { let library = Library::new();"
 msgstr ""
 
-#: src/exercises/day-1/solutions-afternoon.md:113
-msgid ""
-"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
-"    //\n"
-"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    //\n"
-"    //library.print_books();\n"
-"    //\n"
-"    //match library.oldest_book() {\n"
-"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
-"    //    None => println!(\"My library is empty!\"),\n"
-"    //}\n"
-"    //\n"
-"    //println!(\"Our library has {} books\", library.len());\n"
-"}\n"
-"// ANCHOR_END: main"
+#: src/exercises/day-1/solutions-afternoon.md:126
+msgid "} // ANCHOR_END: main"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:129
 msgid ""
-"#[test]\n"
-"fn test_library_len() {\n"
-"    let mut library = Library::new();\n"
-"    assert_eq!(library.len(), 0);\n"
-"    assert!(library.is_empty());"
+"\\#\\[test\\] fn test_library_len() { let mut library = Library::new(); "
+"assert_eq!(library.len(), 0); assert!(library.is_empty());"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:135
 msgid ""
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    assert_eq!(library.len(), 2);\n"
-"    assert!(!library.is_empty());\n"
-"}"
+"```\n"
+"library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"assert_eq!(library.len(), 2);\n"
+"assert!(!library.is_empty());\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:141
 msgid ""
-"#[test]\n"
-"fn test_library_is_empty() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.is_empty());"
+"\\#\\[test\\] fn test_library_is_empty() { let mut library = Library::new(); "
+"assert!(library.is_empty());"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:146
 msgid ""
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert!(!library.is_empty());\n"
-"}"
+"```\n"
+"library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"assert!(!library.is_empty());\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:150
 msgid ""
-"#[test]\n"
-"fn test_library_print_books() {\n"
-"    let mut library = Library::new();\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    // We could try and capture stdout, but let us just call the\n"
-"    // method to start with.\n"
-"    library.print_books();\n"
-"}"
+"\\#\\[test\\] fn test_library_print_books() { let mut library = Library::"
+"new(); library.add_book(Book::new(\"Lord of the Rings\", 1954)); library."
+"add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865)); // We could "
+"try and capture stdout, but let us just call the // method to start with. "
+"library.print_books(); }"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:160
 msgid ""
-"#[test]\n"
-"fn test_library_oldest_book() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.oldest_book().is_none());"
+"\\#\\[test\\] fn test_library_oldest_book() { let mut library = Library::"
+"new(); assert!(library.oldest_book().is_none());"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:165
 msgid ""
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Lord of the Rings\")\n"
-"    );"
+"```\n"
+"library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"assert_eq!(\n"
+"    library.oldest_book().map(|b| b.title.as_str()),\n"
+"    Some(\"Lord of the Rings\")\n"
+");\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:171
 msgid ""
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
-"1865));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Alice's Adventures in Wonderland\")\n"
-"    );\n"
-"}\n"
+"```\n"
+"library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"assert_eq!(\n"
+"    library.oldest_book().map(|b| b.title.as_str()),\n"
+"    Some(\"Alice's Adventures in Wonderland\")\n"
+");\n"
 "```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 2 Morning Exercises"
-msgstr "# Dzień 2 Ćwiczenia poranne"
-
-#: src/exercises/day-2/solutions-morning.md:3
-#, fuzzy
-msgid "## Points and Polygons"
-msgstr "## Punkty i wielokąty"
+msgid "Day 2 Morning Exercises"
+msgstr "Dzień 2 Ćwiczenia poranne"
 
 #: src/exercises/day-2/solutions-morning.md:5
 msgid "([back to exercise](points-polygons.md))"
@@ -17359,381 +17176,285 @@ msgstr "([powrót do ćwiczenia](points-polygons.md))"
 
 #: src/exercises/day-2/solutions-morning.md:22
 msgid ""
-"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-"// ANCHOR: Point\n"
-"pub struct Point {\n"
-"    // ANCHOR_END: Point\n"
-"    x: i32,\n"
-"    y: i32,\n"
-"}"
+"\\#\\[derive(Debug, Copy, Clone, PartialEq, Eq)\\] // ANCHOR: Point pub "
+"struct Point { // ANCHOR_END: Point x: i32, y: i32, }"
 msgstr ""
-"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-"// ANCHOR: Point\n"
-"pub struct Point {\n"
-"    // ANCHOR_END: Point\n"
-"    x: i32,\n"
-"    y: i32,\n"
-"}"
+"\\#\\[derive(Debug, Copy, Clone, PartialEq, Eq)\\] // ANCHOR: Point pub "
+"struct Point { // ANCHOR_END: Point x: i32, y: i32, }"
 
 #: src/exercises/day-2/solutions-morning.md:30
 msgid ""
-"// ANCHOR: Point-impl\n"
-"impl Point {\n"
-"    // ANCHOR_END: Point-impl\n"
-"    pub fn new(x: i32, y: i32) -> Point {\n"
-"        Point { x, y }\n"
-"    }"
+"// ANCHOR: Point-impl impl Point { // ANCHOR_END: Point-impl pub fn new(x: "
+"i32, y: i32) -> Point { Point { x, y } }"
 msgstr ""
-"// ANCHOR: Point-impl\n"
-"impl Point {\n"
-"    // ANCHOR_END: Point-impl\n"
-"    pub fn new(x: i32, y: i32) -> Point {\n"
-"        Point { x, y }\n"
-"    }"
+"// ANCHOR: Point-impl impl Point { // ANCHOR_END: Point-impl pub fn new(x: "
+"i32, y: i32) -> Point { Point { x, y } }"
 
 #: src/exercises/day-2/solutions-morning.md:37
 msgid ""
-"    pub fn magnitude(self) -> f64 {\n"
-"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-"    }"
+"```\n"
+"pub fn magnitude(self) -> f64 {\n"
+"    f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn magnitude(self) -> f64 {\n"
-"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-"    }"
+"```\n"
+"pub fn magnitude(self) -> f64 {\n"
+"    f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:41
 msgid ""
-"    pub fn dist(self, other: Point) -> f64 {\n"
-"        (self - other).magnitude()\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn dist(self, other: Point) -> f64 {\n"
+"    (self - other).magnitude()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn dist(self, other: Point) -> f64 {\n"
-"        (self - other).magnitude()\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn dist(self, other: Point) -> f64 {\n"
+"    (self - other).magnitude()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:49
 msgid ""
-"    fn add(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x + other.x,\n"
-"            y: self.y + other.y,\n"
-"        }\n"
+"```\n"
+"fn add(self, other: Self) -> Self::Output {\n"
+"    Self {\n"
+"        x: self.x + other.x,\n"
+"        y: self.y + other.y,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
-"    fn add(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x + other.x,\n"
-"            y: self.y + other.y,\n"
-"        }\n"
+"```\n"
+"fn add(self, other: Self) -> Self::Output {\n"
+"    Self {\n"
+"        x: self.x + other.x,\n"
+"        y: self.y + other.y,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:57
-msgid "impl std::ops::Sub for Point {\n    type Output = Self;"
-msgstr "impl std::ops::Sub for Point {\n    type Output = Self;"
+msgid "impl std::ops::Sub for Point { type Output = Self;"
+msgstr "impl std::ops::Sub for Point { type Output = Self;"
 
 #: src/exercises/day-2/solutions-morning.md:60
 msgid ""
-"    fn sub(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x - other.x,\n"
-"            y: self.y - other.y,\n"
-"        }\n"
+"```\n"
+"fn sub(self, other: Self) -> Self::Output {\n"
+"    Self {\n"
+"        x: self.x - other.x,\n"
+"        y: self.y - other.y,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
-"    fn sub(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x - other.x,\n"
-"            y: self.y - other.y,\n"
-"        }\n"
+"```\n"
+"fn sub(self, other: Self) -> Self::Output {\n"
+"    Self {\n"
+"        x: self.x - other.x,\n"
+"        y: self.y - other.y,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:68
 msgid ""
-"// ANCHOR: Polygon\n"
-"pub struct Polygon {\n"
-"    // ANCHOR_END: Polygon\n"
-"    points: Vec<Point>,\n"
-"}"
+"// ANCHOR: Polygon pub struct Polygon { // ANCHOR_END: Polygon points: Vec"
 msgstr ""
-"// ANCHOR: Polygon\n"
-"pub struct Polygon {\n"
-"    // ANCHOR_END: Polygon\n"
-"    points: Vec<Point>,\n"
-"}"
+"// ANCHOR: Polygon pub struct Polygon { // ANCHOR_END: Polygon points: Vec"
 
 #: src/exercises/day-2/solutions-morning.md:74
 msgid ""
-"// ANCHOR: Polygon-impl\n"
-"impl Polygon {\n"
-"    // ANCHOR_END: Polygon-impl\n"
-"    pub fn new() -> Polygon {\n"
-"        Polygon { points: Vec::new() }\n"
-"    }"
+"// ANCHOR: Polygon-impl impl Polygon { // ANCHOR_END: Polygon-impl pub fn "
+"new() -> Polygon { Polygon { points: Vec::new() } }"
 msgstr ""
-"// ANCHOR: Polygon-impl\n"
-"impl Polygon {\n"
-"    // ANCHOR_END: Polygon-impl\n"
-"    pub fn new() -> Polygon {\n"
-"        Polygon { points: Vec::new() }\n"
-"    }"
+"// ANCHOR: Polygon-impl impl Polygon { // ANCHOR_END: Polygon-impl pub fn "
+"new() -> Polygon { Polygon { points: Vec::new() } }"
 
 #: src/exercises/day-2/solutions-morning.md:81
 msgid ""
-"    pub fn add_point(&mut self, point: Point) {\n"
-"        self.points.push(point);\n"
-"    }"
+"```\n"
+"pub fn add_point(&mut self, point: Point) {\n"
+"    self.points.push(point);\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn add_point(&mut self, point: Point) {\n"
-"        self.points.push(point);\n"
-"    }"
+"```\n"
+"pub fn add_point(&mut self, point: Point) {\n"
+"    self.points.push(point);\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:85
 msgid ""
-"    pub fn left_most_point(&self) -> Option<Point> {\n"
-"        self.points.iter().min_by_key(|p| p.x).copied()\n"
-"    }"
+"```\n"
+"pub fn left_most_point(&self) -> Option<Point> {\n"
+"    self.points.iter().min_by_key(|p| p.x).copied()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn left_most_point(&self) -> Option<Point> {\n"
-"        self.points.iter().min_by_key(|p| p.x).copied()\n"
-"    }"
+"```\n"
+"pub fn left_most_point(&self) -> Option<Point> {\n"
+"    self.points.iter().min_by_key(|p| p.x).copied()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:89
 msgid ""
-"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-"        self.points.iter()\n"
-"    }"
+"```\n"
+"pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"    self.points.iter()\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-"        self.points.iter()\n"
-"    }"
+"```\n"
+"pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"    self.points.iter()\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:93
 msgid ""
-"    pub fn length(&self) -> f64 {\n"
-"        if self.points.is_empty() {\n"
-"            return 0.0;\n"
-"        }"
+"```\n"
+"pub fn length(&self) -> f64 {\n"
+"    if self.points.is_empty() {\n"
+"        return 0.0;\n"
+"    }\n"
+"```"
 msgstr ""
-"    pub fn length(&self) -> f64 {\n"
-"        if self.points.is_empty() {\n"
-"            return 0.0;\n"
-"        }"
+"```\n"
+"pub fn length(&self) -> f64 {\n"
+"    if self.points.is_empty() {\n"
+"        return 0.0;\n"
+"    }\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:98
 msgid ""
-"        let mut result = 0.0;\n"
-"        let mut last_point = self.points[0];\n"
-"        for point in &self.points[1..] {\n"
-"            result += last_point.dist(*point);\n"
-"            last_point = *point;\n"
-"        }\n"
-"        result += last_point.dist(self.points[0]);\n"
-"        result\n"
+"```\n"
+"    let mut result = 0.0;\n"
+"    let mut last_point = self.points[0];\n"
+"    for point in &self.points[1..] {\n"
+"        result += last_point.dist(*point);\n"
+"        last_point = *point;\n"
 "    }\n"
-"}"
+"    result += last_point.dist(self.points[0]);\n"
+"    result\n"
+"}\n"
+"```"
 msgstr ""
-"        let mut result = 0.0;\n"
-"        let mut last_point = self.points[0];\n"
-"        for point in &self.points[1..] {\n"
-"            result += last_point.dist(*point);\n"
-"            last_point = *point;\n"
-"        }\n"
-"        result += last_point.dist(self.points[0]);\n"
-"        result\n"
+"```\n"
+"    let mut result = 0.0;\n"
+"    let mut last_point = self.points[0];\n"
+"    for point in &self.points[1..] {\n"
+"        result += last_point.dist(*point);\n"
+"        last_point = *point;\n"
 "    }\n"
-"}"
+"    result += last_point.dist(self.points[0]);\n"
+"    result\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:109
 msgid ""
-"// ANCHOR: Circle\n"
-"pub struct Circle {\n"
-"    // ANCHOR_END: Circle\n"
-"    center: Point,\n"
-"    radius: i32,\n"
-"}"
+"// ANCHOR: Circle pub struct Circle { // ANCHOR_END: Circle center: Point, "
+"radius: i32, }"
 msgstr ""
-"// ANCHOR: Circle\n"
-"pub struct Circle {\n"
-"    // ANCHOR_END: Circle\n"
-"    center: Point,\n"
-"    radius: i32,\n"
-"}"
+"// ANCHOR: Circle pub struct Circle { // ANCHOR_END: Circle center: Point, "
+"radius: i32, }"
 
 #: src/exercises/day-2/solutions-morning.md:116
 msgid ""
-"// ANCHOR: Circle-impl\n"
-"impl Circle {\n"
-"    // ANCHOR_END: Circle-impl\n"
-"    pub fn new(center: Point, radius: i32) -> Circle {\n"
-"        Circle { center, radius }\n"
-"    }"
+"// ANCHOR: Circle-impl impl Circle { // ANCHOR_END: Circle-impl pub fn "
+"new(center: Point, radius: i32) -> Circle { Circle { center, radius } }"
 msgstr ""
-"// ANCHOR: Circle-impl\n"
-"impl Circle {\n"
-"    // ANCHOR_END: Circle-impl\n"
-"    pub fn new(center: Point, radius: i32) -> Circle {\n"
-"        Circle { center, radius }\n"
-"    }"
+"// ANCHOR: Circle-impl impl Circle { // ANCHOR_END: Circle-impl pub fn "
+"new(center: Point, radius: i32) -> Circle { Circle { center, radius } }"
 
 #: src/exercises/day-2/solutions-morning.md:123
 msgid ""
-"    pub fn circumference(&self) -> f64 {\n"
-"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-"    }"
+"```\n"
+"pub fn circumference(&self) -> f64 {\n"
+"    2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn circumference(&self) -> f64 {\n"
-"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-"    }"
+"```\n"
+"pub fn circumference(&self) -> f64 {\n"
+"    2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:127
 msgid ""
-"    pub fn dist(&self, other: &Self) -> f64 {\n"
-"        self.center.dist(other.center)\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn dist(&self, other: &Self) -> f64 {\n"
+"    self.center.dist(other.center)\n"
+"}\n"
+"```"
 msgstr ""
-"    pub fn dist(&self, other: &Self) -> f64 {\n"
-"        self.center.dist(other.center)\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn dist(&self, other: &Self) -> f64 {\n"
+"    self.center.dist(other.center)\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-morning.md:132
 msgid ""
-"// ANCHOR: Shape\n"
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}\n"
-"// ANCHOR_END: Shape"
+"// ANCHOR: Shape pub enum Shape { Polygon(Polygon), Circle(Circle), } // "
+"ANCHOR_END: Shape"
 msgstr ""
-"// ANCHOR: Shape\n"
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}\n"
-"// ANCHOR_END: Shape"
+"// ANCHOR: Shape pub enum Shape { Polygon(Polygon), Circle(Circle), } // "
+"ANCHOR_END: Shape"
 
 #: src/exercises/day-2/solutions-morning.md:139
-msgid ""
-"impl From<Polygon> for Shape {\n"
-"    fn from(poly: Polygon) -> Self {\n"
-"        Shape::Polygon(poly)\n"
-"    }\n"
-"}"
-msgstr ""
-"impl From<Polygon> for Shape {\n"
-"    fn from(poly: Polygon) -> Self {\n"
-"        Shape::Polygon(poly)\n"
-"    }\n"
-"}"
+#: src/exercises/day-2/solutions-morning.md:145
+msgid "impl From"
+msgstr "impl From"
+
+#: src/exercises/day-2/solutions-morning.md:139
+msgid " for Shape { fn from(poly: Polygon) -> Self { Shape::Polygon(poly) } }"
+msgstr " for Shape { fn from(poly: Polygon) -> Self { Shape::Polygon(poly) } }"
 
 #: src/exercises/day-2/solutions-morning.md:145
 msgid ""
-"impl From<Circle> for Shape {\n"
-"    fn from(circle: Circle) -> Self {\n"
-"        Shape::Circle(circle)\n"
-"    }\n"
-"}"
+" for Shape { fn from(circle: Circle) -> Self { Shape::Circle(circle) } }"
 msgstr ""
-"impl From<Circle> for Shape {\n"
-"    fn from(circle: Circle) -> Self {\n"
-"        Shape::Circle(circle)\n"
-"    }\n"
-"}"
+" for Shape { fn from(circle: Circle) -> Self { Shape::Circle(circle) } }"
 
 #: src/exercises/day-2/solutions-morning.md:151
 msgid ""
-"impl Shape {\n"
-"    pub fn perimeter(&self) -> f64 {\n"
-"        match self {\n"
-"            Shape::Polygon(poly) => poly.length(),\n"
-"            Shape::Circle(circle) => circle.circumference(),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Shape { pub fn perimeter(&self) -> f64 { match self { Shape::"
+"Polygon(poly) => poly.length(), Shape::Circle(circle) => circle."
+"circumference(), } } }"
 msgstr ""
-"impl Shape {\n"
-"    pub fn perimeter(&self) -> f64 {\n"
-"        match self {\n"
-"            Shape::Polygon(poly) => poly.length(),\n"
-"            Shape::Circle(circle) => circle.circumference(),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Shape { pub fn perimeter(&self) -> f64 { match self { Shape::"
+"Polygon(poly) => poly.length(), Shape::Circle(circle) => circle."
+"circumference(), } } }"
 
 #: src/exercises/day-2/solutions-morning.md:160
-msgid ""
-"// ANCHOR: unit-tests\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;"
-msgstr ""
-"// ANCHOR: unit-tests\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;"
+msgid "// ANCHOR: unit-tests \\#\\[cfg(test)\\] mod tests { use super::\\*;"
+msgstr "// ANCHOR: unit-tests \\#\\[cfg(test)\\] mod tests { use super::\\*;"
 
-#: src/exercises/day-2/solutions-morning.md:213
-msgid ""
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: unit-tests"
-msgstr ""
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: unit-tests"
+#: src/exercises/day-2/solutions-morning.md:230
+#: src/exercises/day-2/solutions-afternoon.md:171
+msgid "} // ANCHOR_END: unit-tests"
+msgstr "} // ANCHOR_END: unit-tests"
 
-#: src/exercises/day-2/solutions-morning.md:233 src/exercises/day-2/solutions-afternoon.md:174
-msgid "fn main() {}\n```"
-msgstr "fn main() {}\n```"
+#: src/exercises/day-2/solutions-morning.md:233
+#: src/exercises/day-2/solutions-afternoon.md:174
+msgid "fn main() {}"
+msgstr "fn main() {}"
 
 #: src/exercises/day-2/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 2 Afternoon Exercises"
-msgstr "# Dzień 2 Ćwiczenia popołudniowe"
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Luhn Algorithm"
-msgstr "## Algorytm Luhna"
+msgid "Day 2 Afternoon Exercises"
+msgstr "Dzień 2 Ćwiczenia popołudniowe"
 
 #: src/exercises/day-2/solutions-afternoon.md:5
 msgid "([back to exercise](luhn.md))"
@@ -17741,64 +17462,123 @@ msgstr "([powrót do ćwiczenia](luhn.md))"
 
 #: src/exercises/day-2/solutions-afternoon.md:22
 msgid ""
-"// ANCHOR: luhn\n"
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    // ANCHOR_END: luhn\n"
-"    let mut digits_seen = 0;\n"
-"    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' "
-"').enumerate() {\n"
-"        match ch.to_digit(10) {\n"
-"            Some(d) => {\n"
-"                sum += if i % 2 == 1 {\n"
-"                    let dd = d * 2;\n"
-"                    dd / 10 + dd % 10\n"
-"                } else {\n"
-"                    d\n"
-"                };\n"
-"                digits_seen += 1;\n"
-"            }\n"
-"            None => return false,\n"
-"        }\n"
-"    }"
+"// ANCHOR: luhn pub fn luhn(cc_number: &str) -> bool { // ANCHOR_END: luhn "
+"let mut digits_seen = 0; let mut sum = 0; for (i, ch) in cc_number.chars()."
+"rev().filter(|&ch| ch != ' ').enumerate() { match ch.to_digit(10) { Some(d) "
+"=> { sum += if i % 2 == 1 { let dd = d * 2; dd / 10 + dd % 10 } else { d }; "
+"digits_seen += 1; } None => return false, } }"
 msgstr ""
-"// ANCHOR: luhn\n"
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    // ANCHOR_END: luhn\n"
-"    let mut digits_seen = 0;\n"
-"    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' "
-"').enumerate() {\n"
-"        match ch.to_digit(10) {\n"
-"            Some(d) => {\n"
-"                sum += if i % 2 == 1 {\n"
-"                    let dd = d * 2;\n"
-"                    dd / 10 + dd % 10\n"
-"                } else {\n"
-"                    d\n"
-"                };\n"
-"                digits_seen += 1;\n"
-"            }\n"
-"            None => return false,\n"
-"        }\n"
-"    }"
+"// ANCHOR: luhn pub fn luhn(cc_number: &str) -> bool { // ANCHOR_END: luhn "
+"let mut digits_seen = 0; let mut sum = 0; for (i, ch) in cc_number.chars()."
+"rev().filter(|&ch| ch != ' ').enumerate() { match ch.to_digit(10) { Some(d) "
+"=> { sum += if i % 2 == 1 { let dd = d * 2; dd / 10 + dd % 10 } else { d }; "
+"digits_seen += 1; } None => return false, } }"
 
 #: src/exercises/day-2/solutions-afternoon.md:42
 msgid ""
-"    if digits_seen < 2 {\n"
-"        return false;\n"
-"    }"
+"```\n"
+"if digits_seen < 2 {\n"
+"    return false;\n"
+"}\n"
+"```"
 msgstr ""
-"    if digits_seen < 2 {\n"
-"        return false;\n"
-"    }"
+"```\n"
+"if digits_seen < 2 {\n"
+"    return false;\n"
+"}\n"
+"```"
 
 #: src/exercises/day-2/solutions-afternoon.md:46
-msgid "    sum % 10 == 0\n}"
-msgstr "    sum % 10 == 0\n}"
+msgid ""
+"```\n"
+"sum % 10 == 0\n"
+"```"
+msgstr ""
+"```\n"
+"sum % 10 == 0\n"
+"```"
 
 #: src/exercises/day-2/solutions-afternoon.md:49
 msgid ""
+"fn main() { let cc_number = \"1234 5678 1234 5670\"; println!( \"Is {} a "
+"valid credit card number? {}\", cc_number, if luhn(cc_number) { \"yes\" } "
+"else { \"no\" } ); }"
+msgstr ""
+"fn main() { let cc_number = \"1234 5678 1234 5670\"; println!( \"Czy {} to "
+"prawidłowy numer karty kredytowej? {}\", cc_number, if luhn(cc_number) "
+"{ \"tak\" } else { \"nie\" } ); }"
+
+#: src/exercises/day-2/solutions-afternoon.md:58
+msgid ""
+"// ANCHOR: unit-tests \\#\\[test\\] fn test_non_digit_cc_number() { assert!(!"
+"luhn(\"foo\")); }"
+msgstr ""
+"// ANCHOR: unit-tests \\#\\[test\\] fn test_non_digit_cc_number() { assert!(!"
+"luhn(\"foo\")); }"
+
+#: src/exercises/day-2/solutions-afternoon.md:89
+msgid ""
+"\\#\\[test\\] fn test_invalid_cc_number() { assert!(!luhn(\"4223 9826 4026 "
+"9299\")); assert!(!luhn(\"4539 3195 0343 6476\")); assert!(!luhn(\"8273 1232 "
+"7352 0569\")); } // ANCHOR_END: unit-tests"
+msgstr ""
+"\\#\\[test\\] fn test_invalid_cc_number() { assert!(!luhn(\"4223 9826 4026 "
+"9299\")); assert!(!luhn(\"4539 3195 0343 6476\")); assert!(!luhn(\"8273 1232 "
+"7352 0569\")); } // ANCHOR_END: unit-tests"
+
+#: src/exercises/day-2/solutions-afternoon.md:96
+msgid ""
+"```\n"
+"\n"
+"# Day 2 Afternoon Exercises\n"
+"\n"
+"## Luhn Algorithm\n"
+"\n"
+"([back to exercise](luhn.md))\n"
+"\n"
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"// ANCHOR: luhn\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    // ANCHOR_END: luhn\n"
+"    let mut digits_seen = 0;\n"
+"    let mut sum = 0;\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Some(d) => {\n"
+"                sum += if i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd / 10 + dd % 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                digits_seen += 1;\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    if digits_seen < 2 {\n"
+"        return false;\n"
+"    }\n"
+"\n"
+"    sum % 10 == 0\n"
+"}\n"
+"\n"
 "fn main() {\n"
 "    let cc_number = \"1234 5678 1234 5670\";\n"
 "    println!(\n"
@@ -17806,8 +17586,160 @@ msgid ""
 "        cc_number,\n"
 "        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
 "    );\n"
-"}"
+"}\n"
+"\n"
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_non_digit_cc_number() {\n"
+"    assert!(!luhn(\"foo\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}\n"
+"\n"
+"## Strings and Iterators\n"
+"\n"
+"([back to exercise](strings-iterators.md))\n"
+"\n"
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
+"// ANCHOR: prefix_matches\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    // ANCHOR_END: prefix_matches\n"
+"    let prefixes = prefix.split('/');\n"
+"    let request_paths = request_path\n"
+"        .split('/')\n"
+"        .map(|p| Some(p))\n"
+"        .chain(std::iter::once(None));\n"
+"\n"
+"    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"        match request_path {\n"
+"            Some(request_path) => {\n"
+"                if (prefix != \"*\") && (prefix != request_path) {\n"
+"                    return false;\n"
+"                }\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"}\n"
+"\n"
+"// ANCHOR: unit-tests\n"
+"#[test]\n"
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
+"}\n"
+"// ANCHOR_END: unit-tests\n"
+"\n"
+"fn main() {}\n"
+"```"
 msgstr ""
+"```\n"
+"\n"
+"# Dzień 2 Ćwiczenia popołudniowe\n"
+"\n"
+"## Algorytm Luhna\n"
+"\n"
+"([powrót do ćwiczenia](luhn.md))\n"
+"\n"
+"\n"
+"\n"
+"// ANCHOR: luhn\n"
+"pub fn luhn(cc_number: &str) -> bool {\n"
+"    // ANCHOR_END: luhn\n"
+"    let mut digits_seen = 0;\n"
+"    let mut sum = 0;\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
+"        match ch.to_digit(10) {\n"
+"            Some(d) => {\n"
+"                sum += if i % 2 == 1 {\n"
+"                    let dd = d * 2;\n"
+"                    dd / 10 + dd % 10\n"
+"                } else {\n"
+"                    d\n"
+"                };\n"
+"                digits_seen += 1;\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"\n"
+"    if digits_seen < 2 {\n"
+"        return false;\n"
+"    }\n"
+"\n"
+"    sum % 10 == 0\n"
+"}\n"
+"\n"
 "fn main() {\n"
 "    let cc_number = \"1234 5678 1234 5670\";\n"
 "    println!(\n"
@@ -17815,46 +17747,91 @@ msgstr ""
 "        cc_number,\n"
 "        if luhn(cc_number) { \"tak\" } else { \"nie\" }\n"
 "    );\n"
-"}"
-
-#: src/exercises/day-2/solutions-afternoon.md:58
-msgid ""
+"}\n"
+"\n"
 "// ANCHOR: unit-tests\n"
 "#[test]\n"
 "fn test_non_digit_cc_number() {\n"
 "    assert!(!luhn(\"foo\"));\n"
-"}"
-msgstr ""
+"}\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"## Łańcuchy i iteratory\n"
+"\n"
+"([powrót do ćwiczenia](strings-iterators.md))\n"
+"\n"
+"\n"
+"\n"
+"// ANCHOR: prefix_matches\n"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
+"    // ANCHOR_END: prefix_matches\n"
+"    let prefixes = prefix.split('/');\n"
+"    let request_paths = request_path\n"
+"        .split('/')\n"
+"        .map(|p| Some(p))\n"
+"        .chain(std::iter::once(None));\n"
+"\n"
+"    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"        match request_path {\n"
+"            Some(request_path) => {\n"
+"                if (prefix != \"*\") && (prefix != request_path) {\n"
+"                    return false;\n"
+"                }\n"
+"            }\n"
+"            None => return false,\n"
+"        }\n"
+"    }\n"
+"    true\n"
+"}\n"
+"\n"
 "// ANCHOR: unit-tests\n"
 "#[test]\n"
-"fn test_non_digit_cc_number() {\n"
-"    assert!(!luhn(\"foo\"));\n"
-"}"
-
-#: src/exercises/day-2/solutions-afternoon.md:89
-msgid ""
+"fn test_matches_without_wildcard() {\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
+"}\n"
+"\n"
 "#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
+"    assert!(!prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/booksByAuthor\"\n"
+"    ));\n"
 "}\n"
 "// ANCHOR_END: unit-tests\n"
+"\n"
+"fn main() {}\n"
 "```"
-msgstr ""
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
-"}\n"
-"// ANCHOR_END: unit-tests\n"
-"```"
-
-#: src/exercises/day-2/solutions-afternoon.md:98
-#, fuzzy
-msgid "## Strings and Iterators"
-msgstr "## Łańcuchy i iteratory"
 
 #: src/exercises/day-2/solutions-afternoon.md:100
 msgid "([back to exercise](strings-iterators.md))"
@@ -17862,100 +17839,62 @@ msgstr "([powrót do ćwiczenia](strings-iterators.md))"
 
 #: src/exercises/day-2/solutions-afternoon.md:117
 msgid ""
-"// ANCHOR: prefix_matches\n"
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"    // ANCHOR_END: prefix_matches\n"
-"    let prefixes = prefix.split('/');\n"
-"    let request_paths = request_path\n"
-"        .split('/')\n"
-"        .map(|p| Some(p))\n"
-"        .chain(std::iter::once(None));"
+"// ANCHOR: prefix_matches pub fn prefix_matches(prefix: &str, request_path: "
+"&str) -> bool { // ANCHOR_END: prefix_matches let prefixes = prefix."
+"split('/'); let request_paths = request_path .split('/') .map(|p| Some(p)) ."
+"chain(std::iter::once(None));"
 msgstr ""
-"// ANCHOR: prefix_matches\n"
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"    // ANCHOR_END: prefix_matches\n"
-"    let prefixes = prefix.split('/');\n"
-"    let request_paths = request_path\n"
-"        .split('/')\n"
-"        .map(|p| Some(p))\n"
-"        .chain(std::iter::once(None));"
+"// ANCHOR: prefix_matches pub fn prefix_matches(prefix: &str, request_path: "
+"&str) -> bool { // ANCHOR_END: prefix_matches let prefixes = prefix."
+"split('/'); let request_paths = request_path .split('/') .map(|p| Some(p)) ."
+"chain(std::iter::once(None));"
 
 #: src/exercises/day-2/solutions-afternoon.md:126
 msgid ""
-"    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
-"        match request_path {\n"
-"            Some(request_path) => {\n"
-"                if (prefix != \"*\") && (prefix != request_path) {\n"
-"                    return false;\n"
-"                }\n"
+"```\n"
+"for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"    match request_path {\n"
+"        Some(request_path) => {\n"
+"            if (prefix != \"*\") && (prefix != request_path) {\n"
+"                return false;\n"
 "            }\n"
-"            None => return false,\n"
 "        }\n"
+"        None => return false,\n"
 "    }\n"
-"    true\n"
-"}"
+"}\n"
+"true\n"
+"```"
 msgstr ""
-"    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
-"        match request_path {\n"
-"            Some(request_path) => {\n"
-"                if (prefix != \"*\") && (prefix != request_path) {\n"
-"                    return false;\n"
-"                }\n"
+"```\n"
+"for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"    match request_path {\n"
+"        Some(request_path) => {\n"
+"            if (prefix != \"*\") && (prefix != request_path) {\n"
+"                return false;\n"
 "            }\n"
-"            None => return false,\n"
 "        }\n"
+"        None => return false,\n"
 "    }\n"
-"    true\n"
-"}"
+"}\n"
+"true\n"
+"```"
 
 #: src/exercises/day-2/solutions-afternoon.md:139
 msgid ""
-"// ANCHOR: unit-tests\n"
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));"
+"// ANCHOR: unit-tests \\#\\[test\\] fn test_matches_without_wildcard() "
+"{ assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\")); assert!"
+"(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\")); assert!"
+"(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));"
 msgstr ""
-"// ANCHOR: unit-tests\n"
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", "
-"\"/v1/publishers/abc/books\"));"
-
-#: src/exercises/day-2/solutions-afternoon.md:166
-msgid ""
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
-"// ANCHOR_END: unit-tests"
-msgstr ""
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", "
-"\"/v1/publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
-"// ANCHOR_END: unit-tests"
+"// ANCHOR: unit-tests \\#\\[test\\] fn test_matches_without_wildcard() "
+"{ assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\")); assert!"
+"(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\")); assert!"
+"(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));"
 
 #: src/exercises/day-3/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 3 Morning Exercise"
-msgstr "# Dzień 3 Poranna gimnastyka"
-
-#: src/exercises/day-3/solutions-morning.md:3
-msgid "## A Simple GUI Library"
-msgstr "## Prosta biblioteka GUI"
+msgid "Day 3 Morning Exercise"
+msgstr "Dzień 3 Poranna gimnastyka"
 
 #: src/exercises/day-3/solutions-morning.md:5
 msgid "([back to exercise](simple-gui.md))"
@@ -17963,15 +17902,11 @@ msgstr "([powrót do ćwiczenia](simple-gui.md))"
 
 #: src/exercises/day-3/solutions-morning.md:22
 msgid ""
-"// ANCHOR: setup\n"
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;"
+"// ANCHOR: setup pub trait Widget { /// Natural width of `self`. fn "
+"width(&self) -> usize;"
 msgstr ""
-"// ANCHOR: setup\n"
-"pub trait Widget {\n"
-"    /// Naturalna szerokość `self`.\n"
-"    fn width(&self) -> usize;"
+"// ANCHOR: setup pub trait Widget { /// Naturalna szerokość `self`. fn "
+"width(&self) -> usize;"
 
 #: src/exercises/day-3/solutions-morning.md:82
 msgid "// ANCHOR_END: setup"
@@ -17979,180 +17914,154 @@ msgstr "// ANCHOR_END: setup"
 
 #: src/exercises/day-3/solutions-morning.md:84
 msgid ""
-"// ANCHOR: Window-width\n"
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Window-width\n"
-"        std::cmp::max(\n"
-"            self.title.chars().count(),\n"
-"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-"        )\n"
-"    }"
+"// ANCHOR: Window-width impl Widget for Window { fn width(&self) -> usize "
+"{ // ANCHOR_END: Window-width std::cmp::max( self.title.chars().count(), "
+"self.widgets.iter().map(|w| w.width()).max().unwrap_or(0), ) }"
 msgstr ""
-"// ANCHOR: Window-width\n"
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Window-width\n"
-"        std::cmp::max(\n"
-"            self.title.chars().count(),\n"
-"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-"        )\n"
-"    }"
+"// ANCHOR: Window-width impl Widget for Window { fn width(&self) -> usize "
+"{ // ANCHOR_END: Window-width std::cmp::max( self.title.chars().count(), "
+"self.widgets.iter().map(|w| w.width()).max().unwrap_or(0), ) }"
 
 #: src/exercises/day-3/solutions-morning.md:94
 msgid ""
-"    // ANCHOR: Window-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Window-draw_into\n"
-"        let mut inner = String::new();\n"
-"        for widget in &self.widgets {\n"
-"            widget.draw_into(&mut inner);\n"
-"        }"
+"```\n"
+"// ANCHOR: Window-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Window-draw_into\n"
+"    let mut inner = String::new();\n"
+"    for widget in &self.widgets {\n"
+"        widget.draw_into(&mut inner);\n"
+"    }\n"
+"```"
 msgstr ""
-"    // ANCHOR: Window-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Window-draw_into\n"
-"        let mut inner = String::new();\n"
-"        for widget in &self.widgets {\n"
-"            widget.draw_into(&mut inner);\n"
-"        }"
+"```\n"
+"// ANCHOR: Window-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Window-draw_into\n"
+"    let mut inner = String::new();\n"
+"    for widget in &self.widgets {\n"
+"        widget.draw_into(&mut inner);\n"
+"    }\n"
+"```"
 
 #: src/exercises/day-3/solutions-morning.md:102
-msgid "        let window_width = self.width();"
-msgstr "        let window_width = self.width();"
+msgid ""
+"```\n"
+"    let window_width = self.width();\n"
+"```"
+msgstr ""
+"```\n"
+"    let window_width = self.width();\n"
+"```"
 
 #: src/exercises/day-3/solutions-morning.md:104
 msgid ""
-"        // TODO: after learning about error handling, you can change\n"
-"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
-"        // the ?-operator here instead of .unwrap().\n"
-"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
-"        writeln!(buffer, \"| {:^window_width$} |\", &self.title).unwrap();\n"
-"        writeln!(buffer, \"+={:=<window_width$}=+\", \"\").unwrap();\n"
-"        for line in inner.lines() {\n"
-"            writeln!(buffer, \"| {:window_width$} |\", line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"```\n"
+"    // TODO: after learning about error handling, you can change\n"
+"    // draw_into to return Result<(), std::fmt::Error>. Then use\n"
+"    // the ?-operator here instead of .unwrap().\n"
+"    writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"    writeln!(buffer, \"| {:^window_width$} |\", &self.title).unwrap();\n"
+"    writeln!(buffer, \"+={:=<window_width$}=+\", \"\").unwrap();\n"
+"    for line in inner.lines() {\n"
+"        writeln!(buffer, \"| {:window_width$} |\", line).unwrap();\n"
 "    }\n"
-"}"
+"    writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:117
 msgid ""
-"// ANCHOR: Button-width\n"
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Button-width\n"
-"        self.label.width() + 8 // add a bit of padding\n"
-"    }"
+"// ANCHOR: Button-width impl Widget for Button { fn width(&self) -> usize "
+"{ // ANCHOR_END: Button-width self.label.width() + 8 // add a bit of "
+"padding }"
 msgstr ""
-"// ANCHOR: Button-width\n"
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Button-width\n"
-"        self.label.width() + 8 // dodaj trochę wypełnienia\n"
-"    }"
+"// ANCHOR: Button-width impl Widget for Button { fn width(&self) -> usize "
+"{ // ANCHOR_END: Button-width self.label.width() + 8 // dodaj trochę "
+"wypełnienia }"
 
 #: src/exercises/day-3/solutions-morning.md:124
 msgid ""
-"    // ANCHOR: Button-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Button-draw_into\n"
-"        let width = self.width();\n"
-"        let mut label = String::new();\n"
-"        self.label.draw_into(&mut label);"
+"```\n"
+"// ANCHOR: Button-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Button-draw_into\n"
+"    let width = self.width();\n"
+"    let mut label = String::new();\n"
+"    self.label.draw_into(&mut label);\n"
+"```"
 msgstr ""
-"    // ANCHOR: Button-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Button-draw_into\n"
-"        let width = self.width();\n"
-"        let mut label = String::new();\n"
-"        self.label.draw_into(&mut label);"
+"```\n"
+"// ANCHOR: Button-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Button-draw_into\n"
+"    let width = self.width();\n"
+"    let mut label = String::new();\n"
+"    self.label.draw_into(&mut label);\n"
+"```"
 
 #: src/exercises/day-3/solutions-morning.md:131
 msgid ""
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
-"        for line in label.lines() {\n"
-"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"```\n"
+"    writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    for line in label.lines() {\n"
+"        writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
 "    }\n"
-"}"
+"    writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"}\n"
+"```"
 msgstr ""
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
-"        for line in label.lines() {\n"
-"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"```\n"
+"    writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    for line in label.lines() {\n"
+"        writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
 "    }\n"
-"}"
+"    writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"}\n"
+"```"
 
 #: src/exercises/day-3/solutions-morning.md:139
 msgid ""
-"// ANCHOR: Label-width\n"
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Label-width\n"
-"        self.label\n"
-"            .lines()\n"
-"            .map(|line| line.chars().count())\n"
-"            .max()\n"
-"            .unwrap_or(0)\n"
-"    }"
+"// ANCHOR: Label-width impl Widget for Label { fn width(&self) -> usize { // "
+"ANCHOR_END: Label-width self.label .lines() .map(|line| line.chars()."
+"count()) .max() .unwrap_or(0) }"
 msgstr ""
-"// ANCHOR: Label-width\n"
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Label-width\n"
-"        self.label\n"
-"            .lines()\n"
-"            .map(|line| line.chars().count())\n"
-"            .max()\n"
-"            .unwrap_or(0)\n"
-"    }"
+"// ANCHOR: Label-width impl Widget for Label { fn width(&self) -> usize { // "
+"ANCHOR_END: Label-width self.label .lines() .map(|line| line.chars()."
+"count()) .max() .unwrap_or(0) }"
 
 #: src/exercises/day-3/solutions-morning.md:150
 msgid ""
-"    // ANCHOR: Label-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Label-draw_into\n"
-"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
-"    }\n"
-"}"
+"```\n"
+"// ANCHOR: Label-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Label-draw_into\n"
+"    writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"}\n"
+"```"
 msgstr ""
-"    // ANCHOR: Label-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Label-draw_into\n"
-"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
-"    }\n"
-"}"
+"```\n"
+"// ANCHOR: Label-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Label-draw_into\n"
+"    writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"}\n"
+"```"
 
 #: src/exercises/day-3/solutions-morning.md:157
 msgid ""
-"// ANCHOR: main\n"
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI "
-"demo.\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\",\n"
-"        Box::new(|| println!(\"You clicked the button!\")),\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"// ANCHOR_END: main\n"
-"```"
+"// ANCHOR: main fn main() { let mut window = Window::new(\"Rust GUI Demo "
+"1.23\"); window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\"))); window.add_widget(Box::new(Button::new( \"Click me!\", Box::"
+"new(|| println!(\"You clicked the button!\")), ))); window.draw(); } // "
+"ANCHOR_END: main"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 3 Afternoon Exercises"
-msgstr "# Dzień 3 Ćwiczenia popołudniowe"
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Safe FFI Wrapper"
-msgstr "## Bezpieczne opakowanie FFI"
+msgid "Day 3 Afternoon Exercises"
+msgstr "Dzień 3 Ćwiczenia popołudniowe"
 
 #: src/exercises/day-3/solutions-afternoon.md:5
 msgid "([back to exercise](safe-ffi-wrapper.md))"
@@ -18160,111 +18069,68 @@ msgstr "([powrót do ćwiczenia](safe-ffi-wrapper.md))"
 
 #: src/exercises/day-3/solutions-afternoon.md:22
 msgid ""
-"// ANCHOR: ffi\n"
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+"// ANCHOR: ffi mod ffi { use std::os::raw::{c_char, c_int, c_long, c_ulong, "
+"c_ushort};"
 msgstr ""
-"// ANCHOR: ffi\n"
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+"// ANCHOR: ffi mod ffi { use std::os::raw::{c_char, c_int, c_long, c_ulong, "
+"c_ushort};"
 
 #: src/exercises/day-3/solutions-afternoon.md:53
 msgid ""
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}\n"
-"// ANCHOR_END: ffi"
+"\\#\\[derive(Debug)\\] struct DirectoryIterator { path: CString, dir: \\*mut "
+"ffi::DIR, } // ANCHOR_END: ffi"
 msgstr ""
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}\n"
-"// ANCHOR_END: ffi"
+"\\#\\[derive(Debug)\\] struct DirectoryIterator { path: CString, dir: \\*mut "
+"ffi::DIR, } // ANCHOR_END: ffi"
 
 #: src/exercises/day-3/solutions-afternoon.md:60
 msgid ""
-"// ANCHOR: DirectoryIterator\n"
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
-"        // ANCHOR_END: DirectoryIterator\n"
-"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
-"{err}\"))?;\n"
-"        // SAFETY: path.as_ptr() cannot be NULL.\n"
-"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
-"        if dir.is_null() {\n"
-"            Err(format!(\"Could not open {:?}\", path))\n"
-"        } else {\n"
-"            Ok(DirectoryIterator { path, dir })\n"
-"        }\n"
-"    }\n"
-"}"
+"// ANCHOR: DirectoryIterator impl DirectoryIterator { fn new(path: &str) -> "
+"Result\\<DirectoryIterator, String> { // Call opendir and return a Ok value "
+"if that worked, // otherwise return Err with a message. // ANCHOR_END: "
+"DirectoryIterator let path = CString::new(path).map_err(|err| format!"
+"(\"Invalid path: {err}\"))?; // SAFETY: path.as_ptr() cannot be NULL. let "
+"dir = unsafe { ffi::opendir(path.as_ptr()) }; if dir.is_null() { Err(format!"
+"(\"Could not open {:?}\", path)) } else { Ok(DirectoryIterator { path, "
+"dir }) } } }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:77
 msgid ""
-"// ANCHOR: Iterator\n"
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
-"        // ANCHOR_END: Iterator\n"
-"        // SAFETY: self.dir is never NULL.\n"
-"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
-"        if dirent.is_null() {\n"
-"            // We have reached the end of the directory.\n"
-"            return None;\n"
-"        }\n"
-"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
-"        // terminated.\n"
-"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
-"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
-"        Some(os_str.to_owned())\n"
-"    }\n"
-"}"
+"// ANCHOR: Iterator impl Iterator for DirectoryIterator { type Item = "
+"OsString; fn next(&mut self) -> Option"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:80
+msgid ""
+" { // Keep calling readdir until we get a NULL pointer back. // ANCHOR_END: "
+"Iterator // SAFETY: self.dir is never NULL. let dirent = unsafe { ffi::"
+"readdir(self.dir) }; if dirent.is_null() { // We have reached the end of the "
+"directory. return None; } // SAFETY: dirent is not NULL and dirent.d_name is "
+"NUL // terminated. let d_name = unsafe { CStr::from_ptr((\\*dirent).d_name."
+"as_ptr()) }; let os_str = OsStr::from_bytes(d_name.to_bytes()); Some(os_str."
+"to_owned()) } }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:97
 msgid ""
-"// ANCHOR: Drop\n"
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        // ANCHOR_END: Drop\n"
-"        if !self.dir.is_null() {\n"
-"            // SAFETY: self.dir is not NULL.\n"
-"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
-"                panic!(\"Could not close {:?}\", self.path);\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"}"
+"// ANCHOR: Drop impl Drop for DirectoryIterator { fn drop(&mut self) { // "
+"Call closedir as needed. // ANCHOR_END: Drop if !self.dir.is_null() { // "
+"SAFETY: self.dir is not NULL. if unsafe { ffi::closedir(self.dir) } != 0 "
+"{ panic!(\"Could not close {:?}\", self.path); } } } }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:111
 msgid ""
-"// ANCHOR: main\n"
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"// ANCHOR_END: main\n"
-"```"
+"// ANCHOR: main fn main() -> Result\\<(), String> { let iter = "
+"DirectoryIterator::new(\".\")?; println!(\"files: {:#?}\", iter.collect::"
+"\\<Vec\\<\\_\\>>()); Ok(()) } // ANCHOR_END: main"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 4 Morning Exercise"
-msgstr "# Dzień 4 Poranna gimnastyka"
-
-#: src/exercises/day-4/solutions-morning.md:3
-msgid "## Dining Philosophers"
-msgstr "## Ucztujący filozofowie"
+msgid "Day 4 Morning Exercise"
+msgstr "Dzień 4 Poranna gimnastyka"
 
 #: src/exercises/day-4/solutions-morning.md:5
 msgid "([back to exercise](dining-philosophers.md))"
@@ -18272,122 +18138,125 @@ msgstr "([powrót do ćwiczenia](dining-philosophers.md))"
 
 #: src/exercises/day-4/solutions-morning.md:22
 msgid ""
-"// ANCHOR: Philosopher\n"
-"use std::sync::mpsc;\n"
-"use std::sync::{Arc, Mutex};\n"
-"use std::thread;\n"
-"use std::time::Duration;"
+"// ANCHOR: Philosopher use std::sync::mpsc; use std::sync::{Arc, Mutex}; use "
+"std::thread; use std::time::Duration;"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:30
 #, fuzzy
 msgid ""
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // ANCHOR_END: Philosopher\n"
-"    left_fork: Arc<Mutex<Fork>>,\n"
-"    right_fork: Arc<Mutex<Fork>>,\n"
-"    thoughts: mpsc::SyncSender<String>,\n"
-"}"
+"struct Philosopher { name: String, // ANCHOR_END: Philosopher left_fork: "
+"Arc\\<Mutex"
 msgstr ""
-"struktura Filozof {\n"
-"    imię: Ciąg,\n"
-"    // ANCHOR_END: Filozof\n"
-"    left_fork: Arc<Mutex<Fork>>,\n"
-"    right_fork: Arc<Mutex<Fork>>,\n"
-"    myśli: mpsc::SyncSender<String>,\n"
-"}"
+"struktura Filozof { imię: Ciąg, // ANCHOR_END: Filozof left_fork: Arc\\<Mutex"
+
+#: src/exercises/day-4/solutions-morning.md:33
+#, fuzzy
+msgid "\\>, right_fork: Arc\\<Mutex"
+msgstr "\\>, right_fork: Arc\\<Mutex"
+
+#: src/exercises/day-4/solutions-morning.md:34
+#, fuzzy
+msgid "\\>, thoughts: mpsc::SyncSender"
+msgstr "\\>, myśli: mpsc::SyncSender"
 
 #: src/exercises/day-4/solutions-morning.md:38
 msgid ""
-"// ANCHOR: Philosopher-think\n"
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }\n"
-"    // ANCHOR_END: Philosopher-think"
+"// ANCHOR: Philosopher-think impl Philosopher { fn think(&self) { self."
+"thoughts .send(format!(\"Eureka! {} has a new idea!\", &self.name)) ."
+"unwrap(); } // ANCHOR_END: Philosopher-think"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:47
 msgid ""
-"    // ANCHOR: Philosopher-eat\n"
-"    fn eat(&self) {\n"
-"        // ANCHOR_END: Philosopher-eat\n"
-"        println!(\"{} is trying to eat\", &self.name);\n"
-"        let left = self.left_fork.lock().unwrap();\n"
-"        let right = self.right_fork.lock().unwrap();"
+"```\n"
+"// ANCHOR: Philosopher-eat\n"
+"fn eat(&self) {\n"
+"    // ANCHOR_END: Philosopher-eat\n"
+"    println!(\"{} is trying to eat\", &self.name);\n"
+"    let left = self.left_fork.lock().unwrap();\n"
+"    let right = self.right_fork.lock().unwrap();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:54
 msgid ""
-"        // ANCHOR: Philosopher-eat-end\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}"
+"```\n"
+"    // ANCHOR: Philosopher-eat-end\n"
+"    println!(\"{} is eating...\", &self.name);\n"
+"    thread::sleep(Duration::from_millis(10));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:63
 msgid ""
-"fn main() {\n"
-"    // ANCHOR_END: Philosopher-eat-end\n"
-"    let (tx, rx) = mpsc::sync_channel(10);"
+"fn main() { // ANCHOR_END: Philosopher-eat-end let (tx, rx) = mpsc::"
+"sync_channel(10);"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:67
 msgid ""
-"    let forks = (0..PHILOSOPHERS.len())\n"
-"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
-"        .collect::<Vec<_>>();"
+"```\n"
+"let forks = (0..PHILOSOPHERS.len())\n"
+"    .map(|_| Arc::new(Mutex::new(Fork)))\n"
+"    .collect::<Vec<_>>();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:71
 msgid ""
-"    for i in 0..forks.len() {\n"
-"        let tx = tx.clone();\n"
-"        let mut left_fork = forks[i].clone();\n"
-"        let mut right_fork = forks[(i + 1) % forks.len()].clone();"
+"```\n"
+"for i in 0..forks.len() {\n"
+"    let tx = tx.clone();\n"
+"    let mut left_fork = forks[i].clone();\n"
+"    let mut right_fork = forks[(i + 1) % forks.len()].clone();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:76
 msgid ""
-"        // To avoid a deadlock, we have to break the symmetry\n"
-"        // somewhere. This will swap the forks without deinitializing\n"
-"        // either of them.\n"
-"        if i == forks.len() - 1 {\n"
-"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
-"        }"
+"```\n"
+"    // To avoid a deadlock, we have to break the symmetry\n"
+"    // somewhere. This will swap the forks without deinitializing\n"
+"    // either of them.\n"
+"    if i == forks.len() - 1 {\n"
+"        std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"    }\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:83
 msgid ""
-"        let philosopher = Philosopher {\n"
-"            name: PHILOSOPHERS[i].to_string(),\n"
-"            thoughts: tx,\n"
-"            left_fork,\n"
-"            right_fork,\n"
-"        };"
+"```\n"
+"    let philosopher = Philosopher {\n"
+"        name: PHILOSOPHERS[i].to_string(),\n"
+"        thoughts: tx,\n"
+"        left_fork,\n"
+"        right_fork,\n"
+"    };\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:90
 msgid ""
-"        thread::spawn(move || {\n"
-"            for _ in 0..100 {\n"
-"                philosopher.eat();\n"
-"                philosopher.think();\n"
-"            }\n"
-"        });\n"
-"    }"
+"```\n"
+"    thread::spawn(move || {\n"
+"        for _ in 0..100 {\n"
+"            philosopher.eat();\n"
+"            philosopher.think();\n"
+"        }\n"
+"    });\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:98
 msgid ""
-"    drop(tx);\n"
-"    for thought in rx {\n"
-"        println!(\"{thought}\");\n"
-"    }\n"
+"```\n"
+"drop(tx);\n"
+"for thought in rx {\n"
+"    println!(\"{thought}\");\n"
 "}\n"
 "```"
 msgstr ""


### PR DESCRIPTION
Before, po/pl.po had these statistics:

    441 translated messages, 713 fuzzy translations, 627 untranslated messages.

Afterwards, the statistics for po/pl.po is:

    666 translated messages, 882 fuzzy translations, 919 untranslated messages.

The number of translated messages changed from 25% to 27%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.