### PR TITLE
fr: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -5,34 +5,33 @@ msgstr ""
 "PO-Revision-Date: 2023-07-27 05:03-0400\n"
 "Last-Translator: Olivier Charrez <olivier.charrez@hotmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
-"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.3.1\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Bienvenue à Comprehensive Rust (le guide complet de Rust) 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Comment présenter le cours"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Structure du cours"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Traductions"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Utiliser Cargo"
 
@@ -57,55 +56,55 @@ msgstr "Jour 1 : Matin"
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Qu'est-ce que Rust ?"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Bonjour le monde!"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "Petit exemple"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "Pourquoi Rust ?"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "Garanties à la compilation"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "Garanties à l'exécution"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "Fonctionnalités modernes"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "Syntaxe de base"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "Types scalaires"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "Types composés"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "Références"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "Références invalides"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "Tranches"
 
@@ -113,15 +112,16 @@ msgstr "Tranches"
 msgid "String vs str"
 msgstr "String vs str"
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "Fonctions"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr "Rustdoc"
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "Méthodes"
 
@@ -132,10 +132,14 @@ msgstr "Surcharge"
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
 #: src/SUMMARY.md:253 src/SUMMARY.md:275 src/SUMMARY.md:296
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
+#: src/exercises/concurrency/morning.md:1
+#: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "Exercices"
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "Conversions implicites"
 
@@ -147,11 +151,11 @@ msgstr "Tableaux et boucles for"
 msgid "Day 1: Afternoon"
 msgstr "Jour 1 : Après-midi"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "Variables"
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "Inférence de type"
 
@@ -159,11 +163,11 @@ msgstr "Inférence de type"
 msgid "static & const"
 msgstr "static & const"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "Portée et masquage"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "Gestion de la mémoire"
 
@@ -171,15 +175,15 @@ msgstr "Gestion de la mémoire"
 msgid "Stack vs Heap"
 msgstr "Pile et Tas"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "Mémoire de pile"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "Gestion manuelle de la mémoire"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "Gestion de la mémoire basée sur la portée"
 
@@ -191,60 +195,60 @@ msgstr "Collecte des ordures"
 msgid "Rust Memory Management"
 msgstr "Gestion de la mémoire avec Rust"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "Comparaison"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
 msgstr "Propriété"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "Sémantique de déplacement"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "String déplacées avec Rust"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "Double libération de mémoire en C++ moderne"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "Déplacements dans les appels de fonction"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "Copie et clonage"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "Emprunt"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "Emprunts partagés et uniques"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "Durées de vie"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "Durées de vie dans les appels de fonction"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "Durées de vie dans les structures de données"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
 #, fuzzy
 msgid "Storing Books"
 msgstr "String"
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "Itérateurs et propriété"
 
@@ -252,63 +256,64 @@ msgstr "Itérateurs et propriété"
 msgid "Day 2: Morning"
 msgstr "Jour 2 : Matin"
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
 msgstr "Structures"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "Structures de tuple"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "Syntaxe abrégée des champs"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
 msgstr "Énumérations"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "Contenu variable"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "Tailles d'énumération"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "Récepteur de méthode"
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:274
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "Exemple"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "Correspondance de motifs"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "Déstructuration des énumérations"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "Déstructuration des structures"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "Déstructuration des tableaux"
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "Gardes de match"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "Statistiques de santé"
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "Points et polygones"
 
@@ -316,11 +321,11 @@ msgstr "Points et polygones"
 msgid "Day 2: Afternoon"
 msgstr "Jour 2 : Après-midi"
 
-#: src/SUMMARY.md:96 src/SUMMARY.md:288
+#: src/SUMMARY.md:96 src/SUMMARY.md:288 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "Flux de contrôle"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "Blocs"
 
@@ -356,7 +361,7 @@ msgstr "expressions `match`"
 msgid "break & continue"
 msgstr "break & continue"
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
 msgstr "Bibliothèque standard"
 
@@ -364,7 +369,7 @@ msgstr "Bibliothèque standard"
 msgid "Option and Result"
 msgstr "Option et Result"
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
 msgstr "String"
 
@@ -384,7 +389,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "Types de données récursifs"
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "Optimisation de niche"
 
@@ -392,27 +397,29 @@ msgstr "Optimisation de niche"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr "Modules"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "Visibilité"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr "Chemins"
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "Hiérarchie du système de fichiers"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Algorithme de Luhn"
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:97
 msgid "Strings and Iterators"
 msgstr "Strings et Iterators"
 
@@ -420,39 +427,39 @@ msgstr "Strings et Iterators"
 msgid "Day 3: Morning"
 msgstr "Jour 3 : Matin"
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/generics.md:1
 msgid "Generics"
 msgstr "Génériques"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "Types de données génériques"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "Méthodes génériques"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "Monomorphisation"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits.md:1
 msgid "Traits"
 msgstr "Caractéristiques"
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "Objets implementant des caractéristiques"
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "Caractéristiques dérivées"
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md:136 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "Méthodes par défaut"
 
-#: src/SUMMARY.md:137
+#: src/SUMMARY.md:137 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "Exigences de caractéristique"
 
@@ -460,7 +467,7 @@ msgstr "Exigences de caractéristique"
 msgid "impl Trait"
 msgstr "impl caractéristique"
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "Caractéristiques importantes"
 
@@ -468,7 +475,7 @@ msgstr "Caractéristiques importantes"
 msgid "Iterator"
 msgstr "Iterator"
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -496,7 +503,8 @@ msgstr "Opérateurs : Add, Mul, ..."
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr ""
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "Une bibliothèque d'interface graphique"
 
@@ -504,11 +512,11 @@ msgstr "Une bibliothèque d'interface graphique"
 msgid "Day 3: Afternoon"
 msgstr "Jour 3 : Après-midi"
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "Gestion des erreurs"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Paniques"
 
@@ -524,68 +532,69 @@ msgstr "Gestion structurée des erreurs"
 msgid "Propagating Errors with ?"
 msgstr "Propagation des erreurs avec ?"
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "Conversion des types d'erreur"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "Dérivation des énumérations d'erreur"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "Types d'erreurs dynamiques"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "Ajout de contexte aux erreurs"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
 msgstr "Tester"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "Tests unitaires"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "Modules de test"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "Test de documentation"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "Test d'intégration"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/bare-metal/useful-crates.md:1
 #, fuzzy
 msgid "Useful crates"
-msgstr "# Caisses utiles"
+msgstr "Caisses utiles"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Rust risqué"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "Déréférencement des pointeurs bruts"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "Variables statiques mutables"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "Unions"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "Appel de fonctions risquées"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "Ecrire des fonctions risquées"
 
@@ -593,23 +602,25 @@ msgstr "Ecrire des fonctions risquées"
 msgid "Extern Functions"
 msgstr "Fonctions externes"
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "Implémentation de traits risqués"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "Enveloppe FFI sûre"
 
 #: src/SUMMARY.md:181 src/SUMMARY.md:251
+#: src/running-the-course/course-structure.md:16 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/android/setup.md:1
 msgid "Setup"
 msgstr "Installation"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "Règles de construction"
 
@@ -621,7 +632,7 @@ msgstr "Binaire"
 msgid "Library"
 msgstr "Bibliothèque"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -637,7 +648,7 @@ msgstr "Mise en œuvre"
 msgid "Server"
 msgstr "Serveur"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:194 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "Déployer"
 
@@ -645,15 +656,16 @@ msgstr "Déployer"
 msgid "Client"
 msgstr "Client"
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:196 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "Modification de l'API"
 
-#: src/SUMMARY.md:197 src/SUMMARY.md:241
+#: src/SUMMARY.md:197 src/SUMMARY.md:241 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "Journalisation"
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "Interopérabilité"
 
@@ -669,7 +681,7 @@ msgstr "Appeler C avec Bindgen"
 msgid "Calling Rust from C"
 msgstr "Appeler Rust depuis C"
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "Avec C++"
 
@@ -693,11 +705,11 @@ msgstr "Un exemple minimal"
 msgid "alloc"
 msgstr "alloc"
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "Microcontrôleurs"
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "MMIO brut"
 
@@ -725,7 +737,7 @@ msgstr "embedded-hal"
 msgid "probe-rs, cargo-embed"
 msgstr "probe-rs, cargo-embed"
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "Débogage"
 
@@ -733,7 +745,8 @@ msgstr "Débogage"
 msgid "Other Projects"
 msgstr "Autres projets"
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:226 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "Boussole"
 
@@ -745,7 +758,7 @@ msgstr "Bare Metal : Après-midi"
 msgid "Application Processors"
 msgstr "Processeurs d'applications"
 
-#: src/SUMMARY.md:231
+#: src/SUMMARY.md:231 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr ""
 
@@ -769,7 +782,7 @@ msgstr "Plus de traits"
 msgid "A Better UART Driver"
 msgstr "Un meilleur pilote UART"
 
-#: src/SUMMARY.md:237
+#: src/SUMMARY.md:237 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr "Bitflags"
 
@@ -777,7 +790,7 @@ msgstr "Bitflags"
 msgid "Multiple Registers"
 msgstr "Registres multiples"
 
-#: src/SUMMARY.md:239
+#: src/SUMMARY.md:239 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "Pilote"
 
@@ -785,7 +798,7 @@ msgstr "Pilote"
 msgid "Using It"
 msgstr "En l'utilisant"
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md:243 src/bare-metal/aps/exceptions.md:1
 #, fuzzy
 msgid "Exceptions"
 msgstr "Fonctions"
@@ -814,7 +827,7 @@ msgstr "tinyvec"
 msgid "spin"
 msgstr "spin"
 
-#: src/SUMMARY.md:252
+#: src/SUMMARY.md:252 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr "vmbase"
 
@@ -826,23 +839,23 @@ msgstr "Pilote RTC"
 msgid "Concurrency: Morning"
 msgstr "Concurrence : Matin"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:262 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "Threads"
 
-#: src/SUMMARY.md:263
+#: src/SUMMARY.md:263 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "Threads délimités"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "Canaux"
 
-#: src/SUMMARY.md:265
+#: src/SUMMARY.md:265 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Canaux illimités"
 
-#: src/SUMMARY.md:266
+#: src/SUMMARY.md:266 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Canaux limités"
 
@@ -858,11 +871,11 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:270
+#: src/SUMMARY.md:270 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "Exemples"
 
-#: src/SUMMARY.md:271
+#: src/SUMMARY.md:271 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "État partagé"
 
@@ -875,10 +888,12 @@ msgid "Mutex"
 msgstr "Mutex"
 
 #: src/SUMMARY.md:276 src/SUMMARY.md:297
+#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "Dîner des philosophes"
 
-#: src/SUMMARY.md:277
+#: src/SUMMARY.md:277 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "Vérificateur de liens à plusieurs threads"
 
@@ -895,34 +910,37 @@ msgstr ""
 msgid "async/await"
 msgstr ""
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md:283 src/async/futures.md:1
+#, fuzzy
 msgid "Futures"
-msgstr ""
+msgstr "Fermetures"
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/async/runtimes.md:1
 #, fuzzy
 msgid "Runtimes"
 msgstr "Garanties d'exécution"
 
-#: src/SUMMARY.md:285
+#: src/SUMMARY.md:285 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr ""
 
-#: src/SUMMARY.md:286
+#: src/SUMMARY.md:286 src/exercises/concurrency/link-checker.md:106
+#: src/exercises/concurrency/chat-app.md:140 src/async/tasks.md:1
 msgid "Tasks"
 msgstr "Tâches"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:287 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "Canaux asynchrones"
 
-#: src/SUMMARY.md:289
+#: src/SUMMARY.md:289 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:290
+#: src/SUMMARY.md:290 src/async/control-flow/select.md:1
+#, fuzzy
 msgid "Select"
-msgstr ""
+msgstr "Installation"
 
 #: src/SUMMARY.md:291
 msgid "Pitfalls"
@@ -932,21 +950,22 @@ msgstr "Pièges"
 msgid "Blocking the Executor"
 msgstr ""
 
-#: src/SUMMARY.md:293
+#: src/SUMMARY.md:293 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr ""
 
-#: src/SUMMARY.md:294
+#: src/SUMMARY.md:294 src/async/pitfalls/async-traits.md:1
 #, fuzzy
 msgid "Async Traits"
 msgstr "Traits asynchrones"
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md:295 src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
 msgstr "Traductions"
 
-#: src/SUMMARY.md:298
+#: src/SUMMARY.md:298 src/exercises/concurrency/chat-app.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:113
 msgid "Broadcast Chat Application"
 msgstr ""
 
@@ -954,7 +973,7 @@ msgstr ""
 msgid "Final Words"
 msgstr "Derniers mots"
 
-#: src/SUMMARY.md:305
+#: src/SUMMARY.md:305 src/thanks.md:1
 msgid "Thanks!"
 msgstr "Merci!"
 
@@ -962,11 +981,11 @@ msgstr "Merci!"
 msgid "Other Resources"
 msgstr "Autres ressources"
 
-#: src/SUMMARY.md:307
+#: src/SUMMARY.md:307 src/credits.md:1
 msgid "Credits"
 msgstr "Crédits"
 
-#: src/SUMMARY.md:310
+#: src/SUMMARY.md:310 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "Solutions"
 
@@ -998,7 +1017,7 @@ msgstr "Jour 3 Après-midi"
 msgid "Bare Metal Rust Morning"
 msgstr "Bare Metal Rust Matin"
 
-#: src/SUMMARY.md:322
+#: src/SUMMARY.md:322 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "Bare Metal Rust Après-midi"
 
@@ -1009,10 +1028,6 @@ msgstr "Matin concurrence"
 #: src/SUMMARY.md:324
 msgid "Concurrency Afternoon"
 msgstr "Après-midi concurrence"
-
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Bienvenue à Comprehensive Rust (le guide complet de Rust) 🦀"
 
 #: src/welcome.md:3
 msgid ""
@@ -1033,18 +1048,17 @@ msgstr "Flux de construction"
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 msgstr ""
 "[![Flux de construction](https://img.shields.io/github/actions/workflow/"
 "status/google/comprehensive-rust/build.yml?style=flat-square)](https://"
 "github.com/google/comprehensive-rust/actions/workflows/build.yml?"
-"query=branch%3Amain)\n"
-"[![Contributeurs GitHub](https://img.shields.io/github/contributors/google/"
-"comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)"
+"query=branch%3Amain) [![Contributeurs GitHub](https://img.shields.io/github/"
+"contributors/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/graphs/contributors)"
 
 #: src/welcome.md:4
 msgid "GitHub contributors"
@@ -1054,17 +1068,15 @@ msgstr "Contributeurs GitHub"
 msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 "[![Contributeurs GitHub](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub étoiles](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers )"
+"comprehensive-rust/graphs/contributors) [![GitHub étoiles](https://img."
+"shields.io/github/stars/google/comprehensive-rust?style=flat-square)]"
+"(https://github.com/google/comprehensive-rust/stargazers)"
 
 #: src/welcome.md:5
 msgid "GitHub stars"
@@ -1083,373 +1095,147 @@ msgstr ""
 #: src/welcome.md:7
 msgid ""
 "This is a three day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 "Ce cours Rust de trois jours a été développé par l'équipe Android. Le cours "
-"couvre\n"
-"l'ensemble du langage Rust, de la syntaxe de base aux sujets avancés comme "
-"les\n"
-"génériques et la gestion des erreurs. Il inclut également du contenu "
-"spécifique à\n"
-"Android le dernier jour."
+"couvre l'ensemble du langage Rust, de la syntaxe de base aux sujets avancés "
+"comme les génériques et la gestion des erreurs. Il inclut également du "
+"contenu spécifique à Android le dernier jour."
 
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
 "Le but du cours est de vous apprendre Rust. Nous supposons que vous ne savez "
-"rien\n"
-"à propos de Rust et espérons :"
+"rien à propos de Rust et espérons :"
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
 msgstr ""
-"* Vous donner une compréhension complète de la syntaxe et du langage Rust.\n"
-"* Vous permettre de modifier des programmes existants et d'écrire de "
-"nouveaux programmes en Rust.\n"
-"* Vous montrer les constructions fréquentes (idiomes) en Rust."
+"Vous donner une compréhension complète de la syntaxe et du langage Rust."
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr ""
+"Vous permettre de modifier des programmes existants et d'écrire de nouveaux "
+"programmes en Rust."
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
+msgstr "Vous montrer les constructions fréquentes (idiomes) en Rust."
 
 #: src/welcome.md:18
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, "
-"you're\n"
-"invited to dive into one or more specialized topics:"
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
-"Les trois premiers jours sont consacrés aux fondamentaux du langage.\n"
-"Vous pouvez ensuite approfondir un ou plusieurs des sujets suivant:"
+"Les trois premiers jours sont consacrés aux fondamentaux du langage. Vous "
+"pouvez ensuite approfondir un ou plusieurs des sujets suivant:"
 
 #: src/welcome.md:21
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android "
-"platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-"
-"metal\n"
-"  (embedded) development. Both microcontrollers and application processors "
-"are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a whole-day class on concurrency in Rust. "
-"We\n"
-"  cover both classical concurrency (preemptively scheduling using threads "
-"and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"* [Android](android.md): un cours d'une demi-journée consacré à "
-"l'utilisation de Rust dans le cadre du\n"
-"  développement pour la plate-forme Android.\n"
-"  Ce cours couvre également l'interopérabilité avec les langages C, C++ et "
-"Java.\n"
-"* [Bare-metal](bare-metal.md): un cours d'une journée consacré à "
-"l'utilisation\n"
-"  de Rust pour le développement embarqué. Le cours touche à la fois aux\n"
-"  microcontrôleurs et aux processeurs d'applications.\n"
-"* [Programmation concurrente](concurrency.md): un cours d'une journée "
-"consacré à la programmation\n"
-"  concurrente en Rust. Nous couvrons la concurrence classique (planification "
-"à base de threads et\n"
-"  mutex) ainsi que la concurrence async/await (multitâche coopératif à base "
-"de futures)."
+"[Android](android.md): un cours d'une demi-journée consacré à l'utilisation "
+"de Rust dans le cadre du développement pour la plate-forme Android. Ce cours "
+"couvre également l'interopérabilité avec les langages C, C++ et Java."
+
+#: src/welcome.md:23
+msgid ""
+"[Bare-metal](bare-metal.md): a whole-day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+"[Bare-metal](bare-metal.md): un cours d'une journée consacré à l'utilisation "
+"de Rust pour le développement embarqué. Le cours touche à la fois aux "
+"microcontrôleurs et aux processeurs d'applications."
+
+#: src/welcome.md:26
+msgid ""
+"[Concurrency](concurrency.md): a whole-day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
+msgstr ""
+"[Programmation concurrente](concurrency.md): un cours d'une journée consacré "
+"à la programmation concurrente en Rust. Nous couvrons la concurrence "
+"classique (planification à base de threads et mutex) ainsi que la "
+"concurrence async/await (multitâche coopératif à base de futures)."
 
 #: src/welcome.md:32
-msgid "## Non-Goals"
-msgstr "## Non-objectifs"
+msgid "Non-Goals"
+msgstr "Non-objectifs"
 
 #: src/welcome.md:34
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 "Rust est un grand langage et nous ne pourrons pas tout couvrir en quelques "
-"jours.\n"
-"Certains non-objectifs de ce cours sont :"
+"jours. Certains non-objectifs de ce cours sont :"
 
 #: src/welcome.md:37
 #, fuzzy
 msgid ""
-"* Learning how to develop macros: please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learning how to develop macros: please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
 "Nous aborderons ensuite brièvement les capacités dangereuses. Pour plus de "
-"détails, veuillez consulter\n"
-"[Chapitre 19.1 du Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-"
-"rust.html)\n"
-"et le [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"détails, veuillez consulter [Chapitre 19.1 du Rust Book](https://doc.rust-"
+"lang.org/book/ch19-01-unsafe-rust.html) et le [Rustonomicon](https://doc."
+"rust-lang.org/nomicon/)."
 
 #: src/welcome.md:41
-msgid "## Assumptions"
-msgstr "## Hypothèses"
+msgid "Assumptions"
+msgstr "Hypothèses"
 
 #: src/welcome.md:43
 #, fuzzy
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically-\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically- typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
-"Le cours suppose que vous savez déjà programmer. Rust est un language\n"
+"Le cours suppose que vous savez déjà programmer. Rust est un language "
 "statiquement typé et on fera parfois des comparaisons avec C et C++ pour "
-"mieux\n"
-"expliquer ou contraster l'approche de Rust."
+"mieux expliquer ou contraster l'approche de Rust."
 
 #: src/welcome.md:47
 #, fuzzy
 msgid ""
-"If you know how to program in a dynamically-typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically-typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 "Si vous savez programmer dans un langage à typage dynamique tel que Python "
-"ou\n"
-"JavaScript, alors vous pourrez également très bien suivre."
-
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/scalar-types.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/references.md:21
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/methods.md:32 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:100
-#: src/structs.md:29 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums.md:32
-#: src/enums/variant-payloads.md:33 src/enums/sizes.md:27 src/methods.md:28
-#: src/methods/receiver.md:22 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:41
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:21
-#: src/control-flow/while-let-expressions.md:24
-#: src/control-flow/for-expressions.md:23
-#: src/control-flow/loop-expressions.md:25
-#: src/control-flow/match-expressions.md:26 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:42 src/exercises/day-2/afternoon.md:5
-#: src/generics/data-types.md:19 src/generics/methods.md:23
-#: src/traits/trait-objects.md:70 src/traits/default-methods.md:30
-#: src/traits/trait-bounds.md:33 src/traits/impl-trait.md:21
-#: src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/drop.md:32 src/traits/default.md:38
-#: src/traits/operators.md:24 src/traits/closures.md:32
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:46
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:25 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:12
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/android/morning.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:37 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/entry-point.md:75
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart.md:53 src/bare-metal/aps/uart/traits.md:22
-#: src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:49 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:44 src/bare-metal/aps/exceptions.md:62
-#: src/bare-metal/aps/other-projects.md:15
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/scoped-threads.md:35 src/concurrency/channels.md:25
-#: src/concurrency/channels/bounded.md:29 src/concurrency/send-sync.md:18
-#: src/concurrency/send-sync/send.md:11 src/concurrency/send-sync/sync.md:12
-#: src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21
-#: src/exercises/concurrency/morning.md:10 src/async/async-await.md:23
-#: src/async/futures.md:30 src/async/runtimes.md:18
-#: src/async/runtimes/tokio.md:31 src/async/tasks.md:50
-#: src/async/channels.md:33 src/async/control-flow/join.md:34
-#: src/async/control-flow/select.md:60
-#: src/async/pitfalls/blocking-executor.md:27 src/async/pitfalls/pin.md:66
-#: src/async/pitfalls/cancellation.md:70
-#: src/exercises/concurrency/afternoon.md:11
-#: src/exercises/concurrency/dining-philosophers-async.md:75
-msgid "<details>"
-msgstr "<details>"
+"ou JavaScript, alors vous pourrez également très bien suivre."
 
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 "Ceci est un exemple de _note du conférencier_. Nous les utiliserons pour "
-"ajouter d'autres\n"
-"informations sur les diapositives. Cela pourrait être des points clés que "
-"l'instructeur devrait\n"
-"couvrir, ainsi que des réponses aux questions typiques posées en classe."
-
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:46 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:23
-#: src/why-rust/modern.md:66 src/basic-syntax/scalar-types.md:43
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:29
-#: src/basic-syntax/slices.md:36 src/basic-syntax/string-slices.md:44
-#: src/basic-syntax/functions.md:41 src/basic-syntax/rustdoc.md:33
-#: src/basic-syntax/methods.md:45 src/basic-syntax/functions-interlude.md:30
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:104
-#: src/structs.md:42 src/structs/tuple-structs.md:44
-#: src/structs/field-shorthand.md:72 src/enums.md:42
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:28 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:29
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:47
-#: src/control-flow/if-expressions.md:37
-#: src/control-flow/if-let-expressions.md:41
-#: src/control-flow/while-let-expressions.md:29
-#: src/control-flow/for-expressions.md:30
-#: src/control-flow/loop-expressions.md:32
-#: src/control-flow/match-expressions.md:33 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:42 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:71 src/exercises/day-2/afternoon.md:11
-#: src/generics/data-types.md:25 src/generics/methods.md:31
-#: src/traits/trait-objects.md:83 src/traits/default-methods.md:60
-#: src/traits/trait-bounds.md:50 src/traits/impl-trait.md:44
-#: src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/drop.md:42 src/traits/default.md:47
-#: src/traits/operators.md:40 src/traits/closures.md:63
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:53
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:43 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:18
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/android/morning.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:49
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/entry-point.md:101
-#: src/bare-metal/aps/inline-assembly.md:58 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:55 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:49 src/bare-metal/aps/exceptions.md:75
-#: src/bare-metal/aps/other-projects.md:29
-#: src/bare-metal/useful-crates/zerocopy.md:53
-#: src/bare-metal/useful-crates/aarch64-paging.md:33
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
-#: src/bare-metal/useful-crates/tinyvec.md:26
-#: src/bare-metal/useful-crates/spin.md:30 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/scoped-threads.md:40 src/concurrency/channels.md:32
-#: src/concurrency/channels/bounded.md:35 src/concurrency/send-sync.md:23
-#: src/concurrency/send-sync/send.md:16 src/concurrency/send-sync/sync.md:18
-#: src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56
-#: src/exercises/concurrency/morning.md:16 src/async/async-await.md:48
-#: src/async/futures.md:45 src/async/runtimes.md:29
-#: src/async/runtimes/tokio.md:49 src/async/tasks.md:63
-#: src/async/channels.md:49 src/async/control-flow/join.md:50
-#: src/async/control-flow/select.md:79
-#: src/async/pitfalls/blocking-executor.md:50 src/async/pitfalls/pin.md:112
-#: src/async/pitfalls/async-traits.md:63 src/async/pitfalls/cancellation.md:114
-#: src/exercises/concurrency/afternoon.md:17
-#: src/exercises/concurrency/dining-philosophers-async.md:79
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# Comment présenter le cours"
+"ajouter d'autres informations sur les diapositives. Cela pourrait être des "
+"points clés que l'instructeur devrait couvrir, ainsi que des réponses aux "
+"questions typiques posées en classe."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> Cette page est destinée au formateur."
+msgid "This page is for the course instructor."
+msgstr "Cette page est destinée au formateur."
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
+"course internally at Google."
 msgstr ""
 "Voici quelques informations générales sur la façon dont nous avons organisé "
-"le cours\n"
-"en interne chez Google."
+"le cours en interne chez Google."
 
 #: src/running-the-course.md:8
 msgid "Before you run the course, you will want to:"
@@ -1458,140 +1244,116 @@ msgstr "Avant de suivre le cours, vous voudriez :"
 #: src/running-the-course.md:10
 #, fuzzy
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   to help highlight the key points (please help us by contributing more "
-"speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes "
-"in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). "
-"This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Decide on the dates. Since the course takes at least three full days, we "
-"recommend that you\n"
-"   schedule the days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-25 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself "
-"and for the\n"
-"   students: you will all need to be able to sit and work with your "
-"laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, "
-"so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups.\n"
-"   We typically spend 30-45 minutes on exercises in the morning and in the "
-"afternoon (including time to review the solutions).\n"
-"   Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. Familiarisez-vous avec le matériel de cours. Nous avons inclus les notes "
-"du conférencier\n"
-"   pour aider à mettre en évidence les points clés (veuillez nous aider en "
-"contribuant à plus de\n"
-"   remarques!). Lors de la présentation, vous devez vous assurer d'ouvrir "
-"les notes du présentateur dans un\n"
-"   popup (cliquez sur le lien avec une petite flèche à côté de \"Notes du "
-"conférencier\"). Ainsi,\n"
-"   vous avez un écran propre à présenter à la classe.\n"
+"Familiarisez-vous avec le matériel de cours. Nous avons inclus les notes du "
+"conférencier pour aider à mettre en évidence les points clés (veuillez nous "
+"aider en contribuant à plus de remarques!). Lors de la présentation, vous "
+"devez vous assurer d'ouvrir les notes du présentateur dans un popup (cliquez "
+"sur le lien avec une petite flèche à côté de \"Notes du conférencier\"). "
+"Ainsi, vous avez un écran propre à présenter à la classe."
+
+#: src/running-the-course.md:16
+#, fuzzy
+msgid ""
+"Decide on the dates. Since the course takes at least three full days, we "
+"recommend that you schedule the days over two weeks. Course participants "
+"have said that they find it helpful to have a gap in the course since it "
+"helps them process all the information we give them."
+msgstr ""
+"Sélectionnez votre sujet pour l'après-midi du quatrième jour. Cela peut être "
+"basé sur le public que vous attendez, ou sur votre propre expertise."
+
+#: src/running-the-course.md:21
+#, fuzzy
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-25 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"Décidez des dates. Comme le parcours est vaste, nous vous recommandons de "
+"répartir les quatre jours sur deux semaines. Les participants au cours ont "
+"dit qu'ils trouvent utile d'avoir une pause dans le cours, car cela les aide "
+"à traiter toutes les informations que nous leur donnons."
+
+#: src/running-the-course.md:29
+#, fuzzy
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"Trouvez une salle suffisamment grande pour vos participants en personne. "
+"Nous recommandons un classe de 15 à 20 personnes. C'est assez petit pour que "
+"les gens soient à l'aise pour poser des questions --- c'est aussi assez "
+"petit pour qu'un instructeur ait le temps de répondre aux questions. Assurez-"
+"vous que la salle dispose de _bureaux_ pour vous et pour les étudiants : "
+"vous devriez tous pouvoir vous asseoir et travailler avec vos ordinateurs "
+"portables. En particulier, vous ferez beaucoup de programmation en direct en "
+"tant qu'instructeur, donc un pupitre ne sera pas très utile pour vous."
+
+#: src/running-the-course.md:35
+#, fuzzy
+msgid ""
+"Let people solve the exercises by themselves or in small groups. We "
+"typically spend 30-45 minutes on exercises in the morning and in the "
+"afternoon (including time to review the solutions). Make sure to ask people "
+"if they're stuck or if there is anything you can help with. When you see "
+"that several people have the same problem, call it out to the class and "
+"offer a solution, e.g., by showing people where to find the relevant "
+"information in the standard library."
+msgstr ""
+"Le jour de votre cours, présentez-vous à la salle un peu en avance pour "
+"préparer les choses. Nous vous recommandons de présenter directement en "
+"utilisant `mdbook serve` exécuté sur votre ordinateur portable (voir les "
+"[instructions d'installation](https://github.com/google/comprehensive-"
+"rust#building)). Cela garantit des performances optimales sans décalage "
+"lorsque vous changez de page. L'utilisation de votre ordinateur portable "
+"vous permettra également de corriger les fautes de frappe lorsque que vous "
+"ou les participants les repèrent.\n"
 "\n"
-"1. Sélectionnez votre sujet pour l'après-midi du quatrième jour. Cela peut "
-"être basé sur\n"
-"   le public que vous attendez, ou sur votre propre expertise.\n"
+"Laissez les participants résoudre les exercices seuls ou en petits groupes. "
+"Assurez-vous de demandez aux gens s'ils sont coincés ou s'il y a quelque "
+"chose où vous pouvez aider. Quand vous voyez que plusieurs personnes ont le "
+"même problème, dites-le à la classe et proposez une solution, par exemple en "
+"montrant aux gens où trouver les informations dans la bibliothèque "
+"standard.\n"
 "\n"
-"1. Décidez des dates. Comme le parcours est vaste, nous vous recommandons "
-"de\n"
-"   répartir les quatre jours sur deux semaines. Les participants au cours "
-"ont dit\n"
-"   qu'ils trouvent utile d'avoir une pause dans le cours, car cela les aide "
-"à traiter\n"
-"   toutes les informations que nous leur donnons.\n"
-"\n"
-"1. Trouvez une salle suffisamment grande pour vos participants en personne. "
-"Nous recommandons un\n"
-"   classe de 15 à 20 personnes. C'est assez petit pour que les gens soient à "
-"l'aise pour\n"
-"   poser des questions --- c'est aussi assez petit pour qu'un instructeur "
-"ait\n"
-"   le temps de répondre aux questions. Assurez-vous que la salle dispose de "
-"_bureaux_ pour vous et pour les\n"
-"   étudiants : vous devriez tous pouvoir vous asseoir et travailler avec vos "
-"ordinateurs portables.\n"
-"   En particulier, vous ferez beaucoup de programmation en direct en tant "
-"qu'instructeur, donc un pupitre\n"
-"   ne sera pas très utile pour vous.\n"
-"\n"
-"1. Le jour de votre cours, présentez-vous à la salle un peu en avance pour "
-"préparer les choses.\n"
-"   Nous vous recommandons de présenter directement en utilisant `mdbook "
-"serve` exécuté sur votre\n"
-"   ordinateur portable (voir les [instructions d'installation][3]). Cela "
-"garantit des performances optimales\n"
-"   sans décalage lorsque vous changez de page.\n"
-"   L'utilisation de votre ordinateur portable vous permettra également de "
-"corriger les fautes de frappe lorsque que vous ou\n"
-"   les participants les repèrent.\n"
-"\n"
-"1. Laissez les participants résoudre les exercices seuls ou en petits "
-"groupes. Assurez-vous de\n"
-"   demandez aux gens s'ils sont coincés ou s'il y a quelque chose où vous "
-"pouvez aider. Quand\n"
-"   vous voyez que plusieurs personnes ont le même problème, dites-le à la "
-"classe\n"
-"   et proposez une solution, par exemple en montrant aux gens où trouver "
-"les\n"
-"   informations dans la bibliothèque standard.\n"
-"\n"
-"1. Préparez tout ce dont vous avez besoin pour l'après-midi du jour 4."
+"Préparez tout ce dont vous avez besoin pour l'après-midi du jour 4."
 
 #: src/running-the-course.md:43
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
+"for you as it has been for us!"
 msgstr ""
 "C'est tout, bonne chance pour suivre le cours ! Nous espérons que ce sera "
-"aussi amusant pour\n"
-"vous comme il l'a été pour nous !"
+"aussi amusant pour vous comme il l'a été pour nous !"
 
 #: src/running-the-course.md:46
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"Veuillez [fournir des commentaires][1] par la suite afin que nous puissions "
-"continuer à améliorer le\n"
-"cours. Nous aimerions savoir ce qui a bien fonctionné pour vous et ce qui "
-"peut être mieux fait.\n"
-"Vos élèves sont également les bienvenus pour [envoyer des commentaires][2] !"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# Structure du cours"
+"Veuillez [fournir des commentaires](https://github.com/google/comprehensive-"
+"rust/discussions/86) par la suite afin que nous puissions continuer à "
+"améliorer le cours. Nous aimerions savoir ce qui a bien fonctionné pour vous "
+"et ce qui peut être mieux fait. Vos élèves sont également les bienvenus pour "
+"[envoyer des commentaires](https://github.com/google/comprehensive-rust/"
+"discussions/100) !"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
@@ -1599,116 +1361,106 @@ msgstr "Le cours est rapide et couvre beaucoup de terrain:"
 
 #: src/running-the-course/course-structure.md:7
 #, fuzzy
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "Jour 1 : Rust de base, propriété et vérificateur d'emprunt."
+
+#: src/running-the-course/course-structure.md:8
+#, fuzzy
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
 msgstr ""
-"* Jour 1 : Rust de base, propriété et vérificateur d'emprunt.\n"
-"* Jour 2 : Types de données composés, filtrage de motifs, bibliothèque "
-"standard.\n"
-"* Jour 3 : Caractéristiques et génériques, gestion des erreurs, tests, Rust "
+"Jour 2 : Types de données composés, filtrage de motifs, bibliothèque "
+"standard."
+
+#: src/running-the-course/course-structure.md:9
+#, fuzzy
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr ""
+"Jour 3 : Caractéristiques et génériques, gestion des erreurs, tests, Rust "
 "risqué.\n"
-"* Jour 4 : Concurrence avec Rust et voir Rust en action."
+"\n"
+"Jour 4 : Concurrence avec Rust et voir Rust en action."
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
+msgid "Deep Dives"
 msgstr ""
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
 msgstr ""
-
-#: src/running-the-course/course-structure.md:16
-#, fuzzy
-msgid "### Android"
-msgstr "## Android"
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
 "The [Android Deep Dive](../android.md) is a half-day course on using Rust "
-"for\n"
-"Android platform development. This includes interoperability with C, C++, "
-"and\n"
-"Java."
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
 
 #: src/running-the-course/course-structure.md:22
 #, fuzzy
 msgid ""
-"You will need an [AOSP checkout][1]. Make a checkout of the [course\n"
-"repository][2] on the same machine and move the `src/android/` directory "
-"into\n"
-"the root of your AOSP checkout. This will ensure that the Android build "
-"system\n"
-"sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
 "Si vous avez choisi Android pour l'après-midi du jour 4, vous aurez besoin "
-"d'un [AOSP checkout][1].\n"
-"Effectuez un checkout du [répertoire du cours][2] sur la même machine et "
-"déplacez le dossier\n"
-"`src/android/` à la racine de votre checkout AOSP. Cela assurera\n"
-"que le système de construction d'Android voit les fichiers `Android.bp` dans "
-"`src/android/`."
+"d'un [AOSP checkout](https://source.android.com/docs/setup/download/"
+"downloading). Effectuez un checkout du [répertoire du cours](https://github."
+"com/google/comprehensive-rust) sur la même machine et déplacez le dossier "
+"`src/android/` à la racine de votre checkout AOSP. Cela assurera que le "
+"système de construction d'Android voit les fichiers `Android.bp` dans `src/"
+"android/`."
 
 #: src/running-the-course/course-structure.md:27
 #, fuzzy
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
-"all\n"
-"Android examples using `src/android/build_all.sh`. Read the script to see "
-"the\n"
-"commands it runs and make sure they work when you run them by hand."
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
 "Assurez-vous que `adb sync` fonctionne avec votre émulateur ou votre "
-"appareil réel et pré-construisez\n"
-"tous les exemples Android en utilisant `src/android/build_all.sh`. Lisez le "
-"script pour voir\n"
-"les commandes éxécutées et assurez-vous qu'elles fonctionnent lorsque vous "
-"les exécutez à la main."
+"appareil réel et pré-construisez tous les exemples Android en utilisant `src/"
+"android/build_all.sh`. Lisez le script pour voir les commandes éxécutées et "
+"assurez-vous qu'elles fonctionnent lorsque vous les exécutez à la main."
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
+msgid "Bare-Metal"
 msgstr ""
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
 "The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
-"for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
 
 #: src/running-the-course/course-structure.md:45
 #, fuzzy
-msgid "### Concurrency"
+msgid "Concurrency"
 msgstr "Concurrence"
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
 "The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
-"classical\n"
-"as well as `async`/`await` concurrency."
+"classical as well as `async`/`await` concurrency."
 msgstr ""
 
 #: src/running-the-course/course-structure.md:50
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
-"to\n"
-"go. You can then copy/paste the examples into `src/main.rs` to experiment "
-"with\n"
-"them:"
+"to go. You can then copy/paste the examples into `src/main.rs` to experiment "
+"with them:"
 msgstr ""
 
 #: src/running-the-course/course-structure.md:54
@@ -1722,56 +1474,80 @@ msgid ""
 msgstr ""
 
 #: src/running-the-course/course-structure.md:61
-msgid "## Format"
-msgstr "##Format"
+msgid "Format"
+msgstr "\\##Format"
 
 #: src/running-the-course/course-structure.md:63
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
-"Le cours se veut très interactif et nous recommandons de laisser les\n"
+"Le cours se veut très interactif et nous recommandons de laisser les "
 "questions guider l'exploration de Rust !"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# Raccourcis clavier"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Il existe plusieurs raccourcis clavier utiles dans mdBook :"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Flèche vers la gauche</kbd> : Navigue à la page précédente.\n"
-"* <kbd>Flèche vers la droite</kbd> : Navigue à la page suivante.\n"
-"* <kbd>Ctrl + Entrée</kbd> : Exécute l'exemple de code qui a le focus.\n"
-"* <kbd>s</kbd> : Active la barre de recherche."
+msgid "Arrow-Left"
+msgstr "Flèche vers la gauche"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# Traductions"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr " : Navigue à la page précédente."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Flèche vers la droite"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr " : Navigue à la page suivante."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Entrée"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr " : Exécute l'exemple de code qui a le focus."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr " : Active la barre de recherche."
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
 msgstr ""
-"Le cours a été traduit dans d'autres langues par un ensemble de merveilleux\n"
+"Le cours a été traduit dans d'autres langues par un ensemble de merveilleux "
 "bénévoles:"
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
 msgstr ""
-"* [portugais brésilien][pt-BR] par [@rastringer] et [@hugojacob].\n"
-"* [coréen][ko] par [@keispace], [@jiyongp] et [@jooyunghan]."
+"[portugais brésilien](https://google.github.io/comprehensive-rust/pt-BR/) "
+"par [@rastringer](https://github.com/rastringer) et [@hugojacob](https://"
+"github.com/hugojacob)."
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
+msgstr ""
+"[coréen](https://google.github.io/comprehensive-rust/ko/) par [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) et "
+"[@jooyunghan](https://github.com/jooyunghan)."
 
 #: src/running-the-course/translations.md:9
 msgid ""
@@ -1782,72 +1558,82 @@ msgstr ""
 
 #: src/running-the-course/translations.md:11
 #, fuzzy
-msgid "## Incomplete Translations"
-msgstr "# Traductions"
+msgid "Incomplete Translations"
+msgstr "Traductions"
 
 #: src/running-the-course/translations.md:13
 msgid ""
-"There is a large number of in-progress translations. We link to the most\n"
+"There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
 
 #: src/running-the-course/translations.md:16
 msgid ""
-"* [Bengali][bn] by [@raselmandol].\n"
-"* [French][fr] by [@KookaS] and [@vcaen].\n"
-"* [German][de] by [@Throvn] and [@ronaldfw].\n"
-"* [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105]."
+"[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
+"(https://github.com/raselmandol)."
+msgstr ""
+
+#: src/running-the-course/translations.md:17
+msgid ""
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+msgstr ""
+
+#: src/running-the-course/translations.md:18
+msgid ""
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+msgstr ""
+
+#: src/running-the-course/translations.md:19
+msgid ""
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
 msgstr ""
 
 #: src/running-the-course/translations.md:21
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"Si vous souhaitez contribuer à cet effort, veuillez consulter [nos "
-"instructions] pour savoir comment\n"
-"se lancer. Les traductions sont coordonnées sur le [traqueur de problèmes]."
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# Utiliser Cargo"
+"Si vous souhaitez contribuer à cet effort, veuillez consulter \\[nos "
+"instructions\\] pour savoir comment se lancer. Les traductions sont "
+"coordonnées sur le \\[traqueur de problèmes\\]."
 
 #: src/cargo.md:3
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
 "Lorsque vous commencerez à lire sur Rust, vous rencontrerez bientôt [Cargo]"
-"(https://doc.rust-lang.org/cargo/), l'outil standard\n"
-"utilisé dans l'écosystème Rust pour créer et exécuter des applications Rust. "
-"Ici, nous voulons\n"
-"donner un bref aperçu de ce qu'est Cargo et comment il s'intègre dans le "
-"large écosystème\n"
-"et comment cela s'inscrit dans cette formation."
+"(https://doc.rust-lang.org/cargo/), l'outil standard utilisé dans "
+"l'écosystème Rust pour créer et exécuter des applications Rust. Ici, nous "
+"voulons donner un bref aperçu de ce qu'est Cargo et comment il s'intègre "
+"dans le large écosystème et comment cela s'inscrit dans cette formation."
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## Installation"
+msgid "Installation"
+msgstr "Installation"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (recommandé)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (recommandé)"
 
 #: src/cargo.md:12
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
 "Vous pouvez suivre les instructions pour installer Cargo et le compilateur "
 "Rust, parmi d'autres outils de l'écosystème standard avec l'outil [rustup]"
-"[3], qui est maintenu par la Foundation Rust."
+"(https://rust-analyzer.github.io/), qui est maintenu par la Foundation Rust."
 
 #: src/cargo.md:14
 msgid ""
@@ -1860,20 +1646,20 @@ msgstr ""
 "d'outils, configurer une compilation croisée, etc."
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### Gestionnaires de packages"
+msgid "Package Managers"
+msgstr "\\### Gestionnaires de packages"
 
 #: src/cargo.md:18
-msgid "#### Debian"
-msgstr "#### Debian"
+msgid "Debian"
+msgstr "Debian"
 
 #: src/cargo.md:20
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
 "Sur Debian/Ubuntu, vous pouvez installer Cargo, la source Rust et le "
-"[formateur Rust][6] avec"
+"[formateur Rust](https://github.com/rust-lang/rustfmt) avec"
 
 #: src/cargo.md:22
 msgid ""
@@ -1884,31 +1670,32 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"Cela permettra à [rust-analyzer][1] de passer directement aux définitions. "
-"Nous suggérons d'utiliser\n"
-"[VS Code][2] pour modifier le code (mais tout éditeur LSP compatible "
-"fonctionne)."
+"Cela permettra à \\[rust-analyzer\\]\\[1\\] de passer directement aux "
+"définitions. Nous suggérons d'utiliser [VS Code](https://code.visualstudio."
+"com/) pour modifier le code (mais tout éditeur LSP compatible fonctionne)."
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"Certaines personnes aiment également utiliser la famille d'IDE [JetBrains] "
-"[4], qui effectuent leur propre analyse mais ont leurs propres compromis. Si "
-"vous les préférez, vous pouvez installer le [Plugin Rust][5]. Veuillez noter "
-"qu'à partir de janvier 2023, le débogage ne fonctionne que sur la version "
-"CLion de la suite JetBrains IDEA."
+"Certaines personnes aiment également utiliser la famille d'IDE "
+"\\[JetBrains\\] [4](https://www.jetbrains.com/clion/), qui effectuent leur "
+"propre analyse mais ont leurs propres compromis. Si vous les préférez, vous "
+"pouvez installer le [Plugin Rust](https://www.jetbrains.com/rust/). Veuillez "
+"noter qu'à partir de janvier 2023, le débogage ne fonctionne que sur la "
+"version CLion de la suite JetBrains IDEA."
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# L'écosystème de Rust"
+msgid "The Rust Ecosystem"
+msgstr "L'écosystème de Rust"
 
 #: src/cargo/rust-ecosystem.md:3
 msgid ""
@@ -1919,44 +1706,39 @@ msgstr ""
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc` : le compilateur Rust qui transforme les fichiers `.rs` en "
-"binaires et autres\n"
-"  formats intermédiaires.\n"
-"\n"
-"* `cargo` : le gestionnaire de dépendances Rust et l'outil de construction. "
-"Cargo sait comment\n"
-"  télécharger les dépendances hébergées sur <https://crates.io> et il les "
-"transmettra à\n"
-"  `rustc` lors de la construction de votre projet. Cargo est également livré "
-"avec un exécuteur de test\n"
-"  qui est utilisé pour exécuter des tests unitaires.\n"
-"\n"
-"* `rustup` : le programme d'installation et de mise à jour de la chaîne "
-"d'outils Rust. Cet outil sert à\n"
-"  installer et mettez à jour `rustc` et `cargo` lorsque de nouvelles "
-"versions de Rust sont publiées.\n"
-"  De plus, `rustup` peut également télécharger la documentation de la \n"
-"  bibliothèque standard. Vous pouvez avoir plusieurs versions de Rust "
-"installées à la fois et `rustup`\n"
-"  vous permettra de basculer entre elles au besoin."
+"`rustc` : le compilateur Rust qui transforme les fichiers `.rs` en binaires "
+"et autres formats intermédiaires."
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
+msgstr ""
+"`cargo` : le gestionnaire de dépendances Rust et l'outil de construction. "
+"Cargo sait comment télécharger les dépendances hébergées sur <https://crates."
+"io> et il les transmettra à `rustc` lors de la construction de votre projet. "
+"Cargo est également livré avec un exécuteur de test qui est utilisé pour "
+"exécuter des tests unitaires."
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
+"`rustup` : le programme d'installation et de mise à jour de la chaîne "
+"d'outils Rust. Cet outil sert à installer et mettez à jour `rustc` et "
+"`cargo` lorsque de nouvelles versions de Rust sont publiées. De plus, "
+"`rustup` peut également télécharger la documentation de la  bibliothèque "
+"standard. Vous pouvez avoir plusieurs versions de Rust installées à la fois "
+"et `rustup` vous permettra de basculer entre elles au besoin."
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1971,118 +1753,143 @@ msgstr "Points clés:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust a un calendrier de publication rapide avec une nouvelle version qui "
-"sort\n"
-"  toutes les six semaines. Les nouvelles versions maintiennent la "
-"rétrocompatibilité avec les\n"
-"  anciennes versions --- en plus, elles activent de nouvelles "
-"fonctionnalités.\n"
-"\n"
-"* Il existe trois canaux de sortie : \"stable\", \"beta\" et \"nightly\".\n"
-"\n"
-"* De nouvelles fonctionnalités sont testées sur \"nightly\", \"beta\" est ce "
-"qui devient\n"
-"  \"stable\" toutes les six semaines.\n"
-"\n"
-"* Rust a également des [éditions] : l'édition actuelle est Rust 2021.\n"
-"  Les éditions passées étaient Rust 2015 et Rust 2018.\n"
-"\n"
-"  * Les éditions sont autorisées à apporter des modifications "
-"rétrocompatibles à\n"
-"    la langue.\n"
-"\n"
-"  * Pour éviter de casser le code, les éditions sont opt-in : vous "
-"sélectionnez\n"
-"    l'édition pour votre crate via le fichier `Cargo.toml`.\n"
-"\n"
-"  * Pour éviter de diviser l'écosystème, les compilateurs Rust peuvent "
-"mélanger le code\n"
-"    écrit pour différentes éditions.\n"
-"\n"
-"  * Veuillez noter qu'il est assez rare d'utiliser le compilateur "
-"directement et non via `cargo` (la plupart des utilisateurs ne le font "
-"jamais).\n"
-"\n"
-"  * Il peut être utile de mentionner que Cargo lui-même est un outil "
-"extrêmement puissant et complet. Il est capable de nombreuses "
-"fonctionnalités avancées, y compris, mais sans s'y limiter :\n"
-"      * Structure du projet/paquets\n"
-"      * [espaces de travail]\n"
-"      * Gestion/mise en cache des dépendances de développement et des "
-"dépendances d'exécution\n"
-"      * [créer des scripts]\n"
-"      * [installation globale]\n"
-"      * Il est également extensible avec des plugins de sous-commande (tels "
-"que [cargo clippy]).\n"
-"  * En savoir plus sur le [livre officiel de Cargo]"
+"Rust a un calendrier de publication rapide avec une nouvelle version qui "
+"sort toutes les six semaines. Les nouvelles versions maintiennent la "
+"rétrocompatibilité avec les anciennes versions --- en plus, elles activent "
+"de nouvelles fonctionnalités."
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr ""
+"Il existe trois canaux de sortie : \"stable\", \"beta\" et \"nightly\"."
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr ""
+"De nouvelles fonctionnalités sont testées sur \"nightly\", \"beta\" est ce "
+"qui devient \"stable\" toutes les six semaines."
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"Rust a également des \\[éditions\\] : l'édition actuelle est Rust 2021. Les "
+"éditions passées étaient Rust 2015 et Rust 2018."
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr ""
+"Les éditions sont autorisées à apporter des modifications rétrocompatibles à "
+"la langue."
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"Pour éviter de casser le code, les éditions sont opt-in : vous sélectionnez "
+"l'édition pour votre crate via le fichier `Cargo.toml`."
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr ""
+"Pour éviter de diviser l'écosystème, les compilateurs Rust peuvent mélanger "
+"le code écrit pour différentes éditions."
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+"Veuillez noter qu'il est assez rare d'utiliser le compilateur directement et "
+"non via `cargo` (la plupart des utilisateurs ne le font jamais)."
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+"Il peut être utile de mentionner que Cargo lui-même est un outil extrêmement "
+"puissant et complet. Il est capable de nombreuses fonctionnalités avancées, "
+"y compris, mais sans s'y limiter :"
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "Structure du projet/paquets"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr "\\[espaces de travail\\]"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr ""
+"Gestion/mise en cache des dépendances de développement et des dépendances "
+"d'exécution"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr "\\[créer des scripts\\]"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr "\\[installation globale\\]"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"Il est également extensible avec des plugins de sous-commande (tels que "
+"[cargo clippy](https://github.com/rust-lang/rust-clippy))."
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr "En savoir plus sur le \\[livre officiel de Cargo\\]"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# Échantillons de code dans cette formation"
+msgid "Code Samples in This Training"
+msgstr "Échantillons de code dans cette formation"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
 "Pour cette formation, nous allons surtout explorer le langage Rust à travers "
-"des exemples\n"
-"qui peuvent être exécuté via votre navigateur. Cela rend la configuration "
-"beaucoup plus facile et\n"
-"assure une expérience cohérente pour chacun."
+"des exemples qui peuvent être exécuté via votre navigateur. Cela rend la "
+"configuration beaucoup plus facile et assure une expérience cohérente pour "
+"chacun."
 
 #: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
 "L'installation de Cargo est tout de même encouragée : elle vous facilitera "
-"la tâche\n"
-"des exercices. Le dernier jour, nous ferons un exercice plus large qui vous "
-"montrera comment\n"
-"travailler avec des dépendances et pour cela vous avez besoin de Cargo."
+"la tâche des exercices. Le dernier jour, nous ferons un exercice plus large "
+"qui vous montrera comment travailler avec des dépendances et pour cela vous "
+"avez besoin de Cargo."
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -2098,66 +1905,59 @@ msgid ""
 msgstr ""
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
-msgstr ""
-"Vous pouvez utiliser <kbd>Ctrl + Entrée</kbd> pour exécuter le code lorsque "
-"le focus est dans la\n"
-"zone de texte."
+msgid "You can use "
+msgstr "Vous pouvez utiliser "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr " pour exécuter le code lorsque le focus est dans la zone de texte."
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
 "La plupart des exemples de code sont modifiables comme indiqué ci-dessus. "
-"Quelques exemples de code\n"
-"ne sont pas modifiables pour diverses raisons :"
+"Quelques exemples de code ne sont pas modifiables pour diverses raisons :"
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* Les terrains de jeu intégrés ne peuvent pas exécuter de tests unitaires. "
-"Copiez-collez le\n"
-"  code et ouvrez-le dans le vrai terrain de jeu pour démontrer les tests "
-"unitaires.\n"
-"\n"
-"* Les terrains de jeux intégrées perdent leur état au moment où vous "
-"naviguez\n"
-"  loin de la page! C'est la raison pour laquelle les élèves doivent\n"
-"  résoudre les exercices en utilisant une installation Rust locale ou via "
-"le\n"
-"  terrain de jeu."
+"Les terrains de jeu intégrés ne peuvent pas exécuter de tests unitaires. "
+"Copiez-collez le code et ouvrez-le dans le vrai terrain de jeu pour "
+"démontrer les tests unitaires."
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"Les terrains de jeux intégrées perdent leur état au moment où vous naviguez "
+"loin de la page! C'est la raison pour laquelle les élèves doivent résoudre "
+"les exercices en utilisant une installation Rust locale ou via le terrain de "
+"jeu."
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# Exécuter le code localement avec Cargo"
+msgid "Running Code Locally with Cargo"
+msgstr "Exécuter le code localement avec Cargo"
 
 #: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
 "Si vous souhaitez expérimenter le code sur votre propre système, vous aurez "
-"besoin\n"
-"pour installer d'abord de Rust. Pour ce faire, suivez les [instructions dans "
-"le livre Rust][1].\n"
-"Cela devrait vous donner un \"rustc\" et un \"cargo\" fonctionnels. Au "
-"moment de\n"
-"l'écriture, la dernière version stable de Rust a ces numéros de version:"
+"besoin pour installer d'abord de Rust. Pour ce faire, suivez les "
+"[instructions dans le livre Rust](https://doc.rust-lang.org/book/ch01-01-"
+"installation.html). Cela devrait vous donner un \"rustc\" et un \"cargo\" "
+"fonctionnels. Au moment de l'écriture, la dernière version stable de Rust a "
+"ces numéros de version:"
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -2172,115 +1972,135 @@ msgstr ""
 #: src/cargo/running-locally.md:15
 #, fuzzy
 msgid ""
-"With this in place, follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this in place, follow these steps to build a Rust binary from one of "
+"the examples in this training:"
 msgstr ""
 "Une fois cela en place, suivez ces étapes pour créer un binaire Rust à "
-"partir d'un\n"
-"des exemples dans cette formation :"
+"partir d'un des exemples dans cette formation :"
 
 #: src/cargo/running-locally.md:18
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr ""
+
+#: src/cargo/running-locally.md:20
 msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in `target/"
-"debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr ""
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr ""
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr ""
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
 msgstr ""
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
-"Essayez d'encourager les participants à installer Cargo et à utiliser un\n"
-"éditeur local. Cela leur facilitera la vie puisqu'ils auront un\n"
+"Essayez d'encourager les participants à installer Cargo et à utiliser un "
+"éditeur local. Cela leur facilitera la vie puisqu'ils auront un "
 "environnement de développement normal."
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# Bienvenue au jour 1"
+msgid "Welcome to Day 1"
+msgstr "Bienvenue au jour 1"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr ""
 "C'est le premier jour de Comprehensive Rust(le guide complet de Rust). Nous "
-"couvrirons beaucoup de terrain\n"
-"aujourd'hui:"
+"couvrirons beaucoup de terrain aujourd'hui:"
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* Syntaxe de base de Rust : variables, types scalaires et composés, "
-"énumérations, structures,\n"
-"  références, fonctions et méthodes.\n"
-"\n"
-"* Gestion de la mémoire : pile contre tas, gestion manuelle de la mémoire, "
-"gestion de la mémoire basée sur la portée\n"
-"  et le ramassage des ordures.\n"
-"\n"
-"* Propriété : sémantique de déplacement, copie et clonage, emprunt et durée "
-"de vie."
+"Syntaxe de base de Rust : variables, types scalaires et composés, "
+"énumérations, structures, références, fonctions et méthodes."
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+"Gestion de la mémoire : pile contre tas, gestion manuelle de la mémoire, "
+"gestion de la mémoire basée sur la portée et le ramassage des ordures."
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"Propriété : sémantique de déplacement, copie et clonage, emprunt et durée de "
+"vie."
 
 #: src/welcome-day-1.md:16
 msgid "Please remind the students that:"
@@ -2289,158 +2109,188 @@ msgstr "Veuillez rappeler aux élèves que :"
 #: src/welcome-day-1.md:18
 #, fuzzy
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i."
-"e.,\n"
-"    keep the discussions related to how Rust does things vs some other "
-"language. \n"
-"    It can be hard to find the right balance, but err on the side of "
-"allowing \n"
-"    discussions since they engage people much more than one-way "
-"communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
 msgstr ""
-"* Ils doivent poser des questions lorsqu'ils les reçoivent, ne les "
-"enregistrez pas jusqu'à la fin.\n"
-"* Le cours se veut interactif et les discussions sont vivement "
-"encouragées !\n"
-"  * En tant qu'instructeur, vous devez essayer de garder les discussions "
-"pertinentes, c'est-à-dire,\n"
-"    garder le lien avec la façon dont Rust fait les choses par rapport à un "
-"autre langage. Ça peut être\n"
-"    difficile de trouver le bon équilibre, mais privilégiez les discussions\n"
-"    car elles engagent les gens bien plus que la communication à sens "
-"unique.\n"
-"* Les questions signifieront probablement que nous parlons de choses avant "
-"les diapositives.\n"
-"  * C'est tout à fait correct! La répétition est une partie importante de "
-"l'apprentissage. N'oubliez pas\n"
-"  que les diapositives ne sont qu'un support et que vous êtes libre de les "
-"sauter si vous le souhaitez."
+"Ils doivent poser des questions lorsqu'ils les reçoivent, ne les enregistrez "
+"pas jusqu'à la fin."
+
+#: src/welcome-day-1.md:19
+#, fuzzy
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr ""
+"Le cours se veut interactif et les discussions sont vivement encouragées !"
+
+#: src/welcome-day-1.md:20
+#, fuzzy
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
+msgstr ""
+"En tant qu'instructeur, vous devez essayer de garder les discussions "
+"pertinentes, c'est-à-dire, garder le lien avec la façon dont Rust fait les "
+"choses par rapport à un autre langage. Ça peut être difficile de trouver le "
+"bon équilibre, mais privilégiez les discussions car elles engagent les gens "
+"bien plus que la communication à sens unique."
+
+#: src/welcome-day-1.md:24
+#, fuzzy
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+"Les questions signifieront probablement que nous parlons de choses avant les "
+"diapositives."
+
+#: src/welcome-day-1.md:25
+#, fuzzy
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"C'est tout à fait correct! La répétition est une partie importante de "
+"l'apprentissage. N'oubliez pas que les diapositives ne sont qu'un support et "
+"que vous êtes libre de les sauter si vous le souhaitez."
 
 #: src/welcome-day-1.md:29
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
 "L'idée du premier jour est de montrer _juste assez_ de Rust pour pouvoir "
-"parler\n"
-"du célèbre vérificateur d'emprunt. La façon dont Rust gère la mémoire est "
-"une caractéristique majeure\n"
-"et nous devrions montrer cela aux élèves tout de suite."
+"parler du célèbre vérificateur d'emprunt. La façon dont Rust gère la mémoire "
+"est une caractéristique majeure et nous devrions montrer cela aux élèves "
+"tout de suite."
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
 "Si vous enseignez cela dans une salle de classe, c'est un bon endroit pour "
-"passer en revue le\n"
-"calendrier. Nous suggérons de diviser la journée en deux parties (suivant "
-"les diapositives) :"
+"passer en revue le calendrier. Nous suggérons de diviser la journée en deux "
+"parties (suivant les diapositives) :"
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* Matin : 9h00 à 12h00,\n"
-"* Après-midi : 13h00 à 16h00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "Matin : 9h00 à 12h00,"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "Après-midi : 13h00 à 16h00."
 
 #: src/welcome-day-1.md:39
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
+"breaks, we recommend a break every hour!"
 msgstr ""
 "Vous pouvez bien sûr ajuster cela si nécessaire. Assurez-vous d'inclure les "
-"pauses,\n"
-"nous recommandons une pause toutes les heures !"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# Qu'est-ce que Rust?"
+"pauses, nous recommandons une pause toutes les heures !"
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
 "Rust est un nouveau langage de programmation qui a eu sa [version 1.0 en "
-"2015][1] :"
+"2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html) :"
 
 #: src/welcome-day-1/what-is-rust.md:5
+#, fuzzy
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "Rust est un langage compilé statiquement dans un rôle similaire à C++"
+
+#: src/welcome-day-1/what-is-rust.md:6
+#, fuzzy
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` utilise LLVM comme backend."
+
+#: src/welcome-day-1/what-is-rust.md:7
+#, fuzzy
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"* Rust est un langage compilé statiquement dans un rôle similaire à C++\n"
-"  * `rustc` utilise LLVM comme backend.\n"
-"* Rust prend en charge de nombreuses [plates-formes et\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  *Linux, Mac, Windows, ...\n"
-"* Rust est utilisé pour une large gamme d'appareils :\n"
-"  * firmware et chargeurs de démarrage,\n"
-"  * écrans intelligents,\n"
-"  * téléphones portables,\n"
-"  * ordinateurs de bureau,\n"
-"  * serveurs."
+"Rust prend en charge de nombreuses [plates-formes et architectures](https://"
+"doc.rust-lang.org/nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+#, fuzzy
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ... \\*Linux, Mac, Windows, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+#, fuzzy
+msgid "Linux, Mac, Windows, ..."
+msgstr "Rust est utilisé pour une large gamme d'appareils :"
+
+#: src/welcome-day-1/what-is-rust.md:11
+#, fuzzy
+msgid "Rust is used for a wide range of devices:"
+msgstr "firmware et chargeurs de démarrage,"
+
+#: src/welcome-day-1/what-is-rust.md:12
+#, fuzzy
+msgid "firmware and boot loaders,"
+msgstr "écrans intelligents,"
+
+#: src/welcome-day-1/what-is-rust.md:13
+#, fuzzy
+msgid "smart displays,"
+msgstr "téléphones portables,"
+
+#: src/welcome-day-1/what-is-rust.md:14
+#, fuzzy
+msgid "mobile phones,"
+msgstr "ordinateurs de bureau,"
+
+#: src/welcome-day-1/what-is-rust.md:15
+#, fuzzy
+msgid "desktops,"
+msgstr "serveurs."
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr ""
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust s'inscrit dans le même domaine que C++ :"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* Grande flexibilité.\n"
-"* Haut niveau de contrôle.\n"
-"* Peut être réduit à des appareils très limités comme les téléphones "
-"mobiles.\n"
-"* N'a pas de temps d'exécution ou de récupération d'ordures.\n"
-"* Se concentre sur la fiabilité et la sécurité sans sacrifier les "
-"performances."
+msgid "High flexibility."
+msgstr "Grande flexibilité."
 
-#: src/hello-world.md:1
-#, fuzzy
-msgid "# Hello World!"
-msgstr "# Bonjour le monde!"
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "Haut niveau de contrôle."
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr ""
+"Peut être réduit à des appareils très limités comme les téléphones mobiles."
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "N'a pas de temps d'exécution ou de récupération d'ordures."
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"Se concentre sur la fiabilité et la sécurité sans sacrifier les performances."
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
 "Passons au programme Rust le plus simple possible, un Bonjour Monde "
-"classique\n"
-"programme:"
+"classique programme:"
 
 #: src/hello-world.md:6
 #, fuzzy
@@ -2462,75 +2312,76 @@ msgid "What you see:"
 msgstr "Ce que tu vois:"
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "Les fonctions sont introduites avec `fn`."
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "Les blocs sont délimités par des accolades comme en C et C++."
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "La fonction `main` est le point d'entrée du programme."
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr "Rust a des macros hygiéniques, `println!` en est un exemple."
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
-"* Les fonctions sont introduites avec `fn`.\n"
-"* Les blocs sont délimités par des accolades comme en C et C++.\n"
-"* La fonction `main` est le point d'entrée du programme.\n"
-"* Rust a des macros hygiéniques, `println!` en est un exemple.\n"
-"* Les strings Rust sont encodées en UTF-8 et peuvent contenir n'importe quel "
+"Les strings Rust sont encodées en UTF-8 et peuvent contenir n'importe quel "
 "caractère Unicode."
 
 #: src/hello-world.md:22
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 "Cette diapositive tente de mettre les étudiants à l'aise avec le code Rust. "
-"Ils en verront\n"
-"une tonne durant les quatre prochains jours, alors nous commençons petit "
-"avec quelque chose de familier."
+"Ils en verront une tonne durant les quatre prochains jours, alors nous "
+"commençons petit avec quelque chose de familier."
 
 #: src/hello-world.md:27
 #, fuzzy
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude."
-"md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/"
-"hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rust ressemble beaucoup aux autres langages traditionnels C/C++/Java. "
-"C'est\n"
-"  impératif (non fonctionnel) et il n'essaie pas de réinventer les choses à "
-"moins\n"
-"  qu'absolument nécessaire.\n"
-"\n"
-"* Rust est moderne avec un support complet pour des choses comme Unicode.\n"
-"\n"
-"* Rust utilise des macros pour les situations où vous souhaitez avoir un "
-"nombre variable\n"
-"  d'arguments (pas de fonction [surchargées](basic-syntax/functions-"
-"interlude.md)).\n"
-"\n"
-"* Les macros étant \"hygiéniques\", elles ne capturent pas accidentellement "
-"les identifiants de\n"
-"  la portée dans laquelle elles sont utilisées. Les macros Rust ne sont en "
-"fait que\n"
-"  [partiellement hygiénique](https://veykril.github.io/tlborm/decl-macros/"
-"minutiae/hygiene.html)."
+"Rust ressemble beaucoup aux autres langages traditionnels C/C++/Java. C'est "
+"impératif (non fonctionnel) et il n'essaie pas de réinventer les choses à "
+"moins qu'absolument nécessaire."
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# Petit exemple"
+#: src/hello-world.md:31
+#, fuzzy
+msgid "Rust is modern with full support for things like Unicode."
+msgstr ""
+"Rust est moderne avec un support complet pour des choses comme Unicode."
+
+#: src/hello-world.md:33
+#, fuzzy
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"Rust utilise des macros pour les situations où vous souhaitez avoir un "
+"nombre variable d'arguments (pas de fonction [surchargées](basic-syntax/"
+"functions-interlude.md))."
+
+#: src/hello-world.md:36
+#, fuzzy
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
+msgstr ""
+"Les macros étant \"hygiéniques\", elles ne capturent pas accidentellement "
+"les identifiants de la portée dans laquelle elles sont utilisées. Les macros "
+"Rust ne sont en fait que [partiellement hygiénique](https://veykril.github."
+"io/tlborm/decl-macros/minutiae/hygiene.html)."
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2573,201 +2424,209 @@ msgstr ""
 #: src/hello-world/small-example.md:23
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
-"Le code implémente la conjecture de Collatz : on pense que la boucle\n"
+"Le code implémente la conjecture de Collatz : on pense que la boucle "
 "finissent toujours, mais cela n'est pas encore prouvé. Modifiez le code et "
-"jouez avec différentes\n"
-"entrées."
+"jouez avec différentes entrées."
 
 #: src/hello-world/small-example.md:29
 #, fuzzy
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::"
-"fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library.\n"
-"    \n"
-"    * In a shell `rustup doc std::fmt` will open a browser on the local std::"
-"fmt documentation"
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* Expliquez que toutes les variables sont typées statiquement. Essayez de "
-"supprimer `i32` pour déclencher\n"
-"  l'inférence de type. Essayez avec `i8` à la place et déclenchez un "
-"débordement d'entier à l'exécution.\n"
-"\n"
-"* Remplacez `let mut x` par `let x`, discutez de l'erreur du compilateur.\n"
-"\n"
-"* Montrez comment `print!` génère une erreur de compilation si les arguments "
-"ne correspondent pas aux\n"
-"  format des string.\n"
-"\n"
-"* Montrez comment vous devez utiliser `{}` comme espace réservé si vous "
-"souhaitez imprimer une\n"
-"  expression qui est plus complexe qu'une simple variable.\n"
-"\n"
-"* Montrez aux étudiants la bibliothèque standard, montrez-leur comment "
-"rechercher `std :: fmt`\n"
-"  qui a les règles du mini-langage de formatage. Il est important que le\n"
-"  les étudiants se familiarisent avec la recherche dans la bibliothèque "
-"standard."
+"Expliquez que toutes les variables sont typées statiquement. Essayez de "
+"supprimer `i32` pour déclencher l'inférence de type. Essayez avec `i8` à la "
+"place et déclenchez un débordement d'entier à l'exécution."
 
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# Pourquoi Rust ?"
+#: src/hello-world/small-example.md:32
+#, fuzzy
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr ""
+"Remplacez `let mut x` par `let x`, discutez de l'erreur du compilateur."
+
+#: src/hello-world/small-example.md:34
+#, fuzzy
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+"Montrez comment `print!` génère une erreur de compilation si les arguments "
+"ne correspondent pas aux format des string."
+
+#: src/hello-world/small-example.md:37
+#, fuzzy
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+"Montrez comment vous devez utiliser `{}` comme espace réservé si vous "
+"souhaitez imprimer une expression qui est plus complexe qu'une simple "
+"variable."
+
+#: src/hello-world/small-example.md:40
+#, fuzzy
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"Montrez aux étudiants la bibliothèque standard, montrez-leur comment "
+"rechercher `std :: fmt` qui a les règles du mini-langage de formatage. Il "
+"est important que le les étudiants se familiarisent avec la recherche dans "
+"la bibliothèque standard."
+
+#: src/hello-world/small-example.md:44
+msgid ""
+"In a shell `rustup doc std::fmt` will open a browser on the local std::fmt "
+"documentation"
+msgstr ""
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Quelques arguments de vente uniques à Rust :"
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* Sécurité de la mémoire à la compilation.\n"
-"* Absence de comportement d'exécution indéfini.\n"
-"* Caractéristiques du langage moderne."
+msgid "Compile time memory safety."
+msgstr "Sécurité de la mémoire à la compilation."
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "Absence de comportement d'exécution indéfini."
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "Caractéristiques du langage moderne."
 
 #: src/why-rust.md:11
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
 "Assurez-vous de demander à la classe dans quelles langues ils ont de "
-"l'expérience. Selon\n"
-"la réponse, vous pouvez mettre en évidence différentes fonctionnalités de "
-"Rust :"
+"l'expérience. Selon la réponse, vous pouvez mettre en évidence différentes "
+"fonctionnalités de Rust :"
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* Expérience avec C ou C++ : Rust élimine toute une classe d'_erreurs "
-"d'exécution_\n"
-"  via le vérificateur d'emprunt. Vous obtenez des performances comme en C et "
-"C++, mais sans\n"
-"  problèmes d'insécurité de la mémoire. De plus, vous obtenez une langue "
-"moderne avec\n"
-"  des constructions telles que la correspondance de motifs et la gestion "
-"intégrée des dépendances.\n"
-"\n"
-"* Expérience avec Java, Go, Python, JavaScript... : Vous bénéficiez de la "
-"même sécurité mémoire\n"
-"  comme dans ces langages, plus un sentiment de langage de haut niveau "
-"similaire. En outre\n"
-"  vous obtenez des performances rapides et prévisibles comme C et C++ (pas "
-"de ramassage d'ordures)\n"
-"  ainsi que l'accès au matériel de bas niveau (si vous en avez besoin)"
+"Expérience avec C ou C++ : Rust élimine toute une classe d'_erreurs "
+"d'exécution_ via le vérificateur d'emprunt. Vous obtenez des performances "
+"comme en C et C++, mais sans problèmes d'insécurité de la mémoire. De plus, "
+"vous obtenez une langue moderne avec des constructions telles que la "
+"correspondance de motifs et la gestion intégrée des dépendances."
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# Garanties à la compilation"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"Expérience avec Java, Go, Python, JavaScript... : Vous bénéficiez de la même "
+"sécurité mémoire comme dans ces langages, plus un sentiment de langage de "
+"haut niveau similaire. En outre vous obtenez des performances rapides et "
+"prévisibles comme C et C++ (pas de ramassage d'ordures) ainsi que l'accès au "
+"matériel de bas niveau (si vous en avez besoin)"
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "Gestion de la mémoire statique à la compilation :"
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* Aucune variable non initialisée.\n"
-"* Aucune fuite de mémoire (_surtout_, voir les notes).\n"
-"* Pas de double libération de mémoire.\n"
-"* Aucune utilisation après la libération.\n"
-"* Pas de pointeurs `NULL`.\n"
-"* Pas de mutex verrouillés oubliés.\n"
-"* Pas de courses de données entre les threads.\n"
-"* Aucune invalidation d'itérateur."
+msgid "No uninitialized variables."
+msgstr "Aucune variable non initialisée."
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "Aucune fuite de mémoire (_surtout_, voir les notes)."
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "Pas de double libération de mémoire."
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "Aucune utilisation après la libération."
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "Pas de pointeurs `NULL`."
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "Pas de mutex verrouillés oubliés."
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "Pas de courses de données entre les threads."
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "Aucune invalidation d'itérateur."
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr ""
 "Il est possible de produire des fuites de mémoire avec Rust (sûr). Quelques "
-"exemples\n"
-"sont:"
+"exemples sont:"
 
 #: src/why-rust/compile-time.md:19
 #, fuzzy
 msgid ""
-"* You can use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* Vous pouvez utiliser [`Box::leak`] pour divulguer un pointeur. Une "
-"utilisation de cela pourrait\n"
-"  être d'obtenir des variables statiques initialisées et dimensionnées à "
-"l'exécution\n"
-"* Vous pouvez utiliser [`std::mem::forget`] pour que le compilateur "
-"\"oublie\"\n"
-"  une valeur (ce qui signifie que le destructeur n'est jamais exécuté).\n"
-"* Vous pouvez également créer accidentellement un [cycle de référence] avec "
-"`Rc` ou\n"
-"  \"Arc\".\n"
-"* En fait, certains considéreront le fait de peupler à l'infini une "
-"collection tel qu'une\n"
-"  fuite de mémoire et Rust ne protège pas de celles-ci."
+"Vous pouvez utiliser [`Box::leak`](https://doc.rust-lang.org/std/boxed/"
+"struct.Box.html#method.leak) pour divulguer un pointeur. Une utilisation de "
+"cela pourrait être d'obtenir des variables statiques initialisées et "
+"dimensionnées à l'exécution"
+
+#: src/why-rust/compile-time.md:21
+#, fuzzy
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"Vous pouvez utiliser [`std::mem::forget`](https://doc.rust-lang.org/std/mem/"
+"fn.forget.html) pour que le compilateur \"oublie\" une valeur (ce qui "
+"signifie que le destructeur n'est jamais exécuté)."
+
+#: src/why-rust/compile-time.md:23
+#, fuzzy
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"Vous pouvez également créer accidentellement un \\[cycle de référence\\] "
+"avec `Rc` ou \"Arc\"."
+
+#: src/why-rust/compile-time.md:25
+#, fuzzy
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"En fait, certains considéreront le fait de peupler à l'infini une collection "
+"tel qu'une fuite de mémoire et Rust ne protège pas de celles-ci."
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"Pour les besoins de ce cours, \"Aucune fuite de mémoire\" doit être compris\n"
-"comme \"Pratiquement pas de fuites de mémoire *accidentelles*\"."
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# Garanties à l'exécution"
+"Pour les besoins de ce cours, \"Aucune fuite de mémoire\" doit être compris "
+"comme \"Pratiquement pas de fuites de mémoire _accidentelles_\"."
 
 #: src/why-rust/runtime.md:3
 #, fuzzy
@@ -2776,46 +2635,41 @@ msgstr "Aucun comportement indéfini à l'exécution :"
 
 #: src/why-rust/runtime.md:5
 #, fuzzy
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined (panic or wrap-around)."
-msgstr ""
-"* L'accès au tableau est vérifié dans les limites.\n"
-"* Le débordement d'entier est défini."
+msgid "Array access is bounds checked."
+msgstr "L'accès au tableau est vérifié dans les limites."
+
+#: src/why-rust/runtime.md:6
+#, fuzzy
+msgid "Integer overflow is defined (panic or wrap-around)."
+msgstr "Le débordement d'entier est défini."
 
 #: src/why-rust/runtime.md:12
 #, fuzzy
 msgid ""
-"* Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
-"lang.org/rustc/codegen-options/index.html#overflow-checks)\n"
-"  compile-time flag. If enabled, the program will panic (a controlled\n"
-"  crash of the program), otherwise you get wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via the [`overflow-checks`](https://doc.rust-"
+"lang.org/rustc/codegen-options/index.html#overflow-checks) compile-time "
+"flag. If enabled, the program will panic (a controlled crash of the "
+"program), otherwise you get wrap-around semantics. By default, you get "
+"panics in debug mode (`cargo build`) and wrap-around in release mode (`cargo "
+"build --release`)."
 msgstr ""
-"* Le débordement d'entier est défini via un indicateur de compilation. Les "
-"options sont\n"
-"  soit une panique (un plantage contrôlé du programme) ou un bouclage\n"
-"  sémantique. Par défaut, vous obtenez des paniques en mode débogage (`cargo "
-"build`)\n"
-"  et bouclage en mode release (`cargo build --release`).\n"
-"\n"
-"* La vérification des limites ne peut pas être désactivée avec un indicateur "
-"de compilateur. Ça peut aussi\n"
-"  ne pas être désactivé directement avec le mot-clé `unsafe`. Cependant,\n"
-"  `unsafe` vous permet d'appeler des fonctions telles que `slice::"
-"get_unchecked`\n"
-"  qui ne vérifie pas les bornes."
+"Le débordement d'entier est défini via un indicateur de compilation. Les "
+"options sont soit une panique (un plantage contrôlé du programme) ou un "
+"bouclage sémantique. Par défaut, vous obtenez des paniques en mode débogage "
+"(`cargo build`) et bouclage en mode release (`cargo build --release`)."
 
-#: src/why-rust/modern.md:1
+#: src/why-rust/runtime.md:18
 #, fuzzy
-msgid "# Modern Features"
-msgstr "# Fonctionnalités modernes"
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"La vérification des limites ne peut pas être désactivée avec un indicateur "
+"de compilateur. Ça peut aussi ne pas être désactivé directement avec le mot-"
+"clé `unsafe`. Cependant, `unsafe` vous permet d'appeler des fonctions telles "
+"que `slice::get_unchecked` qui ne vérifie pas les bornes."
 
 #: src/why-rust/modern.md:3
 #, fuzzy
@@ -2826,151 +2680,167 @@ msgstr ""
 
 #: src/why-rust/modern.md:5
 #, fuzzy
-msgid "## Language Features"
-msgstr "## Caractéristiques linguistiques"
+msgid "Language Features"
+msgstr "Caractéristiques linguistiques"
 
 #: src/why-rust/modern.md:7
 #, fuzzy
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* Énumérations et correspondance de modèles.\n"
-"* Génériques.\n"
-"* Pas de frais généraux FFI.\n"
-"* Abstractions à coût zéro."
+msgid "Enums and pattern matching."
+msgstr "Énumérations et correspondance de modèles."
+
+#: src/why-rust/modern.md:8
+#, fuzzy
+msgid "Generics."
+msgstr "Génériques."
+
+#: src/why-rust/modern.md:9
+#, fuzzy
+msgid "No overhead FFI."
+msgstr "Pas de frais généraux FFI."
+
+#: src/why-rust/modern.md:10
+#, fuzzy
+msgid "Zero-cost abstractions."
+msgstr "Abstractions à coût zéro."
 
 #: src/why-rust/modern.md:12
 #, fuzzy
-msgid "## Tooling"
-msgstr "## Outillage"
+msgid "Tooling"
+msgstr "Outillage"
 
 #: src/why-rust/modern.md:14
 #, fuzzy
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* Grandes erreurs de compilation.\n"
-"* Gestionnaire de dépendances intégré.\n"
-"* Support intégré pour les tests.\n"
-"* Excellente prise en charge du protocole de serveur de langue."
+msgid "Great compiler errors."
+msgstr "Grandes erreurs de compilation."
+
+#: src/why-rust/modern.md:15
+#, fuzzy
+msgid "Built-in dependency manager."
+msgstr "Gestionnaire de dépendances intégré."
+
+#: src/why-rust/modern.md:16
+#, fuzzy
+msgid "Built-in support for testing."
+msgstr "Support intégré pour les tests."
+
+#: src/why-rust/modern.md:17
+#, fuzzy
+msgid "Excellent Language Server Protocol support."
+msgstr "Excellente prise en charge du protocole de serveur de langue."
 
 #: src/why-rust/modern.md:23
 #, fuzzy
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* Les abstractions à coût nul, similaires à C++, signifient que vous n'avez "
-"pas à \"payer\"\n"
-"  pour les constructions de programmation de niveau supérieur avec mémoire "
-"ou CPU. Par exemple,\n"
-"  écrire une boucle en utilisant `for` devrait aboutir à peu près au même "
-"niveau bas\n"
-"  instructions comme utilisant la construction `.iter().fold()`.\n"
-"\n"
-"* Il peut être utile de mentionner que les énumérations Rust sont des "
-"\"types de données algébriques\", également\n"
-"  connus sous le nom de \"types de somme\", qui permettent au système de "
-"type d'exprimer des choses comme\n"
-"  `Option<T>` et `Résultat<T, E>`.\n"
-"\n"
-"* Rappelez aux gens de lire les erreurs --- de nombreux développeurs se sont "
-"habitués à\n"
-"  ignorer la longue sortie du compilateur. Le compilateur Rust est beaucoup "
-"plus\n"
-"  bavard que les autres compilateurs. Il vous fournira souvent "
-"_actionnable_\n"
-"  feedback, prêt à copier-coller dans votre code.\n"
-"\n"
-"* La bibliothèque standard Rust est petite comparée à des langages comme "
-"Java, Python,\n"
-"  et aller. La rouille ne vient pas avec plusieurs choses que vous pourriez "
-"considérer comme standard et\n"
-"  essentiel:\n"
-"\n"
-"  * un générateur de nombres aléatoires, mais voir [rand].\n"
-"  * prise en charge de SSL ou TLS, mais voir [rusttls].\n"
-"  * support pour JSON, mais voir [serde_json].\n"
-"\n"
-"  Le raisonnement sous-jacent est que la fonctionnalité de la bibliothèque "
-"standard ne peut pas\n"
-"  s'en aller, il doit donc être très stable. Pour les exemples ci-dessus, le "
-"Rust\n"
-"  la communauté travaille toujours à trouver la meilleure solution --- et "
-"peut-être là\n"
-"  n'est pas une seule \"meilleure solution\" pour certaines de ces choses.\n"
-"\n"
-"  Rust est livré avec un gestionnaire de packages intégré sous la forme de "
-"Cargo, ce qui rend\n"
-"  il est trivial de télécharger et de compiler des caisses tierces. Une "
-"conséquence de ce\n"
-"  est que la bibliothèque standard peut être plus petite.\n"
-"\n"
-"  Découvrir de bonnes caisses tierces peut être un problème. Des sites "
-"comme\n"
-"  <https://lib.rs/> aide à cela en vous permettant de comparer les mesures "
-"de santé pour\n"
-"  caisses pour en trouver une bonne et de confiance.\n"
-"  \n"
-"* [rust-analyzer] est une implémentation LSP bien prise en charge utilisée "
-"dans les principaux\n"
-"  IDE et éditeurs de texte."
+"Les abstractions à coût nul, similaires à C++, signifient que vous n'avez "
+"pas à \"payer\" pour les constructions de programmation de niveau supérieur "
+"avec mémoire ou CPU. Par exemple, écrire une boucle en utilisant `for` "
+"devrait aboutir à peu près au même niveau bas instructions comme utilisant "
+"la construction `.iter().fold()`."
 
-#: src/basic-syntax.md:1
+#: src/why-rust/modern.md:28
 #, fuzzy
-msgid "# Basic Syntax"
-msgstr "# Syntaxe de base"
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+"Il peut être utile de mentionner que les énumérations Rust sont des \"types "
+"de données algébriques\", également connus sous le nom de \"types de "
+"somme\", qui permettent au système de type d'exprimer des choses comme "
+"`Option<T>` et `Résultat<T, E>`."
+
+#: src/why-rust/modern.md:32
+#, fuzzy
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"Rappelez aux gens de lire les erreurs --- de nombreux développeurs se sont "
+"habitués à ignorer la longue sortie du compilateur. Le compilateur Rust est "
+"beaucoup plus bavard que les autres compilateurs. Il vous fournira souvent "
+"_actionnable_ feedback, prêt à copier-coller dans votre code."
+
+#: src/why-rust/modern.md:37
+#, fuzzy
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+"La bibliothèque standard Rust est petite comparée à des langages comme Java, "
+"Python, et aller. La rouille ne vient pas avec plusieurs choses que vous "
+"pourriez considérer comme standard et essentiel:"
+
+#: src/why-rust/modern.md:41
+#, fuzzy
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr ""
+"un générateur de nombres aléatoires, mais voir [rand](https://docs.rs/rand/)."
+
+#: src/why-rust/modern.md:42
+#, fuzzy
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr ""
+"prise en charge de SSL ou TLS, mais voir [rusttls](https://docs.rs/rustls/)."
+
+#: src/why-rust/modern.md:43
+#, fuzzy
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+"support pour JSON, mais voir [serde_json](https://docs.rs/serde_json/)."
+
+#: src/why-rust/modern.md:45
+#, fuzzy
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+"Le raisonnement sous-jacent est que la fonctionnalité de la bibliothèque "
+"standard ne peut pas s'en aller, il doit donc être très stable. Pour les "
+"exemples ci-dessus, le Rust la communauté travaille toujours à trouver la "
+"meilleure solution --- et peut-être là n'est pas une seule \"meilleure "
+"solution\" pour certaines de ces choses."
+
+#: src/why-rust/modern.md:50
+#, fuzzy
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+"Rust est livré avec un gestionnaire de packages intégré sous la forme de "
+"Cargo, ce qui rend il est trivial de télécharger et de compiler des caisses "
+"tierces. Une conséquence de ce est que la bibliothèque standard peut être "
+"plus petite."
+
+#: src/why-rust/modern.md:54
+#, fuzzy
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+"Découvrir de bonnes caisses tierces peut être un problème. Des sites comme "
+"<https://lib.rs/> aide à cela en vous permettant de comparer les mesures de "
+"santé pour caisses pour en trouver une bonne et de confiance."
+
+#: src/why-rust/modern.md:58
+#, fuzzy
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/) est une implémentation LSP "
+"bien prise en charge utilisée dans les principaux IDE et éditeurs de texte."
 
 #: src/basic-syntax.md:3
 #, fuzzy
@@ -2981,58 +2851,137 @@ msgstr ""
 
 #: src/basic-syntax.md:5
 #, fuzzy
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "Les blocs et les portées sont délimités par des accolades."
+
+#: src/basic-syntax.md:6
+#, fuzzy
 msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/"
-"* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"* Les blocs et les portées sont délimités par des accolades.\n"
-"* Les commentaires de ligne commencent par `//`, les commentaires de bloc "
-"sont délimités par `/* ...\n"
-"  */`.\n"
-"* Des mots-clés comme `if` et `while` fonctionnent de la même manière.\n"
-"* L'affectation des variables se fait avec `=`, la comparaison se fait avec "
+"Les commentaires de ligne commencent par `//`, les commentaires de bloc sont "
+"délimités par `/* ... */`."
+
+#: src/basic-syntax.md:8
+#, fuzzy
+msgid "Keywords like `if` and `while` work the same."
+msgstr "Des mots-clés comme `if` et `while` fonctionnent de la même manière."
+
+#: src/basic-syntax.md:9
+#, fuzzy
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+"L'affectation des variables se fait avec `=`, la comparaison se fait avec "
 "`==`."
 
-#: src/basic-syntax/scalar-types.md:1
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
 #, fuzzy
-msgid "# Scalar Types"
-msgstr "# Types scalaires"
+msgid "Types"
+msgstr "Types"
 
-#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
 #, fuzzy
-msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | "
-"`\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
+msgid "Literals"
+msgstr "Littéraux"
+
+#: src/basic-syntax/scalar-types.md:5
+#, fuzzy
+msgid "Signed integers"
+msgstr "Entiers signés"
+
+#: src/basic-syntax/scalar-types.md:5
+#, fuzzy
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+#, fuzzy
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+#, fuzzy
+msgid "Unsigned integers"
+msgstr "Entiers non signés"
+
+#: src/basic-syntax/scalar-types.md:6
+#, fuzzy
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+#, fuzzy
+msgid "`0`, `123`, `10u16`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:7
+#, fuzzy
+msgid "Floating point numbers"
+msgstr "Nombres à virgule flottante"
+
+#: src/basic-syntax/scalar-types.md:7
+#, fuzzy
+msgid "`f32`, `f64`"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+#, fuzzy
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:8
+#, fuzzy
+msgid "Strings"
+msgstr "Cordes"
+
+#: src/basic-syntax/scalar-types.md:8
+#, fuzzy
+msgid "`&str`"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+#, fuzzy
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr "`\"foo\"`, `r#\"\\\\\"#`"
+
+#: src/basic-syntax/scalar-types.md:9
+#, fuzzy
+msgid "Unicode scalar values"
+msgstr "Valeurs scalaires Unicode"
+
+#: src/basic-syntax/scalar-types.md:9
+#, fuzzy
+msgid "`char`"
+msgstr "`car`"
+
+#: src/basic-syntax/scalar-types.md:9
+#, fuzzy
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:10
+#, fuzzy
+msgid "Booleans"
+msgstr "Chaînes d'octets"
+
+#: src/basic-syntax/scalar-types.md:10
+#, fuzzy
+msgid "`bool`"
+msgstr "`&[u8]`"
+
+#: src/basic-syntax/scalar-types.md:10
+#, fuzzy
+msgid "`true`, `false`"
 msgstr ""
-"| | Types | Littéraux |\n"
-"|-----------------------|------------------------ "
-"--------------------|-------------------------------------- --|\n"
-"| Entiers signés | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, "
-"`1_000`, `123i64` |\n"
-"| Entiers non signés | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16` |\n"
-"| Nombres à virgule flottante | `f32`, `f64` | `3.14`, `-10.0e20`, `2f32` |\n"
-"| Cordes | `&str` | `\"foo\"`, `r#\"\\\\\"#` |\n"
-"| Valeurs scalaires Unicode | `car` | `'a'`, `'α'`, `'∞'` |\n"
-"| Chaînes d'octets | `&[u8]` | `b\"abc\"`, `br#\" \" \"#` |\n"
-"| Booléens | `bool` | 'vrai', 'faux' |"
+"`b\"abc\"`, `br#\" \" \"#`\n"
+"\n"
+"Booléens\n"
+"\n"
+"`bool`\n"
+"\n"
+"'vrai', 'faux'"
 
 #: src/basic-syntax/scalar-types.md:12
 #, fuzzy
@@ -3041,16 +2990,23 @@ msgstr "Les types ont des largeurs comme suit :"
 
 #: src/basic-syntax/scalar-types.md:14
 #, fuzzy
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bits wide,\n"
-"* `bool` is 8 bits wide."
-msgstr ""
-"* `iN`, `uN` et `fN` ont une largeur de _N_ bits,\n"
-"* `isize` et `usize` sont la largeur d'un pointeur,\n"
-"* `char` a une largeur de 32 bits,\n"
-"* `bool` a une largeur de 8 bits."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN` et `fN` ont une largeur de _N_ bits,"
+
+#: src/basic-syntax/scalar-types.md:15
+#, fuzzy
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` et `usize` sont la largeur d'un pointeur,"
+
+#: src/basic-syntax/scalar-types.md:16
+#, fuzzy
+msgid "`char` is 32 bits wide,"
+msgstr "`char` a une largeur de 32 bits,"
+
+#: src/basic-syntax/scalar-types.md:17
+#, fuzzy
+msgid "`bool` is 8 bits wide."
+msgstr "`bool` a une largeur de 8 bits."
 
 #: src/basic-syntax/scalar-types.md:21
 msgid "There are a few syntaxes which are not shown above:"
@@ -3058,43 +3014,57 @@ msgstr ""
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
 
-#: src/basic-syntax/compound-types.md:1
-#, fuzzy
-msgid "# Compound Types"
-msgstr "# Types de composés"
-
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:27
 msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:8
@@ -3136,24 +3106,28 @@ msgstr "Tableaux :"
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
-"compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:47
@@ -3163,48 +3137,46 @@ msgstr "Tuples :"
 
 #: src/basic-syntax/compound-types.md:49
 #, fuzzy
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
-msgstr ""
-"* Comme les tableaux, les tuples ont une longueur fixe.\n"
-"\n"
-"* Les tuples regroupent des valeurs de différents types dans un type "
-"composé.\n"
-"\n"
-"* Les champs d'un tuple sont accessibles par le point et l'index de la "
-"valeur, par ex. `t.0`, `t.1`.\n"
-"\n"
-"* Le tuple vide `()` est également appelé \"type d'unité\". C'est à la fois "
-"un type et\n"
-"  la seule valeur valide de ce type - c'est-à-dire à la fois le type et sa "
-"valeur\n"
-"  sont exprimés par `()`. Il est utilisé pour indiquer, par exemple, qu'une "
-"fonction ou\n"
-"  expression n'a pas de valeur de retour, comme nous le verrons dans une "
-"prochaine diapositive.\n"
-"    * Vous pouvez le considérer comme un \"vide\" qui peut vous être "
-"familier d'autres\n"
-"      langages de programmation."
+msgid "Like arrays, tuples have a fixed length."
+msgstr "Comme les tableaux, les tuples ont une longueur fixe."
 
-#: src/basic-syntax/references.md:1
+#: src/basic-syntax/compound-types.md:51
 #, fuzzy
-msgid "# References"
-msgstr "# Les références"
+msgid "Tuples group together values of different types into a compound type."
+msgstr ""
+"Les tuples regroupent des valeurs de différents types dans un type composé."
+
+#: src/basic-syntax/compound-types.md:53
+#, fuzzy
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr ""
+"Les champs d'un tuple sont accessibles par le point et l'index de la valeur, "
+"par ex. `t.0`, `t.1`."
+
+#: src/basic-syntax/compound-types.md:55
+#, fuzzy
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+"Le tuple vide `()` est également appelé \"type d'unité\". C'est à la fois un "
+"type et la seule valeur valide de ce type - c'est-à-dire à la fois le type "
+"et sa valeur sont exprimés par `()`. Il est utilisé pour indiquer, par "
+"exemple, qu'une fonction ou expression n'a pas de valeur de retour, comme "
+"nous le verrons dans une prochaine diapositive."
+
+#: src/basic-syntax/compound-types.md:59
+#, fuzzy
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr ""
+"Vous pouvez le considérer comme un \"vide\" qui peut vous être familier "
+"d'autres langages de programmation."
 
 #: src/basic-syntax/references.md:3
 #, fuzzy
@@ -3231,42 +3203,42 @@ msgstr "Quelques notes:"
 #: src/basic-syntax/references.md:16
 #, fuzzy
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* Nous devons déréférencer `ref_x` lors de son affectation, comme pour les "
-"pointeurs C et C++.\n"
-"* Rust déréférencera automatiquement dans certains cas, en particulier lors "
-"de l'appel\n"
-"  méthodes (essayez `ref_x.count_ones()`).\n"
-"* Les références déclarées comme \"mut\" peuvent être liées à différentes "
+"Nous devons déréférencer `ref_x` lors de son affectation, comme pour les "
+"pointeurs C et C++."
+
+#: src/basic-syntax/references.md:17
+#, fuzzy
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+"Rust déréférencera automatiquement dans certains cas, en particulier lors de "
+"l'appel méthodes (essayez `ref_x.count_ones()`)."
+
+#: src/basic-syntax/references.md:19
+#, fuzzy
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"Les références déclarées comme \"mut\" peuvent être liées à différentes "
 "valeurs au cours de leur durée de vie."
 
 #: src/basic-syntax/references.md:25
 #, fuzzy
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"* Assurez-vous de noter la différence entre `let mut ref_x: &i32` et `let "
-"ref_x:\n"
-"  &mut i32`. Le premier représente une référence mutable qui peut être liée "
-"à\n"
-"  différentes valeurs, tandis que la seconde représente une référence à une "
-"valeur modifiable."
-
-#: src/basic-syntax/references-dangling.md:1
-#, fuzzy
-msgid "# Dangling References"
-msgstr "# Références pendantes"
+"Assurez-vous de noter la différence entre `let mut ref_x: &i32` et `let "
+"ref_x: &mut i32`. Le premier représente une référence mutable qui peut être "
+"liée à différentes valeurs, tandis que la seconde représente une référence à "
+"une valeur modifiable."
 
 #: src/basic-syntax/references-dangling.md:3
 #, fuzzy
@@ -3289,23 +3261,24 @@ msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
 #, fuzzy
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
+msgid "A reference is said to \"borrow\" the value it refers to."
 msgstr ""
-"* Une référence est dite \"emprunter\" la valeur à laquelle elle se réfère.\n"
-"* Rust suit la durée de vie de toutes les références pour s'assurer qu'elles "
-"durent longtemps\n"
-"  assez.\n"
-"* Nous parlerons davantage de l'emprunt lorsque nous arriverons à la "
-"propriété."
+"Une référence est dite \"emprunter\" la valeur à laquelle elle se réfère."
 
-#: src/basic-syntax/slices.md:1
+#: src/basic-syntax/references-dangling.md:17
 #, fuzzy
-msgid "# Slices"
-msgstr "# tranches"
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"Rust suit la durée de vie de toutes les références pour s'assurer qu'elles "
+"durent longtemps assez."
+
+#: src/basic-syntax/references-dangling.md:19
+#, fuzzy
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr ""
+"Nous parlerons davantage de l'emprunt lorsque nous arriverons à la propriété."
 
 #: src/basic-syntax/slices.md:3
 #, fuzzy
@@ -3327,74 +3300,91 @@ msgstr ""
 
 #: src/basic-syntax/slices.md:15
 #, fuzzy
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
+msgid "Slices borrow data from the sliced type."
 msgstr ""
-"* Les tranches empruntent des données au type en tranches.\n"
-"* Question : Que se passe-t-il si vous modifiez `a[3]` ?"
+"Les tranches empruntent des données au type en tranches. \\* Question : Que "
+"se passe-t-il si vous modifiez `a[3]` ?"
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr ""
 
 #: src/basic-syntax/slices.md:20
 #, fuzzy
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
-"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use "
-"`&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
-"(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
 msgstr ""
-"* Nous créons une tranche en empruntant `a` et en spécifiant les index de "
-"début et de fin entre parenthèses.\n"
-"\n"
-"* Si la tranche commence à l'index 0, la syntaxe de plage de Rust nous "
-"permet de supprimer l'index de départ, ce qui signifie que `&a[0..a.len()]` "
-"et `&a[..a.len()]` sont identiques .\n"
-"    \n"
-"* Il en va de même pour le dernier index, donc `&a[2..a.len()]` et `&a[2..]` "
-"sont identiques.\n"
-"\n"
-"* Pour créer facilement une tranche du tableau complet, on peut donc "
-"utiliser `&a[..]`.\n"
-"\n"
-"* `s` est une référence à une tranche de `i32`s. Notez que le type de `s` "
+"Nous créons une tranche en empruntant `a` et en spécifiant les index de "
+"début et de fin entre parenthèses."
+
+#: src/basic-syntax/slices.md:22
+#, fuzzy
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"Si la tranche commence à l'index 0, la syntaxe de plage de Rust nous permet "
+"de supprimer l'index de départ, ce qui signifie que `&a[0..a.len()]` et "
+"`&a[..a.len()]` sont identiques ."
+
+#: src/basic-syntax/slices.md:24
+#, fuzzy
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"Il en va de même pour le dernier index, donc `&a[2..a.len()]` et `&a[2..]` "
+"sont identiques."
+
+#: src/basic-syntax/slices.md:26
+#, fuzzy
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+"Pour créer facilement une tranche du tableau complet, on peut donc utiliser "
+"`&a[..]`."
+
+#: src/basic-syntax/slices.md:28
+#, fuzzy
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+"`s` est une référence à une tranche de `i32`s. Notez que le type de `s` "
 "(`&[i32]`) ne mentionne plus la longueur du tableau. Cela nous permet "
-"d'effectuer des calculs sur des tranches de tailles différentes.\n"
-" \n"
-"* Les tranches empruntent toujours à un autre objet. Dans cet exemple, \"a\" "
+"d'effectuer des calculs sur des tranches de tailles différentes."
+
+#: src/basic-syntax/slices.md:30
+#, fuzzy
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"Les tranches empruntent toujours à un autre objet. Dans cet exemple, \"a\" "
 "doit rester \"vivant\" (dans la portée) au moins aussi longtemps que notre "
-"tranche.\n"
-"    \n"
-"* La question sur la modification de `a[3]` peut susciter une discussion "
+"tranche."
+
+#: src/basic-syntax/slices.md:32
+#, fuzzy
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
+"La question sur la modification de `a[3]` peut susciter une discussion "
 "intéressante, mais la réponse est que pour des raisons de sécurité de la "
-"mémoire\n"
-"  vous ne pouvez pas le faire via `a` après avoir créé une tranche, mais "
-"vous pouvez lire les données de `a` et `s` en toute sécurité.\n"
-"  Plus de détails seront expliqués dans la section Vérificateur d'emprunt."
+"mémoire vous ne pouvez pas le faire via `a` après avoir créé une tranche, "
+"mais vous pouvez lire les données de `a` et `s` en toute sécurité. Plus de "
+"détails seront expliqués dans la section Vérificateur d'emprunt."
 
 #: src/basic-syntax/string-slices.md:1
 #, fuzzy
-msgid "# `String` vs `str`"
-msgstr "# `Chaîne` vs `chaîne`"
+msgid "`String` vs `str`"
+msgstr "`Chaîne` vs `chaîne`"
 
 #: src/basic-syntax/string-slices.md:3
 #, fuzzy
@@ -3427,48 +3417,53 @@ msgstr "Terminologie de la rouille :"
 
 #: src/basic-syntax/string-slices.md:22
 #, fuzzy
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* `&str` une référence immuable à une tranche de chaîne.\n"
-"* `String` un tampon de chaîne mutable."
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str` une référence immuable à une tranche de chaîne."
+
+#: src/basic-syntax/string-slices.md:23
+#, fuzzy
+msgid "`String` a mutable string buffer."
+msgstr "`String` un tampon de chaîne mutable."
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::"
-"string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
 
-#: src/basic-syntax/functions.md:1
-#, fuzzy
-msgid "# Functions"
-msgstr "# Les fonctions"
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
 
 #: src/basic-syntax/functions.md:3
 #, fuzzy
@@ -3512,22 +3507,33 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
-"`=n`, which causes it to include the upper bound."
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:1
-#, fuzzy
-msgid "# Rustdoc"
-msgstr "# Rustdoc"
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"`=n`, which causes it to include the upper bound."
+msgstr ""
 
 #: src/basic-syntax/rustdoc.md:3
 #, fuzzy
@@ -3557,60 +3563,53 @@ msgstr ""
 #: src/basic-syntax/rustdoc.md:17
 #, fuzzy
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
 "Le contenu est traité comme Markdown. Toutes les caisses de bibliothèque "
-"Rust publiées sont\n"
-"automatiquement documenté sur [`docs.rs`](https://docs.rs) en utilisant le\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html). C'est\n"
-"idiomatic pour documenter tous les éléments publics dans une API utilisant "
-"ce modèle."
+"Rust publiées sont automatiquement documenté sur [`docs.rs`](https://docs."
+"rs) en utilisant le [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-"
+"rustdoc.html). C'est idiomatic pour documenter tous les éléments publics "
+"dans une API utilisant ce modèle."
 
 #: src/basic-syntax/rustdoc.md:24
 #, fuzzy
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
-"* Montrez aux élèves les documents générés pour la caisse \"rand\" sur\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* Ce cours n'inclut pas rustdoc sur les diapositives, juste pour économiser "
-"de l'espace, mais dans\n"
-"  code réel, ils doivent être présents.\n"
-"\n"
-"* Les commentaires de la documentation interne sont discutés plus tard (dans "
-"la page sur les modules) et n'ont pas besoin\n"
-"  être abordé ici."
+"Montrez aux élèves les documents générés pour la caisse \"rand\" sur [`docs."
+"rs/rand`](https://docs.rs/rand)."
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
+#: src/basic-syntax/rustdoc.md:27
 #, fuzzy
-msgid "# Methods"
-msgstr "# Méthodes"
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+"Ce cours n'inclut pas rustdoc sur les diapositives, juste pour économiser de "
+"l'espace, mais dans code réel, ils doivent être présents."
+
+#: src/basic-syntax/rustdoc.md:30
+#, fuzzy
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr ""
+"Les commentaires de la documentation interne sont discutés plus tard (dans "
+"la page sur les modules) et n'ont pas besoin être abordé ici."
 
 #: src/basic-syntax/methods.md:3
 #, fuzzy
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
-"method is\n"
-"an instance of the type it is associated with:"
+"method is an instance of the type it is associated with:"
 msgstr ""
 "Rust a des méthodes, ce sont simplement des fonctions qui sont associées à "
-"un type particulier. Le\n"
-"le premier argument d'une méthode est une instance du type auquel elle est "
-"associée :"
+"un type particulier. Le le premier argument d'une méthode est une instance "
+"du type auquel elle est associée :"
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3642,30 +3641,35 @@ msgstr ""
 #: src/basic-syntax/methods.md:30
 #, fuzzy
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
-"* Nous nous pencherons beaucoup plus sur les méthodes dans l'exercice "
+"Nous nous pencherons beaucoup plus sur les méthodes dans l'exercice "
 "d'aujourd'hui et dans le cours de demain."
 
 #: src/basic-syntax/methods.md:34
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
+msgstr ""
+
+#: src/basic-syntax/methods.md:36
 msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
 msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:1
 #, fuzzy
-msgid "# Function Overloading"
-msgstr "# Surcharge de fonction"
+msgid "Function Overloading"
+msgstr "Surcharge de fonction"
 
 #: src/basic-syntax/functions-interlude.md:3
 #, fuzzy
@@ -3674,20 +3678,33 @@ msgstr "La surcharge n'est pas prise en charge :"
 
 #: src/basic-syntax/functions-interlude.md:5
 #, fuzzy
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* Chaque fonction a une seule implémentation :\n"
-"  * Prend toujours un nombre fixe de paramètres.\n"
-"  * Prend toujours un seul ensemble de types de paramètres.\n"
-"* Les valeurs par défaut ne sont pas prises en charge :\n"
-"  * Tous les sites d'appel ont le même nombre d'arguments.\n"
-"  * Les macros sont parfois utilisées comme alternative."
+msgid "Each function has a single implementation:"
+msgstr "Chaque fonction a une seule implémentation :"
+
+#: src/basic-syntax/functions-interlude.md:6
+#, fuzzy
+msgid "Always takes a fixed number of parameters."
+msgstr "Prend toujours un nombre fixe de paramètres."
+
+#: src/basic-syntax/functions-interlude.md:7
+#, fuzzy
+msgid "Always takes a single set of parameter types."
+msgstr "Prend toujours un seul ensemble de types de paramètres."
+
+#: src/basic-syntax/functions-interlude.md:8
+#, fuzzy
+msgid "Default values are not supported:"
+msgstr "Les valeurs par défaut ne sont pas prises en charge :"
+
+#: src/basic-syntax/functions-interlude.md:9
+#, fuzzy
+msgid "All call sites have the same number of arguments."
+msgstr "Tous les sites d'appel ont le même nombre d'arguments."
+
+#: src/basic-syntax/functions-interlude.md:10
+#, fuzzy
+msgid "Macros are sometimes used as an alternative."
+msgstr "Les macros sont parfois utilisées comme alternative."
 
 #: src/basic-syntax/functions-interlude.md:12
 #, fuzzy
@@ -3711,20 +3728,18 @@ msgstr ""
 #: src/basic-syntax/functions-interlude.md:27
 #, fuzzy
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
-"* Lors de l'utilisation de génériques, la bibliothèque standard `Into<T>` "
-"peut fournir une sorte de\n"
-"  polymorphisme sur les types d'arguments. Nous verrons plus de détails dans "
-"une section ultérieure."
+"Lors de l'utilisation de génériques, la bibliothèque standard `Into<T>` peut "
+"fournir une sorte de polymorphisme sur les types d'arguments. Nous verrons "
+"plus de détails dans une section ultérieure."
 
 #: src/exercises/day-1/morning.md:1
 #, fuzzy
-msgid "# Day 1: Morning Exercises"
-msgstr "# Jour 1 : Exercices du matin"
+msgid "Day 1: Morning Exercises"
+msgstr "Jour 1 : Exercices du matin"
 
 #: src/exercises/day-1/morning.md:3
 #, fuzzy
@@ -3733,14 +3748,13 @@ msgstr "Dans ces exercices, nous allons explorer deux parties de Rust :"
 
 #: src/exercises/day-1/morning.md:5
 #, fuzzy
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
-msgstr ""
-"* Conversions implicites entre les types.\n"
-"\n"
-"* Tableaux et boucles \"for\"."
+msgid "Implicit conversions between types."
+msgstr "Conversions implicites entre les types."
+
+#: src/exercises/day-1/morning.md:7
+#, fuzzy
+msgid "Arrays and `for` loops."
+msgstr "Tableaux et boucles \"for\"."
 
 #: src/exercises/day-1/morning.md:11
 #, fuzzy
@@ -3750,31 +3764,27 @@ msgstr "Quelques points à considérer lors de la résolution des exercices :"
 #: src/exercises/day-1/morning.md:13
 #, fuzzy
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* Utilisez une installation Rust locale, si possible. De cette façon, vous "
-"pouvez obtenir\n"
-"  auto-complétion dans votre éditeur. Voir la page sur [Utiliser Cargo] pour "
-"plus de détails\n"
-"  lors de l'installation de Rust.\n"
-"\n"
-"* Vous pouvez également utiliser le Rust Playground."
+"Utilisez une installation Rust locale, si possible. De cette façon, vous "
+"pouvez obtenir auto-complétion dans votre éditeur. Voir la page sur "
+"\\[Utiliser Cargo\\] pour plus de détails lors de l'installation de Rust."
+
+#: src/exercises/day-1/morning.md:17
+#, fuzzy
+msgid "Alternatively, use the Rust Playground."
+msgstr "Vous pouvez également utiliser le Rust Playground."
 
 #: src/exercises/day-1/morning.md:19
 #, fuzzy
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
 "Les extraits de code ne sont pas modifiables à dessein : les extraits de "
-"code en ligne perdent\n"
-"leur état si vous quittez la page."
+"code en ligne perdent leur état si vous quittez la page."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
@@ -3784,26 +3794,21 @@ msgstr ""
 #: src/exercises/concurrency/afternoon.md:13
 #, fuzzy
 msgid ""
-"After looking at the exercises, you can look at the [solutions] provided."
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
 msgstr ""
-"Après avoir regardé les exercices, vous pouvez regarder les [solutions] "
+"Après avoir regardé les exercices, vous pouvez regarder les \\[solutions\\] "
 "fournies."
-
-#: src/exercises/day-1/implicit-conversions.md:1
-#, fuzzy
-msgid "# Implicit Conversions"
-msgstr "# Conversions implicites"
 
 #: src/exercises/day-1/implicit-conversions.md:3
 #, fuzzy
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
 "Rust n'appliquera pas automatiquement les _conversions implicites_ entre les "
-"types ([contrairement à\n"
-"C++][3]). Vous pouvez le voir dans un programme comme celui-ci :"
+"types ([contrairement à C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). Vous pouvez le voir dans un programme comme celui-ci :"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
@@ -3824,84 +3829,79 @@ msgstr ""
 #: src/exercises/day-1/implicit-conversions.md:19
 #, fuzzy
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Les types entiers Rust implémentent tous les [`From<T>`][1] et [`Into<T>`]"
-"[2]\n"
-"traits pour nous permettre de convertir entre eux. Le trait `From<T>` a un "
-"seul `from()`\n"
-"et de même, le trait `Into<T>` a une seule méthode `into()`.\n"
-"La mise en œuvre de ces traits est la façon dont un type exprime qu'il peut "
-"être converti en\n"
-"un autre type."
+"Les types entiers Rust implémentent tous les [`From<T>`](https://doc.rust-"
+"lang.org/std/convert/trait.From.html) et [`Into<T>`](https://doc.rust-lang."
+"org/std/convert/trait.Into.html) traits pour nous permettre de convertir "
+"entre eux. Le trait `From<T>` a un seul `from()` et de même, le trait "
+"`Into<T>` a une seule méthode `into()`. La mise en œuvre de ces traits est "
+"la façon dont un type exprime qu'il peut être converti en un autre type."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 #, fuzzy
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
 "La bibliothèque standard a une implémentation de `From<i8> for i16`, ce qui "
-"signifie\n"
-"que nous pouvons convertir une variable `x` de type `i8` en un `i16` en "
-"appelant\n"
-"`i16::from(x)`. Ou, plus simple, avec `x.into()`, car `From<i8> for i16`\n"
-"créer automatiquement une implémentation de `Into<i16> for i8`."
+"signifie que nous pouvons convertir une variable `x` de type `i8` en un "
+"`i16` en appelant `i16::from(x)`. Ou, plus simple, avec `x.into()`, car "
+"`From<i8> for i16` créer automatiquement une implémentation de `Into<i16> "
+"for i8`."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 #, fuzzy
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
 "Il en va de même pour vos propres implémentations `From` pour vos propres "
-"types, il est donc\n"
-"suffisant pour implémenter uniquement `From` pour obtenir automatiquement "
-"une implémentation `Into` respective."
+"types, il est donc suffisant pour implémenter uniquement `From` pour obtenir "
+"automatiquement une implémentation `Into` respective."
 
 #: src/exercises/day-1/implicit-conversions.md:33
 #, fuzzy
-msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+msgid "Execute the above program and look at the compiler error."
+msgstr "Exécutez le programme ci-dessus et examinez l'erreur du compilateur."
+
+#: src/exercises/day-1/implicit-conversions.md:35
+#, fuzzy
+msgid "Update the code above to use `into()` to do the conversion."
 msgstr ""
-"1. Exécutez le programme ci-dessus et examinez l'erreur du compilateur.\n"
-"\n"
-"2. Mettez à jour le code ci-dessus pour utiliser `into()` pour effectuer la "
-"conversion.\n"
-"\n"
-"3. Remplacez les types de `x` et `y` par d'autres éléments (tels que `f32`, "
-"`bool`,\n"
-"   `i128`) pour voir quels types vous pouvez convertir vers quels autres "
-"types. Essayer\n"
-"   convertir de petits types en grands types et inversement. Vérifier la\n"
-"   [documentation de la bibliothèque standard][1] pour voir si `From<T>` est "
-"implémenté pour\n"
-"   les paires que vous cochez."
+"Mettez à jour le code ci-dessus pour utiliser `into()` pour effectuer la "
+"conversion."
+
+#: src/exercises/day-1/implicit-conversions.md:37
+#, fuzzy
+msgid ""
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
+msgstr ""
+"Remplacez les types de `x` et `y` par d'autres éléments (tels que `f32`, "
+"`bool`, `i128`) pour voir quels types vous pouvez convertir vers quels "
+"autres types. Essayer convertir de petits types en grands types et "
+"inversement. Vérifier la [documentation de la bibliothèque standard](https://"
+"doc.rust-lang.org/std/convert/trait.From.html) pour voir si `From<T>` est "
+"implémenté pour les paires que vous cochez."
 
 #: src/exercises/day-1/for-loops.md:1
+#: src/exercises/day-1/solutions-morning.md:3
 #, fuzzy
-msgid "# Arrays and `for` Loops"
-msgstr "# Tableaux et boucles `for`"
+msgid "Arrays and `for` Loops"
+msgstr "Tableaux et boucles `for`"
 
 #: src/exercises/day-1/for-loops.md:3
 #, fuzzy
@@ -3937,12 +3937,11 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:18
 #, fuzzy
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr ""
 "Rust vous permet d'itérer sur des choses comme des tableaux et des plages en "
-"utilisant le `for`\n"
-"mot-clé:"
+"utilisant le `for` mot-clé:"
 
 #: src/exercises/day-1/for-loops.md:21
 msgid ""
@@ -3968,14 +3967,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
 "Utilisez ce qui précède pour écrire une fonction `pretty_print` qui imprime "
-"joliment une matrice et\n"
-"une fonction `transpose` qui va transposer une matrice (transformer les "
-"lignes en colonnes):"
+"joliment une matrice et une fonction `transpose` qui va transposer une "
+"matrice (transformer les lignes en colonnes):"
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3996,12 +3993,11 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:49
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
 "Copiez le code ci-dessous sur <https://play.rust-lang.org/> et implémentez "
-"le\n"
-"les fonctions:"
+"le les fonctions:"
 
 #: src/exercises/day-1/for-loops.md:52
 msgid ""
@@ -4036,57 +4032,47 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:80
 #, fuzzy
-msgid "## Bonus Question"
-msgstr "## Question bonus"
+msgid "Bonus Question"
+msgstr "Question bonus"
 
 #: src/exercises/day-1/for-loops.md:82
 #, fuzzy
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
 "Pourriez-vous utiliser des tranches `&[i32]` au lieu de matrices 3 × 3 "
-"codées en dur pour votre\n"
-"types d'argument et de retour ? Quelque chose comme `&[&[i32]]` pour un "
-"fichier bidimensionnel\n"
-"tranche de tranches. Pourquoi ou pourquoi pas?"
+"codées en dur pour votre types d'argument et de retour ? Quelque chose comme "
+"`&[&[i32]]` pour un fichier bidimensionnel tranche de tranches. Pourquoi ou "
+"pourquoi pas?"
 
 #: src/exercises/day-1/for-loops.md:87
 #, fuzzy
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
 "Voir le [`ndarray` crate](https://docs.rs/ndarray/) pour une qualité de "
-"production\n"
-"mise en œuvre."
+"production mise en œuvre."
 
 #: src/exercises/day-1/for-loops.md:92
 #, fuzzy
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"La solution et la réponse à la section bonus sont disponibles dans le\n"
+"La solution et la réponse à la section bonus sont disponibles dans le "
 "Section [Solution](solutions-morning.md#arrays-and-for-loops)."
-
-#: src/basic-syntax/variables.md:1
-#, fuzzy
-msgid "# Variables"
-msgstr "#Variable"
 
 #: src/basic-syntax/variables.md:3
 #, fuzzy
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
+"by default:"
 msgstr ""
 "Rust fournit une sécurité de type via le typage statique. Les liaisons "
-"variables sont immuables par\n"
-"défaut:"
+"variables sont immuables par défaut:"
 
 #: src/basic-syntax/variables.md:6
 msgid ""
@@ -4103,21 +4089,21 @@ msgstr ""
 #: src/basic-syntax/variables.md:17
 #, fuzzy
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
+msgstr ""
+"En raison de l'inférence de type, le `i32` est facultatif. Nous montrerons "
+"progressivement les types de moins en moins au fur et à mesure que le cours "
+"avance."
+
+#: src/basic-syntax/variables.md:18
+#, fuzzy
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
 "function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
-"* En raison de l'inférence de type, le `i32` est facultatif. Nous montrerons "
-"progressivement les types de moins en moins au fur et à mesure que le cours "
-"avance.\n"
-"* Notez que puisque `println!` est une macro, `x` n'est pas déplacé, même en "
+"Notez que puisque `println!` est une macro, `x` n'est pas déplacé, même en "
 "utilisant la fonction comme syntaxe de `println!(\"x: {}\", x)`"
-
-#: src/basic-syntax/type-inference.md:1
-#, fuzzy
-msgid "# Type Inference"
-msgstr "# Inférence de type"
 
 #: src/basic-syntax/type-inference.md:3
 #, fuzzy
@@ -4161,17 +4147,16 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 "Il est très important de souligner que les variables déclarées de cette "
-"manière ne sont pas d'une sorte de \"tout type\" dynamique qui peut\n"
-"détenir des données. Le code machine généré par une telle déclaration est "
-"identique à la déclaration explicite d'un type.\n"
-"Le compilateur fait le travail pour nous et nous aide à écrire un code plus "
-"concis."
+"manière ne sont pas d'une sorte de \"tout type\" dynamique qui peut détenir "
+"des données. Le code machine généré par une telle déclaration est identique "
+"à la déclaration explicite d'un type. Le compilateur fait le travail pour "
+"nous et nous aide à écrire un code plus concis."
 
 #: src/basic-syntax/type-inference.md:32
 #, fuzzy
@@ -4207,13 +4192,13 @@ msgid ""
 "rust-lang.org/std/iter/trait.FromIterator.html) implements."
 msgstr ""
 "[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
-"html#method.collect) repose sur `FromIterator`, qui [`HashSet`](https:/ /doc."
-"rust-lang.org/std/iter/trait.FromIterator.html) implémente."
+"html#method.collect) repose sur `FromIterator`, qui \\[`HashSet`\\](https:/ /"
+"doc.rust-lang.org/std/iter/trait.FromIterator.html) implémente."
 
 #: src/basic-syntax/static-and-const.md:1
 #, fuzzy
-msgid "# Static and Constant Variables"
-msgstr "# Variables statiques et constantes"
+msgid "Static and Constant Variables"
+msgstr "Variables statiques et constantes"
 
 #: src/basic-syntax/static-and-const.md:3
 #, fuzzy
@@ -4222,8 +4207,8 @@ msgstr "L'état global est géré avec des variables statiques et constantes."
 
 #: src/basic-syntax/static-and-const.md:5
 #, fuzzy
-msgid "## `const`"
-msgstr "## `const`"
+msgid "`const`"
+msgstr "`const`"
 
 #: src/basic-syntax/static-and-const.md:7
 #, fuzzy
@@ -4254,14 +4239,17 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:27
 #, fuzzy
-msgid "According to the [Rust RFC Book][1] these are inlined upon use."
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
 msgstr ""
-"Selon le [Rust RFC Book] [1], ceux-ci sont intégrés lors de l'utilisation."
+"Selon le \\[Rust RFC Book\\] [1](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), ceux-ci sont intégrés lors de l'utilisation."
 
 #: src/basic-syntax/static-and-const.md:29
 #, fuzzy
-msgid "## `static`"
-msgstr "## `statique`"
+msgid "`static`"
+msgstr "`statique`"
 
 #: src/basic-syntax/static-and-const.md:31
 #, fuzzy
@@ -4282,15 +4270,16 @@ msgstr ""
 #: src/basic-syntax/static-and-const.md:41
 #, fuzzy
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
-"Comme indiqué dans le [Rust RFC Book] [1], ceux-ci ne sont pas alignés lors "
-"de l'utilisation et ont un emplacement de mémoire associé réel. Ceci est "
-"utile pour le code non sécurisé et intégré, et la variable vit tout au long "
-"de l'exécution du programme."
+"Comme indiqué dans le \\[Rust RFC Book\\] [1](https://rust-lang.github.io/"
+"rfcs/0246-const-vs-static.html), ceux-ci ne sont pas alignés lors de "
+"l'utilisation et ont un emplacement de mémoire associé réel. Ceci est utile "
+"pour le code non sécurisé et intégré, et la variable vit tout au long de "
+"l'exécution du programme."
 
 #: src/basic-syntax/static-and-const.md:44
 #, fuzzy
@@ -4303,35 +4292,37 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:48
 #, fuzzy
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
-"* Mentionnez que `const` se comporte sémantiquement de la même manière que "
-"`constexpr` de C++.\n"
-"* `static`, d'autre part, ressemble beaucoup plus à une variable globale "
-"`const` ou mutable en C++.\n"
-"* Il n'est pas très courant d'avoir besoin d'une constante évaluée à "
-"l'exécution, mais c'est utile et plus sûr que d'utiliser un statique."
+"Mentionnez que `const` se comporte sémantiquement de la même manière que "
+"`constexpr` de C++."
 
-#: src/basic-syntax/scopes-shadowing.md:1
+#: src/basic-syntax/static-and-const.md:49
 #, fuzzy
-msgid "# Scopes and Shadowing"
-msgstr "# Portées et ombrage"
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+"`static`, d'autre part, ressemble beaucoup plus à une variable globale "
+"`const` ou mutable en C++."
+
+#: src/basic-syntax/static-and-const.md:50
+#, fuzzy
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+"Il n'est pas très courant d'avoir besoin d'une constante évaluée à "
+"l'exécution, mais c'est utile et plus sûr que d'utiliser un statique."
 
 #: src/basic-syntax/scopes-shadowing.md:3
 #, fuzzy
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
+"the same scope:"
 msgstr ""
 "Vous pouvez masquer des variables, à la fois celles des portées externes et "
-"celles des\n"
-"même périmètre :"
+"celles des même périmètre :"
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
@@ -4356,24 +4347,37 @@ msgstr ""
 #: src/basic-syntax/scopes-shadowing.md:25
 #, fuzzy
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"Définition : l'occultation est différente de la mutation, car après "
+"l'occultation, les emplacements de mémoire des deux variables existent en "
+"même temps. Les deux sont disponibles sous le même nom, selon l'endroit où "
+"vous l'utilisez dans le code."
+
+#: src/basic-syntax/scopes-shadowing.md:26
+#, fuzzy
+msgid "A shadowing variable can have a different type. "
+msgstr "Une variable d'occultation peut avoir un type différent."
+
+#: src/basic-syntax/scopes-shadowing.md:27
+#, fuzzy
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+"L'ombrage semble obscur au début, mais est pratique pour conserver les "
+"valeurs après `.unwrap()`."
+
+#: src/basic-syntax/scopes-shadowing.md:28
+#, fuzzy
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
-"* Définition : l'occultation est différente de la mutation, car après "
-"l'occultation, les emplacements de mémoire des deux variables existent en "
-"même temps. Les deux sont disponibles sous le même nom, selon l'endroit où "
-"vous l'utilisez dans le code.\n"
-"* Une variable d'occultation peut avoir un type différent.\n"
-"* L'ombrage semble obscur au début, mais est pratique pour conserver les "
-"valeurs après `.unwrap()`.\n"
-"* Le code suivant montre pourquoi le compilateur ne peut pas simplement "
+"Le code suivant montre pourquoi le compilateur ne peut pas simplement "
 "réutiliser les emplacements de mémoire lors de l'observation d'une variable "
 "immuable dans une portée, même si le type ne change pas."
 
@@ -4389,11 +4393,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-#, fuzzy
-msgid "# Memory Management"
-msgstr "# Gestion de la mémoire"
-
 #: src/memory-management.md:3
 #, fuzzy
 msgid "Traditionally, languages have fallen into two broad categories:"
@@ -4402,14 +4401,17 @@ msgstr ""
 
 #: src/memory-management.md:5
 #, fuzzy
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr ""
+"Contrôle total via la gestion manuelle de la mémoire : C, C++, Pascal, ..."
+
+#: src/memory-management.md:6
+#, fuzzy
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
-"* Contrôle total via la gestion manuelle de la mémoire : C, C++, "
-"Pascal, ...\n"
-"* Sécurité totale via la gestion automatique de la mémoire à l'exécution : "
+"Sécurité totale via la gestion automatique de la mémoire à l'exécution : "
 "Java, Python, Go, Haskell, ..."
 
 #: src/memory-management.md:8
@@ -4420,12 +4422,11 @@ msgstr "Rust propose un nouveau mix :"
 #: src/memory-management.md:10
 #, fuzzy
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
-"> Contrôle total * et * sécurité via l'application du temps de compilation "
-"de la mémoire correcte\n"
-"> gestion."
+"Contrôle total * et * sécurité via l'application du temps de compilation de "
+"la mémoire correcte gestion."
 
 #: src/memory-management.md:13
 #, fuzzy
@@ -4440,51 +4441,64 @@ msgstr ""
 
 #: src/memory-management/stack-vs-heap.md:1
 #, fuzzy
-msgid "# The Stack vs The Heap"
-msgstr "# La pile contre le tas"
+msgid "The Stack vs The Heap"
+msgstr "La pile contre le tas"
 
 #: src/memory-management/stack-vs-heap.md:3
 #, fuzzy
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* Pile : Zone continue de mémoire pour les variables locales.\n"
-"  * Les valeurs ont des tailles fixes connues au moment de la compilation.\n"
-"  * Extrêmement rapide : il suffit de déplacer un pointeur de pile.\n"
-"  * Facile à gérer : suit les appels de fonction.\n"
-"  * Grande localité de mémoire.\n"
-"\n"
-"* Heap : Stockage de valeurs en dehors des appels de fonction.\n"
-"  * Les valeurs ont des tailles dynamiques déterminées au moment de "
-"l'exécution.\n"
-"  * Légèrement plus lent que la pile : une certaine comptabilité est "
-"nécessaire.\n"
-"  * Aucune garantie de localisation de la mémoire."
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "Pile : Zone continue de mémoire pour les variables locales."
 
-#: src/memory-management/stack.md:1
+#: src/memory-management/stack-vs-heap.md:4
 #, fuzzy
-msgid "# Stack Memory"
-msgstr "# Mémoire de pile"
+msgid "Values have fixed sizes known at compile time."
+msgstr "Les valeurs ont des tailles fixes connues au moment de la compilation."
+
+#: src/memory-management/stack-vs-heap.md:5
+#, fuzzy
+msgid "Extremely fast: just move a stack pointer."
+msgstr "Extrêmement rapide : il suffit de déplacer un pointeur de pile."
+
+#: src/memory-management/stack-vs-heap.md:6
+#, fuzzy
+msgid "Easy to manage: follows function calls."
+msgstr "Facile à gérer : suit les appels de fonction."
+
+#: src/memory-management/stack-vs-heap.md:7
+#, fuzzy
+msgid "Great memory locality."
+msgstr "Grande localité de mémoire."
+
+#: src/memory-management/stack-vs-heap.md:9
+#, fuzzy
+msgid "Heap: Storage of values outside of function calls."
+msgstr "Heap : Stockage de valeurs en dehors des appels de fonction."
+
+#: src/memory-management/stack-vs-heap.md:10
+#, fuzzy
+msgid "Values have dynamic sizes determined at runtime."
+msgstr ""
+"Les valeurs ont des tailles dynamiques déterminées au moment de l'exécution."
+
+#: src/memory-management/stack-vs-heap.md:11
+#, fuzzy
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr ""
+"Légèrement plus lent que la pile : une certaine comptabilité est nécessaire."
+
+#: src/memory-management/stack-vs-heap.md:12
+#, fuzzy
+msgid "No guarantee of memory locality."
+msgstr "Aucune garantie de localisation de la mémoire."
 
 #: src/memory-management/stack.md:3
 #, fuzzy
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 "La création d'une \"chaîne\" place des données de taille fixe sur la pile et "
-"dimensionnées dynamiquement\n"
-"données sur le tas :"
+"dimensionnées dynamiquement données sur le tas :"
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -4514,39 +4528,43 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/manual.md:1
-#, fuzzy
-msgid "# Manual Memory Management"
-msgstr "# Gestion manuelle de la mémoire"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/memory-management/manual.md:3
 #, fuzzy
@@ -4564,8 +4582,8 @@ msgstr ""
 
 #: src/memory-management/manual.md:7
 #, fuzzy
-msgid "## C Example"
-msgstr "## C Exemple"
+msgid "C Example"
+msgstr "C Exemple"
 
 #: src/memory-management/manual.md:9
 #, fuzzy
@@ -4591,17 +4609,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
 "La mémoire est perdue si la fonction revient tôt entre `malloc` et `free` : "
-"le\n"
-"pointeur est perdu et nous ne pouvons pas désallouer la mémoire."
-
-#: src/memory-management/scope-based.md:1
-#, fuzzy
-msgid "# Scope-Based Memory Management"
-msgstr "# Gestion de la mémoire basée sur la portée"
+"le pointeur est perdu et nous ne pouvons pas désallouer la mémoire."
 
 #: src/memory-management/scope-based.md:3
 #, fuzzy
@@ -4614,32 +4625,27 @@ msgstr ""
 #: src/memory-management/scope-based.md:5
 #, fuzzy
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
 "En enveloppant un pointeur dans un objet, vous pouvez libérer de la mémoire "
-"lorsque l'objet est\n"
-"détruit. Le compilateur garantit que cela se produit, même si une exception "
-"est\n"
-"soulevé."
+"lorsque l'objet est détruit. Le compilateur garantit que cela se produit, "
+"même si une exception est soulevé."
 
 #: src/memory-management/scope-based.md:9
 #, fuzzy
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr ""
 "Ceci est souvent appelé _l'acquisition de ressources est initialisée_ (RAII) "
-"et donne\n"
-"vous pointeurs intelligents."
+"et donne vous pointeurs intelligents."
 
 #: src/memory-management/scope-based.md:12
 #, fuzzy
-msgid "## C++ Example"
-msgstr "## Exemple C++"
+msgid "C++ Example"
+msgstr "Exemple C++"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -4653,15 +4659,21 @@ msgstr ""
 #: src/memory-management/scope-based.md:20
 #, fuzzy
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
 msgstr ""
-"* L'objet `std::unique_ptr` est alloué sur la pile et pointe vers\n"
-"  mémoire allouée sur le tas.\n"
-"* À la fin de `say_hello`, le destructeur `std::unique_ptr` s'exécutera.\n"
-"* Le destructeur libère l'objet `Person` vers lequel il pointe."
+"L'objet `std::unique_ptr` est alloué sur la pile et pointe vers mémoire "
+"allouée sur le tas."
+
+#: src/memory-management/scope-based.md:22
+#, fuzzy
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr "À la fin de `say_hello`, le destructeur `std::unique_ptr` s'exécutera."
+
+#: src/memory-management/scope-based.md:23
+#, fuzzy
+msgid "The destructor frees the `Person` object it points to."
+msgstr "Le destructeur libère l'objet `Person` vers lequel il pointe."
 
 #: src/memory-management/scope-based.md:25
 #, fuzzy
@@ -4681,35 +4693,36 @@ msgstr ""
 
 #: src/memory-management/garbage-collection.md:1
 #, fuzzy
-msgid "# Automatic Memory Management"
-msgstr "# Gestion automatique de la mémoire"
+msgid "Automatic Memory Management"
+msgstr "Gestion automatique de la mémoire"
 
 #: src/memory-management/garbage-collection.md:3
 #, fuzzy
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
+"memory management:"
 msgstr ""
 "Une alternative à la gestion manuelle et basée sur la portée de la mémoire "
-"est la mémoire automatique\n"
-"gestion:"
+"est la mémoire automatique gestion:"
 
 #: src/memory-management/garbage-collection.md:6
 #, fuzzy
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "Le programmeur n'alloue ou ne libère jamais de mémoire explicitement."
+
+#: src/memory-management/garbage-collection.md:7
+#, fuzzy
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
 msgstr ""
-"* Le programmeur n'alloue ou ne libère jamais de mémoire explicitement.\n"
-"* Un ramasse-miettes trouve la mémoire inutilisée et la libère pour le "
+"Un ramasse-miettes trouve la mémoire inutilisée et la libère pour le "
 "programmeur."
 
 #: src/memory-management/garbage-collection.md:9
 #, fuzzy
-msgid "## Java Example"
-msgstr "## Exemple Java"
+msgid "Java Example"
+msgstr "Exemple Java"
 
 #: src/memory-management/garbage-collection.md:11
 #, fuzzy
@@ -4727,8 +4740,8 @@ msgstr ""
 
 #: src/memory-management/rust.md:1
 #, fuzzy
-msgid "# Memory Management in Rust"
-msgstr "# Gestion de la mémoire avec Rust"
+msgid "Memory Management in Rust"
+msgstr "Gestion de la mémoire avec Rust"
 
 #: src/memory-management/rust.md:3
 #, fuzzy
@@ -4737,23 +4750,35 @@ msgstr "La gestion de la mémoire avec Rust est un mélange :"
 
 #: src/memory-management/rust.md:5
 #, fuzzy
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "Sûr et correct comme Java, mais sans ramasse-miettes."
+
+#: src/memory-management/rust.md:6
+#, fuzzy
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+"Selon l'abstraction (ou la combinaison d'abstractions) que vous choisissez, "
+"il peut s'agir d'un seul pointeur unique, d'une référence comptée ou d'une "
+"référence atomique comptée."
+
+#: src/memory-management/rust.md:7
+#, fuzzy
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+"Basé sur la portée comme C++, mais le compilateur applique une adhésion "
+"totale."
+
+#: src/memory-management/rust.md:8
+#, fuzzy
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
-"* Sûr et correct comme Java, mais sans ramasse-miettes.\n"
-"* Selon l'abstraction (ou la combinaison d'abstractions) que vous "
-"choisissez, il peut s'agir d'un seul pointeur unique, d'une référence "
-"comptée ou d'une référence atomique comptée.\n"
-"* Basé sur la portée comme C++, mais le compilateur applique une adhésion "
-"totale.\n"
-"* Un utilisateur de Rust peut choisir la bonne abstraction pour la "
-"situation, certains n'ont même aucun coût à l'exécution comme C."
+"Un utilisateur de Rust peut choisir la bonne abstraction pour la situation, "
+"certains n'ont même aucun coût à l'exécution comme C."
 
 #: src/memory-management/rust.md:10
 #, fuzzy
@@ -4763,27 +4788,30 @@ msgstr "Il y parvient en modélisant explicitement _ownership_."
 #: src/memory-management/rust.md:14
 #, fuzzy
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* Si on vous demande comment à ce stade, vous pouvez mentionner qu'avec "
-"Rust, cela est généralement géré par des types de wrapper RAII tels que "
-"[Box], [Vec], [Rc] ou [Arc]. Ceux-ci encapsulent la propriété et "
-"l'allocation de mémoire par divers moyens et empêchent les erreurs "
-"potentielles dans C.\n"
-"\n"
-"* Vous pouvez être interrogé sur les destructeurs ici, le trait [Drop] est "
-"l'équivalent de Rust."
+"Si on vous demande comment à ce stade, vous pouvez mentionner qu'avec Rust, "
+"cela est généralement géré par des types de wrapper RAII tels que [Box]"
+"(https://doc.rust-lang.org/std/boxed/struct.Box.html), [Vec](https://doc."
+"rust-lang.org/std/vec/struct.Vec.html), [Rc](https://doc.rust-lang.org/std/"
+"rc/struct.Rc.html) ou [Arc](https://doc.rust-lang.org/std/sync/struct.Arc."
+"html). Ceux-ci encapsulent la propriété et l'allocation de mémoire par "
+"divers moyens et empêchent les erreurs potentielles dans C."
 
-#: src/memory-management/comparison.md:1
+#: src/memory-management/rust.md:16
 #, fuzzy
-msgid "# Comparison"
-msgstr "# Comparaison"
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
+msgstr ""
+"Vous pouvez être interrogé sur les destructeurs ici, le trait [Drop](https://"
+"doc.rust-lang.org/std/ops/trait.Drop.html) est l'équivalent de Rust."
 
 #: src/memory-management/comparison.md:3
 #, fuzzy
@@ -4793,89 +4821,120 @@ msgstr ""
 
 #: src/memory-management/comparison.md:5
 #, fuzzy
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## Avantages des différentes techniques de gestion de la mémoire"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "Avantages des différentes techniques de gestion de la mémoire"
 
-#: src/memory-management/comparison.md:7
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* Manuel comme C :\n"
-"  * Aucune surcharge d'exécution.\n"
-"* Automatique comme Java :\n"
-"  * Entièrement automatique.\n"
-"  * Sûr et correct.\n"
-"* Basé sur la portée comme C++ :\n"
-"  * Partiellement automatique.\n"
-"  * Aucune surcharge d'exécution.\n"
-"* Basé sur la portée imposée par le compilateur comme Rust :\n"
-"  * Appliqué par le compilateur.\n"
-"  * Aucune surcharge d'exécution.\n"
-"  * Sûr et correct."
+msgid "Manual like C:"
+msgstr "Manuel comme C :"
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+#, fuzzy
+msgid "No runtime overhead."
+msgstr "Aucune surcharge d'exécution."
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+#, fuzzy
+msgid "Automatic like Java:"
+msgstr "Automatique comme Java :"
+
+#: src/memory-management/comparison.md:10
+#, fuzzy
+msgid "Fully automatic."
+msgstr "Entièrement automatique."
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+#, fuzzy
+msgid "Safe and correct."
+msgstr "Sûr et correct."
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+#, fuzzy
+msgid "Scope-based like C++:"
+msgstr "Basé sur la portée comme C++ :"
+
+#: src/memory-management/comparison.md:13
+#, fuzzy
+msgid "Partially automatic."
+msgstr "Partiellement automatique."
+
+#: src/memory-management/comparison.md:15
+#, fuzzy
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "Basé sur la portée imposée par le compilateur comme Rust :"
+
+#: src/memory-management/comparison.md:16
+#, fuzzy
+msgid "Enforced by compiler."
+msgstr "Appliqué par le compilateur."
 
 #: src/memory-management/comparison.md:20
 #, fuzzy
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## Inconvénients des différentes techniques de gestion de la mémoire"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "Inconvénients des différentes techniques de gestion de la mémoire"
 
-#: src/memory-management/comparison.md:22
+#: src/memory-management/comparison.md:23
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* Manuel comme C :\n"
-"  * Utiliser-après-libre.\n"
-"  * Double-gratuit.\n"
-"  * Fuites de mémoire.\n"
-"* Automatique comme Java :\n"
-"  * La collecte des ordures s'arrête.\n"
-"  * Retards de destructeur.\n"
-"* Basé sur la portée comme C++ :\n"
-"  * Complexe, opt-in par le programmeur.\n"
-"  * Potentiel d'utilisation-après-libre.\n"
-"* Renforcé par le compilateur et basé sur la portée comme Rust :\n"
-"  * Une certaine complexité initiale.\n"
-"  * Peut rejeter les programmes valides."
+msgid "Use-after-free."
+msgstr "Utiliser-après-libre."
 
-#: src/ownership.md:1
+#: src/memory-management/comparison.md:24
 #, fuzzy
-msgid "# Ownership"
-msgstr "# La possession"
+msgid "Double-frees."
+msgstr "Double-gratuit."
+
+#: src/memory-management/comparison.md:25
+#, fuzzy
+msgid "Memory leaks."
+msgstr "Fuites de mémoire."
+
+#: src/memory-management/comparison.md:27
+#, fuzzy
+msgid "Garbage collection pauses."
+msgstr "La collecte des ordures s'arrête."
+
+#: src/memory-management/comparison.md:28
+#, fuzzy
+msgid "Destructor delays."
+msgstr "Retards de destructeur."
+
+#: src/memory-management/comparison.md:30
+#, fuzzy
+msgid "Complex, opt-in by programmer."
+msgstr "Complexe, opt-in par le programmeur."
+
+#: src/memory-management/comparison.md:31
+#, fuzzy
+msgid "Potential for use-after-free."
+msgstr "Potentiel d'utilisation-après-libre."
+
+#: src/memory-management/comparison.md:32
+#, fuzzy
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "Renforcé par le compilateur et basé sur la portée comme Rust :"
+
+#: src/memory-management/comparison.md:33
+#, fuzzy
+msgid "Some upfront complexity."
+msgstr "Une certaine complexité initiale."
+
+#: src/memory-management/comparison.md:34
+#, fuzzy
+msgid "Can reject valid programs."
+msgstr "Peut rejeter les programmes valides."
 
 #: src/ownership.md:3
 #, fuzzy
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
+"to use a variable outside its scope:"
 msgstr ""
 "Toutes les liaisons de variables ont un _scope_ où elles sont valides et "
-"c'est une erreur de\n"
-"utiliser une variable en dehors de sa portée :"
+"c'est une erreur de utiliser une variable en dehors de sa portée :"
 
 #: src/ownership.md:6
 msgid ""
@@ -4895,18 +4954,19 @@ msgstr ""
 #: src/ownership.md:18
 #, fuzzy
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr ""
-"* A la fin du scope, la variable est _dropped_ et les données sont "
-"libérées.\n"
-"* Un destructeur peut s'exécuter ici pour libérer des ressources.\n"
-"* On dit que la variable _possède_ la valeur."
+"A la fin du scope, la variable est _dropped_ et les données sont libérées."
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
-msgstr "# Sémantique de déplacement"
+#: src/ownership.md:19
+#, fuzzy
+msgid "A destructor can run here to free up resources."
+msgstr "Un destructeur peut s'exécuter ici pour libérer des ressources."
+
+#: src/ownership.md:20
+#, fuzzy
+msgid "We say that the variable _owns_ the value."
+msgstr "On dit que la variable _possède_ la valeur."
 
 #: src/ownership/move-semantics.md:3
 #, fuzzy
@@ -4927,39 +4987,46 @@ msgstr ""
 
 #: src/ownership/move-semantics.md:14
 #, fuzzy
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "L'affectation de `s1` à `s2` transfère la propriété."
+
+#: src/ownership/move-semantics.md:15
+#, fuzzy
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr "Les données ont été _déplacées_ de `s1` et `s1` n'est plus accessible."
+
+#: src/ownership/move-semantics.md:16
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
 msgstr ""
-"* L'affectation de `s1` à `s2` transfère la propriété.\n"
-"* Les données ont été _déplacées_ de `s1` et `s1` n'est plus accessible.\n"
-"* Lorsque `s1` sort de la portée, rien ne se passe : il n'a pas de "
-"propriété.\n"
-"* Lorsque `s2` sort de la portée, les données de la chaîne sont libérées.\n"
-"* Il y a toujours _exactement_ une liaison de variable qui possède une "
-"valeur."
+"Lorsque `s1` sort de la portée, rien ne se passe : il n'a pas de propriété."
+
+#: src/ownership/move-semantics.md:17
+#, fuzzy
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr ""
+"Lorsque `s2` sort de la portée, les données de la chaîne sont libérées."
+
+#: src/ownership/move-semantics.md:18
+#, fuzzy
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr ""
+"Il y a toujours _exactement_ une liaison de variable qui possède une valeur."
 
 #: src/ownership/move-semantics.md:22
 #, fuzzy
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* Mentionnez que c'est l'opposé des valeurs par défaut en C++, qui copie par "
+"Mentionnez que c'est l'opposé des valeurs par défaut en C++, qui copie par "
 "valeur à moins que vous n'utilisiez `std::move` (et que le constructeur de "
-"déplacement soit défini !).\n"
-"\n"
-"* Dans Rust, les clones sont explicites (en utilisant `clone`)."
+"déplacement soit défini !)."
 
-#: src/ownership/moved-strings-rust.md:1
+#: src/ownership/move-semantics.md:24
 #, fuzzy
-msgid "# Moved Strings in Rust"
-msgstr "# Chaînes déplacées dans Rust"
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "Dans Rust, les clones sont explicites (en utilisant `clone`)."
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4973,12 +5040,14 @@ msgstr ""
 
 #: src/ownership/moved-strings-rust.md:10
 #, fuzzy
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "Les données de tas de `s1` sont réutilisées pour `s2`."
+
+#: src/ownership/moved-strings-rust.md:11
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
 msgstr ""
-"* Les données de tas de `s1` sont réutilisées pour `s2`.\n"
-"* Lorsque `s1` sort de la portée, rien ne se passe (il a été déplacé de)."
+"Lorsque `s1` sort de la portée, rien ne se passe (il a été déplacé de)."
 
 #: src/ownership/moved-strings-rust.md:13
 #, fuzzy
@@ -5032,11 +5101,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:1
-#, fuzzy
-msgid "# Double Frees in Modern C++"
-msgstr "# Double Frees en C++ moderne"
-
 #: src/ownership/double-free-modern-cpp.md:3
 #, fuzzy
 msgid "Modern C++ solves this differently:"
@@ -5053,13 +5117,16 @@ msgstr ""
 #: src/ownership/double-free-modern-cpp.md:10
 #, fuzzy
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
-"* Les données de tas de `s1` sont dupliquées et `s2` obtient sa propre copie "
-"indépendante.\n"
-"* Lorsque `s1` et `s2` sortent de la portée, ils libèrent chacun leur propre "
+"Les données de tas de `s1` sont dupliquées et `s2` obtient sa propre copie "
+"indépendante."
+
+#: src/ownership/double-free-modern-cpp.md:11
+#, fuzzy
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"Lorsque `s1` et `s2` sortent de la portée, ils libèrent chacun leur propre "
 "mémoire."
 
 #: src/ownership/double-free-modern-cpp.md:13
@@ -5113,20 +5180,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:1
-#, fuzzy
-msgid "# Moves in Function Calls"
-msgstr "# Déplacements dans les appels de fonction"
-
 #: src/ownership/moves-function-calls.md:3
 #, fuzzy
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 "Lorsque vous transmettez une valeur à une fonction, la valeur est affectée à "
-"la fonction\n"
-"paramètre. Cela transfère la propriété :"
+"la fonction paramètre. Cela transfère la propriété :"
 
 #: src/ownership/moves-function-calls.md:6
 msgid ""
@@ -5146,34 +5207,48 @@ msgstr ""
 #: src/ownership/moves-function-calls.md:20
 #, fuzzy
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* Avec le premier appel à `say_hello`, `main` abandonne la propriété de "
-"`name`. Ensuite, `name` ne peut plus être utilisé dans `main`.\n"
-"* La mémoire de tas allouée pour `name` sera libérée à la fin de la fonction "
-"`say_hello`.\n"
-"* `main` peut conserver la propriété s'il passe `name` comme référence "
-"(`&name`) et si `say_hello` accepte une référence comme paramètre.\n"
-"* Alternativement, `main` peut passer un clone de `name` dans le premier "
-"appel (`name.clone()`).\n"
-"* Rust rend plus difficile que C++ la création de copies par inadvertance en "
+"Avec le premier appel à `say_hello`, `main` abandonne la propriété de "
+"`name`. Ensuite, `name` ne peut plus être utilisé dans `main`."
+
+#: src/ownership/moves-function-calls.md:21
+#, fuzzy
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+"La mémoire de tas allouée pour `name` sera libérée à la fin de la fonction "
+"`say_hello`."
+
+#: src/ownership/moves-function-calls.md:22
+#, fuzzy
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"`main` peut conserver la propriété s'il passe `name` comme référence "
+"(`&name`) et si `say_hello` accepte une référence comme paramètre."
+
+#: src/ownership/moves-function-calls.md:23
+#, fuzzy
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+"Alternativement, `main` peut passer un clone de `name` dans le premier appel "
+"(`name.clone()`)."
+
+#: src/ownership/moves-function-calls.md:24
+#, fuzzy
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"Rust rend plus difficile que C++ la création de copies par inadvertance en "
 "faisant de la sémantique de déplacement la valeur par défaut et en forçant "
 "les programmeurs à rendre les clones explicites."
-
-#: src/ownership/copy-clone.md:1
-#, fuzzy
-msgid "# Copying and Cloning"
-msgstr "# Copie et clonage"
 
 #: src/ownership/copy-clone.md:3
 #, fuzzy
@@ -5223,12 +5298,14 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:30
 #, fuzzy
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr "Après l'affectation, `p1` et `p2` possèdent leurs propres données."
+
+#: src/ownership/copy-clone.md:31
+#, fuzzy
+msgid "We can also use `p1.clone()` to explicitly copy the data."
 msgstr ""
-"* Après l'affectation, `p1` et `p2` possèdent leurs propres données.\n"
-"* Nous pouvons également utiliser `p1.clone()` pour copier explicitement les "
+"Nous pouvons également utiliser `p1.clone()` pour copier explicitement les "
 "données."
 
 #: src/ownership/copy-clone.md:35
@@ -5239,21 +5316,34 @@ msgstr "La copie et le clonage ne sont pas la même chose :"
 #: src/ownership/copy-clone.md:37
 #, fuzzy
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C+"
-"+).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
 msgstr ""
-"* La copie fait référence aux copies au niveau du bit des régions de mémoire "
-"et ne fonctionne pas sur des objets arbitraires.\n"
-"* La copie ne permet pas de logique personnalisée (contrairement aux "
-"constructeurs de copie en C++).\n"
-"* Le clonage est une opération plus générale et permet également un "
-"comportement personnalisé en implémentant le trait \"Cloner\".\n"
-"* La copie ne fonctionne pas sur les types qui implémentent le trait `Drop`."
+"La copie fait référence aux copies au niveau du bit des régions de mémoire "
+"et ne fonctionne pas sur des objets arbitraires."
+
+#: src/ownership/copy-clone.md:38
+#, fuzzy
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+"La copie ne permet pas de logique personnalisée (contrairement aux "
+"constructeurs de copie en C++)."
+
+#: src/ownership/copy-clone.md:39
+#, fuzzy
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+"Le clonage est une opération plus générale et permet également un "
+"comportement personnalisé en implémentant le trait \"Cloner\"."
+
+#: src/ownership/copy-clone.md:40
+#, fuzzy
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr ""
+"La copie ne fonctionne pas sur les types qui implémentent le trait `Drop`."
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 #, fuzzy
@@ -5263,45 +5353,46 @@ msgstr "Dans l'exemple ci-dessus, essayez ce qui suit :"
 #: src/ownership/copy-clone.md:44
 #, fuzzy
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* Ajoutez un champ `String` à `struct Point`. Il ne sera pas compilé car "
-"`String` n'est pas un type `Copy`.\n"
-"* Supprimer `Copy` de l'attribut `derive`. L'erreur du compilateur est "
-"maintenant dans `println!` pour `p1`.\n"
-"* Montrez que cela fonctionne si vous clonez `p1` à la place."
+"Ajoutez un champ `String` à `struct Point`. Il ne sera pas compilé car "
+"`String` n'est pas un type `Copy`."
+
+#: src/ownership/copy-clone.md:45
+#, fuzzy
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"Supprimer `Copy` de l'attribut `derive`. L'erreur du compilateur est "
+"maintenant dans `println!` pour `p1`."
+
+#: src/ownership/copy-clone.md:46
+#, fuzzy
+msgid "Show that it works if you clone `p1` instead."
+msgstr "Montrez que cela fonctionne si vous clonez `p1` à la place."
 
 #: src/ownership/copy-clone.md:48
 #, fuzzy
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated."
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 "Si les étudiants posent des questions sur \"dériver\", il suffit de dire que "
-"c'est un moyen de générer du code dans Rust\n"
-"au moment de la compilation. Dans ce cas, les implémentations par défaut des "
-"traits `Copy` et `Clone` sont générées."
-
-#: src/ownership/borrowing.md:1
-#, fuzzy
-msgid "# Borrowing"
-msgstr "# Emprunter"
+"c'est un moyen de générer du code dans Rust au moment de la compilation. "
+"Dans ce cas, les implémentations par défaut des traits `Copy` et `Clone` "
+"sont générées."
 
 #: src/ownership/borrowing.md:3
 #, fuzzy
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
 "Au lieu de transférer la propriété lors de l'appel d'une fonction, vous "
-"pouvez laisser une\n"
-"la fonction _emprunte_ la valeur :"
+"pouvez laisser une la fonction _emprunte_ la valeur :"
 
 #: src/ownership/borrowing.md:6
 msgid ""
@@ -5324,12 +5415,13 @@ msgstr ""
 
 #: src/ownership/borrowing.md:22
 #, fuzzy
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
-msgstr ""
-"* La fonction `add` _emprunte_ deux points et renvoie un nouveau point.\n"
-"* L'appelant conserve la propriété des entrées."
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr "La fonction `add` _emprunte_ deux points et renvoie un nouveau point."
+
+#: src/ownership/borrowing.md:23
+#, fuzzy
+msgid "The caller retains ownership of the inputs."
+msgstr "L'appelant conserve la propriété des entrées."
 
 #: src/ownership/borrowing.md:27
 #, fuzzy
@@ -5338,41 +5430,46 @@ msgstr "Remarques sur les retours de pile :"
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can "
+"Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while they stay the same when changing to the "
-"\"RELEASE\" setting:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification "
-"because constructors can have side effects. In Rust, this is not an issue at "
-"all. If RVO did not happen, Rust will always perform a simple and efficient "
-"`memcpy` copy."
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/ownership/shared-unique-borrows.md:1
-#, fuzzy
-msgid "# Shared and Unique Borrows"
-msgstr "# Emprunts partagés et uniques"
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr ""
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
+"copy."
+msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:3
 #, fuzzy
@@ -5383,12 +5480,13 @@ msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:5
 #, fuzzy
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* Vous pouvez avoir une ou plusieurs valeurs `&T` à tout moment, _ou_\n"
-"* Vous pouvez avoir exactement une valeur `&mut T`."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "Vous pouvez avoir une ou plusieurs valeurs `&T` à tout moment, _ou_"
+
+#: src/ownership/shared-unique-borrows.md:6
+#, fuzzy
+msgid "You can have exactly one `&mut T` value."
+msgstr "Vous pouvez avoir exactement une valeur `&mut T`."
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
@@ -5411,27 +5509,32 @@ msgstr ""
 #: src/ownership/shared-unique-borrows.md:25
 #, fuzzy
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+"Le code ci-dessus ne se compile pas car 'a' est emprunté comme mutable (via "
+"'c') et comme immuable (via 'b') en même temps."
+
+#: src/ownership/shared-unique-borrows.md:26
+#, fuzzy
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"Déplacez l'instruction `println!` pour `b` avant la portée qui introduit `c` "
+"pour que le code soit compilé."
+
+#: src/ownership/shared-unique-borrows.md:27
+#, fuzzy
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"* Le code ci-dessus ne se compile pas car 'a' est emprunté comme mutable "
-"(via 'c') et comme immuable (via 'b') en même temps.\n"
-"* Déplacez l'instruction `println!` pour `b` avant la portée qui introduit "
-"`c` pour que le code soit compilé.\n"
-"* Après ce changement, le compilateur se rend compte que 'b' n'est utilisé "
+"Après ce changement, le compilateur se rend compte que 'b' n'est utilisé "
 "qu'avant le nouvel emprunt mutable de 'a' à 'c'. Il s'agit d'une "
 "fonctionnalité du vérificateur d'emprunt appelée \"durées de vie non "
 "lexicales\"."
-
-#: src/ownership/lifetimes.md:1
-#, fuzzy
-msgid "# Lifetimes"
-msgstr "# Durées de vie"
 
 #: src/ownership/lifetimes.md:3
 #, fuzzy
@@ -5439,27 +5542,40 @@ msgid "A borrowed value has a _lifetime_:"
 msgstr "Une valeur empruntée a une _durée de vie_ :"
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully "
-"specified,\n"
-"  but Rust allows lifetimes to be elided in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
 msgstr ""
 
-#: src/ownership/lifetimes-function-calls.md:1
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr ""
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
 #, fuzzy
-msgid "# Lifetimes in Function Calls"
-msgstr "# Durées de vie dans les appels de fonction"
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+"Lire `&'a Point` comme \"un `Point` emprunté qui est valide pour au moins "
+"durée de vie 'a'\"."
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+
+#: src/ownership/lifetimes.md:13
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows lifetimes to be elided in most cases with [a few simple "
+"rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:3
 #, fuzzy
@@ -5491,63 +5607,83 @@ msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:21
 #, fuzzy
-msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`'a` est un paramètre générique, il est déduit par le compilateur."
+
+#: src/ownership/lifetimes-function-calls.md:22
+#, fuzzy
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
 msgstr ""
-"* `'a` est un paramètre générique, il est déduit par le compilateur.\n"
-"* Les durées de vie commencent par `'` et `'a` est un nom par défaut "
-"typique.\n"
-"* Lire `&'a Point` comme \"un `Point` emprunté qui est valide pour au moins\n"
-"  durée de vie 'a'\".\n"
-"  * La partie _au moins_ est importante lorsque les paramètres sont dans des "
+"Les durées de vie commencent par `'` et `'a` est un nom par défaut typique."
+
+#: src/ownership/lifetimes-function-calls.md:25
+#, fuzzy
+msgid ""
+"The _at least_ part is important when parameters are in different scopes."
+msgstr ""
+"La partie _au moins_ est importante lorsque les paramètres sont dans des "
 "portées différentes."
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:1
-#, fuzzy
-msgid "# Lifetimes in Data Structures"
-msgstr "# Durées de vie dans les structures de données"
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:50
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
 #, fuzzy
@@ -5582,40 +5718,59 @@ msgstr ""
 #: src/ownership/lifetimes-data-structures.md:25
 #, fuzzy
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data "
+"In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This "
-"can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one "
-"lifetime annotation. This can be necessary if there is a need to describe "
-"lifetime relationships between the references themselves, in addition to the "
-"lifetime of the struct itself. Those are very advanced use cases."
+"`Highlight` that uses that data."
 msgstr ""
-"* Dans l'exemple ci-dessus, l'annotation sur `Highlight` impose que les "
+"Dans l'exemple ci-dessus, l'annotation sur `Highlight` impose que les "
 "données sous-jacentes au `&str` contenu vivent au moins aussi longtemps que "
-"toute instance de `Highlight` qui utilise ces données.\n"
-"* Si `text` est consommé avant la fin de la durée de vie de `fox` (ou "
-"`dog`), le vérificateur d'emprunt génère une erreur.\n"
-"* Les types avec des données empruntées obligent les utilisateurs à "
-"conserver les données d'origine. Cela peut être utile pour créer des vues "
-"légères, mais cela les rend généralement un peu plus difficiles à utiliser.\n"
-"* Dans la mesure du possible, faites en sorte que les structures de données "
-"soient directement propriétaires de leurs données.\n"
-"* Certaines structures contenant plusieurs références peuvent avoir "
-"plusieurs annotations de durée de vie. Cela peut être nécessaire s'il est "
-"nécessaire de décrire les relations de durée de vie entre les références "
-"elles-mêmes, en plus de la durée de vie de la structure elle-même. Ce sont "
-"des cas d'utilisation très avancés."
+"toute instance de `Highlight` qui utilise ces données."
+
+#: src/ownership/lifetimes-data-structures.md:26
+#, fuzzy
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"Si `text` est consommé avant la fin de la durée de vie de `fox` (ou `dog`), "
+"le vérificateur d'emprunt génère une erreur."
+
+#: src/ownership/lifetimes-data-structures.md:27
+#, fuzzy
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"Les types avec des données empruntées obligent les utilisateurs à conserver "
+"les données d'origine. Cela peut être utile pour créer des vues légères, "
+"mais cela les rend généralement un peu plus difficiles à utiliser."
+
+#: src/ownership/lifetimes-data-structures.md:28
+#, fuzzy
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+"Dans la mesure du possible, faites en sorte que les structures de données "
+"soient directement propriétaires de leurs données."
+
+#: src/ownership/lifetimes-data-structures.md:29
+#, fuzzy
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"Certaines structures contenant plusieurs références peuvent avoir plusieurs "
+"annotations de durée de vie. Cela peut être nécessaire s'il est nécessaire "
+"de décrire les relations de durée de vie entre les références elles-mêmes, "
+"en plus de la durée de vie de la structure elle-même. Ce sont des cas "
+"d'utilisation très avancés."
 
 #: src/exercises/day-1/afternoon.md:1
 #, fuzzy
-msgid "# Day 1: Afternoon Exercises"
-msgstr "# Jour 1 : Exercices de l'après-midi"
+msgid "Day 1: Afternoon Exercises"
+msgstr "Jour 1 : Exercices de l'après-midi"
 
 #: src/exercises/day-1/afternoon.md:3
 #, fuzzy
@@ -5624,30 +5779,23 @@ msgstr "Nous allons regarder deux choses :"
 
 #: src/exercises/day-1/afternoon.md:5
 #, fuzzy
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
-msgstr ""
-"* Une petite bibliothèque de livres,\n"
-"\n"
-"* Itérateurs et propriété (difficile)."
+msgid "A small book library,"
+msgstr "Une petite bibliothèque de livres,"
 
-#: src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/afternoon.md:7
 #, fuzzy
-msgid "# Storing Books"
-msgstr "# Chaîne"
+msgid "Iterators and ownership (hard)."
+msgstr "Itérateurs et propriété (difficile)."
 
 #: src/exercises/day-1/book-library.md:3
 #, fuzzy
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
 "Nous en apprendrons beaucoup plus sur les structures et le type `Vec<T>` "
-"demain. Pour l'instant,\n"
-"vous avez juste besoin de connaître une partie de son API :"
+"demain. Pour l'instant, vous avez juste besoin de connaître une partie de "
+"son API :"
 
 #: src/exercises/day-1/book-library.md:6
 msgid ""
@@ -5667,13 +5815,12 @@ msgstr ""
 #: src/exercises/day-1/book-library.md:18
 #, fuzzy
 msgid ""
-"Use this to model a library's book collection. Copy the code below to\n"
+"Use this to model a library's book collection. Copy the code below to "
 "<https://play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 "Utilisez-le pour créer une application de bibliothèque. Copiez le code ci-"
-"dessous pour\n"
-"<https://play.rust-lang.org/> et mettez à jour les types pour le faire "
-"compiler :"
+"dessous pour <https://play.rust-lang.org/> et mettez à jour les types pour "
+"le faire compiler :"
 
 #: src/exercises/day-1/book-library.md:21
 msgid ""
@@ -5766,44 +5913,34 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr "[Solution](solutions-afternoon.md#designing-a-library)"
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-#, fuzzy
-msgid "# Iterators and Ownership"
-msgstr "# Itérateurs et propriété"
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 #, fuzzy
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 "Le modèle de propriété de Rust affecte de nombreuses API. Un exemple en est "
-"le\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) et\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"le [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) et "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "caractéristiques."
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
 #, fuzzy
-msgid "## `Iterator`"
-msgstr "## `Itérateur`"
+msgid "`Iterator`"
+msgstr "`Itérateur`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 #, fuzzy
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
 "Les traits sont comme des interfaces : ils décrivent le comportement "
-"(méthodes) d'un type. Le\n"
-"Le trait `Iterator` indique simplement que vous pouvez appeler `next` "
-"jusqu'à ce que vous obteniez `None` :"
+"(méthodes) d'un type. Le Le trait `Iterator` indique simplement que vous "
+"pouvez appeler `next` jusqu'à ce que vous obteniez `None` :"
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
 msgid ""
@@ -5860,20 +5997,19 @@ msgstr "Pourquoi ce type est-il utilisé ?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
 #, fuzzy
-msgid "## `IntoIterator`"
-msgstr "## `IntoIterator`"
+msgid "`IntoIterator`"
+msgstr "`IntoIterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 #, fuzzy
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
 "Le trait `Iterator` vous indique comment _itérer_ une fois que vous avez "
-"créé un\n"
-"itérateur. Le trait connexe \"IntoIterator\" vous indique comment créer "
-"l'itérateur :"
+"créé un itérateur. Le trait connexe \"IntoIterator\" vous indique comment "
+"créer l'itérateur :"
 
 #: src/exercises/day-1/iterators-and-ownership.md:53
 msgid ""
@@ -5890,28 +6026,29 @@ msgstr ""
 #: src/exercises/day-1/iterators-and-ownership.md:62
 #, fuzzy
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
-"La syntaxe ici signifie que chaque implémentation de `IntoIterator` doit\n"
+"La syntaxe ici signifie que chaque implémentation de `IntoIterator` doit "
 "déclarer deux types :"
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
 #, fuzzy
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
-msgstr ""
-"* `Item` : le type sur lequel nous itérons, tel que `i8`,\n"
-"* `IntoIter` : le type `Iterator` renvoyé par la méthode `into_iter`."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr "`Item` : le type sur lequel nous itérons, tel que `i8`,"
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+#, fuzzy
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr "`IntoIter` : le type `Iterator` renvoyé par la méthode `into_iter`."
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 #, fuzzy
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
-"Notez que `IntoIter` et `Item` sont liés : l'itérateur doit avoir le même\n"
+"Notez que `IntoIter` et `Item` sont liés : l'itérateur doit avoir le même "
 "Type `Item`, ce qui signifie qu'il renvoie `Option<Item>`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:71
@@ -5935,21 +6072,19 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
 #, fuzzy
-msgid "## `for` Loops"
-msgstr "## Boucles `for`"
+msgid "`for` Loops"
+msgstr "Boucles `for`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 #, fuzzy
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 "Maintenant que nous connaissons à la fois `Iterator` et `IntoIterator`, nous "
-"pouvons construire des boucles `for`.\n"
-"Ils appellent `into_iter()` sur une expression et itèrent sur le résultat\n"
-"itérateur :"
+"pouvons construire des boucles `for`. Ils appellent `into_iter()` sur une "
+"expression et itèrent sur le résultat itérateur :"
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
@@ -5977,30 +6112,22 @@ msgstr "Quel est le type de \"mot\" dans chaque boucle ?"
 #: src/exercises/day-1/iterators-and-ownership.md:105
 #, fuzzy
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 "Expérimentez avec le code ci-dessus, puis consultez la documentation de "
-"[`impl\n"
-"IntoIterator pour\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"et [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"pour vérifier vos réponses."
+"[`impl IntoIterator pour &Vec<T>`](https://doc.rust-lang.org/std/vec/struct."
+"Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) et [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) pour vérifier vos réponses."
 
 #: src/welcome-day-2.md:1
 #, fuzzy
-msgid "# Welcome to Day 2"
-msgstr "# Bienvenue au jour 2"
+msgid "Welcome to Day 2"
+msgstr "Bienvenue au jour 2"
 
 #: src/welcome-day-2.md:3
 #, fuzzy
@@ -6011,40 +6138,38 @@ msgstr ""
 
 #: src/welcome-day-2.md:5
 #, fuzzy
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
-msgstr ""
-"* Structures, énumérations, méthodes.\n"
-"\n"
-"* Pattern matching : déstructuration des énumérations, des structures et des "
-"tableaux.\n"
-"\n"
-"* Constructions de flux de contrôle : `if`, `if let`, `while`, `while let`, "
-"`break` et\n"
-"  'continuer'.\n"
-"\n"
-"* La bibliothèque standard : `String`, `Option` et `Result`, `Vec`, "
-"`HashMap`, `Rc`\n"
-"  et \"Arc\".\n"
-"\n"
-"* Modules : visibilité, chemins et hiérarchie du système de fichiers."
+msgid "Structs, enums, methods."
+msgstr "Structures, énumérations, méthodes."
 
-#: src/structs.md:1
+#: src/welcome-day-2.md:7
 #, fuzzy
-msgid "# Structs"
-msgstr "# Structures"
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr ""
+"Pattern matching : déstructuration des énumérations, des structures et des "
+"tableaux."
+
+#: src/welcome-day-2.md:9
+#, fuzzy
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+"Constructions de flux de contrôle : `if`, `if let`, `while`, `while let`, "
+"`break` et 'continuer'."
+
+#: src/welcome-day-2.md:12
+#, fuzzy
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+"La bibliothèque standard : `String`, `Option` et `Result`, `Vec`, `HashMap`, "
+"`Rc` et \"Arc\"."
+
+#: src/welcome-day-2.md:15
+#, fuzzy
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr "Modules : visibilité, chemins et hiérarchie du système de fichiers."
 
 #: src/structs.md:3
 #, fuzzy
@@ -6086,28 +6211,48 @@ msgid "Key Points:"
 msgstr "Points clés:"
 
 #: src/structs.md:33
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
 msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
-
-#: src/structs/tuple-structs.md:1
-#, fuzzy
-msgid "# Tuple Structs"
-msgstr "# Structures de tuple"
 
 #: src/structs/tuple-structs.md:3
 #, fuzzy
@@ -6159,45 +6304,64 @@ msgstr ""
 #: src/structs/tuple-structs.md:37
 #, fuzzy
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics).\n"
-"* The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
+msgstr ""
+"Les nouveaux types sont un excellent moyen d'encoder des informations "
+"supplémentaires sur la valeur dans un type primitif, par exemple :"
+
+#: src/structs/tuple-structs.md:38
+#, fuzzy
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+"Le nombre est mesuré dans certaines unités : `Newtons` dans l'exemple ci-"
+"dessus."
+
+#: src/structs/tuple-structs.md:39
+#, fuzzy
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"La valeur a été validée lors de sa création, vous n'avez donc plus besoin de "
+"la valider à chaque utilisation : 'PhoneNumber(String)`ou`OddNumber(u32)\\`."
+
+#: src/structs/tuple-structs.md:40
+#, fuzzy
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+"Montrez comment ajouter une valeur `f64` à un type `Newtons` en accédant au "
+"champ unique dans le nouveau type."
+
+#: src/structs/tuple-structs.md:41
+#, fuzzy
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+"Rust n'aime généralement pas les choses inexplicites, comme le déballage "
+"automatique ou, par exemple, l'utilisation de booléens comme entiers."
+
+#: src/structs/tuple-structs.md:42
+#, fuzzy
+msgid "Operator overloading is discussed on Day 3 (generics)."
+msgstr "La surcharge des opérateurs est discutée le jour 3 (génériques)."
+
+#: src/structs/tuple-structs.md:43
+msgid ""
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
 "wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
-"* Les nouveaux types sont un excellent moyen d'encoder des informations "
-"supplémentaires sur la valeur dans un type primitif, par exemple :\n"
-"  * Le nombre est mesuré dans certaines unités : `Newtons` dans l'exemple ci-"
-"dessus.\n"
-"  * La valeur a été validée lors de sa création, vous n'avez donc plus "
-"besoin de la valider à chaque utilisation : 'PhoneNumber(String)` ou "
-"`OddNumber(u32)`.\n"
-"* Montrez comment ajouter une valeur `f64` à un type `Newtons` en accédant "
-"au champ unique dans le nouveau type.\n"
-"  * Rust n'aime généralement pas les choses inexplicites, comme le déballage "
-"automatique ou, par exemple, l'utilisation de booléens comme entiers.\n"
-"  * La surcharge des opérateurs est discutée le jour 3 (génériques)."
-
-#: src/structs/field-shorthand.md:1
-#, fuzzy
-msgid "# Field Shorthand Syntax"
-msgstr "# Syntaxe abrégée du champ"
 
 #: src/structs/field-shorthand.md:3
 #, fuzzy
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
-"Si vous avez déjà des variables avec les bons noms, vous pouvez créer le\n"
+"Si vous avez déjà des variables avec les bons noms, vous pouvez créer le "
 "struct en utilisant un raccourci :"
 
 #: src/structs/field-shorthand.md:6
@@ -6224,68 +6388,83 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use "
-"the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-#, fuzzy
-msgid "# Enums"
-msgstr "# Énumérations"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
 
 #: src/enums.md:3
 #, fuzzy
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
-"Le mot clé `enum` permet la création d'un type qui a quelques\n"
-"différentes variantes :"
+"Le mot clé `enum` permet la création d'un type qui a quelques différentes "
+"variantes :"
 
 #: src/enums.md:6
 msgid ""
@@ -6318,48 +6497,62 @@ msgstr ""
 
 #: src/enums.md:36
 #, fuzzy
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr ""
+"Les énumérations vous permettent de collecter un ensemble de valeurs sous un "
+"type"
+
+#: src/enums.md:37
+#, fuzzy
 msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+"Cette page propose un type d'énumération `CoinFlip` avec deux variantes "
+"`Heads` et `Tail`. Vous pouvez noter l'espace de noms lors de l'utilisation "
+"de variantes."
+
+#: src/enums.md:38
+#, fuzzy
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr "C'est peut-être le bon moment pour comparer Structs et Enums :"
+
+#: src/enums.md:39
+#, fuzzy
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"Dans les deux cas, vous pouvez avoir une version simple sans champs "
+"(structure d'unité) ou une version avec différents types de champs (charges "
+"utiles variantes)."
+
+#: src/enums.md:40
+#, fuzzy
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr ""
+"Dans les deux cas, les fonctions associées sont définies dans un bloc `impl`."
+
+#: src/enums.md:41
+#, fuzzy
+msgid ""
+"You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
 msgstr ""
-"* Les énumérations vous permettent de collecter un ensemble de valeurs sous "
-"un type\n"
-"* Cette page propose un type d'énumération `CoinFlip` avec deux variantes "
-"`Heads` et `Tail`. Vous pouvez noter l'espace de noms lors de l'utilisation "
-"de variantes.\n"
-"* C'est peut-être le bon moment pour comparer Structs et Enums :\n"
-"  * Dans les deux cas, vous pouvez avoir une version simple sans champs "
-"(structure d'unité) ou une version avec différents types de champs (charges "
-"utiles variantes).\n"
-"  * Dans les deux cas, les fonctions associées sont définies dans un bloc "
-"`impl`.\n"
-"  * Vous pouvez même implémenter les différentes variantes d'une énumération "
+"Vous pouvez même implémenter les différentes variantes d'une énumération "
 "avec des structures distinctes, mais elles ne seraient alors pas du même "
 "type que si elles étaient toutes définies dans une énumération."
-
-#: src/enums/variant-payloads.md:1
-#, fuzzy
-msgid "# Variant Payloads"
-msgstr "# Charges utiles variantes"
 
 #: src/enums/variant-payloads.md:3
 #, fuzzy
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 "Vous pouvez définir des énumérations plus riches où les variantes "
-"transportent des données. Vous pouvez ensuite utiliser le\n"
-"instruction `match` pour extraire les données de chaque variante :"
+"transportent des données. Vous pouvez ensuite utiliser le instruction "
+"`match` pour extraire les données de chaque variante :"
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -6394,55 +6587,85 @@ msgstr ""
 #: src/enums/variant-payloads.md:35
 #, fuzzy
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There "
-"is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example.  \n"
-"  "
+"after the `=>`."
 msgstr ""
-"* Les valeurs des variantes enum ne sont accessibles qu'après avoir été "
-"mises en correspondance avec le modèle. Le modèle lie les références aux "
-"champs dans le \"match arm\" après le `=>`.\n"
-"  * L'expression est comparée aux modèles de haut en bas. Il n'y a pas de "
-"basculement comme en C ou C++.\n"
-"  * L'expression de correspondance a une valeur. La valeur est la dernière "
-"expression du bras de correspondance qui a été exécutée.\n"
-"  * En partant du haut, nous cherchons quel modèle correspond à la valeur, "
-"puis exécutons le code en suivant la flèche. Une fois que nous trouvons une "
-"correspondance, nous nous arrêtons.\n"
-"* Démontrer ce qui se passe lorsque la recherche est inépuisable. Notez "
-"l'avantage que le compilateur Rust fournit en confirmant quand tous les cas "
-"sont traités.\n"
-"* `match` inspecte un champ discriminant caché dans `enum`.\n"
-"* Il est possible de récupérer le discriminant en appelant `std::mem::"
-"discriminant()`\n"
-"  * Ceci est utile, par exemple, si vous implémentez `PartialEq` pour des "
-"structures où la comparaison des valeurs de champ n'affecte pas l'égalité.\n"
-"* `WebEvent::Click { ... }` n'est pas exactement le même que `WebEvent::"
-"Click(Click)` avec un niveau supérieur `struct Click { ... }`. La version en "
-"ligne ne peut pas implémenter de traits, par exemple.\n"
-"  "
+"Les valeurs des variantes enum ne sont accessibles qu'après avoir été mises "
+"en correspondance avec le modèle. Le modèle lie les références aux champs "
+"dans le \"match arm\" après le `=>`."
 
-#: src/enums/sizes.md:1
+#: src/enums/variant-payloads.md:36
 #, fuzzy
-msgid "# Enum Sizes"
-msgstr "# Tailles d'énumération"
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+"L'expression est comparée aux modèles de haut en bas. Il n'y a pas de "
+"basculement comme en C ou C++."
+
+#: src/enums/variant-payloads.md:37
+#, fuzzy
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+"L'expression de correspondance a une valeur. La valeur est la dernière "
+"expression du bras de correspondance qui a été exécutée."
+
+#: src/enums/variant-payloads.md:38
+#, fuzzy
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+"En partant du haut, nous cherchons quel modèle correspond à la valeur, puis "
+"exécutons le code en suivant la flèche. Une fois que nous trouvons une "
+"correspondance, nous nous arrêtons."
+
+#: src/enums/variant-payloads.md:39
+#, fuzzy
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+"Démontrer ce qui se passe lorsque la recherche est inépuisable. Notez "
+"l'avantage que le compilateur Rust fournit en confirmant quand tous les cas "
+"sont traités."
+
+#: src/enums/variant-payloads.md:40
+#, fuzzy
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr "`match` inspecte un champ discriminant caché dans `enum`."
+
+#: src/enums/variant-payloads.md:41
+#, fuzzy
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+"Il est possible de récupérer le discriminant en appelant `std::mem::"
+"discriminant()`"
+
+#: src/enums/variant-payloads.md:42
+#, fuzzy
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+"Ceci est utile, par exemple, si vous implémentez `PartialEq` pour des "
+"structures où la comparaison des valeurs de champ n'affecte pas l'égalité."
+
+#: src/enums/variant-payloads.md:43
+#, fuzzy
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
+"`WebEvent::Click { ... }` n'est pas exactement le même que `WebEvent::"
+"Click(Click)` avec un niveau supérieur `struct Click { ... }`. La version en "
+"ligne ne peut pas implémenter de traits, par exemple."
 
 #: src/enums/sizes.md:3
 #, fuzzy
@@ -6479,166 +6702,197 @@ msgstr ""
 #: src/enums/sizes.md:25
 #, fuzzy
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 msgstr ""
-"* Voir la [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"Voir la [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 
 #: src/enums/sizes.md:31
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+
+#: src/enums/sizes.md:33
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr ""
+
+#: src/enums/sizes.md:35
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with "
-"C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:50
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+
+#: src/enums/sizes.md:54
+msgid "Try out other types such as"
+msgstr ""
+
+#: src/enums/sizes.md:56
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr ""
+
+#: src/enums/sizes.md:57
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+
+#: src/enums/sizes.md:58
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+
+#: src/enums/sizes.md:59
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+
+#: src/enums/sizes.md:61
+msgid ""
+"Niche optimization: Rust will merge unused bit patterns for the enum "
+"discriminant."
+msgstr ""
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits "
-"2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche "
-"optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit "
-"machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* "
-"look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees "
-"regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
 "\n"
-"     More complex example if you want to discuss what happens when we chain "
-"more than 256 `Option`s together.\n"
+"use std::mem::transmute;\n"
 "\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
 "signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
 "Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods.md:3
 #, fuzzy
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
 "Rust vous permet d'associer des fonctions à vos nouveaux types. Vous faites "
-"cela avec un\n"
-"Bloc `impl` :"
+"cela avec un Bloc `impl` :"
 
 #: src/methods.md:6
 msgid ""
@@ -6667,135 +6921,159 @@ msgstr ""
 
 #: src/methods.md:31
 #, fuzzy
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
-"* Il peut être utile d'introduire des méthodes en les comparant à des "
-"fonctions.\n"
-"  * Les méthodes sont appelées sur une instance d'un type (tel qu'un struct "
-"ou un enum), le premier paramètre représente l'instance en tant que "
-"\"self\".\n"
-"  * Les développeurs peuvent choisir d'utiliser des méthodes pour tirer "
-"parti de la syntaxe du récepteur de méthode et pour mieux les organiser. En "
-"utilisant des méthodes, nous pouvons conserver tout le code d'implémentation "
-"en un seul endroit prévisible.\n"
-"* Soulignez l'utilisation du mot-clé `self`, un récepteur de méthode.\n"
-"  * Montrez qu'il s'agit d'un terme abrégé pour `self:&Self` et montrez peut-"
-"être comment le nom de la structure pourrait également être utilisé.\n"
-"  * Expliquez que `Self` est un alias de type pour le type dans lequel se "
-"trouve le bloc `impl` et peut être utilisé ailleurs dans le bloc.\n"
-"  * Notez comment `self` est utilisé comme d'autres structures et la "
-"notation par points peut être utilisée pour faire référence à des champs "
-"individuels.\n"
-"  * C'est peut-être le bon moment pour démontrer en quoi `&self` diffère de "
-"`self` en modifiant le code et en essayant d'exécuter say_hello deux fois.\n"
-"* Nous décrivons ensuite la distinction entre les récepteurs de méthode.\n"
-"   "
+"Il peut être utile d'introduire des méthodes en les comparant à des "
+"fonctions."
 
-#: src/methods/receiver.md:1
+#: src/methods.md:32
 #, fuzzy
-msgid "# Method Receiver"
-msgstr "# Méthode Récepteur"
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+"Les méthodes sont appelées sur une instance d'un type (tel qu'un struct ou "
+"un enum), le premier paramètre représente l'instance en tant que \"self\"."
+
+#: src/methods.md:33
+#, fuzzy
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+"Les développeurs peuvent choisir d'utiliser des méthodes pour tirer parti de "
+"la syntaxe du récepteur de méthode et pour mieux les organiser. En utilisant "
+"des méthodes, nous pouvons conserver tout le code d'implémentation en un "
+"seul endroit prévisible."
+
+#: src/methods.md:34
+#, fuzzy
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr "Soulignez l'utilisation du mot-clé `self`, un récepteur de méthode."
+
+#: src/methods.md:35
+#, fuzzy
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+"Montrez qu'il s'agit d'un terme abrégé pour `self:&Self` et montrez peut-"
+"être comment le nom de la structure pourrait également être utilisé."
+
+#: src/methods.md:36
+#, fuzzy
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+"Expliquez que `Self` est un alias de type pour le type dans lequel se trouve "
+"le bloc `impl` et peut être utilisé ailleurs dans le bloc."
+
+#: src/methods.md:37
+#, fuzzy
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+"Notez comment `self` est utilisé comme d'autres structures et la notation "
+"par points peut être utilisée pour faire référence à des champs individuels."
+
+#: src/methods.md:38
+#, fuzzy
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+"C'est peut-être le bon moment pour démontrer en quoi `&self` diffère de "
+"`self` en modifiant le code et en essayant d'exécuter say_hello deux fois."
+
+#: src/methods.md:39
+#, fuzzy
+msgid "We describe the distinction between method receivers next."
+msgstr "Nous décrivons ensuite la distinction entre les récepteurs de méthode."
 
 #: src/methods/receiver.md:3
 #, fuzzy
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
 "Le `&self` ci-dessus indique que la méthode emprunte l'objet de manière "
-"immuable. Là\n"
-"sont d'autres récepteurs possibles pour une méthode :"
+"immuable. Là sont d'autres récepteurs possibles pour une méthode :"
 
 #: src/methods/receiver.md:6
 #, fuzzy
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted. Complete ownership does not automatically mean mutability.\n"
-"* `mut self`: same as above, but the method can mutate the object. \n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
 msgstr ""
-"* `&self` : emprunte l'objet à l'appelant en utilisant un partage et "
-"immuable\n"
-"  référence. L'objet peut être réutilisé par la suite.\n"
-"* `&mut self` : emprunte l'objet à l'appelant en utilisant un nom unique et "
-"mutable\n"
-"  référence. L'objet peut être réutilisé par la suite.\n"
-"* `self` : prend possession de l'objet et l'éloigne de l'appelant. Le\n"
-"  méthode devient le propriétaire de l'objet. L'objet sera supprimé "
-"(désalloué)\n"
-"  lorsque la méthode revient, sauf si sa propriété est explicitement\n"
-"  transmis.\n"
-"* `mut self` : comme ci-dessus, mais tant que la méthode possède l'objet, "
-"elle peut\n"
-"  le faire muter aussi. La propriété complète ne signifie pas "
-"automatiquement la mutabilité.\n"
-"* Pas de récepteur : cela devient une méthode statique sur la structure. "
-"Généralement utilisé pour\n"
-"  créer des constructeurs appelés \"nouveaux\" par convention."
+"`&self` : emprunte l'objet à l'appelant en utilisant un partage et immuable "
+"référence. L'objet peut être réutilisé par la suite."
+
+#: src/methods/receiver.md:8
+#, fuzzy
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+"`&mut self` : emprunte l'objet à l'appelant en utilisant un nom unique et "
+"mutable référence. L'objet peut être réutilisé par la suite."
+
+#: src/methods/receiver.md:10
+#, fuzzy
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+"`self` : prend possession de l'objet et l'éloigne de l'appelant. Le méthode "
+"devient le propriétaire de l'objet. L'objet sera supprimé (désalloué) "
+"lorsque la méthode revient, sauf si sa propriété est explicitement transmis."
+
+#: src/methods/receiver.md:14
+#, fuzzy
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+"`mut self` : comme ci-dessus, mais tant que la méthode possède l'objet, elle "
+"peut le faire muter aussi. La propriété complète ne signifie pas "
+"automatiquement la mutabilité."
+
+#: src/methods/receiver.md:15
+#, fuzzy
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
+msgstr ""
+"Pas de récepteur : cela devient une méthode statique sur la structure. "
+"Généralement utilisé pour créer des constructeurs appelés \"nouveaux\" par "
+"convention."
 
 #: src/methods/receiver.md:18
 #, fuzzy
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
-"Au-delà des variantes sur \"self\", il y a aussi\n"
-"[types d'emballage spéciaux] (https://doc.rust-lang.org/reference/special-"
-"types-and-traits.html)\n"
-"autorisés à être des types de récepteurs, tels que `Box<Self>`."
+"Au-delà des variantes sur \"self\", il y a aussi \\[types d'emballage "
+"spéciaux\\] (https://doc.rust-lang.org/reference/special-types-and-traits."
+"html) autorisés à être des types de récepteurs, tels que `Box<Self>`."
 
 #: src/methods/receiver.md:24
 #, fuzzy
 msgid ""
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it."
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 "Pensez à mettre l'accent sur \"partagé et immuable\" et \"unique et "
-"modifiable\". Ces contraintes viennent toujours\n"
-"ensemble dans Rust en raison des règles du vérificateur d'emprunt, et "
-"\"self\" ne fait pas exception. Il n'est pas possible de\n"
-"référencez une structure à partir de plusieurs emplacements et appelez une "
-"méthode de mutation (`&mut self`) sur celle-ci."
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-#, fuzzy
-msgid "# Example"
-msgstr "# Exemple"
+"modifiable\". Ces contraintes viennent toujours ensemble dans Rust en raison "
+"des règles du vérificateur d'emprunt, et \"self\" ne fait pas exception. Il "
+"n'est pas possible de référencez une structure à partir de plusieurs "
+"emplacements et appelez une méthode de mutation (`&mut self`) sur celle-ci."
 
 #: src/methods/example.md:3
 msgid ""
@@ -6845,48 +7123,59 @@ msgstr ""
 
 #: src/methods/example.md:47
 #, fuzzy
+msgid "All four methods here use a different method receiver."
+msgstr "Les quatre méthodes ici utilisent un récepteur de méthode différent."
+
+#: src/methods/example.md:48
+#, fuzzy
 msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+"Vous pouvez indiquer comment cela change ce que la fonction peut faire avec "
+"les valeurs des variables et si/comment elle peut être réutilisée dans "
+"`main`."
+
+#: src/methods/example.md:49
+#, fuzzy
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+"Vous pouvez afficher l'erreur qui apparaît lorsque vous essayez d'appeler "
+"\"finish\" deux fois."
+
+#: src/methods/example.md:50
+#, fuzzy
+msgid ""
+"Note that although the method receivers are different, the non-static "
 "functions are called the same way in the main body. Rust enables automatic "
 "referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
-"over. We describe vectors in more detail in the afternoon. "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
 msgstr ""
-"* Les quatre méthodes ici utilisent un récepteur de méthode différent.\n"
-"  * Vous pouvez indiquer comment cela change ce que la fonction peut faire "
-"avec les valeurs des variables et si/comment elle peut être réutilisée dans "
-"`main`.\n"
-"  * Vous pouvez afficher l'erreur qui apparaît lorsque vous essayez "
-"d'appeler \"finish\" deux fois.\n"
-"* Notez que bien que les récepteurs de méthode soient différents, les "
+"Notez que bien que les récepteurs de méthode soient différents, les "
 "fonctions non statiques sont appelées de la même manière dans le corps "
 "principal. Rust permet le référencement et le déréférencement automatique "
 "lors de l'appel de méthodes. Rust ajoute automatiquement les `&`, `*`, "
-"`muts` afin que cet objet corresponde à la signature de la méthode.\n"
-"* Vous pourriez remarquer que `print_laps` utilise un vecteur qui est itéré. "
-"Nous décrivons les vecteurs plus en détail dans l'après-midi."
+"`muts` afin que cet objet corresponde à la signature de la méthode."
 
-#: src/pattern-matching.md:1
+#: src/methods/example.md:51
 #, fuzzy
-msgid "# Pattern Matching"
-msgstr "# Correspondance de modèle"
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
+msgstr ""
+"Vous pourriez remarquer que `print_laps` utilise un vecteur qui est itéré. "
+"Nous décrivons les vecteurs plus en détail dans l'après-midi."
 
 #: src/pattern-matching.md:3
 #, fuzzy
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 "Le mot clé `match` vous permet de faire correspondre une valeur à un ou "
-"plusieurs _patterns_. Le\n"
-"les comparaisons se font de haut en bas et le premier match l'emporte."
+"plusieurs _patterns_. Le les comparaisons se font de haut en bas et le "
+"premier match l'emporte."
 
 #: src/pattern-matching.md:6
 #, fuzzy
@@ -6921,50 +7210,66 @@ msgstr ""
 #: src/pattern-matching.md:26
 #, fuzzy
 msgid ""
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
-"* Vous pouvez indiquer comment certains caractères spécifiques sont utilisés "
-"dans un modèle\n"
-"  * `|` comme un `ou`\n"
-"  * `..` peut s'étendre autant que nécessaire\n"
-"  * `1..=5` représente une plage inclusive\n"
-"  * `_` est un joker\n"
-"* Il peut être utile de montrer comment fonctionne la liaison, par exemple "
-"en remplaçant un caractère générique par une variable ou en supprimant les "
-"guillemets autour de `q`.\n"
-"* Vous pouvez démontrer la correspondance sur une référence.\n"
-"* C'est peut-être le bon moment pour évoquer le concept de modèles "
-"irréfutables, car le terme peut apparaître dans les messages d'erreur.\n"
-"   "
+"Vous pouvez indiquer comment certains caractères spécifiques sont utilisés "
+"dans un modèle"
 
-#: src/pattern-matching/destructuring-enums.md:1
+#: src/pattern-matching.md:27
 #, fuzzy
-msgid "# Destructuring Enums"
-msgstr "# déstructuration des énumérations"
+msgid "`|` as an `or`"
+msgstr "`|` comme un `ou`"
+
+#: src/pattern-matching.md:28
+#, fuzzy
+msgid "`..` can expand as much as it needs to be"
+msgstr "`..` peut s'étendre autant que nécessaire"
+
+#: src/pattern-matching.md:29
+#, fuzzy
+msgid "`1..=5` represents an inclusive range"
+msgstr "`1..=5` représente une plage inclusive"
+
+#: src/pattern-matching.md:30
+#, fuzzy
+msgid "`_` is a wild card"
+msgstr "`_` est un joker"
+
+#: src/pattern-matching.md:31
+#, fuzzy
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+"Il peut être utile de montrer comment fonctionne la liaison, par exemple en "
+"remplaçant un caractère générique par une variable ou en supprimant les "
+"guillemets autour de `q`."
+
+#: src/pattern-matching.md:32
+#, fuzzy
+msgid "You can demonstrate matching on a reference."
+msgstr "Vous pouvez démontrer la correspondance sur une référence."
+
+#: src/pattern-matching.md:33
+#, fuzzy
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
+msgstr ""
+"C'est peut-être le bon moment pour évoquer le concept de modèles "
+"irréfutables, car le terme peut apparaître dans les messages d'erreur."
 
 #: src/pattern-matching/destructuring-enums.md:3
 #, fuzzy
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 "Les modèles peuvent également être utilisés pour lier des variables à des "
-"parties de vos valeurs. C'est ainsi\n"
-"vous inspectez la structure de vos types. Commençons par un simple type "
-"`enum` :"
+"parties de vos valeurs. C'est ainsi vous inspectez la structure de vos "
+"types. Commençons par un simple type `enum` :"
 
 #: src/pattern-matching/destructuring-enums.md:6
 msgid ""
@@ -6995,38 +7300,34 @@ msgstr ""
 #: src/pattern-matching/destructuring-enums.md:29
 #, fuzzy
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
 "Ici, nous avons utilisé les bras pour _déstructurer_ la valeur `Result`. En "
-"premier\n"
-"arm, `half` est lié à la valeur à l'intérieur de la variante `Ok`. Dans le "
-"deuxième bras,\n"
-"`msg` est lié au message d'erreur."
+"premier arm, `half` est lié à la valeur à l'intérieur de la variante `Ok`. "
+"Dans le deuxième bras, `msg` est lié au message d'erreur."
 
 #: src/pattern-matching/destructuring-enums.md:36
 #, fuzzy
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
-"* L'expression `if`/`else` renvoie une énumération qui est ensuite "
-"décompressée avec une `match`.\n"
-"* Vous pouvez essayer d'ajouter une troisième variante à la définition enum "
-"et d'afficher les erreurs lors de l'exécution du code. Indiquez les endroits "
-"où votre code est maintenant inexhaustif et comment le compilateur essaie de "
-"vous donner des indices."
+"L'expression `if`/`else` renvoie une énumération qui est ensuite "
+"décompressée avec une `match`."
 
-#: src/pattern-matching/destructuring-structs.md:1
+#: src/pattern-matching/destructuring-enums.md:37
 #, fuzzy
-msgid "# Destructuring Structs"
-msgstr "# Structures déstructurantes"
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
+msgstr ""
+"Vous pouvez essayer d'ajouter une troisième variante à la définition enum et "
+"d'afficher les erreurs lors de l'exécution du code. Indiquez les endroits où "
+"votre code est maintenant inexhaustif et comment le compilateur essaie de "
+"vous donner des indices."
 
 #: src/pattern-matching/destructuring-structs.md:3
 #, fuzzy
@@ -7055,19 +7356,19 @@ msgid ""
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard "
-"to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that "
-"it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-msgid "# Destructuring Arrays"
-msgstr "# Déstructuration des tableaux"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:25
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
+msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
 #, fuzzy
@@ -7095,50 +7396,57 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were "
-"ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of "
-"elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:1
-#, fuzzy
-msgid "# Match Guards"
-msgstr "# Match Guards"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 #, fuzzy
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 "Lors de la correspondance, vous pouvez ajouter un _guard_ à un motif. Ceci "
-"est un booléen arbitraire\n"
-"expression qui sera exécutée si le motif correspond à :"
+"est un booléen arbitraire expression qui sera exécutée si le motif "
+"correspond à :"
 
 #: src/pattern-matching/match-guards.md:6
 msgid ""
@@ -7160,37 +7468,48 @@ msgstr ""
 #: src/pattern-matching/match-guards.md:23
 #, fuzzy
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr ""
+"Les gardes de correspondance en tant que fonctionnalité de syntaxe distincte "
+"sont importants et nécessaires lorsque nous souhaitons exprimer de manière "
+"concise des idées plus complexes que ne le permettraient les modèles seuls."
+
+#: src/pattern-matching/match-guards.md:24
+#, fuzzy
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`."
+"result in other arms of the original `match` expression being considered."
 msgstr ""
-"* Les gardes de correspondance en tant que fonctionnalité de syntaxe "
-"distincte sont importants et nécessaires lorsque nous souhaitons exprimer de "
-"manière concise des idées plus complexes que ne le permettraient les modèles "
-"seuls.\n"
-"* Ils ne sont pas identiques à une expression \"if\" séparée à l'intérieur "
-"du bras de match. Une expression `if` à l'intérieur du bloc de branche "
-"(après `=>`) se produit après la sélection du bras de correspondance. "
-"L'échec de la condition \"si\" à l'intérieur de ce bloc n'entraînera pas "
-"d'autres bras\n"
-"de l'expression \"match\" d'origine considérée.\n"
-"* Vous pouvez utiliser les variables définies dans le modèle dans votre "
-"expression if.\n"
-"* La condition définie dans la garde s'applique à chaque expression dans un "
+"Ils ne sont pas identiques à une expression \"if\" séparée à l'intérieur du "
+"bras de match. Une expression `if` à l'intérieur du bloc de branche (après "
+"`=>`) se produit après la sélection du bras de correspondance. L'échec de la "
+"condition \"si\" à l'intérieur de ce bloc n'entraînera pas d'autres bras de "
+"l'expression \"match\" d'origine considérée."
+
+#: src/pattern-matching/match-guards.md:26
+#, fuzzy
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+"Vous pouvez utiliser les variables définies dans le modèle dans votre "
+"expression if."
+
+#: src/pattern-matching/match-guards.md:27
+#, fuzzy
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr ""
+"La condition définie dans la garde s'applique à chaque expression dans un "
 "modèle avec un `|`."
 
 #: src/exercises/day-2/morning.md:1
 #, fuzzy
-msgid "# Day 2: Morning Exercises"
-msgstr "# Jour 2 : Exercices du matin"
+msgid "Day 2: Morning Exercises"
+msgstr "Jour 2 : Exercices du matin"
 
 #: src/exercises/day-2/morning.md:3
 #, fuzzy
@@ -7200,55 +7519,43 @@ msgstr ""
 
 #: src/exercises/day-2/morning.md:5
 #, fuzzy
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
-msgstr ""
-"* Structure simple qui suit les statistiques de santé.\n"
-"\n"
-"* Plusieurs structures et énumérations pour une bibliothèque de dessins."
+msgid "Simple struct which tracks health statistics."
+msgstr "Structure simple qui suit les statistiques de santé."
 
-#: src/exercises/day-2/health-statistics.md:1
+#: src/exercises/day-2/morning.md:7
 #, fuzzy
-msgid "# Health Statistics"
-msgstr "# Statistiques de santé"
+msgid "Multiple structs and enums for a drawing library."
+msgstr "Plusieurs structures et énumérations pour une bibliothèque de dessins."
 
 #: src/exercises/day-2/health-statistics.md:3
 #, fuzzy
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
 "Vous travaillez à la mise en place d'un système de surveillance de la santé. "
-"Dans le cadre de cela, vous\n"
-"besoin de suivre les statistiques de santé des utilisateurs."
+"Dans le cadre de cela, vous besoin de suivre les statistiques de santé des "
+"utilisateurs."
 
 #: src/exercises/day-2/health-statistics.md:6
 #, fuzzy
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 "Vous commencerez avec quelques fonctions stub dans un bloc `impl` ainsi "
-"qu'un `User`\n"
-"définition de structure. Votre objectif est d'implémenter les méthodes "
-"tronquées sur le\n"
-"`User` `struct` défini dans le bloc `impl`."
+"qu'un `User` définition de structure. Votre objectif est d'implémenter les "
+"méthodes tronquées sur le `User` `struct` défini dans le bloc `impl`."
 
 #: src/exercises/day-2/health-statistics.md:10
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 "Copiez le code ci-dessous sur <https://play.rust-lang.org/> et remplissez "
-"les champs manquants\n"
-"méthodes :"
+"les champs manquants méthodes :"
 
 #: src/exercises/day-2/health-statistics.md:13
 msgid ""
@@ -7311,23 +7618,19 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
 #, fuzzy
-msgid "# Polygon Struct"
-msgstr "# Structure Polygone"
+msgid "Polygon Struct"
+msgstr "Structure Polygone"
 
 #: src/exercises/day-2/points-polygons.md:3
 #, fuzzy
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 "Nous allons créer une structure `Polygon` contenant des points. Copiez le "
-"code ci-dessous\n"
-"à <https://play.rust-lang.org/> et remplissez les méthodes manquantes pour "
-"faire le\n"
-"les tests passent :"
+"code ci-dessous à <https://play.rust-lang.org/> et remplissez les méthodes "
+"manquantes pour faire le les tests passent :"
 
 #: src/exercises/day-2/points-polygons.md:7
 msgid ""
@@ -7444,14 +7747,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 "Étant donné que les signatures de méthode manquent dans les énoncés de "
-"problème, la partie clé\n"
-"de l'exercice consiste à les spécifier correctement. Vous n'avez pas à "
-"modifier les tests."
+"problème, la partie clé de l'exercice consiste à les spécifier correctement. "
+"Vous n'avez pas à modifier les tests."
 
 #: src/exercises/day-2/points-polygons.md:120
 #, fuzzy
@@ -7461,55 +7762,43 @@ msgstr "Autres parties intéressantes de l'exercice :"
 #: src/exercises/day-2/points-polygons.md:122
 #, fuzzy
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
-"* Dérivez un trait `Copy` pour certaines structures, car dans les tests, les "
-"méthodes n'empruntent parfois pas leurs arguments.\n"
-"* Découvrez que le trait `Add` doit être implémenté pour que deux objets "
+"Dérivez un trait `Copy` pour certaines structures, car dans les tests, les "
+"méthodes n'empruntent parfois pas leurs arguments."
+
+#: src/exercises/day-2/points-polygons.md:123
+#, fuzzy
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
+"Découvrez que le trait `Add` doit être implémenté pour que deux objets "
 "puissent être ajoutés via \"+\". Notez que nous ne discutons pas des "
 "génériques avant le Jour 3."
-
-#: src/control-flow.md:1
-#, fuzzy
-msgid "# Control Flow"
-msgstr "# Flux de contrôle"
 
 #: src/control-flow.md:3
 #, fuzzy
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
 "Comme nous l'avons vu, `if` est une expression en Rust. Il est utilisé pour "
-"conditionnellement\n"
-"évaluer l'un des deux blocs, mais les blocs peuvent avoir une valeur qui "
-"devient alors\n"
-"la valeur de l'expression \"if\". D'autres expressions de flux de contrôle "
-"fonctionnent de manière similaire\n"
-"à Rust."
-
-#: src/control-flow/blocks.md:1
-#, fuzzy
-msgid "# Blocks"
-msgstr "# Blocs"
+"conditionnellement évaluer l'un des deux blocs, mais les blocs peuvent avoir "
+"une valeur qui devient alors la valeur de l'expression \"if\". D'autres "
+"expressions de flux de contrôle fonctionnent de manière similaire à Rust."
 
 #: src/control-flow/blocks.md:3
 #, fuzzy
 msgid ""
-"A block in Rust contains a sequence of expressions.\n"
-"Each block has a value and a type,\n"
-"which are those of the last expression of the block:"
+"A block in Rust contains a sequence of expressions. Each block has a value "
+"and a type, which are those of the last expression of the block:"
 msgstr ""
 "Un bloc en Rust a une valeur et un type : la valeur est la dernière "
-"expression du\n"
-"bloc:"
+"expression du bloc:"
 
 #: src/control-flow/blocks.md:7
 msgid ""
@@ -7542,12 +7831,11 @@ msgstr ""
 #: src/control-flow/blocks.md:28
 #, fuzzy
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
 "La même règle est utilisée pour les fonctions : la valeur du corps de la "
-"fonction est le\n"
-"valeur de retour :"
+"fonction est le valeur de retour :"
 
 #: src/control-flow/blocks.md:31
 msgid ""
@@ -7565,31 +7853,31 @@ msgstr ""
 #: src/control-flow/blocks.md:44
 #, fuzzy
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
 msgstr ""
-"* Le but de cette diapositive est de montrer que les blocs ont un type et "
-"une valeur dans Rust.\n"
-"* Vous pouvez montrer comment la valeur du bloc change en modifiant la "
+"Le but de cette diapositive est de montrer que les blocs ont un type et une "
+"valeur dans Rust."
+
+#: src/control-flow/blocks.md:45
+#, fuzzy
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
+msgstr ""
+"Vous pouvez montrer comment la valeur du bloc change en modifiant la "
 "dernière ligne du bloc. Par exemple, ajouter/supprimer un point-virgule ou "
-"utiliser un \"retour\".\n"
-"   "
+"utiliser un \"retour\"."
 
 #: src/control-flow/if-expressions.md:1
 #, fuzzy
-msgid "# `if` expressions"
-msgstr "# expressions \"si\""
+msgid "`if` expressions"
+msgstr "expressions \"si\""
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
 
 #: src/control-flow/if-expressions.md:7
@@ -7609,7 +7897,7 @@ msgstr ""
 #: src/control-flow/if-expressions.md:18
 #, fuzzy
 msgid ""
-"In addition, you can use `if` as an expression. The last expression of each\n"
+"In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
 "De plus, vous pouvez l'utiliser comme expression. Cela fait la même chose "
@@ -7638,16 +7926,14 @@ msgstr ""
 
 #: src/control-flow/if-let-expressions.md:1
 #, fuzzy
-msgid "# `if let` expressions"
-msgstr "# expressions `si nous allons`"
+msgid "`if let` expressions"
+msgstr "expressions `si nous allons`"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:7
@@ -7670,49 +7956,60 @@ msgstr ""
 #, fuzzy
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
 "Voir [pattern matching](../pattern-matching.md) pour plus de détails sur les "
-"modèles dans\n"
-"Rouiller."
+"modèles dans Rouiller."
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* Unlike `match`, `if let` does not have to cover all branches. This can "
-"make it more concise than `match`.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"Unlike `match`, `if let` does not have to cover all branches. This can make "
+"it more concise than `match`."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:26
+msgid ""
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) construct allows to do a destructuring "
 "assignment, or if it fails, execute a block which is required to abort "
-"normal control flow (with `panic`/`return`/`break`/`continue`):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"normal control flow (with `panic`/`return`/`break`/`continue`):"
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:1
 #, fuzzy
-msgid "# `while` loops"
-msgstr "# Expressions `while`"
+msgid "`while` loops"
+msgstr "Expressions `while`"
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:6
@@ -7734,19 +8031,18 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
 #, fuzzy
-msgid "# `while let` loops"
-msgstr "# expressions `while let`"
+msgid "`while let` loops"
+msgstr "expressions `while let`"
 
 #: src/control-flow/while-let-expressions.md:3
 #, fuzzy
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variant which repeatedly tests a value against a pattern:"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
 "Comme avec `if`, il existe une variante `while let` qui teste à plusieurs "
-"reprises une valeur\n"
-"contre un modèle :"
+"reprises une valeur contre un modèle :"
 
 #: src/control-flow/while-let-expressions.md:6
 msgid ""
@@ -7766,48 +8062,49 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
-"Ici, l'itérateur renvoyé par `v.iter()` renverra une `Option<i32>` à chaque\n"
+"Ici, l'itérateur renvoyé par `v.iter()` renverra une `Option<i32>` à chaque "
 "appel à `next()`. Il renvoie `Some(x)` jusqu'à ce qu'il soit terminé, après "
-"quoi il\n"
-"renvoie \"Aucun\". Le `while let` nous permet de continuer à parcourir tous "
-"les éléments."
+"quoi il renvoie \"Aucun\". Le `while let` nous permet de continuer à "
+"parcourir tous les éléments."
 
 #: src/control-flow/while-let-expressions.md:26
 #, fuzzy
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
-"statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
 msgstr ""
-"* Soulignez que la boucle `while let` continuera tant que la valeur "
-"correspond au modèle.\n"
-"* Vous pouvez réécrire la boucle `while let` comme une boucle infinie avec "
-"une instruction if qui s'interrompt lorsqu'il n'y a pas de valeur à déballer "
+"Soulignez que la boucle `while let` continuera tant que la valeur correspond "
+"au modèle."
+
+#: src/control-flow/while-let-expressions.md:27
+#, fuzzy
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
+msgstr ""
+"Vous pouvez réécrire la boucle `while let` comme une boucle infinie avec une "
+"instruction if qui s'interrompt lorsqu'il n'y a pas de valeur à déballer "
 "pour `iter.next()`. Le `while let` fournit du sucre syntaxique pour le "
-"scénario ci-dessus.\n"
-"    "
+"scénario ci-dessus."
 
 #: src/control-flow/for-expressions.md:1
 #, fuzzy
-msgid "# `for` loops"
-msgstr "## Boucles `for`"
+msgid "`for` loops"
+msgstr "Boucles `for`"
 
 #: src/control-flow/for-expressions.md:3
 #, fuzzy
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely\n"
-"related to the [`while let` loop](while-let-expressions.md). It will\n"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expressions.md). It will "
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
-"L'expression `for` est étroitement liée à l'expression `while let`. Ce sera\n"
+"L'expression `for` est étroitement liée à l'expression `while let`. Ce sera "
 "appelez automatiquement `into_iter()` sur l'expression, puis parcourez-la :"
 
 #: src/control-flow/for-expressions.md:7
@@ -7834,33 +8131,44 @@ msgstr "Vous pouvez utiliser `break` et `continue` ici comme d'habitude."
 
 #: src/control-flow/for-expressions.md:25
 #, fuzzy
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr ""
+"L'itération d'index n'est pas une syntaxe spéciale dans Rust pour ce cas "
+"précis."
+
+#: src/control-flow/for-expressions.md:26
+#, fuzzy
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "`(0..10)` est une plage qui implémente un trait `Iterator`."
+
+#: src/control-flow/for-expressions.md:27
+#, fuzzy
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+"`step_by` est une méthode qui renvoie un autre `Iterator` qui saute tous les "
+"autres éléments."
+
+#: src/control-flow/for-expressions.md:28
+#, fuzzy
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
-"* L'itération d'index n'est pas une syntaxe spéciale dans Rust pour ce cas "
-"précis.\n"
-"* `(0..10)` est une plage qui implémente un trait `Iterator`.\n"
-"* `step_by` est une méthode qui renvoie un autre `Iterator` qui saute tous "
-"les autres éléments.\n"
-"* Modifier les éléments du vecteur et expliquer les erreurs du compilateur. "
+"Modifier les éléments du vecteur et expliquer les erreurs du compilateur. "
 "Modifiez le vecteur `v` pour qu'il soit modifiable et la boucle for en `for "
 "x in v.iter_mut()`."
 
 #: src/control-flow/loop-expressions.md:1
 #, fuzzy
-msgid "# `loop` expressions"
-msgstr "# expressions de \"boucle\""
+msgid "`loop` expressions"
+msgstr "\\# expressions de \"boucle\""
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
 "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:6
@@ -7868,8 +8176,7 @@ msgstr ""
 msgid "Here you must either `break` or `return` to stop the loop:"
 msgstr ""
 "Enfin, il existe un mot-clé `loop` qui crée une boucle sans fin. Ici, vous "
-"devez\n"
-"soit `break` ou `return` pour arrêter la boucle :"
+"devez soit `break` ou `return` pour arrêter la boucle :"
 
 #: src/control-flow/loop-expressions.md:8
 msgid ""
@@ -7892,32 +8199,31 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:27
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr ""
+
+#: src/control-flow/loop-expressions.md:28
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-"
-"trivial\n"
-"  value. This is because it's guaranteed to be entered at least once "
-"(unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:1
 #, fuzzy
-msgid "# `match` expressions"
-msgstr "# expressions \"correspondantes\""
+msgid "`match` expressions"
+msgstr "expressions \"correspondantes\""
 
 #: src/control-flow/match-expressions.md:3
 #, fuzzy
 msgid ""
 "The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
-"expr.html)\n"
-"is used to match a value against one or more patterns. In that sense, it "
-"works\n"
-"like a series of `if let` expressions:"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
 "Le mot clé `match` est utilisé pour faire correspondre une valeur à un ou "
-"plusieurs modèles. Dans\n"
-"en ce sens, cela fonctionne comme une série d'expressions \"if let\":"
+"plusieurs modèles. Dans en ce sens, cela fonctionne comme une série "
+"d'expressions \"if let\":"
 
 #: src/control-flow/match-expressions.md:7
 msgid ""
@@ -7938,63 +8244,77 @@ msgstr ""
 #: src/control-flow/match-expressions.md:20
 #, fuzzy
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 "Comme `if let`, chaque bras de correspondance doit avoir le même type. Le "
-"type est le dernier\n"
-"expression du bloc, le cas échéant. Dans l'exemple ci-dessus, le type est "
-"`()`."
+"type est le dernier expression du bloc, le cas échéant. Dans l'exemple ci-"
+"dessus, le type est `()`."
 
 #: src/control-flow/match-expressions.md:28
 #, fuzzy
-msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`."
+msgid "Save the match expression to a variable and print it out."
 msgstr ""
-"* Enregistrez l'expression de correspondance dans une variable et imprimez-"
-"la.\n"
-"* Supprimez `.as_deref()` et expliquez l'erreur.\n"
-"    * `std::env::args().next()` renvoie une `Option<String>`, mais nous ne "
-"pouvons pas comparer `String`.\n"
-"    * `as_deref()` transforme une `Option<T>` en `Option<&T::Target>`. Dans "
-"notre cas, cela transforme `Option<String>` en `Option<&str>`.\n"
-"    * Nous pouvons maintenant utiliser le pattern matching pour faire "
-"correspondre le `&str` à l'intérieur de `Option`."
+"Enregistrez l'expression de correspondance dans une variable et imprimez-la."
+
+#: src/control-flow/match-expressions.md:29
+#, fuzzy
+msgid "Remove `.as_deref()` and explain the error."
+msgstr "Supprimez `.as_deref()` et expliquez l'erreur."
+
+#: src/control-flow/match-expressions.md:30
+#, fuzzy
+msgid ""
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
+msgstr ""
+"`std::env::args().next()` renvoie une `Option<String>`, mais nous ne pouvons "
+"pas comparer `String`."
+
+#: src/control-flow/match-expressions.md:31
+#, fuzzy
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+"`as_deref()` transforme une `Option<T>` en `Option<&T::Target>`. Dans notre "
+"cas, cela transforme `Option<String>` en `Option<&str>`."
+
+#: src/control-flow/match-expressions.md:32
+#, fuzzy
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
+msgstr ""
+"Nous pouvons maintenant utiliser le pattern matching pour faire correspondre "
+"le `&str` à l'intérieur de `Option`."
 
 #: src/control-flow/break-continue.md:1
 #, fuzzy
-msgid "# `break` and `continue`"
-msgstr "# `pause` et `continue`"
+msgid "`break` and `continue`"
+msgstr "`pause` et `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
+msgstr ""
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
 msgstr ""
 
 #: src/control-flow/break-continue.md:7
 #, fuzzy
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
-"used\n"
-"to break out of nested loops:"
+"used to break out of nested loops:"
 msgstr ""
 "Si vous voulez quitter une boucle plus tôt, utilisez `break`, si vous voulez "
-"commencer immédiatement\n"
-"la prochaine itération utilise `continue`. `continue` et `break` peuvent "
-"éventuellement\n"
-"prenez un argument d'étiquette qui est utilisé pour sortir des boucles "
-"imbriquées :"
+"commencer immédiatement la prochaine itération utilise `continue`. "
+"`continue` et `break` peuvent éventuellement prenez un argument d'étiquette "
+"qui est utilisé pour sortir des boucles imbriquées :"
 
 #: src/control-flow/break-continue.md:10
 msgid ""
@@ -8025,25 +8345,17 @@ msgstr ""
 "Dans ce cas, nous cassons la boucle externe après 3 itérations de la boucle "
 "interne."
 
-#: src/std.md:1
-#, fuzzy
-msgid "# Standard Library"
-msgstr "# Bibliothèque standard"
-
 #: src/std.md:3
 #, fuzzy
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 "Rust est livré avec une bibliothèque standard qui permet d'établir un "
-"ensemble de types communs\n"
-"utilisé par la bibliothèque et les programmes Rust. De cette façon, deux "
-"bibliothèques peuvent travailler ensemble\n"
-"en douceur car ils utilisent tous les deux le même type `String`."
+"ensemble de types communs utilisé par la bibliothèque et les programmes "
+"Rust. De cette façon, deux bibliothèques peuvent travailler ensemble en "
+"douceur car ils utilisent tous les deux le même type `String`."
 
 #: src/std.md:7
 #, fuzzy
@@ -8053,67 +8365,88 @@ msgstr "Les types de vocabulaire courants comprennent :"
 #: src/std.md:9
 #, fuzzy
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
+msgstr ""
+"Types [`Option` et `Result`](std/option-result.md) : utilisés pour les "
+"valeurs facultatives et \\[gestion des erreurs\\] (error-handling.md)."
+
+#: src/std.md:12
+#, fuzzy
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+"[`String`](std/string.md) : le type de chaîne par défaut utilisé pour les "
+"données détenues."
+
+#: src/std.md:14
+#, fuzzy
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr "[`Vec`](std/vec.md) : un vecteur extensible standard."
+
+#: src/std.md:16
+#, fuzzy
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr ""
+"[`HashMap`](std/hashmap.md) : un type de carte de hachage avec un hachage "
+"configurable algorithme."
+
+#: src/std.md:19
+#, fuzzy
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr ""
+"[`Box`](std/box.md) : un pointeur propriétaire pour les données allouées par "
+"tas."
+
+#: src/std.md:21
+#, fuzzy
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
 "data."
 msgstr ""
-"* Types [`Option` et `Result`](std/option-result.md) : utilisés pour les "
-"valeurs facultatives\n"
-"  et [gestion des erreurs] (error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md) : le type de chaîne par défaut utilisé pour les "
-"données détenues.\n"
-"\n"
-"* [`Vec`](std/vec.md) : un vecteur extensible standard.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md) : un type de carte de hachage avec un hachage "
-"configurable\n"
-"  algorithme.\n"
-"\n"
-"* [`Box`](std/box.md) : un pointeur propriétaire pour les données allouées "
-"par tas.\n"
-"\n"
-"* [`Rc`](std/rc.md) : un pointeur partagé compté par référence pour les "
+"[`Rc`](std/rc.md) : un pointeur partagé compté par référence pour les "
 "données allouées par tas."
 
 #: src/std.md:25
 #, fuzzy
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
 msgstr ""
-"  * En fait, Rust contient plusieurs couches de la bibliothèque standard : "
-"`core`, `alloc` et `std`.\n"
-"  * `core` inclut les types et fonctions les plus basiques qui ne dépendent "
-"pas de `libc`, de l'allocateur ou\n"
-"    même la présence d'un système d'exploitation.\n"
-"  * `alloc` inclut les types qui nécessitent un allocateur de tas global, "
-"tels que `Vec`, `Box` et `Arc`.\n"
-"  * Les applications Embedded Rust n'utilisent souvent que \"core\" et "
-"parfois \"alloc\"."
+"En fait, Rust contient plusieurs couches de la bibliothèque standard : "
+"`core`, `alloc` et `std`."
+
+#: src/std.md:26
+#, fuzzy
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+"`core` inclut les types et fonctions les plus basiques qui ne dépendent pas "
+"de `libc`, de l'allocateur ou même la présence d'un système d'exploitation."
+
+#: src/std.md:28
+#, fuzzy
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+"`alloc` inclut les types qui nécessitent un allocateur de tas global, tels "
+"que `Vec`, `Box` et `Arc`."
+
+#: src/std.md:29
+#, fuzzy
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"Les applications Embedded Rust n'utilisent souvent que \"core\" et parfois "
+"\"alloc\"."
 
 #: src/std/option-result.md:1
 #, fuzzy
-msgid "# `Option` and `Result`"
-msgstr "# `Option` et `Résultat`"
+msgid "`Option` and `Result`"
+msgstr "`Option` et `Résultat`"
 
 #: src/std/option-result.md:3
 #, fuzzy
@@ -8136,37 +8469,51 @@ msgstr ""
 
 #: src/std/option-result.md:18
 #, fuzzy
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
-"* `Option` et `Result` sont largement utilisés, pas seulement dans la "
-"bibliothèque standard.\n"
-"* `Option<&T>` n'a aucune surcharge d'espace par rapport à `&T`.\n"
-"* `Result` est le type standard pour implémenter la gestion des erreurs, "
-"comme nous le verrons le jour 3.\n"
-"* `binary_search` renvoie `Result<usize, usize>`.\n"
-"  * Si trouvé, `Result::Ok` contient l'index où se trouve l'élément.\n"
-"  * Sinon, `Result::Err` contient l'index où un tel élément doit être inséré."
+"`Option` et `Result` sont largement utilisés, pas seulement dans la "
+"bibliothèque standard."
 
-#: src/std/string.md:1
+#: src/std/option-result.md:19
 #, fuzzy
-msgid "# String"
-msgstr "# Chaîne"
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "`Option<&T>` n'a aucune surcharge d'espace par rapport à `&T`."
+
+#: src/std/option-result.md:20
+#, fuzzy
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+"`Result` est le type standard pour implémenter la gestion des erreurs, comme "
+"nous le verrons le jour 3."
+
+#: src/std/option-result.md:21
+#, fuzzy
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "`binary_search` renvoie `Result<usize, usize>`."
+
+#: src/std/option-result.md:22
+#, fuzzy
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr "Si trouvé, `Result::Ok` contient l'index où se trouve l'élément."
+
+#: src/std/option-result.md:23
+#, fuzzy
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr ""
+"Sinon, `Result::Err` contient l'index où un tel élément doit être inséré."
 
 #: src/std/string.md:3
 #, fuzzy
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
-"[`String`][1] est le tampon de chaîne UTF-8 évolutif standard alloué par "
-"tas :"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) est le "
+"tampon de chaîne UTF-8 évolutif standard alloué par tas :"
 
 #: src/std/string.md:5
 msgid ""
@@ -8191,50 +8538,92 @@ msgstr ""
 #: src/std/string.md:22
 #, fuzzy
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` implémente [`Deref<Target = str>`][2], ce qui signifie que vous "
-"pouvez appeler tous\n"
-"Méthodes `str` sur une `String`."
+"`String` implémente [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), ce qui signifie que vous "
+"pouvez appeler tous Méthodes `str` sur une `String`."
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to index a `String`:\n"
-"    * To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-"
-"bound, out-of-bounds.\n"
-"    * To a substring by using `s3[0..4]`, where that slice is on character "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
 #: src/std/vec.md:1
 #, fuzzy
-msgid "# `Vec`"
-msgstr "# `Vec`"
+msgid "`Vec`"
+msgstr "`Vec`"
 
 #: src/std/vec.md:3
 #, fuzzy
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
-msgstr "[`Vec`][1] est le tampon standard redimensionnable alloué au tas :"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
+msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) est le tampon "
+"standard redimensionnable alloué au tas :"
 
 #: src/std/vec.md:5
 msgid ""
@@ -8266,40 +8655,51 @@ msgstr ""
 #: src/std/vec.md:29
 #, fuzzy
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
-"`Vec` implémente [`Deref<Target = [T]>`][2], ce qui signifie que vous pouvez "
-"appeler slice\n"
-"méthodes sur un `Vec`."
+"`Vec` implémente [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), ce qui signifie que vous pouvez "
+"appeler slice méthodes sur un `Vec`."
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
 #, fuzzy
-msgid "# `HashMap`"
-msgstr "# `HashMap`"
+msgid "`HashMap`"
+msgstr "`HashMap`"
 
 #: src/std/hashmap.md:3
 #, fuzzy
@@ -8347,50 +8747,82 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
 #, fuzzy
-msgid "# `Box`"
-msgstr "# `Boîte`"
+msgid "`Box`"
+msgstr "`Boîte`"
 
 #: src/std/box.md:3
 #, fuzzy
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "[`Box`][1] est un pointeur propriétaire vers des données sur le tas :"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) est un pointeur "
+"propriétaire vers des données sur le tas :"
 
 #: src/std/box.md:5
 msgid ""
@@ -8422,43 +8854,60 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 "`Box<T>` implémente `Deref<Target = T>`, ce qui signifie que vous pouvez "
-"[appeler des méthodes\n"
-"depuis `T` directement sur une `Box<T>`][2]."
+"[appeler des méthodes depuis `T` directement sur une `Box<T>`](https://doc."
+"rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion)."
 
 #: src/std/box.md:34
 #, fuzzy
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
 msgstr ""
-"* `Box` est comme `std::unique_ptr` en C++, sauf qu'il est garanti qu'il "
-"n'est pas nul.\n"
-"* Dans l'exemple ci-dessus, vous pouvez même omettre le `*` dans "
-"l'instruction `println!` grâce à `Deref`.\n"
-"* Une `Box` peut être utile lorsque vous :\n"
-"   * avoir un type dont la taille ne peut pas être connue au moment de la "
-"compilation, mais le compilateur Rust veut connaître une taille exacte.\n"
-"   * souhaitez transférer la propriété d'une grande quantité de données. "
-"Pour éviter de copier de grandes quantités de données sur la pile, stockez "
-"plutôt les données sur le tas dans une `Box` afin que seul le pointeur soit "
-"déplacé."
+"`Box` est comme `std::unique_ptr` en C++, sauf qu'il est garanti qu'il n'est "
+"pas nul."
+
+#: src/std/box.md:35
+#, fuzzy
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+"Dans l'exemple ci-dessus, vous pouvez même omettre le `*` dans l'instruction "
+"`println!` grâce à `Deref`."
+
+#: src/std/box.md:36
+#, fuzzy
+msgid "A `Box` can be useful when you:"
+msgstr "Une `Box` peut être utile lorsque vous :"
+
+#: src/std/box.md:37
+#, fuzzy
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+"avoir un type dont la taille ne peut pas être connue au moment de la "
+"compilation, mais le compilateur Rust veut connaître une taille exacte."
+
+#: src/std/box.md:38
+#, fuzzy
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
+msgstr ""
+"souhaitez transférer la propriété d'une grande quantité de données. Pour "
+"éviter de copier de grandes quantités de données sur la pile, stockez plutôt "
+"les données sur le tas dans une `Box` afin que seul le pointeur soit déplacé."
 
 #: src/std/box-recursive.md:1
 #, fuzzy
-msgid "# Box with Recursive Data Structures"
-msgstr "# Boîte avec des structures de données récursives"
+msgid "Box with Recursive Data Structures"
+msgstr "Boîte avec des structures de données récursives"
 
 #: src/std/box-recursive.md:3
 #, fuzzy
@@ -8510,50 +8959,43 @@ msgstr ""
 #: src/std/box-recursive.md:33
 #, fuzzy
 msgid ""
-"* If `Box` was not used and we attempted to embed a `List` directly into the "
-"`List`,\n"
-"the compiler would not compute a fixed size of the struct in memory (`List` "
-"would be of infinite size).\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If `Box` was not used and we attempted to embed a `List` directly into the "
+"`List`, the compiler would not compute a fixed size of the struct in memory "
+"(`List` would be of infinite size)."
 msgstr ""
-"* Si la `Box` n'a pas été utilisée ici et que nous avons essayé d'intégrer "
-"une `List` directement dans la `List`,\n"
-"le compilateur ne calculerait pas une taille fixe de la structure en "
-"mémoire, elle semblerait infinie.\n"
-"\n"
-"* `Box` résout ce problème car il a la même taille qu'un pointeur normal et "
-"pointe simplement vers le prochain\n"
-"élément de la `Liste` dans le tas.\n"
-"\n"
-"* Supprimez la `Box` dans la définition de la liste et affichez l'erreur du "
+"Si la `Box` n'a pas été utilisée ici et que nous avons essayé d'intégrer une "
+"`List` directement dans la `List`, le compilateur ne calculerait pas une "
+"taille fixe de la structure en mémoire, elle semblerait infinie."
+
+#: src/std/box-recursive.md:36
+#, fuzzy
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+"`Box` résout ce problème car il a la même taille qu'un pointeur normal et "
+"pointe simplement vers le prochain élément de la `Liste` dans le tas."
+
+#: src/std/box-recursive.md:39
+#, fuzzy
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
+"Supprimez la `Box` dans la définition de la liste et affichez l'erreur du "
 "compilateur. \"Récursif avec indirection\" est un indice que vous voudrez "
 "peut-être utiliser une boîte ou une référence quelconque, au lieu de stocker "
-"une valeur directement.\n"
-"    "
-
-#: src/std/box-niche.md:1
-#, fuzzy
-msgid "# Niche Optimization"
-msgstr "# Optimisation de niche"
+"une valeur directement."
 
 #: src/std/box-niche.md:16
 #, fuzzy
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 "Une `Box` ne peut pas être vide, donc le pointeur est toujours valide et non "
-"`null`. Ce\n"
-"permet au compilateur d'optimiser la disposition de la mémoire :"
+"`null`. Ce permet au compilateur d'optimiser la disposition de la mémoire :"
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -8579,19 +9021,19 @@ msgstr ""
 
 #: src/std/rc.md:1
 #, fuzzy
-msgid "# `Rc`"
-msgstr "# `Rc`"
+msgid "`Rc`"
+msgstr "`Rc`"
 
 #: src/std/rc.md:3
 #, fuzzy
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`][1] est un pointeur partagé compté par référence. Utilisez-le lorsque "
-"vous avez besoin de vous référer\n"
-"aux mêmes données depuis plusieurs endroits :"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) est un pointeur "
+"partagé compté par référence. Utilisez-le lorsque vous avez besoin de vous "
+"référer aux mêmes données depuis plusieurs endroits :"
 
 #: src/std/rc.md:6
 msgid ""
@@ -8611,61 +9053,94 @@ msgstr ""
 #: src/std/rc.md:18
 #, fuzzy
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
 msgstr ""
-"* Si vous avez besoin de muter les données à l'intérieur d'un `Rc`, vous "
-"devrez envelopper les données dans\n"
-"  un type tel que [`Cell` ou `RefCell`][2].\n"
-"* Voir [`Arc`][3] si vous êtes dans un contexte multi-thread.\n"
-"* Vous pouvez *rétrograder* un pointeur partagé en un pointeur [`Weak`][4] "
-"pour créer des cycles\n"
-"  qui va tomber."
+"Si vous avez besoin de muter les données à l'intérieur d'un `Rc`, vous "
+"devrez envelopper les données dans un type tel que [`Cell` ou `RefCell`](../"
+"concurrency/shared_state/arc.md)."
+
+#: src/std/rc.md:20
+#, fuzzy
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+"Voir [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) si vous "
+"êtes dans un contexte multi-thread."
+
+#: src/std/rc.md:21
+#, fuzzy
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
+"Vous pouvez _rétrograder_ un pointeur partagé en un pointeur [`Weak`]"
+"(https://doc.rust-lang.org/std/rc/struct.Weak.html) pour créer des cycles "
+"qui va tomber."
 
 #: src/std/rc.md:31
 #, fuzzy
 msgid ""
-"* `Rc`'s count ensures that its contained value is valid for as long as "
-"there are references.\n"
-"* `Rc` in Rust is like `std::shared_ptr` in C++.\n"
-"* `Rc::clone` is cheap: it creates a pointer to the same allocation and "
-"increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-"
-"write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable "
-"borrows that are enforced at compile time. `RefCell` enables (im)mutable "
-"borrows that are enforced at run time and will panic if it fails at "
-"runtime.\n"
-"* `Rc::downgrade` gives you a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
 msgstr ""
-"* Le comptage de `Rc` garantit que sa valeur contenue est valide tant qu'il "
-"y a des références.\n"
-"* Comme `std::shared_ptr` de C++.\n"
-"* `clone` est bon marché : il crée un pointeur vers la même allocation et "
+"Le comptage de `Rc` garantit que sa valeur contenue est valide tant qu'il y "
+"a des références."
+
+#: src/std/rc.md:32
+#, fuzzy
+msgid "`Rc` in Rust is like `std::shared_ptr` in C++."
+msgstr "Comme `std::shared_ptr` de C++."
+
+#: src/std/rc.md:33
+#, fuzzy
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"increases the reference count. Does not make a deep clone and can generally "
+"be ignored when looking for performance issues in code."
+msgstr ""
+"`clone` est bon marché : il crée un pointeur vers la même allocation et "
 "augmente le nombre de références. Ne crée pas de clone profond et peut "
 "généralement être ignoré lors de la recherche de problèmes de performances "
-"dans le code.\n"
-"* `make_mut` clone en fait la valeur interne si nécessaire (\"clone-on-"
-"write\") et renvoie une référence mutable.\n"
-"* Utilisez `Rc::strong_count` pour vérifier le nombre de références.\n"
-"* Comparez les différents types de données mentionnés. `Box` active les "
+"dans le code."
+
+#: src/std/rc.md:34
+#, fuzzy
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+"`make_mut` clone en fait la valeur interne si nécessaire (\"clone-on-"
+"write\") et renvoie une référence mutable."
+
+#: src/std/rc.md:35
+#, fuzzy
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr "Utilisez `Rc::strong_count` pour vérifier le nombre de références."
+
+#: src/std/rc.md:36
+#, fuzzy
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+"Comparez les différents types de données mentionnés. `Box` active les "
 "emprunts (im)mutables qui sont appliqués au moment de la compilation. "
 "`RefCell` active les emprunts (im)mutables qui sont appliqués au moment de "
-"l'exécution et paniqueront s'ils échouent au moment de l'exécution.\n"
-"* Vous pouvez `downgrader()` un `Rc` en un objet *faiblement compté en "
-"référence* pour\n"
-"  créer des cycles qui seront supprimés correctement (probablement en "
-"combinaison avec\n"
-"  `RefCell`)."
+"l'exécution et paniqueront s'ils échouent au moment de l'exécution."
+
+#: src/std/rc.md:37
+#, fuzzy
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
+msgstr ""
+"Vous pouvez `downgrader()` un `Rc` en un objet _faiblement compté en "
+"référence_ pour créer des cycles qui seront supprimés correctement "
+"(probablement en combinaison avec `RefCell`)."
 
 #: src/std/rc.md:41
 msgid ""
@@ -8697,11 +9172,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/modules.md:1
-#, fuzzy
-msgid "# Modules"
-msgstr "# Modules"
 
 #: src/modules.md:3
 #, fuzzy
@@ -8742,23 +9212,27 @@ msgstr ""
 #: src/modules.md:28
 #, fuzzy
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
-"* Les packages fournissent des fonctionnalités et incluent un fichier `Cargo."
-"toml` qui décrit comment créer un ensemble de 1+ caisses.\n"
-"* Les caisses sont un arbre de modules, où une caisse binaire crée un "
-"exécutable et une caisse de bibliothèque se compile en une bibliothèque.\n"
-"* Les modules définissent l'organisation, la portée et sont au centre de "
-"cette section."
+"Les packages fournissent des fonctionnalités et incluent un fichier `Cargo."
+"toml` qui décrit comment créer un ensemble de 1+ caisses."
 
-#: src/modules/visibility.md:1
+#: src/modules.md:29
 #, fuzzy
-msgid "# Visibility"
-msgstr "# Visibilité"
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+"Les caisses sont un arbre de modules, où une caisse binaire crée un "
+"exécutable et une caisse de bibliothèque se compile en une bibliothèque."
+
+#: src/modules.md:30
+#, fuzzy
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr ""
+"Les modules définissent l'organisation, la portée et sont au centre de cette "
+"section."
 
 #: src/modules/visibility.md:3
 #, fuzzy
@@ -8767,19 +9241,24 @@ msgstr "Les modules sont une limite de confidentialité :"
 
 #: src/modules/visibility.md:5
 #, fuzzy
-msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+msgid "Module items are private by default (hides implementation details)."
 msgstr ""
-"* Les éléments du module sont privés par défaut (cache les détails "
-"d'implémentation).\n"
-"* Les éléments parents et frères sont toujours visibles.\n"
-"* En d'autres termes, si un élément est visible dans le module `foo`, il est "
-"visible dans tous les\n"
-"  descendants de `foo`."
+"Les éléments du module sont privés par défaut (cache les détails "
+"d'implémentation)."
+
+#: src/modules/visibility.md:6
+#, fuzzy
+msgid "Parent and sibling items are always visible."
+msgstr "Les éléments parents et frères sont toujours visibles."
+
+#: src/modules/visibility.md:7
+#, fuzzy
+msgid ""
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
+msgstr ""
+"En d'autres termes, si un élément est visible dans le module `foo`, il est "
+"visible dans tous les descendants de `foo`."
 
 #: src/modules/visibility.md:10
 msgid ""
@@ -8813,8 +9292,8 @@ msgstr ""
 
 #: src/modules/visibility.md:39
 #, fuzzy
-msgid "* Use the `pub` keyword to make modules public."
-msgstr "* Utilisez le mot-clé `pub` pour rendre les modules publics."
+msgid "Use the `pub` keyword to make modules public."
+msgstr "Utilisez le mot-clé `pub` pour rendre les modules publics."
 
 #: src/modules/visibility.md:41
 #, fuzzy
@@ -8828,25 +9307,32 @@ msgstr ""
 #: src/modules/visibility.md:43
 #, fuzzy
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+msgstr ""
+"Voir la [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
+
+#: src/modules/visibility.md:44
+#, fuzzy
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+"La configuration de la visibilité de `pub(crate)` est un modèle courant."
+
+#: src/modules/visibility.md:45
+#, fuzzy
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+"Plus rarement, vous pouvez donner de la visibilité à un chemin spécifique."
+
+#: src/modules/visibility.md:46
+#, fuzzy
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
 "its descendants)."
 msgstr ""
-"* Voir la [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* La configuration de la visibilité de `pub(crate)` est un modèle courant.\n"
-"* Plus rarement, vous pouvez donner de la visibilité à un chemin "
-"spécifique.\n"
-"* Dans tous les cas, la visibilité doit être accordée à un module ancêtre "
-"(et à tous ses descendants)."
-
-#: src/modules/paths.md:1
-#, fuzzy
-msgid "# Paths"
-msgstr "# Chemins"
+"Dans tous les cas, la visibilité doit être accordée à un module ancêtre (et "
+"à tous ses descendants)."
 
 #: src/modules/paths.md:3
 #, fuzzy
@@ -8855,27 +9341,38 @@ msgstr "Les chemins sont résolus comme suit :"
 
 #: src/modules/paths.md:5
 #, fuzzy
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
-msgstr ""
-"1. En tant que chemin relatif :\n"
-"   * `foo` ou `self::foo` fait référence à `foo` dans le module actuel,\n"
-"   * `super::foo` fait référence à `foo` dans le module parent.\n"
-"\n"
-"2. En tant que chemin absolu :\n"
-"   * `crate::foo` fait référence à `foo` à la racine du crate actuel,\n"
-"   * `bar::foo` fait référence à `foo` dans le crate `bar`."
+msgid "As a relative path:"
+msgstr "En tant que chemin relatif :"
+
+#: src/modules/paths.md:6
+#, fuzzy
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr "`foo` ou `self::foo` fait référence à `foo` dans le module actuel,"
+
+#: src/modules/paths.md:7
+#, fuzzy
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr "`super::foo` fait référence à `foo` dans le module parent."
+
+#: src/modules/paths.md:9
+#, fuzzy
+msgid "As an absolute path:"
+msgstr "En tant que chemin absolu :"
+
+#: src/modules/paths.md:10
+#, fuzzy
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr "`crate::foo` fait référence à `foo` à la racine du crate actuel,"
+
+#: src/modules/paths.md:11
+#, fuzzy
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr "`bar::foo` fait référence à `foo` dans le crate `bar`."
 
 #: src/modules/paths.md:13
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
 
 #: src/modules/paths.md:16
@@ -8885,11 +9382,6 @@ msgid ""
 "use std::mem::transmute;\n"
 "```"
 msgstr ""
-
-#: src/modules/filesystem.md:1
-#, fuzzy
-msgid "# Filesystem Hierarchy"
-msgstr "# Hiérarchie du système de fichiers"
 
 #: src/modules/filesystem.md:3
 #, fuzzy
@@ -8910,12 +9402,13 @@ msgstr "Le contenu du module \"jardin\" se trouve à :"
 
 #: src/modules/filesystem.md:11
 #, fuzzy
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden.rs` (style Rust 2018 moderne)\n"
-"* `src/garden/mod.rs` (ancien style Rust 2015)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr "`src/garden.rs` (style Rust 2018 moderne)"
+
+#: src/modules/filesystem.md:12
+#, fuzzy
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/mod.rs` (ancien style Rust 2015)"
 
 #: src/modules/filesystem.md:14
 #, fuzzy
@@ -8924,12 +9417,13 @@ msgstr "De même, un module `garden::legumes` peut être trouvé à :"
 
 #: src/modules/filesystem.md:16
 #, fuzzy
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden/vegetables.rs` (style Rust 2018 moderne)\n"
-"* `src/garden/vegetables/mod.rs` (ancien style Rust 2015)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr "`src/garden/vegetables.rs` (style Rust 2018 moderne)"
+
+#: src/modules/filesystem.md:17
+#, fuzzy
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/vegetables/mod.rs` (ancien style Rust 2015)"
 
 #: src/modules/filesystem.md:19
 #, fuzzy
@@ -8938,23 +9432,24 @@ msgstr "La racine `crate` se trouve dans :"
 
 #: src/modules/filesystem.md:21
 #, fuzzy
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
-msgstr ""
-"* `src/lib.rs` (pour une caisse de bibliothèque)\n"
-"* `src/main.rs` (pour un crate binaire)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr "`src/lib.rs` (pour une caisse de bibliothèque)"
+
+#: src/modules/filesystem.md:22
+#, fuzzy
+msgid "`src/main.rs` (for a binary crate)"
+msgstr "`src/main.rs` (pour un crate binaire)"
 
 #: src/modules/filesystem.md:24
 #, fuzzy
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
-"comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 "Les modules définis dans les fichiers peuvent également être documentés à "
-"l'aide de \"commentaires de documentation internes\".\n"
-"Ceux-ci documentent l'élément qui les contient -- dans ce cas, un module."
+"l'aide de \"commentaires de documentation internes\". Ceux-ci documentent "
+"l'élément qui les contient -- dans ce cas, un module."
 
 #: src/modules/filesystem.md:27
 msgid ""
@@ -8977,42 +9472,55 @@ msgstr ""
 
 #: src/modules/filesystem.md:44
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:47
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:57
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:60
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:63
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:68
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
 #, fuzzy
-msgid "# Day 2: Afternoon Exercises"
-msgstr "# Jour 2 : Exercices de l'après-midi"
+msgid "Day 2: Afternoon Exercises"
+msgstr "Jour 2 : Exercices de l'après-midi"
 
 #: src/exercises/day-2/afternoon.md:3
 #, fuzzy
@@ -9020,65 +9528,60 @@ msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr ""
 "Les exercices de cet après-midi porteront sur les chaînes et les itérateurs."
 
-#: src/exercises/day-2/luhn.md:1
-#, fuzzy
-msgid "# Luhn Algorithm"
-msgstr "# Algorithme de Luhn"
-
 #: src/exercises/day-2/luhn.md:3
 #, fuzzy
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 "L'[algorithme de Luhn](https://en.wikipedia.org/wiki/Luhn_algorithm) est "
-"utilisé pour\n"
-"valider les numéros de carte de crédit. L'algorithme prend une chaîne en "
-"entrée et fait le\n"
-"suivant pour valider le numéro de carte bancaire :"
+"utilisé pour valider les numéros de carte de crédit. L'algorithme prend une "
+"chaîne en entrée et fait le suivant pour valider le numéro de carte "
+"bancaire :"
 
 #: src/exercises/day-2/luhn.md:7
 #, fuzzy
-msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+msgid "Ignore all spaces. Reject number with less than two digits."
 msgstr ""
-"* Ignorer tous les espaces. Numéro de rejet comportant moins de deux "
-"chiffres.\n"
-"\n"
-"* En se déplaçant de droite à gauche, doubler tous les deux chiffres : pour "
-"le nombre `1234`,\n"
-"  on double '3' et '1'.\n"
-"\n"
-"* Après avoir doublé un chiffre, additionnez les chiffres. Donc doubler '7' "
-"devient '14' ce qui\n"
-"  devient '5'.\n"
-"\n"
-"* Additionnez tous les chiffres non doublés et doublés.\n"
-"\n"
-"* Le numéro de carte de crédit est valide si la somme se termine par '0'."
+"Ignorer tous les espaces. Numéro de rejet comportant moins de deux chiffres."
+
+#: src/exercises/day-2/luhn.md:9
+#, fuzzy
+msgid ""
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
+msgstr ""
+"En se déplaçant de droite à gauche, doubler tous les deux chiffres : pour le "
+"nombre `1234`, on double '3' et '1'."
+
+#: src/exercises/day-2/luhn.md:12
+#, fuzzy
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+"Après avoir doublé un chiffre, additionnez les chiffres. Donc doubler '7' "
+"devient '14' ce qui devient '5'."
+
+#: src/exercises/day-2/luhn.md:15
+#, fuzzy
+msgid "Sum all the undoubled and doubled digits."
+msgstr "Additionnez tous les chiffres non doublés et doublés."
+
+#: src/exercises/day-2/luhn.md:17
+#, fuzzy
+msgid "The credit card number is valid if the sum ends with `0`."
+msgstr ""
+"Le numéro de carte de crédit est valide si la somme se termine par '0'."
 
 #: src/exercises/day-2/luhn.md:19
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
-"Copiez le code suivant sur <https://play.rust-lang.org/> et implémentez le\n"
+"Copiez le code suivant sur <https://play.rust-lang.org/> et implémentez le "
 "fonction:"
 
 #: src/exercises/day-2/luhn.md:23
@@ -9133,37 +9636,27 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-#, fuzzy
-msgid "# Strings and Iterators"
-msgstr "# Chaînes et itérateurs"
-
 #: src/exercises/day-2/strings-iterators.md:3
 #, fuzzy
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 "Dans cet exercice, vous implémentez un composant de routage d'un serveur "
-"Web. Le\n"
-"le serveur est configuré avec un certain nombre de _préfixes de chemin_ qui "
-"sont mis en correspondance\n"
-"_demander des chemins_. Les préfixes de chemin peuvent contenir un caractère "
-"générique qui\n"
-"correspond à un segment complet. Voir les tests unitaires ci-dessous."
+"Web. Le le serveur est configuré avec un certain nombre de _préfixes de "
+"chemin_ qui sont mis en correspondance _demander des chemins_. Les préfixes "
+"de chemin peuvent contenir un caractère générique qui correspond à un "
+"segment complet. Voir les tests unitaires ci-dessous."
 
 #: src/exercises/day-2/strings-iterators.md:8
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
-"Copiez le code suivant sur <https://play.rust-lang.org/> et faites les "
-"tests\n"
+"Copiez le code suivant sur <https://play.rust-lang.org/> et faites les tests "
 "passer. Essayez d'éviter d'attribuer un \"Vec\" à vos résultats "
 "intermédiaires :"
 
@@ -9218,8 +9711,8 @@ msgstr ""
 
 #: src/welcome-day-3.md:1
 #, fuzzy
-msgid "# Welcome to Day 3"
-msgstr "# Bienvenue au jour 3"
+msgid "Welcome to Day 3"
+msgstr "Bienvenue au jour 3"
 
 #: src/welcome-day-3.md:3
 #, fuzzy
@@ -9229,58 +9722,50 @@ msgstr "Aujourd'hui, nous aborderons quelques sujets plus avancés de Rust :"
 #: src/welcome-day-3.md:5
 #, fuzzy
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
-"* Traits : traits dérivés, méthodes par défaut et bibliothèque standard "
-"importante\n"
-"  caractéristiques.\n"
-"\n"
-"* Génériques : types de données génériques, méthodes génériques, "
-"monomorphisation et trait\n"
-"  objets.\n"
-"\n"
-"* Gestion des erreurs : paniques, « Résultat » et l'opérateur d'essai "
-"« ? ».\n"
-"\n"
-"* Tests : tests unitaires, tests de documentation et tests d'intégration.\n"
-"\n"
-"* Unsafe Rust : pointeurs bruts, variables statiques, fonctions non "
-"sécurisées et extern\n"
-"  les fonctions."
+"Traits : traits dérivés, méthodes par défaut et bibliothèque standard "
+"importante caractéristiques."
 
-#: src/generics.md:1
+#: src/welcome-day-3.md:8
 #, fuzzy
-msgid "# Generics"
-msgstr "# Génériques"
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+"Génériques : types de données génériques, méthodes génériques, "
+"monomorphisation et trait objets."
+
+#: src/welcome-day-3.md:11
+#, fuzzy
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+"Gestion des erreurs : paniques, « Résultat » et l'opérateur d'essai « ? »."
+
+#: src/welcome-day-3.md:13
+#, fuzzy
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+"Tests : tests unitaires, tests de documentation et tests d'intégration."
+
+#: src/welcome-day-3.md:15
+#, fuzzy
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
+"Unsafe Rust : pointeurs bruts, variables statiques, fonctions non sécurisées "
+"et extern les fonctions."
 
 #: src/generics.md:3
 #, fuzzy
 msgid ""
-"Rust support generics, which lets you abstract algorithms or data "
-"structures\n"
-"(such as sorting or a binary tree)\n"
-"over the types used or stored."
+"Rust support generics, which lets you abstract algorithms or data structures "
+"(such as sorting or a binary tree) over the types used or stored."
 msgstr ""
 "Rust prend en charge les génériques, ce qui vous permet d'abstraire un "
-"algorithme (comme le tri)\n"
-"sur les types utilisés dans l'algorithme."
-
-#: src/generics/data-types.md:1
-#, fuzzy
-msgid "# Generic Data Types"
-msgstr "# Types de données génériques"
+"algorithme (comme le tri) sur les types utilisés dans l'algorithme."
 
 #: src/generics/data-types.md:3
 #, fuzzy
@@ -9306,16 +9791,12 @@ msgid ""
 msgstr ""
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
 msgstr ""
 
-#: src/generics/methods.md:1
-#, fuzzy
-msgid "# Generic Methods"
-msgstr "# Méthodes génériques"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
+msgstr ""
 
 #: src/generics/methods.md:3
 #, fuzzy
@@ -9346,28 +9827,39 @@ msgstr ""
 #: src/generics/methods.md:25
 #, fuzzy
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
-"* *Q :* Pourquoi `T` est spécifié deux fois dans `impl<T> Point<T> {}` ? "
-"N'est-ce pas redondant ?\n"
-"    * C'est parce qu'il s'agit d'une section d'implémentation générique pour "
-"le type générique. Ils sont indépendamment génériques.\n"
-"    * Cela signifie que ces méthodes sont définies pour n'importe quel `T`.\n"
-"    * Il est possible d'écrire `impl Point<u32> { .. }`.\n"
-"      * `Point` est toujours générique et vous pouvez utiliser `Point<f64>`, "
-"mais les méthodes de ce bloc ne seront disponibles que pour `Point<u32>`."
+"_Q :_ Pourquoi `T` est spécifié deux fois dans `impl<T> Point<T> {}` ? N'est-"
+"ce pas redondant ?"
 
-#: src/generics/monomorphization.md:1
+#: src/generics/methods.md:26
 #, fuzzy
-msgid "# Monomorphization"
-msgstr "# Monomorphisation"
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"C'est parce qu'il s'agit d'une section d'implémentation générique pour le "
+"type générique. Ils sont indépendamment génériques."
+
+#: src/generics/methods.md:27
+#, fuzzy
+msgid "It means these methods are defined for any `T`."
+msgstr "Cela signifie que ces méthodes sont définies pour n'importe quel `T`."
+
+#: src/generics/methods.md:28
+#, fuzzy
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "Il est possible d'écrire `impl Point<u32> { .. }`."
+
+#: src/generics/methods.md:29
+#, fuzzy
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"`Point` est toujours générique et vous pouvez utiliser `Point<f64>`, mais "
+"les méthodes de ce bloc ne seront disponibles que pour `Point<u32>`."
 
 #: src/generics/monomorphization.md:3
 #, fuzzy
@@ -9415,17 +9907,11 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 "Il s'agit d'une abstraction à coût nul : vous obtenez exactement le même "
-"résultat que si vous aviez\n"
-"codé à la main les structures de données sans l'abstraction."
-
-#: src/traits.md:1
-#, fuzzy
-msgid "# Traits"
-msgstr "# Caractéristiques"
+"résultat que si vous aviez codé à la main les structures de données sans "
+"l'abstraction."
 
 #: src/traits.md:3
 #, fuzzy
@@ -9474,11 +9960,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/trait-objects.md:1
-#, fuzzy
-msgid "# Trait Objects"
-msgstr "# Objets de trait"
 
 #: src/traits/trait-objects.md:3
 #, fuzzy
@@ -9586,29 +10067,39 @@ msgstr ""
 
 #: src/traits/trait-objects.md:72
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Pet>` in the example above.\n"
-"* `dyn Pet` is a way to tell the compiler about a dynamically sized type "
-"that implements `Pet`.\n"
-"* In the example, `pets` holds *fat pointers* to objects that implement "
-"`Pet`. The fat pointer consists of two components, a pointer to the actual "
-"object and a pointer to the virtual method table for the `Pet` "
-"implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"     ```"
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Pet>` in the example above."
 msgstr ""
 
-#: src/traits/deriving-traits.md:1
-#, fuzzy
-msgid "# Deriving Traits"
-msgstr "# Traits dérivés"
+#: src/traits/trait-objects.md:73
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/traits/trait-objects.md:74
+msgid ""
+"In the example, `pets` holds _fat pointers_ to objects that implement `Pet`. "
+"The fat pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Pet` implementation of "
+"that particular object."
+msgstr ""
+
+#: src/traits/trait-objects.md:75
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits/trait-objects.md:76
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
+msgstr ""
 
 #: src/traits/deriving-traits.md:3
 #, fuzzy
@@ -9634,11 +10125,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/default-methods.md:1
-#, fuzzy
-msgid "# Default Methods"
-msgstr "# Méthodes par défaut"
 
 #: src/traits/default-methods.md:3
 #, fuzzy
@@ -9678,66 +10164,74 @@ msgstr ""
 #: src/traits/default-methods.md:32
 #, fuzzy
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to\n"
-"  implement themselves. Methods with default implementations can rely on "
-"required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `Equals` a super trait for `NotEqual`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `Equals` as a super "
-"trait for `NotEqual`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
-"* Les caractéristiques peuvent spécifier des méthodes pré-implémentées (par "
-"défaut) et des méthodes que les utilisateurs sont tenus de suivre\n"
-"  mettre en œuvre eux-mêmes. Les méthodes avec des implémentations par "
-"défaut peuvent s'appuyer sur les méthodes requises.\n"
-"\n"
-"* Déplacez la méthode `not_equal` vers un nouveau trait `NotEqual`.\n"
-"\n"
-"* Faites de `NotEqual` un super trait pour `Equal`.\n"
-"\n"
-"* Fournir une implémentation globale de `NotEqual` pour `Equal`.\n"
-"  * Avec l'implémentation globale, vous n'avez plus besoin de `NotEqual` "
-"comme super trait pour `Equal`."
+"Les caractéristiques peuvent spécifier des méthodes pré-implémentées (par "
+"défaut) et des méthodes que les utilisateurs sont tenus de suivre mettre en "
+"œuvre eux-mêmes. Les méthodes avec des implémentations par défaut peuvent "
+"s'appuyer sur les méthodes requises."
 
-#: src/traits/trait-bounds.md:1
+#: src/traits/default-methods.md:35
 #, fuzzy
-msgid "# Trait Bounds"
-msgstr "# Limites de trait"
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr "Déplacez la méthode `not_equal` vers un nouveau trait `NotEqual`."
+
+#: src/traits/default-methods.md:37
+#, fuzzy
+msgid "Make `Equals` a super trait for `NotEqual`."
+msgstr "Faites de `NotEqual` un super trait pour `Equal`."
+
+#: src/traits/default-methods.md:38
+#, fuzzy
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr "Fournir une implémentation globale de `NotEqual` pour `Equal`."
+
+#: src/traits/default-methods.md:46
+#, fuzzy
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr ""
+"Avec l'implémentation globale, vous n'avez plus besoin de `NotEqual` comme "
+"super trait pour `Equal`."
+
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `Equals` as a super "
+"trait for `NotEqual`."
+msgstr ""
 
 #: src/traits/trait-bounds.md:3
 #, fuzzy
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 "Lorsque vous travaillez avec des génériques, vous souhaitez souvent exiger "
-"que les types implémentent\n"
-"un trait, afin que vous puissiez appeler les méthodes de ce trait."
+"que les types implémentent un trait, afin que vous puissiez appeler les "
+"méthodes de ce trait."
 
 #: src/traits/trait-bounds.md:6
 #, fuzzy
@@ -9793,34 +10287,38 @@ msgstr ""
 
 #: src/traits/trait-bounds.md:46
 #, fuzzy
-msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":"
-"\" can be arbitrary, like `Option<T>`.\n"
-"    "
+msgid "It declutters the function signature if you have many parameters."
 msgstr ""
-"* Cela désencombre la signature de la fonction si vous avez beaucoup de "
-"paramètres.\n"
-"* Il a des fonctionnalités supplémentaires qui le rendent plus puissant.\n"
-"    * Si quelqu'un demande, la fonctionnalité supplémentaire est que le type "
-"à gauche de \":\" peut être arbitraire, comme `Option<T>`.\n"
-"    "
+"Cela désencombre la signature de la fonction si vous avez beaucoup de "
+"paramètres."
+
+#: src/traits/trait-bounds.md:47
+#, fuzzy
+msgid "It has additional features making it more powerful."
+msgstr "Il a des fonctionnalités supplémentaires qui le rendent plus puissant."
+
+#: src/traits/trait-bounds.md:48
+#, fuzzy
+msgid ""
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
+msgstr ""
+"Si quelqu'un demande, la fonctionnalité supplémentaire est que le type à "
+"gauche de \":\" peut être arbitraire, comme `Option<T>`."
 
 #: src/traits/impl-trait.md:1
 #, fuzzy
-msgid "# `impl Trait`"
-msgstr "# `Trait d'implémentation`"
+msgid "`impl Trait`"
+msgstr "`Trait d'implémentation`"
 
 #: src/traits/impl-trait.md:3
 #, fuzzy
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 "Semblable aux limites de trait, une syntaxe `impl Trait` peut être utilisée "
-"dans la fonction\n"
-"arguments et valeurs de retour :"
+"dans la fonction arguments et valeurs de retour :"
 
 #: src/traits/impl-trait.md:6
 msgid ""
@@ -9840,10 +10338,10 @@ msgstr ""
 
 #: src/traits/impl-trait.md:19
 #, fuzzy
-msgid "* `impl Trait` allows you to work with types which you cannot name."
+msgid "`impl Trait` allows you to work with types which you cannot name."
 msgstr ""
-"* `impl Trait` vous permet de travailler avec des types que vous ne pouvez "
-"pas nommer."
+"`impl Trait` vous permet de travailler avec des types que vous ne pouvez pas "
+"nommer."
 
 #: src/traits/impl-trait.md:23
 #, fuzzy
@@ -9856,73 +10354,59 @@ msgstr ""
 #: src/traits/impl-trait.md:25
 #, fuzzy
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` "
-"picks\n"
-"  the concrete type it returns, without writing it out in the source. A "
-"function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let "
-"x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
 msgstr ""
-"* Pour un paramètre, `impl Trait` est comme un paramètre générique anonyme "
-"avec un trait lié.\n"
-"\n"
-"* Pour un type de retour, cela signifie que le type de retour est un type "
-"concret qui implémente le trait,\n"
-"  sans nommer le type. Cela peut être utile lorsque vous ne souhaitez pas "
-"exposer le type concret dans un\n"
-"  API publique.\n"
-"\n"
-"  L'inférence est difficile en position de retour. Une fonction renvoyant "
-"`impl Foo` sélectionne\n"
-"  le type concret qu'il renvoie, sans l'écrire dans la source. Une fonction\n"
-"  retourner un type générique comme `collect<B>() -> B` peut retourner "
-"n'importe quel type\n"
-"  satisfaisant `B`, et l'appelant peut avoir besoin d'en choisir un, comme "
-"avec `let x :\n"
-"  Vec<_> = foo.collect()` ou avec le turbofish, `foo.collect ::<Vec<_>>()`."
+"Pour un paramètre, `impl Trait` est comme un paramètre générique anonyme "
+"avec un trait lié."
+
+#: src/traits/impl-trait.md:27
+#, fuzzy
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+"Pour un type de retour, cela signifie que le type de retour est un type "
+"concret qui implémente le trait, sans nommer le type. Cela peut être utile "
+"lorsque vous ne souhaitez pas exposer le type concret dans un API publique."
+
+#: src/traits/impl-trait.md:31
+#, fuzzy
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
+msgstr ""
+"L'inférence est difficile en position de retour. Une fonction renvoyant "
+"`impl Foo` sélectionne le type concret qu'il renvoie, sans l'écrire dans la "
+"source. Une fonction retourner un type générique comme `collect<B>() -> B` "
+"peut retourner n'importe quel type satisfaisant `B`, et l'appelant peut "
+"avoir besoin d'en choisir un, comme avec `let x : Vec<_> = foo.collect()` ou "
+"avec le turbofish, `foo.collect ::<Vec<_>>()`."
 
 #: src/traits/impl-trait.md:37
 #, fuzzy
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters."
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 "Cet exemple est génial, car il utilise `impl Display` deux fois. Cela aide à "
-"expliquer que\n"
-"rien ici n'impose qu'il s'agisse du _même_ type `impl Display`. Si nous "
-"utilisions un seul\n"
-"`T: Display`, cela imposerait la contrainte selon laquelle l'entrée `T` et "
-"le type de retour `T` sont du même type.\n"
-"Cela ne fonctionnerait pas pour cette fonction particulière, car le type que "
-"nous attendons en entrée n'est probablement pas\n"
-"quel `format!` renvoie. Si nous voulions faire la même chose via la syntaxe "
-"`: Display`, nous aurions besoin de deux\n"
-"paramètres génériques indépendants."
-
-#: src/traits/important-traits.md:1
-#, fuzzy
-msgid "# Important Traits"
-msgstr "# Caractéristiques importantes"
+"expliquer que rien ici n'impose qu'il s'agisse du _même_ type `impl "
+"Display`. Si nous utilisions un seul `T: Display`, cela imposerait la "
+"contrainte selon laquelle l'entrée `T` et le type de retour `T` sont du même "
+"type. Cela ne fonctionnerait pas pour cette fonction particulière, car le "
+"type que nous attendons en entrée n'est probablement pas quel `format!` "
+"renvoie. Si nous voulions faire la même chose via la syntaxe `: Display`, "
+"nous aurions besoin de deux paramètres génériques indépendants."
 
 #: src/traits/important-traits.md:3
 #, fuzzy
@@ -9936,30 +10420,76 @@ msgstr ""
 #: src/traits/important-traits.md:5
 #, fuzzy
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
 msgstr ""
-"* [`Iterator`][1] et [`IntoIterator`][2] utilisés dans les boucles `for`,\n"
-"* [`From`][3] et [`Into`][4] utilisés pour convertir les valeurs,\n"
-"* [`Read`][5] et [`Write`][6] utilisés pour IO,\n"
-"* [`Add`][7], [`Mul`][8], ... utilisé pour la surcharge de l'opérateur, et\n"
-"* [`Drop`][9] utilisé pour définir les destructeurs.\n"
-"* [`Default`][10] utilisé pour construire une instance par défaut d'un type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) et "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"utilisés dans les boucles `for`,"
+
+#: src/traits/important-traits.md:6
+#, fuzzy
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) et [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) utilisés pour "
+"convertir les valeurs,"
+
+#: src/traits/important-traits.md:7
+#, fuzzy
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) et [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) utilisés pour IO,"
+
+#: src/traits/important-traits.md:8
+#, fuzzy
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... utilisé pour la surcharge de "
+"l'opérateur, et"
+
+#: src/traits/important-traits.md:9
+#, fuzzy
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) utilisé pour "
+"définir les destructeurs."
+
+#: src/traits/important-traits.md:10
+#, fuzzy
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) "
+"utilisé pour construire une instance par défaut d'un type."
 
 #: src/traits/iterator.md:1
 #, fuzzy
-msgid "# Iterators"
-msgstr "# Itérateurs"
+msgid "Iterators"
+msgstr "Itérateurs"
 
 #: src/traits/iterator.md:3
 #, fuzzy
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
-"Vous pouvez implémenter le trait [`Iterator`][1] sur vos propres types :"
+"Vous pouvez implémenter le trait [`Iterator`](https://doc.rust-lang.org/std/"
+"iter/trait.Iterator.html) sur vos propres types :"
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -9992,48 +10522,42 @@ msgstr ""
 #: src/traits/iterator.md:32
 #, fuzzy
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
-"* Le trait `Iterator` implémente de nombreuses opérations de programmation "
-"fonctionnelles courantes sur les collections\n"
-"  (par exemple, `map`, `filter`, `reduce`, etc.). C'est le trait où vous "
-"pouvez trouver toute la documentation\n"
-"  à propos d'eux. Dans Rust, ces fonctions devraient produire le code aussi "
-"efficace que l'impératif équivalent\n"
-"  implémentations.\n"
-"    \n"
-"* `IntoIterator` est le trait qui fait fonctionner les boucles. Il est "
-"implémenté par des types de collection tels que\n"
-"  `Vec<T>` et leurs références telles que `&Vec<T>` et `&[T]`. Les gammes "
-"l'implémentent également. C'est pourquoi\n"
-"  vous pouvez itérer sur un vecteur avec `for i in some_vec { .. }` mais\n"
-"  `some_vec.next()` n'existe pas."
+"Le trait `Iterator` implémente de nombreuses opérations de programmation "
+"fonctionnelles courantes sur les collections (par exemple, `map`, `filter`, "
+"`reduce`, etc.). C'est le trait où vous pouvez trouver toute la "
+"documentation à propos d'eux. Dans Rust, ces fonctions devraient produire le "
+"code aussi efficace que l'impératif équivalent implémentations."
 
-#: src/traits/from-iterator.md:1
+#: src/traits/iterator.md:37
 #, fuzzy
-msgid "# FromIterator"
-msgstr "# FromIterator"
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
+"`IntoIterator` est le trait qui fait fonctionner les boucles. Il est "
+"implémenté par des types de collection tels que `Vec<T>` et leurs références "
+"telles que `&Vec<T>` et `&[T]`. Les gammes l'implémentent également. C'est "
+"pourquoi vous pouvez itérer sur un vecteur avec `for i in some_vec { .. }` "
+"mais `some_vec.next()` n'existe pas."
 
 #: src/traits/from-iterator.md:3
 #, fuzzy
 msgid ""
-"[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
-"[`FromIterator`][1] vous permet de créer une collection à partir d'un "
-"[`Iterator`][2]."
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"vous permet de créer une collection à partir d'un [`Iterator`](https://doc."
+"rust-lang.org/std/iter/trait.Iterator.html)."
 
 #: src/traits/from-iterator.md:5
 msgid ""
@@ -10051,40 +10575,38 @@ msgstr ""
 #: src/traits/from-iterator.md:17
 #, fuzzy
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"Implémente `Iterator`\n"
-"`fn collect<B>(soi) -> B\n"
-"où\n"
-"    B : FromIterator<Self::Item>,\n"
-"    Auto : dimensionné"
+"Implémente `Iterator` \\`fn collect\n"
+"\n"
+"(soi) -> B où B : FromIterator<Self::Item>, Auto : dimensionné"
 
 #: src/traits/from-iterator.md:23
 #, fuzzy
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 "Il existe également des implémentations qui vous permettent de faire des "
-"choses sympas comme convertir un\n"
-"`Iterator<Item = Result<V, E>>` en un `Result<Vec<V>, E>`."
+"choses sympas comme convertir un `Iterator<Item = Result<V, E>>` en un "
+"`Result<Vec<V>, E>`."
 
 #: src/traits/from-into.md:1
 #, fuzzy
-msgid "# `From` and `Into`"
-msgstr "# `De` et `Dans`"
+msgid "`From` and `Into`"
+msgstr "`De` et `Dans`"
 
 #: src/traits/from-into.md:3
 #, fuzzy
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
-"Les types implémentent [`From`][1] et [`Into`][2] pour faciliter les "
-"conversions de type :"
+"Les types implémentent [`From`](https://doc.rust-lang.org/std/convert/trait."
+"From.html) et [`Into`](https://doc.rust-lang.org/std/convert/trait.Into."
+"html) pour faciliter les conversions de type :"
 
 #: src/traits/from-into.md:5
 msgid ""
@@ -10102,10 +10624,13 @@ msgstr ""
 #: src/traits/from-into.md:15
 #, fuzzy
 msgid ""
-"[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
-"[`Into`][2] est automatiquement implémenté lorsque [`From`][1] est "
-"implémenté :"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) est "
+"automatiquement implémenté lorsque [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) est implémenté :"
 
 #: src/traits/from-into.md:17
 msgid ""
@@ -10123,35 +10648,40 @@ msgstr ""
 #: src/traits/from-into.md:29
 #, fuzzy
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
 msgstr ""
-"* C'est pourquoi il est courant de n'implémenter que `From`, car votre type "
-"recevra également l'implémentation `Into`.\n"
-"* Lors de la déclaration d'un type d'entrée d'argument de fonction comme "
+"C'est pourquoi il est courant de n'implémenter que `From`, car votre type "
+"recevra également l'implémentation `Into`."
+
+#: src/traits/from-into.md:30
+#, fuzzy
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
+msgstr ""
+"Lors de la déclaration d'un type d'entrée d'argument de fonction comme "
 "\"tout ce qui peut être converti en `String`\", la règle est opposée, vous "
-"devez utiliser `Into`.\n"
-"  Votre fonction acceptera les types qui implémentent `From` et ceux qui "
-"implémentent _uniquement_ `Into`.\n"
-"    "
+"devez utiliser `Into`. Votre fonction acceptera les types qui implémentent "
+"`From` et ceux qui implémentent _uniquement_ `Into`."
 
 #: src/traits/read-write.md:1
 #, fuzzy
-msgid "# `Read` and `Write`"
-msgstr "# `Lire` et `Ecrire`"
+msgid "`Read` and `Write`"
+msgstr "`Lire` et `Ecrire`"
 
 #: src/traits/read-write.md:3
 #, fuzzy
 msgid ""
-"Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
 msgstr ""
-"En utilisant [`Read`][1] et [`BufRead`][2], vous pouvez résumer les sources "
-"`u8` :"
+"En utilisant [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) et "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), vous "
+"pouvez résumer les sources `u8` :"
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -10176,8 +10706,12 @@ msgstr ""
 
 #: src/traits/read-write.md:23
 #, fuzzy
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
-msgstr "De même, [`Write`][3] vous permet d'abstraire les puits `u8` :"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
+msgstr ""
+"De même, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) vous "
+"permet d'abstraire les puits `u8` :"
 
 #: src/traits/read-write.md:25
 msgid ""
@@ -10201,17 +10735,18 @@ msgstr ""
 
 #: src/traits/drop.md:1
 #, fuzzy
-msgid "# The `Drop` Trait"
-msgstr "# Le trait `Lâcher`"
+msgid "The `Drop` Trait"
+msgstr "Le trait `Lâcher`"
 
 #: src/traits/drop.md:3
 #, fuzzy
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
-"Les valeurs qui implémentent [`Drop`][1] peuvent spécifier le code à "
-"exécuter lorsqu'elles sortent de la portée :"
+"Les valeurs qui implémentent [`Drop`](https://doc.rust-lang.org/std/ops/"
+"trait.Drop.html) peuvent spécifier le code à exécuter lorsqu'elles sortent "
+"de la portée :"
 
 #: src/traits/drop.md:5
 msgid ""
@@ -10250,30 +10785,37 @@ msgstr "Points de discussion:"
 
 #: src/traits/drop.md:36
 #, fuzzy
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "Pourquoi `Drop::drop` ne prend-il pas `self` ?"
+
+#: src/traits/drop.md:37
+#, fuzzy
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
-"* Pourquoi `Drop::drop` ne prend-il pas `self` ?\n"
-"    * Réponse courte : si c'était le cas, `std::mem::drop` serait appelé à "
-"la fin de\n"
-"        le bloc, résultant en un autre appel à `Drop :: drop`, et une pile\n"
-"        débordement!\n"
-"* Essayez de remplacer `drop(a)` par `a.drop()`."
+"Réponse courte : si c'était le cas, `std::mem::drop` serait appelé à la fin "
+"de le bloc, résultant en un autre appel à `Drop :: drop`, et une pile "
+"débordement!"
+
+#: src/traits/drop.md:40
+#, fuzzy
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "Essayez de remplacer `drop(a)` par `a.drop()`."
 
 #: src/traits/default.md:1
 #, fuzzy
-msgid "# The `Default` Trait"
-msgstr "# Le trait \"par défaut\""
+msgid "The `Default` Trait"
+msgstr "Le trait \"par défaut\""
 
 #: src/traits/default.md:3
 #, fuzzy
-msgid "[`Default`][1] trait produces a default value for a type."
-msgstr "[`Default`][1] trait fournit une implémentation par défaut d'un trait."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
+msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"fournit une implémentation par défaut d'un trait."
 
 #: src/traits/default.md:5
 msgid ""
@@ -10314,41 +10856,64 @@ msgstr ""
 #: src/traits/default.md:40
 #, fuzzy
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * A derived implementation will produce a value where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e."
-"g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr ""
+"Il peut être implémenté directement ou il peut être dérivé via "
+"`#[derive(Default)]`."
+
+#: src/traits/default.md:41
+#, fuzzy
+msgid ""
+"A derived implementation will produce a value where all fields are set to "
+"their default values."
+msgstr ""
+"L'implémentation dérivée produira une instance où tous les champs sont "
+"définis sur leurs valeurs par défaut."
+
+#: src/traits/default.md:42
+#, fuzzy
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+"Cela signifie que tous les types de la structure doivent également "
+"implémenter `Default`."
+
+#: src/traits/default.md:43
+#, fuzzy
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+"Les types Rust standard implémentent souvent `Default` avec des valeurs "
+"raisonnables (par exemple `0`, `\"\"`, etc.)."
+
+#: src/traits/default.md:44
+#, fuzzy
+msgid "The partial struct copy works nicely with default."
+msgstr ""
+"La copie de structure partielle fonctionne bien avec la valeur par défaut."
+
+#: src/traits/default.md:45
+#, fuzzy
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
-"  * Il peut être implémenté directement ou il peut être dérivé via "
-"`#[derive(Default)]`.\n"
-"  * L'implémentation dérivée produira une instance où tous les champs sont "
-"définis sur leurs valeurs par défaut.\n"
-"    * Cela signifie que tous les types de la structure doivent également "
-"implémenter `Default`.\n"
-"  * Les types Rust standard implémentent souvent `Default` avec des valeurs "
-"raisonnables (par exemple `0`, `\"\"`, etc.).\n"
-"  * La copie de structure partielle fonctionne bien avec la valeur par "
-"défaut.\n"
-"  * La bibliothèque standard Rust est consciente que les types peuvent "
+"La bibliothèque standard Rust est consciente que les types peuvent "
 "implémenter `Default` et fournit des méthodes pratiques qui l'utilisent."
 
 #: src/traits/operators.md:1
 #, fuzzy
-msgid "# `Add`, `Mul`, ..."
-msgstr "# `Ajouter`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
+msgstr "`Ajouter`, `Mul`, ..."
 
 #: src/traits/operators.md:3
 #, fuzzy
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
 "La surcharge d'opérateur est implémentée via des traits dans [`std::ops`]"
-"[1] :"
+"(https://doc.rust-lang.org/std/ops/index.html) :"
 
 #: src/traits/operators.md:5
 msgid ""
@@ -10375,61 +10940,65 @@ msgstr ""
 #: src/traits/operators.md:28
 #, fuzzy
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter of "
-"the method?\n"
-"    * Short answer: Function type parameters are controlled by the caller, "
-"but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait.\n"
-"* You could implement `Add` for two different types, e.g.\n"
-"  `impl Add<(i32, i32)> for Point` would add a tuple to a `Point`."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
 msgstr ""
-"* Vous pouvez implémenter `Add` pour `&Point`. Dans quelles situations est-"
-"ce utile ?\n"
-"    * Réponse : `Add:add` consomme `self`. Si tapez `T` pour lequel vous "
-"êtes\n"
-"        la surcharge de l'opérateur n'est pas `Copy`, vous devriez envisager "
-"de surcharger\n"
-"        l'opérateur pour `&T` également. Cela évite un clonage inutile sur "
-"le\n"
-"        site d'appel.\n"
-"* Pourquoi `Output` est-il un type associé ? Pourrait-il en faire un "
-"paramètre de type?\n"
-"    * Réponse courte : les paramètres de type sont contrôlés par l'appelant, "
-"mais\n"
-"        les types associés (comme `Output`) sont contrôlés par "
-"l'implémenteur d'un\n"
-"        trait."
+"Vous pouvez implémenter `Add` pour `&Point`. Dans quelles situations est-ce "
+"utile ?"
+
+#: src/traits/operators.md:29
+#, fuzzy
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"Réponse : `Add:add` consomme `self`. Si tapez `T` pour lequel vous êtes la "
+"surcharge de l'opérateur n'est pas `Copy`, vous devriez envisager de "
+"surcharger l'opérateur pour `&T` également. Cela évite un clonage inutile "
+"sur le site d'appel. \\* Pourquoi `Output` est-il un type associé ? Pourrait-"
+"il en faire un paramètre de type?"
+
+#: src/traits/operators.md:33
+#, fuzzy
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr ""
+"Réponse courte : les paramètres de type sont contrôlés par l'appelant, mais "
+"les types associés (comme `Output`) sont contrôlés par l'implémenteur d'un "
+"trait."
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementor of a "
+"trait."
+msgstr ""
+
+#: src/traits/operators.md:37
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
+msgstr ""
 
 #: src/traits/closures.md:1
 #, fuzzy
-msgid "# Closures"
-msgstr "# Fermetures"
+msgid "Closures"
+msgstr "Fermetures"
 
 #: src/traits/closures.md:3
 #, fuzzy
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 "Les fermetures ou les expressions lambda ont des types qui ne peuvent pas "
-"être nommés. Cependant, ils\n"
-"implémenter [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html) "
-"spécial,\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), et\n"
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) :"
+"être nommés. Cependant, ils implémenter [`Fn`](https://doc.rust-lang.org/std/"
+"ops/trait.Fn.html) spécial, [`FnMut`](https://doc.rust-lang.org/std/ops/"
+"trait.FnMut.html), et [`FnOnce`](https://doc.rust-lang.org/std/ops/trait."
+"FnOnce.html) :"
 
 #: src/traits/closures.md:8
 msgid ""
@@ -10462,19 +11031,17 @@ msgstr ""
 #, fuzzy
 msgid ""
 "An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
-"perhaps captures\n"
-"nothing at all. It can be called multiple times concurrently."
+"perhaps captures nothing at all. It can be called multiple times "
+"concurrently."
 msgstr ""
 "Un `Fn` ne consomme ni ne modifie les valeurs capturées, ou peut-être ne "
-"capture rien du tout, il peut donc\n"
-"être appelé plusieurs fois simultanément."
+"capture rien du tout, il peut donc être appelé plusieurs fois simultanément."
 
 #: src/traits/closures.md:37
 #, fuzzy
 msgid ""
 "An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
-"multiple times,\n"
-"but not concurrently."
+"multiple times, but not concurrently."
 msgstr ""
 "Un `FnMut` peut faire muter les valeurs capturées, vous pouvez donc "
 "l'appeler plusieurs fois mais pas simultanément."
@@ -10483,8 +11050,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
-"might consume\n"
-"captured values."
+"might consume captured values."
 msgstr ""
 "Si vous avez un \"FnOnce\", vous ne pouvez l'appeler qu'une seule fois. Cela "
 "peut consommer des valeurs capturées."
@@ -10493,29 +11059,24 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 "`FnMut` est un sous-type de `FnOnce`. `Fn` est un sous-type de `FnMut` et "
-"`FnOnce`. C'est à dire. vous pouvez utiliser un\n"
-"`FnMut` partout où un `FnOnce` est appelé, et vous pouvez utiliser un `Fn` "
-"partout où un `FnMut` ou `FnOnce`\n"
-"est réclamé."
+"`FnOnce`. C'est à dire. vous pouvez utiliser un `FnMut` partout où un "
+"`FnOnce` est appelé, et vous pouvez utiliser un `Fn` partout où un `FnMut` "
+"ou `FnOnce` est réclamé."
 
 #: src/traits/closures.md:47
 msgid ""
 "The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
-"`multiply_sum`),\n"
-"depending on what the closure captures."
+"`multiply_sum`), depending on what the closure captures."
 msgstr ""
 
 #: src/traits/closures.md:50
 msgid ""
 "By default, closures will capture by reference if they can. The `move` "
-"keyword makes them capture\n"
-"by value."
+"keyword makes them capture by value."
 msgstr ""
 
 #: src/traits/closures.md:52
@@ -10534,8 +11095,8 @@ msgstr ""
 
 #: src/exercises/day-3/morning.md:1
 #, fuzzy
-msgid "# Day 3: Morning Exercises"
-msgstr "# Jour 3 : Exercices du matin"
+msgid "Day 3: Morning Exercises"
+msgstr "Jour 3 : Exercices du matin"
 
 #: src/exercises/day-3/morning.md:3
 #, fuzzy
@@ -10544,20 +11105,14 @@ msgstr ""
 "Nous allons concevoir une bibliothèque de traits et d'objets de traits "
 "d'interface graphique classique."
 
-#: src/exercises/day-3/simple-gui.md:1
-#, fuzzy
-msgid "# A Simple GUI Library"
-msgstr "# Une bibliothèque d'interface graphique simple"
-
 #: src/exercises/day-3/simple-gui.md:3
 #, fuzzy
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 "Concevons une bibliothèque d'interface graphique classique en utilisant nos "
-"nouvelles connaissances sur les traits et\n"
-"objets trait."
+"nouvelles connaissances sur les traits et objets trait."
 
 #: src/exercises/day-3/simple-gui.md:6
 #, fuzzy
@@ -10566,17 +11121,22 @@ msgstr "Nous aurons un certain nombre de widgets dans notre bibliothèque :"
 
 #: src/exercises/day-3/simple-gui.md:8
 #, fuzzy
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr "`Window` : a un `title` et contient d'autres widgets."
+
+#: src/exercises/day-3/simple-gui.md:9
+#, fuzzy
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
 msgstr ""
-"* `Window` : a un `title` et contient d'autres widgets.\n"
-"* `Button` : a un `label` et une fonction de rappel qui est invoquée lorsque "
-"le\n"
-"  bouton est enfoncé.\n"
-"* `Label` : a un `label`."
+"`Button` : a un `label` et une fonction de rappel qui est invoquée lorsque "
+"le bouton est enfoncé."
+
+#: src/exercises/day-3/simple-gui.md:11
+#, fuzzy
+msgid "`Label`: has a `label`."
+msgstr "`Label` : a un `label`."
 
 #: src/exercises/day-3/simple-gui.md:13
 #, fuzzy
@@ -10586,12 +11146,12 @@ msgstr "Les widgets implémenteront un trait `Widget`, voir ci-dessous."
 #: src/exercises/day-3/simple-gui.md:15
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 "Copiez le code ci-dessous sur <https://play.rust-lang.org/>, remplissez les "
-"champs manquants\n"
-"méthodes `draw_into` afin que vous implémentiez le trait `Widget` :"
+"champs manquants méthodes `draw_into` afin que vous implémentiez le trait "
+"`Widget` :"
 
 #: src/exercises/day-3/simple-gui.md:18
 msgid ""
@@ -10732,18 +11292,16 @@ msgstr ""
 #: src/exercises/day-3/simple-gui.md:142
 #, fuzzy
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
-"Si vous voulez dessiner du texte aligné, vous pouvez utiliser le\n"
+"Si vous voulez dessiner du texte aligné, vous pouvez utiliser le "
 "[remplissage/alignement](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"opérateurs de formatage. En particulier, notez comment vous pouvez compléter "
-"avec différents\n"
-"caractères (ici un `'/'`) et comment vous pouvez contrôler l'alignement :"
+"html#fillalignment) opérateurs de formatage. En particulier, notez comment "
+"vous pouvez compléter avec différents caractères (ici un `'/'`) et comment "
+"vous pouvez contrôler l'alignement :"
 
 #: src/exercises/day-3/simple-gui.md:147
 msgid ""
@@ -10779,11 +11337,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-#, fuzzy
-msgid "# Error Handling"
-msgstr "# La gestion des erreurs"
-
 #: src/error-handling.md:3
 #, fuzzy
 msgid "Error handling in Rust is done using explicit control flow:"
@@ -10793,18 +11346,15 @@ msgstr ""
 
 #: src/error-handling.md:5
 #, fuzzy
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
+msgid "Functions that can have errors list this in their return type,"
 msgstr ""
-"* Les fonctions qui peuvent avoir des erreurs le listent dans leur type de "
-"retour,\n"
-"* Il n'y a aucune exception."
+"Les fonctions qui peuvent avoir des erreurs le listent dans leur type de "
+"retour,"
 
-#: src/error-handling/panics.md:1
+#: src/error-handling.md:6
 #, fuzzy
-msgid "# Panics"
-msgstr "# paniques"
+msgid "There are no exceptions."
+msgstr "Il n'y a aucune exception."
 
 #: src/error-handling/panics.md:3
 #, fuzzy
@@ -10825,20 +11375,26 @@ msgstr ""
 
 #: src/error-handling/panics.md:12
 #, fuzzy
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "Les paniques concernent les erreurs irrécupérables et inattendues."
+
+#: src/error-handling/panics.md:13
+#, fuzzy
+msgid "Panics are symptoms of bugs in the program."
+msgstr "Les paniques sont des symptômes de bogues dans le programme."
+
+#: src/error-handling/panics.md:14
+#, fuzzy
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
-"* Les paniques concernent les erreurs irrécupérables et inattendues.\n"
-"  * Les paniques sont des symptômes de bogues dans le programme.\n"
-"* Utilisez des API qui ne paniquent pas (telles que `Vec::get`) si le "
-"plantage n'est pas acceptable."
+"Utilisez des API qui ne paniquent pas (telles que `Vec::get`) si le plantage "
+"n'est pas acceptable."
 
 #: src/error-handling/panic-unwind.md:1
 #, fuzzy
-msgid "# Catching the Stack Unwinding"
-msgstr "# Attraper la pile qui se déroule"
+msgid "Catching the Stack Unwinding"
+msgstr "Attraper la pile qui se déroule"
 
 #: src/error-handling/panic-unwind.md:3
 #, fuzzy
@@ -10871,31 +11427,32 @@ msgstr ""
 #: src/error-handling/panic-unwind.md:21
 #, fuzzy
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* Cela peut être utile dans les serveurs qui doivent continuer à fonctionner "
-"même si un seul\n"
-"  la demande se bloque.\n"
-"* Cela ne fonctionne pas si `panic = 'abort'` est défini dans votre `Cargo."
+"Cela peut être utile dans les serveurs qui doivent continuer à fonctionner "
+"même si un seul la demande se bloque."
+
+#: src/error-handling/panic-unwind.md:23
+#, fuzzy
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+"Cela ne fonctionne pas si `panic = 'abort'` est défini dans votre `Cargo."
 "toml`."
 
 #: src/error-handling/result.md:1
 #, fuzzy
-msgid "# Structured Error Handling with `Result`"
-msgstr "# Gestion structurée des erreurs avec `Result`"
+msgid "Structured Error Handling with `Result`"
+msgstr "Gestion structurée des erreurs avec `Result`"
 
 #: src/error-handling/result.md:3
 #, fuzzy
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
 "Nous avons déjà vu l'énumération `Result`. Ceci est utilisé partout lorsque "
-"des erreurs sont\n"
-"prévu dans le cadre d'un fonctionnement normal :"
+"des erreurs sont prévu dans le cadre d'un fonctionnement normal :"
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10922,45 +11479,41 @@ msgstr ""
 #: src/error-handling/result.md:27
 #, fuzzy
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
 msgstr ""
-"  * Comme pour `Option`, la valeur réussie se trouve à l'intérieur de "
-"`Result`, obligeant le développeur à\n"
-"    l'extraire explicitement. Cela encourage la vérification des erreurs. "
-"Dans le cas où une erreur ne devrait jamais se produire,\n"
-"    `unwrap()` ou `expect()` peut être appelé, et c'est aussi un signal de "
-"l'intention du développeur.\n"
-"  * La documentation `Result` est une lecture recommandée. Pas pendant le "
-"cours, mais cela vaut la peine d'être mentionné.\n"
-"    Il contient de nombreuses méthodes et fonctions pratiques qui facilitent "
-"la programmation de style fonctionnel.\n"
-"    "
+"Comme pour `Option`, la valeur réussie se trouve à l'intérieur de `Result`, "
+"obligeant le développeur à l'extraire explicitement. Cela encourage la "
+"vérification des erreurs. Dans le cas où une erreur ne devrait jamais se "
+"produire, `unwrap()` ou `expect()` peut être appelé, et c'est aussi un "
+"signal de l'intention du développeur."
+
+#: src/error-handling/result.md:30
+#, fuzzy
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr ""
+"La documentation `Result` est une lecture recommandée. Pas pendant le cours, "
+"mais cela vaut la peine d'être mentionné. Il contient de nombreuses méthodes "
+"et fonctions pratiques qui facilitent la programmation de style fonctionnel."
 
 #: src/error-handling/try-operator.md:1
 #, fuzzy
-msgid "# Propagating Errors with `?`"
-msgstr "# Propagation des erreurs avec `?`"
+msgid "Propagating Errors with `?`"
+msgstr "Propagation des erreurs avec `?`"
 
 #: src/error-handling/try-operator.md:3
 #, fuzzy
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
+"turn the common"
 msgstr ""
 "L'opérateur try `?` est utilisé pour renvoyer des erreurs à l'appelant. Il "
-"vous permet de tourner\n"
-"le commun"
+"vous permet de tourner le commun"
 
 #: src/error-handling/try-operator.md:6
 msgid ""
@@ -11021,20 +11574,18 @@ msgstr ""
 #: src/error-handling/try-operator.md:50
 #: src/error-handling/converting-error-types-example.md:52
 #, fuzzy
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
-msgstr ""
-"* La variable `username` peut être soit `Ok(string)` soit `Err(error)`.\n"
-"* Utilisez l'appel `fs::write` pour tester les différents scénarios : pas de "
-"fichier, fichier vide, fichier avec nom d'utilisateur."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr "La variable `username` peut être soit `Ok(string)` soit `Err(error)`."
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
 #, fuzzy
-msgid "# Converting Error Types"
-msgstr "# Conversion des types d'erreurs"
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
+"Utilisez l'appel `fs::write` pour tester les différents scénarios : pas de "
+"fichier, fichier vide, fichier avec nom d'utilisateur."
 
 #: src/error-handling/converting-error-types.md:3
 #, fuzzy
@@ -11070,13 +11621,11 @@ msgstr ""
 #: src/error-handling/converting-error-types.md:18
 #, fuzzy
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
 "L'appel `From::from` ici signifie que nous essayons de convertir le type "
-"d'erreur en\n"
-"type renvoyé par la fonction :"
+"d'erreur en type renvoyé par la fonction :"
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -11131,36 +11680,26 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
 msgstr ""
 "C'est une bonne pratique pour tous les types d'erreurs d'implémenter `std::"
-"error::Error`, qui nécessite `Debug` et\n"
-"'Affichage'. Il est généralement utile pour eux d'implémenter `Clone` et "
-"`Eq` aussi lorsque cela est possible, pour faire\n"
-"la vie plus facile pour les testeurs et les consommateurs de votre "
-"bibliothèque. Dans ce cas, nous ne pouvons pas le faire facilement, car\n"
-"`io::Error` ne les implémente pas."
-
-#: src/error-handling/deriving-error-enums.md:1
-#, fuzzy
-msgid "# Deriving Error Enums"
-msgstr "# Dérivation des énumérations d'erreur"
+"error::Error`, qui nécessite `Debug` et 'Affichage'. Il est généralement "
+"utile pour eux d'implémenter `Clone` et `Eq` aussi lorsque cela est "
+"possible, pour faire la vie plus facile pour les testeurs et les "
+"consommateurs de votre bibliothèque. Dans ce cas, nous ne pouvons pas le "
+"faire facilement, car `io::Error` ne les implémente pas."
 
 #: src/error-handling/deriving-error-enums.md:3
 #, fuzzy
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
 "La caisse [thiserror](https://docs.rs/thiserror/) est un moyen populaire de "
-"créer un\n"
-"error enum comme nous l'avons fait sur la page précédente :"
+"créer un error enum comme nous l'avons fait sur la page précédente :"
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -11200,16 +11739,13 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 "La macro de dérivation de `thiserror` implémente automatiquement `std::"
-"error::Error` et éventuellement `Display`\n"
-"(si les attributs `#[error(...)]` sont fournis) et `From` (si l'attribut "
-"`#[from]` est ajouté).\n"
-"Cela fonctionne également pour les structures."
+"error::Error` et éventuellement `Display` (si les attributs `#[error(...)]` "
+"sont fournis) et `From` (si l'attribut `#[from]` est ajouté). Cela "
+"fonctionne également pour les structures."
 
 #: src/error-handling/deriving-error-enums.md:43
 #, fuzzy
@@ -11218,21 +11754,16 @@ msgstr ""
 "Cela n'affecte pas votre API publique, ce qui le rend bon pour les "
 "bibliothèques."
 
-#: src/error-handling/dynamic-errors.md:1
-#, fuzzy
-msgid "# Dynamic Error Types"
-msgstr "# Types d'erreurs dynamiques"
-
 #: src/error-handling/dynamic-errors.md:3
 #, fuzzy
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 "Parfois, nous voulons permettre à tout type d'erreur d'être renvoyé sans "
-"écrire notre propre énumération couvrant\n"
-"toutes les différentes possibilités. `std::error::Error` rend cela facile."
+"écrire notre propre énumération couvrant toutes les différentes "
+"possibilités. `std::error::Error` rend cela facile."
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -11269,37 +11800,28 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
 "Cela permet d'économiser du code, mais abandonne la possibilité de gérer "
-"proprement différents cas d'erreur différemment dans\n"
-"le programme. En tant que tel, ce n'est généralement pas une bonne idée "
-"d'utiliser `Box<dyn Error>` dans l'API publique d'un\n"
-"bibliothèque, mais cela peut être une bonne option dans un programme où vous "
-"voulez juste afficher le message d'erreur\n"
+"proprement différents cas d'erreur différemment dans le programme. En tant "
+"que tel, ce n'est généralement pas une bonne idée d'utiliser `Box<dyn "
+"Error>` dans l'API publique d'un bibliothèque, mais cela peut être une bonne "
+"option dans un programme où vous voulez juste afficher le message d'erreur "
 "quelque part."
-
-#: src/error-handling/error-contexts.md:1
-#, fuzzy
-msgid "# Adding Context to Errors"
-msgstr "# Ajouter du contexte aux erreurs"
 
 #: src/error-handling/error-contexts.md:3
 #, fuzzy
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 "La caisse [anyhow](https://docs.rs/anyhow/) largement utilisée peut vous "
-"aider à ajouter\n"
-"des informations contextuelles à vos erreurs et vous permet d'avoir moins\n"
-"types d'erreur personnalisés :"
+"aider à ajouter des informations contextuelles à vos erreurs et vous permet "
+"d'avoir moins types d'erreur personnalisés :"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -11332,33 +11854,39 @@ msgstr ""
 
 #: src/error-handling/error-contexts.md:35
 #, fuzzy
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
-"* `anyhow::Result<V>` est un alias de type pour `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` est essentiellement un wrapper autour de `Box<dyn Error>`. "
-"En tant que tel, ce n'est généralement pas\n"
-"  un bon choix pour l'API publique d'une bibliothèque, mais il est largement "
-"utilisé dans les applications.\n"
-"* Le type d'erreur réel à l'intérieur peut être extrait pour examen si "
-"nécessaire.\n"
-"* La fonctionnalité fournie par `anyhow::Result<T>` peut être familière aux "
-"développeurs Go, car elle fournit\n"
-"  modèles d'utilisation et ergonomie similaires à `(T, erreur)` de Go."
+"`anyhow::Result<V>` est un alias de type pour `Result<V, anyhow::Error>`."
 
-#: src/testing.md:1
+#: src/error-handling/error-contexts.md:36
 #, fuzzy
-msgid "# Testing"
-msgstr "# Test"
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+"`anyhow::Error` est essentiellement un wrapper autour de `Box<dyn Error>`. "
+"En tant que tel, ce n'est généralement pas un bon choix pour l'API publique "
+"d'une bibliothèque, mais il est largement utilisé dans les applications."
+
+#: src/error-handling/error-contexts.md:38
+#, fuzzy
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+"Le type d'erreur réel à l'intérieur peut être extrait pour examen si "
+"nécessaire."
+
+#: src/error-handling/error-contexts.md:39
+#, fuzzy
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"La fonctionnalité fournie par `anyhow::Result<T>` peut être familière aux "
+"développeurs Go, car elle fournit modèles d'utilisation et ergonomie "
+"similaires à `(T, erreur)` de Go."
 
 #: src/testing.md:3
 #, fuzzy
@@ -11367,19 +11895,14 @@ msgstr "Rust et Cargo sont livrés avec un cadre de test unitaire simple :"
 
 #: src/testing.md:5
 #, fuzzy
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
-msgstr ""
-"* Les tests unitaires sont pris en charge dans tout votre code.\n"
-"\n"
-"* Les tests d'intégration sont pris en charge via le répertoire `tests/`."
+msgid "Unit tests are supported throughout your code."
+msgstr "Les tests unitaires sont pris en charge dans tout votre code."
 
-#: src/testing/unit-tests.md:1
+#: src/testing.md:7
 #, fuzzy
-msgid "# Unit Tests"
-msgstr "# Tests unitaires"
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr ""
+"Les tests d'intégration sont pris en charge via le répertoire `tests/`."
 
 #: src/testing/unit-tests.md:3
 #, fuzzy
@@ -11418,20 +11941,14 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr "Utilisez `cargo test` pour rechercher et exécuter les tests unitaires."
 
-#: src/testing/test-modules.md:1
-#, fuzzy
-msgid "# Test Modules"
-msgstr "# Modules d'essai"
-
 #: src/testing/test-modules.md:3
 #, fuzzy
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 "Les tests unitaires sont souvent placés dans un module imbriqué (exécuter "
-"des tests sur le\n"
-"[Terrain de jeu](https://play.rust-lang.org/)) :"
+"des tests sur le [Terrain de jeu](https://play.rust-lang.org/)) :"
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -11458,17 +11975,14 @@ msgstr ""
 
 #: src/testing/test-modules.md:26
 #, fuzzy
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
-msgstr ""
-"* Cela vous permet de tester unitairement les helpers privés.\n"
-"* L'attribut `#[cfg(test)]` n'est actif que lorsque vous lancez `cargo test`."
+msgid "This lets you unit test private helpers."
+msgstr "Cela vous permet de tester unitairement les helpers privés."
 
-#: src/testing/doc-tests.md:1
+#: src/testing/test-modules.md:27
 #, fuzzy
-msgid "# Documentation Tests"
-msgstr "# Essais documentaires"
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr ""
+"L'attribut `#[cfg(test)]` n'est actif que lorsque vous lancez `cargo test`."
 
 #: src/testing/doc-tests.md:3
 #, fuzzy
@@ -11493,22 +12007,24 @@ msgstr ""
 
 #: src/testing/doc-tests.md:18
 #, fuzzy
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr ""
+"Les blocs de code dans les commentaires `///` sont automatiquement "
+"considérés comme du code Rust."
+
+#: src/testing/doc-tests.md:19
+#, fuzzy
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "Le code sera compilé et exécuté dans le cadre du `cargo test`."
+
+#: src/testing/doc-tests.md:20
+#, fuzzy
 msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"* Les blocs de code dans les commentaires `///` sont automatiquement "
-"considérés comme du code Rust.\n"
-"* Le code sera compilé et exécuté dans le cadre du `cargo test`.\n"
-"* Testez le code ci-dessus sur [Rust Playground](https://play.rust-lang.org/?"
+"Testez le code ci-dessus sur [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
-
-#: src/testing/integration-tests.md:1
-#, fuzzy
-msgid "# Integration Tests"
-msgstr "# Tests d'intégration"
 
 #: src/testing/integration-tests.md:3
 #, fuzzy
@@ -11541,8 +12057,8 @@ msgstr "Ces tests n'ont accès qu'à l'API publique de votre crate."
 
 #: src/testing/useful-crates.md:1
 #, fuzzy
-msgid "## Useful crates for writing tests"
-msgstr "# Caisses utiles"
+msgid "Useful crates for writing tests"
+msgstr "Caisses utiles"
 
 #: src/testing/useful-crates.md:3
 #, fuzzy
@@ -11555,17 +12071,19 @@ msgstr ""
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
-"tests."
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
 msgstr ""
 
-#: src/unsafe.md:1
-#, fuzzy
-msgid "# Unsafe Rust"
-msgstr "# Rouille dangereuse"
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr ""
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
+msgstr ""
 
 #: src/unsafe.md:3
 #, fuzzy
@@ -11574,36 +12092,37 @@ msgstr "Le langage Rust comporte deux parties :"
 
 #: src/unsafe.md:5
 #, fuzzy
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr ""
+"**Safe Rust :** mémoire sécurisée, aucun comportement indéfini possible."
+
+#: src/unsafe.md:6
+#, fuzzy
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
-"* **Safe Rust :** mémoire sécurisée, aucun comportement indéfini possible.\n"
-"* **Unsafe Rust :** peut déclencher un comportement indéfini si les "
-"conditions préalables ne sont pas respectées."
+"**Unsafe Rust :** peut déclencher un comportement indéfini si les conditions "
+"préalables ne sont pas respectées."
 
 #: src/unsafe.md:8
 #, fuzzy
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr ""
 "Nous verrons principalement Rust sûr dans ce cours, mais il est important de "
-"savoir\n"
-"ce qu'est la rouille dangereuse."
+"savoir ce qu'est la rouille dangereuse."
 
 #: src/unsafe.md:11
 #, fuzzy
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 "Le code dangereux est généralement petit et isolé, et son exactitude doit "
-"être soigneusement\n"
-"documenté. Il est généralement enveloppé dans une couche d'abstraction sûre."
+"être soigneusement documenté. Il est généralement enveloppé dans une couche "
+"d'abstraction sûre."
 
 #: src/unsafe.md:14
 #, fuzzy
@@ -11612,54 +12131,54 @@ msgstr "Unsafe Rust vous donne accès à cinq nouvelles fonctionnalités :"
 
 #: src/unsafe.md:16
 #, fuzzy
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
+msgid "Dereference raw pointers."
+msgstr "Déréférencer les pointeurs bruts."
+
+#: src/unsafe.md:17
+#, fuzzy
+msgid "Access or modify mutable static variables."
+msgstr "Accéder ou modifier des variables statiques mutables."
+
+#: src/unsafe.md:18
+#, fuzzy
+msgid "Access `union` fields."
+msgstr "Accéder aux champs \"union\"."
+
+#: src/unsafe.md:19
+#, fuzzy
+msgid "Call `unsafe` functions, including `extern` functions."
 msgstr ""
-"* Déréférencer les pointeurs bruts.\n"
-"* Accéder ou modifier des variables statiques mutables.\n"
-"* Accéder aux champs \"union\".\n"
-"* Appelez les fonctions `unsafe`, y compris les fonctions `extern`.\n"
-"* Mettre en œuvre les traits \" non sécurisés \"."
+"Appelez les fonctions `unsafe`, y compris les fonctions `extern`. \\* Mettre "
+"en œuvre les traits \" non sécurisés \"."
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
+msgstr ""
 
 #: src/unsafe.md:22
 #, fuzzy
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
+"We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 "Nous aborderons ensuite brièvement les capacités dangereuses. Pour plus de "
-"détails, veuillez consulter\n"
-"[Chapitre 19.1 du Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-"
-"rust.html)\n"
-"et le [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"détails, veuillez consulter [Chapitre 19.1 du Rust Book](https://doc.rust-"
+"lang.org/book/ch19-01-unsafe-rust.html) et le [Rustonomicon](https://doc."
+"rust-lang.org/nomicon/)."
 
 #: src/unsafe.md:28
 #, fuzzy
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
 "Unsafe Rust ne signifie pas que le code est incorrect. Cela signifie que les "
-"développeurs ont\n"
-"désactivé les fonctionnalités de sécurité du compilateur et doit écrire le "
-"code correct en\n"
-"eux-mêmes. Cela signifie que le compilateur n'applique plus les règles de "
-"sécurité de la mémoire de Rust."
-
-#: src/unsafe/raw-pointers.md:1
-#, fuzzy
-msgid "# Dereferencing Raw Pointers"
-msgstr "# Déréférencement des pointeurs bruts"
+"développeurs ont désactivé les fonctionnalités de sécurité du compilateur et "
+"doit écrire le code correct en eux-mêmes. Cela signifie que le compilateur "
+"n'applique plus les règles de sécurité de la mémoire de Rust."
 
 #: src/unsafe/raw-pointers.md:3
 #, fuzzy
@@ -11696,59 +12215,63 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 "Il est recommandé (et requis par le guide de style Android Rust) d'écrire un "
-"commentaire pour chaque\n"
-"Bloc `unsafe` expliquant comment le code à l'intérieur satisfait aux "
-"exigences de sécurité de l'unsafe\n"
-"opérations qu'il effectue."
+"commentaire pour chaque Bloc `unsafe` expliquant comment le code à "
+"l'intérieur satisfait aux exigences de sécurité de l'unsafe opérations qu'il "
+"effectue."
 
 #: src/unsafe/raw-pointers.md:31
 #, fuzzy
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 "Dans le cas des déréférencements de pointeurs, cela signifie que les "
-"pointeurs doivent être\n"
-"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), c'est-à-"
-"dire :"
+"pointeurs doivent être [_valid_](https://doc.rust-lang.org/std/ptr/index."
+"html#safety), c'est-à-dire :"
 
 #: src/unsafe/raw-pointers.md:34
 #, fuzzy
+msgid "The pointer must be non-null."
+msgstr "Le pointeur doit être non nul."
+
+#: src/unsafe/raw-pointers.md:35
+#, fuzzy
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
 msgstr ""
-" * Le pointeur doit être non nul.\n"
-" * Le pointeur doit être _dereferenceable_ (dans les limites d'un seul objet "
-"alloué).\n"
-" * L'objet ne doit pas avoir été désalloué.\n"
-" * Il ne doit pas y avoir d'accès simultanés au même endroit.\n"
-" * Si le pointeur a été obtenu en transtypant une référence, l'objet sous-"
-"jacent doit être actif et non\n"
-"   référence peut être utilisée pour accéder à la mémoire."
+"Le pointeur doit être _dereferenceable_ (dans les limites d'un seul objet "
+"alloué)."
+
+#: src/unsafe/raw-pointers.md:36
+#, fuzzy
+msgid "The object must not have been deallocated."
+msgstr "L'objet ne doit pas avoir été désalloué."
+
+#: src/unsafe/raw-pointers.md:37
+#, fuzzy
+msgid "There must not be concurrent accesses to the same location."
+msgstr "Il ne doit pas y avoir d'accès simultanés au même endroit."
+
+#: src/unsafe/raw-pointers.md:38
+#, fuzzy
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr ""
+"Si le pointeur a été obtenu en transtypant une référence, l'objet sous-"
+"jacent doit être actif et non référence peut être utilisée pour accéder à la "
+"mémoire."
 
 #: src/unsafe/raw-pointers.md:41
 #, fuzzy
 msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 "Dans la plupart des cas, le pointeur doit également être correctement aligné."
-
-#: src/unsafe/mutable-static-variables.md:1
-#, fuzzy
-msgid "# Mutable Static Variables"
-msgstr "# Variables statiques mutables"
 
 #: src/unsafe/mutable-static-variables.md:3
 #, fuzzy
@@ -11769,12 +12292,11 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:13
 #, fuzzy
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 "Cependant, étant donné que des courses de données peuvent se produire, il "
-"n'est pas sûr de lire et d'écrire mutable\n"
-"variables statiques :"
+"n'est pas sûr de lire et d'écrire mutable variables statiques :"
 
 #: src/unsafe/mutable-static-variables.md:16
 msgid ""
@@ -11797,19 +12319,13 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 "L'utilisation d'une statique mutable est généralement une mauvaise idée, "
-"mais il y a des cas où cela peut avoir du sens\n"
-"dans le code `no_std` de bas niveau, comme l'implémentation d'un allocation "
-"de tas ou l'utilisation de certaines API C."
-
-#: src/unsafe/unions.md:1
-#, fuzzy
-msgid "# Unions"
-msgstr "# syndicats"
+"mais il y a des cas où cela peut avoir du sens dans le code `no_std` de bas "
+"niveau, comme l'implémentation d'un allocation de tas ou l'utilisation de "
+"certaines API C."
 
 #: src/unsafe/unions.md:3
 #, fuzzy
@@ -11839,43 +12355,34 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 "Les unions sont très rarement nécessaires dans Rust car vous pouvez "
-"généralement utiliser une énumération. Ils sont parfois nécessaires\n"
-"pour interagir avec les API de la bibliothèque C."
+"généralement utiliser une énumération. Ils sont parfois nécessaires pour "
+"interagir avec les API de la bibliothèque C."
 
 #: src/unsafe/unions.md:24
 #, fuzzy
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
+"If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 "Si vous voulez simplement réinterpréter les octets comme un type différent, "
-"vous voudrez probablement\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) ou un coffre-fort\n"
-"wrapper tel que la caisse [`zerocopy`](https://crates.io/crates/zerocopy)."
-
-#: src/unsafe/calling-unsafe-functions.md:1
-#, fuzzy
-msgid "# Calling Unsafe Functions"
-msgstr "# Appel de fonctions non sûres"
+"vous voudrez probablement [`std::mem::transmute`](https://doc.rust-lang.org/"
+"stable/std/mem/fn.transmute.html) ou un coffre-fort wrapper tel que la "
+"caisse [`zerocopy`](https://crates.io/crates/zerocopy)."
 
 #: src/unsafe/calling-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 "Une fonction ou une méthode peut être marquée \"unsafe\" si elle a des "
-"conditions préalables supplémentaires que vous\n"
-"doit respecter pour éviter un comportement indéfini :"
+"conditions préalables supplémentaires que vous doit respecter pour éviter un "
+"comportement indéfini :"
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
@@ -11907,21 +12414,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-#, fuzzy
-msgid "# Writing Unsafe Functions"
-msgstr "# Écrire des fonctions non sécurisées"
-
 #: src/unsafe/writing-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
 "Vous pouvez marquer vos propres fonctions comme \"non sécurisées\" si elles "
-"nécessitent des conditions particulières pour éviter undefined\n"
-"comportement."
+"nécessitent des conditions particulières pour éviter undefined comportement."
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -11964,28 +12464,26 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 "Notez que le code non sécurisé est autorisé dans une fonction non sécurisée "
-"sans bloc « non sécurisé ». Nous pouvons\n"
-"interdisez cela avec `#[deny(unsafe_op_in_unsafe_fn)]`. Essayez de l'ajouter "
-"et voyez ce qui se passe."
+"sans bloc « non sécurisé ». Nous pouvons interdisez cela avec "
+"`#[deny(unsafe_op_in_unsafe_fn)]`. Essayez de l'ajouter et voyez ce qui se "
+"passe."
 
 #: src/unsafe/extern-functions.md:1
 #, fuzzy
-msgid "# Calling External Code"
-msgstr "# Appeler le code externe"
+msgid "Calling External Code"
+msgstr "Appeler le code externe"
 
 #: src/unsafe/extern-functions.md:3
 #, fuzzy
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
-"Les fonctions d'autres langages peuvent violer les garanties de Rust. Appel\n"
+"Les fonctions d'autres langages peuvent violer les garanties de Rust. Appel "
 "eux est donc dangereux :"
 
 #: src/unsafe/extern-functions.md:6
@@ -12008,48 +12506,37 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 "Ce n'est généralement un problème que pour les fonctions externes qui font "
-"des choses avec des pointeurs qui pourraient\n"
-"violer le modèle de mémoire de Rust, mais en général, toute fonction C peut "
-"avoir un comportement indéfini sous n'importe quel\n"
-"circonstances arbitraires."
+"des choses avec des pointeurs qui pourraient violer le modèle de mémoire de "
+"Rust, mais en général, toute fonction C peut avoir un comportement indéfini "
+"sous n'importe quel circonstances arbitraires."
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/"
-"external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-#, fuzzy
-msgid "# Implementing Unsafe Traits"
-msgstr "# Implémenter des traits dangereux"
 
 #: src/unsafe/unsafe-traits.md:3
 #, fuzzy
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 "Comme avec les fonctions, vous pouvez marquer un trait comme \"non "
-"sécurisé\" si l'implémentation doit garantir\n"
-"conditions particulières pour éviter un comportement indéfini."
+"sécurisé\" si l'implémentation doit garantir conditions particulières pour "
+"éviter un comportement indéfini."
 
 #: src/unsafe/unsafe-traits.md:6
 #, fuzzy
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
-"Par exemple, la caisse \"zérocopie\" a un trait dangereux qui semble\n"
+"Par exemple, la caisse \"zérocopie\" a un trait dangereux qui semble "
 "[quelque chose comme ça](https://docs.rs/zerocopy/latest/zerocopy/trait."
 "AsBytes.html):"
 
@@ -12080,12 +12567,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
 "Il devrait y avoir une section `# Sécurité` sur le Rustdoc pour le trait "
-"expliquant les exigences pour\n"
-"le trait à mettre en œuvre en toute sécurité."
+"expliquant les exigences pour le trait à mettre en œuvre en toute sécurité."
 
 #: src/unsafe/unsafe-traits.md:33
 #, fuzzy
@@ -12103,8 +12588,8 @@ msgstr "Les traits intégrés \"Envoyer\" et \"Synchroniser\" ne sont pas sûrs.
 
 #: src/exercises/day-3/afternoon.md:1
 #, fuzzy
-msgid "# Day 3: Afternoon Exercises"
-msgstr "# Jour 3 : Exercices de l'après-midi"
+msgid "Day 3: Afternoon Exercises"
+msgstr "Jour 3 : Exercices de l'après-midi"
 
 #: src/exercises/day-3/afternoon.md:3
 #, fuzzy
@@ -12113,39 +12598,36 @@ msgstr "Construisons un wrapper sûr pour lire le contenu du répertoire !"
 
 #: src/exercises/day-3/afternoon.md:5
 msgid ""
-"For this exercise, we suggest using a local dev environment instead\n"
-"of the Playground. This will allow you to run your binary on your own "
-"machine."
+"For this exercise, we suggest using a local dev environment instead of the "
+"Playground. This will allow you to run your binary on your own machine."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:8
-msgid "To get started, follow the [running locally] instructions."
+msgid ""
+"To get started, follow the [running locally](../../cargo/running-locally.md) "
+"instructions."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:14
 #, fuzzy
-msgid "After looking at the exercise, you can look at the [solution] provided."
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
-"Après avoir regardé l'exercice, vous pouvez regarder la [solution] fournie."
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-#, fuzzy
-msgid "# Safe FFI Wrapper"
-msgstr "# Enveloppe FFI sécurisée"
+"Après avoir regardé l'exercice, vous pouvez regarder la [solution](solutions-"
+"afternoon.md) fournie."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 #, fuzzy
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 "Rust a un excellent support pour appeler des fonctions via une fonction "
-"_foreign\n"
-"interface_ (FFI). Nous allons l'utiliser pour construire un wrapper sûr pour "
-"la `libc`\n"
-"fonctions que vous utiliseriez à partir de C pour lire les noms de fichiers "
-"d'un répertoire."
+"_foreign interface_ (FFI). Nous allons l'utiliser pour construire un wrapper "
+"sûr pour la `libc` fonctions que vous utiliseriez à partir de C pour lire "
+"les noms de fichiers d'un répertoire."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:7
 #, fuzzy
@@ -12154,33 +12636,74 @@ msgstr "Vous voudrez consulter les pages de manuel :"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
 #, fuzzy
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
-msgstr ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+#, fuzzy
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+#, fuzzy
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module. There you find a "
-"number of\n"
-"string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Encoding"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Use"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"| Types                      | Encoding       | "
-"Use                            |\n"
-"|----------------------------|----------------|--------------------------------|\n"
-"| [`str`] and [`String`]     | UTF-8          | Text processing in "
-"Rust        |\n"
-"| [`CStr`] and [`CString`]   | NUL-terminated | Communicating with C "
-"functions |\n"
-"| [`OsStr`] and [`OsString`] | OS-specific    | Communicating with the "
-"OS      |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "UTF-8"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "Text processing in Rust"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "NUL-terminated"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "Communicating with C functions"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "OS-specific"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "Communicating with the OS"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
@@ -12189,36 +12712,52 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:24
 msgid ""
-"- `&str` to `CString`: you need to allocate space for a trailing `\\0` "
-"character,\n"
-"- `CString` to `*const i8`: you need a pointer to call C functions,\n"
-"- `*const i8` to `&CStr`: you need something which can find the trailing "
-"`\\0` character,\n"
-"- `&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknow data\",\n"
-"- `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
-"html)\n"
-"  to create it,\n"
-"- `&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able "
-"to return it and call\n"
-"  `readdir` again."
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
-msgid "The [Nomicon] also has a very useful chapter about FFI."
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 "Copiez le code ci-dessous sur <https://play.rust-lang.org/> et remplissez "
-"les champs manquants\n"
-"fonctions et méthodes :"
+"les champs manquants fonctions et méthodes :"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:48
 msgid ""
@@ -12329,57 +12868,43 @@ msgstr ""
 
 #: src/android.md:1
 #, fuzzy
-msgid "# Welcome to Rust in Android"
-msgstr "# Bienvenue au jour 1"
+msgid "Welcome to Rust in Android"
+msgstr "Bienvenue au jour 1"
 
 #: src/android.md:3
 #, fuzzy
 msgid ""
 "Rust is supported for native platform development on Android. This means "
-"that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 "Rust est pris en charge pour le développement de plates-formes natives sur "
-"Android. Cela signifie que\n"
-"vous pouvez écrire de nouveaux services de système d'exploitation dans Rust, "
-"ainsi que l'extension\n"
-"prestations existantes."
+"Android. Cela signifie que vous pouvez écrire de nouveaux services de "
+"système d'exploitation dans Rust, ainsi que l'extension prestations "
+"existantes."
 
 #: src/android.md:7
 #, fuzzy
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try "
-"to\n"
-"> find a little corner of your code base where we can move some lines of "
-"code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
-"that\n"
-"> parses some raw bytes would be ideal."
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
-"> Nous allons essayer d'appeler Rust depuis l'un de vos propres projets "
-"aujourd'hui. Alors essayez de\n"
-"> trouvez un petit coin de votre base de code où nous pouvons déplacer "
-"quelques lignes de code vers\n"
-"> Rouille. Moins il y a de dépendances et de types \"exotiques\", mieux "
-"c'est. Quelque chose que\n"
-"> analyser quelques octets bruts serait idéal."
-
-#: src/android/setup.md:1
-#, fuzzy
-msgid "# Setup"
-msgstr "# Installation"
+"Nous allons essayer d'appeler Rust depuis l'un de vos propres projets "
+"aujourd'hui. Alors essayez de trouvez un petit coin de votre base de code où "
+"nous pouvons déplacer quelques lignes de code vers Rouille. Moins il y a de "
+"dépendances et de types \"exotiques\", mieux c'est. Quelque chose que "
+"analyser quelques octets bruts serait idéal."
 
 #: src/android/setup.md:3
 #, fuzzy
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
-"have\n"
-"access to one or create a new one with:"
+"have access to one or create a new one with:"
 msgstr ""
 "Nous utiliserons un appareil virtuel Android pour tester notre code. Assurez-"
-"vous que vous avez\n"
-"accéder à un ou en créer un nouveau avec :"
+"vous que vous avez accéder à un ou en créer un nouveau avec :"
 
 #: src/android/setup.md:6
 msgid ""
@@ -12393,16 +12918,11 @@ msgstr ""
 #: src/android/setup.md:12
 #, fuzzy
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-"Veuillez consulter le [Développeur Android\n"
-"Codelab] (https://source.android.com/docs/setup/start) pour plus de détails."
-
-#: src/android/build-rules.md:1
-#, fuzzy
-msgid "# Build Rules"
-msgstr "# Règles de construction"
+"Veuillez consulter le \\[Développeur Android Codelab\\] (https://source."
+"android.com/docs/setup/start) pour plus de détails."
 
 #: src/android/build-rules.md:3
 #, fuzzy
@@ -12413,46 +12933,111 @@ msgstr ""
 
 #: src/android/build-rules.md:5
 #, fuzzy
-msgid ""
-"| Module Type       | "
-"Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust "
-"binary.                                                                            "
-"|\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
-"`dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
-"provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
-"analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard "
-"Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging "
-"`libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that "
-"provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library "
-"containing Rust bindings to C libraries.              |"
+msgid "Module Type"
+msgstr "Type de module"
+
+#: src/android/build-rules.md:5
+#, fuzzy
+msgid "Description"
+msgstr "Descriptif"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "`rust_binary`"
+msgstr "`rust_binaire`"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "Produces a Rust binary."
+msgstr "Produit un binaire Rust."
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "`rust_library`"
+msgstr "`rust_library`"
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
 msgstr ""
-"| Type de module | Descriptif |\n"
-"|------------------|-------------------------------------- "
-"-------------------------------------------------- ---------------------|\n"
-"| `rust_binaire` | Produit un binaire Rust. |\n"
-"| `rust_library` | Produit une bibliothèque Rust et fournit les variantes "
-"`rlib` et `dylib`. |\n"
-"| `rust_ffi` | Produit une bibliothèque Rust C utilisable par les modules "
-"`cc` et fournit des variantes statiques et partagées. |\n"
-"| `rust_proc_macro` | Produit une bibliothèque Rust `proc-macro`. Ceux-ci "
-"sont analogues aux plugins du compilateur. |\n"
-"| `test_rouille` | Produit un binaire de test Rust qui utilise le harnais de "
-"test Rust standard. |\n"
-"| `rust_fuzz` | Produit un exécutable Rust fuzz utilisant `libfuzzer`. |\n"
-"| `rust_protobuf` | Génère la source et produit une bibliothèque Rust qui "
-"fournit une interface pour un protobuf particulier. |\n"
-"| `rust_bindgen` | Génère la source et produit une bibliothèque Rust "
-"contenant des liaisons Rust aux bibliothèques C. |"
+"Produit une bibliothèque Rust et fournit les variantes `rlib` et `dylib`."
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid "`rust_ffi`"
+msgstr "`rust_ffi`"
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid ""
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+"Produit une bibliothèque Rust C utilisable par les modules `cc` et fournit "
+"des variantes statiques et partagées."
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid "`rust_proc_macro`"
+msgstr "`rust_proc_macro`"
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+"Produit une bibliothèque Rust `proc-macro`. Ceux-ci sont analogues aux "
+"plugins du compilateur."
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "`rust_test`"
+msgstr "`test_rouille`"
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+"Produit un binaire de test Rust qui utilise le harnais de test Rust standard."
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "`rust_fuzz`"
+msgstr "`rust_fuzz`"
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr "Produit un exécutable Rust fuzz utilisant `libfuzzer`."
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid "`rust_protobuf`"
+msgstr "`rust_protobuf`"
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+"Génère la source et produit une bibliothèque Rust qui fournit une interface "
+"pour un protobuf particulier."
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid "`rust_bindgen`"
+msgstr "`rust_bindgen`"
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr ""
+"Génère la source et produit une bibliothèque Rust contenant des liaisons "
+"Rust aux bibliothèques C."
 
 #: src/android/build-rules.md:16
 #, fuzzy
@@ -12461,17 +13046,16 @@ msgstr "Nous examinerons ensuite `rust_binary` et `rust_library`."
 
 #: src/android/build-rules/binary.md:1
 #, fuzzy
-msgid "# Rust Binaries"
-msgstr "# Binaires de rouille"
+msgid "Rust Binaries"
+msgstr "Binaires de rouille"
 
 #: src/android/build-rules/binary.md:3
 #, fuzzy
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr ""
-"Commençons par une application simple. A la racine d'une caisse AOSP, créez\n"
+"Commençons par une application simple. A la racine d'une caisse AOSP, créez "
 "les fichiers suivants :"
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
@@ -12524,8 +13108,8 @@ msgstr ""
 
 #: src/android/build-rules/library.md:1
 #, fuzzy
-msgid "# Rust Libraries"
-msgstr "# Bibliothèques de rouille"
+msgid "Rust Libraries"
+msgstr "Bibliothèques de rouille"
 
 #: src/android/build-rules/library.md:3
 #, fuzzy
@@ -12541,14 +13125,18 @@ msgstr "Ici, nous déclarons une dépendance sur deux bibliothèques :"
 
 #: src/android/build-rules/library.md:7
 #, fuzzy
+msgid "`libgreeting`, which we define below,"
+msgstr "`libgreeting`, que nous définissons ci-dessous,"
+
+#: src/android/build-rules/library.md:8
+#, fuzzy
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"* `libgreeting`, que nous définissons ci-dessous,\n"
-"* `libtextwrap`, qui est une caisse déjà vendue dans\n"
-"  [`externe/rouille/caisses/`][caisses]."
+"`libtextwrap`, qui est une caisse déjà vendue dans \\[`externe/rouille/"
+"caisses/`\\]\\[caisses\\]."
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -12621,35 +13209,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-#, fuzzy
-msgid "# AIDL"
-msgstr "#AIDL"
-
 #: src/android/aidl.md:3
 #, fuzzy
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
-"Le [langage de définition d'interface Android\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) est pris en "
-"charge dans Rust :"
+"Le [langage de définition d'interface Android (AIDL)](https://developer."
+"android.com/guide/components/aidl) est pris en charge dans Rust :"
 
 #: src/android/aidl.md:6
 #, fuzzy
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
-msgstr ""
-"* Le code Rust peut appeler des serveurs AIDL existants,\n"
-"* Vous pouvez créer de nouveaux serveurs AIDL dans Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr "Le code Rust peut appeler des serveurs AIDL existants,"
+
+#: src/android/aidl.md:7
+#, fuzzy
+msgid "You can create new AIDL servers in Rust."
+msgstr "Vous pouvez créer de nouveaux serveurs AIDL dans Rust."
 
 #: src/android/aidl/interface.md:1
 #, fuzzy
-msgid "# AIDL Interfaces"
-msgstr "# Interfaces AIDL"
+msgid "AIDL Interfaces"
+msgstr "Interfaces AIDL"
 
 #: src/android/aidl/interface.md:3
 #, fuzzy
@@ -12659,10 +13241,10 @@ msgstr "Vous déclarez l'API de votre service à l'aide d'une interface AIDL :"
 #: src/android/aidl/interface.md:5
 #, fuzzy
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
-"*service_anniversaire/aidl/com/exemple/serviceanniversaire/IBirthdayService."
-"aidl* :"
+"_service_anniversaire/aidl/com/exemple/serviceanniversaire/IBirthdayService."
+"aidl_ :"
 
 #: src/android/aidl/interface.md:7
 msgid ""
@@ -12679,8 +13261,8 @@ msgstr ""
 
 #: src/android/aidl/interface.md:17
 #, fuzzy
-msgid "*birthday_service/aidl/Android.bp*:"
-msgstr "*service_anniversaire/aidl/Android.bp* :"
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_service_anniversaire/aidl/Android.bp_ :"
 
 #: src/android/aidl/interface.md:19
 msgid ""
@@ -12702,17 +13284,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 "Ajoutez `vendor_available : true` si votre fichier AIDL est utilisé par un "
-"binaire dans le fournisseur\n"
-"cloison."
+"binaire dans le fournisseur cloison."
 
 #: src/android/aidl/implementation.md:1
 #, fuzzy
-msgid "# Service Implementation"
-msgstr "# Mise en œuvre des services"
+msgid "Service Implementation"
+msgstr "Mise en œuvre des services"
 
 #: src/android/aidl/implementation.md:3
 #, fuzzy
@@ -12721,8 +13301,8 @@ msgstr "Nous pouvons maintenant implémenter le service AIDL :"
 
 #: src/android/aidl/implementation.md:5
 #, fuzzy
-msgid "*birthday_service/src/lib.rs*:"
-msgstr "*service_anniversaire/src/lib.rs* :"
+msgid "_birthday_service/src/lib.rs_:"
+msgstr "_service_anniversaire/src/lib.rs_ :"
 
 #: src/android/aidl/implementation.md:7
 msgid ""
@@ -12752,8 +13332,8 @@ msgstr ""
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
 #, fuzzy
-msgid "*birthday_service/Android.bp*:"
-msgstr "*service_anniversaire/Android.bp* :"
+msgid "_birthday_service/Android.bp_:"
+msgstr "_service_anniversaire/Android.bp_ :"
 
 #: src/android/aidl/implementation.md:28
 msgid ""
@@ -12772,8 +13352,8 @@ msgstr ""
 
 #: src/android/aidl/server.md:1
 #, fuzzy
-msgid "# AIDL Server"
-msgstr "# Serveur AIDL"
+msgid "AIDL Server"
+msgstr "Serveur AIDL"
 
 #: src/android/aidl/server.md:3
 #, fuzzy
@@ -12782,8 +13362,8 @@ msgstr "Enfin, nous pouvons créer un serveur qui expose le service :"
 
 #: src/android/aidl/server.md:5
 #, fuzzy
-msgid "*birthday_service/src/server.rs*:"
-msgstr "*service_anniversaire/src/server.rs* :"
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_service_anniversaire/src/server.rs_ :"
 
 #: src/android/aidl/server.md:7
 msgid ""
@@ -12827,11 +13407,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/android/aidl/deploy.md:1
-#, fuzzy
-msgid "# Deploy"
-msgstr "# Déployer"
 
 #: src/android/aidl/deploy.md:3
 #, fuzzy
@@ -12884,8 +13459,8 @@ msgstr ""
 
 #: src/android/aidl/client.md:1
 #, fuzzy
-msgid "# AIDL Client"
-msgstr "# Client AIDL"
+msgid "AIDL Client"
+msgstr "Client AIDL"
 
 #: src/android/aidl/client.md:3
 #, fuzzy
@@ -12894,8 +13469,8 @@ msgstr "Enfin, nous pouvons créer un client Rust pour notre nouveau service."
 
 #: src/android/aidl/client.md:5
 #, fuzzy
-msgid "*birthday_service/src/client.rs*:"
-msgstr "*service_anniversaire/src/client.rs* :"
+msgid "_birthday_service/src/client.rs_:"
+msgstr "_service_anniversaire/src/client.rs_ :"
 
 #: src/android/aidl/client.md:7
 msgid ""
@@ -12970,21 +13545,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-#, fuzzy
-msgid "# Changing API"
-msgstr "# Modification de l'API"
-
 #: src/android/aidl/changing.md:3
 #, fuzzy
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr ""
 "Étendons l'API avec plus de fonctionnalités : nous voulons laisser les "
-"clients spécifier un\n"
-"liste des lignes pour la carte d'anniversaire :"
+"clients spécifier un liste des lignes pour la carte d'anniversaire :"
 
 #: src/android/aidl/changing.md:6
 msgid ""
@@ -12999,21 +13567,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-#, fuzzy
-msgid "# Logging"
-msgstr "# Journalisation"
-
 #: src/android/logging.md:3
 #, fuzzy
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
 "Vous devez utiliser la caisse `log` pour vous connecter automatiquement à "
-"`logcat` (sur l'appareil) ou\n"
-"`stdout` (sur l'hôte) :"
+"`logcat` (sur l'appareil) ou `stdout` (sur l'hôte) :"
 
 #: src/android/logging.md:6
 #, fuzzy
@@ -13096,55 +13657,49 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-#, fuzzy
-msgid "# Interoperability"
-msgstr "# Interopérabilité"
-
 #: src/android/interoperability.md:3
 #, fuzzy
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 "Rust a un excellent support pour l'interopérabilité avec d'autres langages. "
-"Ça signifie\n"
-"Que tu peux:"
+"Ça signifie Que tu peux:"
 
 #: src/android/interoperability.md:6
 #, fuzzy
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
-msgstr ""
-"* Appelez les fonctions Rust à partir d'autres langues.\n"
-"* Fonctions d'appel écrites dans d'autres langages depuis Rust."
+msgid "Call Rust functions from other languages."
+msgstr "Appelez les fonctions Rust à partir d'autres langues."
+
+#: src/android/interoperability.md:7
+#, fuzzy
+msgid "Call functions written in other languages from Rust."
+msgstr "Fonctions d'appel écrites dans d'autres langages depuis Rust."
 
 #: src/android/interoperability.md:9
 #, fuzzy
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 "Lorsque vous appelez des fonctions dans une langue étrangère, nous disons "
-"que vous utilisez un\n"
-"_interface de fonction étrangère_, également connue sous le nom de FFI."
+"que vous utilisez un _interface de fonction étrangère_, également connue "
+"sous le nom de FFI."
 
 #: src/android/interoperability/with-c.md:1
 #, fuzzy
-msgid "# Interoperability with C"
-msgstr "# Interopérabilité avec C"
+msgid "Interoperability with C"
+msgstr "Interopérabilité avec C"
 
 #: src/android/interoperability/with-c.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 "Rust prend entièrement en charge la liaison de fichiers objets avec une "
-"convention d'appel C.\n"
-"De même, vous pouvez exporter des fonctions Rust et les appeler depuis C."
+"convention d'appel C. De même, vous pouvez exporter des fonctions Rust et "
+"les appeler depuis C."
 
 #: src/android/interoperability/with-c.md:6
 #, fuzzy
@@ -13169,21 +13724,20 @@ msgstr ""
 #: src/android/interoperability/with-c.md:20
 #, fuzzy
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
-"Nous avons déjà vu cela dans le [Safe FFI Wrapper\n"
-"exercice](../../exercises/day-3/safe-ffi-wrapper.md)."
+"Nous avons déjà vu cela dans le [Safe FFI Wrapper exercice](../../exercises/"
+"day-3/safe-ffi-wrapper.md)."
 
 #: src/android/interoperability/with-c.md:23
 #, fuzzy
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
-"> Cela suppose une parfaite connaissance de la plateforme cible. Non "
-"recommandé pour\n"
-"> fabrication."
+"Cela suppose une parfaite connaissance de la plateforme cible. Non "
+"recommandé pour fabrication."
 
 #: src/android/interoperability/with-c.md:26
 #, fuzzy
@@ -13192,19 +13746,18 @@ msgstr "Nous examinerons ensuite de meilleures options."
 
 #: src/android/interoperability/with-c/bindgen.md:1
 #, fuzzy
-msgid "# Using Bindgen"
-msgstr "# Utiliser Bindgen"
+msgid "Using Bindgen"
+msgstr "Utiliser Bindgen"
 
 #: src/android/interoperability/with-c/bindgen.md:3
 #, fuzzy
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 "L'outil [bindgen](https://rust-lang.github.io/rust-bindgen/introduction."
-"html)\n"
-"peut générer automatiquement des liaisons à partir d'un fichier d'en-tête C."
+"html) peut générer automatiquement des liaisons à partir d'un fichier d'en-"
+"tête C."
 
 #: src/android/interoperability/with-c/bindgen.md:6
 #, fuzzy
@@ -13274,12 +13827,11 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:44
 #, fuzzy
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 "Créez un fichier d'en-tête wrapper pour la bibliothèque (pas strictement "
-"nécessaire dans ce\n"
-"exemple):"
+"nécessaire dans ce exemple):"
 
 #: src/android/interoperability/with-c/bindgen.md:47
 #, fuzzy
@@ -13393,8 +13945,8 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
 #, fuzzy
-msgid "# Calling Rust"
-msgstr "# Appeler Rust"
+msgid "Calling Rust"
+msgstr "Appeler Rust"
 
 #: src/android/interoperability/with-c/rust.md:3
 #, fuzzy
@@ -13515,61 +14067,52 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 "`#[no_mangle]` désactive la modification du nom habituel de Rust, de sorte "
-"que le symbole exporté sera simplement le nom de\n"
-"la fonction. Vous pouvez également utiliser `#[export_name = \"some_name\"]` "
-"pour spécifier le nom que vous voulez."
-
-#: src/android/interoperability/cpp.md:1
-#, fuzzy
-msgid "# With C++"
-msgstr "# Avec C++"
+"que le symbole exporté sera simplement le nom de la fonction. Vous pouvez "
+"également utiliser `#[export_name = \"some_name\"]` pour spécifier le nom "
+"que vous voulez."
 
 #: src/android/interoperability/cpp.md:3
 #, fuzzy
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
-"La [caisse CXX][1] permet de faire une interopérabilité sûre entre Rust\n"
-"et C++."
+"La [caisse CXX](https://cxx.rs/) permet de faire une interopérabilité sûre "
+"entre Rust et C++."
 
 #: src/android/interoperability/cpp.md:6
 #, fuzzy
 msgid "The overall approach looks like this:"
 msgstr "L'approche globale ressemble à ceci:"
 
-#: src/android/interoperability/cpp.md:8
-#, fuzzy
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr "<img src=\"cpp/overview.svg\">"
-
 #: src/android/interoperability/cpp.md:10
 #, fuzzy
-msgid "See the [CXX tutorial][2] for an full example of using this."
-msgstr "Voir le [tutoriel CXX] [2] pour un exemple complet d'utilisation."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
+msgstr ""
+"Voir le \\[tutoriel CXX\\] [2](https://cxx.rs/tutorial.html) pour un exemple "
+"complet d'utilisation."
 
 #: src/android/interoperability/java.md:1
 #, fuzzy
-msgid "# Interoperability with Java"
-msgstr "# Interopérabilité avec Java"
+msgid "Interoperability with Java"
+msgstr "Interopérabilité avec Java"
 
 #: src/android/interoperability/java.md:3
 #, fuzzy
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
-"Java peut charger des objets partagés via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). Le [`jni`\n"
-"crate](https://docs.rs/jni/) vous permet de créer une bibliothèque "
-"compatible."
+"Java peut charger des objets partagés via [Java Native Interface (JNI)]"
+"(https://en.wikipedia.org/wiki/Java_Native_Interface). Le [`jni` crate]"
+"(https://docs.rs/jni/) vous permet de créer une bibliothèque compatible."
 
 #: src/android/interoperability/java.md:7
 #, fuzzy
@@ -13677,109 +14220,99 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
-#: src/exercises/concurrency/morning.md:1
-#: src/exercises/concurrency/afternoon.md:1
-#, fuzzy
-msgid "# Exercises"
-msgstr "# Des exercices"
-
 #: src/exercises/android/morning.md:3
 #, fuzzy
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
-"and\n"
-"try to integrate some Rust into it. Some suggestions:"
+"and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 "Pour le dernier exercice, nous examinerons l'un des projets sur lesquels "
-"vous travaillez. Laissez-nous\n"
-"regroupez-vous et faites-le ensemble. Quelques suggestions:"
+"vous travaillez. Laissez-nous regroupez-vous et faites-le ensemble. Quelques "
+"suggestions:"
 
 #: src/exercises/android/morning.md:6
 #, fuzzy
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
-msgstr ""
-"* Appelez votre service AIDL avec un client écrit en Rust.\n"
-"\n"
-"* Déplacez une fonction de votre projet vers Rust et appelez-la."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr "Appelez votre service AIDL avec un client écrit en Rust."
+
+#: src/exercises/android/morning.md:8
+#, fuzzy
+msgid "Move a function from your project to Rust and call it."
+msgstr "Déplacez une fonction de votre projet vers Rust et appelez-la."
 
 #: src/exercises/android/morning.md:12
 #, fuzzy
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 "Aucune solution n'est proposée ici car celle-ci est ouverte : elle repose "
-"sur quelqu'un en\n"
-"la classe ayant un morceau de code que vous pouvez remettre à Rust à la "
-"volée."
+"sur quelqu'un en la classe ayant un morceau de code que vous pouvez remettre "
+"à Rust à la volée."
 
 #: src/bare-metal.md:1
 #, fuzzy
-msgid "# Welcome to Bare Metal Rust"
-msgstr "# Bienvenue dans Bare Metal Rust"
+msgid "Welcome to Bare Metal Rust"
+msgstr "Bienvenue dans Bare Metal Rust"
 
 #: src/bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 "Il s'agit d'un cours autonome d'une journée sur la bare-metal Rust, destiné "
-"aux personnes familiarisées avec le\n"
-"bases de Rust (peut-être après avoir terminé le cours Comprehensive Rust(le "
-"guide complet de Rust)), et idéalement aussi avoir quelques\n"
-"expérience de la programmation bare-metal dans un autre langage tel que C."
+"aux personnes familiarisées avec le bases de Rust (peut-être après avoir "
+"terminé le cours Comprehensive Rust(le guide complet de Rust)), et "
+"idéalement aussi avoir quelques expérience de la programmation bare-metal "
+"dans un autre langage tel que C."
 
 #: src/bare-metal.md:7
 #, fuzzy
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 "Aujourd'hui, nous allons parler de Rust \"bare-metal\": exécuter du code "
-"Rust sans système d'exploitation sous nous. Cette volonté\n"
-"être divisé en plusieurs parties :"
+"Rust sans système d'exploitation sous nous. Cette volonté être divisé en "
+"plusieurs parties :"
 
 #: src/bare-metal.md:10
 #, fuzzy
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr "Qu'est-ce que `no_std` Rust ?"
+
+#: src/bare-metal.md:11
+#, fuzzy
+msgid "Writing firmware for microcontrollers."
+msgstr "Ecriture de firmware pour microcontrôleurs."
+
+#: src/bare-metal.md:12
+#, fuzzy
+msgid "Writing bootloader / kernel code for application processors."
 msgstr ""
-"- Qu'est-ce que `no_std` Rust ?\n"
-"- Ecriture de firmware pour microcontrôleurs.\n"
-"- Ecriture du bootloader / code noyau pour les processeurs d'application.\n"
-"- Quelques caisses utiles pour le développement de Rust en métal nu."
+"Ecriture du bootloader / code noyau pour les processeurs d'application."
+
+#: src/bare-metal.md:13
+#, fuzzy
+msgid "Some useful crates for bare-metal Rust development."
+msgstr "Quelques caisses utiles pour le développement de Rust en métal nu."
 
 #: src/bare-metal.md:15
 #, fuzzy
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 "Pour la partie microcontrôleur du cours, nous utiliserons le [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"par exemple. C'est une [carte de développement](https://tech.microbit.org/"
-"hardware/) basée sur le Nordic\n"
-"Microcontrôleur nRF51822 avec quelques LED et boutons, un accéléromètre et "
-"une boussole connectés I2C, et\n"
-"un débogueur SWD intégré."
+"(https://microbit.org/) v2 par exemple. C'est une [carte de développement]"
+"(https://tech.microbit.org/hardware/) basée sur le Nordic Microcontrôleur "
+"nRF51822 avec quelques LED et boutons, un accéléromètre et une boussole "
+"connectés I2C, et un débogueur SWD intégré."
 
 #: src/bare-metal.md:20
 #, fuzzy
@@ -13839,35 +14372,15 @@ msgstr ""
 
 #: src/bare-metal/no_std.md:1
 #, fuzzy
-msgid "# `no_std`"
-msgstr "# `no_std`"
-
-#: src/bare-metal/no_std.md:3
-#, fuzzy
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
-msgstr ""
-"<tableau>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
+msgstr "`no_std`"
 
 #: src/bare-metal/no_std.md:7
 #, fuzzy
 msgid "`core`"
 msgstr "`noyau`"
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-#, fuzzy
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-"</th>\n"
-"<e>"
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 #, fuzzy
 msgid "`alloc`"
 msgstr "`allouer`"
@@ -13877,117 +14390,125 @@ msgstr "`allouer`"
 msgid "`std`"
 msgstr "`std`"
 
-#: src/bare-metal/no_std.md:19
-#, fuzzy
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<dt>"
-
 #: src/bare-metal/no_std.md:24
 #, fuzzy
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
-msgstr ""
-"* Tranches, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Résultat`\n"
-"* `Afficher`, `Déboguer`, `écrire !`...\n"
-"* `Itérateur`\n"
-"* `panique !`, `assert_eq !`...\n"
-"* `NonNull` et toutes les fonctions habituelles liées au pointeur\n"
-"* `Future` et `async`/`wait`\n"
-"* `clôture`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Durée`"
+msgid "Slices, `&str`, `CStr`"
+msgstr "Tranches, `&str`, `CStr`"
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
+#: src/bare-metal/no_std.md:25
 #, fuzzy
-msgid ""
-"</td>\n"
-"<td>"
-msgstr ""
-"</td>\n"
-"<dt>"
+msgid "`NonZeroU8`..."
+msgstr "`NonZeroU8`..."
+
+#: src/bare-metal/no_std.md:26
+#, fuzzy
+msgid "`Option`, `Result`"
+msgstr "`Option`, `Résultat`"
+
+#: src/bare-metal/no_std.md:27
+#, fuzzy
+msgid "`Display`, `Debug`, `write!`..."
+msgstr "`Afficher`, `Déboguer`, `écrire !`..."
+
+#: src/bare-metal/no_std.md:29
+#, fuzzy
+msgid "`panic!`, `assert_eq!`..."
+msgstr "`panique !`, `assert_eq !`..."
+
+#: src/bare-metal/no_std.md:30
+#, fuzzy
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr "`NonNull` et toutes les fonctions habituelles liées au pointeur"
+
+#: src/bare-metal/no_std.md:31
+#, fuzzy
+msgid "`Future` and `async`/`await`"
+msgstr "`Future` et `async`/`wait`"
+
+#: src/bare-metal/no_std.md:32
+#, fuzzy
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr "`clôture`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+
+#: src/bare-metal/no_std.md:33
+#, fuzzy
+msgid "`Duration`"
+msgstr "`Durée`"
 
 #: src/bare-metal/no_std.md:38
 #, fuzzy
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
-msgstr ""
-"* `Boîte`, `Vache`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `Chaîne`, `CString`, `format !`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr "`Boîte`, `Vache`, `Arc`, `Rc`"
+
+#: src/bare-metal/no_std.md:39
+#, fuzzy
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+
+#: src/bare-metal/no_std.md:40
+#, fuzzy
+msgid "`String`, `CString`, `format!`"
+msgstr "`Chaîne`, `CString`, `format !`"
 
 #: src/bare-metal/no_std.md:45
 #, fuzzy
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
-msgstr ""
-"* \"Erreur\"\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrière`, `Une fois`, `RwLock`, `mpsc`\n"
-"* `File` et le reste de `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` et le reste de `io`\n"
-"* `Chemin`, `OsString`\n"
-"* \"net\"\n"
-"* `Commande`, `Enfant`, `Code de sortie`\n"
-"* `spawn`, `sleep` et le reste de `thread`\n"
-"* `SystemTime`, `Instantané`"
+msgid "`Error`"
+msgstr "\"Erreur\""
 
-#: src/bare-metal/no_std.md:56
+#: src/bare-metal/no_std.md:47
 #, fuzzy
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
-msgstr ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<détails>"
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr "`Mutex`, `Condvar`, `Barrière`, `Une fois`, `RwLock`, `mpsc`"
+
+#: src/bare-metal/no_std.md:48
+#, fuzzy
+msgid "`File` and the rest of `fs`"
+msgstr "`File` et le reste de `fs`"
+
+#: src/bare-metal/no_std.md:49
+#, fuzzy
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr "`println!`, `Read`, `Write`, `Stdin`, `Stdout` et le reste de `io`"
+
+#: src/bare-metal/no_std.md:50
+#, fuzzy
+msgid "`Path`, `OsString`"
+msgstr "`Chemin`, `OsString`"
+
+#: src/bare-metal/no_std.md:51
+#, fuzzy
+msgid "`net`"
+msgstr "\"net\""
+
+#: src/bare-metal/no_std.md:52
+#, fuzzy
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr "`Commande`, `Enfant`, `Code de sortie`"
+
+#: src/bare-metal/no_std.md:53
+#, fuzzy
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr "`spawn`, `sleep` et le reste de `thread`"
+
+#: src/bare-metal/no_std.md:54
+#, fuzzy
+msgid "`SystemTime`, `Instant`"
+msgstr "`SystemTime`, `Instantané`"
 
 #: src/bare-metal/no_std.md:62
 #, fuzzy
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
-msgstr ""
-"* `HashMap` dépend de RNG.\n"
-"* `std` réexporte le contenu de `core` et `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr "`HashMap` dépend de RNG."
+
+#: src/bare-metal/no_std.md:63
+#, fuzzy
+msgid "`std` re-exports the contents of both `core` and `alloc`."
+msgstr "`std` réexporte le contenu de `core` et `alloc`."
 
 #: src/bare-metal/minimal.md:1
 #, fuzzy
-msgid "# A minimal `no_std` program"
-msgstr "# Un programme minimal `no_std`"
+msgid "A minimal `no_std` program"
+msgstr "Un programme minimal `no_std`"
 
 #: src/bare-metal/minimal.md:3
 msgid ""
@@ -14005,35 +14526,38 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-#, fuzzy
-msgid "# `alloc`"
-msgstr "# `allouer`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
+msgstr ""
 
 #: src/bare-metal/alloc.md:3
 #, fuzzy
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
-"Pour utiliser `alloc` vous devez implémenter un\n"
-"[allocateur global (de tas)](https://doc.rust-lang.org/stable/std/alloc/"
-"trait.GlobalAlloc.html)."
+"Pour utiliser `alloc` vous devez implémenter un [allocateur global (de tas)]"
+"(https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 
 #: src/bare-metal/alloc.md:6
 msgid ""
@@ -14072,27 +14596,33 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-#, fuzzy
-msgid "# Microcontrollers"
-msgstr "# Microcontrôleurs"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
+msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
 #, fuzzy
@@ -14134,31 +14664,25 @@ msgstr ""
 #: src/bare-metal/microcontrollers.md:25
 #, fuzzy
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
-"* La macro `cortex_m_rt::entry` nécessite que la fonction ait le type `fn() -"
-"> !`, car le retour\n"
-"  au gestionnaire de réinitialisation n'a pas de sens.\n"
-"* Exécutez l'exemple avec `cargo embed --bin minimal`"
+"La macro `cortex_m_rt::entry` nécessite que la fonction ait le type `fn() -"
+"> !`, car le retour au gestionnaire de réinitialisation n'a pas de sens."
 
-#: src/bare-metal/microcontrollers/mmio.md:1
+#: src/bare-metal/microcontrollers.md:27
 #, fuzzy
-msgid "# Raw MMIO"
-msgstr "# MMIO brut"
+msgid "Run the example with `cargo embed --bin minimal`"
+msgstr "Exécutez l'exemple avec `cargo embed --bin minimal`"
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 #, fuzzy
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 "La plupart des microcontrôleurs accèdent aux périphériques via des E/S "
-"mappées en mémoire. Essayons d'allumer une LED sur notre\n"
-"micro:bit:"
+"mappées en mémoire. Essayons d'allumer une LED sur notre micro:bit:"
 
 #: src/bare-metal/microcontrollers/mmio.md:6
 msgid ""
@@ -14228,11 +14752,11 @@ msgstr ""
 #: src/bare-metal/microcontrollers/mmio.md:64
 #, fuzzy
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
-"* La broche 21 du GPIO 0 est connectée à la première colonne de la matrice "
-"LED et la broche 28 à la première rangée."
+"La broche 21 du GPIO 0 est connectée à la première colonne de la matrice LED "
+"et la broche 28 à la première rangée."
 
 #: src/bare-metal/microcontrollers/mmio.md:66
 #: src/bare-metal/microcontrollers/pacs.md:59
@@ -14251,23 +14775,19 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
 #, fuzzy
-msgid "# Peripheral Access Crates"
-msgstr "# Caisses d'accès périphérique"
+msgid "Peripheral Access Crates"
+msgstr "Caisses d'accès périphérique"
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 #, fuzzy
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) génère des wrappers Rust "
-"principalement sûrs pour\n"
-"périphériques mappés en mémoire de [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"des dossiers."
+"principalement sûrs pour périphériques mappés en mémoire de [CMSIS-SVD]"
+"(https://www.keil.com/pack/doc/CMSIS/SVD/html/index.html) des dossiers."
 
 #: src/bare-metal/microcontrollers/pacs.md:7
 msgid ""
@@ -14315,33 +14835,46 @@ msgstr ""
 #: src/bare-metal/microcontrollers/pacs.md:49
 #, fuzzy
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
 msgstr ""
-"* Les fichiers SVD (System View Description) sont des fichiers XML "
-"généralement fournis par les fournisseurs de silicium qui\n"
-"  décrire la carte mémoire de l'appareil.\n"
-"  * Ils sont organisés par périphérique, registre, champ et valeur, avec "
-"noms, descriptions, adresses\n"
-"    et ainsi de suite.\n"
-"  * Les fichiers SVD sont souvent bogués et incomplets, il existe donc "
-"divers projets qui corrigent le\n"
-"    erreurs, ajoutez les détails manquants et publiez les caisses générées.\n"
-"* `cortex-m-rt` fournit la table des vecteurs, entre autres choses.\n"
-"* Si vous \"installez cargo cargo-binutils\", vous pouvez exécuter\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` pour voir le binaire "
-"résultant."
+"Les fichiers SVD (System View Description) sont des fichiers XML "
+"généralement fournis par les fournisseurs de silicium qui décrire la carte "
+"mémoire de l'appareil."
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+#, fuzzy
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+"Ils sont organisés par périphérique, registre, champ et valeur, avec noms, "
+"descriptions, adresses et ainsi de suite."
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+#, fuzzy
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+"Les fichiers SVD sont souvent bogués et incomplets, il existe donc divers "
+"projets qui corrigent le erreurs, ajoutez les détails manquants et publiez "
+"les caisses générées."
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+#, fuzzy
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr "`cortex-m-rt` fournit la table des vecteurs, entre autres choses."
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+#, fuzzy
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
+msgstr ""
+"Si vous \"installez cargo cargo-binutils\", vous pouvez exécuter `cargo "
+"objdump --bin pac -- -d --no-show-raw-insn` pour voir le binaire résultant."
 
 #: src/bare-metal/microcontrollers/pacs.md:61
 msgid ""
@@ -14352,23 +14885,21 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
 #, fuzzy
-msgid "# HAL crates"
-msgstr "# caisses HAL"
+msgid "HAL crates"
+msgstr "caisses HAL"
 
 #: src/bare-metal/microcontrollers/hals.md:3
 #, fuzzy
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 "[Caisses HAL](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) pour\n"
-"de nombreux microcontrôleurs fournissent des wrappers autour de divers "
-"périphériques. Ceux-ci implémentent généralement des traits\n"
-"de [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) pour de nombreux microcontrôleurs fournissent des "
+"wrappers autour de divers périphériques. Ceux-ci implémentent généralement "
+"des traits de [`embedded-hal`](https://crates.io/crates/embedded-hal)."
 
 #: src/bare-metal/microcontrollers/hals.md:7
 msgid ""
@@ -14406,17 +14937,19 @@ msgstr ""
 #: src/bare-metal/microcontrollers/hals.md:39
 #, fuzzy
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
 msgstr ""
-" * `set_low` et `set_high` sont des méthodes sur le trait `embedded_hal` "
-"`OutputPin`.\n"
-" * Les caisses HAL existent pour de nombreux appareils Cortex-M et RISC-V, y "
-"compris divers STM32, GD32, nRF, NXP,\n"
-"   Microcontrôleurs MSP430, AVR et PIC."
+"`set_low` et `set_high` sont des méthodes sur le trait `embedded_hal` "
+"`OutputPin`."
+
+#: src/bare-metal/microcontrollers/hals.md:40
+#, fuzzy
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
+msgstr ""
+"Les caisses HAL existent pour de nombreux appareils Cortex-M et RISC-V, y "
+"compris divers STM32, GD32, nRF, NXP, Microcontrôleurs MSP430, AVR et PIC."
 
 #: src/bare-metal/microcontrollers/hals.md:45
 msgid ""
@@ -14427,8 +14960,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
 #, fuzzy
-msgid "# Board support crates"
-msgstr "# Caisses support planche"
+msgid "Board support crates"
+msgstr "Caisses support planche"
 
 #: src/bare-metal/microcontrollers/board-support.md:3
 #, fuzzy
@@ -14466,21 +14999,25 @@ msgstr ""
 #: src/bare-metal/microcontrollers/board-support.md:28
 #, fuzzy
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
 msgstr ""
-" * Dans ce cas, la caisse de support de carte fournit simplement des noms "
-"plus utiles, et un peu de\n"
-"   initialisation.\n"
-" * La caisse peut également inclure des pilotes pour certains périphériques "
-"embarqués en dehors du microcontrôleur\n"
-"   lui-même.\n"
-"   * `microbit-v2` inclut un pilote simple pour la matrice LED."
+"Dans ce cas, la caisse de support de carte fournit simplement des noms plus "
+"utiles, et un peu de initialisation."
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+#, fuzzy
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+"La caisse peut également inclure des pilotes pour certains périphériques "
+"embarqués en dehors du microcontrôleur lui-même."
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+#, fuzzy
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
+msgstr "`microbit-v2` inclut un pilote simple pour la matrice LED."
 
 #: src/bare-metal/microcontrollers/board-support.md:36
 msgid ""
@@ -14491,8 +15028,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
 #, fuzzy
-msgid "# The type state pattern"
-msgstr "# Le modèle d'état de type"
+msgid "The type state pattern"
+msgstr "Le modèle d'état de type"
 
 #: src/bare-metal/microcontrollers/type-state.md:3
 msgid ""
@@ -14530,201 +15067,258 @@ msgstr ""
 #: src/bare-metal/microcontrollers/type-state.md:32
 #, fuzzy
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
 msgstr ""
-" * Les broches n'implémentent pas `Copy` ou `Clone`, donc une seule instance "
-"de chacun peut exister. Une fois qu'une broche est\n"
-"   déplacé hors de la structure du port, personne d'autre ne peut le "
-"prendre.\n"
-" * La modification de la configuration d'une broche consomme l'ancienne "
-"instance de broche, vous ne pouvez donc pas continuer à utiliser l'ancienne\n"
-"   exemple par la suite.\n"
-" * Le type d'une valeur indique l'état dans lequel elle se trouve : par ex. "
-"dans ce cas, l'état de la configuration\n"
-"   d'une broche GPIO. Cela encode la machine d'état dans le système de type "
-"et garantit que vous ne\n"
-"   essayez d'utiliser une broche d'une certaine manière sans la configurer "
-"correctement au préalable. État illégal\n"
-"   les transitions sont interceptées au moment de la compilation.\n"
-" * Vous pouvez appeler `is_high` sur une broche d'entrée et `set_high` sur "
-"une broche de sortie, mais pas l'inverse.\n"
-" * De nombreuses caisses HAL suivent ce modèle."
+"Les broches n'implémentent pas `Copy` ou `Clone`, donc une seule instance de "
+"chacun peut exister. Une fois qu'une broche est déplacé hors de la structure "
+"du port, personne d'autre ne peut le prendre."
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+#, fuzzy
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+"La modification de la configuration d'une broche consomme l'ancienne "
+"instance de broche, vous ne pouvez donc pas continuer à utiliser l'ancienne "
+"exemple par la suite."
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+#, fuzzy
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+"Le type d'une valeur indique l'état dans lequel elle se trouve : par ex. "
+"dans ce cas, l'état de la configuration d'une broche GPIO. Cela encode la "
+"machine d'état dans le système de type et garantit que vous ne essayez "
+"d'utiliser une broche d'une certaine manière sans la configurer correctement "
+"au préalable. État illégal les transitions sont interceptées au moment de la "
+"compilation."
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+#, fuzzy
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+"Vous pouvez appeler `is_high` sur une broche d'entrée et `set_high` sur une "
+"broche de sortie, mais pas l'inverse."
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+#, fuzzy
+msgid "Many HAL crates follow this pattern."
+msgstr "De nombreuses caisses HAL suivent ce modèle."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
 #, fuzzy
-msgid "# `embedded-hal`"
-msgstr "# `embedded-hal`"
+msgid "`embedded-hal`"
+msgstr "`embedded-hal`"
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 #, fuzzy
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 "La caisse [`embedded-hal`](https://crates.io/crates/embedded-hal) fournit un "
-"certain nombre de caractéristiques\n"
-"couvrant les périphériques de microcontrôleur courants."
+"certain nombre de caractéristiques couvrant les périphériques de "
+"microcontrôleur courants."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
 #, fuzzy
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
-msgstr ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, PEUT\n"
-" * GNA\n"
-" * Minuteries\n"
-" * Chiens de garde"
+msgid "GPIO"
+msgstr "GPIO"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+#, fuzzy
+msgid "ADC"
+msgstr "ADC"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+#, fuzzy
+msgid "I2C, SPI, UART, CAN"
+msgstr "I2C, SPI, UART, PEUT"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+#, fuzzy
+msgid "RNG"
+msgstr "GNA"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+#, fuzzy
+msgid "Timers"
+msgstr "Minuteries"
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+#, fuzzy
+msgid "Watchdogs"
+msgstr "Chiens de garde"
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 #, fuzzy
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
-"D'autres caisses mettent alors en œuvre\n"
-"[pilotes](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) en ce qui concerne ces\n"
-"traits, par ex. un pilote d'accéléromètre peut nécessiter une implémentation "
-"de bus I2C ou SPI."
+"D'autres caisses mettent alors en œuvre [pilotes](https://github.com/rust-"
+"embedded/awesome-embedded-rust#driver-crates) en ce qui concerne ces traits, "
+"par ex. un pilote d'accéléromètre peut nécessiter une implémentation de bus "
+"I2C ou SPI."
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 #, fuzzy
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+"Il existe des implémentations pour de nombreux microcontrôleurs, ainsi que "
+"pour d'autres plates-formes telles que Linux sur Tarte aux framboises."
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+#, fuzzy
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
-" * Il existe des implémentations pour de nombreux microcontrôleurs, ainsi "
-"que pour d'autres plates-formes telles que Linux sur\n"
-"Tarte aux framboises.\n"
-" * Il y a des travaux en cours sur une version `async` de `embedded-hal`, "
-"mais ce n'est pas encore stable."
+"Il y a des travaux en cours sur une version `async` de `embedded-hal`, mais "
+"ce n'est pas encore stable."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
 #, fuzzy
-msgid "# `probe-rs`, `cargo-embed`"
-msgstr "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
+msgstr "`probe-rs`, `cargo-embed`"
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 #, fuzzy
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
 "[probe-rs](https://probe.rs/) est un ensemble d'outils pratique pour le "
-"débogage intégré, comme OpenOCD mais en mieux\n"
-"intégré."
+"débogage intégré, comme OpenOCD mais en mieux intégré."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
 #, fuzzy
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr "SWD"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+#, fuzzy
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr " et JTAG via les sondes CMSIS-DAP, ST-Link et J-Link"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+#, fuzzy
+msgid "GDB stub and Microsoft "
+msgstr "Stub GDB et serveur Microsoft "
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+#, fuzzy
+msgid "DAP"
+msgstr "DAP"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+#, fuzzy
+msgid " server"
+msgstr "Intégration du fret"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> et JTAG via les sondes CMSIS-"
-"DAP, ST-Link et J-Link\n"
-"* Stub GDB et serveur Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</"
-"abbr>\n"
-"* Intégration du fret"
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
 #, fuzzy
-msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
 msgstr ""
 "`cargo-embed` est une sous-commande cargo pour construire et flasher des "
-"binaires, enregistrer\n"
-"Sortie <abbr title=\"Real Time Transfers\">RTT</abbr> et connectez GDB. Il "
-"est configuré par un\n"
-"Fichier `Embed.toml` dans votre répertoire de projet."
+"binaires, enregistrer Sortie "
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+#, fuzzy
+msgid "RTT"
+msgstr "RTT"
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+#, fuzzy
+msgid ""
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
+msgstr ""
+" et connectez GDB. Il est configuré par un Fichier `Embed.toml` dans votre "
+"répertoire de projet."
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 #, fuzzy
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) "
-"est une norme Arm\n"
-"  protocole sur USB pour un débogueur en circuit pour accéder au port "
-"d'accès de débogage CoreSight de divers\n"
-"  Processeurs Arm Cortex. C'est ce que le débogueur embarqué sur le BBC "
-"micro:bit utilise.\n"
-"* ST-Link est une gamme de débogueurs en circuit de ST Microelectronics, J-"
-"Link est une gamme de\n"
-"  SEGER.\n"
-"* Le port d'accès au débogage est généralement une interface JTAG à 5 "
-"broches ou un débogage de fil série à 2 broches.\n"
-"* probe-rs est une bibliothèque que vous pouvez intégrer dans vos propres "
-"outils si vous le souhaitez.\n"
-"* Le [protocole de l'adaptateur de débogage Microsoft] (https://microsoft."
-"github.io/debug-adapter-protocol/) permet\n"
-"  VSCode et d'autres IDE déboguent le code s'exécutant sur n'importe quel "
-"microcontrôleur pris en charge.\n"
-"* cargo-embed est un binaire construit à l'aide de la bibliothèque probe-"
-"rs.\n"
-"* RTT (Real Time Transfers) est un mécanisme de transfert de données entre "
-"l'hôte de débogage et la cible\n"
-"  à travers un certain nombre de tampons circulaires."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) est "
+"une norme Arm protocole sur USB pour un débogueur en circuit pour accéder au "
+"port d'accès de débogage CoreSight de divers Processeurs Arm Cortex. C'est "
+"ce que le débogueur embarqué sur le BBC micro:bit utilise."
 
-#: src/bare-metal/microcontrollers/debugging.md:1
+#: src/bare-metal/microcontrollers/probe-rs.md:19
 #, fuzzy
-msgid "# Debugging"
-msgstr "# Débogage"
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+"ST-Link est une gamme de débogueurs en circuit de ST Microelectronics, J-"
+"Link est une gamme de SEGER."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+#, fuzzy
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+"Le port d'accès au débogage est généralement une interface JTAG à 5 broches "
+"ou un débogage de fil série à 2 broches."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+#, fuzzy
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+"probe-rs est une bibliothèque que vous pouvez intégrer dans vos propres "
+"outils si vous le souhaitez."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+#, fuzzy
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+"Le \\[protocole de l'adaptateur de débogage Microsoft\\] (https://microsoft."
+"github.io/debug-adapter-protocol/) permet VSCode et d'autres IDE déboguent "
+"le code s'exécutant sur n'importe quel microcontrôleur pris en charge."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+#, fuzzy
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+"cargo-embed est un binaire construit à l'aide de la bibliothèque probe-rs."
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+#, fuzzy
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
+msgstr ""
+"RTT (Real Time Transfers) est un mécanisme de transfert de données entre "
+"l'hôte de débogage et la cible à travers un certain nombre de tampons "
+"circulaires."
 
 #: src/bare-metal/microcontrollers/debugging.md:3
 #, fuzzy
@@ -14787,69 +15381,119 @@ msgstr ""
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
 #, fuzzy
-msgid "# Other projects"
-msgstr "# Autres projets"
+msgid "Other projects"
+msgstr "Autres projets"
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
 #, fuzzy
+msgid "[RTIC](https://rtic.rs/)"
+msgstr "\\* [RTIC](https://rtic.rs/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+#, fuzzy
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr "\"Concurrence pilotée par interruption en temps réel\""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
+#, fuzzy
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
 msgstr ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Concurrence pilotée par interruption en temps réel\"\n"
-"   * Gestion des ressources partagées, transmission de messages, "
-"planification des tâches, file d'attente du minuteur\n"
-" * [Ambassade](https://embassy.dev/)\n"
-"   * Exécuteurs \"asynchrones\" avec priorités, minuteries, mise en réseau, "
-"USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * RTOS axé sur la sécurité avec planification préemptive et prise en "
-"charge de l'unité de protection de la mémoire\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS d'Oxide Computer Company avec protection de la "
-"mémoire, pilotes non privilégiés, IPC\n"
-" * [Liaisons pour FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Certaines plates-formes ont des implémentations \"std\", par ex.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Gestion des ressources partagées, transmission de messages, planification "
+"des tâches, file d'attente du minuteur"
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+#, fuzzy
+msgid "[Embassy](https://embassy.dev/)"
+msgstr "[Ambassade](https://embassy.dev/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+#, fuzzy
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+"Exécuteurs \"asynchrones\" avec priorités, minuteries, mise en réseau, USB"
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+#, fuzzy
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr "[TockOS](https://www.tockos.org/documentation/getting-started)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+#, fuzzy
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+"RTOS axé sur la sécurité avec planification préemptive et prise en charge de "
+"l'unité de protection de la mémoire"
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+#, fuzzy
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr "[Hubris](https://hubris.oxide.computer/)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+#, fuzzy
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+"Microkernel RTOS d'Oxide Computer Company avec protection de la mémoire, "
+"pilotes non privilégiés, IPC"
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+#, fuzzy
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr "[Liaisons pour FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+#, fuzzy
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
+msgstr ""
+"Certaines plates-formes ont des implémentations \"std\", par ex. [esp-idf]"
+"(https://esp-rs.github.io/book/overview/using-the-standard-library.html)."
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
 #, fuzzy
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr "RTIC peut être considéré comme un RTOS ou un cadre de concurrence."
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+#, fuzzy
+msgid "It doesn't include any HALs."
+msgstr "Il n'inclut aucun HAL."
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
+#, fuzzy
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+"Il utilise le Cortex-M NVIC (Nested Virtual Interrupt Controller) pour la "
+"planification plutôt qu'un noyau approprié."
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+#, fuzzy
+msgid "Cortex-M only."
+msgstr "Cortex-M uniquement."
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+#, fuzzy
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+"Google utilise TockOS sur le microcontrôleur Haven pour les clés de sécurité "
+"Titan."
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+#, fuzzy
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
-" * RTIC peut être considéré comme un RTOS ou un cadre de concurrence.\n"
-"   * Il n'inclut aucun HAL.\n"
-"   * Il utilise le Cortex-M NVIC (Nested Virtual Interrupt Controller) pour "
-"la planification plutôt qu'un\n"
-"     noyau approprié.\n"
-"   * Cortex-M uniquement.\n"
-" * Google utilise TockOS sur le microcontrôleur Haven pour les clés de "
-"sécurité Titan.\n"
-" * FreeRTOS est principalement écrit en C, mais il existe des liaisons Rust "
+"FreeRTOS est principalement écrit en C, mais il existe des liaisons Rust "
 "pour écrire des applications."
 
 #: src/exercises/bare-metal/morning.md:3
@@ -14861,22 +15505,17 @@ msgstr ""
 "Nous lirons la direction à partir d'une boussole I2C et enregistrerons les "
 "lectures sur un port série."
 
-#: src/exercises/bare-metal/compass.md:1
-#, fuzzy
-msgid "# Compass"
-msgstr "# Boussole"
-
 #: src/exercises/bare-metal/compass.md:3
 #, fuzzy
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
-"serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 "Nous lirons la direction à partir d'une boussole I2C et enregistrerons les "
-"lectures sur un port série. Si tu as\n"
-"temps, essayez de l'afficher sur les LED d'une manière ou d'une autre, ou "
-"utilisez les boutons d'une manière ou d'une autre."
+"lectures sur un port série. Si tu as temps, essayez de l'afficher sur les "
+"LED d'une manière ou d'une autre, ou utilisez les boutons d'une manière ou "
+"d'une autre."
 
 #: src/exercises/bare-metal/compass.md:6
 #, fuzzy
@@ -14886,74 +15525,76 @@ msgstr "Astuces:"
 #: src/exercises/bare-metal/compass.md:8
 #, fuzzy
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C "
-"bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
 msgstr ""
-"- Consultez la documentation du [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) et\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) caisses, "
-"ainsi que les\n"
-"  [matériel micro:bit](https://tech.microbit.org/hardware/).\n"
-"- La centrale de mesure inertielle LSM303AGR est connectée au bus interne "
-"I2C.\n"
-"- TWI est un autre nom pour I2C, donc le périphérique maître I2C s'appelle "
-"TWIM.\n"
-"- Le pilote LSM303AGR a besoin de quelque chose implémentant `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. Le\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) structure\n"
-"  implémente cela.\n"
-"- Vous avez un [`microbit::Board`](https://docs.rs/microbit-v2/latest/"
-"microbit/struct.Board.html)\n"
-"  structure avec des champs pour les différentes broches et périphériques.\n"
-"- Vous pouvez également consulter le\n"
-"  [fiche technique nRF52833](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) si vous le souhaitez, mais\n"
-"  cela ne devrait pas être nécessaire pour cet exercice."
+"Consultez la documentation du [`lsm303agr`](https://docs.rs/lsm303agr/latest/"
+"lsm303agr/) et [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) "
+"caisses, ainsi que les [matériel micro:bit](https://tech.microbit.org/"
+"hardware/)."
+
+#: src/exercises/bare-metal/compass.md:11
+#, fuzzy
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+"La centrale de mesure inertielle LSM303AGR est connectée au bus interne I2C."
+
+#: src/exercises/bare-metal/compass.md:12
+#, fuzzy
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+"TWI est un autre nom pour I2C, donc le périphérique maître I2C s'appelle "
+"TWIM."
+
+#: src/exercises/bare-metal/compass.md:13
+#, fuzzy
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+"Le pilote LSM303AGR a besoin de quelque chose implémentant `embedded_hal::"
+"blocking::i2c::WriteRead` trait. Le [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) structure implémente cela."
+
+#: src/exercises/bare-metal/compass.md:17
+#, fuzzy
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+"Vous avez un [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) structure avec des champs pour les différentes broches et "
+"périphériques."
+
+#: src/exercises/bare-metal/compass.md:19
+#, fuzzy
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
+msgstr ""
+"Vous pouvez également consulter le [fiche technique nRF52833](https://"
+"infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.5.pdf) si vous le souhaitez, "
+"mais cela ne devrait pas être nécessaire pour cet exercice."
 
 #: src/exercises/bare-metal/compass.md:23
 #, fuzzy
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `compass`\n"
-"directory for the following files."
+"look in the `compass` directory for the following files."
 msgstr ""
-"Téléchargez le [modèle d'exercice] (../../comprehensive-rust-exercises.zip) "
-"et regardez dans la `boussole`\n"
-"répertoire pour les fichiers suivants."
+"Téléchargez le \\[modèle d'exercice\\] (../../comprehensive-rust-exercises."
+"zip) et regardez dans la `boussole` répertoire pour les fichiers suivants."
 
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 #, fuzzy
 msgid "`src/main.rs`:"
 msgstr "`src/main.rs` :"
-
-#: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
-#: src/exercises/concurrency/dining-philosophers.md:17
-#: src/exercises/concurrency/link-checker.md:55
-#: src/exercises/concurrency/dining-philosophers-async.md:11
-#, fuzzy
-msgid "<!-- File src/main.rs -->"
-msgstr "<!-- Fichier src/main.rs -->"
 
 #: src/exercises/bare-metal/compass.md:30
 msgid ""
@@ -14997,15 +15638,6 @@ msgstr ""
 msgid "`Cargo.toml` (you shouldn't need to change this):"
 msgstr "`Cargo.toml` (vous ne devriez pas avoir besoin de le modifier) :"
 
-#: src/exercises/bare-metal/compass.md:66 src/exercises/bare-metal/rtc.md:387
-#: src/exercises/concurrency/dining-philosophers.md:63
-#: src/exercises/concurrency/link-checker.md:35
-#: src/exercises/concurrency/dining-philosophers-async.md:60
-#: src/exercises/concurrency/chat-app.md:17
-#, fuzzy
-msgid "<!-- File Cargo.toml -->"
-msgstr "<!-- Fichier Cargo.toml -->"
-
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
 "```toml\n"
@@ -15031,11 +15663,6 @@ msgstr ""
 msgid "`Embed.toml` (you shouldn't need to change this):"
 msgstr "`Embed.toml` (vous ne devriez pas avoir besoin de le modifier) :"
 
-#: src/exercises/bare-metal/compass.md:87
-#, fuzzy
-msgid "<!-- File Embed.toml -->"
-msgstr "<!-- Fichier Embed.toml -->"
-
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
 "```toml\n"
@@ -15055,11 +15682,6 @@ msgstr ""
 msgid "`.cargo/config.toml` (you shouldn't need to change this):"
 msgstr ""
 "`.cargo/config.toml` (vous ne devriez pas avoir besoin de le modifier) :"
-
-#: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
-#, fuzzy
-msgid "<!-- File .cargo/config.toml -->"
-msgstr "<!-- Fichier .cargo/config.toml -->"
 
 #: src/exercises/bare-metal/compass.md:104
 msgid ""
@@ -15106,48 +15728,44 @@ msgstr "Utilisez Ctrl+A Ctrl+Q pour quitter picocom."
 
 #: src/bare-metal/aps.md:1
 #, fuzzy
-msgid "# Application processors"
-msgstr "# Processeurs d'application"
+msgid "Application processors"
+msgstr "Processeurs d'application"
 
 #: src/bare-metal/aps.md:3
 #, fuzzy
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 "Jusqu'à présent, nous avons parlé de microcontrôleurs, tels que la série Arm "
-"Cortex-M. Essayons maintenant d'écrire\n"
-"quelque chose pour Cortex-A. Pour plus de simplicité, nous allons simplement "
-"travailler avec aarch64 de QEMU\n"
+"Cortex-M. Essayons maintenant d'écrire quelque chose pour Cortex-A. Pour "
+"plus de simplicité, nous allons simplement travailler avec aarch64 de QEMU "
 "['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html)."
 
 #: src/bare-metal/aps.md:9
 #, fuzzy
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
 msgstr ""
-"* D'une manière générale, les microcontrôleurs n'ont pas de MMU ou plusieurs "
-"niveaux de privilège (exception\n"
-"  niveaux sur les processeurs Arm, sonne sur x86), contrairement aux "
-"processeurs d'application.\n"
-"* QEMU prend en charge l'émulation de différentes machines ou modèles de "
-"cartes pour chaque architecture. Le\n"
-"  La carte 'virt' ne correspond à aucun matériel réel particulier, mais est "
-"conçue uniquement pour\n"
-"  machines virtuelles."
+"D'une manière générale, les microcontrôleurs n'ont pas de MMU ou plusieurs "
+"niveaux de privilège (exception niveaux sur les processeurs Arm, sonne sur "
+"x86), contrairement aux processeurs d'application."
 
-#: src/bare-metal/aps/entry-point.md:1
-msgid "# Getting Ready to Rust"
+#: src/bare-metal/aps.md:11
+#, fuzzy
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
+"QEMU prend en charge l'émulation de différentes machines ou modèles de "
+"cartes pour chaque architecture. Le La carte 'virt' ne correspond à aucun "
+"matériel réel particulier, mais est conçue uniquement pour machines "
+"virtuelles."
 
 #: src/bare-metal/aps/entry-point.md:3
 msgid ""
@@ -15232,66 +15850,94 @@ msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:77
 msgid ""
-"* This is the same as it would be for C: initialising the processor state, "
-"zeroing the BSS, and\n"
-"  setting up the stack pointer.\n"
-"  * The BSS (block starting symbol, for historical reasons) is the part of "
-"the object file which\n"
-"    containing statically allocated variables which are initialised to zero. "
-"They are omitted from\n"
-"    the image, to avoid wasting space on zeroes. The compiler assumes that "
-"the loader will take care\n"
-"    of zeroing them.\n"
-"* The BSS may already be zeroed, depending on how memory is initialised and "
-"the image is loaded, but\n"
-"  we zero it to be sure.\n"
-"* We need to enable the MMU and cache before reading or writing any memory. "
-"If we don't:\n"
-"  * Unaligned accesses will fault. We build the Rust code for the `aarch64-"
-"unknown-none` target\n"
-"    which sets `+strict-align` to prevent the compiler generating unaligned "
-"accesses, so it should\n"
-"    be fine in this case, but this is not necessarily the case in general.\n"
-"  * If it were running in a VM, this can lead to cache coherency issues. The "
-"problem is that the VM\n"
-"    is accessing memory directly with the cache disabled, while the host has "
-"cachable aliases to the\n"
-"    same memory. Even if the host doesn't explicitly access the memory, "
-"speculative accesses can\n"
-"    lead to cache fills, and then changes from one or the other will get "
-"lost when the cache is\n"
-"    cleaned or the VM enables the cache. (Cache is keyed by physical "
-"address, not VA or IPA.)\n"
-"* For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
-"identity maps the first 1\n"
-"  GiB of address space for devices, the next 1 GiB for DRAM, and another 1 "
-"GiB higher up for more\n"
-"  devices. This matches the memory layout that QEMU uses.\n"
-"* We also set up the exception vector (`vbar_el1`), which we'll see more "
-"about later.\n"
-"* All examples this afternoon assume we will be running at exception level 1 "
-"(EL1). If you need to\n"
-"  run at a different exception level you'll need to modify `entry.S` "
-"accordingly."
+"This is the same as it would be for C: initialising the processor state, "
+"zeroing the BSS, and setting up the stack pointer."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:79
+msgid ""
+"The BSS (block starting symbol, for historical reasons) is the part of the "
+"object file which containing statically allocated variables which are "
+"initialised to zero. They are omitted from the image, to avoid wasting space "
+"on zeroes. The compiler assumes that the loader will take care of zeroing "
+"them."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:83
+msgid ""
+"The BSS may already be zeroed, depending on how memory is initialised and "
+"the image is loaded, but we zero it to be sure."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:85
+msgid ""
+"We need to enable the MMU and cache before reading or writing any memory. If "
+"we don't:"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:86
+msgid ""
+"Unaligned accesses will fault. We build the Rust code for the `aarch64-"
+"unknown-none` target which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses, so it should be fine in this case, but this "
+"is not necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:89
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cachable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost when the cache "
+"is cleaned or the VM enables the cache. (Cache is keyed by physical address, "
+"not VA or IPA.)"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:94
+msgid ""
+"For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
+"identity maps the first 1 GiB of address space for devices, the next 1 GiB "
+"for DRAM, and another 1 GiB higher up for more devices. This matches the "
+"memory layout that QEMU uses."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:97
+msgid ""
+"We also set up the exception vector (`vbar_el1`), which we'll see more about "
+"later."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:98
+msgid ""
+"All examples this afternoon assume we will be running at exception level 1 "
+"(EL1). If you need to run at a different exception level you'll need to "
+"modify `entry.S` accordingly."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
 #, fuzzy
-msgid "# Inline assembly"
-msgstr "# Assemblage en ligne"
+msgid "Inline assembly"
+msgstr "Assemblage en ligne"
 
 #: src/bare-metal/aps/inline-assembly.md:3
 #, fuzzy
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
 msgstr ""
 "Parfois, nous devons utiliser l'assemblage pour faire des choses qui ne sont "
-"pas possibles avec le code Rust. Par exemple,\n"
-"pour effectuer un <abbr title=\"appel hyperviseur\">HVC</abbr> pour indiquer "
-"au micrologiciel d'éteindre le système :"
+"pas possibles avec le code Rust. Par exemple, pour effectuer un "
+
+#: src/bare-metal/aps/inline-assembly.md:4
+#, fuzzy
+msgid "HVC"
+msgstr "HVC"
+
+#: src/bare-metal/aps/inline-assembly.md:4
+#, fuzzy
+msgid " to tell the firmware to power off the system:"
+msgstr " pour indiquer au micrologiciel d'éteindre le système :"
 
 #: src/bare-metal/aps/inline-assembly.md:6
 msgid ""
@@ -15332,126 +15978,151 @@ msgstr ""
 #: src/bare-metal/aps/inline-assembly.md:39
 #, fuzzy
 msgid ""
-"(If you actually want to do this, use the [`smccc`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
-"(Si vous voulez vraiment faire cela, utilisez le crate [`psci`][1] qui "
-"contient des wrappers pour toutes ces fonctions.)"
+"(Si vous voulez vraiment faire cela, utilisez le crate [`psci`](https://"
+"crates.io/crates/smccc) qui contient des wrappers pour toutes ces fonctions.)"
 
 #: src/bare-metal/aps/inline-assembly.md:43
 #, fuzzy
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
-"it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are "
-"conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the "
-"standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–"
-"`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do "
-"anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+"PSCI est l'interface de coordination de l'état de l'alimentation du bras, un "
+"ensemble standard de fonctions pour gérer le système et les états "
+"d'alimentation du processeur, entre autres. Il est implémenté par le "
+"firmware EL3 et les hyperviseurs sur de nombreux systèmes."
+
+#: src/bare-metal/aps/inline-assembly.md:46
+#, fuzzy
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+"La syntaxe `0 => _` signifie initialiser le registre à 0 avant d'exécuter le "
+"code assembleur en ligne, et ignorer son contenu par la suite. Nous devons "
+"utiliser `inout` plutôt que `in` car l'appel pourrait potentiellement "
+"encombrer le contenu des registres."
+
+#: src/bare-metal/aps/inline-assembly.md:49
+#, fuzzy
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+"Cette fonction `main` doit être `#[no_mangle]` et `extern \"C\"` car elle "
+"est appelée depuis notre point d'entrée dans `entry.S`."
+
+#: src/bare-metal/aps/inline-assembly.md:51
+#, fuzzy
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+"`_x0`–`_x3` sont les valeurs des registres `x0`–`x3`, qui sont classiquement "
+"utilisés par le bootloader pour passer des choses comme un pointeur vers "
+"l'arborescence des périphériques. Selon l'appel standard aarch64 convention "
+"(qui est ce que `extern \"C\"` spécifie d'utiliser), les registres `x0`–`x7` "
+"sont utilisés pour la 8 premiers arguments passés à une fonction, donc "
+"`entry.S` n'a rien de spécial à faire sauf assurez-vous qu'il ne modifie pas "
+"ces registres."
+
+#: src/bare-metal/aps/inline-assembly.md:56
+#, fuzzy
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
-"* PSCI est l'interface de coordination de l'état de l'alimentation du bras, "
-"un ensemble standard de fonctions pour gérer le système\n"
-"  et les états d'alimentation du processeur, entre autres. Il est implémenté "
-"par le firmware EL3 et les hyperviseurs sur\n"
-"  de nombreux systèmes.\n"
-"* La syntaxe `0 => _` signifie initialiser le registre à 0 avant d'exécuter "
-"le code assembleur en ligne,\n"
-"  et ignorer son contenu par la suite. Nous devons utiliser `inout` plutôt "
-"que `in` car l'appel pourrait\n"
-"  potentiellement encombrer le contenu des registres.\n"
-"* Cette fonction `main` doit être `#[no_mangle]` et `extern \"C\"` car elle "
-"est appelée depuis notre\n"
-"  point d'entrée dans `entry.S`.\n"
-"* `_x0`–`_x3` sont les valeurs des registres `x0`–`x3`, qui sont "
-"classiquement utilisés par le bootloader\n"
-"  pour passer des choses comme un pointeur vers l'arborescence des "
-"périphériques. Selon l'appel standard aarch64\n"
-"  convention (qui est ce que `extern \"C\"` spécifie d'utiliser), les "
-"registres `x0`–`x7` sont utilisés pour la\n"
-"  8 premiers arguments passés à une fonction, donc `entry.S` n'a rien de "
-"spécial à faire sauf\n"
-"  assurez-vous qu'il ne modifie pas ces registres.\n"
-"* Exécutez l'exemple dans QEMU avec `make qemu_psci` sous `src/bare-metal/"
-"aps/examples`."
+"Exécutez l'exemple dans QEMU avec `make qemu_psci` sous `src/bare-metal/aps/"
+"examples`."
 
 #: src/bare-metal/aps/mmio.md:1
 #, fuzzy
-msgid "# Volatile memory access for MMIO"
-msgstr "# Accès mémoire volatile pour MMIO"
+msgid "Volatile memory access for MMIO"
+msgstr "Accès mémoire volatile pour MMIO"
 
 #: src/bare-metal/aps/mmio.md:3
 #, fuzzy
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr "Utilisez `pointer::read_volatile` et `pointer::write_volatile`."
+
+#: src/bare-metal/aps/mmio.md:4
+#, fuzzy
+msgid "Never hold a reference."
+msgstr "Ne détenez jamais une référence."
+
+#: src/bare-metal/aps/mmio.md:5
+#, fuzzy
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
-" * Utilisez `pointer::read_volatile` et `pointer::write_volatile`.\n"
-" * Ne détenez jamais une référence.\n"
-" * `addr_of!` vous permet d'obtenir des champs de structures sans créer de "
+"`addr_of!` vous permet d'obtenir des champs de structures sans créer de "
 "référence intermédiaire."
 
 #: src/bare-metal/aps/mmio.md:9
 #, fuzzy
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
 msgstr ""
-" * Accès volatile : les opérations de lecture ou d'écriture peuvent avoir "
-"des effets secondaires, évitez donc que le compilateur ou\n"
-"   matériel de les réorganiser, de les dupliquer ou de les supprimer.\n"
-"   * Habituellement, si vous écrivez puis lisez, par ex. via une référence "
-"mutable, le compilateur peut supposer que\n"
-"     la valeur lue est la même que la valeur que vous venez d'écrire et ne "
-"vous souciez pas de lire la mémoire.\n"
-" * Certaines caisses existantes pour l'accès volatile au matériel "
-"contiennent des références, mais ce n'est pas valable.\n"
-"   Chaque fois qu'une référence existe, le compilateur peut choisir de la "
-"déréférencer.\n"
-" * Utilisez la macro `addr_of!` pour obtenir des pointeurs de champ struct à "
+"Accès volatile : les opérations de lecture ou d'écriture peuvent avoir des "
+"effets secondaires, évitez donc que le compilateur ou matériel de les "
+"réorganiser, de les dupliquer ou de les supprimer."
+
+#: src/bare-metal/aps/mmio.md:11
+#, fuzzy
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+"Habituellement, si vous écrivez puis lisez, par ex. via une référence "
+"mutable, le compilateur peut supposer que la valeur lue est la même que la "
+"valeur que vous venez d'écrire et ne vous souciez pas de lire la mémoire."
+
+#: src/bare-metal/aps/mmio.md:13
+#, fuzzy
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+"Certaines caisses existantes pour l'accès volatile au matériel contiennent "
+"des références, mais ce n'est pas valable. Chaque fois qu'une référence "
+"existe, le compilateur peut choisir de la déréférencer."
+
+#: src/bare-metal/aps/mmio.md:15
+#, fuzzy
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
+msgstr ""
+"Utilisez la macro `addr_of!` pour obtenir des pointeurs de champ struct à "
 "partir d'un pointeur vers la struct."
 
 #: src/bare-metal/aps/uart.md:1
 #, fuzzy
-msgid "# Let's write a UART driver"
-msgstr "# Écrivons un pilote UART"
+msgid "Let's write a UART driver"
+msgstr "Écrivons un pilote UART"
 
 #: src/bare-metal/aps/uart.md:3
 #, fuzzy
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
-"La machine QEMU 'virt' a un [PL011][1] UART, écrivons donc un pilote pour "
-"cela."
+"La machine QEMU 'virt' a un [PL011](https://developer.arm.com/documentation/"
+"ddi0183/g) UART, écrivons donc un pilote pour cela."
 
 #: src/bare-metal/aps/uart.md:5
 msgid ""
@@ -15511,51 +16182,46 @@ msgstr ""
 #: src/bare-metal/aps/uart.md:55
 #, fuzzy
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is "
-"because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i."
-"e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else "
-"aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume "
-"the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but "
-"`write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls "
-"`write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving "
-"the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
-"* Notez que `Uart::new` n'est pas sûr alors que les autres méthodes sont "
-"sûres. C'est parce que tant que le\n"
-"  l'appelant de `Uart::new` garantit que ses exigences de sécurité sont "
-"respectées (c'est-à-dire qu'il n'y a\n"
-"  jamais une instance du pilote pour un UART donné, et rien d'autre aliasant "
-"son espace d'adressage),\n"
-"  alors il est toujours sûr d'appeler `write_byte` plus tard car nous "
-"pouvons supposer que le nécessaire\n"
-"  conditions préalables.\n"
-"* Nous aurions pu faire l'inverse (rendre `new` sûr mais `write_byte` non "
-"sûr), mais cela\n"
-"  serait beaucoup moins pratique à utiliser car chaque endroit qui appelle "
-"`write_byte` aurait besoin de raisonner\n"
-"  sur la sécurité\n"
-"* Il s'agit d'un modèle courant pour écrire des wrappers sûrs de code non "
-"sécurisé : déplacer la charge de la preuve pour\n"
-"  solidité d'un grand nombre d'endroits à un plus petit nombre d'endroits."
+"Notez que `Uart::new` n'est pas sûr alors que les autres méthodes sont "
+"sûres. C'est parce que tant que le l'appelant de `Uart::new` garantit que "
+"ses exigences de sécurité sont respectées (c'est-à-dire qu'il n'y a jamais "
+"une instance du pilote pour un UART donné, et rien d'autre aliasant son "
+"espace d'adressage), alors il est toujours sûr d'appeler `write_byte` plus "
+"tard car nous pouvons supposer que le nécessaire conditions préalables."
 
-#: src/bare-metal/aps/uart.md:66
+#: src/bare-metal/aps/uart.md:60
 #, fuzzy
-msgid "</detais>"
-msgstr "</détails>"
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+"Nous aurions pu faire l'inverse (rendre `new` sûr mais `write_byte` non "
+"sûr), mais cela serait beaucoup moins pratique à utiliser car chaque endroit "
+"qui appelle `write_byte` aurait besoin de raisonner sur la sécurité"
+
+#: src/bare-metal/aps/uart.md:63
+#, fuzzy
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
+msgstr ""
+"Il s'agit d'un modèle courant pour écrire des wrappers sûrs de code non "
+"sécurisé : déplacer la charge de la preuve pour solidité d'un grand nombre "
+"d'endroits à un plus petit nombre d'endroits."
 
 #: src/bare-metal/aps/uart/traits.md:1
 #, fuzzy
-msgid "# More traits"
-msgstr "# Plus de traits"
+msgid "More traits"
+msgstr "Plus de traits"
 
 #: src/bare-metal/aps/uart/traits.md:3
 #, fuzzy
@@ -15589,84 +16255,244 @@ msgstr ""
 #: src/bare-metal/aps/uart/traits.md:24
 #, fuzzy
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with "
-"our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+"L'implémentation de `Write` nous permet d'utiliser les macros `write!` et "
+"`writeln!` avec notre type `Uart`."
+
+#: src/bare-metal/aps/uart/traits.md:25
+#, fuzzy
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
-"* L'implémentation de `Write` nous permet d'utiliser les macros `write!` et "
-"`writeln!` avec notre type `Uart`.\n"
-"* Exécutez l'exemple dans QEMU avec `make qemu_minimal` sous `src/bare-metal/"
+"Exécutez l'exemple dans QEMU avec `make qemu_minimal` sous `src/bare-metal/"
 "aps/examples`."
 
 #: src/bare-metal/aps/better-uart.md:1
 #, fuzzy
-msgid "# A better UART driver"
-msgstr "# Un meilleur pilote UART"
+msgid "A better UART driver"
+msgstr "Un meilleur pilote UART"
 
 #: src/bare-metal/aps/better-uart.md:3
 #, fuzzy
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
-"Le PL011 a en fait [un tas de registres supplémentaires] [1], et ajoute des "
-"décalages pour construire des pointeurs pour accéder\n"
-"est sujette aux erreurs et difficile à lire. De plus, certains d'entre eux "
-"sont des champs de bits, ce qui serait bien de\n"
-"accéder de manière structurée."
+"Le PL011 a en fait \\[un tas de registres supplémentaires\\] [1](https://"
+"developer.arm.com/documentation/ddi0183/g/programmers-model/summary-of-"
+"registers), et ajoute des décalages pour construire des pointeurs pour "
+"accéder est sujette aux erreurs et difficile à lire. De plus, certains "
+"d'entre eux sont des champs de bits, ce qui serait bien de accéder de "
+"manière structurée."
 
 #: src/bare-metal/aps/better-uart.md:7
 #, fuzzy
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
-msgstr ""
-"| Décalage | Nom du registre | Largeur |\n"
-"| ------ | -------------- | ----- |\n"
-"| 0x00 | DR | 12 |\n"
-"| 0x04 | RSR | 4 |\n"
-"| 0x18 | EN | 9 |\n"
-"| 0x20 | ILPR | 8 |\n"
-"| 0x24 | BIRD | 16 |\n"
-"| 0x28 | FBRD | 6 |\n"
-"| 0x2c | LCR_H | 8 |\n"
-"| 0x30 | CR | 16 |\n"
-"| 0x34 | IFLS | 6 |\n"
-"| 0x38 | IMSC | 11 |\n"
-"| 0x3c | SIR | 11 |\n"
-"| 0x40 | SIG | 11 |\n"
-"| 0x44 | RIC | 11 |\n"
-"| 0x48 | DMACR | 3 |"
+msgid "Offset"
+msgstr "Décalage"
+
+#: src/bare-metal/aps/better-uart.md:7
+#, fuzzy
+msgid "Register name"
+msgstr "Nom du registre"
+
+#: src/bare-metal/aps/better-uart.md:7
+#, fuzzy
+msgid "Width"
+msgstr "Largeur"
+
+#: src/bare-metal/aps/better-uart.md:9
+#, fuzzy
+msgid "0x00"
+msgstr "0x00"
+
+#: src/bare-metal/aps/better-uart.md:9
+#, fuzzy
+msgid "DR"
+msgstr "DR"
+
+#: src/bare-metal/aps/better-uart.md:9
+#, fuzzy
+msgid "12"
+msgstr "12"
+
+#: src/bare-metal/aps/better-uart.md:10
+#, fuzzy
+msgid "0x04"
+msgstr "0x04"
+
+#: src/bare-metal/aps/better-uart.md:10
+#, fuzzy
+msgid "RSR"
+msgstr "RSR"
+
+#: src/bare-metal/aps/better-uart.md:10
+#, fuzzy
+msgid "4"
+msgstr "4"
+
+#: src/bare-metal/aps/better-uart.md:11
+#, fuzzy
+msgid "0x18"
+msgstr "0x18"
+
+#: src/bare-metal/aps/better-uart.md:11
+#, fuzzy
+msgid "FR"
+msgstr "EN"
+
+#: src/bare-metal/aps/better-uart.md:11
+#, fuzzy
+msgid "9"
+msgstr "9"
+
+#: src/bare-metal/aps/better-uart.md:12
+#, fuzzy
+msgid "0x20"
+msgstr "0x20"
+
+#: src/bare-metal/aps/better-uart.md:12
+#, fuzzy
+msgid "ILPR"
+msgstr "ILPR"
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+#, fuzzy
+msgid "8"
+msgstr "8"
+
+#: src/bare-metal/aps/better-uart.md:13
+#, fuzzy
+msgid "0x24"
+msgstr "0x24"
+
+#: src/bare-metal/aps/better-uart.md:13
+#, fuzzy
+msgid "IBRD"
+msgstr "BIRD"
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+#, fuzzy
+msgid "16"
+msgstr "16"
+
+#: src/bare-metal/aps/better-uart.md:14
+#, fuzzy
+msgid "0x28"
+msgstr "0x28"
+
+#: src/bare-metal/aps/better-uart.md:14
+#, fuzzy
+msgid "FBRD"
+msgstr "FBRD"
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+#, fuzzy
+msgid "6"
+msgstr "6"
+
+#: src/bare-metal/aps/better-uart.md:15
+#, fuzzy
+msgid "0x2c"
+msgstr "0x2c"
+
+#: src/bare-metal/aps/better-uart.md:15
+#, fuzzy
+msgid "LCR_H"
+msgstr "LCR_H"
+
+#: src/bare-metal/aps/better-uart.md:16
+#, fuzzy
+msgid "0x30"
+msgstr "0x30"
+
+#: src/bare-metal/aps/better-uart.md:16
+#, fuzzy
+msgid "CR"
+msgstr "CR"
+
+#: src/bare-metal/aps/better-uart.md:17
+#, fuzzy
+msgid "0x34"
+msgstr "0x34"
+
+#: src/bare-metal/aps/better-uart.md:17
+#, fuzzy
+msgid "IFLS"
+msgstr "IFLS"
+
+#: src/bare-metal/aps/better-uart.md:18
+#, fuzzy
+msgid "0x38"
+msgstr "0x38"
+
+#: src/bare-metal/aps/better-uart.md:18
+#, fuzzy
+msgid "IMSC"
+msgstr "IMSC"
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+#, fuzzy
+msgid "11"
+msgstr "11"
+
+#: src/bare-metal/aps/better-uart.md:19
+#, fuzzy
+msgid "0x3c"
+msgstr "0x3c"
+
+#: src/bare-metal/aps/better-uart.md:19
+#, fuzzy
+msgid "RIS"
+msgstr "SIR"
+
+#: src/bare-metal/aps/better-uart.md:20
+#, fuzzy
+msgid "0x40"
+msgstr "0x40"
+
+#: src/bare-metal/aps/better-uart.md:20
+#, fuzzy
+msgid "MIS"
+msgstr "SIG"
+
+#: src/bare-metal/aps/better-uart.md:21
+#, fuzzy
+msgid "0x44"
+msgstr "0x44"
+
+#: src/bare-metal/aps/better-uart.md:21
+#, fuzzy
+msgid "ICR"
+msgstr "RIC"
+
+#: src/bare-metal/aps/better-uart.md:22
+#, fuzzy
+msgid "0x48"
+msgstr "0x48"
+
+#: src/bare-metal/aps/better-uart.md:22
+#, fuzzy
+msgid "DMACR"
+msgstr "DMACR"
+
+#: src/bare-metal/aps/better-uart.md:22
+#, fuzzy
+msgid "3"
+msgstr "3"
 
 #: src/bare-metal/aps/better-uart.md:26
 #, fuzzy
-msgid "- There are also some ID registers which have been omitted for brevity."
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
-"- Il existe également des registres d'identification qui ont été omis par "
+"Il existe également des registres d'identification qui ont été omis par "
 "souci de brièveté."
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-#, fuzzy
-msgid "# Bitflags"
-msgstr "# Bitflags"
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
 #, fuzzy
@@ -15713,18 +16539,16 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 #, fuzzy
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
-"with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
-"* La macro `bitflags!` crée un nouveau type quelque chose comme "
-"`Flags(u16)`, avec un tas de méthodes\n"
-"  implémentations pour obtenir et définir des drapeaux."
+"La macro `bitflags!` crée un nouveau type quelque chose comme `Flags(u16)`, "
+"avec un tas de méthodes implémentations pour obtenir et définir des drapeaux."
 
 #: src/bare-metal/aps/better-uart/registers.md:1
 #, fuzzy
-msgid "# Multiple registers"
-msgstr "# Plusieurs registres"
+msgid "Multiple registers"
+msgstr "Plusieurs registres"
 
 #: src/bare-metal/aps/better-uart/registers.md:3
 #, fuzzy
@@ -15774,27 +16598,18 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/registers.md:41
 #, fuzzy
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust "
-"representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) indique\n"
-"  le compilateur pour disposer les champs struct dans l'ordre, en suivant "
-"les mêmes règles que C. Ceci est\n"
-"  nécessaire pour que notre structure ait une mise en page prévisible, car "
-"la représentation Rust par défaut permet\n"
-"  compilateur pour (entre autres) réorganiser les champs comme bon lui "
-"semble."
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-#, fuzzy
-msgid "# Driver"
-msgstr "# Conducteur"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) indique le compilateur pour disposer les champs struct dans "
+"l'ordre, en suivant les mêmes règles que C. Ceci est nécessaire pour que "
+"notre structure ait une mise en page prévisible, car la représentation Rust "
+"par défaut permet compilateur pour (entre autres) réorganiser les champs "
+"comme bon lui semble."
 
 #: src/bare-metal/aps/better-uart/driver.md:3
 #, fuzzy
@@ -15870,30 +16685,27 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/driver.md:64
 #, fuzzy
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
-"fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
-"* Notez l'utilisation de `addr_of!` / `addr_of_mut!` pour obtenir des "
-"pointeurs vers des champs individuels sans créer\n"
-"  une référence intermédiaire, qui serait malsaine."
+"Notez l'utilisation de `addr_of!` / `addr_of_mut!` pour obtenir des "
+"pointeurs vers des champs individuels sans créer une référence "
+"intermédiaire, qui serait malsaine."
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
 #, fuzzy
-msgid "# Using it"
-msgstr "# En l'utilisant"
+msgid "Using it"
+msgstr "En l'utilisant"
 
 #: src/bare-metal/aps/better-uart/using.md:3
 #, fuzzy
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
-"and echo incoming\n"
-"bytes."
+"and echo incoming bytes."
 msgstr ""
 "Écrivons un petit programme en utilisant notre pilote pour écrire sur la "
-"console série et écho entrant\n"
-"octets."
+"console série et écho entrant octets."
 
 #: src/bare-metal/aps/better-uart/using.md:6
 msgid ""
@@ -15945,29 +16757,32 @@ msgstr ""
 #: src/bare-metal/aps/better-uart/using.md:51
 #, fuzzy
 msgid ""
-"* As in the [inline assembly](../inline-assembly.md) example, this `main` "
-"function is called from our\n"
-"  entry point code in `entry.S`. See the speaker notes there for details.\n"
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/"
-"examples`."
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
 msgstr ""
-"* Comme dans l'exemple [inline assembly](../inline-assembly.md), cette "
-"fonction `main` est appelée depuis notre\n"
-"  code du point d'entrée dans `entry.S`. Voir les notes du conférencier pour "
-"plus de détails.\n"
-"* Exécutez l'exemple dans QEMU avec `make qemu` sous `src/bare-metal/aps/"
+"Comme dans l'exemple [inline assembly](../inline-assembly.md), cette "
+"fonction `main` est appelée depuis notre code du point d'entrée dans `entry."
+"S`. Voir les notes du conférencier pour plus de détails."
+
+#: src/bare-metal/aps/better-uart/using.md:53
+#, fuzzy
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
+msgstr ""
+"Exécutez l'exemple dans QEMU avec `make qemu` sous `src/bare-metal/aps/"
 "examples`."
 
 #: src/bare-metal/aps/logging.md:3
 #, fuzzy
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 "Ce serait bien de pouvoir utiliser les macros de journalisation du crate "
-"[`log`][1]. Nous pouvons le faire en\n"
-"implémentant le trait `Log`."
+"[`log`](https://crates.io/crates/log). Nous pouvons le faire en implémentant "
+"le trait `Log`."
 
 #: src/bare-metal/aps/logging.md:6
 msgid ""
@@ -16018,10 +16833,10 @@ msgstr ""
 #: src/bare-metal/aps/logging.md:50
 #, fuzzy
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
-"* Le déballage dans `log` est sûr car nous initialisons `LOGGER` avant "
+"Le déballage dans `log` est sûr car nous initialisons `LOGGER` avant "
 "d'appeler `set_logger`."
 
 #: src/bare-metal/aps/logging/using.md:3
@@ -16074,30 +16889,27 @@ msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
 #, fuzzy
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+"Notez que notre gestionnaire de panique peut désormais enregistrer les "
+"détails des paniques."
+
+#: src/bare-metal/aps/logging/using.md:47
+#, fuzzy
 msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
-"* Notez que notre gestionnaire de panique peut désormais enregistrer les "
-"détails des paniques.\n"
-"* Exécutez l'exemple dans QEMU avec `make qemu_logger` sous `src/bare-metal/"
+"Exécutez l'exemple dans QEMU avec `make qemu_logger` sous `src/bare-metal/"
 "aps/examples`."
-
-#: src/bare-metal/aps/exceptions.md:1
-#, fuzzy
-msgid "# Exceptions"
-msgstr "# Les fonctions"
 
 #: src/bare-metal/aps/exceptions.md:3
 msgid ""
 "AArch64 defines an exception vector table with 16 entries, for 4 types of "
-"exceptions (synchronous,\n"
-"IRQ, FIQ, SError) from 4 states (current EL with SP0, current EL with SPx, "
-"lower EL using AArch64,\n"
-"lower EL using AArch32). We implement this in assembly to save volatile "
-"registers to the stack\n"
-"before calling into Rust code:"
+"exceptions (synchronous, IRQ, FIQ, SError) from 4 states (current EL with "
+"SP0, current EL with SPx, lower EL using AArch64, lower EL using AArch32). "
+"We implement this in assembly to save volatile registers to the stack before "
+"calling into Rust code:"
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:8
@@ -16158,83 +16970,111 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:64
+msgid "EL is exception level; all our examples this afternoon run in EL1."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:65
 msgid ""
-"* EL is exception level; all our examples this afternoon run in EL1.\n"
-"* For simplicity we aren't distinguishing between SP0 and SPx for the "
-"current EL exceptions, or\n"
-"  between AArch32 and AArch64 for the lower EL exceptions.\n"
-"* For this example we just log the exception and power down, as we don't "
-"expect any of them to\n"
-"  actually happen.\n"
-"* We can think of exception handlers and our main execution context more or "
-"less like different\n"
-"  threads. [`Send` and `Sync`][1] will control what we can share between "
-"them, just like with threads.\n"
-"  For example, if we want to share some value between exception handlers and "
-"the rest of the\n"
-"  program, and it's `Send` but not `Sync`, then we'll need to wrap it in "
-"something like a `Mutex`\n"
-"  and put it in a static."
+"For simplicity we aren't distinguishing between SP0 and SPx for the current "
+"EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:67
+msgid ""
+"For this example we just log the exception and power down, as we don't "
+"expect any of them to actually happen."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:69
+msgid ""
+"We can think of exception handlers and our main execution context more or "
+"less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
+"md) will control what we can share between them, just like with threads. For "
+"example, if we want to share some value between exception handlers and the "
+"rest of the program, and it's `Send` but not `Sync`, then we'll need to wrap "
+"it in something like a `Mutex` and put it in a static."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
 #, fuzzy
-msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling,\n"
-"     page tables\n"
-"   * Some dodginess around cache maintenance and initialisation in Rust, not "
-"necessarily a good\n"
-"     example to copy for production code.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
+msgstr "[oreboot](https://github.com/oreboot/oreboot)"
+
+#: src/bare-metal/aps/other-projects.md:4
+#, fuzzy
+msgid "\"coreboot without the C\""
+msgstr "\"coreboot sans le C\""
+
+#: src/bare-metal/aps/other-projects.md:5
+#, fuzzy
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr "Prend en charge x86, aarch64 et RISC-V."
+
+#: src/bare-metal/aps/other-projects.md:6
+#, fuzzy
+msgid "Relies on LinuxBoot rather than having many drivers itself."
 msgstr ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot sans le C\"\n"
-"   * Prend en charge x86, aarch64 et RISC-V.\n"
-"   * S'appuie sur LinuxBoot plutôt que d'avoir lui-même de nombreux "
-"pilotes.\n"
-" * [Tutoriel Rust RaspberryPi OS] (https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, pilote UART, chargeur de démarrage simple, JTAG, "
-"niveaux d'exception, gestion des exceptions, tables de pages\n"
-"   * Pas tous très bien écrits, alors méfiez-vous.\n"
-" * [`pile-appel-cargo`](https://crates.io/crates/pile-appel-cargo)\n"
-"   * Analyse statique pour déterminer l'utilisation maximale de la pile."
+"S'appuie sur LinuxBoot plutôt que d'avoir lui-même de nombreux pilotes."
+
+#: src/bare-metal/aps/other-projects.md:7
+#, fuzzy
+msgid ""
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+"\\[Tutoriel Rust RaspberryPi OS\\] (https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+
+#: src/bare-metal/aps/other-projects.md:8
+#, fuzzy
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+"Initialisation, pilote UART, chargeur de démarrage simple, JTAG, niveaux "
+"d'exception, gestion des exceptions, tables de pages"
+
+#: src/bare-metal/aps/other-projects.md:10
+#, fuzzy
+msgid ""
+"Some dodginess around cache maintenance and initialisation in Rust, not "
+"necessarily a good example to copy for production code."
+msgstr "Pas tous très bien écrits, alors méfiez-vous."
+
+#: src/bare-metal/aps/other-projects.md:12
+#, fuzzy
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr "[`pile-appel-cargo`](https://crates.io/crates/pile-appel-cargo)"
+
+#: src/bare-metal/aps/other-projects.md:13
+#, fuzzy
+msgid "Static analysis to determine maximum stack usage."
+msgstr "Analyse statique pour déterminer l'utilisation maximale de la pile."
 
 #: src/bare-metal/aps/other-projects.md:17
 msgid ""
-"* The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
-"enabled. This will read\n"
-"  and write memory (e.g. the stack). However:\n"
-"  * Without the MMU and cache, unaligned accesses will fault. It builds with "
-"`aarch64-unknown-none`\n"
-"    which sets `+strict-align` to prevent the compiler generating unaligned "
-"accesses so it should be\n"
-"    alright, but this is not necessarily the case in general.\n"
-"  * If it were running in a VM, this can lead to cache coherency issues. The "
-"problem is that the VM\n"
-"    is accessing memory directly with the cache disabled, while the host has "
-"cachable aliases to the\n"
-"    same memory. Even if the host doesn't explicitly access the memory, "
-"speculative accesses can\n"
-"    lead to cache fills, and then changes from one or the other will get "
-"lost. Again this is alright\n"
-"    in this particular case (running directly on the hardware with no "
-"hypervisor), but isn't a good\n"
-"    pattern in general."
+"The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
+"enabled. This will read and write memory (e.g. the stack). However:"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
-#, fuzzy
-msgid "# Useful crates"
-msgstr "# Caisses utiles"
+#: src/bare-metal/aps/other-projects.md:19
+msgid ""
+"Without the MMU and cache, unaligned accesses will fault. It builds with "
+"`aarch64-unknown-none` which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses so it should be alright, but this is not "
+"necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:22
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cachable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost. Again this is "
+"alright in this particular case (running directly on the hardware with no "
+"hypervisor), but isn't a good pattern in general."
+msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
 #, fuzzy
@@ -16247,19 +17087,19 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
 #, fuzzy
-msgid "# `zerocopy`"
-msgstr "# `zérocopie`"
+msgid "`zerocopy`"
+msgstr "`zérocopie`"
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 #, fuzzy
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
-"La caisse [`zerocopy`][1] (de Fuchsia) fournit des traits et des macros pour "
-"convertir en toute sécurité entre\n"
-"séquences d'octets et autres types."
+"La caisse [`zerocopy`](https://docs.rs/zerocopy/) (de Fuchsia) fournit des "
+"traits et des macros pour convertir en toute sécurité entre séquences "
+"d'octets et autres types."
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
 msgid ""
@@ -16302,57 +17142,69 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 "Ce n'est pas adapté pour MMIO (car il n'utilise pas de lectures et "
-"d'écritures volatiles), mais peut être utile pour\n"
-"travailler avec des structures partagées avec du matériel, par ex. par DMA, "
-"ou envoyé sur une interface externe."
+"d'écritures volatiles), mais peut être utile pour travailler avec des "
+"structures partagées avec du matériel, par ex. par DMA, ou envoyé sur une "
+"interface externe."
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 #, fuzzy
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
 msgstr ""
-"* `FromBytes` peut être implémenté pour les types pour lesquels n'importe "
-"quel modèle d'octet est valide, et peut donc être en toute sécurité\n"
-"  converti à partir d'une séquence d'octets non fiable.\n"
-"* Tenter de dériver `FromBytes` pour ces types échouerait, car `RequestType` "
-"n'utilise pas tous\n"
-"  les valeurs u32 possibles comme discriminants, donc tous les modèles "
-"d'octets ne sont pas valides.\n"
-"* `zerocopy::byteorder` a des types pour les primitives numériques sensibles "
-"à l'ordre des octets.\n"
-"* Exécutez l'exemple avec `cargo run` sous `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (Ce ne sera pas\n"
-"  exécuter dans le Playground en raison de la dépendance de la caisse.)"
+"`FromBytes` peut être implémenté pour les types pour lesquels n'importe quel "
+"modèle d'octet est valide, et peut donc être en toute sécurité converti à "
+"partir d'une séquence d'octets non fiable."
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+#, fuzzy
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+"Tenter de dériver `FromBytes` pour ces types échouerait, car `RequestType` "
+"n'utilise pas tous les valeurs u32 possibles comme discriminants, donc tous "
+"les modèles d'octets ne sont pas valides."
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+#, fuzzy
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+"`zerocopy::byteorder` a des types pour les primitives numériques sensibles à "
+"l'ordre des octets."
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+#, fuzzy
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
+msgstr ""
+"Exécutez l'exemple avec `cargo run` sous `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (Ce ne sera pas exécuter dans le Playground en raison de "
+"la dépendance de la caisse.)"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
 #, fuzzy
-msgid "# `aarch64-paging`"
-msgstr "# `aarch64-pagination`"
+msgid "`aarch64-paging`"
+msgstr "`aarch64-pagination`"
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 #, fuzzy
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
-"La caisse [`aarch64-paging`][1] vous permet de créer des tables de pages en "
-"fonction de la mémoire virtuelle AArch64\n"
-"Architecture du système."
+"La caisse [`aarch64-paging`](https://crates.io/crates/aarch64-paging) vous "
+"permet de créer des tables de pages en fonction de la mémoire virtuelle "
+"AArch64 Architecture du système."
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
 msgid ""
@@ -16380,44 +17232,58 @@ msgstr ""
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 #, fuzzy
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real "
-"hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
 msgstr ""
-"* Pour l'instant, il ne prend en charge que EL1, mais la prise en charge "
-"d'autres niveaux d'exception devrait être simple à\n"
-"  ajouter.\n"
-"* Ceci est utilisé dans Android pour le [micrologiciel de la machine "
-"virtuelle protégée] [2].\n"
-"* Il n'y a pas de moyen simple d'exécuter cet exemple, car il doit être "
+"Pour l'instant, il ne prend en charge que EL1, mais la prise en charge "
+"d'autres niveaux d'exception devrait être simple à ajouter."
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+#, fuzzy
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+"Ceci est utilisé dans Android pour le \\[micrologiciel de la machine "
+"virtuelle protégée\\] [2](https://cs.android.com/android/platform/"
+"superproject/+/master:packages/modules/Virtualization/pvmfw/)."
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+#, fuzzy
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
+msgstr ""
+"Il n'y a pas de moyen simple d'exécuter cet exemple, car il doit être "
 "exécuté sur du matériel réel ou sous QEMU."
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
 #, fuzzy
-msgid "# `buddy_system_allocator`"
-msgstr "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
+msgstr "`buddy_system_allocator`"
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 #, fuzzy
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
-"[`buddy_system_allocator`][1] est une caisse tierce implémentant un système "
-"d'allocation de copains de base.\n"
-"Il peut être utilisé à la fois pour [`LockedHeap`][2] implémentant "
-"[`GlobalAlloc`][3] afin que vous puissiez utiliser le\n"
-"caisse `alloc` standard (comme nous l'avons vu [avant] [4]), ou pour allouer "
-"un autre espace d'adressage. Par exemple,\n"
-"nous pourrions vouloir allouer de l'espace MMIO pour les PCI BAR :"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"est une caisse tierce implémentant un système d'allocation de copains de "
+"base. Il peut être utilisé à la fois pour [`LockedHeap`](https://docs.rs/"
+"buddy_system_allocator/0.9.0/buddy_system_allocator/struct.LockedHeap.html) "
+"implémentant [`GlobalAlloc`](https://doc.rust-lang.org/core/alloc/trait."
+"GlobalAlloc.html) afin que vous puissiez utiliser le caisse `alloc` standard "
+"(comme nous l'avons vu \\[avant\\] [4](../alloc.md)), ou pour allouer un "
+"autre espace d'adressage. Par exemple, nous pourrions vouloir allouer de "
+"l'espace MMIO pour les PCI BAR :"
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
 msgid ""
@@ -16440,40 +17306,40 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
 #, fuzzy
+msgid "PCI BARs always have alignment equal to their size."
+msgstr "Les PCI BAR ont toujours un alignement égal à leur taille."
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
+#, fuzzy
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
-"* Les PCI BAR ont toujours un alignement égal à leur taille.\n"
-"* Exécutez l'exemple avec `cargo run` sous `src/bare-metal/useful-crates/"
-"allocator-example/`. (Ce ne sera pas\n"
-"  exécuter dans le Playground en raison de la dépendance de la caisse.)"
+"Exécutez l'exemple avec `cargo run` sous `src/bare-metal/useful-crates/"
+"allocator-example/`. (Ce ne sera pas exécuter dans le Playground en raison "
+"de la dépendance de la caisse.)"
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
 #, fuzzy
-msgid "# `tinyvec`"
-msgstr "# `tinyvec`"
+msgid "`tinyvec`"
+msgstr "`tinyvec`"
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 #, fuzzy
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
 "Parfois, vous voulez quelque chose qui peut être redimensionné comme un "
-"`Vec`, mais sans allocation de tas.\n"
-"[`tinyvec`][1] fournit ceci : un vecteur soutenu par un tableau ou une "
-"tranche, qui pourrait être statiquement\n"
-"alloué ou sur la pile, qui garde une trace du nombre d'éléments utilisés et "
-"panique si vous essayez de\n"
-"utiliser plus que ce qui est alloué."
+"`Vec`, mais sans allocation de tas. [`tinyvec`](https://crates.io/crates/"
+"tinyvec) fournit ceci : un vecteur soutenu par un tableau ou une tranche, "
+"qui pourrait être statiquement alloué ou sur la pile, qui garde une trace du "
+"nombre d'éléments utilisés et panique si vous essayez de utiliser plus que "
+"ce qui est alloué."
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
 msgid ""
@@ -16494,44 +17360,45 @@ msgstr ""
 #: src/bare-metal/useful-crates/tinyvec.md:23
 #, fuzzy
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
-"initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine "
-"inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
 msgstr ""
-"* `tinyvec` nécessite que le type d'élément implémente `Default` pour "
-"l'initialisation.\n"
-"* Le Rust Playground inclut `tinyvec`, donc cet exemple fonctionnera bien en "
+"`tinyvec` nécessite que le type d'élément implémente `Default` pour "
+"l'initialisation."
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+#, fuzzy
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
+msgstr ""
+"Le Rust Playground inclut `tinyvec`, donc cet exemple fonctionnera bien en "
 "ligne."
 
 #: src/bare-metal/useful-crates/spin.md:1
 #, fuzzy
-msgid "# `spin`"
-msgstr "# `tourner`"
+msgid "`spin`"
+msgstr "`tourner`"
 
 #: src/bare-metal/useful-crates/spin.md:3
 #, fuzzy
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 "`std::sync::Mutex` et les autres primitives de synchronisation de `std::"
-"sync` ne sont pas disponibles dans\n"
-"`core` ou `alloc`. Comment gérer la synchronisation ou la mutabilité "
-"intérieure, comme pour le partage\n"
-"état entre différents processeurs ?"
+"sync` ne sont pas disponibles dans `core` ou `alloc`. Comment gérer la "
+"synchronisation ou la mutabilité intérieure, comme pour le partage état "
+"entre différents processeurs ?"
 
 #: src/bare-metal/useful-crates/spin.md:7
 #, fuzzy
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
-"Le crate [`spin`][1] fournit des équivalents basés sur des verrous d'attente "
-"de plusieurs de ces primitives."
+"Le crate [`spin`](https://crates.io/crates/spin) fournit des équivalents "
+"basés sur des verrous d'attente de plusieurs de ces primitives."
 
 #: src/bare-metal/useful-crates/spin.md:9
 msgid ""
@@ -16549,36 +17416,40 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/android.md:1
-#, fuzzy
-msgid "# Android"
-msgstr "# Android"
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
+msgstr ""
 
 #: src/bare-metal/android.md:3
 #, fuzzy
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 "Pour construire un binaire Rust bare-metal dans AOSP, vous devez utiliser "
-"une règle Soong `rust_ffi_static` pour construire\n"
-"votre code Rust, puis un `cc_binary` avec un script de liaison pour produire "
-"le binaire lui-même, puis un\n"
-"`raw_binary` pour convertir l'ELF en un binaire brut prêt à être exécuté."
+"une règle Soong `rust_ffi_static` pour construire votre code Rust, puis un "
+"`cc_binary` avec un script de liaison pour produire le binaire lui-même, "
+"puis un `raw_binary` pour convertir l'ELF en un binaire brut prêt à être "
+"exécuté."
 
 #: src/bare-metal/android.md:7
 msgid ""
@@ -16622,24 +17493,20 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-#, fuzzy
-msgid "# vmbase"
-msgstr "# vmbase"
-
 #: src/bare-metal/android/vmbase.md:3
 #, fuzzy
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 "Pour les machines virtuelles exécutées sous crosvm sur aarch64, la "
-"bibliothèque [vmbase][1] fournit un script de liaison et des informations "
-"utiles.\n"
-"valeurs par défaut pour les règles de construction, ainsi qu'un point "
-"d'entrée, la journalisation de la console UART et plus encore."
+"bibliothèque [vmbase](https://android.googlesource.com/platform/packages/"
+"modules/Virtualization/+/refs/heads/master/vmbase/) fournit un script de "
+"liaison et des informations utiles. valeurs par défaut pour les règles de "
+"construction, ainsi qu'un point d'entrée, la journalisation de la console "
+"UART et plus encore."
 
 #: src/bare-metal/android/vmbase.md:6
 msgid ""
@@ -16660,17 +17527,20 @@ msgstr ""
 #: src/bare-metal/android/vmbase.md:21
 #, fuzzy
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
 msgstr ""
-"* La macro `main!` marque votre fonction principale, à appeler depuis le "
-"point d'entrée `vmbase`.\n"
-"* Le point d'entrée `vmbase` gère l'initialisation de la console et émet un "
-"PSCI_SYSTEM_OFF pour l'arrêt\n"
-"  la VM si votre fonction principale revient."
+"La macro `main!` marque votre fonction principale, à appeler depuis le point "
+"d'entrée `vmbase`."
+
+#: src/bare-metal/android/vmbase.md:22
+#, fuzzy
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
+msgstr ""
+"Le point d'entrée `vmbase` gère l'initialisation de la console et émet un "
+"PSCI_SYSTEM_OFF pour l'arrêt la VM si votre fonction principale revient."
 
 #: src/exercises/bare-metal/afternoon.md:3
 #, fuzzy
@@ -16680,52 +17550,63 @@ msgstr ""
 "PL031."
 
 #: src/exercises/bare-metal/rtc.md:1
+#: src/exercises/bare-metal/solutions-afternoon.md:3
 #, fuzzy
-msgid "# RTC driver"
-msgstr "# Pilote RTC"
+msgid "RTC driver"
+msgstr "Pilote RTC"
 
 #: src/exercises/bare-metal/rtc.md:3
 #, fuzzy
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. "
-"For this exercise, you\n"
-"should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
-"La machine QEMU aarch64 virt a une horloge en temps réel [PL031] [1] à "
-"0x9010000. Pour cet exercice, vous\n"
-"devrait écrire un pilote pour cela et l'utiliser pour imprimer l'heure "
-"actuelle sur la console série. Vous pouvez utiliser\n"
-"la caisse [`chrono`][2] pour le formatage de la date/heure."
+"La machine QEMU aarch64 virt a une horloge en temps réel \\[PL031\\] [1]"
+"(https://developer.arm.com/documentation/ddi0224/c) à 0x9010000. Pour cet "
+"exercice, vous devrait écrire un pilote pour cela et l'utiliser pour "
+"imprimer l'heure actuelle sur la console série. Vous pouvez utiliser la "
+"caisse [`chrono`](https://crates.io/crates/chrono) pour le formatage de la "
+"date/heure."
 
 #: src/exercises/bare-metal/rtc.md:6
 msgid ""
-"1. Use it to print the current time to the serial console. You can use the "
-"[`chrono`][2] crate for\n"
-"   date/time formatting.\n"
-"2. Use the match register and raw interrupt status to busy-wait until a "
-"given time, e.g. 3 seconds\n"
-"   in the future. (Call [`core::hint::spin_loop`][3] inside the loop.)\n"
-"3. _Extension if you have time:_ Enable and handle the interrupt generated "
-"by the RTC match. You can\n"
-"   use the driver provided in the [`arm-gic`][4] crate to configure the Arm "
-"Generic Interrupt Controller.\n"
-"   - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.\n"
-"   - Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt.\n"
-"   "
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:8
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:10
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:12
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:13
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
 #, fuzzy
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `rtc`\n"
-"directory for the following files."
+"look in the `rtc` directory for the following files."
 msgstr ""
-"Téléchargez le [modèle d'exercice] (../../comprehensive-rust-exercises.zip) "
-"et regardez dans le `rtc`\n"
-"répertoire pour les fichiers suivants."
+"Téléchargez le \\[modèle d'exercice\\] (../../comprehensive-rust-exercises."
+"zip) et regardez dans le `rtc` répertoire pour les fichiers suivants."
 
 #: src/exercises/bare-metal/rtc.md:23
 msgid ""
@@ -16792,11 +17673,6 @@ msgid ""
 "the exercise):"
 msgstr ""
 "`src/exceptions.rs` (vous ne devriez pas avoir besoin de le modifier) :"
-
-#: src/exercises/bare-metal/rtc.md:77
-#, fuzzy
-msgid "<!-- File src/exceptions.rs -->"
-msgstr "<!-- Fichier src/exceptions.rs -->"
 
 #: src/exercises/bare-metal/rtc.md:79
 msgid ""
@@ -16877,11 +17753,6 @@ msgstr ""
 msgid "`src/logger.rs` (you shouldn't need to change this):"
 msgstr "`src/logger.rs` (vous ne devriez pas avoir besoin de le modifier) :"
 
-#: src/exercises/bare-metal/rtc.md:151
-#, fuzzy
-msgid "<!-- File src/logger.rs -->"
-msgstr "<!-- Fichier src/logger.rs -->"
-
 #: src/exercises/bare-metal/rtc.md:153
 msgid ""
 "```rust,compile_fail\n"
@@ -16947,11 +17818,6 @@ msgstr ""
 #, fuzzy
 msgid "`src/pl011.rs` (you shouldn't need to change this):"
 msgstr "`src/pl011.rs` (vous ne devriez pas avoir besoin de le modifier) :"
-
-#: src/exercises/bare-metal/rtc.md:212
-#, fuzzy
-msgid "<!-- File src/pl011.rs -->"
-msgstr "<!-- Fichier src/pl011.rs -->"
 
 #: src/exercises/bare-metal/rtc.md:214
 msgid ""
@@ -17161,11 +18027,6 @@ msgstr ""
 msgid "`build.rs` (you shouldn't need to change this):"
 msgstr "`build.rs` (vous ne devriez pas avoir besoin de le modifier) :"
 
-#: src/exercises/bare-metal/rtc.md:412
-#, fuzzy
-msgid "<!-- File build.rs -->"
-msgstr "<!-- Fichier build.rs -->"
-
 #: src/exercises/bare-metal/rtc.md:414
 msgid ""
 "```rust,compile_fail\n"
@@ -17205,11 +18066,6 @@ msgstr ""
 #, fuzzy
 msgid "`entry.S` (you shouldn't need to change this):"
 msgstr "`entry.S` (vous ne devriez pas avoir besoin de le modifier) :"
-
-#: src/exercises/bare-metal/rtc.md:448
-#, fuzzy
-msgid "<!-- File entry.S -->"
-msgstr "<!-- Entrée de fichier.S -->"
 
 #: src/exercises/bare-metal/rtc.md:450
 msgid ""
@@ -17377,11 +18233,6 @@ msgstr ""
 #, fuzzy
 msgid "`exceptions.S` (you shouldn't need to change this):"
 msgstr "`exceptions.S` (vous ne devriez pas avoir besoin de le modifier) :"
-
-#: src/exercises/bare-metal/rtc.md:597
-#, fuzzy
-msgid "<!-- File exceptions.S -->"
-msgstr "<!-- Fichier exceptions.S -->"
 
 #: src/exercises/bare-metal/rtc.md:599
 msgid ""
@@ -17582,11 +18433,6 @@ msgstr ""
 msgid "`idmap.S` (you shouldn't need to change this):"
 msgstr "`idmap.S` (vous ne devriez pas avoir besoin de le modifier) :"
 
-#: src/exercises/bare-metal/rtc.md:782
-#, fuzzy
-msgid "<!-- File idmap.S -->"
-msgstr "<!-- Fichier idmap.S -->"
-
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
 "```armasm\n"
@@ -17640,11 +18486,6 @@ msgstr ""
 #, fuzzy
 msgid "`image.ld` (you shouldn't need to change this):"
 msgstr "`image.ld` (vous ne devriez pas avoir besoin de le modifier) :"
-
-#: src/exercises/bare-metal/rtc.md:831
-#, fuzzy
-msgid "<!-- File image.ld -->"
-msgstr "<!-- Fichier image.ld -->"
 
 #: src/exercises/bare-metal/rtc.md:833
 msgid ""
@@ -17762,11 +18603,6 @@ msgstr ""
 msgid "`Makefile` (you shouldn't need to change this):"
 msgstr "`Makefile` (vous ne devriez pas avoir besoin de le modifier) :"
 
-#: src/exercises/bare-metal/rtc.md:942
-#, fuzzy
-msgid "<!-- File Makefile -->"
-msgstr "<!-- Fichier Makefile -->"
-
 #: src/exercises/bare-metal/rtc.md:944
 msgid ""
 "```makefile\n"
@@ -17828,39 +18664,29 @@ msgstr "Exécutez le code dans QEMU avec `make qemu`."
 
 #: src/concurrency.md:1
 #, fuzzy
-msgid "# Welcome to Concurrency in Rust"
-msgstr "# Bienvenue à Comprehensive Rust(le guide complet de Rust) 🦀"
+msgid "Welcome to Concurrency in Rust"
+msgstr "Bienvenue à Comprehensive Rust(le guide complet de Rust) 🦀"
 
 #: src/concurrency.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 "Rust prend entièrement en charge la concurrence en utilisant des threads de "
-"système d'exploitation avec des mutex et\n"
-"canaux."
+"système d'exploitation avec des mutex et canaux."
 
 #: src/concurrency.md:6
 #, fuzzy
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 "Le système de type Rust joue un rôle important dans la création de nombreux "
-"bugs de concurrence\n"
-"bogues de temps de compilation. Ceci est souvent appelé _concurrence sans "
-"peur_ puisque vous\n"
-"peut compter sur le compilateur pour assurer l'exactitude au moment de "
-"l'exécution."
-
-#: src/concurrency/threads.md:1
-#, fuzzy
-msgid "# Threads"
-msgstr "# fils"
+"bugs de concurrence bogues de temps de compilation. Ceci est souvent appelé "
+"_concurrence sans peur_ puisque vous peut compter sur le compilateur pour "
+"assurer l'exactitude au moment de l'exécution."
 
 #: src/concurrency/threads.md:3
 #, fuzzy
@@ -17893,52 +18719,56 @@ msgstr ""
 
 #: src/concurrency/threads.md:24
 #, fuzzy
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
-"* Les threads sont tous des threads démons, le thread principal ne les "
-"attend pas.\n"
-"* Les thread panics sont indépendants les uns des autres.\n"
-"  * Les paniques peuvent transporter une charge utile, qui peut être "
+"Les threads sont tous des threads démons, le thread principal ne les attend "
+"pas."
+
+#: src/concurrency/threads.md:25
+#, fuzzy
+msgid "Thread panics are independent of each other."
+msgstr "Les thread panics sont indépendants les uns des autres."
+
+#: src/concurrency/threads.md:26
+#, fuzzy
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr ""
+"Les paniques peuvent transporter une charge utile, qui peut être "
 "décompressée avec `downcast_ref`."
 
 #: src/concurrency/threads.md:32
 #, fuzzy
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
-"* Notez que le thread est arrêté avant d'atteindre 10 — le thread principal "
-"est\n"
-"  pas attendre.\n"
-"\n"
-"* Utilisez `let handle = thread::spawn(...)` et plus tard `handle.join()` "
-"pour attendre\n"
-"  le fil pour finir.\n"
-"\n"
-"* Déclenchez une panique dans le fil, notez que cela n'affecte pas `main`.\n"
-"\n"
-"* Utilisez la valeur de retour `Result` de `handle.join()` pour accéder à la "
-"panique\n"
-"  charge utile. C'est le bon moment pour parler de [`Tous`]."
+"Notez que le thread est arrêté avant d'atteindre 10 — le thread principal "
+"est pas attendre."
 
-#: src/concurrency/scoped-threads.md:1
+#: src/concurrency/threads.md:35
 #, fuzzy
-msgid "# Scoped Threads"
-msgstr "# Threads délimités"
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+"Utilisez `let handle = thread::spawn(...)` et plus tard `handle.join()` pour "
+"attendre le fil pour finir."
+
+#: src/concurrency/threads.md:38
+#, fuzzy
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+"Déclenchez une panique dans le fil, notez que cela n'affecte pas `main`."
+
+#: src/concurrency/threads.md:40
+#, fuzzy
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
+"Utilisez la valeur de retour `Result` de `handle.join()` pour accéder à la "
+"panique charge utile. C'est le bon moment pour parler de \\[`Tous`\\]."
 
 #: src/concurrency/scoped-threads.md:3
 #, fuzzy
@@ -17962,10 +18792,12 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
 #, fuzzy
-msgid "However, you can use a [scoped thread][1] for this:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
 msgstr ""
-"Cependant, vous pouvez utiliser un [fil de discussion de portée][1] pour "
-"cela :"
+"Cependant, vous pouvez utiliser un [fil de discussion de portée](https://doc."
+"rust-lang.org/std/thread/fn.scope.html) pour cela :"
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -17987,36 +18819,32 @@ msgstr ""
 #: src/concurrency/scoped-threads.md:37
 #, fuzzy
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"* La raison en est que lorsque la fonction `thread::scope` se termine, tous "
+"La raison en est que lorsque la fonction `thread::scope` se termine, tous "
 "les threads sont garantis d'être joints, afin qu'ils puissent renvoyer des "
-"données empruntées.\n"
-"* Les règles d'emprunt normales de Rust s'appliquent : vous pouvez soit "
-"emprunter de manière mutable par un thread, soit de manière immuable par "
-"n'importe quel nombre de threads.\n"
-"    "
+"données empruntées."
 
-#: src/concurrency/channels.md:1
+#: src/concurrency/scoped-threads.md:38
 #, fuzzy
-msgid "# Channels"
-msgstr "# Chaînes"
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"Les règles d'emprunt normales de Rust s'appliquent : vous pouvez soit "
+"emprunter de manière mutable par un thread, soit de manière immuable par "
+"n'importe quel nombre de threads."
 
 #: src/concurrency/channels.md:3
 #, fuzzy
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
 "Les canaux Rust ont deux parties : un `Sender<T>` et un `Receiver<T>`. Les "
-"deux parties\n"
-"sont connectés via le canal, mais vous ne voyez que les extrémités."
+"deux parties sont connectés via le canal, mais vous ne voyez que les "
+"extrémités."
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -18043,24 +18871,23 @@ msgstr ""
 #: src/concurrency/channels.md:27
 #, fuzzy
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* `mpsc` signifie Multi-Producer, Single-Consumer. `Sender` et `SyncSender` "
-"implémentent `Clone` (donc\n"
-"  vous pouvez créer plusieurs producteurs) mais `Receiver` ne le fait pas.\n"
-"* `send()` et `recv()` renvoient `Result`. S'ils renvoient `Err`, cela "
-"signifie que la contrepartie `Sender` ou\n"
-"  `Receiver` est supprimé et le canal est fermé."
+"`mpsc` signifie Multi-Producer, Single-Consumer. `Sender` et `SyncSender` "
+"implémentent `Clone` (donc vous pouvez créer plusieurs producteurs) mais "
+"`Receiver` ne le fait pas."
 
-#: src/concurrency/channels/unbounded.md:1
+#: src/concurrency/channels.md:29
 #, fuzzy
-msgid "# Unbounded Channels"
-msgstr "# Canaux illimités"
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()` et `recv()` renvoient `Result`. S'ils renvoient `Err`, cela "
+"signifie que la contrepartie `Sender` ou `Receiver` est supprimé et le canal "
+"est fermé."
 
 #: src/concurrency/channels/unbounded.md:3
 #, fuzzy
@@ -18093,11 +18920,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/concurrency/channels/bounded.md:1
-#, fuzzy
-msgid "# Bounded Channels"
-msgstr "# Canaux limités"
 
 #: src/concurrency/channels/bounded.md:3
 #, fuzzy
@@ -18135,21 +18957,27 @@ msgstr ""
 
 #: src/concurrency/channels/bounded.md:31
 msgid ""
-"* Calling `send` will block the current thread until there is space in the "
+"Calling `send` will block the current thread until there is space in the "
 "channel for the new message. The thread can be blocked indefinitely if there "
-"is nobody who reads from the channel.\n"
-"* A call to `send` will abort with an error (that is why it returns "
-"`Result`) if the channel is closed. A channel is closed when the receiver is "
-"dropped.\n"
-"* A bounded channel with a size of zero is called a \"rendezvous channel\". "
-"Every send will block the current thread until another thread calls `read`.\n"
-"    "
+"is nobody who reads from the channel."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:32
+msgid ""
+"A call to `send` will abort with an error (that is why it returns `Result`) "
+"if the channel is closed. A channel is closed when the receiver is dropped."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:33
+msgid ""
+"A bounded channel with a size of zero is called a \"rendezvous channel\". "
+"Every send will block the current thread until another thread calls `read`."
 msgstr ""
 
 #: src/concurrency/send-sync.md:1
 #, fuzzy
-msgid "# `Send` and `Sync`"
-msgstr "# `Envoyer` et `Synchroniser`"
+msgid "`Send` and `Sync`"
+msgstr "`Envoyer` et `Synchroniser`"
 
 #: src/concurrency/send-sync.md:3
 #, fuzzy
@@ -18163,100 +18991,96 @@ msgstr ""
 #: src/concurrency/send-sync.md:5
 #, fuzzy
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [`Send`][1] : un type `T` est `Send` s'il est sûr de déplacer un `T` à "
-"travers un thread\n"
-"  frontière.\n"
-"* [`Sync`][2] : un type `T` est `Sync` s'il est sûr de déplacer un `&T` à "
-"travers un thread\n"
-"  frontière."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) : un type `T` "
+"est `Send` s'il est sûr de déplacer un `T` à travers un thread frontière."
+
+#: src/concurrency/send-sync.md:7
+#, fuzzy
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) : un type `T` "
+"est `Sync` s'il est sûr de déplacer un `&T` à travers un thread frontière."
 
 #: src/concurrency/send-sync.md:10
 #, fuzzy
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
-"`Send` et `Sync` sont des [caractéristiques non sécurisées] [3]. Le "
-"compilateur les dérivera automatiquement pour vos types\n"
-"tant qu'ils ne contiennent que les types `Send` et `Sync`. Vous pouvez "
-"également les implémenter manuellement lorsque vous\n"
-"sachez qu'il est valide."
+"`Send` et `Sync` sont des \\[caractéristiques non sécurisées\\] [3](../"
+"unsafe/unsafe-traits.md). Le compilateur les dérivera automatiquement pour "
+"vos types tant qu'ils ne contiennent que les types `Send` et `Sync`. Vous "
+"pouvez également les implémenter manuellement lorsque vous sachez qu'il est "
+"valide."
 
 #: src/concurrency/send-sync.md:20
 #, fuzzy
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-"
-"safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr ""
-"* On peut considérer ces traits comme des marqueurs indiquant que le type "
-"possède certaines propriétés de sécurité des threads.\n"
-"* Ils peuvent être utilisés dans les contraintes génériques comme des traits "
-"normaux.\n"
-"  "
+"On peut considérer ces traits comme des marqueurs indiquant que le type "
+"possède certaines propriétés de sécurité des threads."
+
+#: src/concurrency/send-sync.md:21
+#, fuzzy
+msgid "They can be used in the generic constraints as normal traits."
+msgstr ""
+"Ils peuvent être utilisés dans les contraintes génériques comme des traits "
+"normaux."
 
 #: src/concurrency/send-sync/send.md:1
 #, fuzzy
-msgid "# `Send`"
-msgstr "# `Envoyer`"
+msgid "`Send`"
+msgstr "`Envoyer`"
 
 #: src/concurrency/send-sync/send.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
-"> Un type `T` est [`Send`][1] s'il est sûr de déplacer une valeur `T` vers "
-"un autre thread."
+"Un type `T` est [`Send`](https://doc.rust-lang.org/std/marker/trait.Send."
+"html) s'il est sûr de déplacer une valeur `T` vers un autre thread."
 
 #: src/concurrency/send-sync/send.md:5
 #, fuzzy
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 "L'effet du déplacement de la propriété vers un autre thread est que "
-"_destructors_ s'exécutera\n"
-"dans ce fil. La question est donc de savoir quand vous pouvez allouer une "
-"valeur dans un thread\n"
-"et le désallouer dans un autre."
+"_destructors_ s'exécutera dans ce fil. La question est donc de savoir quand "
+"vous pouvez allouer une valeur dans un thread et le désallouer dans un autre."
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
-"a\n"
-"single thread."
+"a single thread."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:1
 #, fuzzy
-msgid "# `Sync`"
-msgstr "# `Synchroniser`"
+msgid "`Sync`"
+msgstr "`Synchroniser`"
 
 #: src/concurrency/send-sync/sync.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"> Un type `T` est [`Sync`][1] s'il est sûr d'accéder à une valeur `T` à "
-"partir de plusieurs\n"
-"> fils en même temps."
+"Un type `T` est [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync."
+"html) s'il est sûr d'accéder à une valeur `T` à partir de plusieurs fils en "
+"même temps."
 
 #: src/concurrency/send-sync/sync.md:6
 #, fuzzy
@@ -18265,8 +19089,8 @@ msgstr "Plus précisément, la définition est :"
 
 #: src/concurrency/send-sync/sync.md:8
 #, fuzzy
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
-msgstr "> `T` est `Sync` si et seulement si `&T` est `Envoyer`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
+msgstr "`T` est `Sync` si et seulement si `&T` est `Envoyer`"
 
 #: src/concurrency/send-sync/sync.md:14
 #, fuzzy
@@ -18295,15 +19119,10 @@ msgstr ""
 "autre thread, car les données auxquelles elle fait référence sont "
 "accessibles à partir de n'importe quel thread en toute sécurité."
 
-#: src/concurrency/send-sync/examples.md:1
-#, fuzzy
-msgid "# Examples"
-msgstr "# Exemples"
-
 #: src/concurrency/send-sync/examples.md:3
 #, fuzzy
-msgid "## `Send + Sync`"
-msgstr "## `Envoyer + Synchroniser`"
+msgid "`Send + Sync`"
+msgstr "`Envoyer + Synchroniser`"
 
 #: src/concurrency/send-sync/examples.md:5
 #, fuzzy
@@ -18311,57 +19130,76 @@ msgid "Most types you come across are `Send + Sync`:"
 msgstr "La plupart des types que vous rencontrez sont `Send + Sync` :"
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 #, fuzzy
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 "Les types génériques sont généralement \"Send + Sync\" lorsque les "
-"paramètres de type sont\n"
-"`Envoyer + Synchroniser`."
+"paramètres de type sont `Envoyer + Synchroniser`."
 
 #: src/concurrency/send-sync/examples.md:17
 #, fuzzy
-msgid "## `Send + !Sync`"
-msgstr "## `Envoyer + !Sync`"
+msgid "`Send + !Sync`"
+msgstr "`Envoyer + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:19
 #, fuzzy
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 "Ces types peuvent être déplacés vers d'autres threads, mais ils ne sont pas "
-"thread-safe.\n"
-"Typiquement à cause de la mutabilité intérieure :"
+"thread-safe. Typiquement à cause de la mutabilité intérieure :"
 
 #: src/concurrency/send-sync/examples.md:22
 #, fuzzy
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Expéditeur<T>`\n"
-"* `mpsc::Récepteur<T>`\n"
-"* `Cellule<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Expéditeur<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+#, fuzzy
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Récepteur<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+#, fuzzy
+msgid "`Cell<T>`"
+msgstr "`Cellule<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+#, fuzzy
+msgid "`RefCell<T>`"
+msgstr "`RefCell<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
 #, fuzzy
-msgid "## `!Send + Sync`"
-msgstr "## ` !Envoyer + Synchroniser`"
+msgid "`!Send + Sync`"
+msgstr "` !Envoyer + Synchroniser`"
 
 #: src/concurrency/send-sync/examples.md:29
 #, fuzzy
@@ -18374,18 +19212,16 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:31
 #, fuzzy
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
-"* `MutexGuard<T>` : utilise des primitives au niveau du système "
-"d'exploitation qui doivent être désallouées sur le\n"
-"  fil qui les a créés."
+"`MutexGuard<T>` : utilise des primitives au niveau du système d'exploitation "
+"qui doivent être désallouées sur le fil qui les a créés."
 
 #: src/concurrency/send-sync/examples.md:34
 #, fuzzy
-msgid "## `!Send + !Sync`"
-msgstr "## `!Envoyer + !Synchroniser`"
+msgid "`!Send + !Sync`"
+msgstr "`!Envoyer + !Synchroniser`"
 
 #: src/concurrency/send-sync/examples.md:36
 #, fuzzy
@@ -18397,57 +19233,63 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:38
 #, fuzzy
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
-"* `Rc<T>` : chaque `Rc<T>` a une référence à un `RcBox<T>`, qui contient un\n"
-"  comptage de référence non atomique.\n"
-"* `*const T`, `*mut T` : Rust suppose que les pointeurs bruts peuvent avoir "
-"des\n"
-"  considérations de concurrence."
+"`Rc<T>` : chaque `Rc<T>` a une référence à un `RcBox<T>`, qui contient un "
+"comptage de référence non atomique."
 
-#: src/concurrency/shared_state.md:1
+#: src/concurrency/send-sync/examples.md:40
 #, fuzzy
-msgid "# Shared State"
-msgstr "# État partagé"
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr ""
+"`*const T`, `*mut T` : Rust suppose que les pointeurs bruts peuvent avoir "
+"des considérations de concurrence."
 
 #: src/concurrency/shared_state.md:3
 #, fuzzy
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 "Rust utilise le système de type pour appliquer la synchronisation des "
-"données partagées. C'est\n"
-"se fait principalement via deux types:"
+"données partagées. C'est se fait principalement via deux types:"
 
 #: src/concurrency/shared_state.md:6
 #, fuzzy
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1], référence atomique comptée `T` : gère le partage entre les "
-"threads et\n"
-"  prend soin de désallouer 'T' lorsque la dernière référence est supprimée,\n"
-"* [`Mutex<T>`][2] : garantit un accès mutuellement exclusif à la valeur `T`."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), référence "
+"atomique comptée `T` : gère le partage entre les threads et prend soin de "
+"désallouer 'T' lorsque la dernière référence est supprimée,"
+
+#: src/concurrency/shared_state.md:8
+#, fuzzy
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) : "
+"garantit un accès mutuellement exclusif à la valeur `T`."
 
 #: src/concurrency/shared_state/arc.md:1
 #, fuzzy
-msgid "# `Arc`"
-msgstr "# `Arc`"
+msgid "`Arc`"
+msgstr "`Arc`"
 
 #: src/concurrency/shared_state/arc.md:3
 #, fuzzy
-msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
 msgstr ""
-"[`Arc<T>`][1] permet un accès partagé en lecture seule via sa méthode "
-"`clone` :"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) permet un "
+"accès partagé en lecture seule via sa méthode `clone` :"
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -18475,46 +19317,59 @@ msgstr ""
 #: src/concurrency/shared_state/arc.md:29
 #, fuzzy
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
 msgstr ""
-"* `Arc` signifie \"Atomic Reference Counted\", une version thread-safe de "
-"`Rc` qui utilise\n"
-"  opérations.\n"
-"* `Arc<T>` implémente `Clone` que `T` le fasse ou non. Il implémente `Send` "
-"et `Sync` ssi `T`\n"
-"  les met en œuvre tous les deux.\n"
-"* `Arc::clone()` a le coût des opérations atomiques qui sont exécutées, mais "
-"après cela, l'utilisation du\n"
-"  'T' est libre.\n"
-"* Méfiez-vous des cycles de référence, `Arc` n'utilise pas de ramasse-"
-"miettes pour les détecter.\n"
-"    * `std::sync::Weak` peut aider."
+"`Arc` signifie \"Atomic Reference Counted\", une version thread-safe de `Rc` "
+"qui utilise opérations."
+
+#: src/concurrency/shared_state/arc.md:31
+#, fuzzy
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+"`Arc<T>` implémente `Clone` que `T` le fasse ou non. Il implémente `Send` et "
+"`Sync` ssi `T` les met en œuvre tous les deux."
+
+#: src/concurrency/shared_state/arc.md:33
+#, fuzzy
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"`Arc::clone()` a le coût des opérations atomiques qui sont exécutées, mais "
+"après cela, l'utilisation du 'T' est libre."
+
+#: src/concurrency/shared_state/arc.md:35
+#, fuzzy
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+"Méfiez-vous des cycles de référence, `Arc` n'utilise pas de ramasse-miettes "
+"pour les détecter."
+
+#: src/concurrency/shared_state/arc.md:36
+#, fuzzy
+msgid "`std::sync::Weak` can help."
+msgstr "`std::sync::Weak` peut aider."
 
 #: src/concurrency/shared_state/mutex.md:1
 #, fuzzy
-msgid "# `Mutex`"
-msgstr "# `Mutex`"
+msgid "`Mutex`"
+msgstr "`Mutex`"
 
 #: src/concurrency/shared_state/mutex.md:3
 #, fuzzy
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
-"[`Mutex<T>`][1] garantit l'exclusion mutuelle _et_ permet un accès mutable à "
-"`T`\n"
-"derrière une interface en lecture seule :"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) garantit "
+"l'exclusion mutuelle _et_ permet un accès mutable à `T` derrière une "
+"interface en lecture seule :"
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -18538,53 +19393,75 @@ msgstr ""
 #: src/concurrency/shared_state/mutex.md:22
 #, fuzzy
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
 "Remarquez comment nous avons une couverture [`impl<T : Send> Sync for "
-"Mutex<T>`][2]\n"
-"mise en œuvre."
+"Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-"
+"for-Mutex%3CT%3E) mise en œuvre."
 
 #: src/concurrency/shared_state/mutex.md:31
 #, fuzzy
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
-"implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
 msgstr ""
-"* `Mutex` dans Rust ressemble à une collection avec un seul élément - les "
-"données protégées.\n"
-"    * Il n'est pas possible d'oublier d'acquérir le mutex avant d'accéder "
-"aux données protégées.\n"
-"* Vous pouvez obtenir un `&mut T` à partir d'un `&Mutex<T>` en prenant le "
-"verrou. Le `MutexGuard` garantit que le\n"
-"  `&mut T` ne survit pas au verrouillage en cours.\n"
-"* `Mutex<T>` implémente à la fois `Send` et `Sync` ssi `T` implémente "
-"`Send`.\n"
-"* Un homologue de verrouillage en lecture-écriture - `RwLock`.\n"
-"* Pourquoi `lock()` renvoie-t-il un `Result` ?\n"
-"    * Si le thread qui contenait le `Mutex` a paniqué, le `Mutex` devient "
-"\"empoisonné\" pour signaler que\n"
-"      les données qu'il protège peuvent être dans un état incohérent. Appel "
-"de `lock()` sur un mutex empoisonné\n"
-"      échoue avec une [`PoisonError`]. Vous pouvez appeler `into_inner()` "
-"sur l'erreur pour récupérer les données\n"
-"      indépendamment de."
+"`Mutex` dans Rust ressemble à une collection avec un seul élément - les "
+"données protégées."
+
+#: src/concurrency/shared_state/mutex.md:32
+#, fuzzy
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr ""
+"Il n'est pas possible d'oublier d'acquérir le mutex avant d'accéder aux "
+"données protégées."
+
+#: src/concurrency/shared_state/mutex.md:33
+#, fuzzy
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+"Vous pouvez obtenir un `&mut T` à partir d'un `&Mutex<T>` en prenant le "
+"verrou. Le `MutexGuard` garantit que le `&mut T` ne survit pas au "
+"verrouillage en cours."
+
+#: src/concurrency/shared_state/mutex.md:35
+#, fuzzy
+msgid ""
+"`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
+"implements `Send`."
+msgstr ""
+"`Mutex<T>` implémente à la fois `Send` et `Sync` ssi `T` implémente `Send`."
+
+#: src/concurrency/shared_state/mutex.md:36
+#, fuzzy
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "Un homologue de verrouillage en lecture-écriture - `RwLock`."
+
+#: src/concurrency/shared_state/mutex.md:37
+#, fuzzy
+msgid "Why does `lock()` return a `Result`? "
+msgstr "Pourquoi `lock()` renvoie-t-il un `Result` ?"
+
+#: src/concurrency/shared_state/mutex.md:38
+#, fuzzy
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"Si le thread qui contenait le `Mutex` a paniqué, le `Mutex` devient "
+"\"empoisonné\" pour signaler que les données qu'il protège peuvent être dans "
+"un état incohérent. Appel de `lock()` sur un mutex empoisonné échoue avec "
+"une [`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError."
+"html). Vous pouvez appeler `into_inner()` sur l'erreur pour récupérer les "
+"données indépendamment de."
 
 #: src/concurrency/shared_state/example.md:3
 #, fuzzy
@@ -18650,22 +19527,37 @@ msgstr "Parties notables :"
 #: src/concurrency/shared_state/example.md:51
 #, fuzzy
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr ""
+"`v` est enveloppé à la fois dans `Arc` et `Mutex`, car leurs préoccupations "
+"sont orthogonales."
+
+#: src/concurrency/shared_state/example.md:52
+#, fuzzy
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+"Envelopper un `Mutex` dans un `Arc` est un modèle courant pour partager un "
+"état mutable entre les threads."
+
+#: src/concurrency/shared_state/example.md:53
+#, fuzzy
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+"`v: Arc<_>` doit être cloné en tant que `v2` avant de pouvoir être déplacé "
+"dans un autre thread. Remarque \"move\" a été ajouté à la signature lambda."
+
+#: src/concurrency/shared_state/example.md:54
+#, fuzzy
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
-"* `v` est enveloppé à la fois dans `Arc` et `Mutex`, car leurs "
-"préoccupations sont orthogonales.\n"
-"  * Envelopper un `Mutex` dans un `Arc` est un modèle courant pour partager "
-"un état mutable entre les threads.\n"
-"* `v: Arc<_>` doit être cloné en tant que `v2` avant de pouvoir être déplacé "
-"dans un autre thread. Remarque \"move\" a été ajouté à la signature lambda.\n"
-"* Des blocs sont introduits pour réduire autant que possible la portée du "
+"Des blocs sont introduits pour réduire autant que possible la portée du "
 "\"LockGuard\"."
 
 #: src/exercises/concurrency/morning.md:3
@@ -18676,22 +19568,18 @@ msgstr ""
 
 #: src/exercises/concurrency/morning.md:5
 #, fuzzy
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
-msgstr ""
-"* Dîner philosophes : un problème classique de la concurrence.\n"
-"\n"
-"* Vérificateur de liens multithread : un projet plus vaste dans lequel vous "
-"utiliserez Cargo pour\n"
-"  télécharger les dépendances puis vérifier les liens en parallèle."
+msgid "Dining philosophers: a classic problem in concurrency."
+msgstr "Dîner philosophes : un problème classique de la concurrence."
 
-#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/morning.md:7
 #, fuzzy
-msgid "# Dining Philosophers"
-msgstr "# Philosophes de la restauration"
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
+msgstr ""
+"Vérificateur de liens multithread : un projet plus vaste dans lequel vous "
+"utiliserez Cargo pour télécharger les dépendances puis vérifier les liens en "
+"parallèle."
 
 #: src/exercises/concurrency/dining-philosophers.md:3
 #, fuzzy
@@ -18703,48 +19591,36 @@ msgstr ""
 #: src/exercises/concurrency/dining-philosophers.md:5
 #, fuzzy
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
-"> Cinq philosophes dînent ensemble à la même table. Chaque philosophe a son\n"
-"> propre place à table. Il y a une fourchette entre chaque assiette. Le plat "
-"servi est\n"
-"> une sorte de spaghetti qui se mange avec deux fourchettes. Chaque "
-"philosophe peut\n"
-"> seulement penser et manger alternativement. De plus, un philosophe ne peut "
-"que manger leur\n"
-"> des spaghettis lorsqu'ils ont à la fois une fourchette gauche et droite. "
-"Ainsi deux fourches ne feront que\n"
-"> être disponible lorsque ses deux voisins les plus proches pensent, ne "
-"mangent pas. Après\n"
-"> un philosophe individuel finit de manger, ils poseront les deux "
+"Cinq philosophes dînent ensemble à la même table. Chaque philosophe a son "
+"propre place à table. Il y a une fourchette entre chaque assiette. Le plat "
+"servi est une sorte de spaghetti qui se mange avec deux fourchettes. Chaque "
+"philosophe peut seulement penser et manger alternativement. De plus, un "
+"philosophe ne peut que manger leur des spaghettis lorsqu'ils ont à la fois "
+"une fourchette gauche et droite. Ainsi deux fourches ne feront que être "
+"disponible lorsque ses deux voisins les plus proches pensent, ne mangent "
+"pas. Après un philosophe individuel finit de manger, ils poseront les deux "
 "fourchettes."
 
 #: src/exercises/concurrency/dining-philosophers.md:13
 #, fuzzy
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to a file called `src/main.rs`, fill out "
-"the\n"
-"blanks, and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 "Vous aurez besoin d'une [installation Cargo](../../cargo/running-locally.md) "
-"locale pour\n"
-"cet exercice. Copiez le code ci-dessous dans un fichier appelé `src/main."
-"rs`, remplissez le\n"
-"vides, et testez que `cargo run` ne se bloque pas :"
+"locale pour cet exercice. Copiez le code ci-dessous dans un fichier appelé "
+"`src/main.rs`, remplissez le vides, et testez que `cargo run` ne se bloque "
+"pas :"
 
 #: src/exercises/concurrency/dining-philosophers.md:19
 msgid ""
@@ -18806,38 +19682,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:1
-#, fuzzy
-msgid "# Multi-threaded Link Checker"
-msgstr "# Vérificateur de lien multithread"
-
 #: src/exercises/concurrency/link-checker.md:3
 #, fuzzy
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 "Utilisons nos nouvelles connaissances pour créer un vérificateur de liens "
-"multi-thread. Cela devrait\n"
-"commencez par une page Web et vérifiez que les liens sur la page sont "
-"valides. Cela devrait\n"
-"vérifier récursivement d'autres pages sur le même domaine et continuer à le "
-"faire jusqu'à ce que tous\n"
-"les pages ont été validées."
+"multi-thread. Cela devrait commencez par une page Web et vérifiez que les "
+"liens sur la page sont valides. Cela devrait vérifier récursivement d'autres "
+"pages sur le même domaine et continuer à le faire jusqu'à ce que tous les "
+"pages ont été validées."
 
 #: src/exercises/concurrency/link-checker.md:8
 #, fuzzy
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
-"Pour cela, vous aurez besoin d'un client HTTP tel que [`reqwest`][1]. Créer "
-"un nouveau\n"
-"Projet Cargo et `reqwest` comme dépendance avec :"
+"Pour cela, vous aurez besoin d'un client HTTP tel que [`reqwest`](https://"
+"docs.rs/reqwest/). Créer un nouveau Projet Cargo et `reqwest` comme "
+"dépendance avec :"
 
 #: src/exercises/concurrency/link-checker.md:11
 msgid ""
@@ -18851,22 +19718,21 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:17
 #, fuzzy
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
-"> Si `cargo add` échoue avec `error: no such subcommand`, veuillez modifier "
-"le\n"
-"> Fichier `Cargo.toml` à la main. Ajoutez les dépendances répertoriées ci-"
+"Si `cargo add` échoue avec `error: no such subcommand`, veuillez modifier le "
+"Fichier `Cargo.toml` à la main. Ajoutez les dépendances répertoriées ci-"
 "dessous."
 
 #: src/exercises/concurrency/link-checker.md:20
 #, fuzzy
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 "Vous aurez également besoin d'un moyen de trouver des liens. Nous pouvons "
-"utiliser [`scraper`][2] pour cela :"
+"utiliser [`scraper`](https://docs.rs/scraper/) pour cela :"
 
 #: src/exercises/concurrency/link-checker.md:22
 msgid ""
@@ -18878,13 +19744,11 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:26
 #, fuzzy
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 "Enfin, nous aurons besoin d'un moyen de gérer les erreurs. Nous utilisons "
-"[`thiserror`][3] pour\n"
-"ce:"
+"[`thiserror`](https://docs.rs/thiserror/) pour ce:"
 
 #: src/exercises/concurrency/link-checker.md:29
 msgid ""
@@ -18921,12 +19785,11 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:50
 #, fuzzy
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 "Vous pouvez maintenant télécharger la page de démarrage. Essayez avec un "
-"petit site comme\n"
-"`https://www.google.org/`."
+"petit site comme `https://www.google.org/`."
 
 #: src/exercises/concurrency/link-checker.md:53
 #, fuzzy
@@ -18992,88 +19855,76 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:106
-#: src/exercises/concurrency/chat-app.md:140
-#, fuzzy
-msgid "## Tasks"
-msgstr "## Tâches"
-
 #: src/exercises/concurrency/link-checker.md:108
 #, fuzzy
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
 msgstr ""
-"* Utilisez des threads pour vérifier les liens en parallèle : envoyez les "
-"URL à vérifier à un\n"
-"  channel et laissez quelques threads vérifier les URL en parallèle.\n"
-"* Étendez ceci pour extraire de manière récursive les liens de toutes les "
-"pages du\n"
-"  domaine \"www.google.org\". Fixez une limite supérieure de 100 pages "
-"environ afin que vous\n"
-"  ne finissez pas par être bloqué par le site."
+"Utilisez des threads pour vérifier les liens en parallèle : envoyez les URL "
+"à vérifier à un channel et laissez quelques threads vérifier les URL en "
+"parallèle."
+
+#: src/exercises/concurrency/link-checker.md:110
+#, fuzzy
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
+msgstr ""
+"Étendez ceci pour extraire de manière récursive les liens de toutes les "
+"pages du domaine \"www.google.org\". Fixez une limite supérieure de 100 "
+"pages environ afin que vous ne finissez pas par être bloqué par le site."
 
 #: src/async.md:1
 #, fuzzy
-msgid "# Async Rust"
-msgstr "# Pourquoi Rust ?"
+msgid "Async Rust"
+msgstr "Pourquoi Rust ?"
 
 #: src/async.md:3
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
-"concurrently by\n"
-"executing each task until it would block, then switching to another task "
-"that is\n"
-"ready to make progress. The model allows running a larger number of tasks on "
-"a\n"
-"limited number of threads. This is because the per-task overhead is "
-"typically\n"
-"very low and operating systems provide primitives for efficiently "
-"identifying\n"
-"I/O that is able to proceed."
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 
 #: src/async.md:10
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
-"that\n"
-"may be completed in the future. Futures are \"polled\" until they signal "
-"that\n"
-"they are complete."
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
 
 #: src/async.md:14
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 
 #: src/async.md:17
 #, fuzzy
-msgid "## Comparisons"
-msgstr "# Comparaison"
+msgid "Comparisons"
+msgstr "Comparaison"
 
 #: src/async.md:19
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type "
-"is\n"
-"   callback-based, and not polled. Async Python programs require a "
-"\"loop\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The "
-"language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
+msgstr ""
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
 msgstr ""
 
 #: src/async/async-await.md:1
-msgid "# `async`/`await`"
+msgid "`async`/`await`"
 msgstr ""
 
 #: src/async/async-await.md:3
@@ -19105,45 +19956,54 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no "
-"long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the "
-"compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current "
-"thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. "
-"Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
 
-#: src/async/futures.md:1
-#, fuzzy
-msgid "# Futures"
-msgstr "# Fermetures"
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr ""
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr ""
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr ""
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr ""
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr ""
 
 #: src/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not "
-"be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
 #: src/async/futures.md:8
@@ -19168,87 +20028,86 @@ msgstr ""
 #: src/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
-"uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` "
-"returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
 
 #: src/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
-"to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers "
-"into\n"
-"    that future remain valid. This is required to allow references to "
-"remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/runtimes.md:1
-#, fuzzy
-msgid "# Runtimes"
-msgstr "# Garanties au temps d'exécution"
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
+msgstr ""
 
 #: src/async/runtimes.md:3
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust "
-"does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
 #: src/async/runtimes.md:7
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem "
-"of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and "
-"includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
+msgstr ""
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
 msgstr ""
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 
 #: src/async/runtimes.md:20
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most "
-"interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/"
-"O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are "
-"never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
 
-#: src/async/runtimes/tokio.md:1
-msgid "# Tokio"
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:4
@@ -19256,10 +20115,15 @@ msgid "Tokio provides: "
 msgstr ""
 
 #: src/async/runtimes/tokio.md:6
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:10
@@ -19287,12 +20151,15 @@ msgid ""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:39
@@ -19301,20 +20168,18 @@ msgstr ""
 
 #: src/async/runtimes/tokio.md:41
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to "
-"wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
 
-#: src/async/tasks.md:1
-#, fuzzy
-msgid "# Tasks"
-msgstr "## Tâches"
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
+msgstr ""
 
 #: src/async/tasks.md:3
 msgid "Rust has a task system, which is a form of lightweight threading."
@@ -19323,12 +20188,10 @@ msgstr ""
 #: src/async/tasks.md:5
 msgid ""
 "A task has a single top-level future which the executor polls to make "
-"progress.\n"
-"That future may have one or more nested futures that its `poll` method "
-"polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible "
-"by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
 
 #: src/async/tasks.md:10
@@ -19382,22 +20245,22 @@ msgstr ""
 
 #: src/async/tasks.md:54
 msgid ""
-"* Ask students to visualize what the state of the example server would be "
-"with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling "
-"using `?`."
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/async/channels.md:1
-#, fuzzy
-msgid "# Async Channels"
-msgstr "# Chaînes"
+#: src/async/tasks.md:57
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+
+#: src/async/tasks.md:61
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
+"using `?`."
+msgstr ""
 
 #: src/async/channels.md:3
 msgid ""
@@ -19437,50 +20300,57 @@ msgid ""
 msgstr ""
 
 #: src/async/channels.md:35
+msgid "Change the channel size to `3` and see how it affects the execution."
+msgstr ""
+
+#: src/async/channels.md:37
 msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be "
-"convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to "
-"combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
 msgstr ""
 
 #: src/async/control-flow.md:1
 #, fuzzy
-msgid "# Futures Control Flow"
-msgstr "# Flux de contrôle"
+msgid "Futures Control Flow"
+msgstr "Flux de contrôle"
 
 #: src/async/control-flow.md:3
 msgid ""
 "Futures can be combined together to produce concurrent compute flow graphs. "
-"We\n"
-"have already seen tasks, that function as independent threads of execution."
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
 
 #: src/async/control-flow.md:6
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
 msgstr ""
 
-#: src/async/control-flow/join.md:1
-msgid "# Join"
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
 msgstr ""
 
 #: src/async/control-flow/join.md:3
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
@@ -19516,46 +20386,40 @@ msgstr ""
 
 #: src/async/control-flow/join.md:38
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` "
-"but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this "
-"would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all "
-"requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but "
-"demonstrates `join!`."
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/select.md:1
-#, fuzzy
-msgid "# Select"
-msgstr "# Installation"
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
+"demonstrates `join!`."
+msgstr ""
 
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
 msgid ""
 "Similar to a match statement, the body of `select!` has a number of arms, "
-"each\n"
-"of the form `pattern = future => statement`. When the `future` is ready, "
-"the\n"
-"`statement` is executed with the variables in `pattern` bound to the "
-"`future`'s\n"
-"result."
+"each of the form `pattern = future => statement`. When the `future` is "
+"ready, the `statement` is executed with the variables in `pattern` bound to "
+"the `future`'s result."
 msgstr ""
 
 #: src/async/control-flow/select.md:13
@@ -19610,32 +20474,38 @@ msgstr ""
 
 #: src/async/control-flow/select.md:62
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick "
-"whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are "
-"supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts "
-"of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` drops unmatched branches, which cancels their "
-"futures.\n"
-"  It is easiest to use when every execution of `select!` creates new "
-"futures.\n"
-"\n"
-"    * An alternative is to pass `&mut future` instead of the future itself, "
-"but\n"
-"      this can lead to issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
+msgstr ""
+
+#: src/async/control-flow/select.md:67
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+
+#: src/async/control-flow/select.md:70
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:73
+msgid ""
+"Note that `select!` drops unmatched branches, which cancels their futures. "
+"It is easiest to use when every execution of `select!` creates new futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:76
+msgid ""
+"An alternative is to pass `&mut future` instead of the future itself, but "
+"this can lead to issues, further discussed in the pinning slide."
 msgstr ""
 
 #: src/async/pitfalls.md:1
-msgid "# Pitfalls of async/await"
+msgid "Pitfalls of async/await"
 msgstr ""
 
 #: src/async/pitfalls.md:3
@@ -19647,23 +20517,31 @@ msgid ""
 msgstr ""
 
 #: src/async/pitfalls.md:5
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfalls/async-traits.md)\n"
-"- [Cancellation](pitfalls/cancellation.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfalls/async-traits.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:8
+msgid "[Cancellation](pitfalls/cancellation.md)"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:1
-msgid "# Blocking the executor"
+msgid "Blocking the executor"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:3
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other "
-"tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:7
@@ -19691,58 +20569,57 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its "
-"result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an "
-"actual\n"
-"  thread and transforms its handle into a future without blocking the "
-"executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and "
-"most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, "
-"where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
-"situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause "
-"another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:1
-msgid "# Pin"
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
 "When you await a future, all local variables (that would ordinarily be "
-"stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. "
-"If your\n"
-"future has pointers to data on the stack, those pointers might get "
-"invalidated.\n"
-"This is unsafe."
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:8
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to "
-"don't\n"
+"Therefore, you must guarantee that the addresses your future points to don't "
 "change. That is why we need to `pin` futures. Using the same future "
-"repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:12
@@ -19804,62 +20681,79 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your "
-"time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!"
-"(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the "
-"`loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to "
-"the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on "
-"every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, "
-"but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that "
-"will send to a `oneshot` channel every 100ms."
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:1
-#, fuzzy
-msgid "# Async Traits"
-msgstr "# Caractéristiques"
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
+msgstr ""
 
 #: src/async/pitfalls/async-traits.md:3
 msgid ""
@@ -19921,43 +20815,33 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:49
-#, fuzzy
-msgid "<details>  "
-msgstr "<details>"
-
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations "
-"to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of "
-"time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:1
-#, fuzzy
-msgid "# Cancellation"
-msgstr "# Traductions"
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
+msgstr ""
 
 #: src/async/pitfalls/cancellation.md:3
 msgid ""
 "Dropping a future implies it can never be polled again. This is called "
-"*cancellation*\n"
-"and it can occur at any `await` point. Care is needed to ensure the system "
-"works\n"
-"correctly even when futures are cancelled. For example, it shouldn't "
-"deadlock or\n"
-"lose data."
+"_cancellation_ and it can occur at any `await` point. Care is needed to "
+"ensure the system works correctly even when futures are cancelled. For "
+"example, it shouldn't deadlock or lose data."
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:8
@@ -20030,54 +20914,75 @@ msgstr ""
 
 #: src/async/pitfalls/cancellation.md:72
 msgid ""
-"* The compiler doesn't help with cancellation-safety. You need to read API\n"
-"  documentation and consider what state your `async fn` holds.\n"
+"The compiler doesn't help with cancellation-safety. You need to read API "
+"documentation and consider what state your `async fn` holds."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:75
+msgid ""
+"Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
+"error-handling)."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:78
+msgid "The example loses parts of the string."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:80
+msgid ""
+"Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
+"dropped."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:82
+msgid ""
+"`LinesReader` can be made cancellation-safe by makeing `buf` part of the "
+"struct:"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:83
+msgid ""
+"```rust,compile_fail\n"
+"struct LinesReader {\n"
+"    stream: DuplexStream,\n"
+"    bytes: Vec<u8>,\n"
+"    buf: [u8; 1],\n"
+"}\n"
 "\n"
-"* Unlike `panic` and `?`, cancellation is part of normal control flow\n"
-"  (vs error-handling).\n"
-"\n"
-"* The example loses parts of the string.\n"
-"\n"
-"    * Whenever the `tick()` branch finishes first, `next()` and its `buf` "
-"are dropped.\n"
-"\n"
-"    * `LinesReader` can be made cancellation-safe by makeing `buf` part of "
-"the struct:\n"
-"        ```rust,compile_fail\n"
-"        struct LinesReader {\n"
-"            stream: DuplexStream,\n"
-"            bytes: Vec<u8>,\n"
-"            buf: [u8; 1],\n"
-"        }\n"
-"\n"
-"        impl LinesReader {\n"
-"            fn new(stream: DuplexStream) -> Self {\n"
-"                Self { stream, bytes: Vec::new(), buf: [0] }\n"
-"            }\n"
-"            async fn next(&mut self) -> io::Result<Option<String>> {\n"
-"                // prefix buf and bytes with self.\n"
-"                // ...\n"
-"                let raw = std::mem::take(&mut self.bytes);\n"
-"                let s = String::from_utf8(raw)\n"
-"                // ...\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"* [`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
-"html#method.tick)\n"
-"  is cancellation-safe because it keeps track of whether a tick has been "
-"'delivered'.\n"
-"\n"
-"* [`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
-"AsyncReadExt.html#method.read)\n"
-"  is cancellation-safe because it either returns or doesn't read data.\n"
-"\n"
-"* [`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
-"AsyncBufReadExt.html#method.read_line)\n"
-"  is similar to the example and *isn't* cancellation-safe. See its "
-"documentation\n"
-"  for details and alternatives."
+"impl LinesReader {\n"
+"    fn new(stream: DuplexStream) -> Self {\n"
+"        Self { stream, bytes: Vec::new(), buf: [0] }\n"
+"    }\n"
+"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
+"        // prefix buf and bytes with self.\n"
+"        // ...\n"
+"        let raw = std::mem::take(&mut self.bytes);\n"
+"        let s = String::from_utf8(raw)\n"
+"        // ...\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:104
+msgid ""
+"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
+"html#method.tick) is cancellation-safe because it keeps track of whether a "
+"tick has been 'delivered'."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:107
+msgid ""
+"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncReadExt.html#method.read) is cancellation-safe because it either "
+"returns or doesn't read data."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:110
+msgid ""
+"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
+"cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:3
@@ -20087,40 +20992,39 @@ msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
-"* Dining philosophers: we already saw this problem in the morning. This "
-"time\n"
-"  you are going to implement it with Async Rust.\n"
-"\n"
-"* A Broadcast Chat Application: this is a larger project that allows you\n"
-"  experiment with more advanced Async Rust features."
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr ""
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:3
 #, fuzzy
-msgid "# Dining Philosophers - Async"
-msgstr "# Philosophes de la restauration"
+msgid "Dining Philosophers - Async"
+msgstr "Philosophes de la restauration"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the\n"
+"See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 #, fuzzy
 msgid ""
-"As before, you will need a local\n"
-"[Cargo installation](../../cargo/running-locally.md) for this exercise. "
-"Copy\n"
-"the code below to a file called `src/main.rs`, fill out the blanks, and "
-"test\n"
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 "Vous aurez besoin d'une [installation Cargo](../../cargo/running-locally.md) "
-"locale pour\n"
-"cet exercice. Copiez le code ci-dessous dans un fichier appelé `src/main."
-"rs`, remplissez le\n"
-"vides, et testez que `cargo run` ne se bloque pas :"
+"locale pour cet exercice. Copiez le code ci-dessous dans un fichier appelé "
+"`src/main.rs`, remplissez le vides, et testez que `cargo run` ne se bloque "
+"pas :"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
 msgid ""
@@ -20172,7 +21076,7 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
 msgid ""
-"Since this time you are using Async Rust, you'll need a `tokio` dependency.\n"
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
@@ -20192,33 +21096,29 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:72
 msgid ""
-"Also note that this time you have to use the `Mutex` and the `mpsc` module\n"
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "* Can you make your implementation single-threaded? "
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:1
-msgid "# Broadcast Chat Application"
+msgid "Can you make your implementation single-threaded? "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
 msgid ""
-"In this exercise, we want to use our new knowledge to implement a broadcast\n"
+"In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
-"publish\n"
-"their messages. The client reads user messages from the standard input, and\n"
-"sends them to the server. The chat server broadcasts each message that it\n"
-"receives to all the clients."
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel][1] on the server, and\n"
-"[`tokio_websockets`][2] for the communication between the client and the\n"
-"server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:13
@@ -20246,48 +21146,64 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:32
-msgid "## The required APIs"
+msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
-"You are going to need the following functions from `tokio` and\n"
-"[`tokio_websockets`][2]. Spend a few minutes to familiarize yourself with "
-"the\n"
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
 "API. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
-"- [WebsocketStream::next()][3]: for asynchronously reading messages from a\n"
-"  Websocket Stream.\n"
-"- [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously\n"
-"  sending messages on a Websocket Stream.\n"
-"- [Lines::next_line()][5]: for asynchronously reading user messages\n"
-"  from the standard input.\n"
-"- [Sender::subscribe()][6]: for subscribing to a broadcast channel."
+"[WebsocketStream::next()](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/proto/struct.WebsocketStream.html#method.next): for "
+"asynchronously reading messages from a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:41
+msgid ""
+"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
 #, fuzzy
-msgid "## Two binaries"
-msgstr "# Binaires de rouille"
+msgid "Two binaries"
+msgstr "Binaires de rouille"
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one\n"
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client,\n"
-"and one for the server. You could potentially make them two separate Cargo\n"
-"projects, but we are going to put them in a single Cargo project with two\n"
-"binaries. For this to work, the client and the server code should go under\n"
-"`src/bin` (see the [documentation][7]). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and\n"
-"`src/bin/client.rs`, respectively. Your task is to complete these files as\n"
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
 
@@ -20296,11 +21212,6 @@ msgstr ""
 #, fuzzy
 msgid "`src/bin/server.rs`:"
 msgstr "`src/main.rs` :"
-
-#: src/exercises/concurrency/chat-app.md:61
-#, fuzzy
-msgid "<!-- File src/bin/server.rs -->"
-msgstr "<!-- Fichier src/main.rs -->"
 
 #: src/exercises/concurrency/chat-app.md:63
 msgid ""
@@ -20350,11 +21261,6 @@ msgstr ""
 msgid "`src/bin/client.rs`:"
 msgstr "`src/main.rs` :"
 
-#: src/exercises/concurrency/chat-app.md:104
-#, fuzzy
-msgid "<!-- File src/bin/client.rs -->"
-msgstr "<!-- Fichier src/main.rs -->"
-
 #: src/exercises/concurrency/chat-app.md:106
 msgid ""
 "```rust,compile_fail\n"
@@ -20382,8 +21288,8 @@ msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:127
 #, fuzzy
-msgid "## Running the binaries"
-msgstr "# Exécution du parcours"
+msgid "Running the binaries"
+msgstr "Exécution du parcours"
 
 #: src/exercises/concurrency/chat-app.md:128
 #, fuzzy
@@ -20410,78 +21316,74 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:142
-msgid ""
-"* Implement the `handle_connection` function in `src/bin/server.rs`.\n"
-"  * Hint: Use `tokio::select!` for concurrently performing two tasks in a\n"
-"    continuous loop. One task receives messages from the client and "
-"broadcasts\n"
-"    them. The other sends messages received by the server to the client.\n"
-"* Complete the main function in `src/bin/client.rs`.\n"
-"  * Hint: As before, use `tokio::select!` in a continuous loop for "
-"concurrently\n"
-"    performing two tasks: (1) reading user messages from standard input and\n"
-"    sending them to the server, and (2) receiving messages from the server, "
-"and\n"
-"    displaying them for the user.\n"
-"* Optional: Once you are done, change the code to broadcast messages to all\n"
-"  clients, but the sender of the message."
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/thanks.md:1
-#, fuzzy
-msgid "# Thanks!"
-msgstr "# Merci!"
+#: src/exercises/concurrency/chat-app.md:143
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:147
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:151
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
+msgstr ""
 
 #: src/thanks.md:3
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
-"that it\n"
-"was useful."
+"that it was useful."
 msgstr ""
 "_Merci d'avoir pris Comprehensive Rust(le guide complet de Rust) 🦀!_ Nous "
-"espérons que vous l'avez apprécié et qu'il\n"
-"était utile."
+"espérons que vous l'avez apprécié et qu'il était utile."
 
 #: src/thanks.md:6
 #, fuzzy
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 "Nous nous sommes beaucoup amusés à préparer le cours. Le cours n'est pas "
-"parfait,\n"
-"donc si vous avez repéré des erreurs ou avez des idées d'améliorations, "
-"n'hésitez pas à nous contacter\n"
-"[contactez-nous au\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Nous "
-"aimerions\n"
+"parfait, donc si vous avez repéré des erreurs ou avez des idées "
+"d'améliorations, n'hésitez pas à nous contacter [contactez-nous au GitHub]"
+"(https://github.com/google/comprehensive-rust/discussions). Nous aimerions "
 "d'avoir de tes nouvelles."
 
 #: src/other-resources.md:1
 #, fuzzy
-msgid "# Other Rust Resources"
-msgstr "# Autres ressources de rouille"
+msgid "Other Rust Resources"
+msgstr "Autres ressources de rouille"
 
 #: src/other-resources.md:3
 #, fuzzy
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 "La communauté Rust a créé une multitude de ressources gratuites et de haute "
-"qualité\n"
-"en ligne."
+"qualité en ligne."
 
 #: src/other-resources.md:6
 #, fuzzy
-msgid "## Official Documentation"
-msgstr "## Documents officiels"
+msgid "Official Documentation"
+msgstr "Documents officiels"
 
 #: src/other-resources.md:8
 #, fuzzy
@@ -20493,40 +21395,44 @@ msgstr ""
 #: src/other-resources.md:10
 #, fuzzy
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
 msgstr ""
-"* [Le langage de programmation Rust](https://doc.rust-lang.org/book/) : le\n"
-"  livre canonique gratuit sur Rust. Couvre la langue en détail et comprend "
-"un\n"
-"  peu de projets à construire.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/) : couvre la "
-"rouille\n"
-"  syntaxe via une série d'exemples qui présentent différentes constructions. "
-"Parfois\n"
-"  comprend de petits exercices où l'on vous demande de développer le code "
-"dans le\n"
-"  exemples.\n"
-"* [Bibliothèque standard Rust](https://doc.rust-lang.org/std/) : "
-"documentation complète de\n"
-"  la bibliothèque standard de Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/) : un livre "
-"incomplet\n"
-"  qui décrit la grammaire et le modèle de mémoire de Rust."
+"[Le langage de programmation Rust](https://doc.rust-lang.org/book/) : le "
+"livre canonique gratuit sur Rust. Couvre la langue en détail et comprend un "
+"peu de projets à construire."
+
+#: src/other-resources.md:13
+#, fuzzy
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/) : couvre la "
+"rouille syntaxe via une série d'exemples qui présentent différentes "
+"constructions. Parfois comprend de petits exercices où l'on vous demande de "
+"développer le code dans le exemples."
+
+#: src/other-resources.md:17
+#, fuzzy
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+"[Bibliothèque standard Rust](https://doc.rust-lang.org/std/) : documentation "
+"complète de la bibliothèque standard de Rust."
+
+#: src/other-resources.md:19
+#, fuzzy
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
+msgstr ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/) : un livre "
+"incomplet qui décrit la grammaire et le modèle de mémoire de Rust."
 
 #: src/other-resources.md:22
 #, fuzzy
@@ -20536,38 +21442,40 @@ msgstr "Des guides plus spécialisés hébergés sur le site officiel de Rust :"
 #: src/other-resources.md:24
 #, fuzzy
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
 msgstr ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/) : couvre la rouille "
-"dangereuse,\n"
-"  y compris le travail avec des pointeurs bruts et l'interfaçage avec "
-"d'autres langages\n"
-"  (FFI).\n"
-"* [Programmation asynchrone dans Rust](https://rust-lang.github.io/async-"
-"book/) :\n"
-"  couvre le nouveau modèle de programmation asynchrone qui a été introduit "
-"après la\n"
-"  Rust Book a été écrit.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-"
-"book/) : un\n"
-"  introduction à l'utilisation de Rust sur des appareils embarqués sans "
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/) : couvre la rouille "
+"dangereuse, y compris le travail avec des pointeurs bruts et l'interfaçage "
+"avec d'autres langages (FFI)."
+
+#: src/other-resources.md:27
+#, fuzzy
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+"[Programmation asynchrone dans Rust](https://rust-lang.github.io/async-"
+"book/) : couvre le nouveau modèle de programmation asynchrone qui a été "
+"introduit après la Rust Book a été écrit."
+
+#: src/other-resources.md:30
+#, fuzzy
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
+msgstr ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/) : "
+"un introduction à l'utilisation de Rust sur des appareils embarqués sans "
 "système d'exploitation."
 
 #: src/other-resources.md:33
 #, fuzzy
-msgid "## Unofficial Learning Material"
-msgstr "## Matériel d'apprentissage non officiel"
+msgid "Unofficial Learning Material"
+msgstr "Matériel d'apprentissage non officiel"
 
 #: src/other-resources.md:35
 #, fuzzy
@@ -20577,190 +21485,166 @@ msgstr "Une petite sélection d'autres guides et tutoriels pour Rust :"
 #: src/other-resources.md:37
 #, fuzzy
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
 msgstr ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/) : couvre "
-"Rust\n"
-"  du point de vue des programmeurs C de bas niveau.\n"
-"* [Rouille pour Embedded C\n"
-"  Programmeurs] (https://docs.opentitan.org/doc/ug/rust_for_c/) : couvre "
-"Rust de\n"
-"  le point de vue des développeurs qui écrivent des firmwares en C.\n"
-"* [Rust pour les professionnels](https://overexact.com/rust-for-"
-"professionals/):\n"
-"  couvre la syntaxe de Rust en utilisant des comparaisons côte à côte avec "
-"d'autres langages\n"
-"  tels que C, C++, Java, JavaScript et Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust) : plus de 100 "
-"exercices pour vous aider\n"
-"  vous apprenez Rust.\n"
-"* [Enseignement ferreux\n"
-"  Matériel] (https://ferrous-systems.github.io/teaching-material/index."
-"html) : un\n"
-"  série de petites présentations couvrant à la fois la partie de base et "
-"avancée de la\n"
-"  Langue de rouille. D'autres sujets tels que WebAssembly et async/wait sont "
-"également\n"
-"  couvert.\n"
-"* [Série débutant à\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"et\n"
-"  [Faites vos premiers pas avec\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/) : "
-"deux\n"
-"  Guides Rust destinés aux nouveaux développeurs. Le premier est un ensemble "
-"de 35 vidéos et le\n"
-"  le second est un ensemble de 11 modules qui couvre la syntaxe Rust et les "
-"constructions de base.\n"
-"* [Apprenez Rust avec trop de liens\n"
-"  Listes] (https://rust-unofficial.github.io/too-many-lists/) : en "
-"profondeur\n"
-"  exploration des règles de gestion de la mémoire de Rust, en implémentant "
-"quelques\n"
-"  différents types de structures de liste."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/) : couvre "
+"Rust du point de vue des programmeurs C de bas niveau."
+
+#: src/other-resources.md:39
+#, fuzzy
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+"\\[Rouille pour Embedded C Programmeurs\\] (https://docs.opentitan.org/doc/"
+"ug/rust_for_c/) : couvre Rust de le point de vue des développeurs qui "
+"écrivent des firmwares en C."
+
+#: src/other-resources.md:42
+#, fuzzy
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+"[Rust pour les professionnels](https://overexact.com/rust-for-"
+"professionals/): couvre la syntaxe de Rust en utilisant des comparaisons "
+"côte à côte avec d'autres langages tels que C, C++, Java, JavaScript et "
+"Python."
+
+#: src/other-resources.md:45
+#, fuzzy
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+"[Rust on Exercism](https://exercism.org/tracks/rust) : plus de 100 exercices "
+"pour vous aider vous apprenez Rust."
+
+#: src/other-resources.md:47
+#, fuzzy
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+"\\[Enseignement ferreux Matériel\\] (https://ferrous-systems.github.io/"
+"teaching-material/index.html) : un série de petites présentations couvrant à "
+"la fois la partie de base et avancée de la Langue de rouille. D'autres "
+"sujets tels que WebAssembly et async/wait sont également couvert."
+
+#: src/other-resources.md:52
+#, fuzzy
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+"[Série débutant à Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) et [Faites vos premiers pas avec Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/) : deux Guides Rust "
+"destinés aux nouveaux développeurs. Le premier est un ensemble de 35 vidéos "
+"et le le second est un ensemble de 11 modules qui couvre la syntaxe Rust et "
+"les constructions de base."
+
+#: src/other-resources.md:58
+#, fuzzy
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
+msgstr ""
+"\\[Apprenez Rust avec trop de liens Listes\\] (https://rust-unofficial."
+"github.io/too-many-lists/) : en profondeur exploration des règles de gestion "
+"de la mémoire de Rust, en implémentant quelques différents types de "
+"structures de liste."
 
 #: src/other-resources.md:63
 #, fuzzy
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
+"for even more Rust books."
 msgstr ""
 "Veuillez consulter le [Little Book of Rust Books](https://lborb.github.io/"
-"book/) pour\n"
-"encore plus de livres Rust."
-
-#: src/credits.md:1
-#, fuzzy
-msgid "# Credits"
-msgstr "# Crédits"
+"book/) pour encore plus de livres Rust."
 
 #: src/credits.md:3
 #, fuzzy
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
 "Le matériel ici s'appuie sur les nombreuses sources de documentation de "
-"Rust.\n"
-"Voir la page sur [autres ressources] (other-resources.md) pour une liste "
-"complète des ressources utiles\n"
-"ressources."
+"Rust. Voir la page sur \\[autres ressources\\] (other-resources.md) pour une "
+"liste complète des ressources utiles ressources."
 
 #: src/credits.md:7
 #, fuzzy
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see\n"
-"[`LICENSE`](https://github.com/google/comprehensive-rust/blob/main/LICENSE) "
-"for\n"
-"details."
+"2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
+"rust/blob/main/LICENSE) for details."
 msgstr ""
 "Le matériel de Comprehensive Rust(le guide complet de Rust) est sous licence "
-"sous les termes de la licence d'Apache 2.0,\n"
-"veuillez consulter [`LICENSE`](../LICENSE) pour plus de détails."
+"sous les termes de la licence d'Apache 2.0, veuillez consulter [`LICENSE`]"
+"(../LICENSE) pour plus de détails."
 
 #: src/credits.md:12
 #, fuzzy
-msgid "## Rust by Example"
-msgstr "## Rouille par exemple"
+msgid "Rust by Example"
+msgstr "Rouille par exemple"
 
 #: src/credits.md:14
 #, fuzzy
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
-"Quelques exemples et exercices ont été copiés et adaptés de [Rust by\n"
-"Exemple](https://doc.rust-lang.org/rust-by-example/). Veuillez consulter le\n"
+"Quelques exemples et exercices ont été copiés et adaptés de [Rust by Exemple]"
+"(https://doc.rust-lang.org/rust-by-example/). Veuillez consulter le "
 "Répertoire `third_party/rust-by-example/` pour plus de détails, y compris la "
-"licence\n"
-"conditions."
+"licence conditions."
 
 #: src/credits.md:19
 #, fuzzy
-msgid "## Rust on Exercism"
-msgstr "## Rouille sur l'exercice"
+msgid "Rust on Exercism"
+msgstr "Rouille sur l'exercice"
 
 #: src/credits.md:21
 #, fuzzy
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"Certains exercices ont été copiés et adaptés de [Rust on\n"
-"Exercice] (https://exercism.org/tracks/rust). Veuillez consulter le\n"
-"Répertoire `third_party/rust-on-exercism/` pour plus de détails, y compris "
-"la licence\n"
+"Certains exercices ont été copiés et adaptés de \\[Rust on Exercice\\] "
+"(https://exercism.org/tracks/rust). Veuillez consulter le Répertoire "
+"`third_party/rust-on-exercism/` pour plus de détails, y compris la licence "
 "conditions."
 
 #: src/credits.md:26
 #, fuzzy
-msgid "## CXX"
-msgstr "## CXX"
+msgid "CXX"
+msgstr "\\## CXX"
 
 #: src/credits.md:28
 #, fuzzy
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 "La section [Interopérabilité avec C++](android/interoperability/cpp.md) "
-"utilise un\n"
-"image de [CXX](https://cxx.rs/). Veuillez consulter le répertoire "
-"`third_party/cxx/`\n"
-"pour plus de détails, y compris les termes de la licence."
-
-#: src/exercises/solutions.md:1
-#, fuzzy
-msgid "# Solutions"
-msgstr "# Solutions"
+"utilise un image de [CXX](https://cxx.rs/). Veuillez consulter le répertoire "
+"`third_party/cxx/` pour plus de détails, y compris les termes de la licence."
 
 #: src/exercises/solutions.md:3
 #, fuzzy
@@ -20770,38 +21654,29 @@ msgstr "Vous trouverez les solutions aux exercices dans les pages suivantes."
 #: src/exercises/solutions.md:5
 #, fuzzy
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
-"N'hésitez pas à poser des questions sur les solutions [sur\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Faites le "
-"nous savoir\n"
-"si vous avez une solution différente ou meilleure que celle présentée ici."
+"N'hésitez pas à poser des questions sur les solutions [sur GitHub](https://"
+"github.com/google/comprehensive-rust/discussions). Faites le nous savoir si "
+"vous avez une solution différente ou meilleure que celle présentée ici."
 
 #: src/exercises/solutions.md:10
 #, fuzzy
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
-"> **Remarque :** Veuillez ignorer `// ANCHOR : libellé` et `// ANCHOR_END : "
-"libellé`\n"
-"> commentaires que vous voyez dans les solutions. Ils sont là pour permettre "
-"de\n"
-"> réutiliser des parties des solutions comme exercices."
+"**Remarque :** Veuillez ignorer `// ANCHOR : libellé` et `// ANCHOR_END : "
+"libellé` commentaires que vous voyez dans les solutions. Ils sont là pour "
+"permettre de réutiliser des parties des solutions comme exercices."
 
 #: src/exercises/day-1/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 1 Morning Exercises"
-msgstr "# Exercices du matin du jour 1"
-
-#: src/exercises/day-1/solutions-morning.md:3
-#, fuzzy
-msgid "## Arrays and `for` Loops"
-msgstr "## Tableaux et boucles `for`"
+msgid "Day 1 Morning Exercises"
+msgstr "Exercices du matin du jour 1"
 
 #: src/exercises/day-1/solutions-morning.md:5
 #, fuzzy
@@ -20885,8 +21760,8 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
 #, fuzzy
-msgid "### Bonus question"
-msgstr "### Question bonus"
+msgid "Bonus question"
+msgstr "Question bonus"
 
 #: src/exercises/day-1/solutions-morning.md:80
 #, fuzzy
@@ -20919,11 +21794,13 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 "Une fois arrivés aux traits et aux génériques, nous pourrons utiliser le "
-"trait [`std::convert::AsRef`][1] pour faire abstraction de tout ce qui peut "
-"être référencé en tant que tranche."
+"trait [`std::convert::AsRef`](https://doc.rust-lang.org/std/convert/trait."
+"AsRef.html) pour faire abstraction de tout ce qui peut être référencé en "
+"tant que tranche."
 
 #: src/exercises/day-1/solutions-morning.md:86
 msgid ""
@@ -20967,13 +21844,13 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 1 Afternoon Exercises"
-msgstr "# Exercices de l'après-midi du jour 1"
+msgid "Day 1 Afternoon Exercises"
+msgstr "Exercices de l'après-midi du jour 1"
 
 #: src/exercises/day-1/solutions-afternoon.md:3
 #, fuzzy
-msgid "## Designing a Library"
-msgstr "## Conception d'une bibliothèque"
+msgid "Designing a Library"
+msgstr "Conception d'une bibliothèque"
 
 #: src/exercises/day-1/solutions-afternoon.md:5
 #, fuzzy
@@ -21179,13 +22056,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 2 Morning Exercises"
-msgstr "# Exercices du matin du jour 2"
-
-#: src/exercises/day-2/solutions-morning.md:3
-#, fuzzy
-msgid "## Points and Polygons"
-msgstr "## Points et polygones"
+msgid "Day 2 Morning Exercises"
+msgstr "Exercices du matin du jour 2"
 
 #: src/exercises/day-2/solutions-morning.md:5
 #, fuzzy
@@ -21426,13 +22298,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 2 Afternoon Exercises"
-msgstr "# Exercices de l'après-midi du jour 2"
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Luhn Algorithm"
-msgstr "## Algorithme de Luhn"
+msgid "Day 2 Afternoon Exercises"
+msgstr "Exercices de l'après-midi du jour 2"
 
 #: src/exercises/day-2/solutions-afternoon.md:5
 #, fuzzy
@@ -21533,11 +22400,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:97
-#, fuzzy
-msgid "## Strings and Iterators"
-msgstr "## Chaînes et itérateurs"
-
 #: src/exercises/day-2/solutions-afternoon.md:99
 #, fuzzy
 msgid "([back to exercise](strings-iterators.md))"
@@ -21634,13 +22496,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 3 Morning Exercise"
-msgstr "# Jour 3 Exercice du matin"
-
-#: src/exercises/day-3/solutions-morning.md:3
-#, fuzzy
-msgid "## A Simple GUI Library"
-msgstr "## Une bibliothèque d'interface graphique simple"
+msgid "Day 3 Morning Exercise"
+msgstr "Jour 3 Exercice du matin"
 
 #: src/exercises/day-3/solutions-morning.md:5
 #, fuzzy
@@ -21821,13 +22678,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 3 Afternoon Exercises"
-msgstr "# Exercices de l'après-midi du jour 3"
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Safe FFI Wrapper"
-msgstr "## Enveloppe FFI sécurisée"
+msgid "Day 3 Afternoon Exercises"
+msgstr "Exercices de l'après-midi du jour 3"
 
 #: src/exercises/day-3/solutions-afternoon.md:5
 #, fuzzy
@@ -22028,13 +22880,8 @@ msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
 #, fuzzy
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr "# Exercice du matin sur la rouille du métal nu"
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-#, fuzzy
-msgid "## Compass"
-msgstr "## Boussole"
+msgid "Bare Metal Rust Morning Exercise"
+msgstr "Exercice du matin sur la rouille du métal nu"
 
 #: src/exercises/bare-metal/solutions-morning.md:5
 #, fuzzy
@@ -22207,16 +23054,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-#, fuzzy
-msgid "# Bare Metal Rust Afternoon"
-msgstr "# Bare Metal Rust Après-midi"
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-#, fuzzy
-msgid "## RTC driver"
-msgstr "## Pilote RTC"
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
 #, fuzzy
@@ -22516,13 +23353,8 @@ msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
 #, fuzzy
-msgid "# Concurrency Morning Exercise"
-msgstr "# Jour 3 Exercice du matin"
-
-#: src/exercises/concurrency/solutions-morning.md:3
-#, fuzzy
-msgid "## Dining Philosophers"
-msgstr "## Philosophes de la restauration"
+msgid "Concurrency Morning Exercise"
+msgstr "Jour 3 Exercice du matin"
 
 #: src/exercises/concurrency/solutions-morning.md:5
 #, fuzzy
@@ -22631,13 +23463,8 @@ msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Concurrency Afternoon Exercise"
-msgstr "# Exercices de l'après-midi du jour 1"
-
-#: src/exercises/concurrency/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Dining Philosophers - Async"
-msgstr "## Philosophes de la restauration"
+msgid "Concurrency Afternoon Exercise"
+msgstr "Exercices de l'après-midi du jour 1"
 
 #: src/exercises/concurrency/solutions-afternoon.md:5
 #, fuzzy
@@ -22756,10 +23583,6 @@ msgid ""
 "    }\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:113
-msgid "## Broadcast Chat Application"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:115
@@ -22913,216 +23736,3 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#~ msgid "Designing a Library"
-#~ msgstr "Conception d'une bibliothèque"
-
-#, fuzzy
-#~ msgid "# Designing a Library"
-#~ msgstr "# Concevoir une bibliothèque"
-
-#, fuzzy
-#~ msgid "`move` closures only implement `FnOnce`."
-#~ msgstr "Les fermetures `move` n'implémentent que `FnOnce`."
-
-#~ msgid "Day 4"
-#~ msgstr "Jour 4"
-
-#~ msgid "Closures"
-#~ msgstr "Fermetures"
-
-#~ msgid "Day 4: Morning"
-#~ msgstr "Jour 4 : Matin"
-
-#~ msgid "Day 4: Afternoon (Android)"
-#~ msgstr "Jour 4 : Après-midi (Android)"
-
-#~ msgid "Day 4 Morning"
-#~ msgstr "Jour 4 Matin"
-
-#~ msgid "On Day 4, we will cover Android-specific things such as:"
-#~ msgstr ""
-#~ "Le 4ème jour, nous couvrirons des éléments spécifiques à Android tels "
-#~ "que :"
-
-#~ msgid ""
-#~ "* Building Android components in Rust.\n"
-#~ "* AIDL servers and clients.\n"
-#~ "* Interoperability with C, C++, and Java."
-#~ msgstr ""
-#~ "* Construire des composants Android avec Rust.\n"
-#~ "* Serveurs et clients AIDL.\n"
-#~ "* Interopérabilité avec C, C++ et Java."
-
-#~ msgid ""
-#~ "It is important to note that this course does not cover Android "
-#~ "**application** \n"
-#~ "development in Rust, and that the Android-specific parts are specifically "
-#~ "about\n"
-#~ "writing code for Android itself, the operating system. "
-#~ msgstr ""
-#~ "Il est important de noter que ce cours ne couvre pas un développement d' "
-#~ "**application** Android\n"
-#~ "avec Rust, et que les parties spécifiques à Android concernent "
-#~ "spécifiquement\n"
-#~ "l'écriture du code pour le système d'exploitation Android lui même, le "
-#~ "système d'exploitation. "
-
-#~ msgid ""
-#~ "* Learn how to use async Rust --- we'll only mention async Rust when\n"
-#~ "  covering traditional concurrency primitives. Please see [Asynchronous\n"
-#~ "  Programming in Rust](https://rust-lang.github.io/async-book/) instead "
-#~ "for\n"
-#~ "  details on this topic.\n"
-#~ "* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-#~ "  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-#~ "  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
-#~ msgstr ""
-#~ "* Apprenez à utiliser Rust asynchrone --- nous ne mentionnerons Rust "
-#~ "asynchrone que lorsque\n"
-#~ "  couvrant les primitives de concurrence traditionnelles. Veuillez "
-#~ "consulter [Programmation\n"
-#~ "  Asynchrone en Rust](https://rust-lang.github.io/async-book/) à la place "
-#~ "de\n"
-#~ "  détails sur ce sujet.\n"
-#~ "* Apprenez à développer des macros, veuillez consulter [Chapitre 19.5 "
-#~ "dans le Livre\n"
-#~ "  Rust](https://doc.rust-lang.org/book/ch19-06-macros.html) et [Rust par\n"
-#~ "  Exemple](https://doc.rust-lang.org/rust-by-example/macros.html) à la "
-#~ "place."
-
-#~ msgid "# Day 4"
-#~ msgstr "# Jour 4"
-
-#~ msgid ""
-#~ "The afternoon of the fourth day should cover a topic of your choice. "
-#~ "Include\n"
-#~ "the topic in the announcement of the course, so that participants know "
-#~ "what to\n"
-#~ "expect."
-#~ msgstr ""
-#~ "L'après-midi du quatrième jour devrait couvrir un sujet de votre choix. "
-#~ "Ajoutez\n"
-#~ "le sujet dans l'annonce du cours, afin que les participants sachent à "
-#~ "quoi\n"
-#~ "s'attendre."
-
-#~ msgid ""
-#~ "This phase of the course is a chance for participants to see Rust in "
-#~ "action on a\n"
-#~ "codebase they might be familiar with. You can choose from the topics "
-#~ "already\n"
-#~ "defined here, or plan your own."
-#~ msgstr ""
-#~ "Cette phase du cours est une chance pour les participants de voir Rust en "
-#~ "action sur une\n"
-#~ "base de code qu'ils connaissent peut-être. Vous pouvez déjà choisir parmi "
-#~ "les sujets\n"
-#~ "définis ici, ou planifiez le vôtre."
-
-#~ msgid "Some topics need additional preparation:"
-#~ msgstr "Certains sujets nécessitent une préparation supplémentaire :"
-
-#, fuzzy
-#~ msgid ""
-#~ "<details>\n"
-#~ "Key points:"
-#~ msgstr ""
-#~ "<détails>\n"
-#~ "Points clés:"
-
-#, fuzzy
-#~ msgid "</defails>"
-#~ msgstr "</defaults>"
-
-#, fuzzy
-#~ msgid ""
-#~ "<details>\n"
-#~ "Key Points: "
-#~ msgstr ""
-#~ "<détails>\n"
-#~ "Points clés:"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Change the literal values in `foo` to match with the other patterns.\n"
-#~ "* Add a new field to `Foo` and make changes to the pattern as needed."
-#~ msgstr ""
-#~ "* Modifiez les valeurs littérales dans `foo` pour qu'elles correspondent "
-#~ "aux autres modèles.\n"
-#~ "* Ajoutez un nouveau champ à `Foo` et modifiez le modèle si nécessaire."
-
-#, fuzzy
-#~ msgid "You use `if` very similarly to how you would in other languages:"
-#~ msgstr ""
-#~ "Vous utilisez `if` de manière très similaire à la façon dont vous le "
-#~ "feriez dans d'autres langues :"
-
-#, fuzzy
-#~ msgid ""
-#~ "If you want to match a value against a pattern, you can use `if let`:"
-#~ msgstr ""
-#~ "Si vous voulez faire correspondre une valeur à un modèle, vous pouvez "
-#~ "utiliser `if let` :"
-
-#, fuzzy
-#~ msgid "The `while` keyword works very similar to other languages:"
-#~ msgstr ""
-#~ "Le mot-clé `while` fonctionne de manière très similaire aux autres "
-#~ "langages :"
-
-#, fuzzy
-#~ msgid "# `for` expressions"
-#~ msgstr "# expressions `pour`"
-
-#, fuzzy
-#~ msgid "* Break the `loop` with a value (e.g. `break 8`) and print it out."
-#~ msgstr ""
-#~ "* Cassez la `boucle` avec une valeur (par exemple `break 8`) et imprimez-"
-#~ "la."
-
-#, fuzzy
-#~ msgid ""
-#~ "You will also want to browse the [`std::ffi`] module, particular for "
-#~ "[`CStr`]\n"
-#~ "and [`CString`] types which are used to hold NUL-terminated strings "
-#~ "coming from\n"
-#~ "C. The [Nomicon] also has a very useful chapter about FFI."
-#~ msgstr ""
-#~ "Vous voudrez également parcourir le module [`std :: ffi`], en particulier "
-#~ "pour [`CStr`]\n"
-#~ "et [`CString`] qui sont utilisés pour contenir des chaînes terminées par "
-#~ "NUL provenant de\n"
-#~ "C. Le [Nomicon] a également un chapitre très utile sur FFI."
-
-#, fuzzy
-#~ msgid "# Welcome to Day 4"
-#~ msgstr "# Bienvenue au jour 4"
-
-#, fuzzy
-#~ msgid ""
-#~ "This morning, we will focus on Concurrency: threads, channels, shared "
-#~ "state, `Send` and `Sync`.\n"
-#~ "In the afternoon, we will have a chance to see Rust in action."
-#~ msgstr ""
-#~ "Ce matin, nous nous concentrerons sur la simultanéité : les threads, les "
-#~ "canaux, l'état partagé, `Send` et `Sync`.\n"
-#~ "Dans l'après-midi, nous aurons la chance de voir Rust en action."
-
-#, fuzzy
-#~ msgid ""
-#~ "This is a good time to give an outline of what you will cover in the "
-#~ "afternoon\n"
-#~ "section, as announced in the course offering."
-#~ msgstr ""
-#~ "C'est le bon moment pour donner un aperçu de ce que vous couvrirez dans "
-#~ "l'après-midi\n"
-#~ "section, tel qu'annoncé dans l'offre de cours."
-
-#, fuzzy
-#~ msgid "# Fearless Concurrency"
-#~ msgstr "# Concurrence intrépide"
-
-#, fuzzy
-#~ msgid "# Day 4 Morning Exercise"
-#~ msgstr "# Jour 4 Exercice du matin"


### PR DESCRIPTION
Before, po/fr.po had these statistics:

    312 translated messages, 984 fuzzy translations, 485 untranslated messages.

Afterwards, the statistics for po/fr.po is:

    343 translated messages, 1363 fuzzy translations, 761 untranslated messages.

The number of translated messages changed from 18% to 14%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.