### PR TITLE
it: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -5,34 +5,33 @@ msgstr ""
 "PO-Revision-Date: 2023-07-13 07:57+0200\n"
 "Last-Translator: Enrico Rivarola\n"
 "Language-Team: \n"
-"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Benvenuti a Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Esecuzione del corso"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Struttura del corso"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Tasti rapidi"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Traduzioni"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Utilizzo di Cargo"
 
@@ -57,55 +56,55 @@ msgstr "Giorno 1: Mattino"
 msgid "Welcome"
 msgstr "Benvenuti"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Cos’è Rust?"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Hello World!"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "Piccolo esempio"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "Perché Rust?"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "Garanzie alla Compilazione"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "Garanzie all’Esecuzione"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "Funzionalità moderne"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "Sintassi di base"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "Tipi Scalari"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "Tipi Composti"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "Riferimenti"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "Riferimenti pendenti"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "Slice"
 
@@ -113,15 +112,16 @@ msgstr "Slice"
 msgid "String vs str"
 msgstr "Differenza tra String e str"
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "Funzioni"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr "Rustdoc"
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "Metodi"
 
@@ -132,10 +132,14 @@ msgstr "Overloading"
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
 #: src/SUMMARY.md:253 src/SUMMARY.md:275 src/SUMMARY.md:296
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
+#: src/exercises/concurrency/morning.md:1
+#: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "Esercizi"
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "Conversione implicita"
 
@@ -147,11 +151,11 @@ msgstr "Array e Cicli for"
 msgid "Day 1: Afternoon"
 msgstr "Giorno 1: Pomeriggio"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "Variabili"
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "Inferenza del Tipo"
 
@@ -159,11 +163,11 @@ msgstr "Inferenza del Tipo"
 msgid "static & const"
 msgstr "static & const"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "Scope e Shadowing"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "Gestione della Memoria"
 
@@ -171,15 +175,15 @@ msgstr "Gestione della Memoria"
 msgid "Stack vs Heap"
 msgstr "Stack vs Heap"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "Memoria sullo Stack"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "Gestione manuale della Memoria"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "Gestione della Memoria basata su Scope"
 
@@ -191,59 +195,59 @@ msgstr "Garbage Collection"
 msgid "Rust Memory Management"
 msgstr "Gestione della Memoria in Rust"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "Comparazione"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
 msgstr "Proprietà"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "Semantica di move"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Stringhe a cui è applicata move"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "Doppio applicazione di free in C++ moderno"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "Move nelle Chiamate a Funzione"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "Copiare (Copy) e Clonare (Clone)"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "Prestito (Borrowing)"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "Prestito (Borrow) Condiviso (Shared) e Unico (Unique)"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "Lifetime"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "Lifetime in Chiamate a Funzione"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "Lifetime in Strutture Dati"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
 msgid "Storing Books"
 msgstr "Memorizza i libri"
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "Iteratori (Iterators) e Proprietà (Ownership)"
 
@@ -251,63 +255,64 @@ msgstr "Iteratori (Iterators) e Proprietà (Ownership)"
 msgid "Day 2: Morning"
 msgstr "Giorno 2: Mattina"
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
 msgstr "Strutture (Struct)"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "Strutture a Tupla (Tuple Structs)"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "Sintassi abbreviata per Campo (Field)"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
 msgstr "Enumerazioni (Enums)"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "Payload Variabili (Variant Payloads)"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "Dimensione degli Enum"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "Ricevitore (Receiver) del Metodo"
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:274
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "Esempio"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "Pattern Matching"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "Destrutturazione di Enum"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "Destrutturazione di Struct"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "Destrutturazione di Array"
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "Match Guards"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "Salute (Health) Statistics"
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "Punti e Poligoni"
 
@@ -315,11 +320,11 @@ msgstr "Punti e Poligoni"
 msgid "Day 2: Afternoon"
 msgstr "Giorno 2: Pomeriggio"
 
-#: src/SUMMARY.md:96 src/SUMMARY.md:288
+#: src/SUMMARY.md:96 src/SUMMARY.md:288 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "Flusso di Controllo"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "Blocchi"
 
@@ -355,7 +360,7 @@ msgstr "espressioni MATCH"
 msgid "break & continue"
 msgstr "break & continue"
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
 msgstr "Libreria standard"
 
@@ -363,7 +368,7 @@ msgstr "Libreria standard"
 msgid "Option and Result"
 msgstr "Option e Result"
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
 msgstr "Stringa (String)"
 
@@ -383,7 +388,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "Tipi di dati ricorsivi"
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "Ottimizzazioni di nicchia"
 
@@ -391,27 +396,29 @@ msgstr "Ottimizzazioni di nicchia"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr "Moduli"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "Visibilità"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr "Percorsi (Paths)"
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "Gerarchia del filesystem"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Algoritmo di Luhn"
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:97
 msgid "Strings and Iterators"
 msgstr "Stringhe (Strings) e Iteratori (Iterators)"
 
@@ -419,39 +426,39 @@ msgstr "Stringhe (Strings) e Iteratori (Iterators)"
 msgid "Day 3: Morning"
 msgstr "Giorno 3: Mattina"
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/generics.md:1
 msgid "Generics"
 msgstr "Generics"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "Tipi di dati Generic"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "Metodi Generic"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "Monomorfizzazione (Monomorphization)"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits.md:1
 msgid "Traits"
 msgstr "Traits"
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "Oggetti che implementano Trait (Trait Objects)"
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "Tratti derivati"
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md:136 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "Metodi predefiniti (Default Methods)"
 
-#: src/SUMMARY.md:137
+#: src/SUMMARY.md:137 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "Trait Bounds"
 
@@ -459,7 +466,7 @@ msgstr "Trait Bounds"
 msgid "impl Trait"
 msgstr "impl Trait"
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "Trait importanti"
 
@@ -467,7 +474,7 @@ msgstr "Trait importanti"
 msgid "Iterator"
 msgstr "Iteratore (Iterator)"
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -495,7 +502,8 @@ msgstr "Operatori: Add, Mul, ..."
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr "Closures: Fn, FnMut, FnOnce"
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "Una semplice libreria per Interfacce Grafiche"
 
@@ -503,11 +511,11 @@ msgstr "Una semplice libreria per Interfacce Grafiche"
 msgid "Day 3: Afternoon"
 msgstr "Giorno 3: Pomeriggio"
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "Gestione degli errori"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Panico (Panics)"
 
@@ -523,67 +531,68 @@ msgstr "Gestione strutturata degli errori"
 msgid "Propagating Errors with ?"
 msgstr "Propagazione degli errori con ?"
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "Conversione dei tipi di errore"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "Derivazione di Enumerazioni (Enums) di errori"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "Tipi di errori dinamici"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "Aggiungere contesto agli errori"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
 msgstr "Testare"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "Test per unità"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "Moduli (Module) di Test"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "Test nella documentazione"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "Test di integrazione"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr "Crates utili"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Unsafe Rust"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "Dereferenziamento dei Puntatori (Pointers) Grezzi (Raw)"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "Variabili Statiche Mutabili"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "Unioni"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "Chiamare Funzioni Unsafe"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "Creare Funzioni Unsafe"
 
@@ -591,23 +600,25 @@ msgstr "Creare Funzioni Unsafe"
 msgid "Extern Functions"
 msgstr "Funzioni Esterne (Extern)"
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "Implementare Unsafe Traits"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "Safe FFI Wrapper"
 
 #: src/SUMMARY.md:181 src/SUMMARY.md:251
+#: src/running-the-course/course-structure.md:16 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/android/setup.md:1
 msgid "Setup"
 msgstr "Setup"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "Regole (Rules) di Build"
 
@@ -619,7 +630,7 @@ msgstr "Binario"
 msgid "Library"
 msgstr "Libreria (Library)"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -635,7 +646,7 @@ msgstr "Implementazione"
 msgid "Server"
 msgstr "Server"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:194 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "Deploy"
 
@@ -643,15 +654,16 @@ msgstr "Deploy"
 msgid "Client"
 msgstr "Client"
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:196 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "Cambiare API"
 
-#: src/SUMMARY.md:197 src/SUMMARY.md:241
+#: src/SUMMARY.md:197 src/SUMMARY.md:241 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "Logging"
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "Interoperabilità"
 
@@ -667,7 +679,7 @@ msgstr "Invocare C con Bindgen"
 msgid "Calling Rust from C"
 msgstr "Invocare Rust da C"
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "Con C++"
 
@@ -691,11 +703,11 @@ msgstr "Un Esempio Minimo"
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "Microcontroller"
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "Raw MMIO"
 
@@ -723,7 +735,7 @@ msgstr "embedded-hal"
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs, cargo-embed"
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "Debugging"
 
@@ -731,7 +743,8 @@ msgstr "Debugging"
 msgid "Other Projects"
 msgstr "Altri Progetti"
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:226 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "Bussola"
 
@@ -743,7 +756,7 @@ msgstr "Bare Metal: Pomeriggio"
 msgid "Application Processors"
 msgstr "Processori di Applicazioni"
 
-#: src/SUMMARY.md:231
+#: src/SUMMARY.md:231 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr ""
 
@@ -767,7 +780,7 @@ msgstr "Traits addizionali"
 msgid "A Better UART Driver"
 msgstr "Un migliore driver UART"
 
-#: src/SUMMARY.md:237
+#: src/SUMMARY.md:237 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "Bitflag"
 
@@ -775,7 +788,7 @@ msgstr "Bitflag"
 msgid "Multiple Registers"
 msgstr "Registri multipli"
 
-#: src/SUMMARY.md:239
+#: src/SUMMARY.md:239 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "Driver"
 
@@ -783,7 +796,7 @@ msgstr "Driver"
 msgid "Using It"
 msgstr "Usandolo"
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md:243 src/bare-metal/aps/exceptions.md:1
 msgid "Exceptions"
 msgstr "Eccezioni"
 
@@ -811,7 +824,7 @@ msgstr "tinyvec"
 msgid "spin"
 msgstr "rotazione (spin)"
 
-#: src/SUMMARY.md:252
+#: src/SUMMARY.md:252 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
@@ -823,23 +836,23 @@ msgstr "Driver RTC"
 msgid "Concurrency: Morning"
 msgstr "Concorrenza: Mattino"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:262 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "Threads"
 
-#: src/SUMMARY.md:263
+#: src/SUMMARY.md:263 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "Thread con Scope (Scoped Threads)"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "Canali (Channels)"
 
-#: src/SUMMARY.md:265
+#: src/SUMMARY.md:265 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Canali illimitati (Unbounded Channels)"
 
-#: src/SUMMARY.md:266
+#: src/SUMMARY.md:266 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Canali delimitati (Bounded Channels)"
 
@@ -855,11 +868,11 @@ msgstr "Send (Inviare)"
 msgid "Sync"
 msgstr "Sync (Sincronizzare)"
 
-#: src/SUMMARY.md:270
+#: src/SUMMARY.md:270 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "Esempi"
 
-#: src/SUMMARY.md:271
+#: src/SUMMARY.md:271 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "Stato Condiviso"
 
@@ -872,10 +885,12 @@ msgid "Mutex"
 msgstr "Mutex"
 
 #: src/SUMMARY.md:276 src/SUMMARY.md:297
+#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "Filosofi a tavola"
 
-#: src/SUMMARY.md:277
+#: src/SUMMARY.md:277 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "Correttore di Link a Thread multipli"
 
@@ -891,31 +906,32 @@ msgstr "Nozioni di base sulla programmazione Async (asincrona)"
 msgid "async/await"
 msgstr "Async/await"
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md:283 src/async/futures.md:1
 msgid "Futures"
 msgstr "Futures"
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "Esecutori"
 
-#: src/SUMMARY.md:285
+#: src/SUMMARY.md:285 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr "Tokio"
 
-#: src/SUMMARY.md:286
+#: src/SUMMARY.md:286 src/exercises/concurrency/link-checker.md:106
+#: src/exercises/concurrency/chat-app.md:140 src/async/tasks.md:1
 msgid "Tasks"
 msgstr "Compiti (Tasks)"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:287 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "Canali asincroni (Async Channels)"
 
-#: src/SUMMARY.md:289
+#: src/SUMMARY.md:289 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr "Giunzione (Join)"
 
-#: src/SUMMARY.md:290
+#: src/SUMMARY.md:290 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr "Selezione (Select)"
 
@@ -927,19 +943,20 @@ msgstr "Insidie"
 msgid "Blocking the Executor"
 msgstr "Blocco dell’Esecutore"
 
-#: src/SUMMARY.md:293
+#: src/SUMMARY.md:293 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr "Spillo (Pin)"
 
-#: src/SUMMARY.md:294
+#: src/SUMMARY.md:294 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "Trait asincroni (Async Trait)"
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md:295 src/async/pitfalls/cancellation.md:1
 msgid "Cancellation"
 msgstr "Cancellazione (cancellation)"
 
-#: src/SUMMARY.md:298
+#: src/SUMMARY.md:298 src/exercises/concurrency/chat-app.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:113
 msgid "Broadcast Chat Application"
 msgstr "Applicazione Chat-Broadcast"
 
@@ -947,7 +964,7 @@ msgstr "Applicazione Chat-Broadcast"
 msgid "Final Words"
 msgstr "Parole finali"
 
-#: src/SUMMARY.md:305
+#: src/SUMMARY.md:305 src/thanks.md:1
 msgid "Thanks!"
 msgstr "Grazie!"
 
@@ -955,11 +972,11 @@ msgstr "Grazie!"
 msgid "Other Resources"
 msgstr "Altre risorse"
 
-#: src/SUMMARY.md:307
+#: src/SUMMARY.md:307 src/credits.md:1
 msgid "Credits"
 msgstr "Crediti"
 
-#: src/SUMMARY.md:310
+#: src/SUMMARY.md:310 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "Soluzioni"
 
@@ -991,7 +1008,7 @@ msgstr "Giorno 3 Pomeriggio"
 msgid "Bare Metal Rust Morning"
 msgstr "Mattina su Bare Metal Rust"
 
-#: src/SUMMARY.md:322
+#: src/SUMMARY.md:322 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "Pomeriggio su Bare Metal Rust"
 
@@ -1002,10 +1019,6 @@ msgstr "Mattina su Concorrenza"
 #: src/SUMMARY.md:324
 msgid "Concurrency Afternoon"
 msgstr "Giorno 1: Pomeriggio"
-
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Benvenuti a Comprehensive Rust 🦀"
 
 #: src/welcome.md:3
 msgid ""
@@ -1022,8 +1035,8 @@ msgstr "Stato Build"
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 msgstr ""
@@ -1036,10 +1049,9 @@ msgstr "Collaboratori di GitHub"
 msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
 #: src/welcome.md:5
@@ -1056,366 +1068,142 @@ msgstr ""
 #: src/welcome.md:7
 msgid ""
 "This is a three day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 "Questo è un corso Rust di tre giorni sviluppato dal team Android. Il corso "
-"copre\n"
-"l'intero spettro di Rust, dalla sintassi di base ad argomenti avanzati come "
-"i generici\n"
-"e gestione degli errori. Include anche contenuti specifici per Android "
-"nell'ultimo giorno."
+"copre l'intero spettro di Rust, dalla sintassi di base ad argomenti avanzati "
+"come i generici e gestione degli errori. Include anche contenuti specifici "
+"per Android nell'ultimo giorno."
 
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
 "L'obiettivo del corso è insegnarti Rust. Partiamo dal presupposto che tu non "
-"sappia nulla\n"
-"su Rust e spero di:"
+"sappia nulla su Rust e spero di:"
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
 msgstr ""
-"* Fornire una comprensione completa della sintassi e del linguaggio di "
-"Rust.\n"
-"* Consentono di modificare i programmi esistenti e scrivere nuovi programmi "
-"in Rust.\n"
-"* Mostra i comuni idiomi di Rust."
+"Fornire una comprensione completa della sintassi e del linguaggio di Rust."
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr ""
+"Consentono di modificare i programmi esistenti e scrivere nuovi programmi in "
+"Rust."
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
+msgstr "Mostra i comuni idiomi di Rust."
 
 #: src/welcome.md:18
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, "
-"you're\n"
-"invited to dive into one or more specialized topics:"
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
 "I primi tre giorni ti mostrano i fondamenti di Rust. A seguito di questo, "
-"sei\n"
-"invitato ad approfondire uno o più argomenti specialistici:"
+"sei invitato ad approfondire uno o più argomenti specialistici:"
 
 #: src/welcome.md:21
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android "
-"platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-"
-"metal\n"
-"  (embedded) development. Both microcontrollers and application processors "
-"are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a whole-day class on concurrency in Rust. "
-"We\n"
-"  cover both classical concurrency (preemptively scheduling using threads "
-"and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"* [Android](android.md): un corso di mezza giornata sull'utilizzo della "
-"piattaforma Rust per Android\n"
-"  sviluppo (AOSP). Ciò include l'interoperabilità con C, C++ e Java.\n"
-"* [Bare-metal](bare-metal.md): una lezione di un'intera giornata "
-"sull'utilizzo di Rust per bare-metal\n"
-"  sviluppo (incorporato). Lo sono sia i microcontrollori che i processori "
-"applicativi\n"
-"  coperto.\n"
-"* [Concurrency](concurrency.md): una lezione di un'intera giornata sulla "
-"concorrenza in Rust. Noi\n"
-"  coprire sia la concorrenza classica (pianificazione preventiva utilizzando "
-"thread e\n"
-"  mutextes) e async/await concurrency (multitasking cooperativo tramite\n"
-"  futuri)."
+"[Android](android.md): un corso di mezza giornata sull'utilizzo della "
+"piattaforma Rust per Android sviluppo (AOSP). Ciò include l'interoperabilità "
+"con C, C++ e Java."
+
+#: src/welcome.md:23
+msgid ""
+"[Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+"[Bare-metal](bare-metal.md): una lezione di un'intera giornata sull'utilizzo "
+"di Rust per bare-metal sviluppo (incorporato). Lo sono sia i "
+"microcontrollori che i processori applicativi coperto."
+
+#: src/welcome.md:26
+msgid ""
+"[Concurrency](concurrency.md): a whole-day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
+msgstr ""
+"[Concurrency](concurrency.md): una lezione di un'intera giornata sulla "
+"concorrenza in Rust. Noi coprire sia la concorrenza classica (pianificazione "
+"preventiva utilizzando thread e mutextes) e async/await concurrency "
+"(multitasking cooperativo tramite futuri)."
 
 #: src/welcome.md:32
-msgid "## Non-Goals"
-msgstr "## Non goal"
+msgid "Non-Goals"
+msgstr "Non goal"
 
 #: src/welcome.md:34
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 "Rust è un linguaggio vasto e non saremo in grado di coprirlo tutto in pochi "
-"giorni.\n"
-"Alcuni non-obiettivi di questo corso sono:"
+"giorni. Alcuni non-obiettivi di questo corso sono:"
 
 #: src/welcome.md:37
 msgid ""
-"* Learning how to develop macros: please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
-"* Imparare come sviluppare le macro, per favore vedi ['Rust "
-"Book' (Capitolo 19.5)](https://doc.rust-lang.org/book/ch19-06-macros.html) e [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
+"Imparare come sviluppare le macro, per favore vedi ['Rust Book' (Capitolo "
+"19.5)](https://doc.rust-lang.org/book/ch19-06-macros.html) e [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
 
 #: src/welcome.md:41
-msgid "## Assumptions"
-msgstr "## Ipotesi"
+msgid "Assumptions"
+msgstr "Ipotesi"
 
 #: src/welcome.md:43
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically-\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically- typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
-"Il corso presuppone che tu sappia già programmare. La ruggine è "
-"staticamente\n"
-"linguaggio digitato e talvolta faremo confronti migliori con C e C++\n"
+"Il corso presuppone che tu sappia già programmare. La ruggine è staticamente "
+"linguaggio digitato e talvolta faremo confronti migliori con C e C++ "
 "spiegare o contrastare l'approccio di Rust."
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically-typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically-typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 "Se sai come programmare in un linguaggio tipizzato dinamicamente come Python "
-"o\n"
-"JavaScript, allora sarai anche in grado di seguire bene."
-
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/scalar-types.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/references.md:21
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/methods.md:32 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:48
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:100
-#: src/structs.md:29 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums.md:32
-#: src/enums/variant-payloads.md:33 src/enums/sizes.md:27 src/methods.md:28
-#: src/methods/receiver.md:22 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:41
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:21
-#: src/control-flow/while-let-expressions.md:24
-#: src/control-flow/for-expressions.md:23
-#: src/control-flow/loop-expressions.md:25
-#: src/control-flow/match-expressions.md:26 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:42 src/exercises/day-2/afternoon.md:5
-#: src/generics/data-types.md:19 src/generics/methods.md:23
-#: src/traits/trait-objects.md:70 src/traits/default-methods.md:30
-#: src/traits/trait-bounds.md:33 src/traits/impl-trait.md:21
-#: src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/drop.md:32 src/traits/default.md:38
-#: src/traits/operators.md:24 src/traits/closures.md:32
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:46
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:25 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:12
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/android/morning.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:37 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/entry-point.md:75
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart.md:53 src/bare-metal/aps/uart/traits.md:22
-#: src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:49 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:44 src/bare-metal/aps/exceptions.md:62
-#: src/bare-metal/aps/other-projects.md:15
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/scoped-threads.md:35 src/concurrency/channels.md:25
-#: src/concurrency/channels/bounded.md:29 src/concurrency/send-sync.md:18
-#: src/concurrency/send-sync/send.md:11 src/concurrency/send-sync/sync.md:12
-#: src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21
-#: src/exercises/concurrency/morning.md:10 src/async/async-await.md:23
-#: src/async/futures.md:30 src/async/runtimes.md:18
-#: src/async/runtimes/tokio.md:31 src/async/tasks.md:50
-#: src/async/channels.md:33 src/async/control-flow/join.md:34
-#: src/async/control-flow/select.md:60
-#: src/async/pitfalls/blocking-executor.md:27 src/async/pitfalls/pin.md:66
-#: src/async/pitfalls/cancellation.md:70
-#: src/exercises/concurrency/afternoon.md:11
-#: src/exercises/concurrency/dining-philosophers-async.md:75
-msgid "<details>"
-msgstr "<details>"
+"o JavaScript, allora sarai anche in grado di seguire bene."
 
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 "Questo è un esempio di _nota del relatore_. Useremo questi per aggiungere "
-"ulteriori\n"
-"informazioni alle diapositive. Questi potrebbero essere punti chiave che "
-"l'istruttore dovrebbe\n"
-"copertina così come le risposte alle domande tipiche che sorgono in classe."
-
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:46 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:23
-#: src/why-rust/modern.md:66 src/basic-syntax/scalar-types.md:43
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:29
-#: src/basic-syntax/slices.md:36 src/basic-syntax/string-slices.md:44
-#: src/basic-syntax/functions.md:41 src/basic-syntax/rustdoc.md:33
-#: src/basic-syntax/methods.md:45 src/basic-syntax/functions-interlude.md:30
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:55
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:104
-#: src/structs.md:42 src/structs/tuple-structs.md:44
-#: src/structs/field-shorthand.md:72 src/enums.md:42
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:28 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:29
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:47
-#: src/control-flow/if-expressions.md:37
-#: src/control-flow/if-let-expressions.md:41
-#: src/control-flow/while-let-expressions.md:29
-#: src/control-flow/for-expressions.md:30
-#: src/control-flow/loop-expressions.md:32
-#: src/control-flow/match-expressions.md:33 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:42 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:71 src/exercises/day-2/afternoon.md:11
-#: src/generics/data-types.md:25 src/generics/methods.md:31
-#: src/traits/trait-objects.md:83 src/traits/default-methods.md:60
-#: src/traits/trait-bounds.md:50 src/traits/impl-trait.md:44
-#: src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/drop.md:42 src/traits/default.md:47
-#: src/traits/operators.md:40 src/traits/closures.md:63
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:53
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:43 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:18
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/android/morning.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:49
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/entry-point.md:101
-#: src/bare-metal/aps/inline-assembly.md:58 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:55 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:49 src/bare-metal/aps/exceptions.md:75
-#: src/bare-metal/aps/other-projects.md:29
-#: src/bare-metal/useful-crates/zerocopy.md:53
-#: src/bare-metal/useful-crates/aarch64-paging.md:33
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
-#: src/bare-metal/useful-crates/tinyvec.md:26
-#: src/bare-metal/useful-crates/spin.md:30 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/scoped-threads.md:40 src/concurrency/channels.md:32
-#: src/concurrency/channels/bounded.md:35 src/concurrency/send-sync.md:23
-#: src/concurrency/send-sync/send.md:16 src/concurrency/send-sync/sync.md:18
-#: src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56
-#: src/exercises/concurrency/morning.md:16 src/async/async-await.md:48
-#: src/async/futures.md:45 src/async/runtimes.md:29
-#: src/async/runtimes/tokio.md:49 src/async/tasks.md:63
-#: src/async/channels.md:49 src/async/control-flow/join.md:50
-#: src/async/control-flow/select.md:79
-#: src/async/pitfalls/blocking-executor.md:50 src/async/pitfalls/pin.md:112
-#: src/async/pitfalls/async-traits.md:63 src/async/pitfalls/cancellation.md:114
-#: src/exercises/concurrency/afternoon.md:17
-#: src/exercises/concurrency/dining-philosophers-async.md:79
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# Esecuzione del corso"
+"ulteriori informazioni alle diapositive. Questi potrebbero essere punti "
+"chiave che l'istruttore dovrebbe copertina così come le risposte alle "
+"domande tipiche che sorgono in classe."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> Questa pagina è per l'istruttore del corso."
+msgid "This page is for the course instructor."
+msgstr "Questa pagina è per l'istruttore del corso."
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
+"course internally at Google."
 msgstr ""
-"Ecco alcune informazioni di base su come abbiamo condotto il corso\n"
+"Ecco alcune informazioni di base su come abbiamo condotto il corso "
 "internamente a Google."
 
 #: src/running-the-course.md:8
@@ -1423,267 +1211,228 @@ msgid "Before you run the course, you will want to:"
 msgstr "Prima di eseguire il corso, vorrai:"
 
 #: src/running-the-course.md:10
+#, fuzzy
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   to help highlight the key points (please help us by contributing more "
-"speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes "
-"in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). "
-"This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Decide on the dates. Since the course takes at least three full days, we "
-"recommend that you\n"
-"   schedule the days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-25 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself "
-"and for the\n"
-"   students: you will all need to be able to sit and work with your "
-"laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, "
-"so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups.\n"
-"   We typically spend 30-45 minutes on exercises in the morning and in the "
-"afternoon (including time to review the solutions).\n"
-"   Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. Acquisisci familiarità con il materiale del corso. Abbiamo incluso le "
-"note del relatore\n"
-"   per aiutare a evidenziare i punti chiave (per favore aiutateci "
-"contribuendo con più relatori\n"
-"   Appunti!). Durante la presentazione, assicurati di aprire le note del "
-"relatore in formato a\n"
-"   popup (fare clic sul collegamento con una piccola freccia accanto a "
-"\"Note del relatore\"). Da questa parte\n"
-"   hai uno schermo pulito da presentare alla classe.\n"
+"Acquisisci familiarità con il materiale del corso. Abbiamo incluso le note "
+"del relatore per aiutare a evidenziare i punti chiave (per favore aiutateci "
+"contribuendo con più relatori Appunti!). Durante la presentazione, "
+"assicurati di aprire le note del relatore in formato a popup (fare clic sul "
+"collegamento con una piccola freccia accanto a \"Note del relatore\"). Da "
+"questa parte hai uno schermo pulito da presentare alla classe."
+
+#: src/running-the-course.md:16
+#, fuzzy
+msgid ""
+"Decide on the dates. Since the course takes at least three full days, we "
+"recommend that you schedule the days over two weeks. Course participants "
+"have said that they find it helpful to have a gap in the course since it "
+"helps them process all the information we give them."
+msgstr ""
+"Seleziona il tuo argomento per il pomeriggio del quarto giorno. Questo può "
+"essere basato su il pubblico che ti aspetti o sulla tua esperienza."
+
+#: src/running-the-course.md:21
+#, fuzzy
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-25 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"Decidi le date. Poiché il corso è grande, ti consigliamo di farlo "
+"programmare i giorni su due settimane. Lo hanno detto i partecipanti al "
+"corso trovano utile avere una pausa nel corso poiché li aiuta a elaborare "
+"tutte le informazioni che diamo loro."
+
+#: src/running-the-course.md:29
+#, fuzzy
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"Trova una stanza abbastanza grande per i tuoi partecipanti di persona. "
+"Consigliamo un dimensione della classe di 15-20 persone. È abbastanza "
+"piccolo da permettere alle persone di sentirsi a proprio agio fare domande "
+"--- è anche abbastanza piccolo che un istruttore avrà tempo per rispondere "
+"alle domande. Assicurati che la stanza abbia _scrivanie_ per te e per il "
+"studenti: dovrete essere tutti in grado di sedervi e lavorare con i vostri "
+"laptop. In particolare, eseguirai molto codice dal vivo come istruttore, "
+"quindi un leggio no essere molto utile per te."
+
+#: src/running-the-course.md:35
+#, fuzzy
+msgid ""
+"Let people solve the exercises by themselves or in small groups. We "
+"typically spend 30-45 minutes on exercises in the morning and in the "
+"afternoon (including time to review the solutions). Make sure to ask people "
+"if they're stuck or if there is anything you can help with. When you see "
+"that several people have the same problem, call it out to the class and "
+"offer a solution, e.g., by showing people where to find the relevant "
+"information in the standard library."
+msgstr ""
+"Il giorno del corso, presentati in aula un po' prima per sistemare le cose "
+"su. Ti consigliamo di presentare direttamente utilizzando `mdbook serve` in "
+"esecuzione sul tuo laptop (vedere le [istruzioni di installazione](https://"
+"github.com/google/comprehensive-rust#building)). Ciò garantisce prestazioni "
+"ottimali senza ritardi quando si cambiano le pagine. L'uso del tuo laptop ti "
+"consentirà anche di correggere errori di battitura come te o il corso i "
+"partecipanti li individuano.\n"
 "\n"
-"1. Seleziona il tuo argomento per il pomeriggio del quarto giorno. Questo "
-"può essere basato su\n"
-"   il pubblico che ti aspetti o sulla tua esperienza.\n"
-"\n"
-"1. Decidi le date. Poiché il corso è grande, ti consigliamo di farlo\n"
-"   programmare i giorni su due settimane. Lo hanno detto i partecipanti al "
-"corso\n"
-"   trovano utile avere una pausa nel corso poiché li aiuta a elaborare\n"
-"   tutte le informazioni che diamo loro.\n"
-"\n"
-"1. Trova una stanza abbastanza grande per i tuoi partecipanti di persona. "
-"Consigliamo un\n"
-"   dimensione della classe di 15-20 persone. È abbastanza piccolo da "
-"permettere alle persone di sentirsi a proprio agio\n"
-"   fare domande --- è anche abbastanza piccolo che un istruttore avrà\n"
-"   tempo per rispondere alle domande. Assicurati che la stanza abbia "
-"_scrivanie_ per te e per il\n"
-"   studenti: dovrete essere tutti in grado di sedervi e lavorare con i "
-"vostri laptop.\n"
-"   In particolare, eseguirai molto codice dal vivo come istruttore, quindi "
-"un leggio no\n"
-"   essere molto utile per te.\n"
-"\n"
-"1. Il giorno del corso, presentati in aula un po' prima per sistemare le "
-"cose\n"
-"   su. Ti consigliamo di presentare direttamente utilizzando `mdbook serve` "
-"in esecuzione sul tuo\n"
-"   laptop (vedere le [istruzioni di installazione][3]). Ciò garantisce "
-"prestazioni ottimali senza ritardi quando si cambiano le pagine.\n"
-"   L'uso del tuo laptop ti consentirà anche di correggere errori di "
-"battitura come te o il corso\n"
-"   i partecipanti li individuano.\n"
-"\n"
-"1. Lascia che le persone risolvano gli esercizi da sole o in piccoli gruppi. "
-"Assicurati che\n"
-"   chiedi alle persone se sono bloccate o se c'è qualcosa in cui puoi "
-"aiutarle. Quando\n"
-"   vedi che diverse persone hanno lo stesso problema, segnalalo alla classe\n"
-"   e offrire una soluzione, ad esempio mostrando alle persone dove trovare "
-"le informazioni pertinenti\n"
-"   informazioni nella libreria standard."
+"Lascia che le persone risolvano gli esercizi da sole o in piccoli gruppi. "
+"Assicurati che chiedi alle persone se sono bloccate o se c'è qualcosa in cui "
+"puoi aiutarle. Quando vedi che diverse persone hanno lo stesso problema, "
+"segnalalo alla classe e offrire una soluzione, ad esempio mostrando alle "
+"persone dove trovare le informazioni pertinenti informazioni nella libreria "
+"standard."
 
 #: src/running-the-course.md:43
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
+"for you as it has been for us!"
 msgstr ""
 "Questo è tutto, buona fortuna con il corso! Speriamo che sarà altrettanto "
-"divertente per\n"
-"te come lo è stato per noi!"
+"divertente per te come lo è stato per noi!"
 
 #: src/running-the-course.md:46
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"Si prega di [fornire feedback][1] in seguito in modo che possiamo continuare "
-"a migliorare il\n"
+"Si prega di [fornire feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) in seguito in modo che possiamo continuare a migliorare il "
 "corso. Ci piacerebbe sapere cosa ha funzionato bene per te e cosa si può "
-"fare\n"
-"Meglio. Anche i tuoi studenti sono i benvenuti a [inviarci feedback][2]!"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# Struttura del corso"
+"fare Meglio. Anche i tuoi studenti sono i benvenuti a [inviarci feedback]"
+"(https://github.com/google/comprehensive-rust/discussions/100)!"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "Il corso è veloce e copre un sacco di terreno:"
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "Giorno 1: Rust base, 'ownership' e 'borrow checker'."
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
+msgstr "Giorno 2: tipi di dati composti, pattern matching, libreria standard."
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
 msgstr ""
-"* Giorno 1: Rust base, 'ownership' e 'borrow checker'.\n"
-"* Giorno 2: tipi di dati composti, pattern matching, libreria standard.\n"
-"* Giorno 3: 'traits' e 'generics', gestione degli errori, test, Rust non sicuro."
+"Giorno 3: 'traits' e 'generics', gestione degli errori, test, Rust non "
+"sicuro."
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
-msgstr "## Immersioni profonde"
+msgid "Deep Dives"
+msgstr "Immersioni profonde"
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
 msgstr ""
-"Oltre alla lezione di 3 giorni sui fondamenti di Rust, ne copriamo "
-"altri\n"
+"Oltre alla lezione di 3 giorni sui fondamenti di Rust, ne copriamo altri "
 "argomenti specialistici:"
-
-#: src/running-the-course/course-structure.md:16
-msgid "### Android"
-msgstr "### Android"
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
 "The [Android Deep Dive](../android.md) is a half-day course on using Rust "
-"for\n"
-"Android platform development. This includes interoperability with C, C++, "
-"and\n"
-"Java."
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
 "L'[Android Deep Dive](../android.md) è un corso di mezza giornata "
-"sull'utilizzo di Rust per\n"
-"Sviluppo sulla piattaforma Android. Ciò include l'interoperabilità con C, C+"
-"+ e\n"
-"Java."
+"sull'utilizzo di Rust per Sviluppo sulla piattaforma Android. Ciò include "
+"l'interoperabilità con C, C++ e Java."
 
 #: src/running-the-course/course-structure.md:22
 msgid ""
-"You will need an [AOSP checkout][1]. Make a checkout of the [course\n"
-"repository][2] on the same machine and move the `src/android/` directory "
-"into\n"
-"the root of your AOSP checkout. This will ensure that the Android build "
-"system\n"
-"sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"Avrai bisogno di un [checkout AOSP][1]. Fai un checkout del [corso\n"
-"repository][2] sulla stessa macchina e sposta la directory `src/android/` "
-"in\n"
-"la radice del tuo checkout AOSP. Ciò garantirà che il sistema di "
-"compilazione Android\n"
-"vede i file `Android.bp` in `src/android/`."
+"Avrai bisogno di un [checkout AOSP](https://source.android.com/docs/setup/"
+"download/downloading). Fai un checkout del [corso repository](https://github."
+"com/google/comprehensive-rust) sulla stessa macchina e sposta la directory "
+"`src/android/` in la radice del tuo checkout AOSP. Ciò garantirà che il "
+"sistema di compilazione Android vede i file `Android.bp` in `src/android/`."
 
 #: src/running-the-course/course-structure.md:27
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
-"all\n"
-"Android examples using `src/android/build_all.sh`. Read the script to see "
-"the\n"
-"commands it runs and make sure they work when you run them by hand."
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
 "Assicurati che `adb sync` funzioni con il tuo emulatore o dispositivo reale "
-"e precompila tutti\n"
-"gli esempi di Android che utilizzano `src/android/build_all.sh`. Leggi lo script "
-"per vedere i\n"
-"comandi che esegue e assicurati che funzionino quando li esegui a mano."
+"e precompila tutti gli esempi di Android che utilizzano `src/android/"
+"build_all.sh`. Leggi lo script per vedere i comandi che esegue e assicurati "
+"che funzionino quando li esegui a mano."
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
-msgstr "### Bare-Metal"
+msgid "Bare-Metal"
+msgstr "Bare-Metal"
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
 "The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
-"for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
 "Il [Bare-Metal Deep Dive](../bare-metal.md): una lezione di un'intera "
-"giornata sull'uso di Rust per\n"
-"sviluppo bare metal (embedded). Sono coperti sia i microcontrollori che "
-"i processori applicativi."
+"giornata sull'uso di Rust per sviluppo bare metal (embedded). Sono coperti "
+"sia i microcontrollori che i processori applicativi."
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
-"Per la parte del microcontrollore, dovrai acquistare la scheda di sviluppo [BBC "
-"micro:bit v2](https://microbit.org/) in anticipo.\n"
-"Si dovranno installare un certo numero di pacchetti come descritto nel file "
-"[welcome\n"
+"Per la parte del microcontrollore, dovrai acquistare la scheda di sviluppo "
+"[BBC micro:bit v2](https://microbit.org/) in anticipo. Si dovranno "
+"installare un certo numero di pacchetti come descritto nel file [welcome "
 "page](../bare-metal.md)."
 
 #: src/running-the-course/course-structure.md:45
-msgid "### Concurrency"
-msgstr "### Concorrenza"
+msgid "Concurrency"
+msgstr "Concorrenza"
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
 "The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
-"classical\n"
-"as well as `async`/`await` concurrency."
+"classical as well as `async`/`await` concurrency."
 msgstr ""
-"L'[approfondimento sulla concorrenza](../concurrency.md) è un corso di un'intera "
-"giornata sulla concorrenza classica in Rust,\n"
-"così come la concorrenza `async`/`await`."
+"L'[approfondimento sulla concorrenza](../concurrency.md) è un corso di "
+"un'intera giornata sulla concorrenza classica in Rust, così come la "
+"concorrenza `async`/`await`."
 
 #: src/running-the-course/course-structure.md:50
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
-"to\n"
-"go. You can then copy/paste the examples into `src/main.rs` to experiment "
-"with\n"
-"them:"
+"to go. You can then copy/paste the examples into `src/main.rs` to experiment "
+"with them:"
 msgstr ""
-"Avrai bisogno di creare un nuovo progetto, con nuove dipendenze "
-"scaricate e pronte per\n"
-"l'utilizzo. Puoi quindi copiare/incollare gli esempi in `src/main.rs` per "
-"sperimentare attraverso di\n"
-"loro:"
+"Avrai bisogno di creare un nuovo progetto, con nuove dipendenze scaricate e "
+"pronte per l'utilizzo. Puoi quindi copiare/incollare gli esempi in `src/main."
+"rs` per sperimentare attraverso di loro:"
 
 #: src/running-the-course/course-structure.md:54
 msgid ""
@@ -1696,56 +1445,80 @@ msgid ""
 msgstr ""
 
 #: src/running-the-course/course-structure.md:61
-msgid "## Format"
-msgstr "## Formato"
+msgid "Format"
+msgstr "Formato"
 
 #: src/running-the-course/course-structure.md:63
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
-"Il corso è pensato per essere molto interattivo e si consiglia di lasciare\n"
+"Il corso è pensato per essere molto interattivo e si consiglia di lasciare "
 "che siano le domande a guidare l'esplorazione di Rust!"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# Tasti rapidi"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Ci sono diverse utili scorciatoie da tastiera in mdBook:"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Freccia-sinistra</kbd>: passa alla pagina precedente.\n"
-"* <kbd>Freccia-destra</kbd>: passa alla pagina successiva.\n"
-"* <kbd>Ctrl + Invio</kbd>: esegue l'esempio di codice attivo.\n"
-"* <kbd>s</kbd>: attiva la barra di ricerca."
+msgid "Arrow-Left"
+msgstr "Freccia-sinistra"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# Traduzioni"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr ": passa alla pagina precedente."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Freccia-destra"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr ": passa alla pagina successiva."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Invio"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr ": esegue l'esempio di codice attivo."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr ": attiva la barra di ricerca."
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
 msgstr ""
-"Il corso è stato tradotto in altre lingue da una serie di meravigliosi\n"
+"Il corso è stato tradotto in altre lingue da una serie di meravigliosi "
 "volontari:"
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
 msgstr ""
-"* [Portoghese brasiliano][pt-BR] di [@rastringer] e [@hugojacob].\n"
-"* [Coreano][ko] di [@keispace], [@jiyongp] e [@jooyunghan]."
+"[Portoghese brasiliano](https://google.github.io/comprehensive-rust/pt-BR/) "
+"di [@rastringer](https://github.com/rastringer) e [@hugojacob](https://"
+"github.com/hugojacob)."
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
+msgstr ""
+"[Coreano](https://google.github.io/comprehensive-rust/ko/) di [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) e "
+"[@jooyunghan](https://github.com/jooyunghan)."
 
 #: src/running-the-course/translations.md:9
 msgid ""
@@ -1755,72 +1528,82 @@ msgstr ""
 "lingua all'altra."
 
 #: src/running-the-course/translations.md:11
-msgid "## Incomplete Translations"
-msgstr "# Traduzioni"
+msgid "Incomplete Translations"
+msgstr "Traduzioni"
 
 #: src/running-the-course/translations.md:13
 msgid ""
-"There is a large number of in-progress translations. We link to the most\n"
+"There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
 
 #: src/running-the-course/translations.md:16
 msgid ""
-"* [Bengali][bn] by [@raselmandol].\n"
-"* [French][fr] by [@KookaS] and [@vcaen].\n"
-"* [German][de] by [@Throvn] and [@ronaldfw].\n"
-"* [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105]."
+"[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
+"(https://github.com/raselmandol)."
+msgstr ""
+
+#: src/running-the-course/translations.md:17
+msgid ""
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+msgstr ""
+
+#: src/running-the-course/translations.md:18
+msgid ""
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+msgstr ""
+
+#: src/running-the-course/translations.md:19
+msgid ""
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
 msgstr ""
 
 #: src/running-the-course/translations.md:21
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"Se vuoi aiutare con questo sforzo, consulta [le nostre istruzioni] per "
-"sapere come farlo\n"
-"andare avanti. Le traduzioni sono coordinate su [issue tracker]."
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# Utilizzo di Cargo"
+"Se vuoi aiutare con questo sforzo, consulta \\[le nostre istruzioni\\] per "
+"sapere come farlo andare avanti. Le traduzioni sono coordinate su [issue "
+"tracker](https://github.com/google/comprehensive-rust/issues/282)."
 
 #: src/cargo.md:3
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
 "Quando inizi a leggere su Rust, incontrerai presto [Cargo](https://doc.rust-"
-"lang.org/cargo/), lo strumento standard\n"
-"utilizzato nell'ecosistema Rust per creare ed eseguire applicazioni Rust. "
-"Qui vogliamo\n"
-"fornire una breve panoramica di cos'è Cargo e di come si inserisce "
-"nell'ecosistema\n"
-"e in questa formazione."
+"lang.org/cargo/), lo strumento standard utilizzato nell'ecosistema Rust per "
+"creare ed eseguire applicazioni Rust. Qui vogliamo fornire una breve "
+"panoramica di cos'è Cargo e di come si inserisce nell'ecosistema e in questa "
+"formazione."
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## Installazione"
+msgid "Installation"
+msgstr "Installazione"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (consigliato)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (consigliato)"
 
 #: src/cargo.md:12
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
 "Puoi seguire le istruzioni per installare il compilatore rust e cargo, tra "
-"gli altri strumenti standard dell'ecosistema con lo strumento [rustup][3], "
-"gestito dalla Rust Foundation."
+"gli altri strumenti standard dell'ecosistema con lo strumento [rustup]"
+"(https://rust-analyzer.github.io/), gestito dalla Rust Foundation."
 
 #: src/cargo.md:14
 msgid ""
@@ -1833,20 +1616,20 @@ msgstr ""
 "la compilazione trasversale, ecc."
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### Gestori di pacchetti"
+msgid "Package Managers"
+msgstr "Gestori di pacchetti"
 
 #: src/cargo.md:18
-msgid "#### Debian"
-msgstr "#### Debian"
+msgid "Debian"
+msgstr "Debian"
 
 #: src/cargo.md:20
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
 "Su Debian/Ubuntu, puoi installare Cargo, i sorgenti di Rust e [Rust "
-"formatter][6] con"
+"formatter](https://github.com/rust-lang/rustfmt) con"
 
 #: src/cargo.md:22
 msgid ""
@@ -1857,30 +1640,32 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"Ciò consentirà a [rust-analyzer][1] di identificare le definizioni. Si "
-"consiglia di utilizzare\n"
-"[VS Code][2] per editare il codice sorgente (ma qualsiasi editor compatibile con "
-"LSP funziona)."
+"Ciò consentirà a \\[rust-analyzer\\]\\[1\\] di identificare le definizioni. "
+"Si consiglia di utilizzare [VS Code](https://code.visualstudio.com/) per "
+"editare il codice sorgente (ma qualsiasi editor compatibile con LSP "
+"funziona)."
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"Ad alcune persone piace anche usare la famiglia di IDE [JetBrains][4], che "
-"eseguono le proprie analisi ma hanno i propri compromessi. Se li preferisci, "
-"puoi installare il [Rust Plugin][5]. Tieni presente che a partire da gennaio "
-"2023 il debug funziona solo sulla versione CLion della suite JetBrains IDEA."
+"Ad alcune persone piace anche usare la famiglia di IDE [JetBrains](https://"
+"www.jetbrains.com/clion/), che eseguono le proprie analisi ma hanno i propri "
+"compromessi. Se li preferisci, puoi installare il [Rust Plugin](https://www."
+"jetbrains.com/rust/). Tieni presente che a partire da gennaio 2023 il debug "
+"funziona solo sulla versione CLion della suite JetBrains IDEA."
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# L'ecosistema di Rust"
+msgid "The Rust Ecosystem"
+msgstr "L'ecosistema di Rust"
 
 #: src/cargo/rust-ecosystem.md:3
 msgid ""
@@ -1891,42 +1676,39 @@ msgstr ""
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc`: il compilatore Rust che trasforma i file `.rs` in binari e altri\n"
-"  formati intermedi.\n"
-"\n"
-"* `cargo`: il gestore delle dipendenze di Rust e lo strumento di "
-"compilazione. Cargo sa come\n"
-"  scaricare le dipendenze ospitate su <https://crates.io> e le passerà a\n"
-"  `rustc` quando costruisci il tuo progetto. Cargo include anche un"
-" gestore di test integrato\n"
-"  che viene utilizzato per eseguire i test predisposti per il progetto (_unit tests_).\n"
-"\n"
-"* `rustup`: il programma di installazione e aggiornamento della toolchain di "
-"Rust. Questo strumento è utilizzato per\n"
-"  installare e aggiornare `rustc` e `cargo` quando vengono rilasciate nuove "
-"versioni di Rust.\n"
-"  Inoltre, `rustup` può anche scaricare la documentazione per la libreria\n"
-"  standard. Puoi avere più versioni di Rust installate contemporaneamente "
-"e `rustup`\n"
-"  ti permetterà di passare da una all'altra secondo le necessità."
+"`rustc`: il compilatore Rust che trasforma i file `.rs` in binari e altri "
+"formati intermedi."
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
+msgstr ""
+"`cargo`: il gestore delle dipendenze di Rust e lo strumento di compilazione. "
+"Cargo sa come scaricare le dipendenze ospitate su <https://crates.io> e le "
+"passerà a `rustc` quando costruisci il tuo progetto. Cargo include anche un "
+"gestore di test integrato che viene utilizzato per eseguire i test "
+"predisposti per il progetto (_unit tests_)."
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
+"`rustup`: il programma di installazione e aggiornamento della toolchain di "
+"Rust. Questo strumento è utilizzato per installare e aggiornare `rustc` e "
+"`cargo` quando vengono rilasciate nuove versioni di Rust. Inoltre, `rustup` "
+"può anche scaricare la documentazione per la libreria standard. Puoi avere "
+"più versioni di Rust installate contemporaneamente e `rustup` ti permetterà "
+"di passare da una all'altra secondo le necessità."
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1941,114 +1723,141 @@ msgstr "Punti chiave:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust ha un programma di rilascio rapido con una nuova versione in uscita\n"
-"  ogni sei settimane. Le nuove versioni mantengono la retrocompatibilità "
-"con\n"
-"  vecchie versioni --- in più abilitano nuove funzionalità.\n"
-"\n"
-"* Esistono tre canali di rilascio: \"stable\", \"beta\" e \"nightly\".\n"
-"\n"
-"* Le nuove funzionalità vengono testate su \"nightly\", \"beta\" è ciò che "
-"diventa\n"
-"  \"stabile\" ogni sei settimane.\n"
-"\n"
-"* Rust ha anche le [edizioni]: l'edizione attuale è Rust 2021. Le precedenti\n"
-"  edizioni erano Rust 2015 e Rust 2018.\n"
-"\n"
-"  * Le edizioni possono apportare modifiche incompatibili con le versioni "
-"precedenti del linguaggio.\n"
-"\n"
-"  * Per evitare incompatibilità del codice, le edizioni sono opt-in: si può selezionare "
-"l'edizione di riferimento'\n"
-"  attraverso il file `Cargo.toml`.\n"
-"\n"
-"  * Per evitare di dividere l'ecosistema, i compilatori di Rust possono "
-"mescolare il codice\n"
-"    scritto per diverse edizioni.\n"
-"\n"
-"  * Nota che è abbastanza raro usare il compilatore direttamente non "
-"attraverso `cargo` (la maggior parte degli utenti non lo fa mai).\n"
-"\n"
-"  * Potrebbe valere la pena accennare al fatto che Cargo stesso è uno "
-"strumento estremamente potente e completo. È in grado di offrire molte "
-"funzionalità avanzate, tra cui, a titolo esemplificativo ma non esaustivo:\n"
-"      * Struttura del progetto/pacchetto\n"
-"      * [aree di lavoro]\n"
-"      * Dipendenze di sviluppo e gestione/memorizzazione nella cache delle "
-"dipendenze di runtime\n"
-"      * [costruzione script]\n"
-"      * [installazione globale]\n"
-"      * È anche estensibile con plug-in di comandi secondari (come "
-"[cargo clippy]).\n"
-"  * Leggi di più dall'[official Cargo Book]"
+"Rust ha un programma di rilascio rapido con una nuova versione in uscita "
+"ogni sei settimane. Le nuove versioni mantengono la retrocompatibilità con "
+"vecchie versioni --- in più abilitano nuove funzionalità."
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "Esistono tre canali di rilascio: \"stable\", \"beta\" e \"nightly\"."
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr ""
+"Le nuove funzionalità vengono testate su \"nightly\", \"beta\" è ciò che "
+"diventa \"stabile\" ogni sei settimane."
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"Rust ha anche le \\[edizioni\\]: l'edizione attuale è Rust 2021. Le "
+"precedenti edizioni erano Rust 2015 e Rust 2018."
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr ""
+"Le edizioni possono apportare modifiche incompatibili con le versioni "
+"precedenti del linguaggio."
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"Per evitare incompatibilità del codice, le edizioni sono opt-in: si può "
+"selezionare l'edizione di riferimento' attraverso il file `Cargo.toml`."
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr ""
+"Per evitare di dividere l'ecosistema, i compilatori di Rust possono "
+"mescolare il codice scritto per diverse edizioni."
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+"Nota che è abbastanza raro usare il compilatore direttamente non attraverso "
+"`cargo` (la maggior parte degli utenti non lo fa mai)."
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+"Potrebbe valere la pena accennare al fatto che Cargo stesso è uno strumento "
+"estremamente potente e completo. È in grado di offrire molte funzionalità "
+"avanzate, tra cui, a titolo esemplificativo ma non esaustivo:"
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "Struttura del progetto/pacchetto"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr "\\[aree di lavoro\\]"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr ""
+"Dipendenze di sviluppo e gestione/memorizzazione nella cache delle "
+"dipendenze di runtime"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr "\\[costruzione script\\]"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr "\\[installazione globale\\]"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"È anche estensibile con plug-in di comandi secondari (come [cargo clippy]"
+"(https://github.com/rust-lang/rust-clippy))."
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr ""
+"Leggi di più dall'[official Cargo Book](https://doc.rust-lang.org/cargo/)"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# Esempi di codice in questo Corso"
+msgid "Code Samples in This Training"
+msgstr "Esempi di codice in questo Corso"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
 "Per questa formazione, esploreremo principalmente il linguaggio Rust "
-"attraverso esempi\n"
-"che possono essere eseguiti tramite il tuo browser. Questo rende la "
-"configurazione molto più semplice e\n"
-"garantisce un'esperienza coerente per tutti."
+"attraverso esempi che possono essere eseguiti tramite il tuo browser. Questo "
+"rende la configurazione molto più semplice e garantisce un'esperienza "
+"coerente per tutti."
 
 #: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
 "L'installazione di Cargo è ancora incoraggiata: ti renderà più facile fare "
-"gli\n"
-"esercizi. L'ultimo giorno faremo un esercizio più ampio che ti mostrerà come "
-"lavorare\n"
-"con le dipendenze e per questo hai bisogno di Cargo."
+"gli esercizi. L'ultimo giorno faremo un esercizio più ampio che ti mostrerà "
+"come lavorare con le dipendenze e per questo hai bisogno di Cargo."
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -2064,61 +1873,56 @@ msgid ""
 msgstr ""
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
-msgstr ""
-"Puoi usare <kbd>Ctrl + Invio</kbd> per eseguire il codice quando il focus è "
-"sulla\n"
-"casella di testo."
+msgid "You can use "
+msgstr "Puoi usare "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr " per eseguire il codice quando il focus è sulla casella di testo."
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
 "La maggior parte degli esempi di codice sono modificabili come mostrato "
-"sopra. Alcuni esempi di codice\n"
-"non sono modificabili per vari motivi:"
+"sopra. Alcuni esempi di codice non sono modificabili per vari motivi:"
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* I playground incorporati non possono eseguire unit test. Copia e incolla "
-"il codice\n"
-"  e aprilo nel Playground reale per dimostrare le 'unit test'.\n"
-"\n"
-"* I playground incorporati perdono il loro stato nel momento in cui esci\n"
-"  dalla pagina! Questo è il motivo per cui gli studenti dovrebbero\n"
-"  risolvere gli esercizi utilizzando un'installazione locale di Rust o "
-"tramite Playground."
+"I playground incorporati non possono eseguire unit test. Copia e incolla il "
+"codice e aprilo nel Playground reale per dimostrare le 'unit test'."
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"I playground incorporati perdono il loro stato nel momento in cui esci dalla "
+"pagina! Questo è il motivo per cui gli studenti dovrebbero risolvere gli "
+"esercizi utilizzando un'installazione locale di Rust o tramite Playground."
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# Esecuzione del codice in locale con Cargo"
+msgid "Running Code Locally with Cargo"
+msgstr "Esecuzione del codice in locale con Cargo"
 
 #: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
-"Se vuoi sperimentare il codice sul tuo sistema, avrai bisogno di\n"
-"per installare prima di tutto Rust. Fallo seguendo le [istruzioni nel 'Rust\n"
-"Book][1]. Questo dovrebbe darti un `rustc` e un `cargo` funzionanti. Al "
-"monento della scrittura,\n"
-" l'ultima versione stabile di Rust ha questi numeri di versione:"
+"Se vuoi sperimentare il codice sul tuo sistema, avrai bisogno di per "
+"installare prima di tutto Rust. Fallo seguendo le [istruzioni nel 'Rust Book]"
+"(https://doc.rust-lang.org/book/ch01-01-installation.html). Questo dovrebbe "
+"darti un `rustc` e un `cargo` funzionanti. Al monento della scrittura, "
+"l'ultima versione stabile di Rust ha questi numeri di versione:"
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -2132,164 +1936,174 @@ msgstr ""
 
 #: src/cargo/running-locally.md:15
 msgid ""
-"With this in place, follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this in place, follow these steps to build a Rust binary from one of "
+"the examples in this training:"
 msgstr ""
 "Con questo è a posto, segui questi passaggi per creare un 'binario Rust' da "
-"uno\n"
-"degli esempi in questo training:"
+"uno degli esempi in questo training:"
 
 #: src/cargo/running-locally.md:18
-msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in `target/"
-"debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr ""
-"1. Click sul bottone \"Copy to clipboard\" nell'esempio che si vuole copiare'.\n"
-"\n"
-"2. Usa `cargo new exercise` per creare una nuova directory `exercise/` per il tuo "
-"codice:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Naviga in `exercise/` e usa `cargo run` per compilare ed eseguire "
-"l'esercizio:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Sostituisci il codice predefinito in `src/main.rs` con il tuo codice. Per\n"
-"   esempio, usando l'esempio della pagina precedente, cambia `src/main.rs` in\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Usa `cargo run` per compilare ed eseguire il codice aggiornato:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Usa `cargo check` per controllare rapidamente gli errori nel tuo progetto, usa `cargo "
-"build`\n"
-"   per compilare senza eseguire. Per una compilazione normale di debug l'output si trova in `target/"
-"debug/`.\n"
-" Usa `cargo build --release` per produrre una versione ottimizzata del codice, in questo caso l'output si trova in `target/release/`.\n"
-"\n"
-"7. Puoi aggiungere dipendenze al tuo progetto modificando il file `Cargo.toml`. Quando "
-"si\n"
-"   esegue il comando `cargo`, sono automaticamente scaricate e compilate le dipendenze mancanti."
+"Click sul bottone \"Copy to clipboard\" nell'esempio che si vuole copiare'."
+
+#: src/cargo/running-locally.md:20
+msgid ""
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr ""
+"Usa `cargo new exercise` per creare una nuova directory `exercise/` per il "
+"tuo codice:"
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr ""
+"Naviga in `exercise/` e usa `cargo run` per compilare ed eseguire "
+"l'esercizio:"
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+"Sostituisci il codice predefinito in `src/main.rs` con il tuo codice. Per "
+"esempio, usando l'esempio della pagina precedente, cambia `src/main.rs` in"
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr "Usa `cargo run` per compilare ed eseguire il codice aggiornato:"
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+"Usa `cargo check` per controllare rapidamente gli errori nel tuo progetto, "
+"usa `cargo build` per compilare senza eseguire. Per una compilazione normale "
+"di debug l'output si trova in `target/debug/`. Usa `cargo build --release` "
+"per produrre una versione ottimizzata del codice, in questo caso l'output si "
+"trova in `target/release/`."
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
+msgstr ""
+"Puoi aggiungere dipendenze al tuo progetto modificando il file `Cargo.toml`. "
+"Quando si esegue il comando `cargo`, sono automaticamente scaricate e "
+"compilate le dipendenze mancanti."
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
 "Cerca di incoraggiare i partecipanti alla classe a installare Cargo e "
-"utilizzare un\n"
-"editore locale. Semplificherà la loro vita poiché avranno un\n"
+"utilizzare un editore locale. Semplificherà la loro vita poiché avranno un "
 "ambiente di sviluppo normale."
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# Benvenuto al primo giorno"
+msgid "Welcome to Day 1"
+msgstr "Benvenuto al primo giorno"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr ""
-"Questo è il primo giorno di 'Comprehensive Rust'.\n"
-"Oggi copriremo un sacco di strada:"
+"Questo è il primo giorno di 'Comprehensive Rust'. Oggi copriremo un sacco di "
+"strada:"
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* Sintassi di base di Rust: variabili, tipi scalari e composti, enum, "
-"struct,\n"
-"  riferimenti, funzioni e metodi.\n"
-"\n"
-"* Gestione della memoria: stack vs heap, gestione manuale della memoria, "
-"memoria basata sull'ambito (scoped),\n"
-" garbage collection.\n"
-"\n"
-"* Ownership: semantica di spostamento (move), copia e clonazione, prestito (borrowing) e durata (lifetimes)."
+"Sintassi di base di Rust: variabili, tipi scalari e composti, enum, struct, "
+"riferimenti, funzioni e metodi."
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+"Gestione della memoria: stack vs heap, gestione manuale della memoria, "
+"memoria basata sull'ambito (scoped), garbage collection."
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"Ownership: semantica di spostamento (move), copia e clonazione, prestito "
+"(borrowing) e durata (lifetimes)."
 
 #: src/welcome-day-1.md:16
 msgid "Please remind the students that:"
@@ -2297,154 +2111,174 @@ msgstr "Si prega di ricordare agli studenti che:"
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i."
-"e.,\n"
-"    keep the discussions related to how Rust does things vs some other "
-"language. \n"
-"    It can be hard to find the right balance, but err on the side of "
-"allowing \n"
-"    discussions since they engage people much more than one-way "
-"communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
 msgstr ""
-"* Dovrebbero fare domande quando ne sentono il bisogno, non trattenerle fino alla fine.\n"
-"* La lezione è pensata per essere interattiva e le discussioni sono molto "
-"incoraggiate!\n"
-"  * In qualità di istruttore, dovresti cercare di mantenere le discussioni "
-"pertinenti, ad es.\n"
-"    mantieni la relazione con il modo in cui Rust fa le cose rispetto a "
-"qualche altro linguaggio. Può essere\n"
-"    difficile trovare il giusto equilibrio, ma è meglio permettere "
-"discussioni che\n"
-"    coinvolgono le persone piuttosto che una comunicazione "
-"unidirezionale.\n"
-"* Le domande probabilmente significheranno che parleremo di cose prima delle "
-"diapositive.\n"
-"  * Questo è perfettamente okay! La ripetizione è una parte importante "
-"dell'apprendimento. Ricordare\n"
-"    che le diapositive sono solo un supporto e sei libero di saltarle come "
-"preferisci."
+"Dovrebbero fare domande quando ne sentono il bisogno, non trattenerle fino "
+"alla fine."
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr ""
+"La lezione è pensata per essere interattiva e le discussioni sono molto "
+"incoraggiate!"
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
+msgstr ""
+"In qualità di istruttore, dovresti cercare di mantenere le discussioni "
+"pertinenti, ad es. mantieni la relazione con il modo in cui Rust fa le cose "
+"rispetto a qualche altro linguaggio. Può essere difficile trovare il giusto "
+"equilibrio, ma è meglio permettere discussioni che coinvolgono le persone "
+"piuttosto che una comunicazione unidirezionale."
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+"Le domande probabilmente significheranno che parleremo di cose prima delle "
+"diapositive."
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"Questo è perfettamente okay! La ripetizione è una parte importante "
+"dell'apprendimento. Ricordare che le diapositive sono solo un supporto e sei "
+"libero di saltarle come preferisci."
 
 #: src/welcome-day-1.md:29
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
 "L'idea per il primo giorno è mostrare _quanto basta_ di Rust per poter "
-"parlare\n"
-"sul famoso _borrow checker_. Il modo in cui Rust gestisce la memoria è "
-"una caratteristica importante\n"
-"e dovremmo mostrarlo subito agli studenti."
+"parlare sul famoso _borrow checker_. Il modo in cui Rust gestisce la memoria "
+"è una caratteristica importante e dovremmo mostrarlo subito agli studenti."
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
-"Se stai insegnando in un'aula, questo è un buon posto per esaminare "
-"il\n"
+"Se stai insegnando in un'aula, questo è un buon posto per esaminare il "
 "programma. Suggeriamo di dividere la giornata in due parti (seguendo le "
 "slide):"
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* Mattina: dalle 9:00 alle 12:00,\n"
-"* Pomeriggio: dalle 13:00 alle 16:00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "Mattina: dalle 9:00 alle 12:00,"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "Pomeriggio: dalle 13:00 alle 16:00."
 
 #: src/welcome-day-1.md:39
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
+"breaks, we recommend a break every hour!"
 msgstr ""
-"Ovviamente puoi regolarlo se necessario. Assicurati di includere pause,\n"
+"Ovviamente puoi regolarlo se necessario. Assicurati di includere pause, "
 "consigliamo una pausa ogni ora!"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# Cos'è Rust?"
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
-"Rust è un nuovo linguaggio di programmazione che ha avuto la sua "
-"[versione 1.0 nel 2015][1]:"
+"Rust è un nuovo linguaggio di programmazione che ha avuto la sua [versione "
+"1.0 nel 2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 
 #: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "Rust è un linguaggio compilato staticamente in modo simile a C++"
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` utilizza LLVM come backend."
+
+#: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"* Rust è un linguaggio compilato staticamente in modo simile a C++\n"
-"  * `rustc` utilizza LLVM come backend.\n"
-"* Rust supporta molte [piattaforme e\n"
-"  architetture](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust è utilizzato per un'ampia gamma di dispositivi:\n"
-"  * firmware e _boot loaders_,\n"
-"  * display 'smart',\n"
-"  * cellulari,\n"
-"  * desktop,\n"
-"  * server."
+"Rust supporta molte [piattaforme e architetture](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, ..."
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rust è utilizzato per un'ampia gamma di dispositivi:"
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "firmware e _boot loaders_,"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "display 'smart',"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "cellulari,"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "desktop,"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "server."
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust è usato nelle stesse aree di C++:"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* Elevata flessibilità.\n"
-"* Alto livello di controllo.\n"
-"* Può essere adattato a dispositivi molto particolari come i telefoni "
-"cellulari.\n"
-"* Non ha runtime o garbage collection.\n"
-"* Si concentra su affidabilità e sicurezza senza sacrificare le prestazioni."
+msgid "High flexibility."
+msgstr "Elevata flessibilità."
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr "# Ciao mondo!"
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "Alto livello di controllo."
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr ""
+"Può essere adattato a dispositivi molto particolari come i telefoni "
+"cellulari."
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "Non ha runtime o garbage collection."
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"Si concentra su affidabilità e sicurezza senza sacrificare le prestazioni."
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
-"Passiamo al programma Rust più semplice possibile,\n"
-"un classico Hello World:"
+"Passiamo al programma Rust più semplice possibile, un classico Hello World:"
 
 #: src/hello-world.md:6
 msgid ""
@@ -2460,71 +2294,73 @@ msgid "What you see:"
 msgstr "Quello che si vede:"
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "Le funzioni sono introdotte con `fn`."
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "I blocchi sono delimitati da parentesi graffe come in C e C++."
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "La funzione `main` è il punto di ingresso del programma."
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr ""
-"* Le funzioni sono introdotte con `fn`.\n"
-"* I blocchi sono delimitati da parentesi graffe come in C e C++.\n"
-"* La funzione `main` è il punto di ingresso del programma.\n"
-"* Rust ha macro definite come 'igieniche' (_hygienic macros_), `println!` ne è un esempio.\n"
-"* Le stringhe Rust sono codificate in UTF-8 e possono contenere qualsiasi "
+"Rust ha macro definite come 'igieniche' (_hygienic macros_), `println!` ne è "
+"un esempio."
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr ""
+"Le stringhe Rust sono codificate in UTF-8 e possono contenere qualsiasi "
 "carattere Unicode."
 
 #: src/hello-world.md:22
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 "Questa diapositiva cerca di mettere gli studenti a proprio agio con il "
-"codice Rust. Vedranno\n"
-"un sacco di Rust nei prossimi quattro giorni, quindi iniziamo in piccolo con "
-"qualcosa di familiare."
+"codice Rust. Vedranno un sacco di Rust nei prossimi quattro giorni, quindi "
+"iniziamo in piccolo con qualcosa di familiare."
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude."
-"md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/"
-"hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rust è molto simile ad altri linguaggi della tradizione C/C++/Java. È\n"
-"  imperativo (non funzionale) e non cerca di reinventare le cose a meno che\n"
-"  non sia assolutamente necessario.\n"
-"\n"
-"* Rust è moderno con pieno supporto per cose come Unicode.\n"
-"\n"
-"* Rust utilizza le macro per le situazioni in cui si desidera avere un "
-"numero variabile di\n"
-"  argomenti (nessun [overloading di funzione](basic-syntax/functions-"
-"interlude.md)).\n"
-"\n"
-"* Le macro definite \"igieniche\" significa che non catturano accidentalmente "
-"identificatori da\n"
-"  l'ambito in cui vengono utilizzate. Le macro di Rust sono in realtà solo\n"
-"  [parzialmente igieniche](https://veykril.github.io/tlborm/decl-macros/"
-"minutiae/hygiene.html)."
+"Rust è molto simile ad altri linguaggi della tradizione C/C++/Java. È "
+"imperativo (non funzionale) e non cerca di reinventare le cose a meno che "
+"non sia assolutamente necessario."
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# Piccolo esempio"
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "Rust è moderno con pieno supporto per cose come Unicode."
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"Rust utilizza le macro per le situazioni in cui si desidera avere un numero "
+"variabile di argomenti (nessun [overloading di funzione](basic-syntax/"
+"functions-interlude.md))."
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
+msgstr ""
+"Le macro definite \"igieniche\" significa che non catturano accidentalmente "
+"identificatori da l'ambito in cui vengono utilizzate. Le macro di Rust sono "
+"in realtà solo [parzialmente igieniche](https://veykril.github.io/tlborm/"
+"decl-macros/minutiae/hygiene.html)."
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2552,456 +2388,513 @@ msgstr ""
 #: src/hello-world/small-example.md:23
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
-"Il codice implementa la congettura di Collatz: si ritiene che il ciclo\n"
+"Il codice implementa la congettura di Collatz: si ritiene che il ciclo "
 "finirà sempre, ma questo non è ancora provato. Modifica il codice e gioca "
-"con diversi\n"
-"ingressi."
+"con diversi ingressi."
 
 #: src/hello-world/small-example.md:29
+#, fuzzy
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::"
-"fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library.\n"
-"    \n"
-"    * In a shell `rustup doc std::fmt` will open a browser on the local std::"
-"fmt documentation"
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* Spiegare che tutte le variabili sono tipizzate staticamente. Prova a "
-"rimuovere `i32` per attivare\n"
-"  l'inferenza di tipo. Prova invece con `i8` e attiva un overflow di runtime "
-"integer.\n"
-"\n"
-"* Modificare `let mut x` in `let x`, discutere l'errore del compilatore.\n"
-"\n"
-"* Mostra come `print!` restituisce un errore di compilazione se gli "
-"argomenti non corrispondono al\n"
-"  formato della stringa.\n"
-"\n"
-"* Mostra come devi usare `{}` come segnaposto se vuoi stampare un'\n"
-"  espressione che è più complessa di una singola variabile.\n"
-"\n"
-"* Mostra agli studenti la libreria standard, mostra loro come cercare `std::"
-"fmt`\n"
-"  che ha le regole del mini-linguaggio di formattazione. È importante che "
-"il\n"
-"  gli studenti acquisiscono familiarità con la ricerca nella libreria "
+"Spiegare che tutte le variabili sono tipizzate staticamente. Prova a "
+"rimuovere `i32` per attivare l'inferenza di tipo. Prova invece con `i8` e "
+"attiva un overflow di runtime integer."
+
+#: src/hello-world/small-example.md:32
+#, fuzzy
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "Modificare `let mut x` in `let x`, discutere l'errore del compilatore."
+
+#: src/hello-world/small-example.md:34
+#, fuzzy
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+"Mostra come `print!` restituisce un errore di compilazione se gli argomenti "
+"non corrispondono al formato della stringa."
+
+#: src/hello-world/small-example.md:37
+#, fuzzy
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+"Mostra come devi usare `{}` come segnaposto se vuoi stampare un' espressione "
+"che è più complessa di una singola variabile."
+
+#: src/hello-world/small-example.md:40
+#, fuzzy
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"Mostra agli studenti la libreria standard, mostra loro come cercare `std::"
+"fmt` che ha le regole del mini-linguaggio di formattazione. È importante che "
+"il gli studenti acquisiscono familiarità con la ricerca nella libreria "
 "standard."
 
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# Perché Rust?"
+#: src/hello-world/small-example.md:44
+msgid ""
+"In a shell `rustup doc std::fmt` will open a browser on the local std::fmt "
+"documentation"
+msgstr ""
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Alcuni punti di forza unici di Rust:"
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* Sicurezza della memoria al tempo di compilazione.\n"
-"* Mancanza di comportamento runtime non definito.\n"
-"* Funzionalità del linguaggio moderno."
+msgid "Compile time memory safety."
+msgstr "Sicurezza della memoria al tempo di compilazione."
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "Mancanza di comportamento runtime non definito."
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "Funzionalità del linguaggio moderno."
 
 #: src/why-rust.md:11
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
-"Assicurati di chiedere alla classe con quali linguaggi hanno esperienza. "
-"In base alla\n"
-"risposta puoi evidenziare diverse caratteristiche di Rust:"
+"Assicurati di chiedere alla classe con quali linguaggi hanno esperienza. In "
+"base alla risposta puoi evidenziare diverse caratteristiche di Rust:"
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* Esperienza con C o C++: Rust elimina un'intera classe di _errori di "
-"runtime_\n"
-"  tramite il _borrow checker_. Ottiene prestazioni come in C e C++, ma "
-"non\n"
-"  hai i problemi di sicurezza della memoria. Inoltre, si ha un "
-"linguaggio moderno con\n"
-"  costrutti come il pattern matching e la gestione delle dipendenze "
-"incorporata.\n"
-"\n"
-"* Esperienza con Java, Go, Python, JavaScript...: Ottiene la stessa "
-"sicurezza della memoria\n"
-"  come in quei linguaggi, più una sensazione simile ad un linguaggio di alto "
-"livello. Inoltre\n"
-"  raggiunge prestazioni veloci e prevedibili come C e C++ (nessun Garbage "
-"Collector)\n"
-"  così come l'accesso all'hardware di basso livello (quando serve)"
+"Esperienza con C o C++: Rust elimina un'intera classe di _errori di runtime_ "
+"tramite il _borrow checker_. Ottiene prestazioni come in C e C++, ma non hai "
+"i problemi di sicurezza della memoria. Inoltre, si ha un linguaggio moderno "
+"con costrutti come il pattern matching e la gestione delle dipendenze "
+"incorporata."
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# Garanzie a Tempo di Compilazione"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"Esperienza con Java, Go, Python, JavaScript...: Ottiene la stessa sicurezza "
+"della memoria come in quei linguaggi, più una sensazione simile ad un "
+"linguaggio di alto livello. Inoltre raggiunge prestazioni veloci e "
+"prevedibili come C e C++ (nessun Garbage Collector) così come l'accesso "
+"all'hardware di basso livello (quando serve)"
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "Gestione statica della memoria in fase di compilazione:"
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* Nessuna variabile non inizializzata.\n"
-"* Nessun _memory leaks_ (_principalmente_, vedi note).\n"
-"* Nessun _double-frees_.\n"
-"* Nessun _use-after-free_.\n"
-"* Nessun puntatore `NULL`.\n"
-"* Nessun mutex dimenticato bloccato.\n"
-"* Nessuna 'situazione di corsa' (_race condition_) di dati tra i thread.\n"
-"* Nessuna invalidazione dell'iteratore."
+msgid "No uninitialized variables."
+msgstr "Nessuna variabile non inizializzata."
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "Nessun _memory leaks_ (_principalmente_, vedi note)."
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "Nessun _double-frees_."
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "Nessun _use-after-free_."
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "Nessun puntatore `NULL`."
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "Nessun mutex dimenticato bloccato."
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "Nessuna 'situazione di corsa' (_race condition_) di dati tra i thread."
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "Nessuna invalidazione dell'iteratore."
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr ""
-"È possibile produrre perdite di memoria in Rust sicuro (Safe Rust). Qualche esempio\n"
-"Sono:"
+"È possibile produrre perdite di memoria in Rust sicuro (Safe Rust). Qualche "
+"esempio Sono:"
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* Puoi usare [`Box::leak`] per far trapelare un puntatore. Un uso di questo "
-"potrebbe\n"
-"  essere quello di ottenere variabili statiche inizializzate/dimensionate in runtime\n"
-"* Puoi usare [`std::mem::forget`] per fare in modo che il compilatore "
-"\"dimentichi\"\n"
-"  un valore (il che significa che il distruttore non viene mai eseguito).\n"
-"* Puoi anche creare accidentalmente un _[reference cycle]_ con `Rc` o\n"
-"  `Arc`.\n"
-"* In effetti, alcuni considereranno il popolamento infinito di una raccolta "
-"un _memory leak_\n"
-"  e Rust non protegge da quello."
+"Puoi usare [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) per far trapelare un puntatore. Un uso di questo potrebbe "
+"essere quello di ottenere variabili statiche inizializzate/dimensionate in "
+"runtime"
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"Puoi usare [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) per fare in modo che il compilatore \"dimentichi\" un valore (il che "
+"significa che il distruttore non viene mai eseguito)."
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"Puoi anche creare accidentalmente un _[reference cycle](https://doc.rust-"
+"lang.org/book/ch15-06-reference-cycles.html)_ con `Rc` o `Arc`."
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"In effetti, alcuni considereranno il popolamento infinito di una raccolta un "
+"_memory leak_ e Rust non protegge da quello."
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
 "Ai fini di questo corso, si dovrebbe intendere \"Nessuna perdita di "
-"memoria\".\n"
-"come \"Praticamente nessuna perdita di memoria *accidentale*\"."
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# Garanzie di autonomia"
+"memoria\". come \"Praticamente nessuna perdita di memoria _accidentale_\"."
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "Nessun comportamento indefinito in fase di esecuzione:"
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined (panic or wrap-around)."
-msgstr ""
-"* L'accesso agli array è controllato dai loro limiti.\n"
-"* L'overflow di numeri interi è definito (panic or wrap-around)."
+msgid "Array access is bounds checked."
+msgstr "L'accesso agli array è controllato dai loro limiti."
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined (panic or wrap-around)."
+msgstr "L'overflow di numeri interi è definito (panic or wrap-around)."
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
-"lang.org/rustc/codegen-options/index.html#overflow-checks)\n"
-"  compile-time flag. If enabled, the program will panic (a controlled\n"
-"  crash of the program), otherwise you get wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
+"lang.org/rustc/codegen-options/index.html#overflow-checks) compile-time "
+"flag. If enabled, the program will panic (a controlled crash of the "
+"program), otherwise you get wrap-around semantics. By default, you get "
+"panics in debug mode (`cargo build`) and wrap-around in release mode (`cargo "
+"build --release`)."
 msgstr ""
-"* L'overflow di numeri interi è definito tramite il flag [`overflow-checks`](https://doc.rust-"
-"lang.org/rustc/codegen-options/index.html#overflow-checks) in fase di "
-"compilazione. Se abilitato il programma _va in panico_ (crash controllato del programma),\n"
-"  altrimenti si ha un _wrap-around_.\n"
-"  Per impostazione predefinita, si ottiene il panico in modalità di "
-"debug (`cargo build`)\n"
-"  e wrap-around in modalità rilascio (`cargo build --release`).\n"
-"\n"
-"* Il controllo dei limiti non può essere disabilitato con un flag del "
-"compilatore. Può anche\n"
-"  non essere disabilitato direttamente con la parola chiave `unsafe`. "
-"Tuttavia,\n"
-"  `unsafe` ti permette di chiamare funzioni come `slice::get_unchecked`\n"
-"  che non esegue il controllo dei limiti."
+"L'overflow di numeri interi è definito tramite il flag [`overflow-checks`]"
+"(https://doc.rust-lang.org/rustc/codegen-options/index.html#overflow-checks) "
+"in fase di compilazione. Se abilitato il programma _va in panico_ (crash "
+"controllato del programma), altrimenti si ha un _wrap-around_. Per "
+"impostazione predefinita, si ottiene il panico in modalità di debug (`cargo "
+"build`) e wrap-around in modalità rilascio (`cargo build --release`)."
 
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# Funzionalità moderne"
+#: src/why-rust/runtime.md:18
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"Il controllo dei limiti non può essere disabilitato con un flag del "
+"compilatore. Può anche non essere disabilitato direttamente con la parola "
+"chiave `unsafe`. Tuttavia, `unsafe` ti permette di chiamare funzioni come "
+"`slice::get_unchecked` che non esegue il controllo dei limiti."
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
 msgstr "Rust è costruito con tutta l'esperienza maturata negli ultimi 40 anni."
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## Caratteristiche del linguaggio"
+msgid "Language Features"
+msgstr "Caratteristiche del linguaggio"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* Enumerazioni (_Enums_) e pattern matching.\n"
-"* Generici (_generic_).\n"
-"* Nessun _overhead_ FFI.\n"
-"* Astrazioni a costo zero (_Zero-cost abstractions_)."
+msgid "Enums and pattern matching."
+msgstr "Enumerazioni (_Enums_) e pattern matching."
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "Generici (_generic_)."
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "Nessun _overhead_ FFI."
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "Astrazioni a costo zero (_Zero-cost abstractions_)."
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
-msgstr "## Tooling"
+msgid "Tooling"
+msgstr "Tooling"
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* Ottimi errori del compilatore.\n"
-"* Gestore delle dipendenze integrato.\n"
-"* Supporto integrato per i test.\n"
-"* Eccellente supporto del protocollo Language Server."
+msgid "Great compiler errors."
+msgstr "Ottimi errori del compilatore."
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "Gestore delle dipendenze integrato."
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "Supporto integrato per i test."
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "Eccellente supporto del protocollo Language Server."
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* Astrazioni a costo zero, simili a C++, significa che non devi \"pagare\"\n"
-"  per costrutti di programmazione di livello superiore con memoria o CPU. "
-"Per esempio,\n"
-"  scrivere un ciclo usando `for` dovrebbe comportare all'incirca lo stesso "
-"livello di\n"
-"  istruzioni come usare il costrutto `.iter().fold()`.\n"
-"\n"
-"* Potrebbe valere la pena ricordare che anche le enum di Rust sono \"tipi di "
-"dati algebrici\"\n"
-"  noti come \"tipi di somma\", che consentono al sistema di tipi di "
-"esprimere cose come\n"
-"  `Option<T>` e `Result<T, E>`.\n"
-"\n"
-"* Ricordare alle persone di leggere gli errori --- molti sviluppatori si "
-"sono abituati a\n"
-"  ignorare l'output del compilatore. Il compilatore Rust è molto "
-"più\n"
-"  \"loquace\" rispetto ad altri compilatori. Spesso fornirà feedback\n"
-"  _pronti all'uso_, pronti per il copia-incolla nel tuo codice.\n"
-"\n"
-"* La libreria standard di Rust è piccola rispetto a linguaggi come Java, "
-"Python,\n"
-"  e Go. Rust non viene fornito con molte cose che potresti considerare "
-"standard e\n"
-"  essenziali:\n"
-"\n"
-"  * un generatore di numeri casuali, ma vedi [rand].\n"
-"  * supporto per SSL o TLS, ma vedi [rusttls].\n"
-"  * supporto per JSON, ma vedi [serde_json].\n"
-"\n"
-"  Il ragionamento alla base di ciò è che una funzionalità nella libreria "
-"standard non può\n"
-"  essere tolta, quindi deve essere molto stabile. Per gli esempi precedenti, "
-"la comunità Rust\n"
-"  sta ancora lavorando per trovare la soluzione migliore --- e "
-"forse \n"
-"  non c'è un'unica \"soluzione migliore\" per alcune di queste cose.\n"
-"\n"
-"  Rust viene fornito con un gestore di pacchetti integrato sotto forma di "
-"Cargo e questo rende\n"
-"  banale scaricare e compilare pacchetti di terze parti (_crates_). Una conseguenza di "
-"ciò\n"
-"  è che la libreria standard può essere più piccola.\n"
-"\n"
-"  La ricerca di buoni 'pacchetti' (_crates_) di terze parti può essere un problema. Siti "
-"come\n"
-"  <https://lib.rs/> aiutano in questo consentendo di confrontare le metriche "
-"per specifiche\n"
-"  _crate_ per trovarne uno buona e affidabile.\n"
-"  \n"
-"* [rust-analyzer] è un'implementazione LSP ben supportata utilizzata nei"
-"maggiori\n"
-"  IDE ed editor di testo."
+"Astrazioni a costo zero, simili a C++, significa che non devi \"pagare\" per "
+"costrutti di programmazione di livello superiore con memoria o CPU. Per "
+"esempio, scrivere un ciclo usando `for` dovrebbe comportare all'incirca lo "
+"stesso livello di istruzioni come usare il costrutto `.iter().fold()`."
 
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
-msgstr "# Sintassi di base"
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+"Potrebbe valere la pena ricordare che anche le enum di Rust sono \"tipi di "
+"dati algebrici\" noti come \"tipi di somma\", che consentono al sistema di "
+"tipi di esprimere cose come `Option<T>` e `Result<T, E>`."
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"Ricordare alle persone di leggere gli errori --- molti sviluppatori si sono "
+"abituati a ignorare l'output del compilatore. Il compilatore Rust è molto "
+"più \"loquace\" rispetto ad altri compilatori. Spesso fornirà feedback "
+"_pronti all'uso_, pronti per il copia-incolla nel tuo codice."
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+"La libreria standard di Rust è piccola rispetto a linguaggi come Java, "
+"Python, e Go. Rust non viene fornito con molte cose che potresti considerare "
+"standard e essenziali:"
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr ""
+"un generatore di numeri casuali, ma vedi [rand](https://docs.rs/rand/)."
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr "supporto per SSL o TLS, ma vedi [rusttls](https://docs.rs/rustls/)."
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr "supporto per JSON, ma vedi [serde_json](https://docs.rs/serde_json/)."
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+"Il ragionamento alla base di ciò è che una funzionalità nella libreria "
+"standard non può essere tolta, quindi deve essere molto stabile. Per gli "
+"esempi precedenti, la comunità Rust sta ancora lavorando per trovare la "
+"soluzione migliore --- e forse  non c'è un'unica \"soluzione migliore\" per "
+"alcune di queste cose."
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+"Rust viene fornito con un gestore di pacchetti integrato sotto forma di "
+"Cargo e questo rende banale scaricare e compilare pacchetti di terze parti "
+"(_crates_). Una conseguenza di ciò è che la libreria standard può essere più "
+"piccola."
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+"La ricerca di buoni 'pacchetti' (_crates_) di terze parti può essere un "
+"problema. Siti come <https://lib.rs/> aiutano in questo consentendo di "
+"confrontare le metriche per specifiche _crate_ per trovarne uno buona e "
+"affidabile."
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/) è un'implementazione LSP "
+"ben supportata utilizzata neimaggiori IDE ed editor di testo."
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr "Gran parte della sintassi di Rust ti sarà familiare da C, C++ o Java:"
 
 #: src/basic-syntax.md:5
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "I blocchi e gli ambiti sono delimitati da parentesi graffe."
+
+#: src/basic-syntax.md:6
 msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/"
-"* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"* I blocchi e gli ambiti sono delimitati da parentesi graffe.\n"
-"* I commenti di riga iniziano con `//`, i commenti di blocco sono delimitati "
-"da `/* ...\n"
-"  */'.\n"
-"* Parole chiave come `if` e `while` funzionano allo stesso modo.\n"
-"* L'assegnazione delle variabili viene eseguita con `=`, il confronto viene "
+"I commenti di riga iniziano con `//`, i commenti di blocco sono delimitati "
+"da \\`/\\* ... \\*/'."
+
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "Parole chiave come `if` e `while` funzionano allo stesso modo."
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+"L'assegnazione delle variabili viene eseguita con `=`, il confronto viene "
 "eseguito con `==`."
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
-msgstr "# Tipi scalari"
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Types"
+msgstr "Tipi"
 
-#: src/basic-syntax/scalar-types.md:3
-msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | "
-"`\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
-msgstr ""
-"| | Tipi | Letterali |\n"
-"|------------------------|------------------------ "
-"---------------------|---------------------------- --|\n"
-"| Interi con segno | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, "
-"`0`, `1_000`, `123i64` |\n"
-"| Interi senza segno | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16` |\n"
-"| Numeri in virgola mobile | `f32`, `f64` | `3.14`, `-10.0e20`, `2f32` |\n"
-"| Corde | `&str` | `\"pippo\"`, `\"due\\nrighe\"` |\n"
-"| Valori scalari Unicode | `char` | `'a'`, `'α'`, `'∞'` |\n"
-"| Booleani | `bool` | `vero`, `falso` |"
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr "Letterali"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr "Interi con segno"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr "Interi senza segno"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr "Numeri in virgola mobile"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr "Corde"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr "`\"pippo\"`, `\"due\\nrighe\"`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr "Valori scalari Unicode"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr "`char`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Booleans"
+msgstr "Booleani"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`bool`"
+msgstr "`bool`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`true`, `false`"
+msgstr "`vero`, `falso`"
 
 #: src/basic-syntax/scalar-types.md:12
 msgid "The types have widths as follows:"
 msgstr "I tipi hanno larghezze come segue:"
 
 #: src/basic-syntax/scalar-types.md:14
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bits wide,\n"
-"* `bool` is 8 bits wide."
-msgstr ""
-"* `iN`, `uN` e `fN` sono larghi _N_ bit,\n"
-"* `isize` e `usize` sono la larghezza di un puntatore,\n"
-"* `char` è largo 32 bit,\n"
-"* `bool` è largo 8 bit."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN` e `fN` sono larghi _N_ bit,"
+
+#: src/basic-syntax/scalar-types.md:15
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` e `usize` sono la larghezza di un puntatore,"
+
+#: src/basic-syntax/scalar-types.md:16
+msgid "`char` is 32 bits wide,"
+msgstr "`char` è largo 32 bit,"
+
+#: src/basic-syntax/scalar-types.md:17
+msgid "`bool` is 8 bits wide."
+msgstr "`bool` è largo 8 bit."
 
 #: src/basic-syntax/scalar-types.md:21
 msgid "There are a few syntaxes which are not shown above:"
@@ -3009,72 +2902,75 @@ msgstr "Ci sono alcune sintassi che non sono mostrate sopra:"
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
-"- Le stringhe non elaborate (_raw_) consentono di creare un valore `&str` con i caratteri"
-" di escape disabilitati: "
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. Puoi racchiudere le doppie virgolette usando una quantità uguale di "
-"`#` su\n"
-"  entrambi i lati delle virgolette:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Le stringhe di byte consentono di creare direttamente un valore `&[u8]`:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Le stringhe non elaborate (_raw_) consentono di creare un valore `&str` con "
+"i caratteri di escape disabilitati: `r\"\\n\" == \"\\\\n\"`. Puoi "
+"racchiudere le doppie virgolette usando una quantità uguale di `#` su "
+"entrambi i lati delle virgolette:"
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr "# Tipi Composti (Compound)"
-
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:27
 msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
 msgstr ""
-"|        | Tipi                         | Letterali                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Array | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuple | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr ""
+"Le stringhe di byte consentono di creare direttamente un valore `&[u8]`:"
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr "Array"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr "`[T; N]`"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr "`[20, 30, 40]`, `[0; 3]`"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr "Tuple"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
 
 #: src/basic-syntax/compound-types.md:8
 msgid "Array assignment and access:"
@@ -3112,86 +3008,80 @@ msgstr "Array:"
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* A value of the array type `[T; N]` holds `N` (a compile-time constant) "
-"elements of the same type `T`.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"A value of the array type `[T; N]` holds `N` (a compile-time constant) "
+"elements of the same type `T`. Note that the length of the array is _part of "
+"its type_, which means that `[u8; 3]` and `[u8; 4]` are considered two "
+"different types."
 msgstr ""
-"* Un valore di un array tipo `[T; N]` contiene `N` (una costante _compile-time_) "
-"elementi dello stesso tipo `T`.\n"
-"  Nota che la lunghezza dell'array è *parte del suo tipo*, il che significa che "
-"`[u8; 3]` e\n"
-"  `[u8; 4]` sono considerati due tipi diversi.\n"
-"\n"
-"* Si possono usare i letterali per assegnare i valori agli array.\n"
-"\n"
-"* Nalla funzione main, l'istruzione print richiede l'implementazione 'debug' "
-"con il parametro `?`:\n"
-"   `{}` da l'output predefinito (_default_), `{:?}` da l'output tipo debug. "
-"Si sarebbe\n"
-"  anche potuto usare `{a}` e `{a:?}` senza specificare il valore dopo la stringa formattata.\n"
-"\n"
-"* Aggiungendo `#`, eg `{a:#?}`, si invoca un formato \"pretty printing\", il quale può "
-"essere più facile da leggere."
+"Un valore di un array tipo `[T; N]` contiene `N` (una costante _compile-"
+"time_) elementi dello stesso tipo `T`. Nota che la lunghezza dell'array è "
+"_parte del suo tipo_, il che significa che `[u8; 3]` e `[u8; 4]` sono "
+"considerati due tipi diversi."
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr "Si possono usare i letterali per assegnare i valori agli array."
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+"Nalla funzione main, l'istruzione print richiede l'implementazione 'debug' "
+"con il parametro `?`: `{}` da l'output predefinito (_default_), `{:?}` da "
+"l'output tipo debug. Si sarebbe anche potuto usare `{a}` e `{a:?}` senza "
+"specificare il valore dopo la stringa formattata."
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
+msgstr ""
+"Aggiungendo `#`, eg `{a:#?}`, si invoca un formato \"pretty printing\", il "
+"quale può essere più facile da leggere."
 
 #: src/basic-syntax/compound-types.md:47
 msgid "Tuples:"
 msgstr "Tuple:"
 
 #: src/basic-syntax/compound-types.md:49
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
-msgstr ""
-"* Come gli array, le tuple hanno una lunghezza fissa.\n"
-"\n"
-"* Le tuple raggruppano valori di tipi diversi in un tipo composto.\n"
-"\n"
-"* È possibile accedere ai campi di una tupla tramite il punto e l'indice del "
-"valore, ad es. `t.0`, `t.1`.\n"
-"\n"
-"* La tupla vuota `()` è anche nota come \"tipo di unità\". È sia un tipo "
-"che\n"
-"  l'unico valore valido di quel tipo, vale a dire sia il tipo che il suo "
-"valore\n"
-"  sono espressi come `()`. Viene utilizzato per indicare, ad esempio, che "
-"una funzione o\n"
-"  espressione che non ha alcun valore di ritorno, come vedremo in una diapositiva "
-"futura.\n"
-"    * Puoi pensarlo come un \"vuoto\" che può esserti familiare da altri\n"
-"      linguaggi di programmazione."
+msgid "Like arrays, tuples have a fixed length."
+msgstr "Come gli array, le tuple hanno una lunghezza fissa."
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
-msgstr "# Riferimenti"
+#: src/basic-syntax/compound-types.md:51
+msgid "Tuples group together values of different types into a compound type."
+msgstr "Le tuple raggruppano valori di tipi diversi in un tipo composto."
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr ""
+"È possibile accedere ai campi di una tupla tramite il punto e l'indice del "
+"valore, ad es. `t.0`, `t.1`."
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+"La tupla vuota `()` è anche nota come \"tipo di unità\". È sia un tipo che "
+"l'unico valore valido di quel tipo, vale a dire sia il tipo che il suo "
+"valore sono espressi come `()`. Viene utilizzato per indicare, ad esempio, "
+"che una funzione o espressione che non ha alcun valore di ritorno, come "
+"vedremo in una diapositiva futura."
+
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr ""
+"Puoi pensarlo come un \"vuoto\" che può esserti familiare da altri linguaggi "
+"di programmazione."
 
 #: src/basic-syntax/references.md:3
 msgid "Like C++, Rust has references:"
@@ -3215,40 +3105,39 @@ msgstr "Alcune note:"
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* Dobbiamo dereferenziare `ref_x` quando lo assegni, in modo simile ai "
-"puntatori C e C++.\n"
-"* In alcuni casi Rust dereferenzia automaticamente, in particolare durante "
-"l'invocazione\n"
-"  di metodi (prova `ref_x.count_ones()`).\n"
-"* I riferimenti dichiarati come `mut` possono essere associati a valori "
+"Dobbiamo dereferenziare `ref_x` quando lo assegni, in modo simile ai "
+"puntatori C e C++."
+
+#: src/basic-syntax/references.md:17
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+"In alcuni casi Rust dereferenzia automaticamente, in particolare durante "
+"l'invocazione di metodi (prova `ref_x.count_ones()`)."
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"I riferimenti dichiarati come `mut` possono essere associati a valori "
 "diversi nel corso della loro durata."
 
 #: src/basic-syntax/references.md:25
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"* Assicurati di notare la differenza tra `let mut ref_x: &i32` e `let "
-"ref_x:\n"
-"  &mut i32`. Il primo rappresenta un riferimento mutevole a cui può essere "
-"associato\n"
-"  valori diversi, mentre il secondo rappresenta un riferimento a un valore "
-"mutabile."
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
-msgstr "# Riferimenti Penzolanti (Dangling References)"
+"Assicurati di notare la differenza tra `let mut ref_x: &i32` e `let ref_x: "
+"&mut i32`. Il primo rappresenta un riferimento mutevole a cui può essere "
+"associato valori diversi, mentre il secondo rappresenta un riferimento a un "
+"valore mutabile."
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -3269,21 +3158,24 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
+msgid "A reference is said to \"borrow\" the value it refers to."
 msgstr ""
-"* Si dice che un riferimento \"prenda in prestito\" (_borrow_) il valore a cui si "
-"riferisce.\n"
-"* Rust tiene traccia delle vite di tutti i riferimenti per assicurarsi che "
-"durino abbastanza a lungo.\n"
-"* Parleremo di più del _borrowing_ quando arriveremo alla proprietà (_ownership_)."
+"Si dice che un riferimento \"prenda in prestito\" (_borrow_) il valore a cui "
+"si riferisce."
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
-msgstr "# Slices"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"Rust tiene traccia delle vite di tutti i riferimenti per assicurarsi che "
+"durino abbastanza a lungo."
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr ""
+"Parleremo di più del _borrowing_ quando arriveremo alla proprietà "
+"(_ownership_)."
 
 #: src/basic-syntax/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
@@ -3303,71 +3195,80 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
-msgstr ""
-"* Le sezioni prendono in prestito i dati dal tipo della raccolta.\n"
-"* Domanda: Cosa succede se modifichi `a[3]`?"
+msgid "Slices borrow data from the sliced type."
+msgstr "Le sezioni prendono in prestito i dati dal tipo della raccolta."
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "Domanda: Cosa succede se modifichi `a[3]`?"
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
-"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use "
-"`&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
-"(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
 msgstr ""
-"* Creiamo una sezione prendendo in prestito `a` e specificando gli indici "
-"iniziale e finale tra parentesi.\n"
-"\n"
-"* Se la slice inizia all'indice 0, la sintassi dell'intervallo di Rust ci "
+"Creiamo una sezione prendendo in prestito `a` e specificando gli indici "
+"iniziale e finale tra parentesi."
+
+#: src/basic-syntax/slices.md:22
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"Se la slice inizia all'indice 0, la sintassi dell'intervallo di Rust ci "
 "consente di eliminare l'indice iniziale, il che significa che `&a[0..a."
-"len()]` e `&a[..a.len()]` sono identici .\n"
-"    \n"
-"* Lo stesso vale per l'ultimo indice, quindi `&a[2..a.len()]` e `&a[2..]` "
-"sono identici.\n"
-"\n"
-"* Per creare facilmente una porzione dell'array completo, possiamo quindi "
-"utilizzare `&a[..]`.\n"
-"\n"
-"* `s` è un riferimento a una porzione di `i32`s. Si noti che il tipo di `s` "
+"len()]` e `&a[..a.len()]` sono identici ."
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"Lo stesso vale per l'ultimo indice, quindi `&a[2..a.len()]` e `&a[2..]` sono "
+"identici."
+
+#: src/basic-syntax/slices.md:26
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+"Per creare facilmente una porzione dell'array completo, possiamo quindi "
+"utilizzare `&a[..]`."
+
+#: src/basic-syntax/slices.md:28
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+"`s` è un riferimento a una porzione di `i32`s. Si noti che il tipo di `s` "
 "(`&[i32]`) non menziona più la lunghezza dell'array. Questo ci permette di "
-"eseguire il calcolo su fette di diverse dimensioni.\n"
-" \n"
-"* Le fette prendono sempre in prestito da un altro oggetto. In questo "
-"esempio, `a` deve rimanere 'vivo' (nello scope) almeno quanto la nostra "
-"fetta.\n"
-"    \n"
-"* La domanda sulla modifica di `a[3]` può innescare una discussione "
-"interessante, ma la risposta è che per motivi di sicurezza della memoria\n"
-"  non puoi farlo tramite \"a\" dopo aver creato una sezione, ma puoi leggere "
-"i dati sia da \"a\" che da \"s\" in modo sicuro.\n"
-"  Maggiori dettagli saranno spiegati nella sezione controllo del prestito."
+"eseguire il calcolo su fette di diverse dimensioni."
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"Le fette prendono sempre in prestito da un altro oggetto. In questo esempio, "
+"`a` deve rimanere 'vivo' (nello scope) almeno quanto la nostra fetta."
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
+"La domanda sulla modifica di `a[3]` può innescare una discussione "
+"interessante, ma la risposta è che per motivi di sicurezza della memoria non "
+"puoi farlo tramite \"a\" dopo aver creato una sezione, ma puoi leggere i "
+"dati sia da \"a\" che da \"s\" in modo sicuro. Maggiori dettagli saranno "
+"spiegati nella sezione controllo del prestito."
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
-msgstr "# `String` vs `str`"
+msgid "`String` vs `str`"
+msgstr "`String` vs `str`"
 
 #: src/basic-syntax/string-slices.md:3
 msgid "We can now understand the two string types in Rust:"
@@ -3396,81 +3297,77 @@ msgid "Rust terminology:"
 msgstr "Terminologia di Rust:"
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* `&str` un riferimento immutabile a uno slice di stringa.\n"
-"* `String` è un buffer di stringa mutabile."
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str` un riferimento immutabile a uno slice di stringa."
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String` è un buffer di stringa mutabile."
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::"
-"string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* `&str` introduce una _string slice_, che è un riferimento immutabile a una "
-" stringa codificata UTF-8\n"
-"  memorizzata in un blocco di memoria. Le Stringhe letterali (`”Hello”`), sono memorizzate "
-"all'interno del programma binario.\n"
-"\n"
-"* Il tipo Rust `String` è costruito attorno a un vettore di bytes. Come con un "
-"`Vec<T>`, possiede i dati.\n"
-"    \n"
-"* Come con molti altri tipi, `String::from()` crea una stringa da un "
-"carattere letterale; `String::new()` \n"
-"  crea una stringa vuota a cui è possibile aggiungere dati utilizzando i metodi "
-"`push()` and `push_str()`.\n"
-"\n"
-"* La macro `format!()` è un modo conveniente per generare una "
-"stringa da valori dinamici.\n"
-"  Accetta la stessa specifica di formato di `println!()`.\n"
-"    \n"
-"* Puoi prendere in prestito le sezioni `&str` da `String` con `&` "
-"e la selezione dell'intervallo opzionale.\n"
-"    \n"
-"* Per i programmatori C++: pensa a `&str` come a `const char*` da C++ "
-"ma che punta sempre a una stringa valida in memoria. \n"
-"  Rust `String` è approssimativamente equivalente a `std::string` da C++ \n"
-"  (differenza principale: può contenere solo byte codificati UTF-8 "
-"   e non utilizzerà mai l'ottimizzazione di stringhe piccole).\n"
-"    "
+"`&str` introduce una _string slice_, che è un riferimento immutabile a una  "
+"stringa codificata UTF-8 memorizzata in un blocco di memoria. Le Stringhe "
+"letterali (`”Hello”`), sono memorizzate all'interno del programma binario."
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
-msgstr "# Funzioni"
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+"Il tipo Rust `String` è costruito attorno a un vettore di bytes. Come con un "
+"`Vec<T>`, possiede i dati."
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"Come con molti altri tipi, `String::from()` crea una stringa da un carattere "
+"letterale; `String::new()`  crea una stringa vuota a cui è possibile "
+"aggiungere dati utilizzando i metodi `push()` and `push_str()`."
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+"La macro `format!()` è un modo conveniente per generare una stringa da "
+"valori dinamici. Accetta la stessa specifica di formato di `println!()`."
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+"Puoi prendere in prestito le sezioni `&str` da `String` con `&` e la "
+"selezione dell'intervallo opzionale."
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"Per i programmatori C++: pensa a `&str` come a `const char*` da C++ ma che "
+"punta sempre a una stringa valida in memoria.  Rust `String` è "
+"approssimativamente equivalente a `std::string` da C++  (differenza "
+"principale: può contenere solo byte codificati UTF-8    e non utilizzerà mai "
+"l'ottimizzazione di stringhe piccole)."
 
 #: src/basic-syntax/functions.md:3
 msgid ""
 "A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
 "Fizz_buzz) interview question:"
 msgstr ""
-"Una versione Rust del famoso gioco [FizzBuzz](https://en."
-"wikipedia.org/wiki/Fizz_buzz):"
+"Una versione Rust del famoso gioco [FizzBuzz](https://en.wikipedia.org/wiki/"
+"Fizz_buzz):"
 
 #: src/basic-syntax/functions.md:5
 msgid ""
@@ -3505,31 +3402,44 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
+msgstr ""
+"In `main` ci si riferisce a una funzione scritta di seguito.  Non sono "
+"necessarie né pre-dichiarazioni né intestazioni."
+
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+"I parametri di dichiarazione sono seguiti da un tipo (il contrario di alcuni "
+"linguaggi di programmazione) e quindi da un tipo restituito."
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+"L'ultima espressione nel corpo di una funzione (o in qualsiasi blocco) "
+"diventa il valore restituito. Basta omettere `;` alla fine dell'espressione."
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+"Alcune funzioni non hanno alcun valore di ritorno e restituiscono il 'tipo "
+"di unità', `()`. Il compilatore lo dedurrà se il tipo restituito `->()` "
+"viene omesso."
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
 "`=n`, which causes it to include the upper bound."
 msgstr ""
-"* In `main` ci si riferisce a una funzione scritta di seguito. "
-" Non sono necessarie né pre-dichiarazioni né intestazioni.\n"
-"* I parametri di dichiarazione sono seguiti da un tipo "
-"(il contrario di alcuni linguaggi di programmazione) e quindi da un tipo restituito.\n"
-"* L'ultima espressione nel corpo di una funzione (o in qualsiasi blocco) "
-"diventa il valore restituito. Basta omettere `;` alla fine dell'espressione.\n"
-"* Alcune funzioni non hanno alcun valore di ritorno e restituiscono il 'tipo di unità', `()`."
-" Il compilatore lo dedurrà se il tipo restituito `->()` viene omesso.\n"
-"* L'espressione di intervallo nel ciclo `for` in `fizzbuzz to()` contiene `=n` "
+"L'espressione di intervallo nel ciclo `for` in `fizzbuzz to()` contiene `=n` "
 "che include il limite superiore."
-
-#: src/basic-syntax/rustdoc.md:1
-msgid "# Rustdoc"
-msgstr "# Rustdoc"
 
 #: src/basic-syntax/rustdoc.md:3
 msgid ""
@@ -3557,58 +3467,48 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
-"I contenuti sono trattati come Markdown. Tutti i _crate_ pubblicati della libreria Rust "
-"sono\n"
-"automaticamente documentati in [`docs.rs`](https://docs.rs) utilizzando lo "
-"strumento \n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html). "
-"È\n"
-"idiomatico per documentare tutti gli elementi pubblici in un'API utilizzando "
-"questo modello."
+"I contenuti sono trattati come Markdown. Tutti i _crate_ pubblicati della "
+"libreria Rust sono automaticamente documentati in [`docs.rs`](https://docs."
+"rs) utilizzando lo strumento  [rustdoc](https://doc.rust-lang.org/rustdoc/"
+"what-is-rustdoc.html). È idiomatico per documentare tutti gli elementi "
+"pubblici in un'API utilizzando questo modello."
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
-"* Mostra agli studenti i documenti generati per il _crate_ `rand` su\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* Questo corso non include rustdoc sulle diapositive, solo per risparmiare "
-"spazio, ma nel contesto\n"
-"  reale dovrebbe essere presente.\n"
-"\n"
-"* I commenti interni al documento sono discussi più avanti (nella pagina sui "
-"moduli) e non è necessario\n"
-"  affrontarli qui."
+"Mostra agli studenti i documenti generati per il _crate_ `rand` su [`docs.rs/"
+"rand`](https://docs.rs/rand)."
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
-msgstr "# Metodi"
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+"Questo corso non include rustdoc sulle diapositive, solo per risparmiare "
+"spazio, ma nel contesto reale dovrebbe essere presente."
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr ""
+"I commenti interni al documento sono discussi più avanti (nella pagina sui "
+"moduli) e non è necessario affrontarli qui."
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
-"method is\n"
-"an instance of the type it is associated with:"
+"method is an instance of the type it is associated with:"
 msgstr ""
 "I metodi sono funzioni associate a un tipo. L'argomento `self` di un metodo "
-"è\n"
-"un'istanza del tipo a cui è associato:"
+"è un'istanza del tipo a cui è associato:"
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3639,59 +3539,69 @@ msgstr ""
 
 #: src/basic-syntax/methods.md:30
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
-"* Approfondiremo maggiormente i metodi nell'esercizio di oggi e nella "
-"lezione di domani."
+"Approfondiremo maggiormente i metodi nell'esercizio di oggi e nella lezione "
+"di domani."
 
 #: src/basic-syntax/methods.md:34
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
+msgstr "Aggiungi un costruttore `Rectangle::new` e chiamalo da `main`:"
+
+#: src/basic-syntax/methods.md:36
 msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
 msgstr ""
-"- Aggiungi un costruttore `Rectangle::new` e chiamalo da `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Aggiungi un costruttore `Rectangle::new_square(width: u32)` per illustrare\n"
-"  che i costruttori possono accettare parametri arbitrari."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
+msgstr ""
+"Aggiungi un costruttore `Rectangle::new_square(width: u32)` per illustrare "
+"che i costruttori possono accettare parametri arbitrari."
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
-msgstr "# Overloading di Funzione"
+msgid "Function Overloading"
+msgstr "Overloading di Funzione"
 
 #: src/basic-syntax/functions-interlude.md:3
 msgid "Overloading is not supported:"
 msgstr "L'Overloading non è supportato:"
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* Ogni funzione ha una singola implementazione:\n"
-"  * Accetta sempre un numero fisso di parametri.\n"
-"  * Accetta sempre un singolo set di tipi di parametro.\n"
-"* I valori predefiniti non sono supportati:\n"
-"  * Tutti i siti di chiamata hanno lo stesso numero di argomenti.\n"
-"  * Le macro sono talvolta utilizzate come alternativa."
+msgid "Each function has a single implementation:"
+msgstr "Ogni funzione ha una singola implementazione:"
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "Accetta sempre un numero fisso di parametri."
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "Accetta sempre un singolo set di tipi di parametro."
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "I valori predefiniti non sono supportati:"
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr "Tutti i siti di chiamata hanno lo stesso numero di argomenti."
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "Le macro sono talvolta utilizzate come alternativa."
 
 #: src/basic-syntax/functions-interlude.md:12
 msgid "However, function parameters can be generic:"
@@ -3713,33 +3623,29 @@ msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
-"* Quando si usano i generici, `Into<T>` della libreria standard può fornire "
-"una sorta di\n"
-"  polimorfismo limitato sui tipi dell'argomento. Vedremo maggiori dettagli in una "
-"sezione successiva."
+"Quando si usano i generici, `Into<T>` della libreria standard può fornire "
+"una sorta di polimorfismo limitato sui tipi dell'argomento. Vedremo maggiori "
+"dettagli in una sezione successiva."
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
-msgstr "# Giorno 1: Esercizi Mattutini"
+msgid "Day 1: Morning Exercises"
+msgstr "Giorno 1: Esercizi Mattutini"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
 msgstr "In questi esercizi esploreremo due parti di Rust:"
 
 #: src/exercises/day-1/morning.md:5
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
-msgstr ""
-"* Conversioni implicite tra tipi.\n"
-"\n"
-"* Array e cicli `for`."
+msgid "Implicit conversions between types."
+msgstr "Conversioni implicite tra tipi."
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
+msgstr "Array e cicli `for`."
 
 #: src/exercises/day-1/morning.md:11
 msgid "A few things to consider while solving the exercises:"
@@ -3747,29 +3653,25 @@ msgstr "Alcune cose da considerare durante la risoluzione degli esercizi:"
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* Utilizzare un'installazione locale di Rust, se possibile. In questo modo "
-"puoi ottenere\n"
-"  completamento automatico nel tuo editor. Vedi la pagina su [Using Cargo] per i dettagli\n"
-"  sull'installazione di Rust.\n"
-"\n"
-"* In alternativa, usa Rust Playground."
+"Utilizzare un'installazione locale di Rust, se possibile. In questo modo "
+"puoi ottenere completamento automatico nel tuo editor. Vedi la pagina su "
+"[Using Cargo](../../cargo.md) per i dettagli sull'installazione di Rust."
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
+msgstr "In alternativa, usa Rust Playground."
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
 "Gli snippet di codice non sono modificabili di proposito: gli snippet di "
-"codice in linea perdono\n"
-"il loro stato se esci dalla pagina."
+"codice in linea perdono il loro stato se esci dalla pagina."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
@@ -3778,23 +3680,19 @@ msgstr ""
 #: src/exercises/concurrency/morning.md:12
 #: src/exercises/concurrency/afternoon.md:13
 msgid ""
-"After looking at the exercises, you can look at the [solutions] provided."
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
 msgstr ""
-"Dopo aver esaminato gli esercizi, puoi esaminare le [solutions] fornite."
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
-msgstr "# Conversioni Implicite"
+"Dopo aver esaminato gli esercizi, puoi esaminare le \\[solutions\\] fornite."
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
 "Rust non applicherà automaticamente le _conversioni implicite_ tra i tipi "
-"([a differenza di\n"
-"C++][3]). Puoi vederlo in un programma come questo:"
+"([a differenza di C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). Puoi vederlo in un programma come questo:"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
@@ -3814,80 +3712,73 @@ msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Tutti i tipi interi in Rust implementano i _traits_ [`From<T>`][1] e [`Into<T>`][2]\n"
-"consentendo la conversione tra di loro. Il _trait_ `From<T>` ha un singolo metodo "
-"`from()`\n"
-" e allo stesso modo, il _trait_ `Into<T>` ha un singolo metodo `into()`.\n"
-"L'implementazione di questi _traits_ esprime il modo in cui un tipo consente "
-" di essere convertito in\n"
-" un altro tipo."
+"Tutti i tipi interi in Rust implementano i _traits_ [`From<T>`](https://doc."
+"rust-lang.org/std/convert/trait.From.html) e [`Into<T>`](https://doc.rust-"
+"lang.org/std/convert/trait.Into.html) consentendo la conversione tra di "
+"loro. Il _trait_ `From<T>` ha un singolo metodo `from()` e allo stesso modo, "
+"il _trait_ `Into<T>` ha un singolo metodo `into()`. L'implementazione di "
+"questi _traits_ esprime il modo in cui un tipo consente  di essere "
+"convertito in un altro tipo."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
 "La libreria standard ha un'implementazione di `From<i8> for i16`, che "
-"significa\n"
-"che possiamo convertire una variabile `x` di tipo `i8` in una `i16` "
-"chiamando\n"
-"`i16::from(x)`. O, più semplicemente, con `x.into()`, perché l'implementazione `From<i8> for "
-"i16`\n"
-" crea automaticamente un'implementazione di `Into<i16> per "
-"i8`."
+"significa che possiamo convertire una variabile `x` di tipo `i8` in una "
+"`i16` chiamando `i16::from(x)`. O, più semplicemente, con `x.into()`, perché "
+"l'implementazione `From<i8> for i16` crea automaticamente un'implementazione "
+"di `Into<i16> per i8`."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
-"Lo stesso vale per le tue implementazioni `From` per i tuoi tipi, così è\n"
+"Lo stesso vale per le tue implementazioni `From` per i tuoi tipi, così è "
 "sufficiente implementare solo `From` per ottenere automaticamente una "
 "rispettiva implementazione `Into`."
 
 #: src/exercises/day-1/implicit-conversions.md:33
-msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+msgid "Execute the above program and look at the compiler error."
+msgstr "Eseguire il programma precedente e osservare l'errore del compilatore."
+
+#: src/exercises/day-1/implicit-conversions.md:35
+msgid "Update the code above to use `into()` to do the conversion."
 msgstr ""
-"1. Eseguire il programma precedente e osservare l'errore del compilatore.\n"
-"\n"
-"2. Aggiornare il codice per utilizzare `into()` per eseguire la "
-"conversione.\n"
-"\n"
-"3. Cambiare i tipi di `x` e `y` in altre cose (come `f32`, `bool`,\n"
-"   `i128`) per vedere quali tipi è possibile convertire in quali altri tipi. "
-"Provare a\n"
-"   convertire tipi \"piccoli\" in tipi \"grandi\" e viceversa. Controlla "
-"la\n"
-"   [documentazione della libreria standard][1] per vedere se `From<T>` è "
-"implementato per\n"
-"   le coppie che controlli."
+"Aggiornare il codice per utilizzare `into()` per eseguire la conversione."
+
+#: src/exercises/day-1/implicit-conversions.md:37
+msgid ""
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
+msgstr ""
+"Cambiare i tipi di `x` e `y` in altre cose (come `f32`, `bool`, `i128`) per "
+"vedere quali tipi è possibile convertire in quali altri tipi. Provare a "
+"convertire tipi \"piccoli\" in tipi \"grandi\" e viceversa. Controlla la "
+"[documentazione della libreria standard](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) per vedere se `From<T>` è implementato per le "
+"coppie che controlli."
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
-msgstr "# Array e Cicli `for`"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "Array e Cicli `for`"
 
 #: src/exercises/day-1/for-loops.md:3
 msgid "We saw that an array can be declared like this:"
@@ -3920,10 +3811,11 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr ""
-"Rust ti consente di iterare cose come array e intervalli usando la parola chiave `for`:"
+"Rust ti consente di iterare cose come array e intervalli usando la parola "
+"chiave `for`:"
 
 #: src/exercises/day-1/for-loops.md:21
 msgid ""
@@ -3948,14 +3840,12 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
 "Usa quanto sopra per scrivere una funzione `pretty_print` che stampa in modo "
-"efficace una matrice e\n"
-"una funzione `transpose` che traspone una matrice (trasforma le righe in "
-"colonne):"
+"efficace una matrice e una funzione `transpose` che traspone una matrice "
+"(trasforma le righe in colonne):"
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3972,7 +3862,7 @@ msgstr "Implementa entrambe le funzioni per operare su matrici 3 × 3."
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
 "Copia il codice qui sotto in <https://play.rust-lang.org/> e implementa le "
@@ -4010,51 +3900,43 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
-msgstr "## Domanda bonus"
+msgid "Bonus Question"
+msgstr "Domanda bonus"
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"Potresti usare _slices_ `&[i32]` invece di matrici 3 × 3 codificate per il tuo\n"
-"argomento e tipi restituiti? Qualcosa come `&[&[i32]]` per un oggetto "
-"bidimensionale\n"
-"_slice-di-slices_. Perché o perché no?"
+"Potresti usare _slices_ `&[i32]` invece di matrici 3 × 3 codificate per il "
+"tuo argomento e tipi restituiti? Qualcosa come `&[&[i32]]` per un oggetto "
+"bidimensionale _slice-di-slices_. Perché o perché no?"
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
-"Guarda il _crate_ [`ndarray`](https://docs.rs/ndarray/) per una implementazione di livello "
-"produzione (_production_)."
+"Guarda il _crate_ [`ndarray`](https://docs.rs/ndarray/) per una "
+"implementazione di livello produzione (_production_)."
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"La soluzione e la risposta alla sezione bonus sono disponibili nella\n"
-"sezione [Soluzione](solutions-morning.md#arrays-and-for-loops)."
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
-msgstr "# Variabili"
+"La soluzione e la risposta alla sezione bonus sono disponibili nella sezione "
+"[Soluzione](solutions-morning.md#arrays-and-for-loops)."
 
 #: src/basic-syntax/variables.md:3
 #, fuzzy
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
+"by default:"
 msgstr ""
 "Rust fornisce sicurezza di tipo tramite tipizzazione statica. Le "
-"associazioni variabili sono immutabili da\n"
-"predefinito:"
+"associazioni variabili sono immutabili da predefinito:"
 
 #: src/basic-syntax/variables.md:6
 msgid ""
@@ -4071,20 +3953,20 @@ msgstr ""
 #: src/basic-syntax/variables.md:17
 #, fuzzy
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
+msgstr ""
+"A causa dell'inferenza del tipo, `i32` è facoltativo. Mostreremo "
+"gradualmente i tipi sempre meno man mano che il corso procede."
+
+#: src/basic-syntax/variables.md:18
+#, fuzzy
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
 "function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
-"* A causa dell'inferenza del tipo, `i32` è facoltativo. Mostreremo "
-"gradualmente i tipi sempre meno man mano che il corso procede.\n"
-"* Nota che poiché `println!` è una macro, `x` non viene spostata, anche "
-"usando la sintassi di funzione simile a `println!(\"x: {}\", x)`"
-
-#: src/basic-syntax/type-inference.md:1
-#, fuzzy
-msgid "# Type Inference"
-msgstr "# Digitare Inferenza"
+"Nota che poiché `println!` è una macro, `x` non viene spostata, anche usando "
+"la sintassi di funzione simile a `println!(\"x: {}\", x)`"
 
 #: src/basic-syntax/type-inference.md:3
 #, fuzzy
@@ -4127,16 +4009,16 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 "È molto importante sottolineare che le variabili dichiarate in questo modo "
-"non sono di una sorta di \"qualsiasi tipo\" dinamico che può\n"
-"detenere alcun dato. Il codice macchina generato da tale dichiarazione è "
-"identico alla dichiarazione esplicita di un tipo.\n"
-"Il compilatore fa il lavoro per noi e ci aiuta a scrivere codice più conciso."
+"non sono di una sorta di \"qualsiasi tipo\" dinamico che può detenere alcun "
+"dato. Il codice macchina generato da tale dichiarazione è identico alla "
+"dichiarazione esplicita di un tipo. Il compilatore fa il lavoro per noi e ci "
+"aiuta a scrivere codice più conciso."
 
 #: src/basic-syntax/type-inference.md:32
 #, fuzzy
@@ -4172,13 +4054,13 @@ msgid ""
 "rust-lang.org/std/iter/trait.FromIterator.html) implements."
 msgstr ""
 "[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
-"html#method.collect) si basa su `FromIterator`, che [`HashSet`](https:/ /doc."
-"rust-lang.org/std/iter/trait.FromIterator.html) implementa."
+"html#method.collect) si basa su `FromIterator`, che \\[`HashSet`\\](https:/ /"
+"doc.rust-lang.org/std/iter/trait.FromIterator.html) implementa."
 
 #: src/basic-syntax/static-and-const.md:1
 #, fuzzy
-msgid "# Static and Constant Variables"
-msgstr "# Variabili statiche e costanti"
+msgid "Static and Constant Variables"
+msgstr "Variabili statiche e costanti"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid ""
@@ -4187,8 +4069,8 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
-msgstr "## `const`"
+msgid "`const`"
+msgstr "`const`"
 
 #: src/basic-syntax/static-and-const.md:7
 #, fuzzy
@@ -4219,12 +4101,16 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:27
 #, fuzzy
-msgid "According to the [Rust RFC Book][1] these are inlined upon use."
-msgstr "Secondo il [Rust RFC Book][1] questi sono incorporati dopo l'uso."
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
+msgstr ""
+"Secondo il [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-"
+"static.html) questi sono incorporati dopo l'uso."
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
-msgstr "## `static`"
+msgid "`static`"
+msgstr "`static`"
 
 #: src/basic-syntax/static-and-const.md:31
 msgid "You can also declare static variables:"
@@ -4244,58 +4130,66 @@ msgstr ""
 #: src/basic-syntax/static-and-const.md:41
 #, fuzzy
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution.\n"
-"When a globally-scoped value does not have a reason to need object identity, "
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution. When a "
+"globally-scoped value does not have a reason to need object identity, "
 "`const` is generally preferred."
 msgstr ""
-"Come notato nel [Rust RFC Book][1], questi non sono allineati durante l'uso "
-"e hanno una posizione di memoria associata effettiva. Questo è utile per il "
-"codice non sicuro e incorporato e la variabile vive per tutta l'esecuzione "
-"del programma."
+"Come notato nel [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), questi non sono allineati durante l'uso e hanno una "
+"posizione di memoria associata effettiva. Questo è utile per il codice non "
+"sicuro e incorporato e la variabile vive per tutta l'esecuzione del "
+"programma."
 
 #: src/basic-syntax/static-and-const.md:45
 msgid ""
 "We will look at [mutating static data](../unsafe/mutable-static-variables."
-"md) in the chapter on Unsafe Rust.\n"
-"Because `static` variables are accessible from any thread, mutable static "
-"variables require manual, unsafe, synchronization of accesses."
+"md) in the chapter on Unsafe Rust. Because `static` variables are accessible "
+"from any thread, mutable static variables require manual, unsafe, "
+"synchronization of accesses."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:50
 #, fuzzy
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* `static` provides object identity: an address in memory and state as "
-"required by types with interior mutability such as `Mutex<T>`.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
-"* Menziona che `const` si comporta semanticamente in modo simile a "
-"`constexpr` del C++.\n"
-"* `static`, d'altra parte, è molto più simile a una `const` o variabile "
-"globale mutabile in C++.\n"
-"* Non è molto comune che si abbia bisogno di una costante valutata in fase "
-"di esecuzione, ma è utile e più sicura rispetto all'utilizzo di una statica."
+"Menziona che `const` si comporta semanticamente in modo simile a `constexpr` "
+"del C++."
 
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
-msgstr "# Scopes (Ambiti) e Shadowing"
+#: src/basic-syntax/static-and-const.md:51
+#, fuzzy
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+"`static`, d'altra parte, è molto più simile a una `const` o variabile "
+"globale mutabile in C++."
+
+#: src/basic-syntax/static-and-const.md:52
+#, fuzzy
+msgid ""
+"`static` provides object identity: an address in memory and state as "
+"required by types with interior mutability such as `Mutex<T>`."
+msgstr ""
+"Non è molto comune che si abbia bisogno di una costante valutata in fase di "
+"esecuzione, ma è utile e più sicura rispetto all'utilizzo di una statica."
+
+#: src/basic-syntax/static-and-const.md:53
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:3
 #, fuzzy
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
+"the same scope:"
 msgstr ""
 "Puoi ombreggiare le variabili, sia quelle degli ambiti esterni che le "
-"variabili del file\n"
-"stessa portata:"
+"variabili del file stessa portata:"
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
@@ -4320,24 +4214,37 @@ msgstr ""
 #: src/basic-syntax/scopes-shadowing.md:25
 #, fuzzy
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"Definizione: l'ombreggiatura è diversa dalla mutazione, perché dopo "
+"l'ombreggiatura le locazioni di memoria di entrambe le variabili esistono "
+"contemporaneamente. Entrambi sono disponibili con lo stesso nome, a seconda "
+"di dove lo usi nel codice."
+
+#: src/basic-syntax/scopes-shadowing.md:26
+#, fuzzy
+msgid "A shadowing variable can have a different type. "
+msgstr "Una variabile di ombreggiatura può avere un tipo diverso."
+
+#: src/basic-syntax/scopes-shadowing.md:27
+#, fuzzy
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+"L'ombreggiatura all'inizio sembra oscura, ma è utile per conservare i valori "
+"dopo `.unwrap()`."
+
+#: src/basic-syntax/scopes-shadowing.md:28
+#, fuzzy
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
-"* Definizione: l'ombreggiatura è diversa dalla mutazione, perché dopo "
-"l'ombreggiatura le locazioni di memoria di entrambe le variabili esistono "
-"contemporaneamente. Entrambi sono disponibili con lo stesso nome, a seconda "
-"di dove lo usi nel codice.\n"
-"* Una variabile di ombreggiatura può avere un tipo diverso.\n"
-"* L'ombreggiatura all'inizio sembra oscura, ma è utile per conservare i "
-"valori dopo `.unwrap()`.\n"
-"* Il codice seguente dimostra perché il compilatore non può semplicemente "
+"Il codice seguente dimostra perché il compilatore non può semplicemente "
 "riutilizzare le posizioni di memoria durante lo shadowing di una variabile "
 "immutabile in un ambito, anche se il tipo non cambia."
 
@@ -4353,10 +4260,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr "# Gestione della Memoria"
-
 #: src/memory-management.md:3
 #, fuzzy
 msgid "Traditionally, languages have fallen into two broad categories:"
@@ -4365,14 +4268,18 @@ msgstr ""
 
 #: src/memory-management.md:5
 #, fuzzy
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr ""
+"Controllo completo tramite gestione manuale della memoria: C, C++, "
+"Pascal, ..."
+
+#: src/memory-management.md:6
+#, fuzzy
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
-"* Controllo completo tramite gestione manuale della memoria: C, C++, "
-"Pascal, ...\n"
-"* Piena sicurezza tramite la gestione automatica della memoria in fase di "
+"Piena sicurezza tramite la gestione automatica della memoria in fase di "
 "esecuzione: Java, Python, Go, Haskell, ..."
 
 #: src/memory-management.md:8
@@ -4382,12 +4289,11 @@ msgstr "Rust offre un nuovo mix:"
 #: src/memory-management.md:10
 #, fuzzy
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
-"> Pieno controllo *e* sicurezza tramite applicazione in fase di compilazione "
-"della memoria corretta\n"
-"> gestione."
+"Pieno controllo _e_ sicurezza tramite applicazione in fase di compilazione "
+"della memoria corretta gestione."
 
 #: src/memory-management.md:13
 msgid "It does this with an explicit ownership concept."
@@ -4400,48 +4306,62 @@ msgstr ""
 "Innanzitutto, aggiorniamo il funzionamento della gestione della memoria."
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
-msgstr "# Lo Stack (Pila) vs l’Heap"
+msgid "The Stack vs The Heap"
+msgstr "Lo Stack (Pila) vs l’Heap"
 
 #: src/memory-management/stack-vs-heap.md:3
 #, fuzzy
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* Stack: area continua di memoria per le variabili locali.\n"
-"  * I valori hanno dimensioni fisse note al momento della compilazione.\n"
-"  * Estremamente veloce: basta spostare un puntatore dello stack.\n"
-"  * Facile da gestire: segue le chiamate alle funzioni.\n"
-"  * Ottima località di memoria.\n"
-"\n"
-"* Heap: archiviazione di valori al di fuori delle chiamate di funzione.\n"
-"  * I valori hanno dimensioni dinamiche determinate in fase di esecuzione.\n"
-"  * Leggermente più lento della pila: è necessaria un po' di contabilità.\n"
-"  * Nessuna garanzia di località di memoria."
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "Stack: area continua di memoria per le variabili locali."
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
-msgstr "# Memoria sullo Stack"
+#: src/memory-management/stack-vs-heap.md:4
+#, fuzzy
+msgid "Values have fixed sizes known at compile time."
+msgstr "I valori hanno dimensioni fisse note al momento della compilazione."
+
+#: src/memory-management/stack-vs-heap.md:5
+#, fuzzy
+msgid "Extremely fast: just move a stack pointer."
+msgstr "Estremamente veloce: basta spostare un puntatore dello stack."
+
+#: src/memory-management/stack-vs-heap.md:6
+#, fuzzy
+msgid "Easy to manage: follows function calls."
+msgstr "Facile da gestire: segue le chiamate alle funzioni."
+
+#: src/memory-management/stack-vs-heap.md:7
+#, fuzzy
+msgid "Great memory locality."
+msgstr "Ottima località di memoria."
+
+#: src/memory-management/stack-vs-heap.md:9
+#, fuzzy
+msgid "Heap: Storage of values outside of function calls."
+msgstr "Heap: archiviazione di valori al di fuori delle chiamate di funzione."
+
+#: src/memory-management/stack-vs-heap.md:10
+#, fuzzy
+msgid "Values have dynamic sizes determined at runtime."
+msgstr "I valori hanno dimensioni dinamiche determinate in fase di esecuzione."
+
+#: src/memory-management/stack-vs-heap.md:11
+#, fuzzy
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "Leggermente più lento della pila: è necessaria un po' di contabilità."
+
+#: src/memory-management/stack-vs-heap.md:12
+#, fuzzy
+msgid "No guarantee of memory locality."
+msgstr "Nessuna garanzia di località di memoria."
 
 #: src/memory-management/stack.md:3
 #, fuzzy
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 "La creazione di una `Stringa` mette i dati di dimensioni fisse nello stack e "
-"dimensionati dinamicamente\n"
-"dati sull'heap:"
+"dimensionati dinamicamente dati sull'heap:"
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -4471,38 +4391,43 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
-msgstr "# Gestione manuale della Memoria"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/memory-management/manual.md:3
 msgid "You allocate and deallocate heap memory yourself."
@@ -4518,8 +4443,8 @@ msgstr ""
 "di sicurezza e perdite di memoria."
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
-msgstr "## Esempio C"
+msgid "C Example"
+msgstr "Esempio C"
 
 #: src/memory-management/manual.md:9
 #, fuzzy
@@ -4543,16 +4468,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
 "La memoria viene persa se la funzione ritorna in anticipo tra `malloc` e "
-"`free`: the\n"
-"puntatore è perso e non possiamo deallocare la memoria."
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
-msgstr "# Gestione della memoria basata sullo Scope (ambito)"
+"`free`: the puntatore è perso e non possiamo deallocare la memoria."
 
 #: src/memory-management/scope-based.md:3
 #, fuzzy
@@ -4565,31 +4484,26 @@ msgstr ""
 #: src/memory-management/scope-based.md:5
 #, fuzzy
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
 "Avvolgendo un puntatore in un oggetto, puoi liberare memoria quando "
-"l'oggetto è\n"
-"distrutto. Il compilatore garantisce che ciò accada, anche se lo è "
-"un'eccezione\n"
-"sollevato."
+"l'oggetto è distrutto. Il compilatore garantisce che ciò accada, anche se lo "
+"è un'eccezione sollevato."
 
 #: src/memory-management/scope-based.md:9
 #, fuzzy
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr ""
 "Questo è spesso chiamato _l'acquisizione delle risorse è l'inizializzazione_ "
-"(RAII) e dà\n"
-"puntatori intelligenti."
+"(RAII) e dà puntatori intelligenti."
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
-msgstr "## Esempio C++"
+msgid "C++ Example"
+msgstr "Esempio C++"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -4603,16 +4517,22 @@ msgstr ""
 #: src/memory-management/scope-based.md:20
 #, fuzzy
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
 msgstr ""
-"* L'oggetto `std::unique_ptr` è allocato nello stack e punta a\n"
-"  memoria allocata nell'heap.\n"
-"* Alla fine di `say_hello`, verrà eseguito il distruttore `std::"
-"unique_ptr`.\n"
-"* Il distruttore libera l'oggetto `Person` a cui punta."
+"L'oggetto `std::unique_ptr` è allocato nello stack e punta a memoria "
+"allocata nell'heap."
+
+#: src/memory-management/scope-based.md:22
+#, fuzzy
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr ""
+"Alla fine di `say_hello`, verrà eseguito il distruttore `std::unique_ptr`."
+
+#: src/memory-management/scope-based.md:23
+#, fuzzy
+msgid "The destructor frees the `Person` object it points to."
+msgstr "Il distruttore libera l'oggetto `Person` a cui punta."
 
 #: src/memory-management/scope-based.md:25
 #, fuzzy
@@ -4631,34 +4551,36 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
-msgstr "# Gestione automatica della Memoria"
+msgid "Automatic Memory Management"
+msgstr "Gestione automatica della Memoria"
 
 #: src/memory-management/garbage-collection.md:3
 #, fuzzy
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
+"memory management:"
 msgstr ""
 "Un'alternativa alla gestione della memoria manuale e basata sull'ambito è la "
-"memoria automatica\n"
-"gestione:"
+"memoria automatica gestione:"
 
 #: src/memory-management/garbage-collection.md:6
 #, fuzzy
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr ""
+"Il programmatore non alloca o dealloca mai la memoria in modo esplicito."
+
+#: src/memory-management/garbage-collection.md:7
+#, fuzzy
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
 msgstr ""
-"* Il programmatore non alloca o dealloca mai la memoria in modo esplicito.\n"
-"* Un Garbage Collector trova la memoria inutilizzata e la dealloca per il "
+"Un Garbage Collector trova la memoria inutilizzata e la dealloca per il "
 "programmatore."
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
-msgstr "## Esempio Java"
+msgid "Java Example"
+msgstr "Esempio Java"
 
 #: src/memory-management/garbage-collection.md:11
 #, fuzzy
@@ -4676,8 +4598,8 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
-msgstr "# Gestione della Memoria in Rust"
+msgid "Memory Management in Rust"
+msgstr "Gestione della Memoria in Rust"
 
 #: src/memory-management/rust.md:3
 msgid "Memory management in Rust is a mix:"
@@ -4685,21 +4607,33 @@ msgstr "La gestione della memoria in Rust è un mix:"
 
 #: src/memory-management/rust.md:5
 #, fuzzy
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "Sicuro e corretto come Java, ma senza un garbage collector."
+
+#: src/memory-management/rust.md:6
+#, fuzzy
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+"A seconda dell'astrazione (o combinazione di astrazioni) scelta, può "
+"trattarsi di un singolo puntatore univoco, del conteggio dei riferimenti o "
+"del conteggio dei riferimenti atomici."
+
+#: src/memory-management/rust.md:7
+#, fuzzy
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+"Basato sull'ambito come C++, ma il compilatore applica la piena aderenza."
+
+#: src/memory-management/rust.md:8
+#, fuzzy
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
-"* Sicuro e corretto come Java, ma senza un garbage collector.\n"
-"* A seconda dell'astrazione (o combinazione di astrazioni) scelta, può "
-"trattarsi di un singolo puntatore univoco, del conteggio dei riferimenti o "
-"del conteggio dei riferimenti atomici.\n"
-"* Basato sull'ambito come C++, ma il compilatore applica la piena aderenza.\n"
-"* Un utente Rust può scegliere l'astrazione giusta per la situazione, alcuni "
+"Un utente Rust può scegliere l'astrazione giusta per la situazione, alcuni "
 "addirittura non hanno alcun costo in fase di esecuzione come C."
 
 #: src/memory-management/rust.md:10
@@ -4710,25 +4644,30 @@ msgstr "Raggiunge questo modellando _ownership_ in modo esplicito."
 #: src/memory-management/rust.md:14
 #, fuzzy
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* Se ti viene chiesto come a questo punto, puoi menzionare che in Rust "
-"questo è solitamente gestito da tipi di wrapper RAII come [Box], [Vec], [Rc] "
-"o [Arc]. Questi incapsulano la proprietà e l'allocazione della memoria "
-"tramite vari mezzi e prevengono i potenziali errori in C.\n"
-"\n"
-"* Qui ti potrebbe essere chiesto dei distruttori, il tratto [Drop] è "
-"l'equivalente di Rust."
+"Se ti viene chiesto come a questo punto, puoi menzionare che in Rust questo "
+"è solitamente gestito da tipi di wrapper RAII come [Box](https://doc.rust-"
+"lang.org/std/boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html) o "
+"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html). Questi "
+"incapsulano la proprietà e l'allocazione della memoria tramite vari mezzi e "
+"prevengono i potenziali errori in C."
 
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
-msgstr "# Confronto"
+#: src/memory-management/rust.md:16
+#, fuzzy
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
+msgstr ""
+"Qui ti potrebbe essere chiesto dei distruttori, il tratto [Drop](https://doc."
+"rust-lang.org/std/ops/trait.Drop.html) è l'equivalente di Rust."
 
 #: src/memory-management/comparison.md:3
 #, fuzzy
@@ -4737,88 +4676,120 @@ msgstr ""
 "Ecco un confronto approssimativo delle tecniche di gestione della memoria."
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## Vantaggi di Tecniche differenti di gestione della Memoria"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "Vantaggi di Tecniche differenti di gestione della Memoria"
 
-#: src/memory-management/comparison.md:7
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* Manuale come C:\n"
-"  * Nessun sovraccarico di runtime.\n"
-"* Automatico come Java:\n"
-"  * Completamente automatico.\n"
-"  * Sicuro e corretto.\n"
-"* Basato sull'ambito come C++:\n"
-"  * Parzialmente automatico.\n"
-"  * Nessun sovraccarico di runtime.\n"
-"* Basato sull'ambito imposto dal compilatore come Rust:\n"
-"  * Applicato dal compilatore.\n"
-"  * Nessun sovraccarico di runtime.\n"
-"  * Sicuro e corretto."
+msgid "Manual like C:"
+msgstr "Manuale come C:"
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+#, fuzzy
+msgid "No runtime overhead."
+msgstr "Nessun sovraccarico di runtime."
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+#, fuzzy
+msgid "Automatic like Java:"
+msgstr "Automatico come Java:"
+
+#: src/memory-management/comparison.md:10
+#, fuzzy
+msgid "Fully automatic."
+msgstr "Completamente automatico."
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+#, fuzzy
+msgid "Safe and correct."
+msgstr "Sicuro e corretto."
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+#, fuzzy
+msgid "Scope-based like C++:"
+msgstr "Basato sull'ambito come C++:"
+
+#: src/memory-management/comparison.md:13
+#, fuzzy
+msgid "Partially automatic."
+msgstr "Parzialmente automatico."
+
+#: src/memory-management/comparison.md:15
+#, fuzzy
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "Basato sull'ambito imposto dal compilatore come Rust:"
+
+#: src/memory-management/comparison.md:16
+#, fuzzy
+msgid "Enforced by compiler."
+msgstr "Applicato dal compilatore."
 
 #: src/memory-management/comparison.md:20
 #, fuzzy
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## Contro di diverse tecniche di gestione della memoria"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "Contro di diverse tecniche di gestione della memoria"
 
-#: src/memory-management/comparison.md:22
+#: src/memory-management/comparison.md:23
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* Manuale come C:\n"
-"  * Usa-dopo-gratis.\n"
-"  * Doppia libera.\n"
-"  * Perdite di memoria.\n"
-"* Automatico come Java:\n"
-"  * La raccolta dei rifiuti si interrompe.\n"
-"  * Ritardi del distruttore.\n"
-"* Basato sull'ambito come C++:\n"
-"  * Complesso, opt-in dal programmatore.\n"
-"  * Potenziale per uso dopo-gratis.\n"
-"* Applicato al compilatore e basato sull'ambito come Rust:\n"
-"  * Qualche complessità iniziale.\n"
-"  * Può rifiutare programmi validi."
+msgid "Use-after-free."
+msgstr "Usa-dopo-gratis."
 
-#: src/ownership.md:1
-msgid "# Ownership"
-msgstr "# Ownership (Proprietà)"
+#: src/memory-management/comparison.md:24
+#, fuzzy
+msgid "Double-frees."
+msgstr "Doppia libera."
+
+#: src/memory-management/comparison.md:25
+#, fuzzy
+msgid "Memory leaks."
+msgstr "Perdite di memoria."
+
+#: src/memory-management/comparison.md:27
+#, fuzzy
+msgid "Garbage collection pauses."
+msgstr "La raccolta dei rifiuti si interrompe."
+
+#: src/memory-management/comparison.md:28
+#, fuzzy
+msgid "Destructor delays."
+msgstr "Ritardi del distruttore."
+
+#: src/memory-management/comparison.md:30
+#, fuzzy
+msgid "Complex, opt-in by programmer."
+msgstr "Complesso, opt-in dal programmatore."
+
+#: src/memory-management/comparison.md:31
+#, fuzzy
+msgid "Potential for use-after-free."
+msgstr "Potenziale per uso dopo-gratis."
+
+#: src/memory-management/comparison.md:32
+#, fuzzy
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "Applicato al compilatore e basato sull'ambito come Rust:"
+
+#: src/memory-management/comparison.md:33
+#, fuzzy
+msgid "Some upfront complexity."
+msgstr "Qualche complessità iniziale."
+
+#: src/memory-management/comparison.md:34
+#, fuzzy
+msgid "Can reject valid programs."
+msgstr "Può rifiutare programmi validi."
 
 #: src/ownership.md:3
 #, fuzzy
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
+"to use a variable outside its scope:"
 msgstr ""
 "Tutte le associazioni di variabili hanno un _scope_ in cui sono valide ed è "
-"un errore\n"
-"usa una variabile al di fuori del suo ambito:"
+"un errore usa una variabile al di fuori del suo ambito:"
 
 #: src/ownership.md:6
 msgid ""
@@ -4838,18 +4809,20 @@ msgstr ""
 #: src/ownership.md:18
 #, fuzzy
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr ""
-"* Alla fine dell'ambito, la variabile viene _eliminata_ ei dati vengono "
-"liberati.\n"
-"* Un distruttore può essere eseguito qui per liberare risorse.\n"
-"* Diciamo che la variabile _possiede_ il valore."
+"Alla fine dell'ambito, la variabile viene _eliminata_ ei dati vengono "
+"liberati."
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
-msgstr "# Semantica di Move (Spostamento)"
+#: src/ownership.md:19
+#, fuzzy
+msgid "A destructor can run here to free up resources."
+msgstr "Un distruttore può essere eseguito qui per liberare risorse."
+
+#: src/ownership.md:20
+#, fuzzy
+msgid "We say that the variable _owns_ the value."
+msgstr "Diciamo che la variabile _possiede_ il valore."
 
 #: src/ownership/move-semantics.md:3
 #, fuzzy
@@ -4870,36 +4843,44 @@ msgstr ""
 
 #: src/ownership/move-semantics.md:14
 #, fuzzy
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "L'assegnazione di \"s1\" a \"s2\" trasferisce la proprietà."
+
+#: src/ownership/move-semantics.md:15
+#, fuzzy
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr "I dati sono stati _spostati_ da `s1` e `s1` non è più accessibile."
+
+#: src/ownership/move-semantics.md:16
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr "Quando `s1` esce dall'ambito, non accade nulla: non ha proprietà."
+
+#: src/ownership/move-semantics.md:17
+#, fuzzy
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr "Quando `s2` esce dall'ambito, i dati della stringa vengono liberati."
+
+#: src/ownership/move-semantics.md:18
+#, fuzzy
+msgid "There is always _exactly_ one variable binding which owns a value."
 msgstr ""
-"* L'assegnazione di \"s1\" a \"s2\" trasferisce la proprietà.\n"
-"* I dati sono stati _spostati_ da `s1` e `s1` non è più accessibile.\n"
-"* Quando `s1` esce dall'ambito, non accade nulla: non ha proprietà.\n"
-"* Quando `s2` esce dall'ambito, i dati della stringa vengono liberati.\n"
-"* C'è sempre _esattamente_ un legame di variabile che possiede un valore."
+"C'è sempre _esattamente_ un legame di variabile che possiede un valore."
 
 #: src/ownership/move-semantics.md:22
 #, fuzzy
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* Menziona che questo è l'opposto dei valori predefiniti in C++, che copia "
-"per valore a meno che tu non usi `std::move` (e il costruttore di movimento "
-"è definito!).\n"
-"\n"
-"* In Rust, i cloni sono espliciti (utilizzando `clone`)."
+"Menziona che questo è l'opposto dei valori predefiniti in C++, che copia per "
+"valore a meno che tu non usi `std::move` (e il costruttore di movimento è "
+"definito!)."
 
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
-msgstr "# Stringhe mosse/spostate in Rust"
+#: src/ownership/move-semantics.md:24
+#, fuzzy
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "In Rust, i cloni sono espliciti (utilizzando `clone`)."
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4913,12 +4894,13 @@ msgstr ""
 
 #: src/ownership/moved-strings-rust.md:10
 #, fuzzy
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
-msgstr ""
-"* I dati dell'heap da `s1` vengono riutilizzati per `s2`.\n"
-"* Quando `s1` esce dall'ambito, non accade nulla (è stato spostato da)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "I dati dell'heap da `s1` vengono riutilizzati per `s2`."
+
+#: src/ownership/moved-strings-rust.md:11
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgstr "Quando `s1` esce dall'ambito, non accade nulla (è stato spostato da)."
 
 #: src/ownership/moved-strings-rust.md:13
 msgid "Before move to `s2`:"
@@ -4970,10 +4952,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr "# Double Free in C++ moderno"
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr "C++ moderno risolve questo problema in modo diverso:"
@@ -4989,13 +4967,16 @@ msgstr ""
 #: src/ownership/double-free-modern-cpp.md:10
 #, fuzzy
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
-"* I dati dell'heap da `s1` vengono duplicati e `s2` ottiene la propria copia "
-"indipendente.\n"
-"* Quando `s1` e `s2` escono dall'ambito, ciascuno libera la propria memoria."
+"I dati dell'heap da `s1` vengono duplicati e `s2` ottiene la propria copia "
+"indipendente."
+
+#: src/ownership/double-free-modern-cpp.md:11
+#, fuzzy
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"Quando `s1` e `s2` escono dall'ambito, ciascuno libera la propria memoria."
 
 #: src/ownership/double-free-modern-cpp.md:13
 msgid "Before copy-assignment:"
@@ -5046,20 +5027,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:1
-#, fuzzy
-msgid "# Moves in Function Calls"
-msgstr "# Sposta nelle chiamate di funzione"
-
 #: src/ownership/moves-function-calls.md:3
 #, fuzzy
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 "Quando si passa un valore a una funzione, il valore viene assegnato alla "
-"funzione\n"
-"parametro. Questo trasferisce la proprietà:"
+"funzione parametro. Questo trasferisce la proprietà:"
 
 #: src/ownership/moves-function-calls.md:6
 msgid ""
@@ -5079,35 +5054,49 @@ msgstr ""
 #: src/ownership/moves-function-calls.md:20
 #, fuzzy
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* Con la prima chiamata a `say_hello`, `main` rinuncia alla proprietà di "
+"Con la prima chiamata a `say_hello`, `main` rinuncia alla proprietà di "
 "`name`. Successivamente, `name` non può più essere utilizzato all'interno di "
-"`main`.\n"
-"* La memoria heap allocata per `name` verrà liberata alla fine della "
-"funzione `say_hello`.\n"
-"* `main` può mantenere la proprietà se passa `name` come riferimento "
-"(`&name`) e se `say_hello` accetta un riferimento come parametro.\n"
-"* In alternativa, `main` può passare un clone di `name` nella prima chiamata "
-"(`name.clone()`).\n"
-"* Rust rende più difficile del C++ creare copie inavvertitamente rendendo la "
+"`main`."
+
+#: src/ownership/moves-function-calls.md:21
+#, fuzzy
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+"La memoria heap allocata per `name` verrà liberata alla fine della funzione "
+"`say_hello`."
+
+#: src/ownership/moves-function-calls.md:22
+#, fuzzy
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"`main` può mantenere la proprietà se passa `name` come riferimento (`&name`) "
+"e se `say_hello` accetta un riferimento come parametro."
+
+#: src/ownership/moves-function-calls.md:23
+#, fuzzy
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+"In alternativa, `main` può passare un clone di `name` nella prima chiamata "
+"(`name.clone()`)."
+
+#: src/ownership/moves-function-calls.md:24
+#, fuzzy
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"Rust rende più difficile del C++ creare copie inavvertitamente rendendo la "
 "semantica di spostamento l'impostazione predefinita e costringendo i "
 "programmatori a rendere espliciti i cloni."
-
-#: src/ownership/copy-clone.md:1
-#, fuzzy
-msgid "# Copying and Cloning"
-msgstr "# Copia e clonazione"
 
 #: src/ownership/copy-clone.md:3
 #, fuzzy
@@ -5158,12 +5147,13 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:30
 #, fuzzy
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
-msgstr ""
-"* Dopo l'assegnazione, sia `p1` che `p2` possiedono i propri dati.\n"
-"* Possiamo anche usare `p1.clone()` per copiare esplicitamente i dati."
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr "Dopo l'assegnazione, sia `p1` che `p2` possiedono i propri dati."
+
+#: src/ownership/copy-clone.md:31
+#, fuzzy
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr "Possiamo anche usare `p1.clone()` per copiare esplicitamente i dati."
 
 #: src/ownership/copy-clone.md:35
 #, fuzzy
@@ -5173,21 +5163,33 @@ msgstr "Copiare e clonare non sono la stessa cosa:"
 #: src/ownership/copy-clone.md:37
 #, fuzzy
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C+"
-"+).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
 msgstr ""
-"* La copia si riferisce a copie bit per bit di aree di memoria e non "
-"funziona su oggetti arbitrari.\n"
-"* La copia non consente la logica personalizzata (a differenza dei "
-"costruttori di copia in C++).\n"
-"* La clonazione è un'operazione più generale e consente anche un "
-"comportamento personalizzato implementando il tratto `Clone`.\n"
-"* La copia non funziona sui tipi che implementano il tratto `Drop`."
+"La copia si riferisce a copie bit per bit di aree di memoria e non funziona "
+"su oggetti arbitrari."
+
+#: src/ownership/copy-clone.md:38
+#, fuzzy
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+"La copia non consente la logica personalizzata (a differenza dei costruttori "
+"di copia in C++)."
+
+#: src/ownership/copy-clone.md:39
+#, fuzzy
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+"La clonazione è un'operazione più generale e consente anche un comportamento "
+"personalizzato implementando il tratto `Clone`."
+
+#: src/ownership/copy-clone.md:40
+#, fuzzy
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr "La copia non funziona sui tipi che implementano il tratto `Drop`."
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 #, fuzzy
@@ -5197,45 +5199,46 @@ msgstr "Nell'esempio precedente, prova quanto segue:"
 #: src/ownership/copy-clone.md:44
 #, fuzzy
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* Aggiungi un campo `String` a `struct Point`. Non verrà compilato perché "
-"`String` non è un tipo `Copy`.\n"
-"* Rimuovi `Copy` dall'attributo `derive`. L'errore del compilatore è ora in "
-"`println!` per `p1`.\n"
-"* Dimostra che funziona se invece cloni `p1`."
+"Aggiungi un campo `String` a `struct Point`. Non verrà compilato perché "
+"`String` non è un tipo `Copy`."
+
+#: src/ownership/copy-clone.md:45
+#, fuzzy
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"Rimuovi `Copy` dall'attributo `derive`. L'errore del compilatore è ora in "
+"`println!` per `p1`."
+
+#: src/ownership/copy-clone.md:46
+#, fuzzy
+msgid "Show that it works if you clone `p1` instead."
+msgstr "Dimostra che funziona se invece cloni `p1`."
 
 #: src/ownership/copy-clone.md:48
 #, fuzzy
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated."
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 "Se gli studenti chiedono informazioni su `derive`, è sufficiente dire che "
-"questo è un modo per generare codice in Rust\n"
-"in fase di compilazione. In questo caso vengono generate le implementazioni "
-"predefinite dei tratti `Copy` e `Clone`."
-
-#: src/ownership/borrowing.md:1
-#, fuzzy
-msgid "# Borrowing"
-msgstr "# Prendere in prestito"
+"questo è un modo per generare codice in Rust in fase di compilazione. In "
+"questo caso vengono generate le implementazioni predefinite dei tratti "
+"`Copy` e `Clone`."
 
 #: src/ownership/borrowing.md:3
 #, fuzzy
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
 "Invece di trasferire la proprietà quando chiami una funzione, puoi lasciare "
-"che a\n"
-"funzione _prende in prestito_ il valore:"
+"che a funzione _prende in prestito_ il valore:"
 
 #: src/ownership/borrowing.md:6
 msgid ""
@@ -5258,13 +5261,15 @@ msgstr ""
 
 #: src/ownership/borrowing.md:22
 #, fuzzy
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
+msgid "The `add` function _borrows_ two points and returns a new point."
 msgstr ""
-"* La funzione `add` _prende in prestito_ due punti e restituisce un nuovo "
-"punto.\n"
-"* Il chiamante mantiene la proprietà degli ingressi."
+"La funzione `add` _prende in prestito_ due punti e restituisce un nuovo "
+"punto."
+
+#: src/ownership/borrowing.md:23
+#, fuzzy
+msgid "The caller retains ownership of the inputs."
+msgstr "Il chiamante mantiene la proprietà degli ingressi."
 
 #: src/ownership/borrowing.md:27
 #, fuzzy
@@ -5273,41 +5278,46 @@ msgstr "Note sui resi dello stack:"
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can "
+"Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while they stay the same when changing to the "
-"\"RELEASE\" setting:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification "
-"because constructors can have side effects. In Rust, this is not an issue at "
-"all. If RVO did not happen, Rust will always perform a simple and efficient "
-"`memcpy` copy."
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/ownership/shared-unique-borrows.md:1
-#, fuzzy
-msgid "# Shared and Unique Borrows"
-msgstr "# Prestiti condivisi e unici"
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr ""
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
+"copy."
+msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:3
 #, fuzzy
@@ -5317,12 +5327,13 @@ msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:5
 #, fuzzy
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* Puoi avere uno o più valori `&T` in qualsiasi momento, _oppure_\n"
-"* Puoi avere esattamente un valore `&mut T`."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "Puoi avere uno o più valori `&T` in qualsiasi momento, _oppure_"
+
+#: src/ownership/shared-unique-borrows.md:6
+#, fuzzy
+msgid "You can have exactly one `&mut T` value."
+msgstr "Puoi avere esattamente un valore `&mut T`."
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
@@ -5345,27 +5356,32 @@ msgstr ""
 #: src/ownership/shared-unique-borrows.md:25
 #, fuzzy
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+"Il codice precedente non viene compilato perché `a` è preso in prestito come "
+"mutabile (attraverso `c`) e come immutabile (attraverso `b`) allo stesso "
+"tempo."
+
+#: src/ownership/shared-unique-borrows.md:26
+#, fuzzy
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"Sposta l'istruzione `println!` per `b` prima dell'ambito che introduce `c` "
+"per far compilare il codice."
+
+#: src/ownership/shared-unique-borrows.md:27
+#, fuzzy
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"* Il codice precedente non viene compilato perché `a` è preso in prestito "
-"come mutabile (attraverso `c`) e come immutabile (attraverso `b`) allo "
-"stesso tempo.\n"
-"* Sposta l'istruzione `println!` per `b` prima dell'ambito che introduce `c` "
-"per far compilare il codice.\n"
-"* Dopo tale modifica, il compilatore si rende conto che `b` è sempre e solo "
+"Dopo tale modifica, il compilatore si rende conto che `b` è sempre e solo "
 "usato prima del nuovo prestito mutabile da `a` a `c`. Questa è una "
 "caratteristica del controllo del prestito chiamata \"vita non lessicale\"."
-
-#: src/ownership/lifetimes.md:1
-#, fuzzy
-msgid "# Lifetimes"
-msgstr "# Vite"
 
 #: src/ownership/lifetimes.md:3
 #, fuzzy
@@ -5373,27 +5389,40 @@ msgid "A borrowed value has a _lifetime_:"
 msgstr "Un valore preso in prestito ha una _durata_:"
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully "
-"specified,\n"
-"  but Rust allows lifetimes to be elided in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
 msgstr ""
 
-#: src/ownership/lifetimes-function-calls.md:1
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr ""
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
 #, fuzzy
-msgid "# Lifetimes in Function Calls"
-msgstr "# Durata delle chiamate di funzione"
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+"Leggi `&'a Point` come \"un `Punto` preso in prestito che è valido almeno "
+"per il vita `a`\"."
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+
+#: src/ownership/lifetimes.md:13
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows lifetimes to be elided in most cases with [a few simple "
+"rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:3
 #, fuzzy
@@ -5425,63 +5454,82 @@ msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:21
 #, fuzzy
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`'a` è un parametro generico, viene dedotto dal compilatore."
+
+#: src/ownership/lifetimes-function-calls.md:22
+#, fuzzy
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr "Le durate iniziano con `'` e `'a` è un tipico nome predefinito."
+
+#: src/ownership/lifetimes-function-calls.md:25
+#, fuzzy
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+"The _at least_ part is important when parameters are in different scopes."
 msgstr ""
-"* `'a` è un parametro generico, viene dedotto dal compilatore.\n"
-"* Le durate iniziano con `'` e `'a` è un tipico nome predefinito.\n"
-"* Leggi `&'a Point` come \"un `Punto` preso in prestito che è valido almeno "
-"per il\n"
-"  vita `a`\".\n"
-"  * La parte _almeno_ è importante quando i parametri si trovano in ambiti "
+"La parte _almeno_ è importante quando i parametri si trovano in ambiti "
 "diversi."
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:1
-#, fuzzy
-msgid "# Lifetimes in Data Structures"
-msgstr "# Durata nelle strutture dati"
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:50
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
 #, fuzzy
@@ -5516,39 +5564,58 @@ msgstr ""
 #: src/ownership/lifetimes-data-structures.md:25
 #, fuzzy
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data "
+"In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This "
-"can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one "
-"lifetime annotation. This can be necessary if there is a need to describe "
-"lifetime relationships between the references themselves, in addition to the "
-"lifetime of the struct itself. Those are very advanced use cases."
+"`Highlight` that uses that data."
 msgstr ""
-"* Nell'esempio precedente, l'annotazione su \"Highlight\" impone che i dati "
+"Nell'esempio precedente, l'annotazione su \"Highlight\" impone che i dati "
 "sottostanti a \"&str\" contenuti durino almeno quanto qualsiasi istanza di "
-"\"Highlight\" che utilizza quei dati.\n"
-"* Se `text` viene consumato prima della fine della vita di `fox` (o `dog`), "
-"il controllo del prestito genera un errore.\n"
-"* I tipi con dati presi in prestito costringono gli utenti a conservare i "
-"dati originali. Questo può essere utile per creare viste leggere, ma in "
-"genere le rende un po' più difficili da usare.\n"
-"* Quando possibile, fare in modo che le strutture dati possiedano "
-"direttamente i propri dati.\n"
-"* Alcune strutture con più riferimenti all'interno possono avere più di "
+"\"Highlight\" che utilizza quei dati."
+
+#: src/ownership/lifetimes-data-structures.md:26
+#, fuzzy
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"Se `text` viene consumato prima della fine della vita di `fox` (o `dog`), il "
+"controllo del prestito genera un errore."
+
+#: src/ownership/lifetimes-data-structures.md:27
+#, fuzzy
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"I tipi con dati presi in prestito costringono gli utenti a conservare i dati "
+"originali. Questo può essere utile per creare viste leggere, ma in genere le "
+"rende un po' più difficili da usare."
+
+#: src/ownership/lifetimes-data-structures.md:28
+#, fuzzy
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+"Quando possibile, fare in modo che le strutture dati possiedano direttamente "
+"i propri dati."
+
+#: src/ownership/lifetimes-data-structures.md:29
+#, fuzzy
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"Alcune strutture con più riferimenti all'interno possono avere più di "
 "un'annotazione di durata. Ciò può essere necessario se è necessario "
 "descrivere le relazioni di durata tra i riferimenti stessi, oltre alla "
 "durata della struttura stessa. Questi sono casi d'uso molto avanzati."
 
 #: src/exercises/day-1/afternoon.md:1
 #, fuzzy
-msgid "# Day 1: Afternoon Exercises"
-msgstr "# Giorno 1: Esercizi pomeridiani"
+msgid "Day 1: Afternoon Exercises"
+msgstr "Giorno 1: Esercizi pomeridiani"
 
 #: src/exercises/day-1/afternoon.md:3
 #, fuzzy
@@ -5557,30 +5624,22 @@ msgstr "Vedremo due cose:"
 
 #: src/exercises/day-1/afternoon.md:5
 #, fuzzy
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
-msgstr ""
-"* Una piccola biblioteca di libri,\n"
-"\n"
-"* Iteratori e proprietà (hard)."
+msgid "A small book library,"
+msgstr "Una piccola biblioteca di libri,"
 
-#: src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/afternoon.md:7
 #, fuzzy
-msgid "# Storing Books"
-msgstr "# Corda"
+msgid "Iterators and ownership (hard)."
+msgstr "Iteratori e proprietà (hard)."
 
 #: src/exercises/day-1/book-library.md:3
 #, fuzzy
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
 "Impareremo molto di più sulle strutture e sul tipo `Vec<T>` domani. Per "
-"adesso,\n"
-"devi solo conoscere parte della sua API:"
+"adesso, devi solo conoscere parte della sua API:"
 
 #: src/exercises/day-1/book-library.md:6
 msgid ""
@@ -5600,10 +5659,10 @@ msgstr ""
 #: src/exercises/day-1/book-library.md:18
 #, fuzzy
 msgid ""
-"Use this to model a library's book collection. Copy the code below to\n"
+"Use this to model a library's book collection. Copy the code below to "
 "<https://play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
-"Usalo per creare un'applicazione libreria. Copia il codice qui sotto per\n"
+"Usalo per creare un'applicazione libreria. Copia il codice qui sotto per "
 "<https://play.rust-lang.org/> e aggiorna i tipi per farlo compilare:"
 
 #: src/exercises/day-1/book-library.md:21
@@ -5697,44 +5756,34 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr "[Soluzione](solutions-afternoon.md#designing-a-library)"
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-#, fuzzy
-msgid "# Iterators and Ownership"
-msgstr "# Iteratori e proprietà"
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 #, fuzzy
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 "Il modello di proprietà di Rust influisce su molte API. Un esempio di questo "
-"è il\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) e\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"è il [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) e "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "tratti."
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
 #, fuzzy
-msgid "## `Iterator`"
-msgstr "## `Iteratore`"
+msgid "`Iterator`"
+msgstr "`Iteratore`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 #, fuzzy
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
 "I tratti sono come interfacce: descrivono il comportamento (metodi) per un "
-"tipo. IL\n"
-"Il tratto \"Iterator\" dice semplicemente che puoi chiamare \"next\" fino a "
-"quando non ottieni \"Nessuno\":"
+"tipo. IL Il tratto \"Iterator\" dice semplicemente che puoi chiamare "
+"\"next\" fino a quando non ottieni \"Nessuno\":"
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
 msgid ""
@@ -5793,18 +5842,17 @@ msgstr "Perché viene utilizzato questo tipo?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
 #, fuzzy
-msgid "## `IntoIterator`"
-msgstr "## `IntoIterator`"
+msgid "`IntoIterator`"
+msgstr "`IntoIterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 #, fuzzy
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
-"Il tratto `Iterator` ti dice come _iterare_ una volta che hai creato un "
-"file\n"
+"Il tratto `Iterator` ti dice come _iterare_ una volta che hai creato un file "
 "iteratore. Il tratto correlato `IntoIterator` ti dice come creare "
 "l'iteratore:"
 
@@ -5823,30 +5871,30 @@ msgstr ""
 #: src/exercises/day-1/iterators-and-ownership.md:62
 #, fuzzy
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
-"La sintassi qui significa che ogni implementazione di \"IntoIterator\" deve\n"
+"La sintassi qui significa che ogni implementazione di \"IntoIterator\" deve "
 "dichiarare due tipi:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
 #, fuzzy
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
-msgstr ""
-"* `Item`: il tipo su cui iteriamo, come `i8`,\n"
-"* `IntoIter`: il tipo `Iterator` restituito dal metodo `into_iter`."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr "`Item`: il tipo su cui iteriamo, come `i8`,"
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+#, fuzzy
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr "`IntoIter`: il tipo `Iterator` restituito dal metodo `into_iter`."
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 #, fuzzy
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 "Nota che \"IntoIter\" e \"Item\" sono collegati: l'iteratore deve avere lo "
-"stesso\n"
-"Tipo `Item`, che significa che restituisce `Option<Item>`"
+"stesso Tipo `Item`, che significa che restituisce `Option<Item>`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:71
 #, fuzzy
@@ -5869,20 +5917,18 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
 #, fuzzy
-msgid "## `for` Loops"
-msgstr "## cicli `for`"
+msgid "`for` Loops"
+msgstr "cicli `for`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 #, fuzzy
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 "Ora che conosciamo sia `Iterator` che `IntoIterator`, possiamo creare cicli "
-"`for`.\n"
-"Chiamano `into_iter()` su un'espressione e itera sul risultato\n"
+"`for`. Chiamano `into_iter()` su un'espressione e itera sul risultato "
 "iteratore:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
@@ -5911,29 +5957,23 @@ msgstr "Qual è il tipo di \"parola\" in ogni ciclo?"
 #: src/exercises/day-1/iterators-and-ownership.md:105
 #, fuzzy
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26'a+Vec%3CT,+A%3E)\n"
-"and [`impl IntoIterator for\n"
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26'a+Vec%3CT,+A%3E) and [`impl IntoIterator for "
 "Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT,+A%3E)\n"
-"to check your answers."
+"for-Vec%3CT,+A%3E) to check your answers."
 msgstr ""
-"Sperimenta con il codice sopra e poi consulta la documentazione per [`impl\n"
-"IntoIteratore per\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"e [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"per controllare le tue risposte."
+"Sperimenta con il codice sopra e poi consulta la documentazione per [`impl "
+"IntoIteratore per &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) e [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) per controllare le tue "
+"risposte."
 
 #: src/welcome-day-2.md:1
 #, fuzzy
-msgid "# Welcome to Day 2"
-msgstr "# Benvenuto al giorno 2"
+msgid "Welcome to Day 2"
+msgstr "Benvenuto al giorno 2"
 
 #: src/welcome-day-2.md:3
 #, fuzzy
@@ -5943,39 +5983,36 @@ msgstr ""
 
 #: src/welcome-day-2.md:5
 #, fuzzy
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
-msgstr ""
-"* Struct, enum, metodi.\n"
-"\n"
-"* Pattern matching: destrutturazione di enum, struct e array.\n"
-"\n"
-"* Costrutti del flusso di controllo: `if`, `if let`, `while`, `while let`, "
-"`break` e\n"
-"  `continua`.\n"
-"\n"
-"* La libreria standard: `String`, `Option` e `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  e \"Arco\".\n"
-"\n"
-"* Moduli: visibilità, percorsi e gerarchia del filesystem."
+msgid "Structs, enums, methods."
+msgstr "Struct, enum, metodi."
 
-#: src/structs.md:1
+#: src/welcome-day-2.md:7
 #, fuzzy
-msgid "# Structs"
-msgstr "# Strutture"
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr "Pattern matching: destrutturazione di enum, struct e array."
+
+#: src/welcome-day-2.md:9
+#, fuzzy
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+"Costrutti del flusso di controllo: `if`, `if let`, `while`, `while let`, "
+"`break` e `continua`."
+
+#: src/welcome-day-2.md:12
+#, fuzzy
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+"La libreria standard: `String`, `Option` e `Result`, `Vec`, `HashMap`, `Rc` "
+"e \"Arco\"."
+
+#: src/welcome-day-2.md:15
+#, fuzzy
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr "Moduli: visibilità, percorsi e gerarchia del filesystem."
 
 #: src/structs.md:3
 #, fuzzy
@@ -6017,28 +6054,48 @@ msgid "Key Points:"
 msgstr "Punti chiave:"
 
 #: src/structs.md:33
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
 msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
-
-#: src/structs/tuple-structs.md:1
-#, fuzzy
-msgid "# Tuple Structs"
-msgstr "# Strutture di tuple"
 
 #: src/structs/tuple-structs.md:3
 #, fuzzy
@@ -6090,45 +6147,65 @@ msgstr ""
 #: src/structs/tuple-structs.md:37
 #, fuzzy
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics).\n"
-"* The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
+msgstr ""
+"I newtype sono un ottimo modo per codificare informazioni aggiuntive sul "
+"valore in un tipo primitivo, ad esempio:"
+
+#: src/structs/tuple-structs.md:38
+#, fuzzy
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+"Il numero è misurato in alcune unità: `Newton` nell'esempio precedente."
+
+#: src/structs/tuple-structs.md:39
+#, fuzzy
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"Il valore ha superato una certa convalida quando è stato creato, quindi non "
+"è più necessario convalidarlo nuovamente a ogni utilizzo: 'Numero di "
+"telefono (Stringa)`o`Numero dispari (u32)\\`."
+
+#: src/structs/tuple-structs.md:40
+#, fuzzy
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+"Dimostra come aggiungere un valore `f64` a un tipo `Newtons` accedendo al "
+"singolo campo nel newtype."
+
+#: src/structs/tuple-structs.md:41
+#, fuzzy
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+"A Rust in genere non piacciono le cose inesplicite, come l'unwrapping "
+"automatico o, ad esempio, l'uso di valori booleani come numeri interi."
+
+#: src/structs/tuple-structs.md:42
+#, fuzzy
+msgid "Operator overloading is discussed on Day 3 (generics)."
+msgstr "Il sovraccarico degli operatori viene discusso il giorno 3 (generici)."
+
+#: src/structs/tuple-structs.md:43
+msgid ""
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
 "wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
-"* I newtype sono un ottimo modo per codificare informazioni aggiuntive sul "
-"valore in un tipo primitivo, ad esempio:\n"
-"  * Il numero è misurato in alcune unità: `Newton` nell'esempio precedente.\n"
-"  * Il valore ha superato una certa convalida quando è stato creato, quindi "
-"non è più necessario convalidarlo nuovamente a ogni utilizzo: 'Numero di "
-"telefono (Stringa)` o `Numero dispari (u32)`.\n"
-"* Dimostra come aggiungere un valore `f64` a un tipo `Newtons` accedendo al "
-"singolo campo nel newtype.\n"
-"  * A Rust in genere non piacciono le cose inesplicite, come l'unwrapping "
-"automatico o, ad esempio, l'uso di valori booleani come numeri interi.\n"
-"  * Il sovraccarico degli operatori viene discusso il giorno 3 (generici)."
-
-#: src/structs/field-shorthand.md:1
-#, fuzzy
-msgid "# Field Shorthand Syntax"
-msgstr "# Sintassi abbreviata dei campi"
 
 #: src/structs/field-shorthand.md:3
 #, fuzzy
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
-"Se disponi già di variabili con i nomi corretti, puoi creare il file\n"
-"struct usando una scorciatoia:"
+"Se disponi già di variabili con i nomi corretti, puoi creare il file struct "
+"usando una scorciatoia:"
 
 #: src/structs/field-shorthand.md:6
 msgid ""
@@ -6154,67 +6231,82 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use "
-"the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-#, fuzzy
-msgid "# Enums"
-msgstr "# Enum"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
 
 #: src/enums.md:3
 #, fuzzy
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
-"La parola chiave `enum` consente la creazione di un tipo che ne ha alcuni\n"
+"La parola chiave `enum` consente la creazione di un tipo che ne ha alcuni "
 "diverse varianti:"
 
 #: src/enums.md:6
@@ -6248,46 +6340,61 @@ msgstr ""
 
 #: src/enums.md:36
 #, fuzzy
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr ""
+"Le enumerazioni consentono di raccogliere un insieme di valori in un unico "
+"tipo"
+
+#: src/enums.md:37
+#, fuzzy
 msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tails`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tails`. You might note the namespace when using variants."
+msgstr ""
+"Questa pagina offre un tipo di enum `CoinFlip` con due varianti `Heads` e "
+"`Tail`. Potresti notare lo spazio dei nomi quando usi le varianti."
+
+#: src/enums.md:38
+#, fuzzy
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr "Questo potrebbe essere un buon momento per confrontare Struct ed Enum:"
+
+#: src/enums.md:39
+#, fuzzy
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"In entrambi, puoi avere una versione semplice senza campi (unit struct) o "
+"una con diversi tipi di campi (variant payload)."
+
+#: src/enums.md:40
+#, fuzzy
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr ""
+"In entrambi, le funzioni associate sono definite all'interno di un blocco "
+"`impl`."
+
+#: src/enums.md:41
+#, fuzzy
+msgid ""
+"You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
 msgstr ""
-"* Le enumerazioni consentono di raccogliere un insieme di valori in un unico "
-"tipo\n"
-"* Questa pagina offre un tipo di enum `CoinFlip` con due varianti `Heads` e "
-"`Tail`. Potresti notare lo spazio dei nomi quando usi le varianti.\n"
-"* Questo potrebbe essere un buon momento per confrontare Struct ed Enum:\n"
-"  * In entrambi, puoi avere una versione semplice senza campi (unit struct) "
-"o una con diversi tipi di campi (variant payload).\n"
-"  * In entrambi, le funzioni associate sono definite all'interno di un "
-"blocco `impl`.\n"
-"  * Potresti persino implementare le diverse varianti di un'enumerazione con "
+"Potresti persino implementare le diverse varianti di un'enumerazione con "
 "strutture separate, ma non sarebbero dello stesso tipo che sarebbero se "
 "fossero tutte definite in un'enumerazione."
-
-#: src/enums/variant-payloads.md:1
-#, fuzzy
-msgid "# Variant Payloads"
-msgstr "# Payload varianti"
 
 #: src/enums/variant-payloads.md:3
 #, fuzzy
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 "È possibile definire enumerazioni più ricche in cui le varianti contengono "
-"dati. È quindi possibile utilizzare il\n"
-"istruzione `match` per estrarre i dati da ciascuna variante:"
+"dati. È quindi possibile utilizzare il istruzione `match` per estrarre i "
+"dati da ciascuna variante:"
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -6322,55 +6429,83 @@ msgstr ""
 #: src/enums/variant-payloads.md:35
 #, fuzzy
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There "
-"is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example.  \n"
-"  "
+"after the `=>`."
 msgstr ""
-"* È possibile accedere ai valori nelle varianti enum solo dopo essere stati "
+"È possibile accedere ai valori nelle varianti enum solo dopo essere stati "
 "abbinati al modello. Il modello lega i riferimenti ai campi nel \"match "
-"arm\" dopo il `=>`.\n"
-"  * L'espressione viene confrontata con i modelli dall'alto verso il basso. "
-"Non c'è fall-through come in C o C++.\n"
-"  * L'espressione di corrispondenza ha un valore. Il valore è l'ultima "
-"espressione nel braccio di corrispondenza che è stata eseguita.\n"
-"  * Partendo dall'alto cerchiamo quale modello corrisponde al valore, quindi "
-"eseguiamo il codice seguendo la freccia. Una volta trovata una "
-"corrispondenza, ci fermiamo.\n"
-"* Dimostrare cosa succede quando la ricerca è inesauribile. Nota il "
-"vantaggio fornito dal compilatore Rust confermando quando tutti i casi "
-"vengono gestiti.\n"
-"* `match` ispeziona un campo discriminante nascosto in `enum`.\n"
-"* È possibile recuperare il discriminante chiamando `std::mem::"
-"discriminant()`\n"
-"  * Ciò è utile, ad esempio, se si implementa `PartialEq` per strutture in "
-"cui il confronto dei valori dei campi non influisce sull'uguaglianza.\n"
-"* `WebEvent::Click { ... }` non è esattamente la stessa cosa di `WebEvent::"
-"Click(Click)` con una `struct Click { ... }` di primo livello. La versione "
-"inline non può implementare tratti, per esempio.\n"
-"  "
+"arm\" dopo il `=>`."
 
-#: src/enums/sizes.md:1
+#: src/enums/variant-payloads.md:36
 #, fuzzy
-msgid "# Enum Sizes"
-msgstr "# Enum Dimensioni"
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+"L'espressione viene confrontata con i modelli dall'alto verso il basso. Non "
+"c'è fall-through come in C o C++."
+
+#: src/enums/variant-payloads.md:37
+#, fuzzy
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+"L'espressione di corrispondenza ha un valore. Il valore è l'ultima "
+"espressione nel braccio di corrispondenza che è stata eseguita."
+
+#: src/enums/variant-payloads.md:38
+#, fuzzy
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+"Partendo dall'alto cerchiamo quale modello corrisponde al valore, quindi "
+"eseguiamo il codice seguendo la freccia. Una volta trovata una "
+"corrispondenza, ci fermiamo."
+
+#: src/enums/variant-payloads.md:39
+#, fuzzy
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+"Dimostrare cosa succede quando la ricerca è inesauribile. Nota il vantaggio "
+"fornito dal compilatore Rust confermando quando tutti i casi vengono gestiti."
+
+#: src/enums/variant-payloads.md:40
+#, fuzzy
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr "`match` ispeziona un campo discriminante nascosto in `enum`."
+
+#: src/enums/variant-payloads.md:41
+#, fuzzy
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+"È possibile recuperare il discriminante chiamando `std::mem::discriminant()`"
+
+#: src/enums/variant-payloads.md:42
+#, fuzzy
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+"Ciò è utile, ad esempio, se si implementa `PartialEq` per strutture in cui "
+"il confronto dei valori dei campi non influisce sull'uguaglianza."
+
+#: src/enums/variant-payloads.md:43
+#, fuzzy
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
+"`WebEvent::Click { ... }` non è esattamente la stessa cosa di `WebEvent::"
+"Click(Click)` con una `struct Click { ... }` di primo livello. La versione "
+"inline non può implementare tratti, per esempio."
 
 #: src/enums/sizes.md:3
 #, fuzzy
@@ -6407,164 +6542,196 @@ msgstr ""
 #: src/enums/sizes.md:25
 #, fuzzy
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 msgstr ""
-"* Vedere il [riferimento Rust](https://doc.rust-lang.org/reference/type-"
-"layout.html)."
+"Vedere il [riferimento Rust](https://doc.rust-lang.org/reference/type-layout."
+"html)."
 
 #: src/enums/sizes.md:31
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+
+#: src/enums/sizes.md:33
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr ""
+
+#: src/enums/sizes.md:35
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with "
-"C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:50
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+
+#: src/enums/sizes.md:54
+msgid "Try out other types such as"
+msgstr ""
+
+#: src/enums/sizes.md:56
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr ""
+
+#: src/enums/sizes.md:57
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+
+#: src/enums/sizes.md:58
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+
+#: src/enums/sizes.md:59
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+
+#: src/enums/sizes.md:61
+msgid ""
+"Niche optimization: Rust will merge unused bit patterns for the enum "
+"discriminant."
+msgstr ""
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits "
-"2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche "
-"optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit "
-"machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* "
-"look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees "
-"regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
 "\n"
-"     More complex example if you want to discuss what happens when we chain "
-"more than 256 `Option`s together.\n"
+"use std::mem::transmute;\n"
 "\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
 "signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
 "Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods.md:3
 #, fuzzy
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
-"Rust ti consente di associare funzioni ai tuoi nuovi tipi. Lo fai con un\n"
+"Rust ti consente di associare funzioni ai tuoi nuovi tipi. Lo fai con un "
 "Blocco `impl`:"
 
 #: src/methods.md:6
@@ -6594,132 +6761,160 @@ msgstr ""
 
 #: src/methods.md:31
 #, fuzzy
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
-msgstr ""
-"* Può essere utile introdurre metodi confrontandoli con funzioni.\n"
-"  * I metodi vengono chiamati su un'istanza di un tipo (come struct o enum), "
-"il primo parametro rappresenta l'istanza come `self`.\n"
-"  * Gli sviluppatori possono scegliere di utilizzare i metodi per sfruttare "
-"la sintassi del ricevitore del metodo e per mantenerli più organizzati. "
-"Utilizzando i metodi possiamo mantenere tutto il codice di implementazione "
-"in un posto prevedibile.\n"
-"* Sottolinea l'uso della parola chiave `self`, un ricevitore di metodo.\n"
-"  * Mostra che è un termine abbreviato per `self:&Self` e forse mostra come "
-"potrebbe essere usato anche il nome struct.\n"
-"  * Spiega che `Self` è un alias di tipo per il tipo in cui si trova il "
-"blocco `impl` e può essere utilizzato altrove nel blocco.\n"
-"  * Nota come `self` viene utilizzato come altre strutture e la notazione "
-"con punto può essere utilizzata per fare riferimento a singoli campi.\n"
-"  * Questo potrebbe essere un buon momento per dimostrare in che modo "
-"`&self` differisce da `self` modificando il codice e provando a eseguire "
-"say_hello due volte.\n"
-"* Di seguito descriviamo la distinzione tra ricevitori di metodi.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
+msgstr "Può essere utile introdurre metodi confrontandoli con funzioni."
 
-#: src/methods/receiver.md:1
+#: src/methods.md:32
 #, fuzzy
-msgid "# Method Receiver"
-msgstr "# Ricevitore del metodo"
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+"I metodi vengono chiamati su un'istanza di un tipo (come struct o enum), il "
+"primo parametro rappresenta l'istanza come `self`."
+
+#: src/methods.md:33
+#, fuzzy
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+"Gli sviluppatori possono scegliere di utilizzare i metodi per sfruttare la "
+"sintassi del ricevitore del metodo e per mantenerli più organizzati. "
+"Utilizzando i metodi possiamo mantenere tutto il codice di implementazione "
+"in un posto prevedibile."
+
+#: src/methods.md:34
+#, fuzzy
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr "Sottolinea l'uso della parola chiave `self`, un ricevitore di metodo."
+
+#: src/methods.md:35
+#, fuzzy
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+"Mostra che è un termine abbreviato per `self:&Self` e forse mostra come "
+"potrebbe essere usato anche il nome struct."
+
+#: src/methods.md:36
+#, fuzzy
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+"Spiega che `Self` è un alias di tipo per il tipo in cui si trova il blocco "
+"`impl` e può essere utilizzato altrove nel blocco."
+
+#: src/methods.md:37
+#, fuzzy
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+"Nota come `self` viene utilizzato come altre strutture e la notazione con "
+"punto può essere utilizzata per fare riferimento a singoli campi."
+
+#: src/methods.md:38
+#, fuzzy
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+"Questo potrebbe essere un buon momento per dimostrare in che modo `&self` "
+"differisce da `self` modificando il codice e provando a eseguire say_hello "
+"due volte."
+
+#: src/methods.md:39
+#, fuzzy
+msgid "We describe the distinction between method receivers next."
+msgstr "Di seguito descriviamo la distinzione tra ricevitori di metodi."
 
 #: src/methods/receiver.md:3
 #, fuzzy
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
 "Il `&self` sopra indica che il metodo prende in prestito l'oggetto in modo "
-"immutabile. Là\n"
-"sono altri possibili ricevitori per un metodo:"
+"immutabile. Là sono altri possibili ricevitori per un metodo:"
 
 #: src/methods/receiver.md:6
 #, fuzzy
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted. Complete ownership does not automatically mean mutability.\n"
-"* `mut self`: same as above, but the method can mutate the object. \n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
 msgstr ""
-"* `&self`: prende in prestito l'oggetto dal chiamante usando un oggetto "
-"condiviso e immutabile\n"
-"  riferimento. L'oggetto può essere riutilizzato in seguito.\n"
-"* `&mut self`: prende in prestito l'oggetto dal chiamante usando un oggetto "
-"unico e mutabile\n"
-"  riferimento. L'oggetto può essere riutilizzato in seguito.\n"
-"* `self`: assume la proprietà dell'oggetto e lo allontana dal chiamante. IL\n"
-"  metodo diventa il proprietario dell'oggetto. L'oggetto verrà eliminato "
-"(deallocato)\n"
-"  quando il metodo ritorna, a meno che la sua proprietà non sia esplicita\n"
-"  trasmesso.\n"
-"* `mut self`: come sopra, ma mentre il metodo possiede l'oggetto, può farlo\n"
-"  muta anche questo. Proprietà completa non significa automaticamente "
-"mutabilità.\n"
-"* Nessun ricevitore: questo diventa un metodo statico sulla struttura. "
-"Tipicamente utilizzato per\n"
-"  creare costruttori che sono chiamati \"nuovi\" per convenzione."
+"`&self`: prende in prestito l'oggetto dal chiamante usando un oggetto "
+"condiviso e immutabile riferimento. L'oggetto può essere riutilizzato in "
+"seguito."
+
+#: src/methods/receiver.md:8
+#, fuzzy
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+"`&mut self`: prende in prestito l'oggetto dal chiamante usando un oggetto "
+"unico e mutabile riferimento. L'oggetto può essere riutilizzato in seguito."
+
+#: src/methods/receiver.md:10
+#, fuzzy
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+"`self`: assume la proprietà dell'oggetto e lo allontana dal chiamante. IL "
+"metodo diventa il proprietario dell'oggetto. L'oggetto verrà eliminato "
+"(deallocato) quando il metodo ritorna, a meno che la sua proprietà non sia "
+"esplicita trasmesso."
+
+#: src/methods/receiver.md:14
+#, fuzzy
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+"`mut self`: come sopra, ma mentre il metodo possiede l'oggetto, può farlo "
+"muta anche questo. Proprietà completa non significa automaticamente "
+"mutabilità."
+
+#: src/methods/receiver.md:15
+#, fuzzy
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
+msgstr ""
+"Nessun ricevitore: questo diventa un metodo statico sulla struttura. "
+"Tipicamente utilizzato per creare costruttori che sono chiamati \"nuovi\" "
+"per convenzione."
 
 #: src/methods/receiver.md:18
 #, fuzzy
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
-"Oltre alle varianti su \"self\", ci sono anche\n"
-"[tipi di wrapper speciali](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"possono essere tipi di ricevitore, come `Box<Self>`."
+"Oltre alle varianti su \"self\", ci sono anche [tipi di wrapper speciali]"
+"(https://doc.rust-lang.org/reference/special-types-and-traits.html) possono "
+"essere tipi di ricevitore, come `Box<Self>`."
 
 #: src/methods/receiver.md:24
 #, fuzzy
 msgid ""
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it."
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 "Prendi in considerazione l'enfasi su \"condiviso e immutabile\" e \"unico e "
-"mutevole\". Questi vincoli arrivano sempre\n"
-"insieme in Rust a causa delle regole del correttore in prestito, e \"self\" "
-"non fa eccezione. Non è possibile\n"
-"fare riferimento a una struttura da più posizioni e chiamare un metodo "
-"mutante (`&mut self`) su di essa."
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-#, fuzzy
-msgid "# Example"
-msgstr "# Esempio"
+"mutevole\". Questi vincoli arrivano sempre insieme in Rust a causa delle "
+"regole del correttore in prestito, e \"self\" non fa eccezione. Non è "
+"possibile fare riferimento a una struttura da più posizioni e chiamare un "
+"metodo mutante (`&mut self`) su di essa."
 
 #: src/methods/example.md:3
 msgid ""
@@ -6769,48 +6964,57 @@ msgstr ""
 
 #: src/methods/example.md:47
 #, fuzzy
+msgid "All four methods here use a different method receiver."
+msgstr "Tutti e quattro i metodi qui usano un ricevitore metodo diverso."
+
+#: src/methods/example.md:48
+#, fuzzy
 msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+"Puoi indicare come ciò cambia ciò che la funzione può fare con i valori "
+"delle variabili e se/come può essere riutilizzata in `main`."
+
+#: src/methods/example.md:49
+#, fuzzy
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+"Puoi mostrare l'errore che appare quando provi a chiamare `finish` due volte."
+
+#: src/methods/example.md:50
+#, fuzzy
+msgid ""
+"Note that although the method receivers are different, the non-static "
 "functions are called the same way in the main body. Rust enables automatic "
 "referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+"Si noti che sebbene i destinatari del metodo siano diversi, le funzioni non "
+"statiche sono chiamate allo stesso modo nel corpo principale. Rust abilita "
+"la referenziazione e la dereferenziazione automatica quando si chiamano i "
+"metodi. Rust aggiunge automaticamente `&`, `*`, `muts` in modo che "
+"quell'oggetto corrisponda alla firma del metodo."
+
+#: src/methods/example.md:51
+#, fuzzy
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
 "over. We describe vectors in more detail in the afternoon. "
 msgstr ""
-"* Tutti e quattro i metodi qui usano un ricevitore metodo diverso.\n"
-"  * Puoi indicare come ciò cambia ciò che la funzione può fare con i valori "
-"delle variabili e se/come può essere riutilizzata in `main`.\n"
-"  * Puoi mostrare l'errore che appare quando provi a chiamare `finish` due "
-"volte.\n"
-"* Si noti che sebbene i destinatari del metodo siano diversi, le funzioni "
-"non statiche sono chiamate allo stesso modo nel corpo principale. Rust "
-"abilita la referenziazione e la dereferenziazione automatica quando si "
-"chiamano i metodi. Rust aggiunge automaticamente `&`, `*`, `muts` in modo "
-"che quell'oggetto corrisponda alla firma del metodo.\n"
-"* Potresti sottolineare che `print_laps` sta usando un vettore che viene "
+"Potresti sottolineare che `print_laps` sta usando un vettore che viene "
 "iterato. Descriviamo i vettori in modo più dettagliato nel pomeriggio."
-
-#: src/pattern-matching.md:1
-#, fuzzy
-msgid "# Pattern Matching"
-msgstr "# Corrispondenza modello"
 
 #: src/pattern-matching.md:3
 #, fuzzy
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 "La parola chiave `match` ti consente di confrontare un valore con uno o più "
-"_pattern_. IL\n"
-"i confronti vengono effettuati dall'alto verso il basso e vince la prima "
-"partita."
+"_pattern_. IL i confronti vengono effettuati dall'alto verso il basso e "
+"vince la prima partita."
 
 #: src/pattern-matching.md:6
 #, fuzzy
@@ -6845,50 +7049,66 @@ msgstr ""
 #: src/pattern-matching.md:26
 #, fuzzy
 msgid ""
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
-"* Potresti sottolineare come vengono utilizzati alcuni caratteri specifici "
-"quando in uno schema\n"
-"  * `|` come `o`\n"
-"  * `..` può espandersi quanto deve essere\n"
-"  * `1..=5` rappresenta un intervallo inclusivo\n"
-"  * `_` è un carattere jolly\n"
-"* Può essere utile mostrare come funziona l'associazione, ad esempio "
-"sostituendo un carattere jolly con una variabile o rimuovendo le virgolette "
-"intorno a `q`.\n"
-"* Puoi dimostrare la corrispondenza su un riferimento.\n"
-"* Questo potrebbe essere un buon momento per far emergere il concetto di "
-"modelli inconfutabili, poiché il termine può apparire nei messaggi di "
-"errore.\n"
-"   "
+"Potresti sottolineare come vengono utilizzati alcuni caratteri specifici "
+"quando in uno schema"
 
-#: src/pattern-matching/destructuring-enums.md:1
+#: src/pattern-matching.md:27
 #, fuzzy
-msgid "# Destructuring Enums"
-msgstr "# Destrutturazione delle enum"
+msgid "`|` as an `or`"
+msgstr "`|` come `o`"
+
+#: src/pattern-matching.md:28
+#, fuzzy
+msgid "`..` can expand as much as it needs to be"
+msgstr "`..` può espandersi quanto deve essere"
+
+#: src/pattern-matching.md:29
+#, fuzzy
+msgid "`1..=5` represents an inclusive range"
+msgstr "`1..=5` rappresenta un intervallo inclusivo"
+
+#: src/pattern-matching.md:30
+#, fuzzy
+msgid "`_` is a wild card"
+msgstr "`_` è un carattere jolly"
+
+#: src/pattern-matching.md:31
+#, fuzzy
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+"Può essere utile mostrare come funziona l'associazione, ad esempio "
+"sostituendo un carattere jolly con una variabile o rimuovendo le virgolette "
+"intorno a `q`."
+
+#: src/pattern-matching.md:32
+#, fuzzy
+msgid "You can demonstrate matching on a reference."
+msgstr "Puoi dimostrare la corrispondenza su un riferimento."
+
+#: src/pattern-matching.md:33
+#, fuzzy
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
+msgstr ""
+"Questo potrebbe essere un buon momento per far emergere il concetto di "
+"modelli inconfutabili, poiché il termine può apparire nei messaggi di errore."
 
 #: src/pattern-matching/destructuring-enums.md:3
 #, fuzzy
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 "I modelli possono anche essere usati per associare variabili a parti dei "
-"tuoi valori. Questo è come\n"
-"ispezioni la struttura dei tuoi tipi. Iniziamo con un semplice tipo `enum`:"
+"tuoi valori. Questo è come ispezioni la struttura dei tuoi tipi. Iniziamo "
+"con un semplice tipo `enum`:"
 
 #: src/pattern-matching/destructuring-enums.md:6
 msgid ""
@@ -6919,38 +7139,34 @@ msgstr ""
 #: src/pattern-matching/destructuring-enums.md:29
 #, fuzzy
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
 "Qui abbiamo usato le braccia per _destrutturare_ il valore `Result`. Nel "
-"primo\n"
-"arm, \"half\" è legato al valore all'interno della variante \"Ok\". Nel "
-"secondo braccio,\n"
-"`msg` è associato al messaggio di errore."
+"primo arm, \"half\" è legato al valore all'interno della variante \"Ok\". "
+"Nel secondo braccio, `msg` è associato al messaggio di errore."
 
 #: src/pattern-matching/destructuring-enums.md:36
 #, fuzzy
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
-"* L'espressione `if`/`else` restituisce un enum che viene successivamente "
-"decompresso con un `match`.\n"
-"* Puoi provare ad aggiungere una terza variante alla definizione enum e "
+"L'espressione `if`/`else` restituisce un enum che viene successivamente "
+"decompresso con un `match`."
+
+#: src/pattern-matching/destructuring-enums.md:37
+#, fuzzy
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
+msgstr ""
+"Puoi provare ad aggiungere una terza variante alla definizione enum e "
 "visualizzare gli errori durante l'esecuzione del codice. Indica i punti in "
 "cui il tuo codice è ora inesausto e come il compilatore cerca di darti "
 "suggerimenti."
-
-#: src/pattern-matching/destructuring-structs.md:1
-#, fuzzy
-msgid "# Destructuring Structs"
-msgstr "# Strutture destrutturanti"
 
 #: src/pattern-matching/destructuring-structs.md:3
 #, fuzzy
@@ -6980,29 +7196,29 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
 #, fuzzy
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard "
-"to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that "
-"it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
-"* Cambia i valori letterali in `foo` in modo che corrispondano agli altri "
-"modelli.\n"
-"* Aggiungi un nuovo campo a \"Foo\" e apporta le modifiche al modello "
-"secondo necessità.\n"
-"* La distinzione tra una cattura e un'espressione costante può essere "
-"difficile da fare\n"
-"  macchiare. Prova a cambiare il \"2\" nel secondo braccio in una variabile "
-"e osservalo sottilmente\n"
-"  non funziona. Cambialo in un `const` e guardalo funzionare di nuovo."
+"Cambia i valori letterali in `foo` in modo che corrispondano agli altri "
+"modelli."
 
-#: src/pattern-matching/destructuring-arrays.md:1
+#: src/pattern-matching/destructuring-structs.md:24
 #, fuzzy
-msgid "# Destructuring Arrays"
-msgstr "# Array destrutturanti"
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+"Aggiungi un nuovo campo a \"Foo\" e apporta le modifiche al modello secondo "
+"necessità."
+
+#: src/pattern-matching/destructuring-structs.md:25
+#, fuzzy
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
+msgstr ""
+"La distinzione tra una cattura e un'espressione costante può essere "
+"difficile da fare macchiare. Prova a cambiare il \"2\" nel secondo braccio "
+"in una variabile e osservalo sottilmente non funziona. Cambialo in un "
+"`const` e guardalo funzionare di nuovo."
 
 #: src/pattern-matching/destructuring-arrays.md:3
 #, fuzzy
@@ -7028,50 +7244,57 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were "
-"ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of "
-"elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:1
-#, fuzzy
-msgid "# Match Guards"
-msgstr "# Partita Guardie"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 #, fuzzy
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 "Durante la corrispondenza, puoi aggiungere una _guard_ a un pattern. Questo "
-"è un booleano arbitrario\n"
-"espressione che verrà eseguita se il modello corrisponde:"
+"è un booleano arbitrario espressione che verrà eseguita se il modello "
+"corrisponde:"
 
 #: src/pattern-matching/match-guards.md:6
 msgid ""
@@ -7093,36 +7316,48 @@ msgstr ""
 #: src/pattern-matching/match-guards.md:23
 #, fuzzy
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr ""
+"Le guardie di corrispondenza come caratteristica di sintassi separata sono "
+"importanti e necessarie quando desideriamo esprimere in modo conciso idee "
+"più complesse di quanto i soli schemi consentirebbero."
+
+#: src/pattern-matching/match-guards.md:24
+#, fuzzy
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`."
+"result in other arms of the original `match` expression being considered."
 msgstr ""
-"* Le guardie di corrispondenza come caratteristica di sintassi separata sono "
-"importanti e necessarie quando desideriamo esprimere in modo conciso idee "
-"più complesse di quanto i soli schemi consentirebbero.\n"
-"* Non sono la stessa cosa dell'espressione `if` separata all'interno del "
+"Non sono la stessa cosa dell'espressione `if` separata all'interno del "
 "braccio della corrispondenza. Un'espressione `if` all'interno del blocco di "
 "diramazione (dopo `=>`) si verifica dopo che è stato selezionato il braccio "
 "di corrispondenza. Il fallimento della condizione \"if\" all'interno di quel "
-"blocco non comporterà altre braccia\n"
-"dell'espressione `match` originale considerata.\n"
-"* È possibile utilizzare le variabili definite nel modello nell'espressione "
-"if.\n"
-"* La condizione definita nella guardia si applica a ogni espressione in un "
+"blocco non comporterà altre braccia dell'espressione `match` originale "
+"considerata."
+
+#: src/pattern-matching/match-guards.md:26
+#, fuzzy
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+"È possibile utilizzare le variabili definite nel modello nell'espressione if."
+
+#: src/pattern-matching/match-guards.md:27
+#, fuzzy
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr ""
+"La condizione definita nella guardia si applica a ogni espressione in un "
 "modello con un `|`."
 
 #: src/exercises/day-2/morning.md:1
 #, fuzzy
-msgid "# Day 2: Morning Exercises"
-msgstr "# Giorno 2: Esercizi mattutini"
+msgid "Day 2: Morning Exercises"
+msgstr "Giorno 2: Esercizi mattutini"
 
 #: src/exercises/day-2/morning.md:3
 #, fuzzy
@@ -7131,55 +7366,43 @@ msgstr "Esamineremo i metodi di implementazione in due contesti:"
 
 #: src/exercises/day-2/morning.md:5
 #, fuzzy
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
-msgstr ""
-"* Struttura semplice che tiene traccia delle statistiche sulla salute.\n"
-"\n"
-"* Strutture multiple ed enum per una libreria di disegni."
+msgid "Simple struct which tracks health statistics."
+msgstr "Struttura semplice che tiene traccia delle statistiche sulla salute."
 
-#: src/exercises/day-2/health-statistics.md:1
+#: src/exercises/day-2/morning.md:7
 #, fuzzy
-msgid "# Health Statistics"
-msgstr "# Statistiche sanitarie"
+msgid "Multiple structs and enums for a drawing library."
+msgstr "Strutture multiple ed enum per una libreria di disegni."
 
 #: src/exercises/day-2/health-statistics.md:3
 #, fuzzy
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
 "Stai lavorando all'implementazione di un sistema di monitoraggio sanitario. "
-"Come parte di questo, tu\n"
-"necessità di tenere traccia delle statistiche sulla salute degli utenti."
+"Come parte di questo, tu necessità di tenere traccia delle statistiche sulla "
+"salute degli utenti."
 
 #: src/exercises/day-2/health-statistics.md:6
 #, fuzzy
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 "Inizierai con alcune funzioni stubbed in un blocco `impl` così come in un "
-"`User`\n"
-"definizione di struttura. Il tuo obiettivo è implementare i metodi eliminati "
-"sul file\n"
-"`User` `struct` definito nel blocco `impl`."
+"`User` definizione di struttura. Il tuo obiettivo è implementare i metodi "
+"eliminati sul file `User` `struct` definito nel blocco `impl`."
 
 #: src/exercises/day-2/health-statistics.md:10
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 "Copia il codice qui sotto in <https://play.rust-lang.org/> e inserisci "
-"quello mancante\n"
-"metodi:"
+"quello mancante metodi:"
 
 #: src/exercises/day-2/health-statistics.md:13
 msgid ""
@@ -7286,23 +7509,19 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
 #, fuzzy
-msgid "# Polygon Struct"
-msgstr "# Struttura poligonale"
+msgid "Polygon Struct"
+msgstr "Struttura poligonale"
 
 #: src/exercises/day-2/points-polygons.md:3
 #, fuzzy
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 "Creeremo una struttura `Polygon` che contiene alcuni punti. Copia il codice "
-"qui sotto\n"
-"a <https://play.rust-lang.org/> e inserire i metodi mancanti per rendere il "
-"file\n"
-"i test superano:"
+"qui sotto a <https://play.rust-lang.org/> e inserire i metodi mancanti per "
+"rendere il file i test superano:"
 
 #: src/exercises/day-2/points-polygons.md:7
 msgid ""
@@ -7419,14 +7638,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 "Poiché le firme del metodo mancano nelle dichiarazioni del problema, la "
-"parte chiave\n"
-"dell'esercizio è specificarli correttamente. Non è necessario modificare i "
-"test."
+"parte chiave dell'esercizio è specificarli correttamente. Non è necessario "
+"modificare i test."
 
 #: src/exercises/day-2/points-polygons.md:120
 #, fuzzy
@@ -7436,55 +7653,43 @@ msgstr "Altre parti interessanti dell'esercizio:"
 #: src/exercises/day-2/points-polygons.md:122
 #, fuzzy
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
-"* Deriva un tratto `Copy` per alcune strutture, poiché nei test i metodi a "
-"volte non prendono in prestito i loro argomenti.\n"
-"* Scopri che il tratto `Add` deve essere implementato affinché due oggetti "
+"Deriva un tratto `Copy` per alcune strutture, poiché nei test i metodi a "
+"volte non prendono in prestito i loro argomenti."
+
+#: src/exercises/day-2/points-polygons.md:123
+#, fuzzy
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
+"Scopri che il tratto `Add` deve essere implementato affinché due oggetti "
 "possano essere aggiunti tramite \"+\". Si noti che non discuteremo di "
 "farmaci generici fino al giorno 3."
-
-#: src/control-flow.md:1
-#, fuzzy
-msgid "# Control Flow"
-msgstr "# Flusso di controllo"
 
 #: src/control-flow.md:3
 #, fuzzy
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
 "Come abbiamo visto, \"if\" è un'espressione in Rust. È usato in modo "
-"condizionale\n"
-"valutare uno dei due blocchi, ma i blocchi possono avere un valore che poi "
-"diventa\n"
-"il valore dell'espressione \"if\". Altre espressioni del flusso di controllo "
-"funzionano in modo simile\n"
-"a Ruggine."
-
-#: src/control-flow/blocks.md:1
-#, fuzzy
-msgid "# Blocks"
-msgstr "# Blocchi"
+"condizionale valutare uno dei due blocchi, ma i blocchi possono avere un "
+"valore che poi diventa il valore dell'espressione \"if\". Altre espressioni "
+"del flusso di controllo funzionano in modo simile a Ruggine."
 
 #: src/control-flow/blocks.md:3
 #, fuzzy
 msgid ""
-"A block in Rust contains a sequence of expressions.\n"
-"Each block has a value and a type,\n"
-"which are those of the last expression of the block:"
+"A block in Rust contains a sequence of expressions. Each block has a value "
+"and a type, which are those of the last expression of the block:"
 msgstr ""
 "Un blocco in Rust ha un valore e un tipo: il valore è l'ultima espressione "
-"del\n"
-"bloccare:"
+"del bloccare:"
 
 #: src/control-flow/blocks.md:7
 msgid ""
@@ -7517,12 +7722,11 @@ msgstr ""
 #: src/control-flow/blocks.md:28
 #, fuzzy
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
 "La stessa regola viene utilizzata per le funzioni: il valore del corpo della "
-"funzione è the\n"
-"valore di ritorno:"
+"funzione è the valore di ritorno:"
 
 #: src/control-flow/blocks.md:31
 msgid ""
@@ -7540,37 +7744,36 @@ msgstr ""
 #: src/control-flow/blocks.md:44
 #, fuzzy
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
 msgstr ""
-"* Lo scopo di questa diapositiva è mostrare che i blocchi hanno un tipo e un "
-"valore in Rust.\n"
-"* Puoi mostrare come cambia il valore del blocco cambiando l'ultima riga nel "
+"Lo scopo di questa diapositiva è mostrare che i blocchi hanno un tipo e un "
+"valore in Rust."
+
+#: src/control-flow/blocks.md:45
+#, fuzzy
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
+msgstr ""
+"Puoi mostrare come cambia il valore del blocco cambiando l'ultima riga nel "
 "blocco. Ad esempio, aggiungendo/rimuovendo un punto e virgola o utilizzando "
-"un `return`.\n"
-"   "
+"un `return`."
 
 #: src/control-flow/if-expressions.md:1
 #, fuzzy
-msgid "# `if` expressions"
-msgstr "# Espressioni `if`"
+msgid "`if` expressions"
+msgstr "Espressioni `if`"
 
 #: src/control-flow/if-expressions.md:3
 #, fuzzy
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
-"Tu usi [`if`\n"
-"espressioni](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"esattamente come le dichiarazioni `if` in altre lingue:"
+"Tu usi [`if` espressioni](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-expressions) esattamente come le dichiarazioni `if` in altre "
+"lingue:"
 
 #: src/control-flow/if-expressions.md:7
 msgid ""
@@ -7589,12 +7792,11 @@ msgstr ""
 #: src/control-flow/if-expressions.md:18
 #, fuzzy
 msgid ""
-"In addition, you can use `if` as an expression. The last expression of each\n"
+"In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
 "Inoltre, puoi usare \"if\" come espressione. L'ultima espressione di "
-"ciascuno\n"
-"block diventa il valore dell'espressione `if`:"
+"ciascuno block diventa il valore dell'espressione `if`:"
 
 #: src/control-flow/if-expressions.md:22
 msgid ""
@@ -7619,23 +7821,19 @@ msgstr ""
 
 #: src/control-flow/if-let-expressions.md:1
 #, fuzzy
-msgid "# `if let` expressions"
-msgstr "# Espressioni `if let`"
+msgid "`if let` expressions"
+msgstr "Espressioni `if let`"
 
 #: src/control-flow/if-let-expressions.md:3
 #, fuzzy
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
-"Il [`se lasciato`\n"
-"espressione](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"ti consente di eseguire codice diverso a seconda che un valore corrisponda a "
-"un modello:"
+"Il [`se lasciato` espressione](https://doc.rust-lang.org/reference/"
+"expressions/if-expr.html#if-let-expressions) ti consente di eseguire codice "
+"diverso a seconda che un valore corrisponda a un modello:"
 
 #: src/control-flow/if-let-expressions.md:7
 msgid ""
@@ -7657,54 +7855,65 @@ msgstr ""
 #, fuzzy
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
 "Vedi [pattern matching](../pattern-matching.md) per maggiori dettagli sui "
-"pattern in\n"
-"Ruggine."
+"pattern in Ruggine."
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* Unlike `match`, `if let` does not have to cover all branches. This can "
-"make it more concise than `match`.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"Unlike `match`, `if let` does not have to cover all branches. This can make "
+"it more concise than `match`."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:26
+msgid ""
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) construct allows to do a destructuring "
 "assignment, or if it fails, execute a block which is required to abort "
-"normal control flow (with `panic`/`return`/`break`/`continue`):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"normal control flow (with `panic`/`return`/`break`/`continue`):"
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:1
 #, fuzzy
-msgid "# `while` loops"
-msgstr "# `while` si ripete"
+msgid "`while` loops"
+msgstr "`while` si ripete"
 
 #: src/control-flow/while-expressions.md:3
 #, fuzzy
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 "La [parola chiave `while`](https://doc.rust-lang.org/reference/expressions/"
-"loop-expr.html#predicate-loops)\n"
-"funziona in modo molto simile ad altre lingue:"
+"loop-expr.html#predicate-loops) funziona in modo molto simile ad altre "
+"lingue:"
 
 #: src/control-flow/while-expressions.md:6
 msgid ""
@@ -7725,19 +7934,19 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
 #, fuzzy
-msgid "# `while let` loops"
-msgstr "# `while let` va in loop"
+msgid "`while let` loops"
+msgstr "`while let` va in loop"
 
 #: src/control-flow/while-let-expressions.md:3
 #, fuzzy
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variant which repeatedly tests a value against a pattern:"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
 "Come con `if let`, c'è un [`while let`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variante che verifica ripetutamente un valore rispetto a un modello:"
+"expressions/loop-expr.html#predicate-pattern-loops) variante che verifica "
+"ripetutamente un valore rispetto a un modello:"
 
 #: src/control-flow/while-let-expressions.md:6
 msgid ""
@@ -7757,53 +7966,52 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 "Qui l'iteratore restituito da `v.iter()` restituirà una `Option<i32>` su "
-"ogni\n"
-"chiamata a `next()`. Restituisce `Some(x)` finché non è finito, dopodiché lo "
-"farà\n"
-"restituire \"Nessuno\". Il `while let` ci consente di continuare a scorrere "
-"tutti gli elementi."
+"ogni chiamata a `next()`. Restituisce `Some(x)` finché non è finito, "
+"dopodiché lo farà restituire \"Nessuno\". Il `while let` ci consente di "
+"continuare a scorrere tutti gli elementi."
 
 #: src/control-flow/while-let-expressions.md:26
 #, fuzzy
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
-"statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
 msgstr ""
-"* Fai notare che il ciclo `while let` continuerà finché il valore "
-"corrisponde al modello.\n"
-"* Potresti riscrivere il ciclo `while let` come un ciclo infinito con "
+"Fai notare che il ciclo `while let` continuerà finché il valore corrisponde "
+"al modello."
+
+#: src/control-flow/while-let-expressions.md:27
+#, fuzzy
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
+msgstr ""
+"Potresti riscrivere il ciclo `while let` come un ciclo infinito con "
 "un'istruzione if che si interrompe quando non c'è alcun valore da scartare "
 "per `iter.next()`. Il `while let` fornisce lo zucchero sintattico per lo "
-"scenario di cui sopra.\n"
-"    "
+"scenario di cui sopra."
 
 #: src/control-flow/for-expressions.md:1
 #, fuzzy
-msgid "# `for` loops"
-msgstr "# Cicli `for`"
+msgid "`for` loops"
+msgstr "Cicli `for`"
 
 #: src/control-flow/for-expressions.md:3
 #, fuzzy
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely\n"
-"related to the [`while let` loop](while-let-expressions.md). It will\n"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expressions.md). It will "
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
 "Il [ciclo `for`](https://doc.rust-lang.org/std/keyword.for.html) è "
-"strettamente\n"
-"relativo al [ciclo `while let`](while-let-expression.md). Lo farà\n"
-"chiama automaticamente `into_iter()` sull'espressione e quindi itera su di "
-"essa:"
+"strettamente relativo al [ciclo `while let`](while-let-expression.md). Lo "
+"farà chiama automaticamente `into_iter()` sull'espressione e quindi itera su "
+"di essa:"
 
 #: src/control-flow/for-expressions.md:7
 msgid ""
@@ -7829,38 +8037,48 @@ msgstr "Puoi usare `break` e `continue` qui come al solito."
 
 #: src/control-flow/for-expressions.md:25
 #, fuzzy
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr ""
+"L'iterazione dell'indice non è una sintassi speciale in Rust solo per quel "
+"caso."
+
+#: src/control-flow/for-expressions.md:26
+#, fuzzy
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "`(0..10)` è un intervallo che implementa un tratto `Iterator`."
+
+#: src/control-flow/for-expressions.md:27
+#, fuzzy
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+"`step_by` è un metodo che restituisce un altro `Iterator` che salta ogni "
+"altro elemento."
+
+#: src/control-flow/for-expressions.md:28
+#, fuzzy
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
-"* L'iterazione dell'indice non è una sintassi speciale in Rust solo per quel "
-"caso.\n"
-"* `(0..10)` è un intervallo che implementa un tratto `Iterator`.\n"
-"* `step_by` è un metodo che restituisce un altro `Iterator` che salta ogni "
-"altro elemento.\n"
-"* Modifica gli elementi nel vettore e spiega gli errori del compilatore. "
+"Modifica gli elementi nel vettore e spiega gli errori del compilatore. "
 "Cambia il vettore `v` in modo che sia mutabile e il ciclo for in `for x in v."
 "iter_mut()`."
 
 #: src/control-flow/loop-expressions.md:1
 #, fuzzy
-msgid "# `loop` expressions"
-msgstr "# Espressioni `loop`"
+msgid "`loop` expressions"
+msgstr "Espressioni `loop`"
 
 #: src/control-flow/loop-expressions.md:3
 #, fuzzy
 msgid ""
 "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 "Infine, c'è una [parola chiave `loop`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"che crea un loop infinito."
+"expressions/loop-expr.html#infinite-loops) che crea un loop infinito."
 
 #: src/control-flow/loop-expressions.md:6
 #, fuzzy
@@ -7889,40 +8107,35 @@ msgstr ""
 
 #: src/control-flow/loop-expressions.md:27
 #, fuzzy
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr "Interrompi il `loop` con un valore (ad es. `break 8`) e stampalo."
+
+#: src/control-flow/loop-expressions.md:28
+#, fuzzy
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-"
-"trivial\n"
-"  value. This is because it's guaranteed to be entered at least once "
-"(unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
-"* Interrompi il `loop` con un valore (ad es. `break 8`) e stampalo.\n"
-"* Si noti che `loop` è l'unico costrutto di ciclo che restituisce un valore "
-"non banale\n"
-"  valore. Questo perché è garantito che venga inserito almeno una volta (a "
-"differenza di\n"
-"  cicli `while` e `for`)."
+"Si noti che `loop` è l'unico costrutto di ciclo che restituisce un valore "
+"non banale valore. Questo perché è garantito che venga inserito almeno una "
+"volta (a differenza di cicli `while` e `for`)."
 
 #: src/control-flow/match-expressions.md:1
 #, fuzzy
-msgid "# `match` expressions"
-msgstr "# Espressioni `match`"
+msgid "`match` expressions"
+msgstr "Espressioni `match`"
 
 #: src/control-flow/match-expressions.md:3
 #, fuzzy
 msgid ""
 "The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
-"expr.html)\n"
-"is used to match a value against one or more patterns. In that sense, it "
-"works\n"
-"like a series of `if let` expressions:"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
 "La [parola chiave `match`](https://doc.rust-lang.org/reference/expressions/"
-"match-expr.html)\n"
-"viene utilizzato per confrontare un valore con uno o più modelli. In questo "
-"senso funziona\n"
-"come una serie di espressioni `if let`:"
+"match-expr.html) viene utilizzato per confrontare un valore con uno o più "
+"modelli. In questo senso funziona come una serie di espressioni `if let`:"
 
 #: src/control-flow/match-expressions.md:7
 msgid ""
@@ -7943,64 +8156,80 @@ msgstr ""
 #: src/control-flow/match-expressions.md:20
 #, fuzzy
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 "Come `if let`, ogni braccio di corrispondenza deve avere lo stesso tipo. Il "
-"tipo è l'ultimo\n"
-"espressione del blocco, se esiste. Nell'esempio precedente, il tipo è `()`."
+"tipo è l'ultimo espressione del blocco, se esiste. Nell'esempio precedente, "
+"il tipo è `()`."
 
 #: src/control-flow/match-expressions.md:28
 #, fuzzy
+msgid "Save the match expression to a variable and print it out."
+msgstr "Salva l'espressione di corrispondenza in una variabile e stampala."
+
+#: src/control-flow/match-expressions.md:29
+#, fuzzy
+msgid "Remove `.as_deref()` and explain the error."
+msgstr "Rimuovi `.as_deref()` e spiega l'errore."
+
+#: src/control-flow/match-expressions.md:30
+#, fuzzy
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
 msgstr ""
-"* Salva l'espressione di corrispondenza in una variabile e stampala.\n"
-"* Rimuovi `.as_deref()` e spiega l'errore.\n"
-"    * `std::env::args().next()` restituisce un `Option<String>`, ma non "
-"possiamo confrontare `String`.\n"
-"    * `as_deref()` trasforma una `Opzione<T>` in `Opzione<&T::Target>`. Nel "
-"nostro caso, questo trasforma `Option<String>` in `Option<&str>`.\n"
-"    * Ora possiamo usare il pattern matching per confrontare con `&str` "
+"`std::env::args().next()` restituisce un `Option<String>`, ma non possiamo "
+"confrontare `String`."
+
+#: src/control-flow/match-expressions.md:31
+#, fuzzy
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+"`as_deref()` trasforma una `Opzione<T>` in `Opzione<&T::Target>`. Nel nostro "
+"caso, questo trasforma `Option<String>` in `Option<&str>`."
+
+#: src/control-flow/match-expressions.md:32
+#, fuzzy
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
+msgstr ""
+"Ora possiamo usare il pattern matching per confrontare con `&str` "
 "all'interno di `Option`."
 
 #: src/control-flow/break-continue.md:1
 #, fuzzy
-msgid "# `break` and `continue`"
-msgstr "# `interrompi` e `continua`"
+msgid "`break` and `continue`"
+msgstr "`interrompi` e `continua`"
 
 #: src/control-flow/break-continue.md:3
 #, fuzzy
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
 msgstr ""
-"- Se vuoi uscire prima da un ciclo, usa [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- Se vuoi iniziare subito\n"
-"l'iterazione successiva usa [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"Se vuoi uscire prima da un ciclo, usa [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
+
+#: src/control-flow/break-continue.md:4
+#, fuzzy
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+msgstr ""
+"Se vuoi iniziare subito l'iterazione successiva usa [`continue`](https://doc."
+"rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
 
 #: src/control-flow/break-continue.md:7
 #, fuzzy
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
-"used\n"
-"to break out of nested loops:"
+"used to break out of nested loops:"
 msgstr ""
 "Sia `continue` che `break` possono facoltativamente accettare un argomento "
-"label che viene utilizzato\n"
-"per uscire dai cicli nidificati:"
+"label che viene utilizzato per uscire dai cicli nidificati:"
 
 #: src/control-flow/break-continue.md:10
 msgid ""
@@ -8031,25 +8260,17 @@ msgstr ""
 "In questo caso interrompiamo il ciclo esterno dopo 3 iterazioni del ciclo "
 "interno."
 
-#: src/std.md:1
-#, fuzzy
-msgid "# Standard Library"
-msgstr "# Libreria standard"
-
 #: src/std.md:3
 #, fuzzy
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 "Rust viene fornito con una libreria standard che aiuta a stabilire un "
-"insieme di tipi comuni\n"
-"utilizzato dalla libreria e dai programmi Rust. In questo modo, due librerie "
-"possono lavorare insieme\n"
-"senza problemi perché entrambi usano lo stesso tipo `Stringa`."
+"insieme di tipi comuni utilizzato dalla libreria e dai programmi Rust. In "
+"questo modo, due librerie possono lavorare insieme senza problemi perché "
+"entrambi usano lo stesso tipo `Stringa`."
 
 #: src/std.md:7
 #, fuzzy
@@ -8059,67 +8280,86 @@ msgstr "I tipi di vocabolario comuni includono:"
 #: src/std.md:9
 #, fuzzy
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
+msgstr ""
+"[Tipi `Option` e `Result`](std/option-result.md): usati per valori "
+"facoltativi e [gestione degli errori](error-handling.md)."
+
+#: src/std.md:12
+#, fuzzy
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+"[`String`](std/string.md): il tipo di stringa predefinito utilizzato per i "
+"dati di proprietà."
+
+#: src/std.md:14
+#, fuzzy
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr "[`Vec`](std/vec.md): un vettore estensibile standard."
+
+#: src/std.md:16
+#, fuzzy
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr ""
+"[`HashMap`](std/hashmap.md): un tipo di mappa hash con un hash configurabile "
+"algoritmo."
+
+#: src/std.md:19
+#, fuzzy
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr ""
+"[`Box`](std/box.md): un puntatore di proprietà per i dati allocati nell'heap."
+
+#: src/std.md:21
+#, fuzzy
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
 "data."
 msgstr ""
-"* [Tipi `Option` e `Result`](std/option-result.md): usati per valori "
-"facoltativi\n"
-"  e [gestione degli errori](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): il tipo di stringa predefinito utilizzato per i "
-"dati di proprietà.\n"
-"\n"
-"* [`Vec`](std/vec.md): un vettore estensibile standard.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): un tipo di mappa hash con un hash "
-"configurabile\n"
-"  algoritmo.\n"
-"\n"
-"* [`Box`](std/box.md): un puntatore di proprietà per i dati allocati "
-"nell'heap.\n"
-"\n"
-"* [`Rc`](std/rc.md): un puntatore con conteggio dei riferimenti condiviso "
-"per i dati allocati nell'heap."
+"[`Rc`](std/rc.md): un puntatore con conteggio dei riferimenti condiviso per "
+"i dati allocati nell'heap."
 
 #: src/std.md:25
 #, fuzzy
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
 msgstr ""
-"  * Infatti, Rust contiene diversi strati della Libreria Standard: `core`, "
-"`alloc` e `std`.\n"
-"  * `core` include i tipi e le funzioni più basilari che non dipendono da "
-"`libc`, allocator o\n"
-"    anche la presenza di un sistema operativo.\n"
-"  * `alloc` include tipi che richiedono un allocatore heap globale, come "
-"`Vec`, `Box` e `Arc`.\n"
-"  * Le applicazioni embedded di Rust spesso usano solo `core` e talvolta "
-"`alloc`."
+"Infatti, Rust contiene diversi strati della Libreria Standard: `core`, "
+"`alloc` e `std`."
+
+#: src/std.md:26
+#, fuzzy
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+"`core` include i tipi e le funzioni più basilari che non dipendono da "
+"`libc`, allocator o anche la presenza di un sistema operativo."
+
+#: src/std.md:28
+#, fuzzy
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+"`alloc` include tipi che richiedono un allocatore heap globale, come `Vec`, "
+"`Box` e `Arc`."
+
+#: src/std.md:29
+#, fuzzy
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"Le applicazioni embedded di Rust spesso usano solo `core` e talvolta `alloc`."
 
 #: src/std/option-result.md:1
 #, fuzzy
-msgid "# `Option` and `Result`"
-msgstr "# `Opzione` e `Risultato`"
+msgid "`Option` and `Result`"
+msgstr "`Opzione` e `Risultato`"
 
 #: src/std/option-result.md:3
 #, fuzzy
@@ -8142,38 +8382,51 @@ msgstr ""
 
 #: src/std/option-result.md:18
 #, fuzzy
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
-"* `Option` e `Result` sono ampiamente usati non solo nella libreria "
-"standard.\n"
-"* `Option<&T>` ha un sovraccarico di spazio pari a zero rispetto a `&T`.\n"
-"* `Result` è il tipo standard per implementare la gestione degli errori, "
-"come vedremo il giorno 3.\n"
-"* `binary_search` restituisce `Result<usize, usize>`.\n"
-"  * Se trovato, `Result::Ok` contiene l'indice in cui si trova l'elemento.\n"
-"  * Altrimenti, `Result::Err` contiene l'indice in cui tale elemento "
-"dovrebbe essere inserito."
+"`Option` e `Result` sono ampiamente usati non solo nella libreria standard."
 
-#: src/std/string.md:1
+#: src/std/option-result.md:19
 #, fuzzy
-msgid "# String"
-msgstr "# Corda"
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "`Option<&T>` ha un sovraccarico di spazio pari a zero rispetto a `&T`."
+
+#: src/std/option-result.md:20
+#, fuzzy
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+"`Result` è il tipo standard per implementare la gestione degli errori, come "
+"vedremo il giorno 3."
+
+#: src/std/option-result.md:21
+#, fuzzy
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "`binary_search` restituisce `Result<usize, usize>`."
+
+#: src/std/option-result.md:22
+#, fuzzy
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr "Se trovato, `Result::Ok` contiene l'indice in cui si trova l'elemento."
+
+#: src/std/option-result.md:23
+#, fuzzy
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr ""
+"Altrimenti, `Result::Err` contiene l'indice in cui tale elemento dovrebbe "
+"essere inserito."
 
 #: src/std/string.md:3
 #, fuzzy
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
-"[`String`][1] è il buffer di stringa UTF-8 espandibile allocato nell'heap "
-"standard:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) è il "
+"buffer di stringa UTF-8 espandibile allocato nell'heap standard:"
 
 #: src/std/string.md:5
 msgid ""
@@ -8198,50 +8451,92 @@ msgstr ""
 #: src/std/string.md:22
 #, fuzzy
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` implementa [`Deref<Target = str>`][2], il che significa che puoi "
-"chiamare tutti\n"
-"metodi `str` su una `stringa`."
+"`String` implementa [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), il che significa che puoi "
+"chiamare tutti metodi `str` su una `stringa`."
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to index a `String`:\n"
-"    * To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-"
-"bound, out-of-bounds.\n"
-"    * To a substring by using `s3[0..4]`, where that slice is on character "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
 #: src/std/vec.md:1
 #, fuzzy
-msgid "# `Vec`"
-msgstr "# `Vec`"
+msgid "`Vec`"
+msgstr "`Vec`"
 
 #: src/std/vec.md:3
 #, fuzzy
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
-msgstr "[`Vec`][1] è il buffer ridimensionabile allocato nell'heap standard:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
+msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) è il buffer "
+"ridimensionabile allocato nell'heap standard:"
 
 #: src/std/vec.md:5
 msgid ""
@@ -8273,40 +8568,51 @@ msgstr ""
 #: src/std/vec.md:29
 #, fuzzy
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
-"`Vec` implementa [`Deref<Target = [T]>`][2], il che significa che puoi "
-"chiamare slice\n"
-"metodi su un `Vec`."
+"`Vec` implementa [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), il che significa che puoi chiamare "
+"slice metodi su un `Vec`."
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
 #, fuzzy
-msgid "# `HashMap`"
-msgstr "# `Mappa hash`"
+msgid "`HashMap`"
+msgstr "`Mappa hash`"
 
 #: src/std/hashmap.md:3
 #, fuzzy
@@ -8353,50 +8659,82 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
 #, fuzzy
-msgid "# `Box`"
-msgstr "# `Scatola`"
+msgid "`Box`"
+msgstr "`Scatola`"
 
 #: src/std/box.md:3
 #, fuzzy
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "[`Box`][1] è un puntatore di proprietà ai dati sull'heap:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) è un puntatore "
+"di proprietà ai dati sull'heap:"
 
 #: src/std/box.md:5
 msgid ""
@@ -8428,42 +8766,60 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 "`Box<T>` implementa `Deref<Target = T>`, il che significa che puoi [chiamare "
-"metodi\n"
-"da `T` direttamente su un `Box<T>`][2]."
+"metodi da `T` direttamente su un `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 
 #: src/std/box.md:34
 #, fuzzy
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
 msgstr ""
-"* `Box` è come `std::unique_ptr` in C++, tranne per il fatto che è garantito "
-"che non sia nullo.\n"
-"* Nell'esempio sopra, puoi anche tralasciare `*` nell'istruzione `println!` "
-"grazie a `Deref`.\n"
-"* Una `Box` può essere utile quando:\n"
-"   * hanno un tipo la cui dimensione non può essere conosciuta in fase di "
-"compilazione, ma il compilatore Rust vuole conoscere una dimensione esatta.\n"
-"   * desidera trasferire la proprietà di una grande quantità di dati. Per "
-"evitare di copiare grandi quantità di dati nello stack, archivia invece i "
-"dati nell'heap in un \"Box\" in modo che venga spostato solo il puntatore."
+"`Box` è come `std::unique_ptr` in C++, tranne per il fatto che è garantito "
+"che non sia nullo."
+
+#: src/std/box.md:35
+#, fuzzy
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+"Nell'esempio sopra, puoi anche tralasciare `*` nell'istruzione `println!` "
+"grazie a `Deref`."
+
+#: src/std/box.md:36
+#, fuzzy
+msgid "A `Box` can be useful when you:"
+msgstr "Una `Box` può essere utile quando:"
+
+#: src/std/box.md:37
+#, fuzzy
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+"hanno un tipo la cui dimensione non può essere conosciuta in fase di "
+"compilazione, ma il compilatore Rust vuole conoscere una dimensione esatta."
+
+#: src/std/box.md:38
+#, fuzzy
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr ""
+"desidera trasferire la proprietà di una grande quantità di dati. Per evitare "
+"di copiare grandi quantità di dati nello stack, archivia invece i dati "
+"nell'heap in un \"Box\" in modo che venga spostato solo il puntatore."
 
 #: src/std/box-recursive.md:1
 #, fuzzy
-msgid "# Box with Recursive Data Structures"
-msgstr "# Box con strutture dati ricorsive"
+msgid "Box with Recursive Data Structures"
+msgstr "Box con strutture dati ricorsive"
 
 #: src/std/box-recursive.md:3
 #, fuzzy
@@ -8515,50 +8871,44 @@ msgstr ""
 #: src/std/box-recursive.md:33
 #, fuzzy
 msgid ""
-"* If `Box` was not used and we attempted to embed a `List` directly into the "
-"`List`,\n"
-"the compiler would not compute a fixed size of the struct in memory (`List` "
-"would be of infinite size).\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If `Box` was not used and we attempted to embed a `List` directly into the "
+"`List`, the compiler would not compute a fixed size of the struct in memory "
+"(`List` would be of infinite size)."
 msgstr ""
-"* Se la `Box` non è stata utilizzata qui e abbiamo tentato di incorporare "
-"una `Lista` direttamente nella `Lista`,\n"
-"il compilatore non calcolerebbe una dimensione fissa della struttura in "
-"memoria, sembrerebbe infinita.\n"
-"\n"
-"* `Box` risolve questo problema poiché ha le stesse dimensioni di un normale "
-"puntatore e punta solo al successivo\n"
-"elemento della \"Lista\" nell'heap.\n"
-"\n"
-"* Rimuovi il `Box` nella definizione dell'elenco e mostra l'errore del "
+"Se la `Box` non è stata utilizzata qui e abbiamo tentato di incorporare una "
+"`Lista` direttamente nella `Lista`, il compilatore non calcolerebbe una "
+"dimensione fissa della struttura in memoria, sembrerebbe infinita."
+
+#: src/std/box-recursive.md:36
+#, fuzzy
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+"`Box` risolve questo problema poiché ha le stesse dimensioni di un normale "
+"puntatore e punta solo al successivo elemento della \"Lista\" nell'heap."
+
+#: src/std/box-recursive.md:39
+#, fuzzy
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
+"Rimuovi il `Box` nella definizione dell'elenco e mostra l'errore del "
 "compilatore. \"Ricorsivo con indiretto\" è un suggerimento che potresti "
 "voler utilizzare un Box o un riferimento di qualche tipo, invece di "
-"memorizzare direttamente un valore.\n"
-"    "
-
-#: src/std/box-niche.md:1
-#, fuzzy
-msgid "# Niche Optimization"
-msgstr "# Ottimizzazione di nicchia"
+"memorizzare direttamente un valore."
 
 #: src/std/box-niche.md:16
 #, fuzzy
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 "Un `Box` non può essere vuoto, quindi il puntatore è sempre valido e non "
-"`null`. Questo\n"
-"consente al compilatore di ottimizzare il layout della memoria:"
+"`null`. Questo consente al compilatore di ottimizzare il layout della "
+"memoria:"
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -8584,19 +8934,19 @@ msgstr ""
 
 #: src/std/rc.md:1
 #, fuzzy
-msgid "# `Rc`"
-msgstr "# `Rc`"
+msgid "`Rc`"
+msgstr "`Rc`"
 
 #: src/std/rc.md:3
 #, fuzzy
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`][1] è un puntatore condiviso con conteggio dei riferimenti. Usalo "
-"quando hai bisogno di fare riferimento\n"
-"agli stessi dati da più posizioni:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) è un puntatore "
+"condiviso con conteggio dei riferimenti. Usalo quando hai bisogno di fare "
+"riferimento agli stessi dati da più posizioni:"
 
 #: src/std/rc.md:6
 msgid ""
@@ -8616,60 +8966,92 @@ msgstr ""
 #: src/std/rc.md:18
 #, fuzzy
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
 msgstr ""
-"* Se hai bisogno di mutare i dati all'interno di un `Rc`, dovrai racchiudere "
-"i dati\n"
-"  un tipo come [`Cell` o `RefCell`][2].\n"
-"* Vedere [`Arc`][3] se ci si trova in un contesto multi-thread.\n"
-"* Puoi *declassare* un puntatore condiviso in un puntatore [`Weak`][4] per "
-"creare cicli\n"
-"  che verrà abbandonato."
+"Se hai bisogno di mutare i dati all'interno di un `Rc`, dovrai racchiudere i "
+"dati un tipo come [`Cell` o `RefCell`](../concurrency/shared_state/arc.md)."
+
+#: src/std/rc.md:20
+#, fuzzy
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+"Vedere [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) se ci "
+"si trova in un contesto multi-thread."
+
+#: src/std/rc.md:21
+#, fuzzy
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
+"Puoi _declassare_ un puntatore condiviso in un puntatore [`Weak`](https://"
+"doc.rust-lang.org/std/rc/struct.Weak.html) per creare cicli che verrà "
+"abbandonato."
 
 #: src/std/rc.md:31
 #, fuzzy
 msgid ""
-"* `Rc`'s count ensures that its contained value is valid for as long as "
-"there are references.\n"
-"* `Rc` in Rust is like `std::shared_ptr` in C++.\n"
-"* `Rc::clone` is cheap: it creates a pointer to the same allocation and "
-"increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-"
-"write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable "
-"borrows that are enforced at compile time. `RefCell` enables (im)mutable "
-"borrows that are enforced at run time and will panic if it fails at "
-"runtime.\n"
-"* `Rc::downgrade` gives you a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
 msgstr ""
-"* Il conteggio di `Rc` assicura che il suo valore contenuto sia valido "
-"finché ci sono riferimenti.\n"
-"* Come `std::shared_ptr` di C++.\n"
-"* `Rc::clone` è economico: crea un puntatore alla stessa allocazione e "
-"aumenta il conteggio dei riferimenti. Non crea un clone profondo e "
-"generalmente può essere ignorato quando si cercano problemi di prestazioni "
-"nel codice.\n"
-"* `make_mut` in realtà clona il valore interno se necessario (\"clone-on-"
-"write\") e restituisce un riferimento mutabile.\n"
-"* Usa `Rc::strong_count` per controllare il conteggio dei riferimenti.\n"
-"* Confronta i diversi tipi di dati menzionati. `Box` abilita i prestiti "
+"Il conteggio di `Rc` assicura che il suo valore contenuto sia valido finché "
+"ci sono riferimenti."
+
+#: src/std/rc.md:32
+#, fuzzy
+msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
+msgstr "Come `std::shared_ptr` di C++."
+
+#: src/std/rc.md:33
+#, fuzzy
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"increases the reference count. Does not make a deep clone and can generally "
+"be ignored when looking for performance issues in code."
+msgstr ""
+"`Rc::clone` è economico: crea un puntatore alla stessa allocazione e aumenta "
+"il conteggio dei riferimenti. Non crea un clone profondo e generalmente può "
+"essere ignorato quando si cercano problemi di prestazioni nel codice."
+
+#: src/std/rc.md:34
+#, fuzzy
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+"`make_mut` in realtà clona il valore interno se necessario (\"clone-on-"
+"write\") e restituisce un riferimento mutabile."
+
+#: src/std/rc.md:35
+#, fuzzy
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr "Usa `Rc::strong_count` per controllare il conteggio dei riferimenti."
+
+#: src/std/rc.md:36
+#, fuzzy
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+"Confronta i diversi tipi di dati menzionati. `Box` abilita i prestiti "
 "(im)mutabili che vengono applicati in fase di compilazione. `RefCell` "
 "abilita i prestiti (im)mutabili che vengono applicati in fase di esecuzione "
-"e andranno in panico se falliscono in fase di esecuzione.\n"
-"* `Rc::downgrade` fornisce un oggetto *debolmente contato* a\n"
-"  creare cicli che verranno eliminati correttamente (probabilmente in "
-"combinazione con\n"
-"  `RefCella`)."
+"e andranno in panico se falliscono in fase di esecuzione."
+
+#: src/std/rc.md:37
+#, fuzzy
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
+msgstr ""
+"`Rc::downgrade` fornisce un oggetto _debolmente contato_ a creare cicli che "
+"verranno eliminati correttamente (probabilmente in combinazione con "
+"`RefCella`)."
 
 #: src/std/rc.md:41
 msgid ""
@@ -8701,11 +9083,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/modules.md:1
-#, fuzzy
-msgid "# Modules"
-msgstr "# Moduli"
 
 #: src/modules.md:3
 #, fuzzy
@@ -8745,23 +9122,27 @@ msgstr ""
 #: src/modules.md:28
 #, fuzzy
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
-"* I pacchetti forniscono funzionalità e includono un file `Cargo.toml` che "
-"descrive come costruire un pacchetto di 1+ casse.\n"
-"* I crate sono un albero di moduli, in cui un crate binario crea un "
-"eseguibile e un crate di libreria viene compilato in una libreria.\n"
-"* I moduli definiscono l'organizzazione, l'ambito e sono il fulcro di questa "
-"sezione."
+"I pacchetti forniscono funzionalità e includono un file `Cargo.toml` che "
+"descrive come costruire un pacchetto di 1+ casse."
 
-#: src/modules/visibility.md:1
+#: src/modules.md:29
 #, fuzzy
-msgid "# Visibility"
-msgstr "# Visibilità"
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+"I crate sono un albero di moduli, in cui un crate binario crea un eseguibile "
+"e un crate di libreria viene compilato in una libreria."
+
+#: src/modules.md:30
+#, fuzzy
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr ""
+"I moduli definiscono l'organizzazione, l'ambito e sono il fulcro di questa "
+"sezione."
 
 #: src/modules/visibility.md:3
 #, fuzzy
@@ -8770,19 +9151,24 @@ msgstr "I moduli sono un limite di privacy:"
 
 #: src/modules/visibility.md:5
 #, fuzzy
-msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+msgid "Module items are private by default (hides implementation details)."
 msgstr ""
-"* Gli elementi del modulo sono privati per impostazione predefinita "
-"(nasconde i dettagli di implementazione).\n"
-"* Gli elementi dei genitori e dei fratelli sono sempre visibili.\n"
-"* In altre parole, se un elemento è visibile nel modulo `foo`, è visibile in "
-"tutti i file\n"
-"  discendenti di `foo`."
+"Gli elementi del modulo sono privati per impostazione predefinita (nasconde "
+"i dettagli di implementazione)."
+
+#: src/modules/visibility.md:6
+#, fuzzy
+msgid "Parent and sibling items are always visible."
+msgstr "Gli elementi dei genitori e dei fratelli sono sempre visibili."
+
+#: src/modules/visibility.md:7
+#, fuzzy
+msgid ""
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
+msgstr ""
+"In altre parole, se un elemento è visibile nel modulo `foo`, è visibile in "
+"tutti i file discendenti di `foo`."
 
 #: src/modules/visibility.md:10
 msgid ""
@@ -8816,8 +9202,8 @@ msgstr ""
 
 #: src/modules/visibility.md:39
 #, fuzzy
-msgid "* Use the `pub` keyword to make modules public."
-msgstr "* Usa la parola chiave `pub` per rendere pubblici i moduli."
+msgid "Use the `pub` keyword to make modules public."
+msgstr "Usa la parola chiave `pub` per rendere pubblici i moduli."
 
 #: src/modules/visibility.md:41
 #, fuzzy
@@ -8831,24 +9217,31 @@ msgstr ""
 #: src/modules/visibility.md:43
 #, fuzzy
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+msgstr ""
+"Vedere il [riferimento Rust](https://doc.rust-lang.org/reference/visibility-"
+"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+
+#: src/modules/visibility.md:44
+#, fuzzy
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+"La configurazione della visibilità di `pub(crate)` è un modello comune."
+
+#: src/modules/visibility.md:45
+#, fuzzy
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr "Meno comunemente, puoi dare visibilità a un percorso specifico."
+
+#: src/modules/visibility.md:46
+#, fuzzy
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
 "its descendants)."
 msgstr ""
-"* Vedere il [riferimento Rust](https://doc.rust-lang.org/reference/"
-"visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* La configurazione della visibilità di `pub(crate)` è un modello comune.\n"
-"* Meno comunemente, puoi dare visibilità a un percorso specifico.\n"
-"* In ogni caso, la visibilità deve essere concessa a un modulo predecessore "
+"In ogni caso, la visibilità deve essere concessa a un modulo predecessore "
 "(ea tutti i suoi discendenti)."
-
-#: src/modules/paths.md:1
-#, fuzzy
-msgid "# Paths"
-msgstr "# Percorsi"
 
 #: src/modules/paths.md:3
 #, fuzzy
@@ -8857,31 +9250,42 @@ msgstr "I percorsi sono risolti come segue:"
 
 #: src/modules/paths.md:5
 #, fuzzy
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
-msgstr ""
-"1. Come percorso relativo:\n"
-"   * `foo` o `self::foo` si riferisce a `foo` nel modulo corrente,\n"
-"   * `super::foo` fa riferimento a `foo` nel modulo genitore.\n"
-"\n"
-"2. Come percorso assoluto:\n"
-"   * `crate::foo` fa riferimento a `foo` nella radice del crate corrente,\n"
-"   * `bar::foo` si riferisce a `foo` nella cassa `bar`."
+msgid "As a relative path:"
+msgstr "Come percorso relativo:"
+
+#: src/modules/paths.md:6
+#, fuzzy
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr "`foo` o `self::foo` si riferisce a `foo` nel modulo corrente,"
+
+#: src/modules/paths.md:7
+#, fuzzy
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr "`super::foo` fa riferimento a `foo` nel modulo genitore."
+
+#: src/modules/paths.md:9
+#, fuzzy
+msgid "As an absolute path:"
+msgstr "Come percorso assoluto:"
+
+#: src/modules/paths.md:10
+#, fuzzy
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr "`crate::foo` fa riferimento a `foo` nella radice del crate corrente,"
+
+#: src/modules/paths.md:11
+#, fuzzy
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr "`bar::foo` si riferisce a `foo` nella cassa `bar`."
 
 #: src/modules/paths.md:13
 #, fuzzy
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
-"Un modulo può portare i simboli di un altro modulo nell'ambito con `use`.\n"
-"In genere vedrai qualcosa di simile nella parte superiore di ogni modulo:"
+"Un modulo può portare i simboli di un altro modulo nell'ambito con `use`. In "
+"genere vedrai qualcosa di simile nella parte superiore di ogni modulo:"
 
 #: src/modules/paths.md:16
 msgid ""
@@ -8890,11 +9294,6 @@ msgid ""
 "use std::mem::transmute;\n"
 "```"
 msgstr ""
-
-#: src/modules/filesystem.md:1
-#, fuzzy
-msgid "# Filesystem Hierarchy"
-msgstr "# Gerarchia del file system"
 
 #: src/modules/filesystem.md:3
 #, fuzzy
@@ -8915,12 +9314,13 @@ msgstr "Il contenuto del modulo `garden` si trova in:"
 
 #: src/modules/filesystem.md:11
 #, fuzzy
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden.rs` (moderno stile Rust 2018)\n"
-"* `src/garden/mod.rs` (vecchio stile Rust 2015)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr "`src/garden.rs` (moderno stile Rust 2018)"
+
+#: src/modules/filesystem.md:12
+#, fuzzy
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/mod.rs` (vecchio stile Rust 2015)"
 
 #: src/modules/filesystem.md:14
 #, fuzzy
@@ -8930,12 +9330,13 @@ msgstr ""
 
 #: src/modules/filesystem.md:16
 #, fuzzy
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden/vegetables.rs` (moderno stile Rust 2018)\n"
-"* `src/garden/vegetables/mod.rs` (vecchio stile Rust 2015)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr "`src/garden/vegetables.rs` (moderno stile Rust 2018)"
+
+#: src/modules/filesystem.md:17
+#, fuzzy
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/vegetables/mod.rs` (vecchio stile Rust 2015)"
 
 #: src/modules/filesystem.md:19
 #, fuzzy
@@ -8944,23 +9345,24 @@ msgstr "La radice di `crate` è in:"
 
 #: src/modules/filesystem.md:21
 #, fuzzy
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
-msgstr ""
-"* `src/lib.rs` (per un crate di libreria)\n"
-"* `src/main.rs` (per una cassa binaria)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr "`src/lib.rs` (per un crate di libreria)"
+
+#: src/modules/filesystem.md:22
+#, fuzzy
+msgid "`src/main.rs` (for a binary crate)"
+msgstr "`src/main.rs` (per una cassa binaria)"
 
 #: src/modules/filesystem.md:24
 #, fuzzy
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
-"comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 "Anche i moduli definiti nei file possono essere documentati utilizzando "
-"\"commenti interni al documento\".\n"
-"Questi documentano l'elemento che li contiene, in questo caso un modulo."
+"\"commenti interni al documento\". Questi documentano l'elemento che li "
+"contiene, in questo caso un modulo."
 
 #: src/modules/filesystem.md:27
 msgid ""
@@ -8983,42 +9385,55 @@ msgstr ""
 
 #: src/modules/filesystem.md:44
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:47
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:57
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:60
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:63
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:68
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
 #, fuzzy
-msgid "# Day 2: Afternoon Exercises"
-msgstr "# Giorno 2: Esercizi pomeridiani"
+msgid "Day 2: Afternoon Exercises"
+msgstr "Giorno 2: Esercizi pomeridiani"
 
 #: src/exercises/day-2/afternoon.md:3
 #, fuzzy
@@ -9026,66 +9441,59 @@ msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr ""
 "Gli esercizi di questo pomeriggio si concentreranno su stringhe e iteratori."
 
-#: src/exercises/day-2/luhn.md:1
-#, fuzzy
-msgid "# Luhn Algorithm"
-msgstr "# Algoritmo di Luhn"
-
 #: src/exercises/day-2/luhn.md:3
 #, fuzzy
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 "L'[algoritmo di Luhn](https://en.wikipedia.org/wiki/Luhn_algorithm) viene "
-"utilizzato per\n"
-"convalidare i numeri di carta di credito. L'algoritmo prende una stringa "
-"come input e fa il\n"
-"seguente per convalidare il numero della carta di credito:"
+"utilizzato per convalidare i numeri di carta di credito. L'algoritmo prende "
+"una stringa come input e fa il seguente per convalidare il numero della "
+"carta di credito:"
 
 #: src/exercises/day-2/luhn.md:7
 #, fuzzy
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr "Ignora tutti gli spazi. Rifiuta il numero con meno di due cifre."
+
+#: src/exercises/day-2/luhn.md:9
+#, fuzzy
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
 msgstr ""
-"* Ignora tutti gli spazi. Rifiuta il numero con meno di due cifre.\n"
-"\n"
-"* Spostandoti da destra a sinistra, raddoppia ogni seconda cifra: per il "
-"numero `1234`,\n"
-"  raddoppiamo \"3\" e \"1\".\n"
-"\n"
-"* Dopo aver raddoppiato una cifra, somma le cifre. Quindi raddoppiando \"7\" "
-"diventa \"14\" which\n"
-"  diventa \"5\".\n"
-"\n"
-"* Somma tutte le cifre non raddoppiate e raddoppiate.\n"
-"\n"
-"* Il numero della carta di credito è valido se la somma termina con `0`."
+"Spostandoti da destra a sinistra, raddoppia ogni seconda cifra: per il "
+"numero `1234`, raddoppiamo \"3\" e \"1\"."
+
+#: src/exercises/day-2/luhn.md:12
+#, fuzzy
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+"Dopo aver raddoppiato una cifra, somma le cifre. Quindi raddoppiando \"7\" "
+"diventa \"14\" which diventa \"5\"."
+
+#: src/exercises/day-2/luhn.md:15
+#, fuzzy
+msgid "Sum all the undoubled and doubled digits."
+msgstr "Somma tutte le cifre non raddoppiate e raddoppiate."
+
+#: src/exercises/day-2/luhn.md:17
+#, fuzzy
+msgid "The credit card number is valid if the sum ends with `0`."
+msgstr "Il numero della carta di credito è valido se la somma termina con `0`."
 
 #: src/exercises/day-2/luhn.md:19
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 "Copia il seguente codice in <https://play.rust-lang.org/> e implementa il "
-"file\n"
-"funzione:"
+"file funzione:"
 
 #: src/exercises/day-2/luhn.md:23
 msgid ""
@@ -9139,36 +9547,27 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-#, fuzzy
-msgid "# Strings and Iterators"
-msgstr "# Stringhe e iteratori"
-
 #: src/exercises/day-2/strings-iterators.md:3
 #, fuzzy
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 "In questo esercizio, implementerai un componente di instradamento di un "
-"server web. IL\n"
-"il server è configurato con un numero di _prefissi di percorso_ che vengono "
-"confrontati\n"
-"_percorsi di richiesta_. I prefissi di percorso possono contenere un "
-"carattere jolly che\n"
-"corrisponde a un segmento completo. Vedere i test unitari di seguito."
+"server web. IL il server è configurato con un numero di _prefissi di "
+"percorso_ che vengono confrontati _percorsi di richiesta_. I prefissi di "
+"percorso possono contenere un carattere jolly che corrisponde a un segmento "
+"completo. Vedere i test unitari di seguito."
 
 #: src/exercises/day-2/strings-iterators.md:8
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
-"Copia il seguente codice in <https://play.rust-lang.org/> ed esegui i test\n"
+"Copia il seguente codice in <https://play.rust-lang.org/> ed esegui i test "
 "passaggio. Prova a evitare di assegnare un `Vec` per i tuoi risultati "
 "intermedi:"
 
@@ -9223,8 +9622,8 @@ msgstr ""
 
 #: src/welcome-day-3.md:1
 #, fuzzy
-msgid "# Welcome to Day 3"
-msgstr "# Benvenuto al giorno 3"
+msgid "Welcome to Day 3"
+msgstr "Benvenuto al giorno 3"
 
 #: src/welcome-day-3.md:3
 #, fuzzy
@@ -9234,57 +9633,48 @@ msgstr "Oggi tratteremo alcuni argomenti più avanzati di Rust:"
 #: src/welcome-day-3.md:5
 #, fuzzy
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
-"* Tratti: tratti derivati, metodi predefiniti e importante libreria "
-"standard\n"
-"  tratti.\n"
-"\n"
-"* Generici: tipi di dati generici, metodi generici, monomorfizzazione e "
-"tratto\n"
-"  oggetti.\n"
-"\n"
-"* Gestione degli errori: panic, `Result` e l'operatore try `?`.\n"
-"\n"
-"* Test: unit test, test di documentazione e test di integrazione.\n"
-"\n"
-"* Unsafe Rust: puntatori grezzi, variabili statiche, funzioni non sicure ed "
-"extern\n"
-"  funzioni."
+"Tratti: tratti derivati, metodi predefiniti e importante libreria standard "
+"tratti."
 
-#: src/generics.md:1
+#: src/welcome-day-3.md:8
 #, fuzzy
-msgid "# Generics"
-msgstr "# Generici"
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+"Generici: tipi di dati generici, metodi generici, monomorfizzazione e tratto "
+"oggetti."
+
+#: src/welcome-day-3.md:11
+#, fuzzy
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr "Gestione degli errori: panic, `Result` e l'operatore try `?`."
+
+#: src/welcome-day-3.md:13
+#, fuzzy
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr "Test: unit test, test di documentazione e test di integrazione."
+
+#: src/welcome-day-3.md:15
+#, fuzzy
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
+"Unsafe Rust: puntatori grezzi, variabili statiche, funzioni non sicure ed "
+"extern funzioni."
 
 #: src/generics.md:3
 #, fuzzy
 msgid ""
-"Rust support generics, which lets you abstract algorithms or data "
-"structures\n"
-"(such as sorting or a binary tree)\n"
-"over the types used or stored."
+"Rust support generics, which lets you abstract algorithms or data structures "
+"(such as sorting or a binary tree) over the types used or stored."
 msgstr ""
 "Rust supporta i generici, che ti consentono di astrarre un algoritmo (come "
-"l'ordinamento)\n"
-"sui tipi utilizzati nell'algoritmo."
-
-#: src/generics/data-types.md:1
-#, fuzzy
-msgid "# Generic Data Types"
-msgstr "# Tipi di dati generici"
+"l'ordinamento) sui tipi utilizzati nell'algoritmo."
 
 #: src/generics/data-types.md:3
 #, fuzzy
@@ -9309,16 +9699,12 @@ msgid ""
 msgstr ""
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
 msgstr ""
 
-#: src/generics/methods.md:1
-#, fuzzy
-msgid "# Generic Methods"
-msgstr "# Metodi generici"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
+msgstr ""
 
 #: src/generics/methods.md:3
 #, fuzzy
@@ -9349,28 +9735,39 @@ msgstr ""
 #: src/generics/methods.md:25
 #, fuzzy
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
-"* *D:* Perché `T` è specificato due volte in `impl<T> Point<T> {}`? Non è "
-"ridondante?\n"
-"    * Questo perché si tratta di una sezione di implementazione generica per "
-"un tipo generico. Sono indipendentemente generici.\n"
-"    * Significa che questi metodi sono definiti per qualsiasi `T`.\n"
-"    * È possibile scrivere `impl Point<u32> { .. }`.\n"
-"      * `Point` è ancora generico e puoi usare `Point<f64>`, ma i metodi in "
-"questo blocco saranno disponibili solo per `Point<u32>`."
+"_D:_ Perché `T` è specificato due volte in `impl<T> Point<T> {}`? Non è "
+"ridondante?"
 
-#: src/generics/monomorphization.md:1
+#: src/generics/methods.md:26
 #, fuzzy
-msgid "# Monomorphization"
-msgstr "# Monomorfizzazione"
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"Questo perché si tratta di una sezione di implementazione generica per un "
+"tipo generico. Sono indipendentemente generici."
+
+#: src/generics/methods.md:27
+#, fuzzy
+msgid "It means these methods are defined for any `T`."
+msgstr "Significa che questi metodi sono definiti per qualsiasi `T`."
+
+#: src/generics/methods.md:28
+#, fuzzy
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "È possibile scrivere `impl Point<u32> { .. }`."
+
+#: src/generics/methods.md:29
+#, fuzzy
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"`Point` è ancora generico e puoi usare `Point<f64>`, ma i metodi in questo "
+"blocco saranno disponibili solo per `Point<u32>`."
 
 #: src/generics/monomorphization.md:3
 #, fuzzy
@@ -9418,17 +9815,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 "Questa è un'astrazione a costo zero: ottieni esattamente lo stesso risultato "
-"che se avessi\n"
-"codificato a mano le strutture dati senza l'astrazione."
-
-#: src/traits.md:1
-#, fuzzy
-msgid "# Traits"
-msgstr "# Tratti"
+"che se avessi codificato a mano le strutture dati senza l'astrazione."
 
 #: src/traits.md:3
 #, fuzzy
@@ -9477,11 +9867,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/trait-objects.md:1
-#, fuzzy
-msgid "# Trait Objects"
-msgstr "# Oggetti tratto"
 
 #: src/traits/trait-objects.md:3
 #, fuzzy
@@ -9589,29 +9974,39 @@ msgstr ""
 
 #: src/traits/trait-objects.md:72
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Pet>` in the example above.\n"
-"* `dyn Pet` is a way to tell the compiler about a dynamically sized type "
-"that implements `Pet`.\n"
-"* In the example, `pets` holds *fat pointers* to objects that implement "
-"`Pet`. The fat pointer consists of two components, a pointer to the actual "
-"object and a pointer to the virtual method table for the `Pet` "
-"implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"     ```"
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Pet>` in the example above."
 msgstr ""
 
-#: src/traits/deriving-traits.md:1
-#, fuzzy
-msgid "# Deriving Traits"
-msgstr "# Tratti derivati"
+#: src/traits/trait-objects.md:73
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/traits/trait-objects.md:74
+msgid ""
+"In the example, `pets` holds _fat pointers_ to objects that implement `Pet`. "
+"The fat pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Pet` implementation of "
+"that particular object."
+msgstr ""
+
+#: src/traits/trait-objects.md:75
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits/trait-objects.md:76
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
+msgstr ""
 
 #: src/traits/deriving-traits.md:3
 #, fuzzy
@@ -9636,11 +10031,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/default-methods.md:1
-#, fuzzy
-msgid "# Default Methods"
-msgstr "# Metodi predefiniti"
 
 #: src/traits/default-methods.md:3
 #, fuzzy
@@ -9680,66 +10070,73 @@ msgstr ""
 #: src/traits/default-methods.md:32
 #, fuzzy
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to\n"
-"  implement themselves. Methods with default implementations can rely on "
-"required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `Equals` a super trait for `NotEqual`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `Equals` as a super "
-"trait for `NotEqual`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
-"* I tratti possono specificare metodi pre-implementati (predefiniti) e "
-"metodi richiesti agli utenti\n"
-"  implementare se stessi. I metodi con implementazioni predefinite possono "
-"fare affidamento sui metodi richiesti.\n"
-"\n"
-"* Sposta il metodo `not_equal` in un nuovo tratto `NotEqual`.\n"
-"\n"
-"* Rendi `NotEqual` un super tratto per `Equal`.\n"
-"\n"
-"* Fornire un'implementazione globale di \"NotEqual\" per \"Equal\".\n"
-"  * Con l'implementazione coperta, non hai più bisogno di \"NotEqual\" come "
+"I tratti possono specificare metodi pre-implementati (predefiniti) e metodi "
+"richiesti agli utenti implementare se stessi. I metodi con implementazioni "
+"predefinite possono fare affidamento sui metodi richiesti."
+
+#: src/traits/default-methods.md:35
+#, fuzzy
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr "Sposta il metodo `not_equal` in un nuovo tratto `NotEqual`."
+
+#: src/traits/default-methods.md:37
+#, fuzzy
+msgid "Make `Equals` a super trait for `NotEqual`."
+msgstr "Rendi `NotEqual` un super tratto per `Equal`."
+
+#: src/traits/default-methods.md:38
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr "Fornire un'implementazione globale di \"NotEqual\" per \"Equal\"."
+
+#: src/traits/default-methods.md:46
+#, fuzzy
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr ""
+"Con l'implementazione coperta, non hai più bisogno di \"NotEqual\" come "
 "super tratto per \"Equal\"."
 
-#: src/traits/trait-bounds.md:1
-#, fuzzy
-msgid "# Trait Bounds"
-msgstr "# Limiti dei tratti"
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `Equals` as a super "
+"trait for `NotEqual`."
+msgstr ""
 
 #: src/traits/trait-bounds.md:3
 #, fuzzy
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 "Quando si lavora con i generici, spesso si desidera richiedere i tipi da "
-"implementare\n"
-"qualche tratto, in modo da poter chiamare i metodi di questo tratto."
+"implementare qualche tratto, in modo da poter chiamare i metodi di questo "
+"tratto."
 
 #: src/traits/trait-bounds.md:6
 #, fuzzy
@@ -9795,33 +10192,36 @@ msgstr ""
 
 #: src/traits/trait-bounds.md:46
 #, fuzzy
+msgid "It declutters the function signature if you have many parameters."
+msgstr "Riordina la firma della funzione se hai molti parametri."
+
+#: src/traits/trait-bounds.md:47
+#, fuzzy
+msgid "It has additional features making it more powerful."
+msgstr "Ha funzionalità aggiuntive che lo rendono più potente."
+
+#: src/traits/trait-bounds.md:48
+#, fuzzy
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":"
-"\" can be arbitrary, like `Option<T>`.\n"
-"    "
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
-"* Riordina la firma della funzione se hai molti parametri.\n"
-"* Ha funzionalità aggiuntive che lo rendono più potente.\n"
-"    * Se qualcuno lo chiede, la caratteristica extra è che il tipo a "
-"sinistra di \":\" può essere arbitrario, come `Option<T>`.\n"
-"    "
+"Se qualcuno lo chiede, la caratteristica extra è che il tipo a sinistra di "
+"\":\" può essere arbitrario, come `Option<T>`."
 
 #: src/traits/impl-trait.md:1
 #, fuzzy
-msgid "# `impl Trait`"
-msgstr "# `Impl Tratto`"
+msgid "`impl Trait`"
+msgstr "`Impl Tratto`"
 
 #: src/traits/impl-trait.md:3
 #, fuzzy
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 "Simile ai limiti dei tratti, in funzione può essere utilizzata una sintassi "
-"`impl Trait`\n"
-"argomenti e valori restituiti:"
+"`impl Trait` argomenti e valori restituiti:"
 
 #: src/traits/impl-trait.md:6
 msgid ""
@@ -9841,8 +10241,8 @@ msgstr ""
 
 #: src/traits/impl-trait.md:19
 #, fuzzy
-msgid "* `impl Trait` allows you to work with types which you cannot name."
-msgstr "* `impl Trait` ti permette di lavorare con tipi che non puoi nominare."
+msgid "`impl Trait` allows you to work with types which you cannot name."
+msgstr "`impl Trait` ti permette di lavorare con tipi che non puoi nominare."
 
 #: src/traits/impl-trait.md:23
 #, fuzzy
@@ -9855,74 +10255,59 @@ msgstr ""
 #: src/traits/impl-trait.md:25
 #, fuzzy
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` "
-"picks\n"
-"  the concrete type it returns, without writing it out in the source. A "
-"function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let "
-"x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
 msgstr ""
-"* Per un parametro, `impl Trait` è come un parametro generico anonimo con un "
-"tratto associato.\n"
-"\n"
-"* Per un tipo restituito, significa che il tipo restituito è un tipo "
-"concreto che implementa il tratto,\n"
-"  senza nominare il tipo. Questo può essere utile quando non vuoi esporre il "
-"tipo concreto in a\n"
-"  API pubblica.\n"
-"\n"
-"  L'inferenza è difficile nella posizione di ritorno. Una funzione che "
-"restituisce le scelte `impl Foo`\n"
-"  il tipo concreto che restituisce, senza scriverlo nella fonte. Una "
-"funzione\n"
-"  restituire un tipo generico come `collect<B>() -> B` può restituire "
-"qualsiasi tipo\n"
-"  soddisfacente `B`, e il chiamante potrebbe aver bisogno di sceglierne uno, "
-"come con `let x:\n"
-"  Vec<_> = foo.collect()` o con il turbofish, `foo.collect::<Vec<_>>()`."
+"Per un parametro, `impl Trait` è come un parametro generico anonimo con un "
+"tratto associato."
+
+#: src/traits/impl-trait.md:27
+#, fuzzy
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+"Per un tipo restituito, significa che il tipo restituito è un tipo concreto "
+"che implementa il tratto, senza nominare il tipo. Questo può essere utile "
+"quando non vuoi esporre il tipo concreto in a API pubblica."
+
+#: src/traits/impl-trait.md:31
+#, fuzzy
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
+msgstr ""
+"L'inferenza è difficile nella posizione di ritorno. Una funzione che "
+"restituisce le scelte `impl Foo` il tipo concreto che restituisce, senza "
+"scriverlo nella fonte. Una funzione restituire un tipo generico come "
+"`collect<B>() -> B` può restituire qualsiasi tipo soddisfacente `B`, e il "
+"chiamante potrebbe aver bisogno di sceglierne uno, come con `let x: Vec<_> = "
+"foo.collect()` o con il turbofish, `foo.collect::<Vec<_>>()`."
 
 #: src/traits/impl-trait.md:37
 #, fuzzy
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters."
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 "Questo esempio è fantastico, perché utilizza `impl Display` due volte. Aiuta "
-"a spiegarlo\n"
-"nulla qui impone che sia _lo stesso_ tipo `impl Display`. Se usiamo un "
-"singolo\n"
-"`T: Display`, imporrebbe il vincolo secondo cui l'input `T` e il tipo "
-"restituito `T` sono dello stesso tipo.\n"
-"Non funzionerebbe per questa particolare funzione, poiché probabilmente non "
-"lo è il tipo che ci aspettiamo come input\n"
-"quale `formato!` restituisce. Se volessimo fare lo stesso tramite la "
-"sintassi `: Display`, ne avremmo bisogno di due\n"
-"parametri generici indipendenti."
-
-#: src/traits/important-traits.md:1
-#, fuzzy
-msgid "# Important Traits"
-msgstr "# Tratti importanti"
+"a spiegarlo nulla qui impone che sia _lo stesso_ tipo `impl Display`. Se "
+"usiamo un singolo `T: Display`, imporrebbe il vincolo secondo cui l'input "
+"`T` e il tipo restituito `T` sono dello stesso tipo. Non funzionerebbe per "
+"questa particolare funzione, poiché probabilmente non lo è il tipo che ci "
+"aspettiamo come input quale `formato!` restituisce. Se volessimo fare lo "
+"stesso tramite la sintassi `: Display`, ne avremmo bisogno di due parametri "
+"generici indipendenti."
 
 #: src/traits/important-traits.md:3
 #, fuzzy
@@ -9935,29 +10320,76 @@ msgstr ""
 #: src/traits/important-traits.md:5
 #, fuzzy
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
 msgstr ""
-"* [`Iterator`][1] e [`IntoIterator`][2] usati nei cicli `for`,\n"
-"* [`From`][3] e [`Into`][4] utilizzati per convertire i valori,\n"
-"* [`Read`][5] e [`Write`][6] usati per IO,\n"
-"* [`Add`][7], [`Mul`][8], ... utilizzato per l'overload degli operatori e\n"
-"* [`Drop`][9] usato per definire i distruttori.\n"
-"* [`Default`][10] utilizzato per costruire un'istanza predefinita di un tipo."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) e "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"usati nei cicli `for`,"
+
+#: src/traits/important-traits.md:6
+#, fuzzy
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) e [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) utilizzati per "
+"convertire i valori,"
+
+#: src/traits/important-traits.md:7
+#, fuzzy
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) e [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) usati per IO,"
+
+#: src/traits/important-traits.md:8
+#, fuzzy
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... utilizzato per l'overload "
+"degli operatori e"
+
+#: src/traits/important-traits.md:9
+#, fuzzy
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) usato per "
+"definire i distruttori."
+
+#: src/traits/important-traits.md:10
+#, fuzzy
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
+"utilizzato per costruire un'istanza predefinita di un tipo."
 
 #: src/traits/iterator.md:1
 #, fuzzy
-msgid "# Iterators"
-msgstr "# Iteratori"
+msgid "Iterators"
+msgstr "Iteratori"
 
 #: src/traits/iterator.md:3
 #, fuzzy
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
-msgstr "Puoi implementare il tratto [`Iterator`][1] sui tuoi tipi:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
+msgstr ""
+"Puoi implementare il tratto [`Iterator`](https://doc.rust-lang.org/std/iter/"
+"trait.Iterator.html) sui tuoi tipi:"
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -9990,47 +10422,41 @@ msgstr ""
 #: src/traits/iterator.md:32
 #, fuzzy
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
-"* Il tratto `Iterator` implementa molte comuni operazioni di programmazione "
-"funzionale sulle raccolte\n"
-"  (ad es. `map`, `filter`, `reduce`, ecc.). Questo è il tratto in cui puoi "
-"trovare tutta la documentazione\n"
-"  su di loro. In Rust queste funzioni dovrebbero produrre il codice tanto "
-"efficiente quanto imperativo equivalente\n"
-"  implementazioni.\n"
-"    \n"
-"* `IntoIterator` è la caratteristica che fa funzionare i cicli for. È "
-"implementato da tipi di raccolta come\n"
-"  `Vec<T>` e riferimenti ad essi come `&Vec<T>` e `&[T]`. Anche le gamme lo "
-"implementano. Ecco perché\n"
-"  puoi iterare su un vettore con `for i in some_vec { .. }` ma\n"
-"  `some_vec.next()` non esiste."
+"Il tratto `Iterator` implementa molte comuni operazioni di programmazione "
+"funzionale sulle raccolte (ad es. `map`, `filter`, `reduce`, ecc.). Questo è "
+"il tratto in cui puoi trovare tutta la documentazione su di loro. In Rust "
+"queste funzioni dovrebbero produrre il codice tanto efficiente quanto "
+"imperativo equivalente implementazioni."
 
-#: src/traits/from-iterator.md:1
+#: src/traits/iterator.md:37
 #, fuzzy
-msgid "# FromIterator"
-msgstr "# FromIterator"
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
+"`IntoIterator` è la caratteristica che fa funzionare i cicli for. È "
+"implementato da tipi di raccolta come `Vec<T>` e riferimenti ad essi come "
+"`&Vec<T>` e `&[T]`. Anche le gamme lo implementano. Ecco perché puoi iterare "
+"su un vettore con `for i in some_vec { .. }` ma `some_vec.next()` non esiste."
 
 #: src/traits/from-iterator.md:3
 #, fuzzy
 msgid ""
-"[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
-"[`FromIterator`][1] consente di creare una raccolta da un [`Iterator`][2]."
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"consente di creare una raccolta da un [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 
 #: src/traits/from-iterator.md:5
 msgid ""
@@ -10048,40 +10474,37 @@ msgstr ""
 #: src/traits/from-iterator.md:17
 #, fuzzy
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"Implementa `Iterator`\n"
-"`fn collect<B>(self) -> B\n"
-"Dove\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Sé: dimensionato`"
+"Implementa `Iterator` `fn collect<B>(self) -> B Dove B: FromIterator<Self::"
+"Item>, Sé: dimensionato`"
 
 #: src/traits/from-iterator.md:23
 #, fuzzy
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 "Ci sono anche implementazioni che ti permettono di fare cose interessanti "
-"come convertire un file\n"
-"`Iterator<Item = Result<V, E>>` in un `Result<Vec<V>, E>`."
+"come convertire un file `Iterator<Item = Result<V, E>>` in un "
+"`Result<Vec<V>, E>`."
 
 #: src/traits/from-into.md:1
 #, fuzzy
-msgid "# `From` and `Into`"
-msgstr "# `Da` e `Into`"
+msgid "`From` and `Into`"
+msgstr "`Da` e `Into`"
 
 #: src/traits/from-into.md:3
 #, fuzzy
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
-"I tipi implementano [`From`][1] e [`Into`][2] per facilitare le conversioni "
-"di tipo:"
+"I tipi implementano [`From`](https://doc.rust-lang.org/std/convert/trait."
+"From.html) e [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) "
+"per facilitare le conversioni di tipo:"
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -10099,10 +10522,13 @@ msgstr ""
 #: src/traits/from-into.md:15
 #, fuzzy
 msgid ""
-"[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
-"[`Into`][2] viene implementato automaticamente quando [`From`][1] è "
-"implementato:"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) viene "
+"implementato automaticamente quando [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) è implementato:"
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -10120,33 +10546,40 @@ msgstr ""
 #: src/traits/from-into.md:29
 #, fuzzy
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
 msgstr ""
-"* Ecco perché è comune implementare solo `From`, poiché anche il tuo tipo "
-"otterrà l'implementazione di `Into`.\n"
-"* Quando si dichiara un tipo di input per l'argomento di una funzione come "
+"Ecco perché è comune implementare solo `From`, poiché anche il tuo tipo "
+"otterrà l'implementazione di `Into`."
+
+#: src/traits/from-into.md:30
+#, fuzzy
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
+msgstr ""
+"Quando si dichiara un tipo di input per l'argomento di una funzione come "
 "\"qualsiasi cosa che può essere convertita in una `Stringa`\", la regola è "
-"opposta, si dovrebbe usare `Into`.\n"
-"  La tua funzione accetterà tipi che implementano `From` e quelli che _solo_ "
-"implementano `Into`.\n"
-"    "
+"opposta, si dovrebbe usare `Into`. La tua funzione accetterà tipi che "
+"implementano `From` e quelli che _solo_ implementano `Into`."
 
 #: src/traits/read-write.md:1
 #, fuzzy
-msgid "# `Read` and `Write`"
-msgstr "# `Leggi` e `Scrivi`"
+msgid "`Read` and `Write`"
+msgstr "`Leggi` e `Scrivi`"
 
 #: src/traits/read-write.md:3
 #, fuzzy
 msgid ""
-"Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
-msgstr "Usando [`Read`][1] e [`BufRead`][2], puoi astrarre su fonti `u8`:"
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr ""
+"Usando [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) e "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), puoi "
+"astrarre su fonti `u8`:"
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -10171,8 +10604,12 @@ msgstr ""
 
 #: src/traits/read-write.md:23
 #, fuzzy
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
-msgstr "Allo stesso modo, [`Write`][3] ti consente di astrarre sui sink `u8`:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
+msgstr ""
+"Allo stesso modo, [`Write`](https://doc.rust-lang.org/std/io/trait.Write."
+"html) ti consente di astrarre sui sink `u8`:"
 
 #: src/traits/read-write.md:25
 msgid ""
@@ -10196,17 +10633,18 @@ msgstr ""
 
 #: src/traits/drop.md:1
 #, fuzzy
-msgid "# The `Drop` Trait"
-msgstr "# Il tratto `Drop`"
+msgid "The `Drop` Trait"
+msgstr "Il tratto `Drop`"
 
 #: src/traits/drop.md:3
 #, fuzzy
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
-"I valori che implementano [`Drop`][1] possono specificare il codice da "
-"eseguire quando escono dall'ambito:"
+"I valori che implementano [`Drop`](https://doc.rust-lang.org/std/ops/trait."
+"Drop.html) possono specificare il codice da eseguire quando escono "
+"dall'ambito:"
 
 #: src/traits/drop.md:5
 msgid ""
@@ -10245,33 +10683,37 @@ msgstr "Punti di discussione:"
 
 #: src/traits/drop.md:36
 #, fuzzy
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "Perché `Drop::drop` non accetta `self`?"
+
+#: src/traits/drop.md:37
+#, fuzzy
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
-"* Perché `Drop::drop` non accetta `self`?\n"
-"    * Risposta breve: se così fosse, `std::mem::drop` verrebbe chiamato alla "
-"fine di\n"
-"        il blocco, risultando in un'altra chiamata a `Drop::drop` e uno "
-"stack\n"
-"        traboccare!\n"
-"* Prova a sostituire `drop(a)` con `a.drop()`."
+"Risposta breve: se così fosse, `std::mem::drop` verrebbe chiamato alla fine "
+"di il blocco, risultando in un'altra chiamata a `Drop::drop` e uno stack "
+"traboccare!"
+
+#: src/traits/drop.md:40
+#, fuzzy
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "Prova a sostituire `drop(a)` con `a.drop()`."
 
 #: src/traits/default.md:1
 #, fuzzy
-msgid "# The `Default` Trait"
-msgstr "# Il tratto `Predefinito`"
+msgid "The `Default` Trait"
+msgstr "Il tratto `Predefinito`"
 
 #: src/traits/default.md:3
 #, fuzzy
-msgid "[`Default`][1] trait produces a default value for a type."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
 msgstr ""
-"Il tratto [`Default`][1] fornisce un'implementazione predefinita di un "
-"tratto."
+"Il tratto [`Default`](https://doc.rust-lang.org/std/default/trait.Default."
+"html) fornisce un'implementazione predefinita di un tratto."
 
 #: src/traits/default.md:5
 msgid ""
@@ -10312,40 +10754,63 @@ msgstr ""
 #: src/traits/default.md:40
 #, fuzzy
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * A derived implementation will produce a value where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e."
-"g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr ""
+"Può essere implementato direttamente o può essere derivato tramite "
+"`#[derive(Default)]`."
+
+#: src/traits/default.md:41
+#, fuzzy
+msgid ""
+"A derived implementation will produce a value where all fields are set to "
+"their default values."
+msgstr ""
+"L'implementazione derivata produrrà un'istanza in cui tutti i campi sono "
+"impostati sui valori predefiniti."
+
+#: src/traits/default.md:42
+#, fuzzy
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+"Ciò significa che anche tutti i tipi nella struttura devono implementare "
+"`Default`."
+
+#: src/traits/default.md:43
+#, fuzzy
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+"I tipi Rust standard spesso implementano `Default` con valori ragionevoli "
+"(ad esempio `0`, `\"\"`, ecc.)."
+
+#: src/traits/default.md:44
+#, fuzzy
+msgid "The partial struct copy works nicely with default."
+msgstr "La copia parziale della struttura funziona bene con default."
+
+#: src/traits/default.md:45
+#, fuzzy
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
-"  * Può essere implementato direttamente o può essere derivato tramite "
-"`#[derive(Default)]`.\n"
-"  * L'implementazione derivata produrrà un'istanza in cui tutti i campi sono "
-"impostati sui valori predefiniti.\n"
-"    * Ciò significa che anche tutti i tipi nella struttura devono "
-"implementare `Default`.\n"
-"  * I tipi Rust standard spesso implementano `Default` con valori "
-"ragionevoli (ad esempio `0`, `\"\"`, ecc.).\n"
-"  * La copia parziale della struttura funziona bene con default.\n"
-"  * La libreria standard di Rust sa che i tipi possono implementare "
-"`Default` e fornisce comodi metodi che lo utilizzano."
+"La libreria standard di Rust sa che i tipi possono implementare `Default` e "
+"fornisce comodi metodi che lo utilizzano."
 
 #: src/traits/operators.md:1
 #, fuzzy
-msgid "# `Add`, `Mul`, ..."
-msgstr "# `Aggiungi`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
+msgstr "`Aggiungi`, `Mul`, ..."
 
 #: src/traits/operators.md:3
 #, fuzzy
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
 "L'overload degli operatori è implementato tramite i tratti in [`std::ops`]"
-"[1]:"
+"(https://doc.rust-lang.org/std/ops/index.html):"
 
 #: src/traits/operators.md:5
 msgid ""
@@ -10372,59 +10837,66 @@ msgstr ""
 #: src/traits/operators.md:28
 #, fuzzy
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter of "
-"the method?\n"
-"    * Short answer: Function type parameters are controlled by the caller, "
-"but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait.\n"
-"* You could implement `Add` for two different types, e.g.\n"
-"  `impl Add<(i32, i32)> for Point` would add a tuple to a `Point`."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
 msgstr ""
-"* Puoi implementare `Aggiungi` per `&Punto`. In quali situazioni è utile?\n"
-"    * Risposta: `Add:add` consuma `self`. Se digita \"T\" per cui sei\n"
-"        l'overloading dell'operatore non è `Copy`, dovresti considerare "
-"l'overloading\n"
-"        anche l'operatore per `&T`. Ciò evita inutili clonazioni sul file\n"
-"        sito di chiamata.\n"
-"* Perché `Output` è un tipo associato? Potrebbe essere reso un parametro di "
-"tipo?\n"
-"    * Risposta breve: i parametri di tipo sono controllati dal chiamante, "
-"ma\n"
-"        i tipi associati (come `Output`) sono controllati "
-"dall'implementatore di a\n"
-"        tratto."
+"Puoi implementare `Aggiungi` per `&Punto`. In quali situazioni è utile?"
+
+#: src/traits/operators.md:29
+#, fuzzy
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"Risposta: `Add:add` consuma `self`. Se digita \"T\" per cui sei "
+"l'overloading dell'operatore non è `Copy`, dovresti considerare "
+"l'overloading anche l'operatore per `&T`. Ciò evita inutili clonazioni sul "
+"file sito di chiamata."
+
+#: src/traits/operators.md:33
+#, fuzzy
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr ""
+"Perché `Output` è un tipo associato? Potrebbe essere reso un parametro di "
+"tipo?"
+
+#: src/traits/operators.md:34
+#, fuzzy
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementor of a "
+"trait."
+msgstr ""
+"Risposta breve: i parametri di tipo sono controllati dal chiamante, ma i "
+"tipi associati (come `Output`) sono controllati dall'implementatore di a "
+"tratto."
+
+#: src/traits/operators.md:37
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
+msgstr ""
 
 #: src/traits/closures.md:1
 #, fuzzy
-msgid "# Closures"
-msgstr "# Chiusure"
+msgid "Closures"
+msgstr "Chiusure"
 
 #: src/traits/closures.md:3
 #, fuzzy
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 "Le chiusure o le espressioni lambda hanno tipi che non possono essere "
-"nominati. Tuttavia, loro\n"
-"implementare speciali [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
-"html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) e\n"
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) "
-"caratteristiche:"
+"nominati. Tuttavia, loro implementare speciali [`Fn`](https://doc.rust-lang."
+"org/std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/"
+"trait.FnMut.html) e [`FnOnce`](https://doc.rust-lang.org/std/ops/trait."
+"FnOnce.html) caratteristiche:"
 
 #: src/traits/closures.md:8
 msgid ""
@@ -10457,19 +10929,17 @@ msgstr ""
 #, fuzzy
 msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
-"perhaps captures\n"
-"nothing at all. It can be called multiple times concurrently."
+"perhaps captures nothing at all. It can be called multiple times "
+"concurrently."
 msgstr ""
 "Un \"Fn\" non consuma né muta i valori acquisiti, o forse non cattura nulla, "
-"quindi può farlo\n"
-"essere chiamato più volte contemporaneamente."
+"quindi può farlo essere chiamato più volte contemporaneamente."
 
 #: src/traits/closures.md:37
 #, fuzzy
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
-"multiple times,\n"
-"but not concurrently."
+"multiple times, but not concurrently."
 msgstr ""
 "Un `FnMut` potrebbe mutare i valori catturati, quindi puoi chiamarlo più "
 "volte ma non contemporaneamente."
@@ -10478,8 +10948,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
-"might consume\n"
-"captured values."
+"might consume captured values."
 msgstr ""
 "Se hai un `FnOnce`, puoi chiamarlo solo una volta. Potrebbe consumare i "
 "valori acquisiti."
@@ -10488,29 +10957,23 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 "\"FnMut\" è un sottotipo di \"FnOnce\". \"Fn\" è un sottotipo di \"FnMut\" e "
-"\"FnOnce\". Cioè. puoi usare un\n"
-"`FnMut` ovunque sia richiesto un `FnOnce` e puoi usare un `Fn` ovunque sia "
-"`FnMut` o `FnOnce`\n"
-"è richiesto."
+"\"FnOnce\". Cioè. puoi usare un `FnMut` ovunque sia richiesto un `FnOnce` e "
+"puoi usare un `Fn` ovunque sia `FnMut` o `FnOnce` è richiesto."
 
 #: src/traits/closures.md:47
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
-"`multiply_sum`),\n"
-"depending on what the closure captures."
+"`multiply_sum`), depending on what the closure captures."
 msgstr ""
 
 #: src/traits/closures.md:50
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
-"keyword makes them capture\n"
-"by value."
+"keyword makes them capture by value."
 msgstr ""
 
 #: src/traits/closures.md:52
@@ -10529,28 +10992,22 @@ msgstr ""
 
 #: src/exercises/day-3/morning.md:1
 #, fuzzy
-msgid "# Day 3: Morning Exercises"
-msgstr "# Giorno 3: Esercizi mattutini"
+msgid "Day 3: Morning Exercises"
+msgstr "Giorno 3: Esercizi mattutini"
 
 #: src/exercises/day-3/morning.md:3
 #, fuzzy
 msgid "We will design a classical GUI library traits and trait objects."
 msgstr "Progetteremo una libreria GUI classica di tratti e oggetti di tratto."
 
-#: src/exercises/day-3/simple-gui.md:1
-#, fuzzy
-msgid "# A Simple GUI Library"
-msgstr "# Una semplice libreria GUI"
-
 #: src/exercises/day-3/simple-gui.md:3
 #, fuzzy
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 "Progettiamo una libreria GUI classica utilizzando la nostra nuova conoscenza "
-"dei tratti e\n"
-"oggetti di tratto."
+"dei tratti e oggetti di tratto."
 
 #: src/exercises/day-3/simple-gui.md:6
 #, fuzzy
@@ -10559,17 +11016,22 @@ msgstr "Avremo una serie di widget nella nostra libreria:"
 
 #: src/exercises/day-3/simple-gui.md:8
 #, fuzzy
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr "`Window`: ha un `title` e contiene altri widget."
+
+#: src/exercises/day-3/simple-gui.md:9
+#, fuzzy
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
 msgstr ""
-"* `Window`: ha un `title` e contiene altri widget.\n"
-"* `Button`: ha una `label` e una funzione di callback che viene richiamata "
-"quando il\n"
-"  pulsante viene premuto.\n"
-"* `Etichetta`: ha una `etichetta`."
+"`Button`: ha una `label` e una funzione di callback che viene richiamata "
+"quando il pulsante viene premuto."
+
+#: src/exercises/day-3/simple-gui.md:11
+#, fuzzy
+msgid "`Label`: has a `label`."
+msgstr "`Etichetta`: ha una `etichetta`."
 
 #: src/exercises/day-3/simple-gui.md:13
 #, fuzzy
@@ -10579,12 +11041,11 @@ msgstr "I widget implementeranno un tratto `Widget`, vedi sotto."
 #: src/exercises/day-3/simple-gui.md:15
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 "Copia il codice qui sotto in <https://play.rust-lang.org/>, inserisci i "
-"campi mancanti\n"
-"metodi `draw_into` in modo da implementare il tratto `Widget`:"
+"campi mancanti metodi `draw_into` in modo da implementare il tratto `Widget`:"
 
 #: src/exercises/day-3/simple-gui.md:18
 msgid ""
@@ -10724,18 +11185,15 @@ msgstr ""
 #: src/exercises/day-3/simple-gui.md:142
 #, fuzzy
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
-"Se vuoi disegnare un testo allineato, puoi usare il\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"operatori di formattazione. In particolare, nota come puoi riempire con "
-"diversi\n"
-"caratteri (qui un `'/'`) e come puoi controllare l'allineamento:"
+"Se vuoi disegnare un testo allineato, puoi usare il [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) operatori di "
+"formattazione. In particolare, nota come puoi riempire con diversi caratteri "
+"(qui un `'/'`) e come puoi controllare l'allineamento:"
 
 #: src/exercises/day-3/simple-gui.md:147
 msgid ""
@@ -10771,11 +11229,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-#, fuzzy
-msgid "# Error Handling"
-msgstr "# Gestione degli errori"
-
 #: src/error-handling.md:3
 #, fuzzy
 msgid "Error handling in Rust is done using explicit control flow:"
@@ -10785,18 +11238,14 @@ msgstr ""
 
 #: src/error-handling.md:5
 #, fuzzy
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
+msgid "Functions that can have errors list this in their return type,"
 msgstr ""
-"* Le funzioni che possono avere errori lo elencano nel loro tipo di "
-"ritorno,\n"
-"* Non ci sono eccezioni."
+"Le funzioni che possono avere errori lo elencano nel loro tipo di ritorno,"
 
-#: src/error-handling/panics.md:1
+#: src/error-handling.md:6
 #, fuzzy
-msgid "# Panics"
-msgstr "# Panico"
+msgid "There are no exceptions."
+msgstr "Non ci sono eccezioni."
 
 #: src/error-handling/panics.md:3
 #, fuzzy
@@ -10817,19 +11266,24 @@ msgstr ""
 
 #: src/error-handling/panics.md:12
 #, fuzzy
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "I panico sono per errori irrecuperabili e imprevisti."
+
+#: src/error-handling/panics.md:13
+#, fuzzy
+msgid "Panics are symptoms of bugs in the program."
+msgstr "I panici sono sintomi di bug nel programma."
+
+#: src/error-handling/panics.md:14
+#, fuzzy
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
-msgstr ""
-"* I panico sono per errori irrecuperabili e imprevisti.\n"
-"  * I panici sono sintomi di bug nel programma.\n"
-"* Usa API senza panico (come `Vec::get`) se il crash non è accettabile."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+msgstr "Usa API senza panico (come `Vec::get`) se il crash non è accettabile."
 
 #: src/error-handling/panic-unwind.md:1
 #, fuzzy
-msgid "# Catching the Stack Unwinding"
-msgstr "# Catturare lo srotolamento della pila"
+msgid "Catching the Stack Unwinding"
+msgstr "Catturare lo srotolamento della pila"
 
 #: src/error-handling/panic-unwind.md:3
 #, fuzzy
@@ -10862,30 +11316,31 @@ msgstr ""
 #: src/error-handling/panic-unwind.md:21
 #, fuzzy
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* Questo può essere utile nei server che dovrebbero continuare a funzionare "
-"anche se un singolo\n"
-"  la richiesta va in crash.\n"
-"* Questo non funziona se `panic = 'abort'` è impostato nel tuo `Cargo.toml`."
+"Questo può essere utile nei server che dovrebbero continuare a funzionare "
+"anche se un singolo la richiesta va in crash."
+
+#: src/error-handling/panic-unwind.md:23
+#, fuzzy
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+"Questo non funziona se `panic = 'abort'` è impostato nel tuo `Cargo.toml`."
 
 #: src/error-handling/result.md:1
 #, fuzzy
-msgid "# Structured Error Handling with `Result`"
-msgstr "# Gestione strutturata degli errori con `Result`"
+msgid "Structured Error Handling with `Result`"
+msgstr "Gestione strutturata degli errori con `Result`"
 
 #: src/error-handling/result.md:3
 #, fuzzy
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
 "Abbiamo già visto l'enumerazione `Result`. Questo è usato in modo pervasivo "
-"quando ci sono errori\n"
-"previsto come parte del normale funzionamento:"
+"quando ci sono errori previsto come parte del normale funzionamento:"
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10912,45 +11367,41 @@ msgstr ""
 #: src/error-handling/result.md:27
 #, fuzzy
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
 msgstr ""
-"  * Come con `Option`, il valore riuscito si trova all'interno di `Result`, "
-"costringendo lo sviluppatore a farlo\n"
-"    estrarlo esplicitamente. Questo incoraggia il controllo degli errori. "
-"Nel caso in cui non dovesse mai verificarsi un errore,\n"
-"    È possibile chiamare `unwrap()` o `expect()`, e anche questo è un "
-"segnale dell'intenzione dello sviluppatore.\n"
-"  * La documentazione `Result` è una lettura consigliata. Non durante il "
-"corso, ma vale la pena menzionarlo.\n"
-"    Contiene molti metodi e funzioni utili che aiutano la programmazione in "
-"stile funzionale.\n"
-"    "
+"Come con `Option`, il valore riuscito si trova all'interno di `Result`, "
+"costringendo lo sviluppatore a farlo estrarlo esplicitamente. Questo "
+"incoraggia il controllo degli errori. Nel caso in cui non dovesse mai "
+"verificarsi un errore, È possibile chiamare `unwrap()` o `expect()`, e anche "
+"questo è un segnale dell'intenzione dello sviluppatore."
+
+#: src/error-handling/result.md:30
+#, fuzzy
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr ""
+"La documentazione `Result` è una lettura consigliata. Non durante il corso, "
+"ma vale la pena menzionarlo. Contiene molti metodi e funzioni utili che "
+"aiutano la programmazione in stile funzionale."
 
 #: src/error-handling/try-operator.md:1
 #, fuzzy
-msgid "# Propagating Errors with `?`"
-msgstr "# Propagazione degli errori con `?`"
+msgid "Propagating Errors with `?`"
+msgstr "Propagazione degli errori con `?`"
 
 #: src/error-handling/try-operator.md:3
 #, fuzzy
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
+"turn the common"
 msgstr ""
 "L'operatore try `?` viene utilizzato per restituire errori al chiamante. Ti "
-"fa girare\n"
-"il comune"
+"fa girare il comune"
 
 #: src/error-handling/try-operator.md:6
 msgid ""
@@ -11011,20 +11462,18 @@ msgstr ""
 #: src/error-handling/try-operator.md:50
 #: src/error-handling/converting-error-types-example.md:52
 #, fuzzy
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
-msgstr ""
-"* La variabile `username` può essere `Ok(string)` o `Err(error)`.\n"
-"* Usa la chiamata `fs::write` per testare i diversi scenari: nessun file, "
-"file vuoto, file con nome utente."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr "La variabile `username` può essere `Ok(string)` o `Err(error)`."
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
 #, fuzzy
-msgid "# Converting Error Types"
-msgstr "# Conversione dei tipi di errore"
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
+"Usa la chiamata `fs::write` per testare i diversi scenari: nessun file, file "
+"vuoto, file con nome utente."
 
 #: src/error-handling/converting-error-types.md:3
 #, fuzzy
@@ -11060,13 +11509,11 @@ msgstr ""
 #: src/error-handling/converting-error-types.md:18
 #, fuzzy
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
 "La chiamata `From::from` qui significa che tentiamo di convertire il tipo di "
-"errore in\n"
-"tipo restituito dalla funzione:"
+"errore in tipo restituito dalla funzione:"
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -11121,36 +11568,25 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
 msgstr ""
 "È buona pratica per tutti i tipi di errore implementare `std::error::Error`, "
-"che richiede `Debug` e\n"
-"`Display`. In genere è utile per loro implementare anche `Clone` e `Eq`, ove "
-"possibile, per fare\n"
-"vita più facile per i test e i consumatori della tua libreria. In questo "
-"caso non possiamo farlo facilmente, perché\n"
-"`io::Error` non li implementa."
-
-#: src/error-handling/deriving-error-enums.md:1
-#, fuzzy
-msgid "# Deriving Error Enums"
-msgstr "# Derivazione delle enumerazioni degli errori"
+"che richiede `Debug` e `Display`. In genere è utile per loro implementare "
+"anche `Clone` e `Eq`, ove possibile, per fare vita più facile per i test e i "
+"consumatori della tua libreria. In questo caso non possiamo farlo "
+"facilmente, perché `io::Error` non li implementa."
 
 #: src/error-handling/deriving-error-enums.md:3
 #, fuzzy
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
 "Il crate [thiserror](https://docs.rs/thiserror/) è un modo popolare per "
-"creare un\n"
-"error enum come abbiamo fatto nella pagina precedente:"
+"creare un error enum come abbiamo fatto nella pagina precedente:"
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -11190,15 +11626,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 "La macro deriva di `thiserror` implementa automaticamente `std::error::"
-"Error` e facoltativamente `Display`\n"
-"(se vengono forniti gli attributi `#[error(...)]`) e `From` (se viene "
-"aggiunto l'attributo `#[from]`).\n"
+"Error` e facoltativamente `Display` (se vengono forniti gli attributi "
+"`#[error(...)]`) e `From` (se viene aggiunto l'attributo `#[from]`). "
 "Funziona anche per le strutture."
 
 #: src/error-handling/deriving-error-enums.md:43
@@ -11207,21 +11640,16 @@ msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr ""
 "Non influisce sulla tua API pubblica, il che lo rende utile per le librerie."
 
-#: src/error-handling/dynamic-errors.md:1
-#, fuzzy
-msgid "# Dynamic Error Types"
-msgstr "# Tipi di errori dinamici"
-
 #: src/error-handling/dynamic-errors.md:3
 #, fuzzy
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 "A volte vogliamo consentire la restituzione di qualsiasi tipo di errore "
-"senza scrivere la nostra copertura enum\n"
-"tutte le diverse possibilità. `std::error::Error` lo rende facile."
+"senza scrivere la nostra copertura enum tutte le diverse possibilità. `std::"
+"error::Error` lo rende facile."
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -11258,37 +11686,28 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
 "Ciò consente di risparmiare sul codice, ma rinuncia alla possibilità di "
-"gestire in modo pulito diversi casi di errore in modo diverso\n"
-"il programma. Pertanto, generalmente non è una buona idea utilizzare "
-"`Box<dyn Error>` nell'API pubblica di a\n"
-"library, ma può essere una buona opzione in un programma in cui si desidera "
-"solo visualizzare il messaggio di errore\n"
-"in qualche luogo."
-
-#: src/error-handling/error-contexts.md:1
-#, fuzzy
-msgid "# Adding Context to Errors"
-msgstr "# Aggiunta di contesto agli errori"
+"gestire in modo pulito diversi casi di errore in modo diverso il programma. "
+"Pertanto, generalmente non è una buona idea utilizzare `Box<dyn Error>` "
+"nell'API pubblica di a library, ma può essere una buona opzione in un "
+"programma in cui si desidera solo visualizzare il messaggio di errore in "
+"qualche luogo."
 
 #: src/error-handling/error-contexts.md:3
 #, fuzzy
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 "La cassa ampiamente utilizzata [comunque](https://docs.rs/anyhow/) può "
-"aiutarti ad aggiungere\n"
-"informazioni contestuali ai tuoi errori e ti permette di averne meno\n"
-"tipi di errore personalizzati:"
+"aiutarti ad aggiungere informazioni contestuali ai tuoi errori e ti permette "
+"di averne meno tipi di errore personalizzati:"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -11321,34 +11740,40 @@ msgstr ""
 
 #: src/error-handling/error-contexts.md:35
 #, fuzzy
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
-"* `comunque::Risultato<V>` è un alias di tipo per `Risultato<V, comunque::"
-"Errore>`.\n"
-"* `anyhow::Error` è essenzialmente un wrapper attorno a `Box<dyn Error>`. In "
-"quanto tale, generalmente non lo è\n"
-"  una buona scelta per l'API pubblica di una libreria, ma è ampiamente "
-"utilizzata nelle applicazioni.\n"
-"* Il tipo di errore effettivo all'interno di esso può essere estratto per "
-"l'esame, se necessario.\n"
-"* La funzionalità fornita da `anyhow::Result<T>` potrebbe essere familiare "
-"agli sviluppatori Go, in quanto fornisce\n"
-"  modelli di utilizzo ed ergonomia simili a `(T, errore)` di Go."
+"`comunque::Risultato<V>` è un alias di tipo per `Risultato<V, comunque::"
+"Errore>`."
 
-#: src/testing.md:1
+#: src/error-handling/error-contexts.md:36
 #, fuzzy
-msgid "# Testing"
-msgstr "# Test"
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+"`anyhow::Error` è essenzialmente un wrapper attorno a `Box<dyn Error>`. In "
+"quanto tale, generalmente non lo è una buona scelta per l'API pubblica di "
+"una libreria, ma è ampiamente utilizzata nelle applicazioni."
+
+#: src/error-handling/error-contexts.md:38
+#, fuzzy
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+"Il tipo di errore effettivo all'interno di esso può essere estratto per "
+"l'esame, se necessario."
+
+#: src/error-handling/error-contexts.md:39
+#, fuzzy
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"La funzionalità fornita da `anyhow::Result<T>` potrebbe essere familiare "
+"agli sviluppatori Go, in quanto fornisce modelli di utilizzo ed ergonomia "
+"simili a `(T, errore)` di Go."
 
 #: src/testing.md:3
 #, fuzzy
@@ -11357,19 +11782,13 @@ msgstr "Rust e Cargo sono dotati di un semplice framework di unit test:"
 
 #: src/testing.md:5
 #, fuzzy
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
-msgstr ""
-"* I test unitari sono supportati in tutto il codice.\n"
-"\n"
-"* I test di integrazione sono supportati tramite la directory `tests/`."
+msgid "Unit tests are supported throughout your code."
+msgstr "I test unitari sono supportati in tutto il codice."
 
-#: src/testing/unit-tests.md:1
+#: src/testing.md:7
 #, fuzzy
-msgid "# Unit Tests"
-msgstr "# Test unitari"
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr "I test di integrazione sono supportati tramite la directory `tests/`."
 
 #: src/testing/unit-tests.md:3
 #, fuzzy
@@ -11408,20 +11827,14 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr "Usa `cargo test` per trovare ed eseguire i test unitari."
 
-#: src/testing/test-modules.md:1
-#, fuzzy
-msgid "# Test Modules"
-msgstr "# Moduli di prova"
-
 #: src/testing/test-modules.md:3
 #, fuzzy
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 "I test unitari vengono spesso inseriti in un modulo nidificato (esegui test "
-"sul file\n"
-"[Parco giochi](https://play.rust-lang.org/)):"
+"sul file [Parco giochi](https://play.rust-lang.org/)):"
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -11448,17 +11861,13 @@ msgstr ""
 
 #: src/testing/test-modules.md:26
 #, fuzzy
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
-msgstr ""
-"* Questo ti consente di testare unitamente gli aiutanti privati.\n"
-"* L'attributo `#[cfg(test)]` è attivo solo quando esegui `cargo test`."
+msgid "This lets you unit test private helpers."
+msgstr "Questo ti consente di testare unitamente gli aiutanti privati."
 
-#: src/testing/doc-tests.md:1
+#: src/testing/test-modules.md:27
 #, fuzzy
-msgid "# Documentation Tests"
-msgstr "# Test di documentazione"
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr "L'attributo `#[cfg(test)]` è attivo solo quando esegui `cargo test`."
 
 #: src/testing/doc-tests.md:3
 #, fuzzy
@@ -11483,23 +11892,24 @@ msgstr ""
 
 #: src/testing/doc-tests.md:18
 #, fuzzy
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr ""
+"I blocchi di codice nei commenti `///` sono visti automaticamente come "
+"codice Rust."
+
+#: src/testing/doc-tests.md:19
+#, fuzzy
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "Il codice verrà compilato ed eseguito come parte di `cargo test`."
+
+#: src/testing/doc-tests.md:20
+#, fuzzy
 msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"* I blocchi di codice nei commenti `///` sono visti automaticamente come "
-"codice Rust.\n"
-"* Il codice verrà compilato ed eseguito come parte di `cargo test`.\n"
-"* Prova il codice precedente su [Rust Playground](https://play.rust-lang."
-"org/?"
+"Prova il codice precedente su [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
-
-#: src/testing/integration-tests.md:1
-#, fuzzy
-msgid "# Integration Tests"
-msgstr "# Test di integrazione"
 
 #: src/testing/integration-tests.md:3
 #, fuzzy
@@ -11532,8 +11942,8 @@ msgstr "Questi test hanno accesso solo all'API pubblica del tuo crate."
 
 #: src/testing/useful-crates.md:1
 #, fuzzy
-msgid "## Useful crates for writing tests"
-msgstr "# Casse utili"
+msgid "Useful crates for writing tests"
+msgstr "Casse utili"
 
 #: src/testing/useful-crates.md:3
 #, fuzzy
@@ -11546,17 +11956,19 @@ msgstr ""
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
-"tests."
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
 msgstr ""
 
-#: src/unsafe.md:1
-#, fuzzy
-msgid "# Unsafe Rust"
-msgstr "# Ruggine non sicura"
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr ""
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
+msgstr ""
 
 #: src/unsafe.md:3
 #, fuzzy
@@ -11565,35 +11977,37 @@ msgstr "Il linguaggio Rust ha due parti:"
 
 #: src/unsafe.md:5
 #, fuzzy
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr ""
+"**Safe Rust:** memoria sicura, nessun comportamento indefinito possibile."
+
+#: src/unsafe.md:6
+#, fuzzy
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
-"* **Safe Rust:** memoria sicura, nessun comportamento indefinito possibile.\n"
-"* **Unsafe Rust:** può attivare un comportamento indefinito se vengono "
-"violate le precondizioni."
+"**Unsafe Rust:** può attivare un comportamento indefinito se vengono violate "
+"le precondizioni."
 
 #: src/unsafe.md:8
 #, fuzzy
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr ""
-"Vedremo Rust per lo più sicuro in questo corso, ma è importante saperlo\n"
+"Vedremo Rust per lo più sicuro in questo corso, ma è importante saperlo "
 "cos'è Unsafe Rust."
 
 #: src/unsafe.md:11
 #, fuzzy
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 "Il codice non sicuro è solitamente piccolo e isolato e la sua correttezza "
-"dovrebbe essere attentamente\n"
-"documentato. Di solito è racchiuso in uno strato di astrazione sicuro."
+"dovrebbe essere attentamente documentato. Di solito è racchiuso in uno "
+"strato di astrazione sicuro."
 
 #: src/unsafe.md:14
 #, fuzzy
@@ -11602,54 +12016,53 @@ msgstr "Unsafe Rust ti dà accesso a cinque nuove funzionalità:"
 
 #: src/unsafe.md:16
 #, fuzzy
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
-msgstr ""
-"* Dereferenzia i puntatori grezzi.\n"
-"* Accedi o modifica variabili statiche mutabili.\n"
-"* Accedi ai campi `union`.\n"
-"* Richiama funzioni `non sicure`, comprese le funzioni `extern`.\n"
-"* Implementa i tratti \"non sicuri\"."
+msgid "Dereference raw pointers."
+msgstr "Dereferenzia i puntatori grezzi."
+
+#: src/unsafe.md:17
+#, fuzzy
+msgid "Access or modify mutable static variables."
+msgstr "Accedi o modifica variabili statiche mutabili."
+
+#: src/unsafe.md:18
+#, fuzzy
+msgid "Access `union` fields."
+msgstr "Accedi ai campi `union`."
+
+#: src/unsafe.md:19
+#, fuzzy
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr "Richiama funzioni `non sicure`, comprese le funzioni `extern`."
+
+#: src/unsafe.md:20
+#, fuzzy
+msgid "Implement `unsafe` traits."
+msgstr "Implementa i tratti \"non sicuri\"."
 
 #: src/unsafe.md:22
 #, fuzzy
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
+"We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 "Tratteremo brevemente le capacità non sicure in seguito. Per tutti i "
-"dettagli, vedere\n"
-"[Capitolo 19.1 nel Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-"
-"rust.html)\n"
-"e il [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"dettagli, vedere [Capitolo 19.1 nel Rust Book](https://doc.rust-lang.org/"
+"book/ch19-01-unsafe-rust.html) e il [Rustonomicon](https://doc.rust-lang.org/"
+"nomicon/)."
 
 #: src/unsafe.md:28
 #, fuzzy
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
 "Unsafe Rust non significa che il codice non sia corretto. Significa che gli "
-"sviluppatori hanno\n"
-"ha disattivato le funzionalità di sicurezza del compilatore e deve scrivere "
-"il codice corretto\n"
-"loro stessi. Significa che il compilatore non applica più le regole di "
-"sicurezza della memoria di Rust."
-
-#: src/unsafe/raw-pointers.md:1
-#, fuzzy
-msgid "# Dereferencing Raw Pointers"
-msgstr "# Dereferenziazione dei puntatori grezzi"
+"sviluppatori hanno ha disattivato le funzionalità di sicurezza del "
+"compilatore e deve scrivere il codice corretto loro stessi. Significa che il "
+"compilatore non applica più le regole di sicurezza della memoria di Rust."
 
 #: src/unsafe/raw-pointers.md:3
 #, fuzzy
@@ -11686,47 +12099,57 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 "È buona norma (e richiesto dalla guida allo stile di Android Rust) scrivere "
-"un commento per ciascuno\n"
-"Blocco `unsafe` che spiega come il codice al suo interno soddisfi i "
-"requisiti di sicurezza dell'unsafe\n"
-"operazioni che sta compiendo."
+"un commento per ciascuno Blocco `unsafe` che spiega come il codice al suo "
+"interno soddisfi i requisiti di sicurezza dell'unsafe operazioni che sta "
+"compiendo."
 
 #: src/unsafe/raw-pointers.md:31
 #, fuzzy
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 "Nel caso di dereferenze puntatore, ciò significa che i puntatori devono "
-"essere\n"
-"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), ovvero:"
+"essere [_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), "
+"ovvero:"
 
 #: src/unsafe/raw-pointers.md:34
 #, fuzzy
+msgid "The pointer must be non-null."
+msgstr "Il puntatore deve essere diverso da null."
+
+#: src/unsafe/raw-pointers.md:35
+#, fuzzy
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
 msgstr ""
-" * Il puntatore deve essere diverso da null.\n"
-" * Il puntatore deve essere _dereferenceable_ (entro i limiti di un singolo "
-"oggetto allocato).\n"
-" * L'oggetto non deve essere stato deallocato.\n"
-" * Non devono esserci accessi contemporanei alla stessa posizione.\n"
-" * Se il puntatore è stato ottenuto lanciando un riferimento, l'oggetto "
-"sottostante deve essere live e no\n"
-"   riferimento può essere utilizzato per accedere alla memoria."
+"Il puntatore deve essere _dereferenceable_ (entro i limiti di un singolo "
+"oggetto allocato)."
+
+#: src/unsafe/raw-pointers.md:36
+#, fuzzy
+msgid "The object must not have been deallocated."
+msgstr "L'oggetto non deve essere stato deallocato."
+
+#: src/unsafe/raw-pointers.md:37
+#, fuzzy
+msgid "There must not be concurrent accesses to the same location."
+msgstr "Non devono esserci accessi contemporanei alla stessa posizione."
+
+#: src/unsafe/raw-pointers.md:38
+#, fuzzy
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr ""
+"Se il puntatore è stato ottenuto lanciando un riferimento, l'oggetto "
+"sottostante deve essere live e no riferimento può essere utilizzato per "
+"accedere alla memoria."
 
 #: src/unsafe/raw-pointers.md:41
 #, fuzzy
@@ -11734,11 +12157,6 @@ msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 "Nella maggior parte dei casi anche il puntatore deve essere correttamente "
 "allineato."
-
-#: src/unsafe/mutable-static-variables.md:1
-#, fuzzy
-msgid "# Mutable Static Variables"
-msgstr "# Variabili statiche mutabili"
 
 #: src/unsafe/mutable-static-variables.md:3
 #, fuzzy
@@ -11759,12 +12177,11 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:13
 #, fuzzy
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 "Tuttavia, poiché possono verificarsi corse di dati, non è sicuro leggere e "
-"scrivere mutabili\n"
-"variabili statiche:"
+"scrivere mutabili variabili statiche:"
 
 #: src/unsafe/mutable-static-variables.md:16
 msgid ""
@@ -11787,19 +12204,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 "L'uso di una statica mutabile è generalmente una cattiva idea, ma ci sono "
-"alcuni casi in cui potrebbe avere senso\n"
-"nel codice `no_std` di basso livello, come implementare un allocatore di "
-"heap o lavorare con alcune API C."
-
-#: src/unsafe/unions.md:1
-#, fuzzy
-msgid "# Unions"
-msgstr "# Sindacati"
+"alcuni casi in cui potrebbe avere senso nel codice `no_std` di basso "
+"livello, come implementare un allocatore di heap o lavorare con alcune API C."
 
 #: src/unsafe/unions.md:3
 #, fuzzy
@@ -11828,43 +12238,33 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 "Le unioni sono molto raramente necessarie in Rust poiché di solito puoi "
-"usare un enum. Occasionalmente sono necessari\n"
-"per interagire con le API della libreria C."
+"usare un enum. Occasionalmente sono necessari per interagire con le API "
+"della libreria C."
 
 #: src/unsafe/unions.md:24
 #, fuzzy
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
+"If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 "Se vuoi solo reinterpretare i byte come un tipo diverso, probabilmente lo "
-"vuoi\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) o una cassaforte\n"
-"wrapper come la cassa [`zerocopy`](https://crates.io/crates/zerocopy)."
-
-#: src/unsafe/calling-unsafe-functions.md:1
-#, fuzzy
-msgid "# Calling Unsafe Functions"
-msgstr "# Chiamata di funzioni non sicure"
+"vuoi [`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) o una cassaforte wrapper come la cassa [`zerocopy`](https://"
+"crates.io/crates/zerocopy)."
 
 #: src/unsafe/calling-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 "Una funzione o un metodo può essere contrassegnato come \"non sicuro\" se ha "
-"precondizioni aggiuntive\n"
-"deve sostenere per evitare comportamenti indefiniti:"
+"precondizioni aggiuntive deve sostenere per evitare comportamenti indefiniti:"
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
@@ -11896,21 +12296,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-#, fuzzy
-msgid "# Writing Unsafe Functions"
-msgstr "# Scrittura di funzioni non sicure"
-
 #: src/unsafe/writing-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
 "Puoi contrassegnare le tue funzioni come \"non sicure\" se richiedono "
-"condizioni particolari per evitare undefined\n"
-"comportamento."
+"condizioni particolari per evitare undefined comportamento."
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -11953,30 +12346,27 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 "Si noti che il codice non sicuro è consentito all'interno di una funzione "
-"non sicura senza un blocco `unsafe`. Noi possiamo\n"
-"proibiscilo con `#[deny(unsafe_op_in_unsafe_fn)]`. Prova ad aggiungerlo e "
-"guarda cosa succede."
+"non sicura senza un blocco `unsafe`. Noi possiamo proibiscilo con "
+"`#[deny(unsafe_op_in_unsafe_fn)]`. Prova ad aggiungerlo e guarda cosa "
+"succede."
 
 #: src/unsafe/extern-functions.md:1
 #, fuzzy
-msgid "# Calling External Code"
-msgstr "# Chiamata codice esterno"
+msgid "Calling External Code"
+msgstr "Chiamata codice esterno"
 
 #: src/unsafe/extern-functions.md:3
 #, fuzzy
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
 "Le funzioni di altri linguaggi potrebbero violare le garanzie di Rust. "
-"Chiamata\n"
-"loro è quindi pericoloso:"
+"Chiamata loro è quindi pericoloso:"
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
@@ -11998,48 +12388,37 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 "Questo di solito è solo un problema per le funzioni esterne che fanno cose "
-"con i puntatori che potrebbero\n"
-"violare il modello di memoria di Rust, ma in generale qualsiasi funzione C "
-"potrebbe avere un comportamento indefinito sotto qualsiasi\n"
-"circostanze arbitrarie."
+"con i puntatori che potrebbero violare il modello di memoria di Rust, ma in "
+"generale qualsiasi funzione C potrebbe avere un comportamento indefinito "
+"sotto qualsiasi circostanze arbitrarie."
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/"
-"external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-#, fuzzy
-msgid "# Implementing Unsafe Traits"
-msgstr "# Implementazione di tratti non sicuri"
 
 #: src/unsafe/unsafe-traits.md:3
 #, fuzzy
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 "Come con le funzioni, puoi contrassegnare un tratto come \"non sicuro\" se "
-"l'implementazione deve garantire\n"
-"condizioni particolari per evitare comportamenti indefiniti."
+"l'implementazione deve garantire condizioni particolari per evitare "
+"comportamenti indefiniti."
 
 #: src/unsafe/unsafe-traits.md:6
 #, fuzzy
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
-"Ad esempio, la cassa \"zerocopy\" ha un tratto non sicuro che sembra\n"
+"Ad esempio, la cassa \"zerocopy\" ha un tratto non sicuro che sembra "
 "[qualcosa del genere](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
 "html):"
 
@@ -12070,12 +12449,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
 "Dovrebbe esserci una sezione `# Safety` su Rustdoc per il tratto che spiega "
-"i requisiti per\n"
-"il tratto da implementare in modo sicuro."
+"i requisiti per il tratto da implementare in modo sicuro."
 
 #: src/unsafe/unsafe-traits.md:33
 #, fuzzy
@@ -12093,8 +12470,8 @@ msgstr "I tratti incorporati \"Invia\" e \"Sincronizza\" non sono sicuri."
 
 #: src/exercises/day-3/afternoon.md:1
 #, fuzzy
-msgid "# Day 3: Afternoon Exercises"
-msgstr "# Giorno 3: Esercizi pomeridiani"
+msgid "Day 3: Afternoon Exercises"
+msgstr "Giorno 3: Esercizi pomeridiani"
 
 #: src/exercises/day-3/afternoon.md:3
 #, fuzzy
@@ -12103,37 +12480,35 @@ msgstr "Costruiamo un wrapper sicuro per leggere il contenuto della directory!"
 
 #: src/exercises/day-3/afternoon.md:5
 msgid ""
-"For this exercise, we suggest using a local dev environment instead\n"
-"of the Playground. This will allow you to run your binary on your own "
-"machine."
+"For this exercise, we suggest using a local dev environment instead of the "
+"Playground. This will allow you to run your binary on your own machine."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:8
-msgid "To get started, follow the [running locally] instructions."
+msgid ""
+"To get started, follow the [running locally](../../cargo/running-locally.md) "
+"instructions."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:14
 #, fuzzy
-msgid "After looking at the exercise, you can look at the [solution] provided."
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
-"Dopo aver esaminato l'esercizio, puoi esaminare la [soluzione] fornita."
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-#, fuzzy
-msgid "# Safe FFI Wrapper"
-msgstr "# Wrapper FFI sicuro"
+"Dopo aver esaminato l'esercizio, puoi esaminare la \\[soluzione\\] fornita."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 #, fuzzy
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 "Rust ha un ottimo supporto per le funzioni di chiamata attraverso una "
-"funzione _foreign\n"
-"interfaccia_ (FFI). Lo useremo per costruire un wrapper sicuro per `libc`\n"
-"funzioni che useresti da C per leggere i nomi dei file di una directory."
+"funzione _foreign interfaccia_ (FFI). Lo useremo per costruire un wrapper "
+"sicuro per `libc` funzioni che useresti da C per leggere i nomi dei file di "
+"una directory."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:7
 #, fuzzy
@@ -12142,46 +12517,95 @@ msgstr "Ti consigliamo di consultare le pagine di manuale:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
 #, fuzzy
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
-msgstr ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+#, fuzzy
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+#, fuzzy
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 #, fuzzy
 msgid ""
-"You will also want to browse the [`std::ffi`] module. There you find a "
-"number of\n"
-"string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
-"Dovrai anche sfogliare il modulo [`std::ffi`]. Lì trovi un numero di\n"
-"tipi di stringa necessari per l'esercizio:"
+"Dovrai anche sfogliare il modulo [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/). Lì trovi un numero di tipi di stringa necessari per l'esercizio:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
 #, fuzzy
+msgid "Encoding"
+msgstr "Codifica"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+#, fuzzy
+msgid "Use"
+msgstr "Usa"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+#, fuzzy
 msgid ""
-"| Types                      | Encoding       | "
-"Use                            |\n"
-"|----------------------------|----------------|--------------------------------|\n"
-"| [`str`] and [`String`]     | UTF-8          | Text processing in "
-"Rust        |\n"
-"| [`CStr`] and [`CString`]   | NUL-terminated | Communicating with C "
-"functions |\n"
-"| [`OsStr`] and [`OsString`] | OS-specific    | Communicating with the "
-"OS      |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
 msgstr ""
-"| Tipi | Codifica | Usa |\n"
-"|----------------------------|----------------|--- "
-"-----------------------------|\n"
-"| [`str`] e [`String`] | UTF-8 | Elaborazione del testo in Rust |\n"
-"| [`CStr`] e [`CString`] | con terminazione NUL | Comunicare con le funzioni "
-"C |\n"
-"| [`OsStr`] e [`OsString`] | specifico del sistema operativo | Comunicazione "
-"con il sistema operativo |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) e [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+#, fuzzy
+msgid "UTF-8"
+msgstr "UTF-8"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+#, fuzzy
+msgid "Text processing in Rust"
+msgstr "Elaborazione del testo in Rust"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+#, fuzzy
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) e [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+#, fuzzy
+msgid "NUL-terminated"
+msgstr "con terminazione NUL"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+#, fuzzy
+msgid "Communicating with C functions"
+msgstr "Comunicare con le funzioni C"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+#, fuzzy
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) e [`OsString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+#, fuzzy
+msgid "OS-specific"
+msgstr "specifico del sistema operativo"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+#, fuzzy
+msgid "Communicating with the OS"
+msgstr "Comunicazione con il sistema operativo"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
 #, fuzzy
@@ -12191,52 +12615,72 @@ msgstr "Potrai convertire tra tutti questi tipi:"
 #: src/exercises/day-3/safe-ffi-wrapper.md:24
 #, fuzzy
 msgid ""
-"- `&str` to `CString`: you need to allocate space for a trailing `\\0` "
-"character,\n"
-"- `CString` to `*const i8`: you need a pointer to call C functions,\n"
-"- `*const i8` to `&CStr`: you need something which can find the trailing "
-"`\\0` character,\n"
-"- `&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknow data\",\n"
-"- `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
-"html)\n"
-"  to create it,\n"
-"- `&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able "
-"to return it and call\n"
-"  `readdir` again."
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
 msgstr ""
-"- Da `&str` a `CString`: è necessario allocare spazio per un carattere "
-"finale `\\0`,\n"
-"- Da `CString` a `*const i8`: è necessario un puntatore per chiamare le "
-"funzioni C,\n"
-"- Da `*const i8` a `&CStr`: hai bisogno di qualcosa che possa trovare il "
-"carattere finale `\\0`,\n"
-"- da `&CStr` a `&[u8]`: una fetta di byte è l'interfaccia universale per "
-"\"alcuni dati sconosciuti\",\n"
-"- Da `&[u8]` a `&OsStr`: `&OsStr` è un passo verso `OsString`, usa\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
-"html)\n"
-"  per crearlo,\n"
-"- `&OsStr` a `OsString`: è necessario clonare i dati in `&OsStr` per poterlo "
-"restituire e chiamare\n"
-"  `readdir` di nuovo."
+"Da `&str` a `CString`: è necessario allocare spazio per un carattere finale "
+"`\\0`,"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+#, fuzzy
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+"Da `CString` a `*const i8`: è necessario un puntatore per chiamare le "
+"funzioni C,"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+#, fuzzy
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+"Da `*const i8` a `&CStr`: hai bisogno di qualcosa che possa trovare il "
+"carattere finale `\\0`,"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+#, fuzzy
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+"da `&CStr` a `&[u8]`: una fetta di byte è l'interfaccia universale per "
+"\"alcuni dati sconosciuti\","
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+#, fuzzy
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+msgstr ""
+"Da `&[u8]` a `&OsStr`: `&OsStr` è un passo verso `OsString`, usa [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) per crearlo,"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+#, fuzzy
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
+msgstr ""
+"`&OsStr` a `OsString`: è necessario clonare i dati in `&OsStr` per poterlo "
+"restituire e chiamare `readdir` di nuovo."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
 #, fuzzy
-msgid "The [Nomicon] also has a very useful chapter about FFI."
-msgstr "Il [Nomicon] ha anche un capitolo molto utile su FFI."
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
+msgstr ""
+"Il [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) ha anche un "
+"capitolo molto utile su FFI."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 "Copia il codice qui sotto in <https://play.rust-lang.org/> e inserisci "
-"quello mancante\n"
-"funzioni e metodi:"
+"quello mancante funzioni e metodi:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:48
 msgid ""
@@ -12347,56 +12791,42 @@ msgstr ""
 
 #: src/android.md:1
 #, fuzzy
-msgid "# Welcome to Rust in Android"
-msgstr "# Benvenuto in Rust su Android"
+msgid "Welcome to Rust in Android"
+msgstr "Benvenuto in Rust su Android"
 
 #: src/android.md:3
 #, fuzzy
 msgid ""
 "Rust is supported for native platform development on Android. This means "
-"that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 "Rust è supportato per lo sviluppo della piattaforma nativa su Android. Ciò "
-"significa che\n"
-"puoi scrivere nuovi servizi del sistema operativo in Rust, oltre ad "
-"estenderli\n"
-"servizi esistenti."
+"significa che puoi scrivere nuovi servizi del sistema operativo in Rust, "
+"oltre ad estenderli servizi esistenti."
 
 #: src/android.md:7
 #, fuzzy
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try "
-"to\n"
-"> find a little corner of your code base where we can move some lines of "
-"code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
-"that\n"
-"> parses some raw bytes would be ideal."
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
-"> Oggi tenteremo di chiamare Rust da uno dei tuoi progetti. Quindi prova a\n"
-"> trova un piccolo angolo della tua base di codice in cui possiamo spostare "
-"alcune righe di codice\n"
-"> Ruggine. Minori sono le dipendenze e i tipi \"esotici\", meglio è. "
-"Qualcosa che\n"
-"> analizza alcuni byte grezzi sarebbe l'ideale."
-
-#: src/android/setup.md:1
-#, fuzzy
-msgid "# Setup"
-msgstr "# Impostare"
+"Oggi tenteremo di chiamare Rust da uno dei tuoi progetti. Quindi prova a "
+"trova un piccolo angolo della tua base di codice in cui possiamo spostare "
+"alcune righe di codice Ruggine. Minori sono le dipendenze e i tipi "
+"\"esotici\", meglio è. Qualcosa che analizza alcuni byte grezzi sarebbe "
+"l'ideale."
 
 #: src/android/setup.md:3
 #, fuzzy
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
-"have\n"
-"access to one or create a new one with:"
+"have access to one or create a new one with:"
 msgstr ""
 "Useremo un dispositivo virtuale Android per testare il nostro codice. "
-"Assicurati di avere\n"
-"accedi a uno o creane uno nuovo con:"
+"Assicurati di avere accedi a uno o creane uno nuovo con:"
 
 #: src/android/setup.md:6
 msgid ""
@@ -12410,16 +12840,11 @@ msgstr ""
 #: src/android/setup.md:12
 #, fuzzy
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-"Si prega di consultare il [Sviluppatore Android\n"
-"Codelab](https://source.android.com/docs/setup/start) per i dettagli."
-
-#: src/android/build-rules.md:1
-#, fuzzy
-msgid "# Build Rules"
-msgstr "# Crea regole"
+"Si prega di consultare il [Sviluppatore Android Codelab](https://source."
+"android.com/docs/setup/start) per i dettagli."
 
 #: src/android/build-rules.md:3
 #, fuzzy
@@ -12430,47 +12855,112 @@ msgstr ""
 
 #: src/android/build-rules.md:5
 #, fuzzy
-msgid ""
-"| Module Type       | "
-"Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust "
-"binary.                                                                            "
-"|\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
-"`dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
-"provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
-"analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard "
-"Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging "
-"`libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that "
-"provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library "
-"containing Rust bindings to C libraries.              |"
+msgid "Module Type"
+msgstr "Tipo di modulo"
+
+#: src/android/build-rules.md:5
+#, fuzzy
+msgid "Description"
+msgstr "Descrizione"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "`rust_binary`"
+msgstr "`binario_ruggine`"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "Produces a Rust binary."
+msgstr "Produce un binario Rust."
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "`rust_library`"
+msgstr "`libreria_ruggine`"
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
 msgstr ""
-"| Tipo di modulo | Descrizione |\n"
-"|-------------------|-------------------------------------- "
-"-------------------------------------------------- ---------------------|\n"
-"| `binario_ruggine` | Produce un binario Rust. |\n"
-"| `libreria_ruggine` | Produce una libreria Rust e fornisce entrambe le "
-"varianti `rlib` e `dylib`. |\n"
-"| `ruggine_ffi` | Produce una libreria Rust C utilizzabile dai moduli `cc` e "
-"fornisce varianti sia statiche che condivise. |\n"
-"| `rust_proc_macro` | Produce una libreria Rust `proc-macro`. Questi sono "
-"analoghi ai plugin del compilatore. |\n"
-"| `test_ruggine` | Produce un file binario di test Rust che utilizza il "
-"cablaggio di test Rust standard. |\n"
-"| `ruggine_fuzz` | Produce un binario fuzz di Rust sfruttando `libfuzzer`. "
-"|\n"
-"| `protobuf_ruggine` | Genera il codice sorgente e produce una libreria Rust "
-"che fornisce un'interfaccia per un particolare protobuf. |\n"
-"| `ruggine_bindgen` | Genera il codice sorgente e produce una libreria Rust "
-"contenente collegamenti Rust alle librerie C. |"
+"Produce una libreria Rust e fornisce entrambe le varianti `rlib` e `dylib`."
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid "`rust_ffi`"
+msgstr "`ruggine_ffi`"
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid ""
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+"Produce una libreria Rust C utilizzabile dai moduli `cc` e fornisce varianti "
+"sia statiche che condivise."
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid "`rust_proc_macro`"
+msgstr "`rust_proc_macro`"
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+"Produce una libreria Rust `proc-macro`. Questi sono analoghi ai plugin del "
+"compilatore."
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "`rust_test`"
+msgstr "`test_ruggine`"
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+"Produce un file binario di test Rust che utilizza il cablaggio di test Rust "
+"standard."
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "`rust_fuzz`"
+msgstr "`ruggine_fuzz`"
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr "Produce un binario fuzz di Rust sfruttando `libfuzzer`."
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid "`rust_protobuf`"
+msgstr "`protobuf_ruggine`"
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+"Genera il codice sorgente e produce una libreria Rust che fornisce "
+"un'interfaccia per un particolare protobuf."
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid "`rust_bindgen`"
+msgstr "`ruggine_bindgen`"
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr ""
+"Genera il codice sorgente e produce una libreria Rust contenente "
+"collegamenti Rust alle librerie C."
 
 #: src/android/build-rules.md:16
 #, fuzzy
@@ -12479,19 +12969,17 @@ msgstr "Vedremo successivamente `rust_binary` e `rust_library`."
 
 #: src/android/build-rules/binary.md:1
 #, fuzzy
-msgid "# Rust Binaries"
-msgstr "# Binari Rust"
+msgid "Rust Binaries"
+msgstr "Binari Rust"
 
 #: src/android/build-rules/binary.md:3
 #, fuzzy
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr ""
 "Iniziamo con una semplice applicazione. Alla radice di un checkout AOSP, "
-"create\n"
-"i seguenti file:"
+"create i seguenti file:"
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 #, fuzzy
@@ -12549,8 +13037,8 @@ msgstr ""
 
 #: src/android/build-rules/library.md:1
 #, fuzzy
-msgid "# Rust Libraries"
-msgstr "# Librerie ruggine"
+msgid "Rust Libraries"
+msgstr "Librerie ruggine"
 
 #: src/android/build-rules/library.md:3
 #, fuzzy
@@ -12564,14 +13052,18 @@ msgstr "Qui dichiariamo una dipendenza da due librerie:"
 
 #: src/android/build-rules/library.md:7
 #, fuzzy
+msgid "`libgreeting`, which we define below,"
+msgstr "`libgreeting`, che definiamo di seguito,"
+
+#: src/android/build-rules/library.md:8
+#, fuzzy
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"* `libgreeting`, che definiamo di seguito,\n"
-"* `libtextwrap`, che è una cassa già venduta\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, che è una cassa già venduta [`external/rust/crates/`](https://"
+"cs.android.com/android/platform/superproject/+/master:external/rust/crates/)."
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -12650,35 +13142,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-#, fuzzy
-msgid "# AIDL"
-msgstr "#AIDL"
-
 #: src/android/aidl.md:3
 #, fuzzy
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
-"Il [linguaggio di definizione dell'interfaccia Android\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) è supportato in "
-"Rust:"
+"Il [linguaggio di definizione dell'interfaccia Android (AIDL)](https://"
+"developer.android.com/guide/components/aidl) è supportato in Rust:"
 
 #: src/android/aidl.md:6
 #, fuzzy
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
-msgstr ""
-"* Il codice Rust può chiamare i server AIDL esistenti,\n"
-"* Puoi creare nuovi server AIDL in Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr "Il codice Rust può chiamare i server AIDL esistenti,"
+
+#: src/android/aidl.md:7
+#, fuzzy
+msgid "You can create new AIDL servers in Rust."
+msgstr "Puoi creare nuovi server AIDL in Rust."
 
 #: src/android/aidl/interface.md:1
 #, fuzzy
-msgid "# AIDL Interfaces"
-msgstr "# Interfacce AIDL"
+msgid "AIDL Interfaces"
+msgstr "Interfacce AIDL"
 
 #: src/android/aidl/interface.md:3
 #, fuzzy
@@ -12688,9 +13174,9 @@ msgstr "Dichiari l'API del tuo servizio utilizzando un'interfaccia AIDL:"
 #: src/android/aidl/interface.md:5
 #, fuzzy
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 
 #: src/android/aidl/interface.md:7
 msgid ""
@@ -12707,8 +13193,8 @@ msgstr ""
 
 #: src/android/aidl/interface.md:17
 #, fuzzy
-msgid "*birthday_service/aidl/Android.bp*:"
-msgstr "*servizio_compleanno/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_servizio_compleanno/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md:19
 msgid ""
@@ -12730,17 +13216,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 "Aggiungi \"vendor_available: true\" se il tuo file AIDL è utilizzato da un "
-"file binario nel fornitore\n"
-"partizione."
+"file binario nel fornitore partizione."
 
 #: src/android/aidl/implementation.md:1
 #, fuzzy
-msgid "# Service Implementation"
-msgstr "# Implementazione del servizio"
+msgid "Service Implementation"
+msgstr "Implementazione del servizio"
 
 #: src/android/aidl/implementation.md:3
 #, fuzzy
@@ -12749,8 +13233,8 @@ msgstr "Ora possiamo implementare il servizio AIDL:"
 
 #: src/android/aidl/implementation.md:5
 #, fuzzy
-msgid "*birthday_service/src/lib.rs*:"
-msgstr "*servizio_compleanno/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
+msgstr "_servizio_compleanno/src/lib.rs_:"
 
 #: src/android/aidl/implementation.md:7
 msgid ""
@@ -12780,8 +13264,8 @@ msgstr ""
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
 #, fuzzy
-msgid "*birthday_service/Android.bp*:"
-msgstr "*servizio_compleanno/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
+msgstr "_servizio_compleanno/Android.bp_:"
 
 #: src/android/aidl/implementation.md:28
 msgid ""
@@ -12800,8 +13284,8 @@ msgstr ""
 
 #: src/android/aidl/server.md:1
 #, fuzzy
-msgid "# AIDL Server"
-msgstr "# Server AIDL"
+msgid "AIDL Server"
+msgstr "Server AIDL"
 
 #: src/android/aidl/server.md:3
 #, fuzzy
@@ -12810,8 +13294,8 @@ msgstr "Infine, possiamo creare un server che espone il servizio:"
 
 #: src/android/aidl/server.md:5
 #, fuzzy
-msgid "*birthday_service/src/server.rs*:"
-msgstr "*servizio_compleanno/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_servizio_compleanno/src/server.rs_:"
 
 #: src/android/aidl/server.md:7
 msgid ""
@@ -12855,11 +13339,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/android/aidl/deploy.md:1
-#, fuzzy
-msgid "# Deploy"
-msgstr "# Distribuisci"
 
 #: src/android/aidl/deploy.md:3
 #, fuzzy
@@ -12924,8 +13403,8 @@ msgstr ""
 
 #: src/android/aidl/client.md:1
 #, fuzzy
-msgid "# AIDL Client"
-msgstr "# Cliente AIDL"
+msgid "AIDL Client"
+msgstr "Cliente AIDL"
 
 #: src/android/aidl/client.md:3
 #, fuzzy
@@ -12934,8 +13413,8 @@ msgstr "Infine, possiamo creare un client Rust per il nostro nuovo servizio."
 
 #: src/android/aidl/client.md:5
 #, fuzzy
-msgid "*birthday_service/src/client.rs*:"
-msgstr "*servizio_compleanno/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
+msgstr "_servizio_compleanno/src/client.rs_:"
 
 #: src/android/aidl/client.md:7
 msgid ""
@@ -13016,21 +13495,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-#, fuzzy
-msgid "# Changing API"
-msgstr "# Modifica dell'API"
-
 #: src/android/aidl/changing.md:3
 #, fuzzy
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr ""
 "Estendiamo l'API con più funzionalità: vogliamo consentire ai client di "
-"specificare a\n"
-"elenco delle righe per il biglietto d'auguri:"
+"specificare a elenco delle righe per il biglietto d'auguri:"
 
 #: src/android/aidl/changing.md:6
 msgid ""
@@ -13045,21 +13517,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-#, fuzzy
-msgid "# Logging"
-msgstr "# Registrazione"
-
 #: src/android/logging.md:3
 #, fuzzy
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
 "Dovresti usare la cassa `log` per accedere automaticamente a `logcat` (sul "
-"dispositivo) o\n"
-"`stdout` (sull'host):"
+"dispositivo) o `stdout` (sull'host):"
 
 #: src/android/logging.md:6
 #, fuzzy
@@ -13148,54 +13613,48 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-#, fuzzy
-msgid "# Interoperability"
-msgstr "# Interoperabilità"
-
 #: src/android/interoperability.md:3
 #, fuzzy
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 "Rust ha un eccellente supporto per l'interoperabilità con altri linguaggi. "
-"Questo significa\n"
-"che tu puoi:"
+"Questo significa che tu puoi:"
 
 #: src/android/interoperability.md:6
 #, fuzzy
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
-msgstr ""
-"* Richiama le funzioni di Rust da altre lingue.\n"
-"* Funzioni di chiamata scritte in altri linguaggi da Rust."
+msgid "Call Rust functions from other languages."
+msgstr "Richiama le funzioni di Rust da altre lingue."
+
+#: src/android/interoperability.md:7
+#, fuzzy
+msgid "Call functions written in other languages from Rust."
+msgstr "Funzioni di chiamata scritte in altri linguaggi da Rust."
 
 #: src/android/interoperability.md:9
 #, fuzzy
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
-"Quando chiami funzioni in una lingua straniera diciamo che stai usando a\n"
+"Quando chiami funzioni in una lingua straniera diciamo che stai usando a "
 "_interfaccia funzione straniera_, nota anche come FFI."
 
 #: src/android/interoperability/with-c.md:1
 #, fuzzy
-msgid "# Interoperability with C"
-msgstr "# Interoperabilità con C"
+msgid "Interoperability with C"
+msgstr "Interoperabilità con C"
 
 #: src/android/interoperability/with-c.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 "Rust ha il pieno supporto per il collegamento di file oggetto con una "
-"convenzione di chiamata C.\n"
-"Allo stesso modo, puoi esportare le funzioni di Rust e chiamarle da C."
+"convenzione di chiamata C. Allo stesso modo, puoi esportare le funzioni di "
+"Rust e chiamarle da C."
 
 #: src/android/interoperability/with-c.md:6
 #, fuzzy
@@ -13220,21 +13679,20 @@ msgstr ""
 #: src/android/interoperability/with-c.md:20
 #, fuzzy
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
-"Lo abbiamo già visto nel [Safe FFI Wrapper\n"
-"esercizio](../../exercises/day-3/safe-ffi-wrapper.md)."
+"Lo abbiamo già visto nel [Safe FFI Wrapper esercizio](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 
 #: src/android/interoperability/with-c.md:23
 #, fuzzy
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
-"> Ciò presuppone la piena conoscenza della piattaforma di destinazione. Non "
-"consigliato per\n"
-"> produzione."
+"Ciò presuppone la piena conoscenza della piattaforma di destinazione. Non "
+"consigliato per produzione."
 
 #: src/android/interoperability/with-c.md:26
 #, fuzzy
@@ -13243,19 +13701,17 @@ msgstr "Vedremo le opzioni migliori in seguito."
 
 #: src/android/interoperability/with-c/bindgen.md:1
 #, fuzzy
-msgid "# Using Bindgen"
-msgstr "# Utilizzo di Bindgen"
+msgid "Using Bindgen"
+msgstr "Utilizzo di Bindgen"
 
 #: src/android/interoperability/with-c/bindgen.md:3
 #, fuzzy
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 "Lo strumento [bindgen](https://rust-lang.github.io/rust-bindgen/introduction."
-"html)\n"
-"può generare automaticamente collegamenti da un file di intestazione C."
+"html) può generare automaticamente collegamenti da un file di intestazione C."
 
 #: src/android/interoperability/with-c/bindgen.md:6
 #, fuzzy
@@ -13325,12 +13781,11 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:44
 #, fuzzy
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 "Crea un file di intestazione wrapper per la libreria (non strettamente "
-"necessario in questo\n"
-"esempio):"
+"necessario in questo esempio):"
 
 #: src/android/interoperability/with-c/bindgen.md:47
 #, fuzzy
@@ -13444,8 +13899,8 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
 #, fuzzy
-msgid "# Calling Rust"
-msgstr "# Calling Rust"
+msgid "Calling Rust"
+msgstr "Calling Rust"
 
 #: src/android/interoperability/with-c/rust.md:3
 #, fuzzy
@@ -13566,61 +14021,51 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 "`#[no_mangle]` disabilita la solita alterazione del nome di Rust, quindi il "
-"simbolo esportato sarà solo il nome di\n"
-"la funzione. Puoi anche usare `#[export_name = \"some_name\"]` per "
-"specificare il nome che desideri."
-
-#: src/android/interoperability/cpp.md:1
-#, fuzzy
-msgid "# With C++"
-msgstr "# Con C++"
+"simbolo esportato sarà solo il nome di la funzione. Puoi anche usare "
+"`#[export_name = \"some_name\"]` per specificare il nome che desideri."
 
 #: src/android/interoperability/cpp.md:3
 #, fuzzy
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
-"Il [CXX crate][1] rende possibile l'interoperabilità sicura tra Rust\n"
-"e C++."
+"Il [CXX crate](https://cxx.rs/) rende possibile l'interoperabilità sicura "
+"tra Rust e C++."
 
 #: src/android/interoperability/cpp.md:6
 #, fuzzy
 msgid "The overall approach looks like this:"
 msgstr "L'approccio generale è simile al seguente:"
 
-#: src/android/interoperability/cpp.md:8
-#, fuzzy
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr "<img src=\"cpp/overview.svg\">"
-
 #: src/android/interoperability/cpp.md:10
 #, fuzzy
-msgid "See the [CXX tutorial][2] for an full example of using this."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
-"Vedere il [tutorial CXX][2] per un esempio completo di utilizzo di questo."
+"Vedere il [tutorial CXX](https://cxx.rs/tutorial.html) per un esempio "
+"completo di utilizzo di questo."
 
 #: src/android/interoperability/java.md:1
 #, fuzzy
-msgid "# Interoperability with Java"
-msgstr "# Interoperabilità con Java"
+msgid "Interoperability with Java"
+msgstr "Interoperabilità con Java"
 
 #: src/android/interoperability/java.md:3
 #, fuzzy
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
-"Java può caricare oggetti condivisi tramite [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). Il [`jni`\n"
-"crate](https://docs.rs/jni/) consente di creare una libreria compatibile."
+"Java può caricare oggetti condivisi tramite [Java Native Interface (JNI)]"
+"(https://en.wikipedia.org/wiki/Java_Native_Interface). Il [`jni` crate]"
+"(https://docs.rs/jni/) consente di creare una libreria compatibile."
 
 #: src/android/interoperability/java.md:7
 #, fuzzy
@@ -13728,65 +14173,51 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
-#: src/exercises/concurrency/morning.md:1
-#: src/exercises/concurrency/afternoon.md:1
-#, fuzzy
-msgid "# Exercises"
-msgstr "# Esercizi"
-
 #: src/exercises/android/morning.md:3
 #, fuzzy
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
-"and\n"
-"try to integrate some Rust into it. Some suggestions:"
+"and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 "Questo è un esercizio di gruppo: esamineremo uno dei progetti con cui lavori "
-"e\n"
-"prova a integrarci un po' di ruggine. Alcuni suggerimenti:"
+"e prova a integrarci un po' di ruggine. Alcuni suggerimenti:"
 
 #: src/exercises/android/morning.md:6
 #, fuzzy
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
-msgstr ""
-"* Chiama il tuo servizio AIDL con un client scritto in Rust.\n"
-"\n"
-"* Sposta una funzione dal tuo progetto a Rust e chiamala."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr "Chiama il tuo servizio AIDL con un client scritto in Rust."
+
+#: src/exercises/android/morning.md:8
+#, fuzzy
+msgid "Move a function from your project to Rust and call it."
+msgstr "Sposta una funzione dal tuo progetto a Rust e chiamala."
 
 #: src/exercises/android/morning.md:12
 #, fuzzy
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 "Nessuna soluzione viene fornita qui poiché questo è a tempo indeterminato: "
-"si basa su qualcuno dentro\n"
-"la classe ha un pezzo di codice che puoi consegnare a Rust al volo."
+"si basa su qualcuno dentro la classe ha un pezzo di codice che puoi "
+"consegnare a Rust al volo."
 
 #: src/bare-metal.md:1
 #, fuzzy
-msgid "# Welcome to Bare Metal Rust"
-msgstr "# Benvenuto in Bare Metal Rust"
+msgid "Welcome to Bare Metal Rust"
+msgstr "Benvenuto in Bare Metal Rust"
 
 #: src/bare-metal.md:3
 #, fuzzy
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 "Questo è un corso autonomo di un giorno sul bare metal Rust, rivolto a "
-"persone che hanno familiarità con il\n"
-"nozioni di base di Rust (forse completando il corso completo di Rust), e "
-"idealmente anche averne alcune\n"
+"persone che hanno familiarità con il nozioni di base di Rust (forse "
+"completando il corso completo di Rust), e idealmente anche averne alcune "
 "esperienza con la programmazione bare metal in qualche altro linguaggio come "
 "C."
 
@@ -13794,45 +14225,46 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 "Oggi parleremo di Rust 'bare-metal': eseguire il codice Rust senza un "
-"sistema operativo sotto di noi. Questo sarà\n"
-"essere suddiviso in più parti:"
+"sistema operativo sotto di noi. Questo sarà essere suddiviso in più parti:"
 
 #: src/bare-metal.md:10
 #, fuzzy
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr "Cos'è \"no_std\" Rust?"
+
+#: src/bare-metal.md:11
+#, fuzzy
+msgid "Writing firmware for microcontrollers."
+msgstr "Scrittura firmware per microcontrollori."
+
+#: src/bare-metal.md:12
+#, fuzzy
+msgid "Writing bootloader / kernel code for application processors."
 msgstr ""
-"- Cos'è \"no_std\" Rust?\n"
-"- Scrittura firmware per microcontrollori.\n"
-"- Scrittura del codice bootloader/kernel per i processori delle "
-"applicazioni.\n"
-"- Alcune casse utili per lo sviluppo di ruggine a metallo nudo."
+"Scrittura del codice bootloader/kernel per i processori delle applicazioni."
+
+#: src/bare-metal.md:13
+#, fuzzy
+msgid "Some useful crates for bare-metal Rust development."
+msgstr "Alcune casse utili per lo sviluppo di ruggine a metallo nudo."
 
 #: src/bare-metal.md:15
 #, fuzzy
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 "Per la parte del corso sui microcontrollori utilizzeremo la [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"come esempio. È una [scheda di sviluppo](https://tech.microbit.org/"
-"hardware/) basata sul Nordic\n"
-"microcontrollore nRF51822 con alcuni LED e pulsanti, un accelerometro e una "
-"bussola collegati a I2C e\n"
-"un debugger SWD integrato."
+"(https://microbit.org/) v2 come esempio. È una [scheda di sviluppo](https://"
+"tech.microbit.org/hardware/) basata sul Nordic microcontrollore nRF51822 con "
+"alcuni LED e pulsanti, un accelerometro e una bussola collegati a I2C e un "
+"debugger SWD integrato."
 
 #: src/bare-metal.md:20
 #, fuzzy
@@ -13891,35 +14323,15 @@ msgstr ""
 
 #: src/bare-metal/no_std.md:1
 #, fuzzy
-msgid "# `no_std`"
-msgstr "# `no_std`"
-
-#: src/bare-metal/no_std.md:3
-#, fuzzy
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
-msgstr ""
-"<tabella>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
+msgstr "`no_std`"
 
 #: src/bare-metal/no_std.md:7
 #, fuzzy
 msgid "`core`"
 msgstr "`nucleo`"
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-#, fuzzy
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-"</th>\n"
-"<th>"
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 #, fuzzy
 msgid "`alloc`"
 msgstr "`alloc`"
@@ -13929,117 +14341,125 @@ msgstr "`alloc`"
 msgid "`std`"
 msgstr "`std`"
 
-#: src/bare-metal/no_std.md:19
-#, fuzzy
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-
 #: src/bare-metal/no_std.md:24
 #, fuzzy
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
-msgstr ""
-"* Fette, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Opzione`, `Risultato`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iteratore`\n"
-"* `panico!`, `assert_eq!`...\n"
-"* `NonNull` e tutte le solite funzioni relative ai puntatori\n"
-"* `Future` e `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Durata`"
+msgid "Slices, `&str`, `CStr`"
+msgstr "Fette, `&str`, `CStr`"
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
+#: src/bare-metal/no_std.md:25
 #, fuzzy
-msgid ""
-"</td>\n"
-"<td>"
-msgstr ""
-"</td>\n"
-"<td>"
+msgid "`NonZeroU8`..."
+msgstr "`NonZeroU8`..."
+
+#: src/bare-metal/no_std.md:26
+#, fuzzy
+msgid "`Option`, `Result`"
+msgstr "`Opzione`, `Risultato`"
+
+#: src/bare-metal/no_std.md:27
+#, fuzzy
+msgid "`Display`, `Debug`, `write!`..."
+msgstr "`Display`, `Debug`, `write!`..."
+
+#: src/bare-metal/no_std.md:29
+#, fuzzy
+msgid "`panic!`, `assert_eq!`..."
+msgstr "`panico!`, `assert_eq!`..."
+
+#: src/bare-metal/no_std.md:30
+#, fuzzy
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr "`NonNull` e tutte le solite funzioni relative ai puntatori"
+
+#: src/bare-metal/no_std.md:31
+#, fuzzy
+msgid "`Future` and `async`/`await`"
+msgstr "`Future` e `async`/`await`"
+
+#: src/bare-metal/no_std.md:32
+#, fuzzy
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+
+#: src/bare-metal/no_std.md:33
+#, fuzzy
+msgid "`Duration`"
+msgstr "`Durata`"
 
 #: src/bare-metal/no_std.md:38
 #, fuzzy
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
-msgstr ""
-"* `Scatola`, `Mucca`, `Arco`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `Stringa`, `CStringa`, `formato!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr "`Scatola`, `Mucca`, `Arco`, `Rc`"
+
+#: src/bare-metal/no_std.md:39
+#, fuzzy
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+
+#: src/bare-metal/no_std.md:40
+#, fuzzy
+msgid "`String`, `CString`, `format!`"
+msgstr "`Stringa`, `CStringa`, `formato!`"
 
 #: src/bare-metal/no_std.md:45
 #, fuzzy
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
-msgstr ""
-"* `Errore`\n"
-"* `Mappa hash`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` e il resto di `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` e il resto di `io`\n"
-"* `Percorso`, `OsString`\n"
-"* `rete`\n"
-"* `Comando`, `Figlio`, `CodiceUscita`\n"
-"* `spawn`, `sleep` e il resto di `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
+msgstr "`Errore`"
 
-#: src/bare-metal/no_std.md:56
+#: src/bare-metal/no_std.md:47
 #, fuzzy
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
-msgstr ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<dettagli>"
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+
+#: src/bare-metal/no_std.md:48
+#, fuzzy
+msgid "`File` and the rest of `fs`"
+msgstr "`File` e il resto di `fs`"
+
+#: src/bare-metal/no_std.md:49
+#, fuzzy
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr "`println!`, `Read`, `Write`, `Stdin`, `Stdout` e il resto di `io`"
+
+#: src/bare-metal/no_std.md:50
+#, fuzzy
+msgid "`Path`, `OsString`"
+msgstr "`Percorso`, `OsString`"
+
+#: src/bare-metal/no_std.md:51
+#, fuzzy
+msgid "`net`"
+msgstr "`rete`"
+
+#: src/bare-metal/no_std.md:52
+#, fuzzy
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr "`Comando`, `Figlio`, `CodiceUscita`"
+
+#: src/bare-metal/no_std.md:53
+#, fuzzy
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr "`spawn`, `sleep` e il resto di `thread`"
+
+#: src/bare-metal/no_std.md:54
+#, fuzzy
+msgid "`SystemTime`, `Instant`"
+msgstr "`SystemTime`, `Instant`"
 
 #: src/bare-metal/no_std.md:62
 #, fuzzy
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
-msgstr ""
-"* `HashMap` dipende da RNG.\n"
-"* `std` riesporta il contenuto sia di `core` che di `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr "`HashMap` dipende da RNG."
+
+#: src/bare-metal/no_std.md:63
+#, fuzzy
+msgid "`std` re-exports the contents of both `core` and `alloc`."
+msgstr "`std` riesporta il contenuto sia di `core` che di `alloc`."
 
 #: src/bare-metal/minimal.md:1
 #, fuzzy
-msgid "# A minimal `no_std` program"
-msgstr "# Un programma `no_std` minimo"
+msgid "A minimal `no_std` program"
+msgstr "Un programma `no_std` minimo"
 
 #: src/bare-metal/minimal.md:3
 msgid ""
@@ -14057,35 +14477,38 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-#, fuzzy
-msgid "# `alloc`"
-msgstr "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
+msgstr ""
 
 #: src/bare-metal/alloc.md:3
 #, fuzzy
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
-"Per usare `alloc` devi implementare a\n"
-"[allocatore globale (heap)](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"Per usare `alloc` devi implementare a [allocatore globale (heap)](https://"
+"doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 
 #: src/bare-metal/alloc.md:6
 msgid ""
@@ -14124,27 +14547,33 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-#, fuzzy
-msgid "# Microcontrollers"
-msgstr "# Microcontrollori"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
+msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
 #, fuzzy
@@ -14186,31 +14615,25 @@ msgstr ""
 #: src/bare-metal/microcontrollers.md:25
 #, fuzzy
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
-"* La macro `cortex_m_rt::entry` richiede che la funzione abbia il tipo `fn() "
-"-> !`, perché restituisce\n"
-"  al gestore di ripristino non ha senso.\n"
-"* Esegui l'esempio con `cargo embed --bin minimal`"
+"La macro `cortex_m_rt::entry` richiede che la funzione abbia il tipo `fn() -"
+"> !`, perché restituisce al gestore di ripristino non ha senso."
 
-#: src/bare-metal/microcontrollers/mmio.md:1
+#: src/bare-metal/microcontrollers.md:27
 #, fuzzy
-msgid "# Raw MMIO"
-msgstr "# MMIO grezzo"
+msgid "Run the example with `cargo embed --bin minimal`"
+msgstr "Esegui l'esempio con `cargo embed --bin minimal`"
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 #, fuzzy
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 "La maggior parte dei microcontrollori accede alle periferiche tramite IO "
-"mappato in memoria. Proviamo ad accendere un LED sul nostro\n"
-"micro:bit:"
+"mappato in memoria. Proviamo ad accendere un LED sul nostro micro:bit:"
 
 #: src/bare-metal/microcontrollers/mmio.md:6
 msgid ""
@@ -14280,10 +14703,10 @@ msgstr ""
 #: src/bare-metal/microcontrollers/mmio.md:64
 #, fuzzy
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
-"* Il pin 21 di GPIO 0 è collegato alla prima colonna della matrice LED e il "
+"Il pin 21 di GPIO 0 è collegato alla prima colonna della matrice LED e il "
 "pin 28 alla prima riga."
 
 #: src/bare-metal/microcontrollers/mmio.md:66
@@ -14303,23 +14726,19 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
 #, fuzzy
-msgid "# Peripheral Access Crates"
-msgstr "# Casse di accesso periferico"
+msgid "Peripheral Access Crates"
+msgstr "Casse di accesso periferico"
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 #, fuzzy
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) genera wrapper Rust per lo "
-"più sicuri per\n"
-"periferiche mappate in memoria da [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"File."
+"più sicuri per periferiche mappate in memoria da [CMSIS-SVD](https://www."
+"keil.com/pack/doc/CMSIS/SVD/html/index.html) File."
 
 #: src/bare-metal/microcontrollers/pacs.md:7
 msgid ""
@@ -14367,33 +14786,45 @@ msgstr ""
 #: src/bare-metal/microcontrollers/pacs.md:49
 #, fuzzy
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
 msgstr ""
-"* I file SVD (System View Description) sono file XML generalmente forniti da "
-"fornitori di silicio che\n"
-"  descrivere la mappa di memoria del dispositivo.\n"
-"  * Sono organizzati per periferica, registro, campo e valore, con nomi, "
-"descrizioni, indirizzi\n"
-"    e così via.\n"
-"  * I file SVD sono spesso difettosi e incompleti, quindi ci sono vari "
-"progetti che correggono il file\n"
-"    errori, aggiungere i dettagli mancanti e pubblicare le casse generate.\n"
-"* `cortex-m-rt` fornisce la tabella dei vettori, tra le altre cose.\n"
-"* Se `cargo installi cargo-binutils` allora puoi eseguire\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` per vedere il binario "
-"risultante."
+"I file SVD (System View Description) sono file XML generalmente forniti da "
+"fornitori di silicio che descrivere la mappa di memoria del dispositivo."
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+#, fuzzy
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+"Sono organizzati per periferica, registro, campo e valore, con nomi, "
+"descrizioni, indirizzi e così via."
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+#, fuzzy
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+"I file SVD sono spesso difettosi e incompleti, quindi ci sono vari progetti "
+"che correggono il file errori, aggiungere i dettagli mancanti e pubblicare "
+"le casse generate."
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+#, fuzzy
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr "`cortex-m-rt` fornisce la tabella dei vettori, tra le altre cose."
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+#, fuzzy
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
+msgstr ""
+"Se `cargo installi cargo-binutils` allora puoi eseguire `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` per vedere il binario risultante."
 
 #: src/bare-metal/microcontrollers/pacs.md:61
 msgid ""
@@ -14404,23 +14835,21 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
 #, fuzzy
-msgid "# HAL crates"
-msgstr "# casse HAL"
+msgid "HAL crates"
+msgstr "casse HAL"
 
 #: src/bare-metal/microcontrollers/hals.md:3
 #, fuzzy
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 "[Casse HAL](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) per\n"
-"molti microcontrollori forniscono wrapper attorno a varie periferiche. "
-"Questi generalmente implementano i tratti\n"
-"da [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) per molti microcontrollori forniscono wrapper attorno "
+"a varie periferiche. Questi generalmente implementano i tratti da [`embedded-"
+"hal`](https://crates.io/crates/embedded-hal)."
 
 #: src/bare-metal/microcontrollers/hals.md:7
 msgid ""
@@ -14458,17 +14887,18 @@ msgstr ""
 #: src/bare-metal/microcontrollers/hals.md:39
 #, fuzzy
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
 msgstr ""
-" * `set_low` e `set_high` sono metodi sul tratto `embedded_hal` "
-"`OutputPin`.\n"
-" * Esistono casse HAL per molti dispositivi Cortex-M e RISC-V, inclusi vari "
-"STM32, GD32, nRF, NXP,\n"
-"   Microcontrollori MSP430, AVR e PIC."
+"`set_low` e `set_high` sono metodi sul tratto `embedded_hal` `OutputPin`."
+
+#: src/bare-metal/microcontrollers/hals.md:40
+#, fuzzy
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
+msgstr ""
+"Esistono casse HAL per molti dispositivi Cortex-M e RISC-V, inclusi vari "
+"STM32, GD32, nRF, NXP, Microcontrollori MSP430, AVR e PIC."
 
 #: src/bare-metal/microcontrollers/hals.md:45
 msgid ""
@@ -14479,8 +14909,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
 #, fuzzy
-msgid "# Board support crates"
-msgstr "# Casse di supporto della scheda"
+msgid "Board support crates"
+msgstr "Casse di supporto della scheda"
 
 #: src/bare-metal/microcontrollers/board-support.md:3
 #, fuzzy
@@ -14518,21 +14948,25 @@ msgstr ""
 #: src/bare-metal/microcontrollers/board-support.md:28
 #, fuzzy
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
 msgstr ""
-" * In questo caso la cassa di supporto della scheda fornisce solo nomi più "
-"utili e un po' di\n"
-"   inizializzazione.\n"
-" * Il crate può anche includere driver per alcuni dispositivi integrati al "
-"di fuori del microcontrollore\n"
-"   si.\n"
-"   * `microbit-v2` include un semplice driver per la matrice LED."
+"In questo caso la cassa di supporto della scheda fornisce solo nomi più "
+"utili e un po' di inizializzazione."
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+#, fuzzy
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+"Il crate può anche includere driver per alcuni dispositivi integrati al di "
+"fuori del microcontrollore si."
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+#, fuzzy
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
+msgstr "`microbit-v2` include un semplice driver per la matrice LED."
 
 #: src/bare-metal/microcontrollers/board-support.md:36
 msgid ""
@@ -14543,8 +14977,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
 #, fuzzy
-msgid "# The type state pattern"
-msgstr "# Il modello di stato del tipo"
+msgid "The type state pattern"
+msgstr "Il modello di stato del tipo"
 
 #: src/bare-metal/microcontrollers/type-state.md:3
 msgid ""
@@ -14582,199 +15016,251 @@ msgstr ""
 #: src/bare-metal/microcontrollers/type-state.md:32
 #, fuzzy
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
 msgstr ""
-" * I pin non implementano `Copy` o `Clone`, quindi può esistere solo "
-"un'istanza di ciascuno. Una volta che uno spillo è\n"
-"   spostato fuori dalla struttura portuale nessun altro può prenderlo.\n"
-" * La modifica della configurazione di un pin consuma la vecchia istanza del "
-"pin, quindi non puoi continuare a utilizzare il vecchio\n"
-"   esempio dopo.\n"
-" * Il tipo di un valore indica lo stato in cui si trova: ad es. in questo "
-"caso, lo stato di configurazione\n"
-"   di un pin GPIO. Questo codifica la macchina a stati nel sistema di tipi e "
-"garantisce che non lo fai\n"
-"   provare a utilizzare un pin in un certo modo senza prima configurarlo "
-"correttamente. Stato illegale\n"
-"   le transizioni vengono rilevate in fase di compilazione.\n"
-" * Puoi chiamare `is_high` su un pin di input e `set_high` su un pin di "
-"output, ma non viceversa.\n"
-" * Molte casse HAL seguono questo schema."
+"I pin non implementano `Copy` o `Clone`, quindi può esistere solo un'istanza "
+"di ciascuno. Una volta che uno spillo è spostato fuori dalla struttura "
+"portuale nessun altro può prenderlo."
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+#, fuzzy
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+"La modifica della configurazione di un pin consuma la vecchia istanza del "
+"pin, quindi non puoi continuare a utilizzare il vecchio esempio dopo."
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+#, fuzzy
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+"Il tipo di un valore indica lo stato in cui si trova: ad es. in questo caso, "
+"lo stato di configurazione di un pin GPIO. Questo codifica la macchina a "
+"stati nel sistema di tipi e garantisce che non lo fai provare a utilizzare "
+"un pin in un certo modo senza prima configurarlo correttamente. Stato "
+"illegale le transizioni vengono rilevate in fase di compilazione."
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+#, fuzzy
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+"Puoi chiamare `is_high` su un pin di input e `set_high` su un pin di output, "
+"ma non viceversa."
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+#, fuzzy
+msgid "Many HAL crates follow this pattern."
+msgstr "Molte casse HAL seguono questo schema."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
 #, fuzzy
-msgid "# `embedded-hal`"
-msgstr "# `hal incorporato`"
+msgid "`embedded-hal`"
+msgstr "`hal incorporato`"
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 #, fuzzy
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 "Il crate [`embedded-hal`](https://crates.io/crates/embedded-hal) fornisce "
-"una serie di caratteristiche\n"
-"che copre le comuni periferiche del microcontrollore."
+"una serie di caratteristiche che copre le comuni periferiche del "
+"microcontrollore."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
 #, fuzzy
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
+msgid "GPIO"
+msgstr "GPIO \\*ADC"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+#, fuzzy
+msgid "ADC"
+msgstr "I2C, SPI, UART, PUÒ"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+#, fuzzy
+msgid "I2C, SPI, UART, CAN"
+msgstr "RNG"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+#, fuzzy
+msgid "RNG"
+msgstr "Timer"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+#, fuzzy
+msgid "Timers"
+msgstr "Cani da guardia"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
 msgstr ""
-" * GPIO\n"
-" *ADC\n"
-" * I2C, SPI, UART, PUÒ\n"
-" * RNG\n"
-" * Timer\n"
-" * Cani da guardia"
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 #, fuzzy
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
-"Altre casse quindi implementano\n"
-"[driver](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in termini di questi\n"
-"tratti, ad es. un driver dell'accelerometro potrebbe richiedere "
-"un'implementazione del bus I2C o SPI."
+"Altre casse quindi implementano [driver](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in termini di questi tratti, ad es. un "
+"driver dell'accelerometro potrebbe richiedere un'implementazione del bus I2C "
+"o SPI."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 #, fuzzy
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+"Ci sono implementazioni per molti microcontrollori, così come altre "
+"piattaforme come Linux su Lampone Pi."
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+#, fuzzy
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
-" * Ci sono implementazioni per molti microcontrollori, così come altre "
-"piattaforme come Linux su\n"
-"Lampone Pi.\n"
-" * C'è lavoro in corso su una versione `async` di `embedded-hal`, ma non è "
+"C'è lavoro in corso su una versione `async` di `embedded-hal`, ma non è "
 "ancora stabile."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
 #, fuzzy
-msgid "# `probe-rs`, `cargo-embed`"
-msgstr "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
+msgstr "`probe-rs`, `cargo-embed`"
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 #, fuzzy
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
 "[probe-rs](https://probe.rs/) è un utile set di strumenti per il debug "
-"integrato, come OpenOCD ma migliore\n"
-"integrato."
+"integrato, come OpenOCD ma migliore integrato."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
 #, fuzzy
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr "SWD"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+#, fuzzy
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr " e JTAG tramite sonde CMSIS-DAP, ST-Link e J-Link"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+#, fuzzy
+msgid "GDB stub and Microsoft "
+msgstr "GDB stub e server Microsoft "
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+#, fuzzy
+msgid "DAP"
+msgstr "DAP"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+#, fuzzy
+msgid " server"
+msgstr "Integrazione del carico"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> e JTAG tramite sonde CMSIS-"
-"DAP, ST-Link e J-Link\n"
-"* GDB stub e server Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</"
-"abbr>\n"
-"* Integrazione del carico"
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
 #, fuzzy
-msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
 msgstr ""
-"`cargo-embed` è un sottocomando cargo per compilare e aggiornare binari, "
-"log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> emette e collega GDB. È "
-"configurato da un\n"
-"\"Embed.toml\" nella directory del progetto."
+"`cargo-embed` è un sottocomando cargo per compilare e aggiornare binari, log "
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+#, fuzzy
+msgid "RTT"
+msgstr "RTT"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+#, fuzzy
+msgid ""
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
+msgstr ""
+" emette e collega GDB. È configurato da un \"Embed.toml\" nella directory "
+"del progetto."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 #, fuzzy
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) è "
-"uno standard Arm\n"
-"  protocollo su USB per un debugger in-circuit per accedere alla porta di "
-"accesso di debug CoreSight di vari\n"
-"  Processori Arm Cortex. È ciò che utilizza il debugger integrato sul micro: "
-"bit della BBC.\n"
-"* ST-Link è una gamma di debugger in-circuit di ST Microelectronics, J-Link "
-"è una gamma di\n"
-"  SEGGER.\n"
-"* La porta di accesso al debug è in genere un'interfaccia JTAG a 5 pin o un "
-"cavo di debug seriale a 2 pin.\n"
-"* probe-rs è una libreria che puoi integrare nei tuoi strumenti se lo "
-"desideri.\n"
-"* Il [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) consente\n"
-"  VSCode e altri IDE eseguono il debug del codice in esecuzione su qualsiasi "
-"microcontrollore supportato.\n"
-"* cargo-embed è un binario creato utilizzando la libreria probe-rs.\n"
-"* RTT (Real Time Transfers) è un meccanismo per trasferire i dati tra l'host "
-"di debug e il target\n"
-"  attraverso una serie di ringbuffer."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) è "
+"uno standard Arm protocollo su USB per un debugger in-circuit per accedere "
+"alla porta di accesso di debug CoreSight di vari Processori Arm Cortex. È "
+"ciò che utilizza il debugger integrato sul micro: bit della BBC."
 
-#: src/bare-metal/microcontrollers/debugging.md:1
+#: src/bare-metal/microcontrollers/probe-rs.md:19
 #, fuzzy
-msgid "# Debugging"
-msgstr "# Debug"
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+"ST-Link è una gamma di debugger in-circuit di ST Microelectronics, J-Link è "
+"una gamma di SEGGER."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+#, fuzzy
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+"La porta di accesso al debug è in genere un'interfaccia JTAG a 5 pin o un "
+"cavo di debug seriale a 2 pin."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+#, fuzzy
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+"probe-rs è una libreria che puoi integrare nei tuoi strumenti se lo desideri."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+#, fuzzy
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+"Il [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) consente VSCode e altri IDE eseguono il debug del codice "
+"in esecuzione su qualsiasi microcontrollore supportato."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+#, fuzzy
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr "cargo-embed è un binario creato utilizzando la libreria probe-rs."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+#, fuzzy
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
+msgstr ""
+"RTT (Real Time Transfers) è un meccanismo per trasferire i dati tra l'host "
+"di debug e il target attraverso una serie di ringbuffer."
 
 #: src/bare-metal/microcontrollers/debugging.md:3
 #, fuzzy
@@ -14837,69 +15323,119 @@ msgstr ""
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
 #, fuzzy
-msgid "# Other projects"
-msgstr "# Altri progetti"
+msgid "Other projects"
+msgstr "Altri progetti"
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
 #, fuzzy
+msgid "[RTIC](https://rtic.rs/)"
+msgstr "[RTIC](https://rtic.rs/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+#, fuzzy
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr "\"Concorrenza basata su interrupt in tempo reale\""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
+#, fuzzy
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
 msgstr ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Concorrenza basata su interrupt in tempo reale\"\n"
-"   * Gestione delle risorse condivise, passaggio di messaggi, pianificazione "
-"delle attività, coda del timer\n"
-" * [Ambasciata](https://embassy.dev/)\n"
-"   * Esecutori `async` con priorità, timer, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * RTOS incentrato sulla sicurezza con pianificazione preventiva e "
-"supporto dell'unità di protezione della memoria\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS di Oxide Computer Company con protezione della "
-"memoria, driver non privilegiati, IPC\n"
-" * [Binding per FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Alcune piattaforme hanno implementazioni `std`, ad es.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Gestione delle risorse condivise, passaggio di messaggi, pianificazione "
+"delle attività, coda del timer"
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+#, fuzzy
+msgid "[Embassy](https://embassy.dev/)"
+msgstr "[Ambasciata](https://embassy.dev/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+#, fuzzy
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr "Esecutori `async` con priorità, timer, networking, USB"
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+#, fuzzy
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr "[TockOS](https://www.tockos.org/documentation/getting-started)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+#, fuzzy
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+"RTOS incentrato sulla sicurezza con pianificazione preventiva e supporto "
+"dell'unità di protezione della memoria"
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+#, fuzzy
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr "[Hubris](https://hubris.oxide.computer/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+#, fuzzy
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+"Microkernel RTOS di Oxide Computer Company con protezione della memoria, "
+"driver non privilegiati, IPC"
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+#, fuzzy
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr "[Binding per FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+#, fuzzy
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
+msgstr ""
+"Alcune piattaforme hanno implementazioni `std`, ad es. [esp-idf](https://esp-"
+"rs.github.io/book/overview/using-the-standard-library.html)."
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
 #, fuzzy
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr "RTIC può essere considerato un RTOS o un framework di concorrenza."
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+#, fuzzy
+msgid "It doesn't include any HALs."
+msgstr "Non include nessun HAL."
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
+#, fuzzy
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+"Utilizza Cortex-M NVIC (Nested Virtual Interrupt Controller) per la "
+"pianificazione piuttosto che un kernel corretto."
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+#, fuzzy
+msgid "Cortex-M only."
+msgstr "Solo Cortex-M."
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+#, fuzzy
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+"Google utilizza TockOS sul microcontrollore Haven per le chiavi di sicurezza "
+"Titan."
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+#, fuzzy
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
-" * RTIC può essere considerato un RTOS o un framework di concorrenza.\n"
-"   * Non include nessun HAL.\n"
-"   * Utilizza Cortex-M NVIC (Nested Virtual Interrupt Controller) per la "
-"pianificazione piuttosto che un\n"
-"     kernel corretto.\n"
-"   * Solo Cortex-M.\n"
-" * Google utilizza TockOS sul microcontrollore Haven per le chiavi di "
-"sicurezza Titan.\n"
-" * FreeRTOS è principalmente scritto in C, ma ci sono collegamenti Rust per "
-"la scrittura di applicazioni."
+"FreeRTOS è principalmente scritto in C, ma ci sono collegamenti Rust per la "
+"scrittura di applicazioni."
 
 #: src/exercises/bare-metal/morning.md:3
 #, fuzzy
@@ -14910,22 +15446,16 @@ msgstr ""
 "Leggeremo la direzione da una bussola I2C e registreremo le letture su una "
 "porta seriale."
 
-#: src/exercises/bare-metal/compass.md:1
-#, fuzzy
-msgid "# Compass"
-msgstr "# Bussola"
-
 #: src/exercises/bare-metal/compass.md:3
 #, fuzzy
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
-"serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 "Leggeremo la direzione da una bussola I2C e registreremo le letture su una "
-"porta seriale. Se hai\n"
-"tempo, prova a visualizzarlo in qualche modo anche sui LED o usa i pulsanti "
-"in qualche modo."
+"porta seriale. Se hai tempo, prova a visualizzarlo in qualche modo anche sui "
+"LED o usa i pulsanti in qualche modo."
 
 #: src/exercises/bare-metal/compass.md:6
 #, fuzzy
@@ -14935,72 +15465,73 @@ msgstr "Suggerimenti:"
 #: src/exercises/bare-metal/compass.md:8
 #, fuzzy
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C "
-"bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
 msgstr ""
-"- Controlla la documentazione per [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) e\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) e le\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- L'unità di misura inerziale LSM303AGR è collegata al bus I2C interno.\n"
-"- TWI è un altro nome per I2C, quindi la periferica master I2C si chiama "
-"TWIM.\n"
-"- Il driver LSM303AGR necessita di qualcosa che implementi `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  tratto. IL\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struttura\n"
-"  implementa questo.\n"
-"- Hai un [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct con campi per i vari pin e periferiche.\n"
-"- Puoi anche guardare il\n"
-"  [scheda tecnica nRF52833](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) se vuoi, ma\n"
-"  non dovrebbe essere necessario per questo esercizio."
+"Controlla la documentazione per [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) e [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) e le [micro:bit hardware](https://tech.microbit.org/hardware/)."
+
+#: src/exercises/bare-metal/compass.md:11
+#, fuzzy
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr "L'unità di misura inerziale LSM303AGR è collegata al bus I2C interno."
+
+#: src/exercises/bare-metal/compass.md:12
+#, fuzzy
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+"TWI è un altro nome per I2C, quindi la periferica master I2C si chiama TWIM."
+
+#: src/exercises/bare-metal/compass.md:13
+#, fuzzy
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+"Il driver LSM303AGR necessita di qualcosa che implementi `embedded_hal::"
+"blocking::i2c::WriteRead` tratto. IL [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struttura implementa "
+"questo."
+
+#: src/exercises/bare-metal/compass.md:17
+#, fuzzy
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+"Hai un [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct con campi per i vari pin e periferiche."
+
+#: src/exercises/bare-metal/compass.md:19
+#, fuzzy
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
+msgstr ""
+"Puoi anche guardare il [scheda tecnica nRF52833](https://infocenter."
+"nordicsemi.com/pdf/nRF52833_PS_v1.5.pdf) se vuoi, ma non dovrebbe essere "
+"necessario per questo esercizio."
 
 #: src/exercises/bare-metal/compass.md:23
 #, fuzzy
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `compass`\n"
-"directory for the following files."
+"look in the `compass` directory for the following files."
 msgstr ""
 "Scarica il [modello di esercizio](../../comprehensive-rust-exercises.zip) e "
-"guarda nella `bussola`\n"
-"directory per i seguenti file."
+"guarda nella `bussola` directory per i seguenti file."
 
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 #, fuzzy
 msgid "`src/main.rs`:"
 msgstr "`src/principale.rs`:"
-
-#: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
-#: src/exercises/concurrency/dining-philosophers.md:17
-#: src/exercises/concurrency/link-checker.md:55
-#: src/exercises/concurrency/dining-philosophers-async.md:11
-#, fuzzy
-msgid "<!-- File src/main.rs -->"
-msgstr "<!-- File src/main.rs -->"
 
 #: src/exercises/bare-metal/compass.md:30
 msgid ""
@@ -15044,15 +15575,6 @@ msgstr ""
 msgid "`Cargo.toml` (you shouldn't need to change this):"
 msgstr "`Cargo.toml` (non dovrebbe essere necessario modificarlo):"
 
-#: src/exercises/bare-metal/compass.md:66 src/exercises/bare-metal/rtc.md:387
-#: src/exercises/concurrency/dining-philosophers.md:63
-#: src/exercises/concurrency/link-checker.md:35
-#: src/exercises/concurrency/dining-philosophers-async.md:60
-#: src/exercises/concurrency/chat-app.md:17
-#, fuzzy
-msgid "<!-- File Cargo.toml -->"
-msgstr "<!-- File Cargo.toml -->"
-
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
 "```toml\n"
@@ -15078,11 +15600,6 @@ msgstr ""
 msgid "`Embed.toml` (you shouldn't need to change this):"
 msgstr "`Embed.toml` (non dovrebbe essere necessario modificarlo):"
 
-#: src/exercises/bare-metal/compass.md:87
-#, fuzzy
-msgid "<!-- File Embed.toml -->"
-msgstr "<!-- File Incorpora.toml -->"
-
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
 "```toml\n"
@@ -15101,11 +15618,6 @@ msgstr ""
 #, fuzzy
 msgid "`.cargo/config.toml` (you shouldn't need to change this):"
 msgstr "`.cargo/config.toml` (non dovresti aver bisogno di cambiarlo):"
-
-#: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
-#, fuzzy
-msgid "<!-- File .cargo/config.toml -->"
-msgstr "<!-- File .cargo/config.toml -->"
 
 #: src/exercises/bare-metal/compass.md:104
 msgid ""
@@ -15152,47 +15664,44 @@ msgstr "Usa Ctrl+A Ctrl+Q per uscire da picocom."
 
 #: src/bare-metal/aps.md:1
 #, fuzzy
-msgid "# Application processors"
-msgstr "# Processori di applicazioni"
+msgid "Application processors"
+msgstr "Processori di applicazioni"
 
 #: src/bare-metal/aps.md:3
 #, fuzzy
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 "Finora abbiamo parlato di microcontrollori, come la serie Arm Cortex-M. Ora "
-"proviamo a scrivere\n"
-"qualcosa per Cortex-A. Per semplicità lavoreremo solo con aarch64 di QEMU\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) scheda."
+"proviamo a scrivere qualcosa per Cortex-A. Per semplicità lavoreremo solo "
+"con aarch64 di QEMU ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) scheda."
 
 #: src/bare-metal/aps.md:9
 #, fuzzy
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
 msgstr ""
-"* In generale, i microcontrollori non hanno una MMU o più livelli di "
-"privilegio (eccezione\n"
-"  livelli su CPU Arm, anelli su x86), mentre i processori delle applicazioni "
-"lo fanno.\n"
-"* QEMU supporta l'emulazione di diverse macchine o modelli di scheda per "
-"ciascuna architettura. IL\n"
-"  La scheda 'virt' non corrisponde a nessun particolare hardware reale, ma è "
-"progettata esclusivamente per\n"
-"  macchine virtuali."
+"In generale, i microcontrollori non hanno una MMU o più livelli di "
+"privilegio (eccezione livelli su CPU Arm, anelli su x86), mentre i "
+"processori delle applicazioni lo fanno."
 
-#: src/bare-metal/aps/entry-point.md:1
-msgid "# Getting Ready to Rust"
+#: src/bare-metal/aps.md:11
+#, fuzzy
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
+"QEMU supporta l'emulazione di diverse macchine o modelli di scheda per "
+"ciascuna architettura. IL La scheda 'virt' non corrisponde a nessun "
+"particolare hardware reale, ma è progettata esclusivamente per macchine "
+"virtuali."
 
 #: src/bare-metal/aps/entry-point.md:3
 msgid ""
@@ -15277,66 +15786,94 @@ msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:77
 msgid ""
-"* This is the same as it would be for C: initialising the processor state, "
-"zeroing the BSS, and\n"
-"  setting up the stack pointer.\n"
-"  * The BSS (block starting symbol, for historical reasons) is the part of "
-"the object file which\n"
-"    containing statically allocated variables which are initialised to zero. "
-"They are omitted from\n"
-"    the image, to avoid wasting space on zeroes. The compiler assumes that "
-"the loader will take care\n"
-"    of zeroing them.\n"
-"* The BSS may already be zeroed, depending on how memory is initialised and "
-"the image is loaded, but\n"
-"  we zero it to be sure.\n"
-"* We need to enable the MMU and cache before reading or writing any memory. "
-"If we don't:\n"
-"  * Unaligned accesses will fault. We build the Rust code for the `aarch64-"
-"unknown-none` target\n"
-"    which sets `+strict-align` to prevent the compiler generating unaligned "
-"accesses, so it should\n"
-"    be fine in this case, but this is not necessarily the case in general.\n"
-"  * If it were running in a VM, this can lead to cache coherency issues. The "
-"problem is that the VM\n"
-"    is accessing memory directly with the cache disabled, while the host has "
-"cachable aliases to the\n"
-"    same memory. Even if the host doesn't explicitly access the memory, "
-"speculative accesses can\n"
-"    lead to cache fills, and then changes from one or the other will get "
-"lost when the cache is\n"
-"    cleaned or the VM enables the cache. (Cache is keyed by physical "
-"address, not VA or IPA.)\n"
-"* For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
-"identity maps the first 1\n"
-"  GiB of address space for devices, the next 1 GiB for DRAM, and another 1 "
-"GiB higher up for more\n"
-"  devices. This matches the memory layout that QEMU uses.\n"
-"* We also set up the exception vector (`vbar_el1`), which we'll see more "
-"about later.\n"
-"* All examples this afternoon assume we will be running at exception level 1 "
-"(EL1). If you need to\n"
-"  run at a different exception level you'll need to modify `entry.S` "
-"accordingly."
+"This is the same as it would be for C: initialising the processor state, "
+"zeroing the BSS, and setting up the stack pointer."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:79
+msgid ""
+"The BSS (block starting symbol, for historical reasons) is the part of the "
+"object file which containing statically allocated variables which are "
+"initialised to zero. They are omitted from the image, to avoid wasting space "
+"on zeroes. The compiler assumes that the loader will take care of zeroing "
+"them."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:83
+msgid ""
+"The BSS may already be zeroed, depending on how memory is initialised and "
+"the image is loaded, but we zero it to be sure."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:85
+msgid ""
+"We need to enable the MMU and cache before reading or writing any memory. If "
+"we don't:"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:86
+msgid ""
+"Unaligned accesses will fault. We build the Rust code for the `aarch64-"
+"unknown-none` target which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses, so it should be fine in this case, but this "
+"is not necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:89
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cachable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost when the cache "
+"is cleaned or the VM enables the cache. (Cache is keyed by physical address, "
+"not VA or IPA.)"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:94
+msgid ""
+"For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
+"identity maps the first 1 GiB of address space for devices, the next 1 GiB "
+"for DRAM, and another 1 GiB higher up for more devices. This matches the "
+"memory layout that QEMU uses."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:97
+msgid ""
+"We also set up the exception vector (`vbar_el1`), which we'll see more about "
+"later."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:98
+msgid ""
+"All examples this afternoon assume we will be running at exception level 1 "
+"(EL1). If you need to run at a different exception level you'll need to "
+"modify `entry.S` accordingly."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
 #, fuzzy
-msgid "# Inline assembly"
-msgstr "# Assemblaggio in linea"
+msgid "Inline assembly"
+msgstr "Assemblaggio in linea"
 
 #: src/bare-metal/aps/inline-assembly.md:3
 #, fuzzy
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
 msgstr ""
 "A volte abbiamo bisogno di usare l'assembly per fare cose che non sono "
-"possibili con il codice Rust. Per esempio,\n"
-"per effettuare un <abbr title=\"hypervisor call\">HVC</abbr> per dire al "
-"firmware di spegnere il sistema:"
+"possibili con il codice Rust. Per esempio, per effettuare un "
+
+#: src/bare-metal/aps/inline-assembly.md:4
+#, fuzzy
+msgid "HVC"
+msgstr "HVC"
+
+#: src/bare-metal/aps/inline-assembly.md:4
+#, fuzzy
+msgid " to tell the firmware to power off the system:"
+msgstr " per dire al firmware di spegnere il sistema:"
 
 #: src/bare-metal/aps/inline-assembly.md:6
 msgid ""
@@ -15377,126 +15914,150 @@ msgstr ""
 #: src/bare-metal/aps/inline-assembly.md:39
 #, fuzzy
 msgid ""
-"(If you actually want to do this, use the [`smccc`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
-"(Se vuoi davvero farlo, usa la cassa [`smccc`][1] che ha wrapper per tutte "
-"queste funzioni.)"
+"(Se vuoi davvero farlo, usa la cassa [`smccc`](https://crates.io/crates/"
+"smccc) che ha wrapper per tutte queste funzioni.)"
 
 #: src/bare-metal/aps/inline-assembly.md:43
 #, fuzzy
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
-"it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are "
-"conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the "
-"standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–"
-"`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do "
-"anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+"PSCI è l'Arm Power State Coordination Interface, un insieme standard di "
+"funzioni per gestire il sistema e gli stati di alimentazione della CPU, tra "
+"le altre cose. È implementato dal firmware EL3 e dagli hypervisor su molti "
+"sistemi."
+
+#: src/bare-metal/aps/inline-assembly.md:46
+#, fuzzy
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+"La sintassi `0 => _` significa inizializzare il registro a 0 prima di "
+"eseguire il codice assembly inline, e ignorarne il contenuto in seguito. "
+"Dobbiamo usare \"inout\" piuttosto che \"in\" perché la chiamata potrebbe "
+"potenzialmente intasare il contenuto dei registri."
+
+#: src/bare-metal/aps/inline-assembly.md:49
+#, fuzzy
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+"Questa funzione `main` deve essere `#[no_mangle]` e `extern \"C\"` perché "
+"viene chiamata dal nostro punto di ingresso in \"entry.S\"."
+
+#: src/bare-metal/aps/inline-assembly.md:51
+#, fuzzy
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+"`_x0`–`_x3` sono i valori dei registri `x0`–`x3`, che sono convenzionalmente "
+"utilizzati dal bootloader per passare cose come un puntatore all'albero dei "
+"dispositivi. Secondo la chiamata standard aarch64 convenzione (che è ciò che "
+"`extern \"C\"` specifica di usare), i registri `x0`–`x7` sono usati per "
+"primi 8 argomenti passati a una funzione, quindi `entry.S` non ha bisogno di "
+"fare niente di speciale tranne assicurati che non modifichi questi registri."
+
+#: src/bare-metal/aps/inline-assembly.md:56
+#, fuzzy
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
-"* PSCI è l'Arm Power State Coordination Interface, un insieme standard di "
-"funzioni per gestire il sistema\n"
-"  e gli stati di alimentazione della CPU, tra le altre cose. È implementato "
-"dal firmware EL3 e dagli hypervisor su\n"
-"  molti sistemi.\n"
-"* La sintassi `0 => _` significa inizializzare il registro a 0 prima di "
-"eseguire il codice assembly inline,\n"
-"  e ignorarne il contenuto in seguito. Dobbiamo usare \"inout\" piuttosto "
-"che \"in\" perché la chiamata potrebbe\n"
-"  potenzialmente intasare il contenuto dei registri.\n"
-"* Questa funzione `main` deve essere `#[no_mangle]` e `extern \"C\"` perché "
-"viene chiamata dal nostro\n"
-"  punto di ingresso in \"entry.S\".\n"
-"* `_x0`–`_x3` sono i valori dei registri `x0`–`x3`, che sono "
-"convenzionalmente utilizzati dal bootloader\n"
-"  per passare cose come un puntatore all'albero dei dispositivi. Secondo la "
-"chiamata standard aarch64\n"
-"  convenzione (che è ciò che `extern \"C\"` specifica di usare), i registri "
-"`x0`–`x7` sono usati per\n"
-"  primi 8 argomenti passati a una funzione, quindi `entry.S` non ha bisogno "
-"di fare niente di speciale tranne\n"
-"  assicurati che non modifichi questi registri.\n"
-"* Eseguire l'esempio in QEMU con `make qemu_psci` in `src/bare-metal/aps/"
+"Eseguire l'esempio in QEMU con `make qemu_psci` in `src/bare-metal/aps/"
 "examples`."
 
 #: src/bare-metal/aps/mmio.md:1
 #, fuzzy
-msgid "# Volatile memory access for MMIO"
-msgstr "# Accesso alla memoria volatile per MMIO"
+msgid "Volatile memory access for MMIO"
+msgstr "Accesso alla memoria volatile per MMIO"
 
 #: src/bare-metal/aps/mmio.md:3
 #, fuzzy
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr "Usa `pointer::read_volatile` e `pointer::write_volatile`."
+
+#: src/bare-metal/aps/mmio.md:4
+#, fuzzy
+msgid "Never hold a reference."
+msgstr "Non tenere mai un riferimento."
+
+#: src/bare-metal/aps/mmio.md:5
+#, fuzzy
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
-" * Usa `pointer::read_volatile` e `pointer::write_volatile`.\n"
-" * Non tenere mai un riferimento.\n"
-" * `addr_of!` consente di ottenere campi di struct senza creare un "
-"riferimento intermedio."
+"`addr_of!` consente di ottenere campi di struct senza creare un riferimento "
+"intermedio."
 
 #: src/bare-metal/aps/mmio.md:9
 #, fuzzy
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
 msgstr ""
-" * Accesso volatile: le operazioni di lettura o scrittura possono avere "
-"effetti collaterali, quindi impedisci al compilatore o\n"
-"   hardware dal riordinarli, duplicarli o eliminarli.\n"
-"   * Di solito se scrivi e poi leggi, ad es. tramite un riferimento "
-"mutabile, il compilatore può assumerlo\n"
-"     il valore letto è uguale al valore appena scritto, e non disturba "
-"effettivamente la lettura della memoria.\n"
-" * Alcuni crate esistenti per l'accesso volatile all'hardware contengono "
-"riferimenti, ma questo non è corretto.\n"
-"   Ogni volta che esiste un riferimento, il compilatore può scegliere di "
-"dereferenziarlo.\n"
-" * Usa la macro `addr_of!` per ottenere i puntatori di campo struct da un "
+"Accesso volatile: le operazioni di lettura o scrittura possono avere effetti "
+"collaterali, quindi impedisci al compilatore o hardware dal riordinarli, "
+"duplicarli o eliminarli."
+
+#: src/bare-metal/aps/mmio.md:11
+#, fuzzy
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+"Di solito se scrivi e poi leggi, ad es. tramite un riferimento mutabile, il "
+"compilatore può assumerlo il valore letto è uguale al valore appena scritto, "
+"e non disturba effettivamente la lettura della memoria."
+
+#: src/bare-metal/aps/mmio.md:13
+#, fuzzy
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+"Alcuni crate esistenti per l'accesso volatile all'hardware contengono "
+"riferimenti, ma questo non è corretto. Ogni volta che esiste un riferimento, "
+"il compilatore può scegliere di dereferenziarlo."
+
+#: src/bare-metal/aps/mmio.md:15
+#, fuzzy
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
+msgstr ""
+"Usa la macro `addr_of!` per ottenere i puntatori di campo struct da un "
 "puntatore alla struct."
 
 #: src/bare-metal/aps/uart.md:1
 #, fuzzy
-msgid "# Let's write a UART driver"
-msgstr "# Scriviamo un driver UART"
+msgid "Let's write a UART driver"
+msgstr "Scriviamo un driver UART"
 
 #: src/bare-metal/aps/uart.md:3
 #, fuzzy
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
-"La macchina QEMU 'virt' ha un [PL011][1] UART, quindi scriviamo un driver "
-"per quello."
+"La macchina QEMU 'virt' ha un [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, quindi scriviamo un driver per quello."
 
 #: src/bare-metal/aps/uart.md:5
 msgid ""
@@ -15556,51 +16117,46 @@ msgstr ""
 #: src/bare-metal/aps/uart.md:55
 #, fuzzy
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is "
-"because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i."
-"e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else "
-"aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume "
-"the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but "
-"`write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls "
-"`write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving "
-"the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
-"* Nota che `Uart::new` non è sicuro mentre gli altri metodi sono sicuri. "
-"Questo perché finché il\n"
-"  chiamante di `Uart::new` garantisce che i suoi requisiti di sicurezza "
-"siano soddisfatti (cioè che ci sia solo\n"
-"  mai un'istanza del driver per un dato UART, e nient'altro che alias il suo "
-"spazio degli indirizzi),\n"
-"  quindi è sempre sicuro chiamare `write_byte` in seguito perché possiamo "
-"assumere il necessario\n"
-"  precondizioni.\n"
-"* Avremmo potuto fare il contrario (rendere `new` sicuro ma `write_byte` non "
-"sicuro), ma quello\n"
-"  sarebbe molto meno conveniente da usare poiché ogni posto che chiama "
-"`write_byte` dovrebbe ragionare\n"
-"  sulla sicurezza\n"
-"* Questo è un modello comune per scrivere wrapper sicuri di codice non "
-"sicuro: spostare l'onere della prova per\n"
-"  solidità da un gran numero di posti a un numero minore di posti."
+"Nota che `Uart::new` non è sicuro mentre gli altri metodi sono sicuri. "
+"Questo perché finché il chiamante di `Uart::new` garantisce che i suoi "
+"requisiti di sicurezza siano soddisfatti (cioè che ci sia solo mai "
+"un'istanza del driver per un dato UART, e nient'altro che alias il suo "
+"spazio degli indirizzi), quindi è sempre sicuro chiamare `write_byte` in "
+"seguito perché possiamo assumere il necessario precondizioni."
 
-#: src/bare-metal/aps/uart.md:66
+#: src/bare-metal/aps/uart.md:60
 #, fuzzy
-msgid "</detais>"
-msgstr "</detais>"
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+"Avremmo potuto fare il contrario (rendere `new` sicuro ma `write_byte` non "
+"sicuro), ma quello sarebbe molto meno conveniente da usare poiché ogni posto "
+"che chiama `write_byte` dovrebbe ragionare sulla sicurezza"
+
+#: src/bare-metal/aps/uart.md:63
+#, fuzzy
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
+msgstr ""
+"Questo è un modello comune per scrivere wrapper sicuri di codice non sicuro: "
+"spostare l'onere della prova per solidità da un gran numero di posti a un "
+"numero minore di posti."
 
 #: src/bare-metal/aps/uart/traits.md:1
 #, fuzzy
-msgid "# More traits"
-msgstr "# Altri tratti"
+msgid "More traits"
+msgstr "Altri tratti"
 
 #: src/bare-metal/aps/uart/traits.md:3
 #, fuzzy
@@ -15634,84 +16190,243 @@ msgstr ""
 #: src/bare-metal/aps/uart/traits.md:24
 #, fuzzy
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with "
-"our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+"L'implementazione di `Write` ci permette di usare le macro `write!` e "
+"`writeln!` con il nostro tipo `Uart`."
+
+#: src/bare-metal/aps/uart/traits.md:25
+#, fuzzy
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
-"* L'implementazione di `Write` ci permette di usare le macro `write!` e "
-"`writeln!` con il nostro tipo `Uart`.\n"
-"* Esegui l'esempio in QEMU con `make qemu_minimal` sotto `src/bare-metal/aps/"
+"Esegui l'esempio in QEMU con `make qemu_minimal` sotto `src/bare-metal/aps/"
 "examples`."
 
 #: src/bare-metal/aps/better-uart.md:1
 #, fuzzy
-msgid "# A better UART driver"
-msgstr "# Un driver UART migliore"
+msgid "A better UART driver"
+msgstr "Un driver UART migliore"
 
 #: src/bare-metal/aps/better-uart.md:3
 #, fuzzy
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
-"Il PL011 in realtà ha [un mucchio di registri in più][1] e aggiunge offset "
-"per costruire puntatori a cui accedere\n"
-"è soggetto a errori e difficile da leggere. Inoltre, alcuni di loro sono "
-"campi di bit che sarebbero carini\n"
-"accedere in modo strutturato."
+"Il PL011 in realtà ha [un mucchio di registri in più](https://developer.arm."
+"com/documentation/ddi0183/g/programmers-model/summary-of-registers) e "
+"aggiunge offset per costruire puntatori a cui accedere è soggetto a errori e "
+"difficile da leggere. Inoltre, alcuni di loro sono campi di bit che "
+"sarebbero carini accedere in modo strutturato."
 
 #: src/bare-metal/aps/better-uart.md:7
 #, fuzzy
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
-msgstr ""
-"| Compensazione | Registra nome | Larghezza |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00 | DR | 12 |\n"
-"| 0x04 | RSR | 4 |\n"
-"| 0x18 | FR | 9 |\n"
-"| 0x20 | ILPR | 8 |\n"
-"| 0x24 | BIRS | 16 |\n"
-"| 0x28 | FBRD | 6 |\n"
-"| 0x2c | LCR_H | 8 |\n"
-"| 0x30 | CR | 16 |\n"
-"| 0x34 | IFL | 6 |\n"
-"| 0x38 | IMSC | 11 |\n"
-"| 0x3c | RIS| 11 |\n"
-"| 0x40 | MIS | 11 |\n"
-"| 0x44 | CRI | 11 |\n"
-"| 0x48 | DMACR | 3 |"
+msgid "Offset"
+msgstr "Compensazione"
+
+#: src/bare-metal/aps/better-uart.md:7
+#, fuzzy
+msgid "Register name"
+msgstr "Registra nome"
+
+#: src/bare-metal/aps/better-uart.md:7
+#, fuzzy
+msgid "Width"
+msgstr "Larghezza"
+
+#: src/bare-metal/aps/better-uart.md:9
+#, fuzzy
+msgid "0x00"
+msgstr "0x00"
+
+#: src/bare-metal/aps/better-uart.md:9
+#, fuzzy
+msgid "DR"
+msgstr "DR"
+
+#: src/bare-metal/aps/better-uart.md:9
+#, fuzzy
+msgid "12"
+msgstr "12"
+
+#: src/bare-metal/aps/better-uart.md:10
+#, fuzzy
+msgid "0x04"
+msgstr "0x04"
+
+#: src/bare-metal/aps/better-uart.md:10
+#, fuzzy
+msgid "RSR"
+msgstr "RSR"
+
+#: src/bare-metal/aps/better-uart.md:10
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/bare-metal/aps/better-uart.md:11
+#, fuzzy
+msgid "0x18"
+msgstr "0x18"
+
+#: src/bare-metal/aps/better-uart.md:11
+#, fuzzy
+msgid "FR"
+msgstr "FR"
+
+#: src/bare-metal/aps/better-uart.md:11
+#, fuzzy
+msgid "9"
+msgstr "9"
+
+#: src/bare-metal/aps/better-uart.md:12
+#, fuzzy
+msgid "0x20"
+msgstr "0x20"
+
+#: src/bare-metal/aps/better-uart.md:12
+#, fuzzy
+msgid "ILPR"
+msgstr "ILPR"
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/bare-metal/aps/better-uart.md:13
+#, fuzzy
+msgid "0x24"
+msgstr "0x24"
+
+#: src/bare-metal/aps/better-uart.md:13
+#, fuzzy
+msgid "IBRD"
+msgstr "BIRS"
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+#, fuzzy
+msgid "16"
+msgstr "16"
+
+#: src/bare-metal/aps/better-uart.md:14
+#, fuzzy
+msgid "0x28"
+msgstr "0x28"
+
+#: src/bare-metal/aps/better-uart.md:14
+#, fuzzy
+msgid "FBRD"
+msgstr "FBRD"
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+#, fuzzy
+msgid "6"
+msgstr "6"
+
+#: src/bare-metal/aps/better-uart.md:15
+#, fuzzy
+msgid "0x2c"
+msgstr "0x2c"
+
+#: src/bare-metal/aps/better-uart.md:15
+#, fuzzy
+msgid "LCR_H"
+msgstr "LCR_H"
+
+#: src/bare-metal/aps/better-uart.md:16
+#, fuzzy
+msgid "0x30"
+msgstr "0x30"
+
+#: src/bare-metal/aps/better-uart.md:16
+#, fuzzy
+msgid "CR"
+msgstr "CR"
+
+#: src/bare-metal/aps/better-uart.md:17
+#, fuzzy
+msgid "0x34"
+msgstr "0x34"
+
+#: src/bare-metal/aps/better-uart.md:17
+#, fuzzy
+msgid "IFLS"
+msgstr "IFL"
+
+#: src/bare-metal/aps/better-uart.md:18
+#, fuzzy
+msgid "0x38"
+msgstr "0x38"
+
+#: src/bare-metal/aps/better-uart.md:18
+#, fuzzy
+msgid "IMSC"
+msgstr "IMSC"
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+#, fuzzy
+msgid "11"
+msgstr "11"
+
+#: src/bare-metal/aps/better-uart.md:19
+#, fuzzy
+msgid "0x3c"
+msgstr "0x3c"
+
+#: src/bare-metal/aps/better-uart.md:19
+#, fuzzy
+msgid "RIS"
+msgstr "RIS"
+
+#: src/bare-metal/aps/better-uart.md:20
+#, fuzzy
+msgid "0x40"
+msgstr "0x40"
+
+#: src/bare-metal/aps/better-uart.md:20
+#, fuzzy
+msgid "MIS"
+msgstr "MIS"
+
+#: src/bare-metal/aps/better-uart.md:21
+#, fuzzy
+msgid "0x44"
+msgstr "0x44"
+
+#: src/bare-metal/aps/better-uart.md:21
+#, fuzzy
+msgid "ICR"
+msgstr "CRI"
+
+#: src/bare-metal/aps/better-uart.md:22
+#, fuzzy
+msgid "0x48"
+msgstr "0x48"
+
+#: src/bare-metal/aps/better-uart.md:22
+#, fuzzy
+msgid "DMACR"
+msgstr "DMACR"
+
+#: src/bare-metal/aps/better-uart.md:22
+#, fuzzy
+msgid "3"
+msgstr "3"
 
 #: src/bare-metal/aps/better-uart.md:26
 #, fuzzy
-msgid "- There are also some ID registers which have been omitted for brevity."
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
-"- Sono inoltre presenti alcuni registri identificativi che per brevità sono "
+"Sono inoltre presenti alcuni registri identificativi che per brevità sono "
 "stati omessi."
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-#, fuzzy
-msgid "# Bitflags"
-msgstr "# Bitflag"
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
 #, fuzzy
@@ -15758,18 +16473,16 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 #, fuzzy
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
-"with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
-"* La macro `bitflags!` crea un nuovo tipo qualcosa come `Flags(u16)`, "
-"insieme a una serie di metodi\n"
-"  implementazioni per ottenere e impostare flag."
+"La macro `bitflags!` crea un nuovo tipo qualcosa come `Flags(u16)`, insieme "
+"a una serie di metodi implementazioni per ottenere e impostare flag."
 
 #: src/bare-metal/aps/better-uart/registers.md:1
 #, fuzzy
-msgid "# Multiple registers"
-msgstr "# Più registri"
+msgid "Multiple registers"
+msgstr "Più registri"
 
 #: src/bare-metal/aps/better-uart/registers.md:3
 #, fuzzy
@@ -15819,26 +16532,18 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/registers.md:41
 #, fuzzy
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust "
-"representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) indica\n"
-"  il compilatore per disporre i campi struct in ordine, seguendo le stesse "
-"regole di C. Questo è\n"
-"  necessario affinché la nostra struttura abbia un layout prevedibile, "
-"poiché la rappresentazione predefinita di Rust lo consente\n"
-"  compilatore per (tra le altre cose) riordinare i campi come meglio crede."
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-#, fuzzy
-msgid "# Driver"
-msgstr "# Autista"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) indica il compilatore per disporre i campi struct in ordine, "
+"seguendo le stesse regole di C. Questo è necessario affinché la nostra "
+"struttura abbia un layout prevedibile, poiché la rappresentazione "
+"predefinita di Rust lo consente compilatore per (tra le altre cose) "
+"riordinare i campi come meglio crede."
 
 #: src/bare-metal/aps/better-uart/driver.md:3
 #, fuzzy
@@ -15913,30 +16618,26 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/driver.md:64
 #, fuzzy
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
-"fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
-"* Notare l'uso di `addr_of!` / `addr_of_mut!` per ottenere puntatori a "
-"singoli campi senza creare\n"
-"  un riferimento intermedio, che sarebbe errato."
+"Notare l'uso di `addr_of!` / `addr_of_mut!` per ottenere puntatori a singoli "
+"campi senza creare un riferimento intermedio, che sarebbe errato."
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
 #, fuzzy
-msgid "# Using it"
-msgstr "# Usandolo"
+msgid "Using it"
+msgstr "Usandolo"
 
 #: src/bare-metal/aps/better-uart/using.md:3
 #, fuzzy
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
-"and echo incoming\n"
-"bytes."
+"and echo incoming bytes."
 msgstr ""
 "Scriviamo un piccolo programma usando il nostro driver per scrivere sulla "
-"console seriale ed echo in entrata\n"
-"byte."
+"console seriale ed echo in entrata byte."
 
 #: src/bare-metal/aps/better-uart/using.md:6
 msgid ""
@@ -15988,29 +16689,31 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/using.md:51
 #, fuzzy
 msgid ""
-"* As in the [inline assembly](../inline-assembly.md) example, this `main` "
-"function is called from our\n"
-"  entry point code in `entry.S`. See the speaker notes there for details.\n"
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/"
-"examples`."
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
 msgstr ""
-"* Come nell'esempio [inline assembly](../inline-assembly.md), questa "
-"funzione `main` è chiamata dal nostro\n"
-"  codice del punto di ingresso in \"entry.S\". Vedi le note del relatore lì "
-"per i dettagli.\n"
-"* Esegui l'esempio in QEMU con `make qemu` sotto `src/bare-metal/aps/"
-"examples`."
+"Come nell'esempio [inline assembly](../inline-assembly.md), questa funzione "
+"`main` è chiamata dal nostro codice del punto di ingresso in \"entry.S\". "
+"Vedi le note del relatore lì per i dettagli."
+
+#: src/bare-metal/aps/better-uart/using.md:53
+#, fuzzy
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
+msgstr ""
+"Esegui l'esempio in QEMU con `make qemu` sotto `src/bare-metal/aps/examples`."
 
 #: src/bare-metal/aps/logging.md:3
 #, fuzzy
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
-"Sarebbe bello poter usare le macro di registrazione dalla cassa [`log`][1]. "
-"Possiamo farlo con\n"
-"implementando il tratto `Log`."
+"Sarebbe bello poter usare le macro di registrazione dalla cassa [`log`]"
+"(https://crates.io/crates/log). Possiamo farlo con implementando il tratto "
+"`Log`."
 
 #: src/bare-metal/aps/logging.md:6
 msgid ""
@@ -16061,11 +16764,11 @@ msgstr ""
 #: src/bare-metal/aps/logging.md:50
 #, fuzzy
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
-"* L'unwrap in `log` è sicuro perché inizializziamo `LOGGER` prima di "
-"chiamare `set_logger`."
+"L'unwrap in `log` è sicuro perché inizializziamo `LOGGER` prima di chiamare "
+"`set_logger`."
 
 #: src/bare-metal/aps/logging/using.md:3
 #, fuzzy
@@ -16117,30 +16820,27 @@ msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
 #, fuzzy
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+"Nota che il nostro gestore del panico ora può registrare i dettagli dei "
+"panico."
+
+#: src/bare-metal/aps/logging/using.md:47
+#, fuzzy
 msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
-"* Nota che il nostro gestore del panico ora può registrare i dettagli dei "
-"panico.\n"
-"* Eseguire l'esempio in QEMU con `make qemu_logger` in `src/bare-metal/aps/"
+"Eseguire l'esempio in QEMU con `make qemu_logger` in `src/bare-metal/aps/"
 "examples`."
-
-#: src/bare-metal/aps/exceptions.md:1
-#, fuzzy
-msgid "# Exceptions"
-msgstr "# Funzioni"
 
 #: src/bare-metal/aps/exceptions.md:3
 msgid ""
 "AArch64 defines an exception vector table with 16 entries, for 4 types of "
-"exceptions (synchronous,\n"
-"IRQ, FIQ, SError) from 4 states (current EL with SP0, current EL with SPx, "
-"lower EL using AArch64,\n"
-"lower EL using AArch32). We implement this in assembly to save volatile "
-"registers to the stack\n"
-"before calling into Rust code:"
+"exceptions (synchronous, IRQ, FIQ, SError) from 4 states (current EL with "
+"SP0, current EL with SPx, lower EL using AArch64, lower EL using AArch32). "
+"We implement this in assembly to save volatile registers to the stack before "
+"calling into Rust code:"
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:8
@@ -16201,82 +16901,110 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:64
+msgid "EL is exception level; all our examples this afternoon run in EL1."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:65
 msgid ""
-"* EL is exception level; all our examples this afternoon run in EL1.\n"
-"* For simplicity we aren't distinguishing between SP0 and SPx for the "
-"current EL exceptions, or\n"
-"  between AArch32 and AArch64 for the lower EL exceptions.\n"
-"* For this example we just log the exception and power down, as we don't "
-"expect any of them to\n"
-"  actually happen.\n"
-"* We can think of exception handlers and our main execution context more or "
-"less like different\n"
-"  threads. [`Send` and `Sync`][1] will control what we can share between "
-"them, just like with threads.\n"
-"  For example, if we want to share some value between exception handlers and "
-"the rest of the\n"
-"  program, and it's `Send` but not `Sync`, then we'll need to wrap it in "
-"something like a `Mutex`\n"
-"  and put it in a static."
+"For simplicity we aren't distinguishing between SP0 and SPx for the current "
+"EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:67
+msgid ""
+"For this example we just log the exception and power down, as we don't "
+"expect any of them to actually happen."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:69
+msgid ""
+"We can think of exception handlers and our main execution context more or "
+"less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
+"md) will control what we can share between them, just like with threads. For "
+"example, if we want to share some value between exception handlers and the "
+"rest of the program, and it's `Send` but not `Sync`, then we'll need to wrap "
+"it in something like a `Mutex` and put it in a static."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
 #, fuzzy
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
+msgstr "[oreboot](https://github.com/oreboot/oreboot)"
+
+#: src/bare-metal/aps/other-projects.md:4
+#, fuzzy
+msgid "\"coreboot without the C\""
+msgstr "\"coreboot senza la C\""
+
+#: src/bare-metal/aps/other-projects.md:5
+#, fuzzy
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr "Supporta x86, aarch64 e RISC-V."
+
+#: src/bare-metal/aps/other-projects.md:6
+#, fuzzy
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr "Si basa su LinuxBoot piuttosto che avere molti driver."
+
+#: src/bare-metal/aps/other-projects.md:7
+#, fuzzy
 msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling,\n"
-"     page tables\n"
-"   * Some dodginess around cache maintenance and initialisation in Rust, not "
-"necessarily a good\n"
-"     example to copy for production code.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
 msgstr ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot senza la C\"\n"
-"   * Supporta x86, aarch64 e RISC-V.\n"
-"   * Si basa su LinuxBoot piuttosto che avere molti driver.\n"
-" * [Tutorial sul sistema operativo Rust RaspberryPi](https://github.com/rust-"
-"embedded/rust-raspberrypi-OS-tutorials)\n"
-"   * Inizializzazione, driver UART, bootloader semplice, JTAG, livelli di "
-"eccezione, gestione delle eccezioni, tabelle delle pagine\n"
-"   * Non tutto molto ben scritto, quindi attenzione.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Analisi statica per determinare l'utilizzo massimo dello stack."
+"[Tutorial sul sistema operativo Rust RaspberryPi](https://github.com/rust-"
+"embedded/rust-raspberrypi-OS-tutorials)"
+
+#: src/bare-metal/aps/other-projects.md:8
+#, fuzzy
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+"Inizializzazione, driver UART, bootloader semplice, JTAG, livelli di "
+"eccezione, gestione delle eccezioni, tabelle delle pagine"
+
+#: src/bare-metal/aps/other-projects.md:10
+#, fuzzy
+msgid ""
+"Some dodginess around cache maintenance and initialisation in Rust, not "
+"necessarily a good example to copy for production code."
+msgstr "Non tutto molto ben scritto, quindi attenzione."
+
+#: src/bare-metal/aps/other-projects.md:12
+#, fuzzy
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+
+#: src/bare-metal/aps/other-projects.md:13
+#, fuzzy
+msgid "Static analysis to determine maximum stack usage."
+msgstr "Analisi statica per determinare l'utilizzo massimo dello stack."
 
 #: src/bare-metal/aps/other-projects.md:17
 msgid ""
-"* The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
-"enabled. This will read\n"
-"  and write memory (e.g. the stack). However:\n"
-"  * Without the MMU and cache, unaligned accesses will fault. It builds with "
-"`aarch64-unknown-none`\n"
-"    which sets `+strict-align` to prevent the compiler generating unaligned "
-"accesses so it should be\n"
-"    alright, but this is not necessarily the case in general.\n"
-"  * If it were running in a VM, this can lead to cache coherency issues. The "
-"problem is that the VM\n"
-"    is accessing memory directly with the cache disabled, while the host has "
-"cachable aliases to the\n"
-"    same memory. Even if the host doesn't explicitly access the memory, "
-"speculative accesses can\n"
-"    lead to cache fills, and then changes from one or the other will get "
-"lost. Again this is alright\n"
-"    in this particular case (running directly on the hardware with no "
-"hypervisor), but isn't a good\n"
-"    pattern in general."
+"The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
+"enabled. This will read and write memory (e.g. the stack). However:"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
-#, fuzzy
-msgid "# Useful crates"
-msgstr "# Casse utili"
+#: src/bare-metal/aps/other-projects.md:19
+msgid ""
+"Without the MMU and cache, unaligned accesses will fault. It builds with "
+"`aarch64-unknown-none` which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses so it should be alright, but this is not "
+"necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:22
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cachable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost. Again this is "
+"alright in this particular case (running directly on the hardware with no "
+"hypervisor), but isn't a good pattern in general."
+msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
 #, fuzzy
@@ -16289,19 +17017,18 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
 #, fuzzy
-msgid "# `zerocopy`"
-msgstr "# `zerocopia`"
+msgid "`zerocopy`"
+msgstr "`zerocopia`"
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 #, fuzzy
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
-"La cassa [`zerocopy`][1] (da Fuchsia) fornisce tratti e macro per la "
-"conversione sicura tra\n"
-"sequenze di byte e altri tipi."
+"La cassa [`zerocopy`](https://docs.rs/zerocopy/) (da Fuchsia) fornisce "
+"tratti e macro per la conversione sicura tra sequenze di byte e altri tipi."
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
 msgid ""
@@ -16344,56 +17071,67 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 "Questo non è adatto per MMIO (poiché non utilizza letture e scritture "
-"volatili), ma può essere utile per\n"
-"lavorare con strutture condivise con l'hardware, ad es. tramite DMA o "
-"inviato tramite un'interfaccia esterna."
+"volatili), ma può essere utile per lavorare con strutture condivise con "
+"l'hardware, ad es. tramite DMA o inviato tramite un'interfaccia esterna."
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 #, fuzzy
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
 msgstr ""
-"* `FromBytes` può essere implementato per i tipi per i quali qualsiasi "
-"modello di byte è valido, e quindi può tranquillamente esserlo\n"
-"  convertito da una sequenza di byte non attendibile.\n"
-"* Il tentativo di derivare `FromBytes` per questi tipi fallirebbe, perché "
-"`RequestType` non usa tutti\n"
-"  possibili valori u32 come discriminanti, quindi non tutti i modelli di "
-"byte sono validi.\n"
-"* `zerocopy::byteorder` ha tipi per primitive numeriche che riconoscono "
-"l'ordine dei byte.\n"
-"* Esegui l'esempio con `cargo run` sotto `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (Non lo farà\n"
-"  eseguito nel Parco giochi a causa della dipendenza dalla cassa.)"
+"`FromBytes` può essere implementato per i tipi per i quali qualsiasi modello "
+"di byte è valido, e quindi può tranquillamente esserlo convertito da una "
+"sequenza di byte non attendibile."
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+#, fuzzy
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+"Il tentativo di derivare `FromBytes` per questi tipi fallirebbe, perché "
+"`RequestType` non usa tutti possibili valori u32 come discriminanti, quindi "
+"non tutti i modelli di byte sono validi."
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+#, fuzzy
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+"`zerocopy::byteorder` ha tipi per primitive numeriche che riconoscono "
+"l'ordine dei byte."
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+#, fuzzy
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
+msgstr ""
+"Esegui l'esempio con `cargo run` sotto `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (Non lo farà eseguito nel Parco giochi a causa della "
+"dipendenza dalla cassa.)"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
 #, fuzzy
-msgid "# `aarch64-paging`"
-msgstr "# `aarch64-paging`"
+msgid "`aarch64-paging`"
+msgstr "`aarch64-paging`"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 #, fuzzy
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
-"Il crate [`aarch64-paging`][1] consente di creare tabelle di pagine in base "
-"alla memoria virtuale AArch64\n"
+"Il crate [`aarch64-paging`](https://crates.io/crates/aarch64-paging) "
+"consente di creare tabelle di pagine in base alla memoria virtuale AArch64 "
 "Architettura di sistema."
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
@@ -16422,43 +17160,57 @@ msgstr ""
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 #, fuzzy
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real "
-"hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
 msgstr ""
-"* Per ora supporta solo EL1, ma il supporto per altri livelli di eccezione "
-"dovrebbe essere semplice\n"
-"  aggiungere.\n"
-"* Viene utilizzato in Android per il [Firmware VM protetto][2].\n"
-"* Non esiste un modo semplice per eseguire questo esempio, poiché deve "
-"essere eseguito su hardware reale o sotto QEMU."
+"Per ora supporta solo EL1, ma il supporto per altri livelli di eccezione "
+"dovrebbe essere semplice aggiungere."
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+#, fuzzy
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+"Viene utilizzato in Android per il [Firmware VM protetto](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+#, fuzzy
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
+msgstr ""
+"Non esiste un modo semplice per eseguire questo esempio, poiché deve essere "
+"eseguito su hardware reale o sotto QEMU."
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
 #, fuzzy
-msgid "# `buddy_system_allocator`"
-msgstr "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
+msgstr "`buddy_system_allocator`"
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 #, fuzzy
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
-"[`buddy_system_allocator`][1] è un crate di terze parti che implementa un "
-"allocatore di sistema buddy di base.\n"
-"Può essere utilizzato sia per [`LockedHeap`][2] che implementa "
-"[`GlobalAlloc`][3] in modo da poter utilizzare il\n"
-"crate standard `alloc` (come abbiamo visto [prima][4]), o per allocare altro "
-"spazio di indirizzi. Per esempio,\n"
-"potremmo voler allocare spazio MMIO per PCI BAR:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"è un crate di terze parti che implementa un allocatore di sistema buddy di "
+"base. Può essere utilizzato sia per [`LockedHeap`](https://docs.rs/"
+"buddy_system_allocator/0.9.0/buddy_system_allocator/struct.LockedHeap.html) "
+"che implementa [`GlobalAlloc`](https://doc.rust-lang.org/core/alloc/trait."
+"GlobalAlloc.html) in modo da poter utilizzare il crate standard `alloc` "
+"(come abbiamo visto [prima](../alloc.md)), o per allocare altro spazio di "
+"indirizzi. Per esempio, potremmo voler allocare spazio MMIO per PCI BAR:"
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
 msgid ""
@@ -16481,40 +17233,40 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
 #, fuzzy
+msgid "PCI BARs always have alignment equal to their size."
+msgstr "Le barre PCI hanno sempre un allineamento uguale alla loro dimensione."
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
+#, fuzzy
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
-"* Le barre PCI hanno sempre un allineamento uguale alla loro dimensione.\n"
-"* Esegui l'esempio con `cargo run` sotto `src/bare-metal/useful-crates/"
-"allocator-example/`. (Non lo farà\n"
-"  eseguito nel Parco giochi a causa della dipendenza dalla cassa.)"
+"Esegui l'esempio con `cargo run` sotto `src/bare-metal/useful-crates/"
+"allocator-example/`. (Non lo farà eseguito nel Parco giochi a causa della "
+"dipendenza dalla cassa.)"
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
 #, fuzzy
-msgid "# `tinyvec`"
-msgstr "# `tinyvec`"
+msgid "`tinyvec`"
+msgstr "`tinyvec`"
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 #, fuzzy
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
 "A volte vuoi qualcosa che possa essere ridimensionato come un `Vec`, ma "
-"senza allocazione dell'heap.\n"
-"[`tinyvec`][1] fornisce questo: un vettore supportato da un array o da una "
-"slice, che potrebbe essere staticamente\n"
-"allocato o in pila, che tiene traccia di quanti elementi vengono utilizzati "
-"e va in panico se ci provi\n"
-"utilizzare più di quanto assegnato."
+"senza allocazione dell'heap. [`tinyvec`](https://crates.io/crates/tinyvec) "
+"fornisce questo: un vettore supportato da un array o da una slice, che "
+"potrebbe essere staticamente allocato o in pila, che tiene traccia di quanti "
+"elementi vengono utilizzati e va in panico se ci provi utilizzare più di "
+"quanto assegnato."
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
 msgid ""
@@ -16535,44 +17287,45 @@ msgstr ""
 #: src/bare-metal/useful-crates/tinyvec.md:23
 #, fuzzy
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
-"initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine "
-"inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
 msgstr ""
-"* `tinyvec` richiede che il tipo di elemento implementi `Default` per "
-"l'inizializzazione.\n"
-"* Rust Playground include `tinyvec`, quindi questo esempio funzionerà "
+"`tinyvec` richiede che il tipo di elemento implementi `Default` per "
+"l'inizializzazione."
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+#, fuzzy
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
+msgstr ""
+"Rust Playground include `tinyvec`, quindi questo esempio funzionerà "
 "correttamente in linea."
 
 #: src/bare-metal/useful-crates/spin.md:1
 #, fuzzy
-msgid "# `spin`"
-msgstr "# `gira`"
+msgid "`spin`"
+msgstr "`gira`"
 
 #: src/bare-metal/useful-crates/spin.md:3
 #, fuzzy
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 "`std::sync::Mutex` e le altre primitive di sincronizzazione da `std::sync` "
-"non sono disponibili in\n"
-"`core` o `alloc`. Come gestire la sincronizzazione o la mutevolezza "
-"interiore, ad esempio per la condivisione\n"
-"stato tra diverse CPU?"
+"non sono disponibili in `core` o `alloc`. Come gestire la sincronizzazione o "
+"la mutevolezza interiore, ad esempio per la condivisione stato tra diverse "
+"CPU?"
 
 #: src/bare-metal/useful-crates/spin.md:7
 #, fuzzy
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
-"La cassa [`spin`][1] fornisce equivalenti basati su spinlock di molte di "
-"queste primitive."
+"La cassa [`spin`](https://crates.io/crates/spin) fornisce equivalenti basati "
+"su spinlock di molte di queste primitive."
 
 #: src/bare-metal/useful-crates/spin.md:9
 msgid ""
@@ -16590,37 +17343,39 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/android.md:1
-#, fuzzy
-msgid "# Android"
-msgstr "#Androide"
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
+msgstr ""
 
 #: src/bare-metal/android.md:3
 #, fuzzy
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 "Per costruire un binario Rust bare-metal in AOSP, devi usare una regola "
-"`rust_ffi_static` Soong per costruire\n"
-"il tuo codice Rust, poi un `cc_binary` con uno script linker per produrre il "
-"binario stesso, e poi a\n"
-"`raw_binary` per convertire l'ELF in un binario grezzo pronto per essere "
-"eseguito."
+"`rust_ffi_static` Soong per costruire il tuo codice Rust, poi un `cc_binary` "
+"con uno script linker per produrre il binario stesso, e poi a `raw_binary` "
+"per convertire l'ELF in un binario grezzo pronto per essere eseguito."
 
 #: src/bare-metal/android.md:7
 msgid ""
@@ -16664,23 +17419,19 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-#, fuzzy
-msgid "# vmbase"
-msgstr "# vbase"
-
 #: src/bare-metal/android/vmbase.md:3
 #, fuzzy
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
-"Per le VM in esecuzione in crosvm su aarch64, la libreria [vmbase][1] "
-"fornisce uno script linker e utili\n"
-"impostazioni predefinite per le regole di compilazione, insieme a un punto "
-"di ingresso, la registrazione della console UART e altro ancora."
+"Per le VM in esecuzione in crosvm su aarch64, la libreria [vmbase](https://"
+"android.googlesource.com/platform/packages/modules/Virtualization/+/refs/"
+"heads/master/vmbase/) fornisce uno script linker e utili impostazioni "
+"predefinite per le regole di compilazione, insieme a un punto di ingresso, "
+"la registrazione della console UART e altro ancora."
 
 #: src/bare-metal/android/vmbase.md:6
 msgid ""
@@ -16701,17 +17452,21 @@ msgstr ""
 #: src/bare-metal/android/vmbase.md:21
 #, fuzzy
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
 msgstr ""
-"* La macro `main!` contrassegna la tua funzione principale, da chiamare dal "
-"punto di ingresso `vmbase`.\n"
-"* Il punto di ingresso `vmbase` gestisce l'inizializzazione della console ed "
-"emette un PSCI_SYSTEM_OFF per l'arresto\n"
-"  la VM se la tua funzione principale ritorna."
+"La macro `main!` contrassegna la tua funzione principale, da chiamare dal "
+"punto di ingresso `vmbase`."
+
+#: src/bare-metal/android/vmbase.md:22
+#, fuzzy
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
+msgstr ""
+"Il punto di ingresso `vmbase` gestisce l'inizializzazione della console ed "
+"emette un PSCI_SYSTEM_OFF per l'arresto la VM se la tua funzione principale "
+"ritorna."
 
 #: src/exercises/bare-metal/afternoon.md:3
 #, fuzzy
@@ -16719,66 +17474,76 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr "Scriveremo un driver per il dispositivo orologio in tempo reale PL031."
 
 #: src/exercises/bare-metal/rtc.md:1
+#: src/exercises/bare-metal/solutions-afternoon.md:3
 #, fuzzy
-msgid "# RTC driver"
-msgstr "# Driver RTC"
+msgid "RTC driver"
+msgstr "Driver RTC"
 
 #: src/exercises/bare-metal/rtc.md:3
 #, fuzzy
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. "
-"For this exercise, you\n"
-"should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
-"La macchina QEMU aarch64 virt ha un orologio in tempo reale [PL031][1] a "
-"0x9010000. Per questo esercizio, tu\n"
-"dovrebbe scrivere un driver per esso."
+"La macchina QEMU aarch64 virt ha un orologio in tempo reale [PL031](https://"
+"developer.arm.com/documentation/ddi0224/c) a 0x9010000. Per questo "
+"esercizio, tu dovrebbe scrivere un driver per esso."
 
 #: src/exercises/bare-metal/rtc.md:6
 #, fuzzy
 msgid ""
-"1. Use it to print the current time to the serial console. You can use the "
-"[`chrono`][2] crate for\n"
-"   date/time formatting.\n"
-"2. Use the match register and raw interrupt status to busy-wait until a "
-"given time, e.g. 3 seconds\n"
-"   in the future. (Call [`core::hint::spin_loop`][3] inside the loop.)\n"
-"3. _Extension if you have time:_ Enable and handle the interrupt generated "
-"by the RTC match. You can\n"
-"   use the driver provided in the [`arm-gic`][4] crate to configure the Arm "
-"Generic Interrupt Controller.\n"
-"   - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.\n"
-"   - Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt.\n"
-"   "
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
 msgstr ""
-"1. Usalo per stampare l'ora corrente sulla console seriale. Puoi usare la "
-"cassa [`chrono`][2] per\n"
-"   formattazione data/ora.\n"
-"2. Utilizzare il registro delle corrispondenze e lo stato di interrupt non "
+"Usalo per stampare l'ora corrente sulla console seriale. Puoi usare la cassa "
+"[`chrono`](https://crates.io/crates/chrono) per formattazione data/ora."
+
+#: src/exercises/bare-metal/rtc.md:8
+#, fuzzy
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+msgstr ""
+"Utilizzare il registro delle corrispondenze e lo stato di interrupt non "
 "elaborato per attendere occupato fino a un determinato momento, ad es. 3 "
-"secondi\n"
-"   in futuro. (Chiama [`core::hint::spin_loop`][3] all'interno del ciclo.)\n"
-"3. _Estensione se hai tempo:_ Abilita e gestisci l'interrupt generato dalla "
-"corrispondenza RTC. Puoi\n"
-"   utilizzare il driver fornito nella cassa [`arm-gic`][4] per configurare "
-"Arm Generic Interrupt Controller.\n"
-"   - Usa l'interrupt RTC, che è cablato al GIC come `IntId::spi(2)`.\n"
-"   - Una volta abilitato l'interrupt, puoi mettere il core in sleep tramite "
-"`arm_gic::wfi()`, che farà dormire il core finché non riceve un interrupt.\n"
-"   "
+"secondi in futuro. (Chiama [`core::hint::spin_loop`](https://doc.rust-lang."
+"org/core/hint/fn.spin_loop.html) all'interno del ciclo.)"
+
+#: src/exercises/bare-metal/rtc.md:10
+#, fuzzy
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+msgstr ""
+"_Estensione se hai tempo:_ Abilita e gestisci l'interrupt generato dalla "
+"corrispondenza RTC. Puoi utilizzare il driver fornito nella cassa [`arm-gic`]"
+"(https://docs.rs/arm-gic/) per configurare Arm Generic Interrupt Controller."
+
+#: src/exercises/bare-metal/rtc.md:12
+#, fuzzy
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr "Usa l'interrupt RTC, che è cablato al GIC come `IntId::spi(2)`."
+
+#: src/exercises/bare-metal/rtc.md:13
+#, fuzzy
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
+msgstr ""
+"Una volta abilitato l'interrupt, puoi mettere il core in sleep tramite "
+"`arm_gic::wfi()`, che farà dormire il core finché non riceve un interrupt."
 
 #: src/exercises/bare-metal/rtc.md:16
 #, fuzzy
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `rtc`\n"
-"directory for the following files."
+"look in the `rtc` directory for the following files."
 msgstr ""
 "Scarica il [modello di esercizio](../../comprehensive-rust-exercises.zip) e "
-"cerca in `rtc`\n"
-"directory per i seguenti file."
+"cerca in `rtc` directory per i seguenti file."
 
 #: src/exercises/bare-metal/rtc.md:23
 msgid ""
@@ -16846,11 +17611,6 @@ msgid ""
 msgstr ""
 "`src/exceptions.rs` (dovresti solo cambiarlo per la terza parte "
 "dell'esercizio):"
-
-#: src/exercises/bare-metal/rtc.md:77
-#, fuzzy
-msgid "<!-- File src/exceptions.rs -->"
-msgstr "<!-- File src/exception.rs -->"
 
 #: src/exercises/bare-metal/rtc.md:79
 msgid ""
@@ -16931,11 +17691,6 @@ msgstr ""
 msgid "`src/logger.rs` (you shouldn't need to change this):"
 msgstr "`src/logger.rs` (non dovrebbe essere necessario modificarlo):"
 
-#: src/exercises/bare-metal/rtc.md:151
-#, fuzzy
-msgid "<!-- File src/logger.rs -->"
-msgstr "<!-- File src/logger.rs -->"
-
 #: src/exercises/bare-metal/rtc.md:153
 msgid ""
 "```rust,compile_fail\n"
@@ -17001,11 +17756,6 @@ msgstr ""
 #, fuzzy
 msgid "`src/pl011.rs` (you shouldn't need to change this):"
 msgstr "`src/pl011.rs` (non dovresti aver bisogno di cambiarlo):"
-
-#: src/exercises/bare-metal/rtc.md:212
-#, fuzzy
-msgid "<!-- File src/pl011.rs -->"
-msgstr "<!-- File src/pl011.rs -->"
 
 #: src/exercises/bare-metal/rtc.md:214
 msgid ""
@@ -17215,11 +17965,6 @@ msgstr ""
 msgid "`build.rs` (you shouldn't need to change this):"
 msgstr "`build.rs` (non dovresti aver bisogno di cambiarlo):"
 
-#: src/exercises/bare-metal/rtc.md:412
-#, fuzzy
-msgid "<!-- File build.rs -->"
-msgstr "<!-- File build.rs -->"
-
 #: src/exercises/bare-metal/rtc.md:414
 msgid ""
 "```rust,compile_fail\n"
@@ -17259,11 +18004,6 @@ msgstr ""
 #, fuzzy
 msgid "`entry.S` (you shouldn't need to change this):"
 msgstr "`entry.S` (non dovresti aver bisogno di cambiarlo):"
-
-#: src/exercises/bare-metal/rtc.md:448
-#, fuzzy
-msgid "<!-- File entry.S -->"
-msgstr "<!-- Voce file.S -->"
 
 #: src/exercises/bare-metal/rtc.md:450
 msgid ""
@@ -17431,11 +18171,6 @@ msgstr ""
 #, fuzzy
 msgid "`exceptions.S` (you shouldn't need to change this):"
 msgstr "`eccezioni.S` (non dovresti aver bisogno di cambiarlo):"
-
-#: src/exercises/bare-metal/rtc.md:597
-#, fuzzy
-msgid "<!-- File exceptions.S -->"
-msgstr "<!-- File eccezioni.S -->"
 
 #: src/exercises/bare-metal/rtc.md:599
 msgid ""
@@ -17636,11 +18371,6 @@ msgstr ""
 msgid "`idmap.S` (you shouldn't need to change this):"
 msgstr "`idmap.S` (non dovresti aver bisogno di cambiarlo):"
 
-#: src/exercises/bare-metal/rtc.md:782
-#, fuzzy
-msgid "<!-- File idmap.S -->"
-msgstr "<!-- File idmap.S -->"
-
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
 "```armasm\n"
@@ -17694,11 +18424,6 @@ msgstr ""
 #, fuzzy
 msgid "`image.ld` (you shouldn't need to change this):"
 msgstr "`image.ld` (non dovresti aver bisogno di cambiarlo):"
-
-#: src/exercises/bare-metal/rtc.md:831
-#, fuzzy
-msgid "<!-- File image.ld -->"
-msgstr "<!-- File image.ld -->"
 
 #: src/exercises/bare-metal/rtc.md:833
 msgid ""
@@ -17816,11 +18541,6 @@ msgstr ""
 msgid "`Makefile` (you shouldn't need to change this):"
 msgstr "`Makefile` (non dovresti aver bisogno di cambiarlo):"
 
-#: src/exercises/bare-metal/rtc.md:942
-#, fuzzy
-msgid "<!-- File Makefile -->"
-msgstr "<!-- File Makefile -->"
-
 #: src/exercises/bare-metal/rtc.md:944
 msgid ""
 "```makefile\n"
@@ -17882,39 +18602,29 @@ msgstr "Esegui il codice in QEMU con `make qemu`."
 
 #: src/concurrency.md:1
 #, fuzzy
-msgid "# Welcome to Concurrency in Rust"
+msgid "Welcome to Concurrency in Rust"
 msgstr "Benvenuti a Comprehensive Rust 🦀"
 
 #: src/concurrency.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 "Rust ha il pieno supporto per la concorrenza utilizzando i thread del "
-"sistema operativo con mutex e\n"
-"canali."
+"sistema operativo con mutex e canali."
 
 #: src/concurrency.md:6
 #, fuzzy
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 "Il sistema di tipo Rust gioca un ruolo importante nella creazione di molti "
-"bug di concorrenza\n"
-"bug in fase di compilazione. Questo è spesso indicato come _concorrenza "
-"senza paura_ da quando tu\n"
-"può fare affidamento sul compilatore per garantire la correttezza in fase di "
-"esecuzione."
-
-#: src/concurrency/threads.md:1
-#, fuzzy
-msgid "# Threads"
-msgstr "# Discussioni"
+"bug di concorrenza bug in fase di compilazione. Questo è spesso indicato "
+"come _concorrenza senza paura_ da quando tu può fare affidamento sul "
+"compilatore per garantire la correttezza in fase di esecuzione."
 
 #: src/concurrency/threads.md:3
 #, fuzzy
@@ -17945,52 +18655,56 @@ msgstr ""
 
 #: src/concurrency/threads.md:24
 #, fuzzy
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
-"* I thread sono tutti thread demoni, il thread principale non li aspetta.\n"
-"* I thread panic sono indipendenti l'uno dall'altro.\n"
-"  * Panics può trasportare un payload, che può essere decompresso con "
+"I thread sono tutti thread demoni, il thread principale non li aspetta."
+
+#: src/concurrency/threads.md:25
+#, fuzzy
+msgid "Thread panics are independent of each other."
+msgstr "I thread panic sono indipendenti l'uno dall'altro."
+
+#: src/concurrency/threads.md:26
+#, fuzzy
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr ""
+"Panics può trasportare un payload, che può essere decompresso con "
 "`downcast_ref`."
 
 #: src/concurrency/threads.md:32
 #, fuzzy
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
-"* Si noti che il thread viene interrotto prima che raggiunga 10 — il thread "
-"principale lo è\n"
-"  non aspettare.\n"
-"\n"
-"* Usa `let handle = thread::spawn(...)` e successivamente `handle.join()` "
-"per aspettare\n"
-"  il filo per finire.\n"
-"\n"
-"* Attivare un panico nel thread, notare come questo non influisca su "
-"`main`.\n"
-"\n"
-"* Usa il valore di ritorno `Result` da `handle.join()` per ottenere "
-"l'accesso al panico\n"
-"  carico utile. Questo è un buon momento per parlare di [`Any`]."
+"Si noti che il thread viene interrotto prima che raggiunga 10 — il thread "
+"principale lo è non aspettare."
 
-#: src/concurrency/scoped-threads.md:1
+#: src/concurrency/threads.md:35
 #, fuzzy
-msgid "# Scoped Threads"
-msgstr "# Thread con ambito"
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+"Usa `let handle = thread::spawn(...)` e successivamente `handle.join()` per "
+"aspettare il filo per finire."
+
+#: src/concurrency/threads.md:38
+#, fuzzy
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+"Attivare un panico nel thread, notare come questo non influisca su `main`."
+
+#: src/concurrency/threads.md:40
+#, fuzzy
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
+"Usa il valore di ritorno `Result` da `handle.join()` per ottenere l'accesso "
+"al panico carico utile. Questo è un buon momento per parlare di [`Any`]"
+"(https://doc.rust-lang.org/std/any/index.html)."
 
 #: src/concurrency/scoped-threads.md:3
 #, fuzzy
@@ -18014,8 +18728,12 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
 #, fuzzy
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "Tuttavia, puoi utilizzare un [thread con ambito][1] per questo:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"Tuttavia, puoi utilizzare un [thread con ambito](https://doc.rust-lang.org/"
+"std/thread/fn.scope.html) per questo:"
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -18037,36 +18755,31 @@ msgstr ""
 #: src/concurrency/scoped-threads.md:37
 #, fuzzy
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"* La ragione di ciò è che quando la funzione `thread::scope` viene "
-"completata, è garantito che tutti i thread vengano uniti, in modo che "
-"possano restituire dati presi in prestito.\n"
-"* Si applicano le normali regole di prestito di Rust: puoi prendere in "
-"prestito in modo mutabile da un thread o immutabile da un numero qualsiasi "
-"di thread.\n"
-"    "
+"La ragione di ciò è che quando la funzione `thread::scope` viene completata, "
+"è garantito che tutti i thread vengano uniti, in modo che possano restituire "
+"dati presi in prestito."
 
-#: src/concurrency/channels.md:1
+#: src/concurrency/scoped-threads.md:38
 #, fuzzy
-msgid "# Channels"
-msgstr "# Canali"
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"Si applicano le normali regole di prestito di Rust: puoi prendere in "
+"prestito in modo mutabile da un thread o immutabile da un numero qualsiasi "
+"di thread."
 
 #: src/concurrency/channels.md:3
 #, fuzzy
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
 "I canali Rust hanno due parti: un `Sender<T>` e un `Receiver<T>`. Le due "
-"parti\n"
-"sono collegati tramite il canale, ma vedi solo i punti finali."
+"parti sono collegati tramite il canale, ma vedi solo i punti finali."
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -18093,24 +18806,22 @@ msgstr ""
 #: src/concurrency/channels.md:27
 #, fuzzy
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* `mpsc` sta per Multi-Producer, Single-Consumer. `Sender` e `SyncSender` "
-"implementano `Clone` (quindi\n"
-"  puoi creare più produttori) ma `Receiver` no.\n"
-"* `send()` e `recv()` restituiscono `Risultato`. Se restituiscono \"Err\", "
-"significa che la controparte \"Mittente\" o\n"
-"  `Receiver` viene eliminato e il canale viene chiuso."
+"`mpsc` sta per Multi-Producer, Single-Consumer. `Sender` e `SyncSender` "
+"implementano `Clone` (quindi puoi creare più produttori) ma `Receiver` no."
 
-#: src/concurrency/channels/unbounded.md:1
+#: src/concurrency/channels.md:29
 #, fuzzy
-msgid "# Unbounded Channels"
-msgstr "# Canali illimitati"
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()` e `recv()` restituiscono `Risultato`. Se restituiscono \"Err\", "
+"significa che la controparte \"Mittente\" o `Receiver` viene eliminato e il "
+"canale viene chiuso."
 
 #: src/concurrency/channels/unbounded.md:3
 #, fuzzy
@@ -18143,11 +18854,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/concurrency/channels/bounded.md:1
-#, fuzzy
-msgid "# Bounded Channels"
-msgstr "# Canali delimitati"
 
 #: src/concurrency/channels/bounded.md:3
 #, fuzzy
@@ -18186,21 +18892,27 @@ msgstr ""
 
 #: src/concurrency/channels/bounded.md:31
 msgid ""
-"* Calling `send` will block the current thread until there is space in the "
+"Calling `send` will block the current thread until there is space in the "
 "channel for the new message. The thread can be blocked indefinitely if there "
-"is nobody who reads from the channel.\n"
-"* A call to `send` will abort with an error (that is why it returns "
-"`Result`) if the channel is closed. A channel is closed when the receiver is "
-"dropped.\n"
-"* A bounded channel with a size of zero is called a \"rendezvous channel\". "
-"Every send will block the current thread until another thread calls `read`.\n"
-"    "
+"is nobody who reads from the channel."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:32
+msgid ""
+"A call to `send` will abort with an error (that is why it returns `Result`) "
+"if the channel is closed. A channel is closed when the receiver is dropped."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:33
+msgid ""
+"A bounded channel with a size of zero is called a \"rendezvous channel\". "
+"Every send will block the current thread until another thread calls `read`."
 msgstr ""
 
 #: src/concurrency/send-sync.md:1
 #, fuzzy
-msgid "# `Send` and `Sync`"
-msgstr "# `Invia` e `Sincronizza`"
+msgid "`Send` and `Sync`"
+msgstr "`Invia` e `Sincronizza`"
 
 #: src/concurrency/send-sync.md:3
 #, fuzzy
@@ -18214,98 +18926,92 @@ msgstr ""
 #: src/concurrency/send-sync.md:5
 #, fuzzy
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [`Send`][1]: un tipo `T` è `Send` se è sicuro spostare una `T` attraverso "
-"un thread\n"
-"  confine.\n"
-"* [`Sync`][2]: un tipo `T` è `Sync` se è sicuro spostare una `&T` attraverso "
-"un thread\n"
-"  confine."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): un tipo `T` "
+"è `Send` se è sicuro spostare una `T` attraverso un thread confine."
+
+#: src/concurrency/send-sync.md:7
+#, fuzzy
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): un tipo `T` "
+"è `Sync` se è sicuro spostare una `&T` attraverso un thread confine."
 
 #: src/concurrency/send-sync.md:10
 #, fuzzy
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
-"\"Send\" e \"Sync\" sono [tratti non sicuri][3]. Il compilatore li deriverà "
-"automaticamente per i tuoi tipi\n"
-"purché contengano solo i tipi \"Send\" e \"Sync\". Puoi anche implementarli "
-"manualmente quando tu\n"
-"sapere che è valido."
+"\"Send\" e \"Sync\" sono [tratti non sicuri](../unsafe/unsafe-traits.md). Il "
+"compilatore li deriverà automaticamente per i tuoi tipi purché contengano "
+"solo i tipi \"Send\" e \"Sync\". Puoi anche implementarli manualmente quando "
+"tu sapere che è valido."
 
 #: src/concurrency/send-sync.md:20
 #, fuzzy
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-"
-"safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr ""
-"* Si può pensare a questi tratti come indicatori che il tipo ha determinate "
-"proprietà di sicurezza del thread.\n"
-"* Possono essere usati nei vincoli generici come tratti normali.\n"
-"  "
+"Si può pensare a questi tratti come indicatori che il tipo ha determinate "
+"proprietà di sicurezza del thread."
+
+#: src/concurrency/send-sync.md:21
+#, fuzzy
+msgid "They can be used in the generic constraints as normal traits."
+msgstr "Possono essere usati nei vincoli generici come tratti normali."
 
 #: src/concurrency/send-sync/send.md:1
 #, fuzzy
-msgid "# `Send`"
-msgstr "# `Invia`"
+msgid "`Send`"
+msgstr "`Invia`"
 
 #: src/concurrency/send-sync/send.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
-"> Un tipo `T` è [`Send`][1] se è sicuro spostare un valore `T` in un altro "
-"thread."
+"Un tipo `T` è [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"se è sicuro spostare un valore `T` in un altro thread."
 
 #: src/concurrency/send-sync/send.md:5
 #, fuzzy
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 "L'effetto dello spostamento della proprietà su un altro thread è che i "
-"_destructors_ verranno eseguiti\n"
-"in quel filo. Quindi la domanda è quando puoi allocare un valore in un "
-"thread\n"
-"e deallocarlo in un altro."
+"_destructors_ verranno eseguiti in quel filo. Quindi la domanda è quando "
+"puoi allocare un valore in un thread e deallocarlo in un altro."
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
-"a\n"
-"single thread."
+"a single thread."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:1
 #, fuzzy
-msgid "# `Sync`"
-msgstr "# `Sincronizza`"
+msgid "`Sync`"
+msgstr "`Sincronizza`"
 
 #: src/concurrency/send-sync/sync.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"> Un tipo `T` è [`Sync`][1] se è sicuro accedere a un valore `T` da più\n"
-"> thread contemporaneamente."
+"Un tipo `T` è [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"se è sicuro accedere a un valore `T` da più thread contemporaneamente."
 
 #: src/concurrency/send-sync/sync.md:6
 #, fuzzy
@@ -18314,8 +19020,8 @@ msgstr "Più precisamente la definizione è:"
 
 #: src/concurrency/send-sync/sync.md:8
 #, fuzzy
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
-msgstr "> `T` è `Sync` se e solo se `&T` è `Send`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
+msgstr "`T` è `Sync` se e solo se `&T` è `Send`"
 
 #: src/concurrency/send-sync/sync.md:14
 #, fuzzy
@@ -18344,15 +19050,10 @@ msgstr ""
 "possibile accedere ai dati a cui fa riferimento da qualsiasi thread in modo "
 "sicuro."
 
-#: src/concurrency/send-sync/examples.md:1
-#, fuzzy
-msgid "# Examples"
-msgstr "# Esempi"
-
 #: src/concurrency/send-sync/examples.md:3
 #, fuzzy
-msgid "## `Send + Sync`"
-msgstr "## \"Invia + Sincronizza\"."
+msgid "`Send + Sync`"
+msgstr "\"Invia + Sincronizza\"."
 
 #: src/concurrency/send-sync/examples.md:5
 #, fuzzy
@@ -18361,57 +19062,76 @@ msgstr ""
 "La maggior parte dei tipi che incontri sono \"Invia + sincronizzazione\":"
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 #, fuzzy
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 "I tipi generici sono in genere \"Send + Sync\" quando i parametri di tipo lo "
-"sono\n"
-"\"Invia + Sincronizza\"."
+"sono \"Invia + Sincronizza\"."
 
 #: src/concurrency/send-sync/examples.md:17
 #, fuzzy
-msgid "## `Send + !Sync`"
-msgstr "## \"Invia + !Sincronizza\"."
+msgid "`Send + !Sync`"
+msgstr "\"Invia + !Sincronizza\"."
 
 #: src/concurrency/send-sync/examples.md:19
 #, fuzzy
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 "Questi tipi possono essere spostati in altri thread, ma non sono thread-"
-"safe.\n"
-"Tipicamente a causa della mutevolezza interna:"
+"safe. Tipicamente a causa della mutevolezza interna:"
 
 #: src/concurrency/send-sync/examples.md:22
 #, fuzzy
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Ricevitore<T>`\n"
-"* `Cella<T>`\n"
-"* `RefCella<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Sender<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+#, fuzzy
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Ricevitore<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+#, fuzzy
+msgid "`Cell<T>`"
+msgstr "`Cella<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+#, fuzzy
+msgid "`RefCell<T>`"
+msgstr "`RefCella<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
 #, fuzzy
-msgid "## `!Send + Sync`"
-msgstr "## `!Invia + Sincronizza`"
+msgid "`!Send + Sync`"
+msgstr "`!Invia + Sincronizza`"
 
 #: src/concurrency/send-sync/examples.md:29
 #, fuzzy
@@ -18424,18 +19144,16 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:31
 #, fuzzy
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
-"* `MutexGuard<T>`: utilizza primitive a livello di sistema operativo che "
-"devono essere deallocate su\n"
-"  thread che li ha creati."
+"`MutexGuard<T>`: utilizza primitive a livello di sistema operativo che "
+"devono essere deallocate su thread che li ha creati."
 
 #: src/concurrency/send-sync/examples.md:34
 #, fuzzy
-msgid "## `!Send + !Sync`"
-msgstr "## `!Invia + !Sync`"
+msgid "`!Send + !Sync`"
+msgstr "`!Invia + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:36
 #, fuzzy
@@ -18447,57 +19165,63 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:38
 #, fuzzy
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
-"* `Rc<T>`: ogni `Rc<T>` ha un riferimento a un `RcBox<T>`, che contiene un\n"
-"  conteggio dei riferimenti non atomici.\n"
-"* `*const T`, `*mut T`: Rust presuppone che i puntatori grezzi possano avere "
-"caratteri speciali\n"
-"  considerazioni sulla concorrenza"
+"`Rc<T>`: ogni `Rc<T>` ha un riferimento a un `RcBox<T>`, che contiene un "
+"conteggio dei riferimenti non atomici."
 
-#: src/concurrency/shared_state.md:1
+#: src/concurrency/send-sync/examples.md:40
 #, fuzzy
-msgid "# Shared State"
-msgstr "# Stato condiviso"
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr ""
+"`*const T`, `*mut T`: Rust presuppone che i puntatori grezzi possano avere "
+"caratteri speciali considerazioni sulla concorrenza"
 
 #: src/concurrency/shared_state.md:3
 #, fuzzy
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 "Rust utilizza il sistema dei tipi per imporre la sincronizzazione dei dati "
-"condivisi. Questo è\n"
-"fatto principalmente tramite due tipi:"
+"condivisi. Questo è fatto principalmente tramite due tipi:"
 
 #: src/concurrency/shared_state.md:6
 #, fuzzy
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1], riferimento atomico contato `T`: gestisce la condivisione "
-"tra thread e\n"
-"  si occupa di deallocare `T` quando viene eliminato l'ultimo riferimento,\n"
-"* [`Mutex<T>`][2]: garantisce l'accesso mutuamente esclusivo al valore `T`."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), riferimento "
+"atomico contato `T`: gestisce la condivisione tra thread e si occupa di "
+"deallocare `T` quando viene eliminato l'ultimo riferimento,"
+
+#: src/concurrency/shared_state.md:8
+#, fuzzy
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): "
+"garantisce l'accesso mutuamente esclusivo al valore `T`."
 
 #: src/concurrency/shared_state/arc.md:1
 #, fuzzy
-msgid "# `Arc`"
-msgstr "# `Arco`"
+msgid "`Arc`"
+msgstr "`Arco`"
 
 #: src/concurrency/shared_state/arc.md:3
 #, fuzzy
-msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
 msgstr ""
-"[`Arc<T>`][1] consente l'accesso condiviso in sola lettura tramite `Arc::"
-"clone`:"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) consente "
+"l'accesso condiviso in sola lettura tramite `Arc::clone`:"
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -18525,45 +19249,58 @@ msgstr ""
 #: src/concurrency/shared_state/arc.md:29
 #, fuzzy
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
 msgstr ""
-"* `Arc` sta per \"Atomic Reference Counted\", una versione thread-safe di "
-"`Rc` che usa atomic\n"
-"  operazioni.\n"
-"* `Arc<T>` implementa `Clone` indipendentemente dal fatto che `T` lo faccia. "
-"Implementa `Send` e `Sync` se e solo `T`\n"
-"  li implementa entrambi.\n"
-"* `Arc::clone()` ha il costo delle operazioni atomiche che vengono eseguite, "
-"ma dopo ciò l'uso di\n"
-"  `T` è gratuito.\n"
-"* Attenzione ai cicli di riferimento, `Arc` non usa un garbage collector per "
-"rilevarli.\n"
-"    * `std::sync::Weak` può aiutare."
+"`Arc` sta per \"Atomic Reference Counted\", una versione thread-safe di `Rc` "
+"che usa atomic operazioni."
+
+#: src/concurrency/shared_state/arc.md:31
+#, fuzzy
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+"`Arc<T>` implementa `Clone` indipendentemente dal fatto che `T` lo faccia. "
+"Implementa `Send` e `Sync` se e solo `T` li implementa entrambi."
+
+#: src/concurrency/shared_state/arc.md:33
+#, fuzzy
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"`Arc::clone()` ha il costo delle operazioni atomiche che vengono eseguite, "
+"ma dopo ciò l'uso di `T` è gratuito."
+
+#: src/concurrency/shared_state/arc.md:35
+#, fuzzy
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+"Attenzione ai cicli di riferimento, `Arc` non usa un garbage collector per "
+"rilevarli."
+
+#: src/concurrency/shared_state/arc.md:36
+#, fuzzy
+msgid "`std::sync::Weak` can help."
+msgstr "`std::sync::Weak` può aiutare."
 
 #: src/concurrency/shared_state/mutex.md:1
 #, fuzzy
-msgid "# `Mutex`"
-msgstr "# `Mutex`"
+msgid "`Mutex`"
+msgstr "`Mutex`"
 
 #: src/concurrency/shared_state/mutex.md:3
 #, fuzzy
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
-"[`Mutex<T>`][1] garantisce l'esclusione reciproca _e_ consente l'accesso "
-"mutabile a `T`\n"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) "
+"garantisce l'esclusione reciproca _e_ consente l'accesso mutabile a `T` "
 "dietro un'interfaccia di sola lettura:"
 
 #: src/concurrency/shared_state/mutex.md:6
@@ -18588,51 +19325,73 @@ msgstr ""
 #: src/concurrency/shared_state/mutex.md:22
 #, fuzzy
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
-"Nota come abbiamo una coperta [`impl<T: Send> Sync per Mutex<T>`][2].\n"
+"Nota come abbiamo una coperta [`impl<T: Send> Sync per Mutex<T>`](https://"
+"doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E). "
 "implementazione."
 
 #: src/concurrency/shared_state/mutex.md:31
 #, fuzzy
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
-"implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
 msgstr ""
-"* `Mutex` in Rust sembra una raccolta con un solo elemento: i dati "
-"protetti.\n"
-"    * Non è possibile dimenticare di acquisire il mutex prima di accedere ai "
-"dati protetti.\n"
-"* Puoi ottenere un `&mut T` da un `&Mutex<T>` prendendo il lock. Il "
-"`MutexGuard` assicura che il file\n"
-"  `&mut T` non sopravvive al blocco mantenuto.\n"
-"* `Mutex<T>` implementa sia `Send` che `Sync` se `T` implementa `Send`.\n"
-"* Una controparte del blocco lettura-scrittura - `RwLock`.\n"
-"* Perché `lock()` restituisce un `Risultato`?\n"
-"    * Se il thread che conteneva il `Mutex` va nel panico, il `Mutex` "
-"diventa \"avvelenato\" per segnalare che\n"
-"      i dati protetti potrebbero trovarsi in uno stato incoerente. Chiamare "
-"`lock()` su un mutex avvelenato\n"
-"      fallisce con un [`PoisonError`]. Puoi chiamare `into_inner()` "
-"sull'errore per recuperare i dati\n"
-"      indipendentemente."
+"`Mutex` in Rust sembra una raccolta con un solo elemento: i dati protetti."
+
+#: src/concurrency/shared_state/mutex.md:32
+#, fuzzy
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr ""
+"Non è possibile dimenticare di acquisire il mutex prima di accedere ai dati "
+"protetti."
+
+#: src/concurrency/shared_state/mutex.md:33
+#, fuzzy
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+"Puoi ottenere un `&mut T` da un `&Mutex<T>` prendendo il lock. Il "
+"`MutexGuard` assicura che il file `&mut T` non sopravvive al blocco "
+"mantenuto."
+
+#: src/concurrency/shared_state/mutex.md:35
+#, fuzzy
+msgid ""
+"`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
+"implements `Send`."
+msgstr "`Mutex<T>` implementa sia `Send` che `Sync` se `T` implementa `Send`."
+
+#: src/concurrency/shared_state/mutex.md:36
+#, fuzzy
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "Una controparte del blocco lettura-scrittura - `RwLock`."
+
+#: src/concurrency/shared_state/mutex.md:37
+#, fuzzy
+msgid "Why does `lock()` return a `Result`? "
+msgstr "Perché `lock()` restituisce un `Risultato`?"
+
+#: src/concurrency/shared_state/mutex.md:38
+#, fuzzy
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"Se il thread che conteneva il `Mutex` va nel panico, il `Mutex` diventa "
+"\"avvelenato\" per segnalare che i dati protetti potrebbero trovarsi in uno "
+"stato incoerente. Chiamare `lock()` su un mutex avvelenato fallisce con un "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"Puoi chiamare `into_inner()` sull'errore per recuperare i dati "
+"indipendentemente."
 
 #: src/concurrency/shared_state/example.md:3
 #, fuzzy
@@ -18698,22 +19457,37 @@ msgstr "Parti notevoli:"
 #: src/concurrency/shared_state/example.md:51
 #, fuzzy
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr ""
+"`v` è racchiuso sia in `Arc` che in `Mutex`, perché i loro interessi sono "
+"ortogonali."
+
+#: src/concurrency/shared_state/example.md:52
+#, fuzzy
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+"Avvolgere un `Mutex` in un `Arc` è un modello comune per condividere lo "
+"stato mutabile tra i thread."
+
+#: src/concurrency/shared_state/example.md:53
+#, fuzzy
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+"`v: Arc<_>` deve essere clonato come `v2` prima di poter essere spostato in "
+"un altro thread. Nota che \"move\" è stato aggiunto alla firma lambda."
+
+#: src/concurrency/shared_state/example.md:54
+#, fuzzy
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
-"* `v` è racchiuso sia in `Arc` che in `Mutex`, perché i loro interessi sono "
-"ortogonali.\n"
-"  * Avvolgere un `Mutex` in un `Arc` è un modello comune per condividere lo "
-"stato mutabile tra i thread.\n"
-"* `v: Arc<_>` deve essere clonato come `v2` prima di poter essere spostato "
-"in un altro thread. Nota che \"move\" è stato aggiunto alla firma lambda.\n"
-"* I blocchi vengono introdotti per restringere il più possibile l'ambito di "
+"I blocchi vengono introdotti per restringere il più possibile l'ambito di "
 "`LockGuard`."
 
 #: src/exercises/concurrency/morning.md:3
@@ -18723,22 +19497,17 @@ msgstr "Mettiamo in pratica le nostre nuove abilità di concorrenza con"
 
 #: src/exercises/concurrency/morning.md:5
 #, fuzzy
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
-msgstr ""
-"* Filosofi a tavola: un classico problema in concorrenza.\n"
-"\n"
-"* Verifica link multi-thread: un progetto più ampio in cui utilizzerai "
-"Cargo\n"
-"  scaricare le dipendenze e quindi controllare i collegamenti in parallelo."
+msgid "Dining philosophers: a classic problem in concurrency."
+msgstr "Filosofi a tavola: un classico problema in concorrenza."
 
-#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/morning.md:7
 #, fuzzy
-msgid "# Dining Philosophers"
-msgstr "# Filosofi da pranzo"
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
+msgstr ""
+"Verifica link multi-thread: un progetto più ampio in cui utilizzerai Cargo "
+"scaricare le dipendenze e quindi controllare i collegamenti in parallelo."
 
 #: src/exercises/concurrency/dining-philosophers.md:3
 #, fuzzy
@@ -18749,49 +19518,35 @@ msgstr ""
 #: src/exercises/concurrency/dining-philosophers.md:5
 #, fuzzy
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
-"> Cinque filosofi cenano insieme alla stessa tavola. Ogni filosofo ha il "
-"suo\n"
-"> proprio posto a tavola. C'è una forchetta tra ogni piatto. Il piatto "
-"servito è\n"
-"> una specie di spaghetto che si mangia con due forchette. Ogni filosofo "
-"può\n"
-"> solo alternativamente pensa e mangia. Inoltre, un filosofo può solo "
-"mangiare il loro\n"
-"> gli spaghetti quando hanno sia la forchetta destra che quella sinistra. "
-"Quindi solo due forchette\n"
-"> essere disponibile quando i loro due vicini più vicini stanno pensando, "
-"non mangiando. Dopo\n"
-"> un singolo filosofo finisce di mangiare, metteranno giù entrambe le "
-"forchette."
+"Cinque filosofi cenano insieme alla stessa tavola. Ogni filosofo ha il suo "
+"proprio posto a tavola. C'è una forchetta tra ogni piatto. Il piatto servito "
+"è una specie di spaghetto che si mangia con due forchette. Ogni filosofo può "
+"solo alternativamente pensa e mangia. Inoltre, un filosofo può solo mangiare "
+"il loro gli spaghetti quando hanno sia la forchetta destra che quella "
+"sinistra. Quindi solo due forchette essere disponibile quando i loro due "
+"vicini più vicini stanno pensando, non mangiando. Dopo un singolo filosofo "
+"finisce di mangiare, metteranno giù entrambe le forchette."
 
 #: src/exercises/concurrency/dining-philosophers.md:13
 #, fuzzy
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to a file called `src/main.rs`, fill out "
-"the\n"
-"blanks, and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 "Avrai bisogno di un'[installazione Cargo](../../cargo/running-locally.md) "
-"locale per\n"
-"questo esercizio. Copia il codice qui sotto in un file chiamato `src/main."
-"rs`, compila il file\n"
-"spazi vuoti e verificare che `cargo run` non vada in stallo:"
+"locale per questo esercizio. Copia il codice qui sotto in un file chiamato "
+"`src/main.rs`, compila il file spazi vuoti e verificare che `cargo run` non "
+"vada in stallo:"
 
 #: src/exercises/concurrency/dining-philosophers.md:19
 msgid ""
@@ -18853,38 +19608,28 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:1
-#, fuzzy
-msgid "# Multi-threaded Link Checker"
-msgstr "# Verifica link multi-thread"
-
 #: src/exercises/concurrency/link-checker.md:3
 #, fuzzy
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 "Usiamo le nostre nuove conoscenze per creare un verificatore di collegamenti "
-"multi-thread. Dovrebbe\n"
-"iniziare da una pagina Web e verificare che i collegamenti sulla pagina "
-"siano validi. Dovrebbe\n"
-"controlla ricorsivamente altre pagine sullo stesso dominio e continua a "
-"farlo fino a quando all\n"
-"le pagine sono state convalidate."
+"multi-thread. Dovrebbe iniziare da una pagina Web e verificare che i "
+"collegamenti sulla pagina siano validi. Dovrebbe controlla ricorsivamente "
+"altre pagine sullo stesso dominio e continua a farlo fino a quando all le "
+"pagine sono state convalidate."
 
 #: src/exercises/concurrency/link-checker.md:8
 #, fuzzy
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
-"Per questo, avrai bisogno di un client HTTP come [`reqwest`][1]. Crea un "
-"nuovo\n"
-"Progetto Cargo e `richiedilo` come dipendenza con:"
+"Per questo, avrai bisogno di un client HTTP come [`reqwest`](https://docs.rs/"
+"reqwest/). Crea un nuovo Progetto Cargo e `richiedilo` come dipendenza con:"
 
 #: src/exercises/concurrency/link-checker.md:11
 msgid ""
@@ -18898,20 +19643,20 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:17
 #, fuzzy
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
-"> Se `cargo add` fallisce con `error: no such subcommand`, modifica il file\n"
-"> File `Cargo.toml` a mano. Aggiungere le dipendenze elencate di seguito."
+"Se `cargo add` fallisce con `error: no such subcommand`, modifica il file "
+"File `Cargo.toml` a mano. Aggiungere le dipendenze elencate di seguito."
 
 #: src/exercises/concurrency/link-checker.md:20
 #, fuzzy
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 "Avrai anche bisogno di un modo per trovare i link. Possiamo usare [`scraper`]"
-"[2] per questo:"
+"(https://docs.rs/scraper/) per questo:"
 
 #: src/exercises/concurrency/link-checker.md:22
 msgid ""
@@ -18923,13 +19668,11 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:26
 #, fuzzy
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 "Infine, avremo bisogno di un modo per gestire gli errori. Usiamo "
-"[`thiserror`][3] per\n"
-"Quello:"
+"[`thiserror`](https://docs.rs/thiserror/) per Quello:"
 
 #: src/exercises/concurrency/link-checker.md:29
 msgid ""
@@ -18965,10 +19708,10 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:50
 #, fuzzy
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
-"Ora puoi scaricare la pagina iniziale. Prova con un piccolo sito come\n"
+"Ora puoi scaricare la pagina iniziale. Prova con un piccolo sito come "
 "`https://www.google.org/`."
 
 #: src/exercises/concurrency/link-checker.md:53
@@ -19035,123 +19778,101 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:106
-#: src/exercises/concurrency/chat-app.md:140
-#, fuzzy
-msgid "## Tasks"
-msgstr "## Compiti"
-
 #: src/exercises/concurrency/link-checker.md:108
 #, fuzzy
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
 msgstr ""
-"* Usa i thread per controllare i collegamenti in parallelo: invia gli URL da "
-"controllare a a\n"
-"  channel e lasciare che alcuni thread controllino gli URL in parallelo.\n"
-"* Estendilo per estrarre in modo ricorsivo i collegamenti da tutte le pagine "
-"del file\n"
-"  dominio \"www.google.org\". Metti un limite massimo di 100 pagine o giù di "
-"lì in modo che tu\n"
-"  non finire per essere bloccato dal sito."
+"Usa i thread per controllare i collegamenti in parallelo: invia gli URL da "
+"controllare a a channel e lasciare che alcuni thread controllino gli URL in "
+"parallelo."
+
+#: src/exercises/concurrency/link-checker.md:110
+#, fuzzy
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
+msgstr ""
+"Estendilo per estrarre in modo ricorsivo i collegamenti da tutte le pagine "
+"del file dominio \"www.google.org\". Metti un limite massimo di 100 pagine o "
+"giù di lì in modo che tu non finire per essere bloccato dal sito."
 
 #: src/async.md:1
 #, fuzzy
-msgid "# Async Rust"
-msgstr "# Ruggine asincrona"
+msgid "Async Rust"
+msgstr "Ruggine asincrona"
 
 #: src/async.md:3
 #, fuzzy
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
-"concurrently by\n"
-"executing each task until it would block, then switching to another task "
-"that is\n"
-"ready to make progress. The model allows running a larger number of tasks on "
-"a\n"
-"limited number of threads. This is because the per-task overhead is "
-"typically\n"
-"very low and operating systems provide primitives for efficiently "
-"identifying\n"
-"I/O that is able to proceed."
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 "\"Async\" è un modello di concorrenza in cui più attività vengono eseguite "
-"contemporaneamente da\n"
-"eseguire ogni attività fino a quando non si bloccherebbe, quindi passare a "
-"un'altra attività che è\n"
-"pronto a fare progressi. Il modello consente di eseguire un numero maggiore "
-"di attività su a\n"
-"numero limitato di thread. Questo perché il sovraccarico per attività è in "
-"genere\n"
-"molto basso e i sistemi operativi forniscono primitive per l'identificazione "
-"efficiente\n"
-"I/O che è in grado di procedere."
+"contemporaneamente da eseguire ogni attività fino a quando non si "
+"bloccherebbe, quindi passare a un'altra attività che è pronto a fare "
+"progressi. Il modello consente di eseguire un numero maggiore di attività su "
+"a numero limitato di thread. Questo perché il sovraccarico per attività è in "
+"genere molto basso e i sistemi operativi forniscono primitive per "
+"l'identificazione efficiente I/O che è in grado di procedere."
 
 #: src/async.md:10
 #, fuzzy
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
-"that\n"
-"may be completed in the future. Futures are \"polled\" until they signal "
-"that\n"
-"they are complete."
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
 "L'operazione asincrona di Rust si basa sui \"futuri\", che rappresentano il "
-"lavoro che\n"
-"potrebbe essere completata in futuro. I futures vengono \"interrogati\" fino "
-"a quando non lo segnalano\n"
-"sono completi."
+"lavoro che potrebbe essere completata in futuro. I futures vengono "
+"\"interrogati\" fino a quando non lo segnalano sono completi."
 
 #: src/async.md:14
 #, fuzzy
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 "I futures vengono interrogati da un runtime asincrono e diversi runtime lo "
-"sono\n"
-"disponibile."
+"sono disponibile."
 
 #: src/async.md:17
 #, fuzzy
-msgid "## Comparisons"
+msgid "Comparisons"
 msgstr "Comparazione"
 
 #: src/async.md:19
 #, fuzzy
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type "
-"is\n"
-"   callback-based, and not polled. Async Python programs require a "
-"\"loop\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The "
-"language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
 msgstr ""
-" * Python ha un modello simile nel suo `asyncio`. Tuttavia, il suo tipo "
-"\"Futuro\" è\n"
-"   basato su callback e non su polling. I programmi Python asincroni "
-"richiedono un \"loop\",\n"
-"   simile a un runtime in Rust.\n"
-"\n"
-" * La \"promessa\" di JavaScript è simile, ma ancora una volta basata su "
-"callback. La lingua\n"
-"   runtime implementa il ciclo di eventi, tanti dei dettagli di Promise\n"
-"   risoluzione sono nascosti."
+"Python ha un modello simile nel suo `asyncio`. Tuttavia, il suo tipo "
+"\"Futuro\" è basato su callback e non su polling. I programmi Python "
+"asincroni richiedono un \"loop\", simile a un runtime in Rust."
+
+#: src/async.md:23
+#, fuzzy
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
+msgstr ""
+"La \"promessa\" di JavaScript è simile, ma ancora una volta basata su "
+"callback. La lingua runtime implementa il ciclo di eventi, tanti dei "
+"dettagli di Promise risoluzione sono nascosti."
 
 #: src/async/async-await.md:1
 #, fuzzy
-msgid "# `async`/`await`"
-msgstr "# `asincrono`/`aspetta`"
+msgid "`async`/`await`"
+msgstr "`asincrono`/`aspetta`"
 
 #: src/async/async-await.md:3
 #, fuzzy
@@ -19185,53 +19906,61 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no "
-"long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the "
-"compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current "
-"thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. "
-"Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
 
-#: src/async/futures.md:1
-#, fuzzy
-msgid "# Futures"
-msgstr "# Futuri"
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr ""
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr ""
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr ""
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr ""
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr ""
 
 #: src/async/futures.md:3
 #, fuzzy
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not "
-"be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
-"[`Futuro`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"è un tratto, implementato da oggetti che rappresentano un'operazione che "
-"potrebbe non essere\n"
-"ancora completo. È possibile eseguire il polling di un futuro e `poll` "
-"restituisce a\n"
-"[`Sondaggio`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Futuro`](https://doc.rust-lang.org/std/future/trait.Future.html) è un "
+"tratto, implementato da oggetti che rappresentano un'operazione che potrebbe "
+"non essere ancora completo. È possibile eseguire il polling di un futuro e "
+"`poll` restituisce a [`Sondaggio`](https://doc.rust-lang.org/std/task/enum."
+"Poll.html)."
 
 #: src/async/futures.md:8
 msgid ""
@@ -19256,133 +19985,121 @@ msgstr ""
 #, fuzzy
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
-"uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` "
-"returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
 "Una funzione asincrona restituisce un `impl Future`. È anche possibile (ma "
-"non comune).\n"
-"implementa `Future` per i tuoi tipi. Ad esempio, è stato restituito "
-"\"JoinHandle\".\n"
-"da `tokio::spawn` implementa `Future` per consentire l'unione ad esso."
+"non comune). implementa `Future` per i tuoi tipi. Ad esempio, è stato "
+"restituito \"JoinHandle\". da `tokio::spawn` implementa `Future` per "
+"consentire l'unione ad esso."
 
 #: src/async/futures.md:27
 #, fuzzy
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
-"to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 "La parola chiave `.await`, applicata a un Future, fa sì che la funzione "
-"async corrente si attivi\n"
-"mettere in pausa fino a quando Future non è pronto, quindi valuta il suo "
-"output."
+"async corrente si attivi mettere in pausa fino a quando Future non è pronto, "
+"quindi valuta il suo output."
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers "
-"into\n"
-"    that future remain valid. This is required to allow references to "
-"remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/runtimes.md:1
-#, fuzzy
-msgid "# Runtimes"
-msgstr "# Runtime"
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
+msgstr ""
 
 #: src/async/runtimes.md:3
 #, fuzzy
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust "
-"does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
-"Un *runtime* fornisce supporto per l'esecuzione di operazioni in modo "
-"asincrono (a\n"
-"*reattore*) ed è responsabile dell'esecuzione dei futures (un *esecutore*). "
-"La ruggine non ha un\n"
-"runtime \"incorporato\", ma sono disponibili diverse opzioni:"
+"Un _runtime_ fornisce supporto per l'esecuzione di operazioni in modo "
+"asincrono (a _reattore_) ed è responsabile dell'esecuzione dei futures (un "
+"_esecutore_). La ruggine non ha un runtime \"incorporato\", ma sono "
+"disponibili diverse opzioni:"
 
 #: src/async/runtimes.md:7
 #, fuzzy
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem "
-"of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and "
-"includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
 msgstr ""
-" * [Tokio](https://tokio.rs/) - performante, con un ecosistema ben "
-"sviluppato di\n"
-"   funzionalità come [Hyper](https://hyper.rs/) per HTTP o\n"
-"   [Tonic](https://github.com/hyperium/tonic) per gRPC.\n"
-" * [async-std](https://async.rs/) - mira a essere uno \"std per async\" e "
-"include un\n"
-"   runtime di base in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - semplice e leggero"
+"[Tokio](https://tokio.rs/) - performante, con un ecosistema ben sviluppato "
+"di funzionalità come [Hyper](https://hyper.rs/) per HTTP o [Tonic](https://"
+"github.com/hyperium/tonic) per gRPC."
+
+#: src/async/runtimes.md:10
+#, fuzzy
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+"[async-std](https://async.rs/) - mira a essere uno \"std per async\" e "
+"include un runtime di base in `async::task`."
+
+#: src/async/runtimes.md:12
+#, fuzzy
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+msgstr "[smol](https://docs.rs/smol/latest/smol/) - semplice e leggero"
 
 #: src/async/runtimes.md:14
 #, fuzzy
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 "Diverse applicazioni più grandi hanno i propri tempi di esecuzione. Per "
-"esempio,\n"
-"[Fucsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"ne ha già uno."
+"esempio, [Fucsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/"
+"src/lib/fuchsia-async/src/lib.rs) ne ha già uno."
 
 #: src/async/runtimes.md:20
 #, fuzzy
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most "
-"interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/"
-"O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are "
-"never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
-"* Si noti che dei runtime elencati, solo Tokio è supportato in Rust\n"
-"  terreno di gioco. Anche il parco giochi non consente alcun I/O, quindi "
-"molto interessante\n"
-"  le cose asincrone non possono essere eseguite nel parco giochi.\n"
-"\n"
-"* I futures sono \"inerti\" in quanto non fanno nulla (nemmeno avviano un I/"
-"O\n"
-"  operazione) a meno che non ci sia un esecutore che li interroga. Questo "
-"differisce da JS\n"
-"  Promesse, ad esempio, che andranno a buon fine anche se non lo saranno "
-"mai\n"
-"  usato."
+"Si noti che dei runtime elencati, solo Tokio è supportato in Rust terreno di "
+"gioco. Anche il parco giochi non consente alcun I/O, quindi molto "
+"interessante le cose asincrone non possono essere eseguite nel parco giochi."
 
-#: src/async/runtimes/tokio.md:1
+#: src/async/runtimes.md:24
 #, fuzzy
-msgid "# Tokio"
-msgstr "# Tokyo"
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
+msgstr ""
+"I futures sono \"inerti\" in quanto non fanno nulla (nemmeno avviano un I/O "
+"operazione) a meno che non ci sia un esecutore che li interroga. Questo "
+"differisce da JS Promesse, ad esempio, che andranno a buon fine anche se non "
+"lo saranno mai usato."
 
 #: src/async/runtimes/tokio.md:4
 #, fuzzy
@@ -19391,14 +20108,18 @@ msgstr "Tokyo fornisce:"
 
 #: src/async/runtimes/tokio.md:6
 #, fuzzy
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
-msgstr ""
-"* Un runtime multithread per l'esecuzione di codice asincrono.\n"
-"* Una versione asincrona della libreria standard.\n"
-"* Un grande ecosistema di biblioteche."
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr "Un runtime multithread per l'esecuzione di codice asincrono."
+
+#: src/async/runtimes/tokio.md:7
+#, fuzzy
+msgid "An asynchronous version of the standard library."
+msgstr "Una versione asincrona della libreria standard."
+
+#: src/async/runtimes/tokio.md:8
+#, fuzzy
+msgid "A large ecosystem of libraries."
+msgstr "Un grande ecosistema di biblioteche."
 
 #: src/async/runtimes/tokio.md:10
 msgid ""
@@ -19426,18 +20147,19 @@ msgstr ""
 
 #: src/async/runtimes/tokio.md:33
 #, fuzzy
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr "Con la macro `tokio::main` ora possiamo rendere `main` asincrono."
+
+#: src/async/runtimes/tokio.md:35
+#, fuzzy
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr "La funzione `spawn` crea un nuovo \"task\" simultaneo."
+
+#: src/async/runtimes/tokio.md:37
+#, fuzzy
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
-"* Con la macro `tokio::main` ora possiamo rendere `main` asincrono.\n"
-"\n"
-"* La funzione `spawn` crea un nuovo \"task\" simultaneo.\n"
-"\n"
-"* Nota: `spawn` prende un `Future`, non devi chiamare `.await` su `count_to`."
+"Nota: `spawn` prende un `Future`, non devi chiamare `.await` su `count_to`."
 
 #: src/async/runtimes/tokio.md:39
 #, fuzzy
@@ -19447,29 +20169,23 @@ msgstr "**Ulteriori esplorazioni:**"
 #: src/async/runtimes/tokio.md:41
 #, fuzzy
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to "
-"wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
-"* Perché `count_to` non arriva (di solito) a 10? Questo è un esempio di "
-"async\n"
-"  cancellazione. `tokio::spawn` restituisce un handle che può essere atteso "
-"per attendere\n"
-"  finché non finisce.\n"
-"\n"
-"* Prova `count_to(10).await` invece di spawnare.\n"
-"\n"
-"* Prova ad attendere il task restituito da `tokio::spawn`."
+"Perché `count_to` non arriva (di solito) a 10? Questo è un esempio di async "
+"cancellazione. `tokio::spawn` restituisce un handle che può essere atteso "
+"per attendere finché non finisce."
 
-#: src/async/tasks.md:1
+#: src/async/runtimes/tokio.md:45
 #, fuzzy
-msgid "# Tasks"
-msgstr "# Compiti"
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr "Prova `count_to(10).await` invece di spawnare."
+
+#: src/async/runtimes/tokio.md:47
+#, fuzzy
+msgid "Try awaiting the task returned from `tokio::spawn`."
+msgstr "Prova ad attendere il task restituito da `tokio::spawn`."
 
 #: src/async/tasks.md:3
 msgid "Rust has a task system, which is a form of lightweight threading."
@@ -19479,19 +20195,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "A task has a single top-level future which the executor polls to make "
-"progress.\n"
-"That future may have one or more nested futures that its `poll` method "
-"polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible "
-"by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
 "Un'attività ha un singolo futuro di primo livello che l'esecutore interroga "
-"per fare progressi.\n"
-"Quel futuro può avere uno o più futuri nidificati che il suo metodo \"poll\" "
-"esegue il polling,\n"
-"corrispondente vagamente a uno stack di chiamate. La concorrenza all'interno "
-"di un'attività è possibile tramite\n"
+"per fare progressi. Quel futuro può avere uno o più futuri nidificati che il "
+"suo metodo \"poll\" esegue il polling, corrispondente vagamente a uno stack "
+"di chiamate. La concorrenza all'interno di un'attività è possibile tramite "
 "polling di più futuri figli, come correre un timer e un'operazione di I/O."
 
 #: src/async/tasks.md:10
@@ -19548,33 +20260,32 @@ msgstr ""
 #: src/async/tasks.md:54
 #, fuzzy
 msgid ""
-"* Ask students to visualize what the state of the example server would be "
-"with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling "
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
+msgstr ""
+"Chiedi agli studenti di visualizzare quale sarebbe lo stato del server di "
+"esempio con a pochi client connessi. Quali compiti esistono? Quali sono i "
+"loro futuri?"
+
+#: src/async/tasks.md:57
+#, fuzzy
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+"Questa è la prima volta che vediamo un blocco `async`. Questo è simile a a "
+"chiusura, ma non accetta argomenti. Il suo valore di ritorno è un Futuro, "
+"simile a un `async fn`."
+
+#: src/async/tasks.md:61
+#, fuzzy
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
 "using `?`."
 msgstr ""
-"* Chiedi agli studenti di visualizzare quale sarebbe lo stato del server di "
-"esempio con a\n"
-"  pochi client connessi. Quali compiti esistono? Quali sono i loro futuri?\n"
-"\n"
-"* Questa è la prima volta che vediamo un blocco `async`. Questo è simile a "
-"a\n"
-"  chiusura, ma non accetta argomenti. Il suo valore di ritorno è un Futuro,\n"
-"  simile a un `async fn`.\n"
-"\n"
-"* Rifattorizzare il blocco asincrono in una funzione e migliorare la "
-"gestione degli errori utilizzando `?`."
-
-#: src/async/channels.md:1
-#, fuzzy
-msgid "# Async Channels"
-msgstr "# Canali asincroni"
+"Rifattorizzare il blocco asincrono in una funzione e migliorare la gestione "
+"degli errori utilizzando `?`."
 
 #: src/async/channels.md:3
 #, fuzzy
@@ -19618,85 +20329,84 @@ msgstr ""
 
 #: src/async/channels.md:35
 #, fuzzy
-msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be "
-"convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to "
-"combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+msgid "Change the channel size to `3` and see how it affects the execution."
 msgstr ""
-"* Cambia la dimensione del canale in \"3\" e guarda come influisce "
-"sull'esecuzione.\n"
-"\n"
-"* Nel complesso, l'interfaccia è simile ai canali `sync` come si vede nel "
-"file\n"
-"  [lezione mattutina](concurrency/channels.md).\n"
-"\n"
-"* Prova a rimuovere la chiamata `std::mem::drop`. Che succede? Perché?\n"
-"\n"
-"* La cassa [Flume](https://docs.rs/flume/latest/flume/) ha canali che\n"
-"  implementa sia `sync` che `async` `send` e `recv`. Questo può essere "
-"conveniente\n"
-"  per applicazioni complesse con attività di elaborazione di CPU e IO "
-"pesanti.\n"
-"\n"
-"* Ciò che rende preferibile lavorare con i canali `async` è la capacità di "
-"combinare\n"
-"  loro con altri `futuri` per combinarli e creare un flusso di controllo "
-"complesso."
+"Cambia la dimensione del canale in \"3\" e guarda come influisce "
+"sull'esecuzione."
+
+#: src/async/channels.md:37
+#, fuzzy
+msgid ""
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+"Nel complesso, l'interfaccia è simile ai canali `sync` come si vede nel file "
+"[lezione mattutina](concurrency/channels.md)."
+
+#: src/async/channels.md:40
+#, fuzzy
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr "Prova a rimuovere la chiamata `std::mem::drop`. Che succede? Perché?"
+
+#: src/async/channels.md:42
+#, fuzzy
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+"La cassa [Flume](https://docs.rs/flume/latest/flume/) ha canali che "
+"implementa sia `sync` che `async` `send` e `recv`. Questo può essere "
+"conveniente per applicazioni complesse con attività di elaborazione di CPU e "
+"IO pesanti."
+
+#: src/async/channels.md:46
+#, fuzzy
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
+msgstr ""
+"Ciò che rende preferibile lavorare con i canali `async` è la capacità di "
+"combinare loro con altri `futuri` per combinarli e creare un flusso di "
+"controllo complesso."
 
 #: src/async/control-flow.md:1
 #, fuzzy
-msgid "# Futures Control Flow"
-msgstr "# Flusso di controllo dei futures"
+msgid "Futures Control Flow"
+msgstr "Flusso di controllo dei futures"
 
 #: src/async/control-flow.md:3
 #, fuzzy
 msgid ""
 "Futures can be combined together to produce concurrent compute flow graphs. "
-"We\n"
-"have already seen tasks, that function as independent threads of execution."
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
 "I futures possono essere combinati insieme per produrre grafici di flusso di "
-"calcolo simultanei. Noi\n"
-"ho già visto le attività, che funzionano come thread di esecuzione "
-"indipendenti."
+"calcolo simultanei. Noi ho già visto le attività, che funzionano come thread "
+"di esecuzione indipendenti."
 
 #: src/async/control-flow.md:6
 #, fuzzy
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
-msgstr ""
-"- [Partecipa](control-flow/join.md)\n"
-"- [Seleziona](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
+msgstr "[Partecipa](control-flow/join.md)"
 
-#: src/async/control-flow/join.md:1
+#: src/async/control-flow.md:7
 #, fuzzy
-msgid "# Join"
-msgstr "# Giuntura"
+msgid "[Select](control-flow/select.md)"
+msgstr "[Seleziona](control-flow/select.md)"
 
 #: src/async/control-flow/join.md:3
 #, fuzzy
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
-"Un'operazione di join attende fino a quando tutti i futures sono pronti e\n"
+"Un'operazione di join attende fino a quando tutti i futures sono pronti e "
 "restituisce una raccolta dei loro risultati. Questo è simile a \"Promise."
-"all\" in\n"
-"JavaScript o `asyncio.gather` in Python."
+"all\" in JavaScript o `asyncio.gather` in Python."
 
 #: src/async/control-flow/join.md:7
 msgid ""
@@ -19731,75 +20441,62 @@ msgstr ""
 #: src/async/control-flow/join.md:38
 #, fuzzy
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` "
-"but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this "
-"would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all "
-"requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but "
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
+msgstr ""
+"Per future multiple di tipi disgiunti, puoi usare `std::future::join!` ma "
+"devi sapere quanti futuri avrai al momento della compilazione. Questo è "
+"attualmente nella cassa `futures`, presto sarà stabilizzata in `std::future`."
+
+#: src/async/control-flow/join.md:42
+#, fuzzy
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+"Il rischio di \"unirsi\" è che uno dei futuri potrebbe non risolversi mai, "
+"questo sì causare l'arresto del programma."
+
+#: src/async/control-flow/join.md:45
+#, fuzzy
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
 "demonstrates `join!`."
 msgstr ""
-"* Per future multiple di tipi disgiunti, puoi usare `std::future::join!` ma\n"
-"  devi sapere quanti futuri avrai al momento della compilazione. Questo è\n"
-"  attualmente nella cassa `futures`, presto sarà stabilizzata in `std::"
-"future`.\n"
-"\n"
-"* Il rischio di \"unirsi\" è che uno dei futuri potrebbe non risolversi mai, "
-"questo sì\n"
-"  causare l'arresto del programma.\n"
-"\n"
-"* Puoi anche combinare `join_all` con `join!`, ad esempio per unire tutte le "
-"richieste\n"
-"  a un servizio http così come una query di database. Prova ad aggiungere "
-"un\n"
-"  `tokio::time::sleep` nel futuro, usando `futures::join!`. Questo non è un\n"
-"  timeout (che richiede `select!`, spiegato nel prossimo capitolo), ma "
-"dimostra `join!`."
-
-#: src/async/control-flow/select.md:1
-#, fuzzy
-msgid "# Select"
-msgstr "# Selezionare"
+"Puoi anche combinare `join_all` con `join!`, ad esempio per unire tutte le "
+"richieste a un servizio http così come una query di database. Prova ad "
+"aggiungere un `tokio::time::sleep` nel futuro, usando `futures::join!`. "
+"Questo non è un timeout (che richiede `select!`, spiegato nel prossimo "
+"capitolo), ma dimostra `join!`."
 
 #: src/async/control-flow/select.md:3
 #, fuzzy
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 "Un'operazione di selezione attende fino a quando uno qualsiasi di un insieme "
-"di futures è pronto e risponde a\n"
-"il risultato di quel futuro. In JavaScript, è simile a `Promise.race`. In\n"
-"Python, confronta con `asyncio.wait(task_set,\n"
+"di futures è pronto e risponde a il risultato di quel futuro. In JavaScript, "
+"è simile a `Promise.race`. In Python, confronta con `asyncio.wait(task_set, "
 "return_when=asyncio.FIRST_COMPLETED)`."
 
 #: src/async/control-flow/select.md:8
 #, fuzzy
 msgid ""
 "Similar to a match statement, the body of `select!` has a number of arms, "
-"each\n"
-"of the form `pattern = future => statement`. When the `future` is ready, "
-"the\n"
-"`statement` is executed with the variables in `pattern` bound to the "
-"`future`'s\n"
-"result."
+"each of the form `pattern = future => statement`. When the `future` is "
+"ready, the `statement` is executed with the variables in `pattern` bound to "
+"the `future`'s result."
 msgstr ""
 "Di solito è una macro, simile a match, con ogni braccio della forma `pattern "
-"=\n"
-"futuro => istruzione`. Quando il futuro è pronto, l'istruzione viene "
-"eseguita con il\n"
-"variabile legata al risultato del futuro."
+"= futuro => istruzione`. Quando il futuro è pronto, l'istruzione viene "
+"eseguita con il variabile legata al risultato del futuro."
 
 #: src/async/control-flow/select.md:13
 msgid ""
@@ -19854,52 +20551,55 @@ msgstr ""
 #: src/async/control-flow/select.md:62
 #, fuzzy
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick "
-"whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are "
-"supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts "
-"of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` drops unmatched branches, which cancels their "
-"futures.\n"
-"  It is easiest to use when every execution of `select!` creates new "
-"futures.\n"
-"\n"
-"    * An alternative is to pass `&mut future` instead of the future itself, "
-"but\n"
-"      this can lead to issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
 msgstr ""
-"* In questo esempio, abbiamo una gara tra un gatto e un cane.\n"
-"  `first_animal_to_finish_race` ascolta entrambi i canali e sceglierà quello "
-"che preferisci\n"
-"  arriva prima. Poiché il cane impiega 50 ms, vince contro il gatto\n"
-"  prendere 500 ms secondi.\n"
-"\n"
-"* In questo esempio puoi usare i canali `oneshot` come dovrebbero\n"
-"  ricevere un solo \"invio\".\n"
-"\n"
-"* Prova ad aggiungere una scadenza alla gara, dimostrando la selezione di "
-"diversi tipi di\n"
-"  futuri.\n"
-"\n"
-"* Nota che `select!` sposta i valori che gli vengono dati. È più facile da "
-"usare\n"
-"  quando ogni esecuzione di `select!` crea nuovi futuri. Un'alternativa è\n"
-"  passa `&mut future` invece del futuro stesso, ma questo può portare a\n"
-"  problemi, ulteriormente discussi nella diapositiva di blocco."
+"In questo esempio, abbiamo una gara tra un gatto e un cane. "
+"`first_animal_to_finish_race` ascolta entrambi i canali e sceglierà quello "
+"che preferisci arriva prima. Poiché il cane impiega 50 ms, vince contro il "
+"gatto prendere 500 ms secondi."
+
+#: src/async/control-flow/select.md:67
+#, fuzzy
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+"In questo esempio puoi usare i canali `oneshot` come dovrebbero ricevere un "
+"solo \"invio\"."
+
+#: src/async/control-flow/select.md:70
+#, fuzzy
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+"Prova ad aggiungere una scadenza alla gara, dimostrando la selezione di "
+"diversi tipi di futuri."
+
+#: src/async/control-flow/select.md:73
+#, fuzzy
+msgid ""
+"Note that `select!` drops unmatched branches, which cancels their futures. "
+"It is easiest to use when every execution of `select!` creates new futures."
+msgstr ""
+"Nota che `select!` sposta i valori che gli vengono dati. È più facile da "
+"usare quando ogni esecuzione di `select!` crea nuovi futuri. Un'alternativa "
+"è passa `&mut future` invece del futuro stesso, ma questo può portare a "
+"problemi, ulteriormente discussi nella diapositiva di blocco."
+
+#: src/async/control-flow/select.md:76
+msgid ""
+"An alternative is to pass `&mut future` instead of the future itself, but "
+"this can lead to issues, further discussed in the pinning slide."
+msgstr ""
 
 #: src/async/pitfalls.md:1
 #, fuzzy
-msgid "# Pitfalls of async/await"
-msgstr "# Insidie di async/await"
+msgid "Pitfalls of async/await"
+msgstr "Insidie di async/await"
 
 #: src/async/pitfalls.md:3
 #, fuzzy
@@ -19916,34 +20616,40 @@ msgstr ""
 
 #: src/async/pitfalls.md:5
 #, fuzzy
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfalls/async-traits.md)\n"
-"- [Cancellation](pitfalls/cancellation.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr "[Blocco dell'esecutore](trappole/blocking-executor.md)"
+
+#: src/async/pitfalls.md:6
+#, fuzzy
+msgid "[Pin](pitfalls/pin.md)"
+msgstr "[Pin](trappole/pin.md)"
+
+#: src/async/pitfalls.md:7
+#, fuzzy
+msgid "[Async Traits](pitfalls/async-traits.md)"
+msgstr "[Tratti asincroni](trapano/async-traits.md)"
+
+#: src/async/pitfalls.md:8
+msgid "[Cancellation](pitfalls/cancellation.md)"
 msgstr ""
-"- [Blocco dell'esecutore](trappole/blocking-executor.md)\n"
-"- [Pin](trappole/pin.md)\n"
-"- [Tratti asincroni](trapano/async-traits.md)"
 
 #: src/async/pitfalls/blocking-executor.md:1
 #, fuzzy
-msgid "# Blocking the executor"
-msgstr "# Blocco dell'esecutore"
+msgid "Blocking the executor"
+msgstr "Blocco dell'esecutore"
 
 #: src/async/pitfalls/blocking-executor.md:3
 #, fuzzy
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other "
-"tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
 "La maggior parte dei runtime asincroni consente solo l'esecuzione simultanea "
-"delle attività di I/O.\n"
-"Ciò significa che le attività di blocco della CPU bloccheranno l'esecutore e "
-"impediranno l'esecuzione di altre attività.\n"
-"Una soluzione semplice consiste nell'usare metodi equivalenti asincroni ove "
+"delle attività di I/O. Ciò significa che le attività di blocco della CPU "
+"bloccheranno l'esecutore e impediranno l'esecuzione di altre attività. Una "
+"soluzione semplice consiste nell'usare metodi equivalenti asincroni ove "
 "possibile."
 
 #: src/async/pitfalls/blocking-executor.md:7
@@ -19972,105 +20678,94 @@ msgstr ""
 #: src/async/pitfalls/blocking-executor.md:29
 #, fuzzy
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its "
-"result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an "
-"actual\n"
-"  thread and transforms its handle into a future without blocking the "
-"executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and "
-"most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, "
-"where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
-"situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause "
-"another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
-"* Esegui il codice e verifica che le interruzioni avvengano consecutivamente "
-"anziché\n"
-"  in concomitanza.\n"
-"\n"
-"* Il profilo `\"current_thread\"` pone tutte le attività su un singolo "
-"thread. Questo rende il\n"
-"  effetto più evidente, ma il bug è ancora presente nel multithread\n"
-"  gusto.\n"
-"\n"
-"* Passa da `std::thread::sleep` a `tokio::time::sleep` e attendi il "
-"risultato.\n"
-"\n"
-"* Un'altra soluzione potrebbe essere `tokio::task::spawn_blocking` che "
-"genera un file effettivo\n"
-"  thread e trasforma il suo handle in un futuro senza bloccare l'esecutore.\n"
-"\n"
-"* Non dovresti pensare alle attività come thread del sistema operativo. Non "
-"mappano 1 a 1 e la maggior parte\n"
-"  gli esecutori consentiranno l'esecuzione di molte attività su un singolo "
-"thread del sistema operativo. Questo è\n"
-"  particolarmente problematico quando si interagisce con altre biblioteche "
-"tramite FFI, dove\n"
-"  quella libreria potrebbe dipendere dall'archiviazione locale del thread o "
-"essere mappata su un sistema operativo specifico\n"
-"  thread (ad esempio, CUDA). Preferisci `tokio::task::spawn_blocking` in "
-"tali situazioni.\n"
-"\n"
-"* Usa i mutex di sincronizzazione con attenzione. Mantenere un mutex sopra "
-"un `.await` può causarne un altro\n"
-"  attività da bloccare e tale attività potrebbe essere in esecuzione sullo "
-"stesso thread."
+"Esegui il codice e verifica che le interruzioni avvengano consecutivamente "
+"anziché in concomitanza."
 
-#: src/async/pitfalls/pin.md:1
+#: src/async/pitfalls/blocking-executor.md:32
 #, fuzzy
-msgid "# Pin"
-msgstr "# Spillo"
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+"Il profilo `\"current_thread\"` pone tutte le attività su un singolo thread. "
+"Questo rende il effetto più evidente, ma il bug è ancora presente nel "
+"multithread gusto."
+
+#: src/async/pitfalls/blocking-executor.md:36
+#, fuzzy
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+"Passa da `std::thread::sleep` a `tokio::time::sleep` e attendi il risultato."
+
+#: src/async/pitfalls/blocking-executor.md:38
+#, fuzzy
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+"Un'altra soluzione potrebbe essere `tokio::task::spawn_blocking` che genera "
+"un file effettivo thread e trasforma il suo handle in un futuro senza "
+"bloccare l'esecutore."
+
+#: src/async/pitfalls/blocking-executor.md:41
+#, fuzzy
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+"Non dovresti pensare alle attività come thread del sistema operativo. Non "
+"mappano 1 a 1 e la maggior parte gli esecutori consentiranno l'esecuzione di "
+"molte attività su un singolo thread del sistema operativo. Questo è "
+"particolarmente problematico quando si interagisce con altre biblioteche "
+"tramite FFI, dove quella libreria potrebbe dipendere dall'archiviazione "
+"locale del thread o essere mappata su un sistema operativo specifico thread "
+"(ad esempio, CUDA). Preferisci `tokio::task::spawn_blocking` in tali "
+"situazioni."
+
+#: src/async/pitfalls/blocking-executor.md:47
+#, fuzzy
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
+msgstr ""
+"Usa i mutex di sincronizzazione con attenzione. Mantenere un mutex sopra un "
+"`.await` può causarne un altro attività da bloccare e tale attività potrebbe "
+"essere in esecuzione sullo stesso thread."
 
 #: src/async/pitfalls/pin.md:3
 #, fuzzy
 msgid ""
 "When you await a future, all local variables (that would ordinarily be "
-"stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. "
-"If your\n"
-"future has pointers to data on the stack, those pointers might get "
-"invalidated.\n"
-"This is unsafe."
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
 "Quando aspetti un futuro, tutte le variabili locali (che normalmente "
-"sarebbero memorizzate su\n"
-"uno stack frame) vengono invece archiviati in Future per il blocco asincrono "
-"corrente. Se tuo\n"
-"future ha puntatori ai dati nello stack, quei puntatori potrebbero essere "
-"invalidati.\n"
-"Questo non è sicuro."
+"sarebbero memorizzate su uno stack frame) vengono invece archiviati in "
+"Future per il blocco asincrono corrente. Se tuo future ha puntatori ai dati "
+"nello stack, quei puntatori potrebbero essere invalidati. Questo non è "
+"sicuro."
 
 #: src/async/pitfalls/pin.md:8
 #, fuzzy
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to "
-"don't\n"
+"Therefore, you must guarantee that the addresses your future points to don't "
 "change. That is why we need to `pin` futures. Using the same future "
-"repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 "Pertanto, è necessario garantire che gli indirizzi futuri puntino a non "
-"farlo\n"
-"modifica. Ecco perché dobbiamo \"bloccare\" i futuri. Usando ripetutamente "
-"lo stesso futuro\n"
-"in un `select!` spesso porta a problemi con i valori bloccati."
+"farlo modifica. Ecco perché dobbiamo \"bloccare\" i futuri. Usando "
+"ripetutamente lo stesso futuro in un `select!` spesso porta a problemi con i "
+"valori bloccati."
 
 #: src/async/pitfalls/pin.md:12
 msgid ""
@@ -20131,62 +20826,79 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your "
-"time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!"
-"(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the "
-"`loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to "
-"the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on "
-"every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, "
-"but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that "
-"will send to a `oneshot` channel every 100ms."
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:1
-#, fuzzy
-msgid "# Async Traits"
-msgstr "# Tratti asincroni"
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
+msgstr ""
 
 #: src/async/pitfalls/async-traits.md:3
 #, fuzzy
@@ -20197,8 +20909,8 @@ msgid ""
 "nightly.html))"
 msgstr ""
 "I metodi asincroni nei tratti non sono ancora supportati nel canale stabile "
-"([Esiste una funzionalità sperimentale in nightly e dovrebbe essere "
-"stabilizzata a medio termine.](https://blog.rust-lang.org/inside-"
+"(\\[Esiste una funzionalità sperimentale in nightly e dovrebbe essere "
+"stabilizzata a medio termine.\\](https://blog.rust-lang.org/inside-"
 "rust/2022/11 /17/async-fn-in-trait-nightly.html))"
 
 #: src/async/pitfalls/async-traits.md:5
@@ -20256,61 +20968,46 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:49
-#, fuzzy
-msgid "<details>  "
-msgstr "<dettagli>"
-
 #: src/async/pitfalls/async-traits.md:51
 #, fuzzy
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations "
-"to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of "
-"time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
 msgstr ""
-"* `async_trait` è facile da usare, ma si noti che utilizza allocazioni di "
-"heap per\n"
-"  raggiungere questo obiettivo. Questa allocazione dell'heap comporta un "
-"sovraccarico delle prestazioni.\n"
-"\n"
-"* Le sfide nel supporto del linguaggio per `async trait` sono il profondo "
-"Rust e\n"
-"  probabilmente non vale la pena descriverlo in modo approfondito. Niko "
-"Matsakis ha fatto un buon lavoro\n"
-"  spiegandoli in [questo\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  se sei interessato a scavare più a fondo.\n"
-"\n"
-"* Prova a creare una nuova struttura dormiente che dormirà per un periodo di "
-"tempo casuale\n"
-"  e aggiungendolo al Vec."
+"`async_trait` è facile da usare, ma si noti che utilizza allocazioni di heap "
+"per raggiungere questo obiettivo. Questa allocazione dell'heap comporta un "
+"sovraccarico delle prestazioni."
 
-#: src/async/pitfalls/cancellation.md:1
+#: src/async/pitfalls/async-traits.md:54
 #, fuzzy
-msgid "# Cancellation"
-msgstr "# Traduzioni"
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+"Le sfide nel supporto del linguaggio per `async trait` sono il profondo Rust "
+"e probabilmente non vale la pena descriverlo in modo approfondito. Niko "
+"Matsakis ha fatto un buon lavoro spiegandoli in [questo post](https://"
+"smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-"
+"hard/) se sei interessato a scavare più a fondo."
+
+#: src/async/pitfalls/async-traits.md:60
+#, fuzzy
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
+msgstr ""
+"Prova a creare una nuova struttura dormiente che dormirà per un periodo di "
+"tempo casuale e aggiungendolo al Vec."
 
 #: src/async/pitfalls/cancellation.md:3
 msgid ""
 "Dropping a future implies it can never be polled again. This is called "
-"*cancellation*\n"
-"and it can occur at any `await` point. Care is needed to ensure the system "
-"works\n"
-"correctly even when futures are cancelled. For example, it shouldn't "
-"deadlock or\n"
-"lose data."
+"_cancellation_ and it can occur at any `await` point. Care is needed to "
+"ensure the system works correctly even when futures are cancelled. For "
+"example, it shouldn't deadlock or lose data."
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:8
@@ -20383,54 +21080,75 @@ msgstr ""
 
 #: src/async/pitfalls/cancellation.md:72
 msgid ""
-"* The compiler doesn't help with cancellation-safety. You need to read API\n"
-"  documentation and consider what state your `async fn` holds.\n"
+"The compiler doesn't help with cancellation-safety. You need to read API "
+"documentation and consider what state your `async fn` holds."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:75
+msgid ""
+"Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
+"error-handling)."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:78
+msgid "The example loses parts of the string."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:80
+msgid ""
+"Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
+"dropped."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:82
+msgid ""
+"`LinesReader` can be made cancellation-safe by makeing `buf` part of the "
+"struct:"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:83
+msgid ""
+"```rust,compile_fail\n"
+"struct LinesReader {\n"
+"    stream: DuplexStream,\n"
+"    bytes: Vec<u8>,\n"
+"    buf: [u8; 1],\n"
+"}\n"
 "\n"
-"* Unlike `panic` and `?`, cancellation is part of normal control flow\n"
-"  (vs error-handling).\n"
-"\n"
-"* The example loses parts of the string.\n"
-"\n"
-"    * Whenever the `tick()` branch finishes first, `next()` and its `buf` "
-"are dropped.\n"
-"\n"
-"    * `LinesReader` can be made cancellation-safe by makeing `buf` part of "
-"the struct:\n"
-"        ```rust,compile_fail\n"
-"        struct LinesReader {\n"
-"            stream: DuplexStream,\n"
-"            bytes: Vec<u8>,\n"
-"            buf: [u8; 1],\n"
-"        }\n"
-"\n"
-"        impl LinesReader {\n"
-"            fn new(stream: DuplexStream) -> Self {\n"
-"                Self { stream, bytes: Vec::new(), buf: [0] }\n"
-"            }\n"
-"            async fn next(&mut self) -> io::Result<Option<String>> {\n"
-"                // prefix buf and bytes with self.\n"
-"                // ...\n"
-"                let raw = std::mem::take(&mut self.bytes);\n"
-"                let s = String::from_utf8(raw)\n"
-"                // ...\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"* [`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
-"html#method.tick)\n"
-"  is cancellation-safe because it keeps track of whether a tick has been "
-"'delivered'.\n"
-"\n"
-"* [`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
-"AsyncReadExt.html#method.read)\n"
-"  is cancellation-safe because it either returns or doesn't read data.\n"
-"\n"
-"* [`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
-"AsyncBufReadExt.html#method.read_line)\n"
-"  is similar to the example and *isn't* cancellation-safe. See its "
-"documentation\n"
-"  for details and alternatives."
+"impl LinesReader {\n"
+"    fn new(stream: DuplexStream) -> Self {\n"
+"        Self { stream, bytes: Vec::new(), buf: [0] }\n"
+"    }\n"
+"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
+"        // prefix buf and bytes with self.\n"
+"        // ...\n"
+"        let raw = std::mem::take(&mut self.bytes);\n"
+"        let s = String::from_utf8(raw)\n"
+"        // ...\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:104
+msgid ""
+"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
+"html#method.tick) is cancellation-safe because it keeps track of whether a "
+"tick has been 'delivered'."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:107
+msgid ""
+"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncReadExt.html#method.read) is cancellation-safe because it either "
+"returns or doesn't read data."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:110
+msgid ""
+"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
+"cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:3
@@ -20440,40 +21158,39 @@ msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
-"* Dining philosophers: we already saw this problem in the morning. This "
-"time\n"
-"  you are going to implement it with Async Rust.\n"
-"\n"
-"* A Broadcast Chat Application: this is a larger project that allows you\n"
-"  experiment with more advanced Async Rust features."
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr ""
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:3
 #, fuzzy
-msgid "# Dining Philosophers - Async"
-msgstr "# Filosofi da pranzo"
+msgid "Dining Philosophers - Async"
+msgstr "Filosofi da pranzo"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the\n"
+"See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 #, fuzzy
 msgid ""
-"As before, you will need a local\n"
-"[Cargo installation](../../cargo/running-locally.md) for this exercise. "
-"Copy\n"
-"the code below to a file called `src/main.rs`, fill out the blanks, and "
-"test\n"
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 "Avrai bisogno di un'[installazione Cargo](../../cargo/running-locally.md) "
-"locale per\n"
-"questo esercizio. Copia il codice qui sotto in un file chiamato `src/main."
-"rs`, compila il file\n"
-"spazi vuoti e verificare che `cargo run` non vada in stallo:"
+"locale per questo esercizio. Copia il codice qui sotto in un file chiamato "
+"`src/main.rs`, compila il file spazi vuoti e verificare che `cargo run` non "
+"vada in stallo:"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
 msgid ""
@@ -20525,7 +21242,7 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
 msgid ""
-"Since this time you are using Async Rust, you'll need a `tokio` dependency.\n"
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
@@ -20545,33 +21262,29 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:72
 msgid ""
-"Also note that this time you have to use the `Mutex` and the `mpsc` module\n"
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "* Can you make your implementation single-threaded? "
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:1
-msgid "# Broadcast Chat Application"
+msgid "Can you make your implementation single-threaded? "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
 msgid ""
-"In this exercise, we want to use our new knowledge to implement a broadcast\n"
+"In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
-"publish\n"
-"their messages. The client reads user messages from the standard input, and\n"
-"sends them to the server. The chat server broadcasts each message that it\n"
-"receives to all the clients."
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel][1] on the server, and\n"
-"[`tokio_websockets`][2] for the communication between the client and the\n"
-"server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:13
@@ -20599,48 +21312,64 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:32
-msgid "## The required APIs"
+msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
-"You are going to need the following functions from `tokio` and\n"
-"[`tokio_websockets`][2]. Spend a few minutes to familiarize yourself with "
-"the\n"
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
 "API. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
-"- [WebsocketStream::next()][3]: for asynchronously reading messages from a\n"
-"  Websocket Stream.\n"
-"- [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously\n"
-"  sending messages on a Websocket Stream.\n"
-"- [Lines::next_line()][5]: for asynchronously reading user messages\n"
-"  from the standard input.\n"
-"- [Sender::subscribe()][6]: for subscribing to a broadcast channel."
+"[WebsocketStream::next()](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/proto/struct.WebsocketStream.html#method.next): for "
+"asynchronously reading messages from a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:41
+msgid ""
+"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
 #, fuzzy
-msgid "## Two binaries"
-msgstr "# Binari Rust"
+msgid "Two binaries"
+msgstr "Binari Rust"
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one\n"
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client,\n"
-"and one for the server. You could potentially make them two separate Cargo\n"
-"projects, but we are going to put them in a single Cargo project with two\n"
-"binaries. For this to work, the client and the server code should go under\n"
-"`src/bin` (see the [documentation][7]). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and\n"
-"`src/bin/client.rs`, respectively. Your task is to complete these files as\n"
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
 
@@ -20649,11 +21378,6 @@ msgstr ""
 #, fuzzy
 msgid "`src/bin/server.rs`:"
 msgstr "`src/driver.rs`:"
-
-#: src/exercises/concurrency/chat-app.md:61
-#, fuzzy
-msgid "<!-- File src/bin/server.rs -->"
-msgstr "<!-- File src/driver.rs -->"
 
 #: src/exercises/concurrency/chat-app.md:63
 msgid ""
@@ -20703,11 +21427,6 @@ msgstr ""
 msgid "`src/bin/client.rs`:"
 msgstr "`src/edificio.rs`:"
 
-#: src/exercises/concurrency/chat-app.md:104
-#, fuzzy
-msgid "<!-- File src/bin/client.rs -->"
-msgstr "<!-- File src/building.rs -->"
-
 #: src/exercises/concurrency/chat-app.md:106
 msgid ""
 "```rust,compile_fail\n"
@@ -20735,8 +21454,8 @@ msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:127
 #, fuzzy
-msgid "## Running the binaries"
-msgstr "# Esecuzione del corso"
+msgid "Running the binaries"
+msgstr "Esecuzione del corso"
 
 #: src/exercises/concurrency/chat-app.md:128
 #, fuzzy
@@ -20763,78 +21482,74 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:142
-msgid ""
-"* Implement the `handle_connection` function in `src/bin/server.rs`.\n"
-"  * Hint: Use `tokio::select!` for concurrently performing two tasks in a\n"
-"    continuous loop. One task receives messages from the client and "
-"broadcasts\n"
-"    them. The other sends messages received by the server to the client.\n"
-"* Complete the main function in `src/bin/client.rs`.\n"
-"  * Hint: As before, use `tokio::select!` in a continuous loop for "
-"concurrently\n"
-"    performing two tasks: (1) reading user messages from standard input and\n"
-"    sending them to the server, and (2) receiving messages from the server, "
-"and\n"
-"    displaying them for the user.\n"
-"* Optional: Once you are done, change the code to broadcast messages to all\n"
-"  clients, but the sender of the message."
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/thanks.md:1
-#, fuzzy
-msgid "# Thanks!"
-msgstr "# Grazie!"
+#: src/exercises/concurrency/chat-app.md:143
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:147
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:151
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
+msgstr ""
 
 #: src/thanks.md:3
 #, fuzzy
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
-"that it\n"
-"was useful."
+"that it was useful."
 msgstr ""
 "_Grazie per aver preso Comprehensive Rust 🦀!_ Ci auguriamo che ti sia "
-"piaciuto e che sia così\n"
-"è stato utile."
+"piaciuto e che sia così è stato utile."
 
 #: src/thanks.md:6
 #, fuzzy
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 "Ci siamo divertiti molto a mettere insieme il corso. Il corso non è "
-"perfetto,\n"
-"quindi se hai individuato errori o hai idee per miglioramenti, entra\n"
-"[contattaci su\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Ci "
-"piacerebbe\n"
-"avere tue notizie."
+"perfetto, quindi se hai individuato errori o hai idee per miglioramenti, "
+"entra [contattaci su GitHub](https://github.com/google/comprehensive-rust/"
+"discussions). Ci piacerebbe avere tue notizie."
 
 #: src/other-resources.md:1
 #, fuzzy
-msgid "# Other Rust Resources"
-msgstr "# Altre risorse di ruggine"
+msgid "Other Rust Resources"
+msgstr "Altre risorse di ruggine"
 
 #: src/other-resources.md:3
 #, fuzzy
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 "La community di Rust ha creato una vasta gamma di risorse gratuite e di alta "
-"qualità\n"
-"in linea."
+"qualità in linea."
 
 #: src/other-resources.md:6
 #, fuzzy
-msgid "## Official Documentation"
-msgstr "## Documentazione ufficiale"
+msgid "Official Documentation"
+msgstr "Documentazione ufficiale"
 
 #: src/other-resources.md:8
 #, fuzzy
@@ -20845,40 +21560,44 @@ msgstr ""
 #: src/other-resources.md:10
 #, fuzzy
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
 msgstr ""
-"* [Il linguaggio di programmazione Rust](https://doc.rust-lang.org/book/): "
-"the\n"
-"  canonico libro gratuito su Rust. Copre la lingua in dettaglio e include a\n"
-"  pochi progetti da costruire per le persone.\n"
-"* [Ruggine per esempio](https://doc.rust-lang.org/rust-by-example/): copre "
-"la Ruggine\n"
-"  sintassi attraverso una serie di esempi che mostrano diversi costrutti. A "
-"volte\n"
-"  include piccoli esercizi in cui ti viene chiesto di espandere il codice "
-"nel file\n"
-"  esempi.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): documentazione "
-"completa di\n"
-"  la libreria standard per Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): un libro "
-"incompleto\n"
-"  che descrive la grammatica e il modello di memoria di Rust."
+"[Il linguaggio di programmazione Rust](https://doc.rust-lang.org/book/): the "
+"canonico libro gratuito su Rust. Copre la lingua in dettaglio e include a "
+"pochi progetti da costruire per le persone."
+
+#: src/other-resources.md:13
+#, fuzzy
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+"[Ruggine per esempio](https://doc.rust-lang.org/rust-by-example/): copre la "
+"Ruggine sintassi attraverso una serie di esempi che mostrano diversi "
+"costrutti. A volte include piccoli esercizi in cui ti viene chiesto di "
+"espandere il codice nel file esempi."
+
+#: src/other-resources.md:17
+#, fuzzy
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): documentazione "
+"completa di la libreria standard per Rust."
+
+#: src/other-resources.md:19
+#, fuzzy
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
+msgstr ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): un libro "
+"incompleto che descrive la grammatica e il modello di memoria di Rust."
 
 #: src/other-resources.md:22
 #, fuzzy
@@ -20888,38 +21607,40 @@ msgstr "Guide più specializzate ospitate sul sito ufficiale di Rust:"
 #: src/other-resources.md:24
 #, fuzzy
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
 msgstr ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): copre Rust non "
-"sicuro,\n"
-"  compreso il lavoro con puntatori grezzi e l'interfacciamento con altre "
-"lingue\n"
-"  (FFI).\n"
-"* [Programmazione asincrona in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  copre il nuovo modello di programmazione asincrona che è stato introdotto "
-"dopo il\n"
-"  Rust Book è stato scritto.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduzione all'utilizzo di Rust su dispositivi embedded senza sistema "
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): copre Rust non "
+"sicuro, compreso il lavoro con puntatori grezzi e l'interfacciamento con "
+"altre lingue (FFI)."
+
+#: src/other-resources.md:27
+#, fuzzy
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+"[Programmazione asincrona in Rust](https://rust-lang.github.io/async-book/): "
+"copre il nuovo modello di programmazione asincrona che è stato introdotto "
+"dopo il Rust Book è stato scritto."
+
+#: src/other-resources.md:30
+#, fuzzy
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
+msgstr ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduzione all'utilizzo di Rust su dispositivi embedded senza sistema "
 "operativo."
 
 #: src/other-resources.md:33
 #, fuzzy
-msgid "## Unofficial Learning Material"
-msgstr "## Materiale didattico non ufficiale"
+msgid "Unofficial Learning Material"
+msgstr "Materiale didattico non ufficiale"
 
 #: src/other-resources.md:35
 #, fuzzy
@@ -20929,191 +21650,162 @@ msgstr "Una piccola selezione di altre guide e tutorial per Rust:"
 #: src/other-resources.md:37
 #, fuzzy
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
 msgstr ""
-"* [Impara la ruggine in modo pericoloso](http://cliffle.com/p/dangerust/): "
-"copre Rust\n"
-"  dal punto di vista dei programmatori C di basso livello.\n"
-"* [Ruggine per Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): copre Rust "
-"da\n"
-"  la prospettiva degli sviluppatori che scrivono firmware in C.\n"
-"* [Ruggine per professionisti](https://overexact.com/rust-for-"
-"professionals/):\n"
-"  copre la sintassi di Rust usando confronti fianco a fianco con altri "
-"linguaggi\n"
-"  come C, C++, Java, JavaScript e Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): oltre 100 esercizi "
-"per aiutarti\n"
-"  impari Ruggine.\n"
-"* [Insegnamento ferroso\n"
-"  Materiale](https://ferrous-systems.github.io/teaching-material/index."
-"html): a\n"
-"  serie di piccole presentazioni che coprono sia la parte di base che quella "
-"avanzata del\n"
-"  Linguaggio ruggine. Sono disponibili anche altri argomenti come "
-"WebAssembly e async/await\n"
-"  coperto.\n"
-"* [Serie per principianti a\n"
-"  Ruggine](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"e\n"
-"  [Fai i tuoi primi passi con\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"due\n"
-"  Guide Rust rivolte ai nuovi sviluppatori. Il primo è un set di 35 video e "
-"il\n"
-"  il secondo è un set di 11 moduli che copre la sintassi di Rust ei "
-"costrutti di base.\n"
-"* [Impara la ruggine con troppi collegamenti\n"
-"  Liste](https://rust-unofficial.github.io/too-many-lists/): "
-"approfondimento\n"
-"  esplorazione delle regole di gestione della memoria di Rust, "
-"implementandone alcune\n"
-"  diversi tipi di strutture di elenchi."
+"[Impara la ruggine in modo pericoloso](http://cliffle.com/p/dangerust/): "
+"copre Rust dal punto di vista dei programmatori C di basso livello."
+
+#: src/other-resources.md:39
+#, fuzzy
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+"[Ruggine per Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): copre Rust da la prospettiva degli sviluppatori che scrivono "
+"firmware in C."
+
+#: src/other-resources.md:42
+#, fuzzy
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+"[Ruggine per professionisti](https://overexact.com/rust-for-professionals/): "
+"copre la sintassi di Rust usando confronti fianco a fianco con altri "
+"linguaggi come C, C++, Java, JavaScript e Python."
+
+#: src/other-resources.md:45
+#, fuzzy
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): oltre 100 esercizi per "
+"aiutarti impari Ruggine."
+
+#: src/other-resources.md:47
+#, fuzzy
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+"[Insegnamento ferroso Materiale](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a serie di piccole presentazioni che coprono sia la "
+"parte di base che quella avanzata del Linguaggio ruggine. Sono disponibili "
+"anche altri argomenti come WebAssembly e async/await coperto."
+
+#: src/other-resources.md:52
+#, fuzzy
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+"[Serie per principianti a Ruggine](https://docs.microsoft.com/en-us/shows/"
+"beginners-series-to-rust/) e [Fai i tuoi primi passi con Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): due Guide Rust rivolte "
+"ai nuovi sviluppatori. Il primo è un set di 35 video e il il secondo è un "
+"set di 11 moduli che copre la sintassi di Rust ei costrutti di base."
+
+#: src/other-resources.md:58
+#, fuzzy
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
+msgstr ""
+"[Impara la ruggine con troppi collegamenti Liste](https://rust-unofficial."
+"github.io/too-many-lists/): approfondimento esplorazione delle regole di "
+"gestione della memoria di Rust, implementandone alcune diversi tipi di "
+"strutture di elenchi."
 
 #: src/other-resources.md:63
 #, fuzzy
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
+"for even more Rust books."
 msgstr ""
 "Si prega di consultare il [Little Book of Rust Books](https://lborb.github."
-"io/book/) per\n"
-"ancora più libri di Rust."
-
-#: src/credits.md:1
-#, fuzzy
-msgid "# Credits"
-msgstr "# Crediti"
+"io/book/) per ancora più libri di Rust."
 
 #: src/credits.md:3
 #, fuzzy
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
-"Il materiale qui si basa sulle molte grandi fonti di documentazione di "
-"Rust.\n"
+"Il materiale qui si basa sulle molte grandi fonti di documentazione di Rust. "
 "Vedere la pagina su [altre risorse](other-resources.md) per un elenco "
-"completo di utili\n"
-"risorse."
+"completo di utili risorse."
 
 #: src/credits.md:7
 #, fuzzy
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see\n"
-"[`LICENSE`](https://github.com/google/comprehensive-rust/blob/main/LICENSE) "
-"for\n"
-"details."
+"2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
+"rust/blob/main/LICENSE) for details."
 msgstr ""
 "Il materiale di Comprehensive Rust è concesso in licenza secondo i termini "
-"di Apache 2.0\n"
-"licenza, vedere [`LICENSE`](../LICENSE) per i dettagli."
+"di Apache 2.0 licenza, vedere [`LICENSE`](../LICENSE) per i dettagli."
 
 #: src/credits.md:12
 #, fuzzy
-msgid "## Rust by Example"
-msgstr "## Ruggine con l'esempio"
+msgid "Rust by Example"
+msgstr "Ruggine con l'esempio"
 
 #: src/credits.md:14
 #, fuzzy
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
-"Alcuni esempi ed esercizi sono stati copiati e adattati da [Rust by\n"
-"Esempio](https://doc.rust-lang.org/rust-by-example/). Si prega di consultare "
-"il\n"
-"directory `Third_party/rust-by-example/` per i dettagli, inclusa la licenza\n"
+"Alcuni esempi ed esercizi sono stati copiati e adattati da [Rust by Esempio]"
+"(https://doc.rust-lang.org/rust-by-example/). Si prega di consultare il "
+"directory `Third_party/rust-by-example/` per i dettagli, inclusa la licenza "
 "termini."
 
 #: src/credits.md:19
 #, fuzzy
-msgid "## Rust on Exercism"
-msgstr "## Ruggine sull'esercizio"
+msgid "Rust on Exercism"
+msgstr "Ruggine sull'esercizio"
 
 #: src/credits.md:21
 #, fuzzy
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"Alcuni esercizi sono stati copiati e adattati da [Rust on\n"
-"Esercizio fisico](https://exercism.org/tracks/rust). Si prega di consultare "
-"il\n"
-"directory `Third_party/rust-on-exercism/` per i dettagli, inclusa la "
-"licenza\n"
-"termini."
+"Alcuni esercizi sono stati copiati e adattati da [Rust on Esercizio fisico]"
+"(https://exercism.org/tracks/rust). Si prega di consultare il directory "
+"`Third_party/rust-on-exercism/` per i dettagli, inclusa la licenza termini."
 
 #: src/credits.md:26
 #, fuzzy
-msgid "## CXX"
-msgstr "##CXX"
+msgid "CXX"
+msgstr "\\##CXX"
 
 #: src/credits.md:28
 #, fuzzy
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 "La sezione [Interoperabilità con C++](android/interoperabilità/cpp.md) "
-"utilizza un file\n"
-"immagine da [CXX](https://cxx.rs/). Si prega di consultare la directory "
-"`Third_party/cxx/`\n"
-"per i dettagli, inclusi i termini di licenza."
-
-#: src/exercises/solutions.md:1
-#, fuzzy
-msgid "# Solutions"
-msgstr "# Soluzioni"
+"utilizza un file immagine da [CXX](https://cxx.rs/). Si prega di consultare "
+"la directory `Third_party/cxx/` per i dettagli, inclusi i termini di licenza."
 
 #: src/exercises/solutions.md:3
 #, fuzzy
@@ -21123,37 +21815,29 @@ msgstr "Troverai le soluzioni degli esercizi nelle pagine seguenti."
 #: src/exercises/solutions.md:5
 #, fuzzy
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
-"Sentiti libero di fare domande sulle soluzioni [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Facci "
-"sapere\n"
-"se hai una soluzione diversa o migliore di quella presentata qui."
+"Sentiti libero di fare domande sulle soluzioni [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Facci sapere se hai una "
+"soluzione diversa o migliore di quella presentata qui."
 
 #: src/exercises/solutions.md:10
 #, fuzzy
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
-"> **Nota:** Si prega di ignorare `// ANCHOR: etichetta` e `// ANCHOR_END: "
-"etichetta`\n"
-"> commenti che vedi nelle soluzioni. Sono lì per renderlo possibile\n"
-"> riutilizzare parti delle soluzioni come esercizi."
+"**Nota:** Si prega di ignorare `// ANCHOR: etichetta` e `// ANCHOR_END: "
+"etichetta` commenti che vedi nelle soluzioni. Sono lì per renderlo possibile "
+"riutilizzare parti delle soluzioni come esercizi."
 
 #: src/exercises/day-1/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 1 Morning Exercises"
-msgstr "# Giorno 1 Esercizi mattutini"
-
-#: src/exercises/day-1/solutions-morning.md:3
-#, fuzzy
-msgid "## Arrays and `for` Loops"
-msgstr "## Array e cicli `for`"
+msgid "Day 1 Morning Exercises"
+msgstr "Giorno 1 Esercizi mattutini"
 
 #: src/exercises/day-1/solutions-morning.md:5
 #, fuzzy
@@ -21237,8 +21921,8 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
 #, fuzzy
-msgid "### Bonus question"
-msgstr "### Domanda bonus"
+msgid "Bonus question"
+msgstr "Domanda bonus"
 
 #: src/exercises/day-1/solutions-morning.md:80
 #, fuzzy
@@ -21269,11 +21953,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 "Una volta arrivati ai tratti e ai generici, saremo in grado di usare il "
-"tratto [`std::convert::AsRef`][1] per astrarre su tutto ciò che può essere "
-"referenziato come slice."
+"tratto [`std::convert::AsRef`](https://doc.rust-lang.org/std/convert/trait."
+"AsRef.html) per astrarre su tutto ciò che può essere referenziato come slice."
 
 #: src/exercises/day-1/solutions-morning.md:86
 msgid ""
@@ -21317,13 +22002,13 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 1 Afternoon Exercises"
-msgstr "# Giorno 1 Esercizi pomeridiani"
+msgid "Day 1 Afternoon Exercises"
+msgstr "Giorno 1 Esercizi pomeridiani"
 
 #: src/exercises/day-1/solutions-afternoon.md:3
 #, fuzzy
-msgid "## Designing a Library"
-msgstr "## Progettare una libreria"
+msgid "Designing a Library"
+msgstr "Progettare una libreria"
 
 #: src/exercises/day-1/solutions-afternoon.md:5
 #, fuzzy
@@ -21529,13 +22214,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 2 Morning Exercises"
-msgstr "# Giorno 2 Esercizi mattutini"
-
-#: src/exercises/day-2/solutions-morning.md:3
-#, fuzzy
-msgid "## Points and Polygons"
-msgstr "## Punti e poligoni"
+msgid "Day 2 Morning Exercises"
+msgstr "Giorno 2 Esercizi mattutini"
 
 #: src/exercises/day-2/solutions-morning.md:5
 #, fuzzy
@@ -21787,13 +22467,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 2 Afternoon Exercises"
-msgstr "# Giorno 2 Esercizi pomeridiani"
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Luhn Algorithm"
-msgstr "## Algoritmo di Luhn"
+msgid "Day 2 Afternoon Exercises"
+msgstr "Giorno 2 Esercizi pomeridiani"
 
 #: src/exercises/day-2/solutions-afternoon.md:5
 #, fuzzy
@@ -21894,11 +22569,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:97
-#, fuzzy
-msgid "## Strings and Iterators"
-msgstr "## Stringhe e iteratori"
-
 #: src/exercises/day-2/solutions-afternoon.md:99
 #, fuzzy
 msgid "([back to exercise](strings-iterators.md))"
@@ -21995,13 +22665,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 3 Morning Exercise"
-msgstr "# Giorno 3 Esercizio mattutino"
-
-#: src/exercises/day-3/solutions-morning.md:3
-#, fuzzy
-msgid "## A Simple GUI Library"
-msgstr "## Una semplice libreria GUI"
+msgid "Day 3 Morning Exercise"
+msgstr "Giorno 3 Esercizio mattutino"
 
 #: src/exercises/day-3/solutions-morning.md:5
 #, fuzzy
@@ -22182,13 +22847,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 3 Afternoon Exercises"
-msgstr "# Giorno 3 Esercizi pomeridiani"
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Safe FFI Wrapper"
-msgstr "## Involucro FFI sicuro"
+msgid "Day 3 Afternoon Exercises"
+msgstr "Giorno 3 Esercizi pomeridiani"
 
 #: src/exercises/day-3/solutions-afternoon.md:5
 #, fuzzy
@@ -22389,13 +23049,8 @@ msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
 #, fuzzy
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr "# Esercizio mattutino ruggine metallo nudo"
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-#, fuzzy
-msgid "## Compass"
-msgstr "## Bussola"
+msgid "Bare Metal Rust Morning Exercise"
+msgstr "Esercizio mattutino ruggine metallo nudo"
 
 #: src/exercises/bare-metal/solutions-morning.md:5
 #, fuzzy
@@ -22568,16 +23223,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-#, fuzzy
-msgid "# Bare Metal Rust Afternoon"
-msgstr "# Bare Metal Ruggine Pomeriggio"
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-#, fuzzy
-msgid "## RTC driver"
-msgstr "## Driver RTC"
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
 #, fuzzy
@@ -22877,13 +23522,8 @@ msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
 #, fuzzy
-msgid "# Concurrency Morning Exercise"
-msgstr "# Esercizio mattutino in concorrenza"
-
-#: src/exercises/concurrency/solutions-morning.md:3
-#, fuzzy
-msgid "## Dining Philosophers"
-msgstr "## Filosofi a tavola"
+msgid "Concurrency Morning Exercise"
+msgstr "Esercizio mattutino in concorrenza"
 
 #: src/exercises/concurrency/solutions-morning.md:5
 #, fuzzy
@@ -22992,13 +23632,8 @@ msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Concurrency Afternoon Exercise"
-msgstr "# Esercizio mattutino in concorrenza"
-
-#: src/exercises/concurrency/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Dining Philosophers - Async"
-msgstr "## Filosofi a tavola"
+msgid "Concurrency Afternoon Exercise"
+msgstr "Esercizio mattutino in concorrenza"
 
 #: src/exercises/concurrency/solutions-afternoon.md:5
 #, fuzzy
@@ -23117,10 +23752,6 @@ msgid ""
 "    }\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:113
-msgid "## Broadcast Chat Application"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:115
@@ -23274,218 +23905,3 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#~ msgid "Designing a Library"
-#~ msgstr "Progettare una Libreria"
-
-#~ msgid "Elevator Operations"
-#~ msgstr "# Operazioni dell’Ascensore"
-
-#~ msgid ""
-#~ "<details>\n"
-#~ "Key points:"
-#~ msgstr ""
-#~ "<details>\n"
-#~ "Punti chiave:"
-
-#, fuzzy
-#~ msgid "Global state is managed with static and constant variables."
-#~ msgstr "Lo stato globale è gestito con variabili statiche e costanti."
-
-#, fuzzy
-#~ msgid ""
-#~ "We will look at mutating static data in the [chapter on Unsafe Rust](../"
-#~ "unsafe.md)."
-#~ msgstr ""
-#~ "Esamineremo la modifica dei dati statici nel [capitolo su Unsafe Rust](../"
-#~ "unsafe.md)."
-
-#, fuzzy
-#~ msgid "# Designing a Library"
-#~ msgstr "# Progettare una libreria"
-
-#, fuzzy
-#~ msgid ""
-#~ "<details>\n"
-#~ "Key Points: "
-#~ msgstr ""
-#~ "<dettagli>\n"
-#~ "Punti chiave:"
-
-#, fuzzy
-#~ msgid "`move` closures only implement `FnOnce`."
-#~ msgstr "Le chiusure `move` implementano solo `FnOnce`."
-
-#, fuzzy
-#~ msgid ""
-#~ "Runtimes have the concept of a \"task\", similar to a thread but much\n"
-#~ "less resource-intensive."
-#~ msgstr ""
-#~ "I runtime hanno il concetto di \"attività\", simile a un thread ma molto\n"
-#~ "meno dispendioso in termini di risorse."
-
-#, fuzzy
-#~ msgid "# Elevator Operation"
-#~ msgstr "# Funzionamento dell'ascensore"
-
-#, fuzzy
-#~ msgid ""
-#~ "Elevators seem simple. You press a button, doors open, you wait, and "
-#~ "you're at\n"
-#~ "the floor you requested. But implementing an elevator controller is "
-#~ "surprisingly\n"
-#~ "difficult! This exercise involves building a simple elevator control "
-#~ "that\n"
-#~ "operates in a simple simulator."
-#~ msgstr ""
-#~ "Gli ascensori sembrano semplici. Premi un pulsante, le porte si aprono, "
-#~ "aspetti e sei a\n"
-#~ "il pavimento che hai richiesto. Ma l'implementazione di un controller per "
-#~ "ascensori è sorprendente\n"
-#~ "difficile! Questo esercizio prevede la costruzione di un semplice "
-#~ "controllo dell'ascensore\n"
-#~ "opera in un semplice simulatore."
-
-#, fuzzy
-#~ msgid ""
-#~ "The overall design of this elevator uses the actor pattern: you will "
-#~ "implement a\n"
-#~ "controller task that communicates with other components of the elevator "
-#~ "system\n"
-#~ "by sending and receiving messages."
-#~ msgstr ""
-#~ "Il progetto complessivo di questo ascensore utilizza il modello "
-#~ "dell'attore: implementerai a\n"
-#~ "attività del controller che comunica con altri componenti del sistema di "
-#~ "ascensori\n"
-#~ "inviando e ricevendo messaggi."
-
-#, fuzzy
-#~ msgid "## Getting Started"
-#~ msgstr "## Iniziare"
-
-#, fuzzy
-#~ msgid ""
-#~ "Download the [exercise template](../../comprehensive-rust-exercises.zip) "
-#~ "and look in the `elevator`\n"
-#~ "directory for the following files."
-#~ msgstr ""
-#~ "Scarica il [modello di esercizio](../../comprehensive-rust-exercises.zip) "
-#~ "e guarda nell'\"ascensore\"\n"
-#~ "directory per i seguenti file."
-
-#, fuzzy
-#~ msgid "`src/controller.rs`:"
-#~ msgstr "`src/controllore.rs`:"
-
-#, fuzzy
-#~ msgid "<!-- File src/controller.rs -->"
-#~ msgstr "<!-- File src/controller.rs -->"
-
-#, fuzzy
-#~ msgid "Use `cargo run` to run the elevator simulation."
-#~ msgstr "Usa `cargo run` per eseguire la simulazione dell'ascensore."
-
-#, fuzzy
-#~ msgid "## Exercises"
-#~ msgstr "Esercizi"
-
-#, fuzzy
-#~ msgid ""
-#~ "Begin by implementing a controller that can transport the passengers "
-#~ "provided by\n"
-#~ "the simple driver. There is only one elevator, and passengers always go "
-#~ "from\n"
-#~ "floor 0 to floor 2, one-by-one."
-#~ msgstr ""
-#~ "Inizia implementando un controller in grado di trasportare i passeggeri "
-#~ "forniti da\n"
-#~ "il semplice conducente. C'è solo un ascensore e i passeggeri vanno sempre "
-#~ "da\n"
-#~ "piano 0 al piano 2, uno per uno."
-
-#, fuzzy
-#~ msgid ""
-#~ "Once you have this done, make the problem more complex. Suggested tasks:"
-#~ msgstr ""
-#~ "Una volta fatto ciò, rendi il problema più complesso. Compiti suggeriti:"
-
-#, fuzzy
-#~ msgid ""
-#~ " * Make the driver more complex, with passengers arriving at random "
-#~ "floors with\n"
-#~ "   random destinations at random times.\n"
-#~ "\n"
-#~ " * Create a building with more than one elevator, and adjust the "
-#~ "controller to\n"
-#~ "   handle this efficiently.\n"
-#~ "\n"
-#~ " * Add additional events and metadata to analyze your controller's "
-#~ "efficiency.\n"
-#~ "   What is the distribution of wait time for passengers? Is the result "
-#~ "fair?\n"
-#~ "\n"
-#~ " * Modify the building to support a maximum passenger capacity for each\n"
-#~ "   elevator, and modify the controller to take this information into "
-#~ "account.\n"
-#~ "\n"
-#~ " * Update the driver to simulate business traffic, with lots of "
-#~ "passengers going\n"
-#~ "   up from the ground floor at the same time, and those passengers "
-#~ "returning to\n"
-#~ "   the ground floor some time later. Can your controller adjust to these\n"
-#~ "   circumstances?\n"
-#~ "\n"
-#~ " * Modify the building to support \"destination dispatch\", where "
-#~ "passengers\n"
-#~ "   signal their destination floor in the elevator lobby, before boarding "
-#~ "the\n"
-#~ "   elevator.\n"
-#~ "\n"
-#~ " * If you are taking the course with other students, trade controllers "
-#~ "or\n"
-#~ "   drivers with another student to see how robust your design is.\n"
-#~ "\n"
-#~ " * Build a textual or graphical display of the elevators as they run."
-#~ msgstr ""
-#~ " * Rendi il conducente più complesso, con i passeggeri che arrivano a "
-#~ "piani casuali\n"
-#~ "   destinazioni casuali in orari casuali.\n"
-#~ "\n"
-#~ " * Crea un edificio con più di un ascensore e regola il controller su\n"
-#~ "   gestirlo in modo efficiente.\n"
-#~ "\n"
-#~ " * Aggiungi ulteriori eventi e metadati per analizzare l'efficienza del "
-#~ "tuo controller.\n"
-#~ "   Qual è la distribuzione del tempo di attesa per i passeggeri? Il "
-#~ "risultato è giusto?\n"
-#~ "\n"
-#~ " * Modificare l'edificio per supportare una capacità massima di "
-#~ "passeggeri per ciascuno\n"
-#~ "   elevatore e modificare il controller per tenere conto di queste "
-#~ "informazioni.\n"
-#~ "\n"
-#~ " * Aggiorna il conducente per simulare il traffico aziendale, con molti "
-#~ "passeggeri in viaggio\n"
-#~ "   dal piano terra allo stesso tempo, e quei passeggeri che tornano a\n"
-#~ "   il piano terra qualche tempo dopo. Il tuo controller può adattarsi a "
-#~ "questi\n"
-#~ "   circostanze?\n"
-#~ "\n"
-#~ " * Modificare l'edificio per supportare la \"spedizione di "
-#~ "destinazione\", dove i passeggeri\n"
-#~ "   segnala il piano di destinazione nella hall dell'ascensore, prima di "
-#~ "salire a bordo\n"
-#~ "   ascensore.\n"
-#~ "\n"
-#~ " * Se stai frequentando il corso con altri studenti, controllori "
-#~ "commerciali o\n"
-#~ "   driver con un altro studente per vedere quanto è robusto il tuo "
-#~ "progetto.\n"
-#~ "\n"
-#~ " * Costruisci una visualizzazione testuale o grafica degli ascensori "
-#~ "mentre corrono."
-
-#, fuzzy
-#~ msgid "</defails>"
-#~ msgstr "</defail>"


### PR DESCRIPTION
Before, po/it.po had these statistics:

    447 translated messages, 927 fuzzy translations, 407 untranslated messages.

Afterwards, the statistics for po/it.po is:

    583 translated messages, 1288 fuzzy translations, 596 untranslated messages.

The number of translated messages changed from 25% to 24%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.