### PR TITLE
es: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -5,34 +5,33 @@ msgstr ""
 "PO-Revision-Date: 2023-03-31 17:10+0200\n"
 "Last-Translator: Walter Javier Franck <walterjfranck@gmail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Bienvenido a Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Seguir el Curso"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Estructura del Curso"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Accesos Rápidos del Teclado"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Traducciones"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Usando Cargo"
 
@@ -56,55 +55,55 @@ msgstr "Día 1: Mañana"
 msgid "Welcome"
 msgstr "Bienvenido"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "¿Qué es Rust?"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "¡Hola Mundo!"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "Ejemplo Rápido"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "¿Por qué Rust?"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "Tiempo de Compilación Garantizado"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "Garantías en Tiempo de Ejecución"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "Características Modernas"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "Sintaxis Básica"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "Tipos Escalares"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "Tipos Compuestos"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "Referencias"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "Referencias Colgantes"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "Slices"
 
@@ -112,11 +111,12 @@ msgstr "Slices"
 msgid "String vs str"
 msgstr ""
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "Funciones"
 
-#: src/SUMMARY.md:34 src/SUMMARY.md:81
+#: src/SUMMARY.md:34 src/SUMMARY.md:81 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "Métodos"
 
@@ -124,12 +124,13 @@ msgstr "Métodos"
 msgid "Overloading"
 msgstr "Sobrecarga"
 
-#: src/SUMMARY.md:36 src/SUMMARY.md:65 src/SUMMARY.md:89 src/SUMMARY.md:118 src/SUMMARY.md:147
-#: src/SUMMARY.md:175 src/SUMMARY.md:198 src/SUMMARY.md:225
+#: src/SUMMARY.md:36 src/SUMMARY.md:65 src/SUMMARY.md:89 src/SUMMARY.md:118
+#: src/SUMMARY.md:147 src/SUMMARY.md:175 src/SUMMARY.md:198 src/SUMMARY.md:225
+#: src/exercises/day-4/morning.md:1 src/exercises/day-4/afternoon.md:1
 msgid "Exercises"
 msgstr "Ejercicios"
 
-#: src/SUMMARY.md:37
+#: src/SUMMARY.md:37 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "Conversiones Implícitas"
 
@@ -141,11 +142,11 @@ msgstr "Arrays y Loops for"
 msgid "Day 1: Afternoon"
 msgstr "Día 1: Tarde"
 
-#: src/SUMMARY.md:42
+#: src/SUMMARY.md:42 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "Variables"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "Infererencia de Tipo"
 
@@ -153,11 +154,11 @@ msgstr "Infererencia de Tipo"
 msgid "static & const"
 msgstr "static & const"
 
-#: src/SUMMARY.md:45
+#: src/SUMMARY.md:45 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "Scopes y Shadowing"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "Manejo de Memoria"
 
@@ -165,15 +166,15 @@ msgstr "Manejo de Memoria"
 msgid "Stack vs Heap"
 msgstr ""
 
-#: src/SUMMARY.md:48
+#: src/SUMMARY.md:48 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "Stack de Memoria"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "Manejo Manual de Memoria"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "Manejo de Memoria basado en Scope (ámbitos)"
 
@@ -185,59 +186,60 @@ msgstr ""
 msgid "Rust Memory Management"
 msgstr "Manejo de la Memoria en Rust"
 
-#: src/SUMMARY.md:53
+#: src/SUMMARY.md:53 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "Comparación"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/ownership.md:1
 msgid "Ownership"
 msgstr "Ownership (dueño)"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "Semantica de Transferencia"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Mover Strings en Rust"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "Frees Dobles en C++ Moderno"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "Transferencia de Objetos en Llamadas de Funciones"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "Copiar y Clonar"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "Préstamos (Referencias)"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "Préstamos Compartidos y Únicos (Referencias)"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "Tiempo de Vida"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "Tiempo de Vida en Llamadas de Funciones"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "Tiempo de Vida de Estructuras de Datos"
 
-#: src/SUMMARY.md:66
+#: src/SUMMARY.md:66 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr "Diseñando una Librería"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "Iteradores y Ownership"
 
@@ -245,63 +247,64 @@ msgstr "Iteradores y Ownership"
 msgid "Day 2: Morning"
 msgstr "Día 2: Mañana"
 
-#: src/SUMMARY.md:75
+#: src/SUMMARY.md:75 src/structs.md:1
 msgid "Structs"
 msgstr ""
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "Estructuras de Tuplas"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "Sintaxis Abreviada de Campos"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/enums.md:1
 msgid "Enums"
 msgstr ""
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "Payloads Variantes"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "Tamaños de Enum"
 
-#: src/SUMMARY.md:82
+#: src/SUMMARY.md:82 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "Método Receptor"
 
 #: src/SUMMARY.md:83 src/SUMMARY.md:158 src/SUMMARY.md:193
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "Ejemplo"
 
-#: src/SUMMARY.md:84
+#: src/SUMMARY.md:84 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "Correspondencia de Patrones"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "Desestructurando Enums"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "Desestructurando Structs"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "Desestructurando Arrays"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "Guardas de Match"
 
-#: src/SUMMARY.md:90
+#: src/SUMMARY.md:90 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "Estadísticas de Estado de Salud"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "Puntos y Polígonos"
 
@@ -309,11 +312,11 @@ msgstr "Puntos y Polígonos"
 msgid "Day 2: Afternoon"
 msgstr "Día 2: Tarde"
 
-#: src/SUMMARY.md:95
+#: src/SUMMARY.md:95 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "Control de Flujo"
 
-#: src/SUMMARY.md:96
+#: src/SUMMARY.md:96 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "Bloques"
 
@@ -349,7 +352,7 @@ msgstr "expresiones match"
 msgid "break & continue"
 msgstr "break y continue"
 
-#: src/SUMMARY.md:105
+#: src/SUMMARY.md:105 src/std.md:1
 msgid "Standard Library"
 msgstr "Librería Standard"
 
@@ -357,7 +360,7 @@ msgstr "Librería Standard"
 msgid "Option and Result"
 msgstr "Option y Result"
 
-#: src/SUMMARY.md:107
+#: src/SUMMARY.md:107 src/std/string.md:1
 msgid "String"
 msgstr ""
 
@@ -377,7 +380,7 @@ msgstr ""
 msgid "Recursive Data Types"
 msgstr "Tipo de Datos Recursivos"
 
-#: src/SUMMARY.md:112
+#: src/SUMMARY.md:112 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "Optimización de Nicho"
 
@@ -385,27 +388,29 @@ msgstr "Optimización de Nicho"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:114
+#: src/SUMMARY.md:114 src/modules.md:1
 msgid "Modules"
 msgstr "Módulos"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "Visibilidad"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/paths.md:1
 msgid "Paths"
 msgstr ""
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "Jerarquía del Sistema de Archivos"
 
-#: src/SUMMARY.md:119
+#: src/SUMMARY.md:119 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Algoritmo de Luhn"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:98
 msgid "Strings and Iterators"
 msgstr "Strings e Iteradores"
 
@@ -413,19 +418,19 @@ msgstr "Strings e Iteradores"
 msgid "Day 3: Morning"
 msgstr "Día 3: Mañana"
 
-#: src/SUMMARY.md:128
+#: src/SUMMARY.md:128 src/traits.md:1
 msgid "Traits"
 msgstr ""
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "Traits Derivados"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "Métodos por Default"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "Traits Importantes"
 
@@ -433,7 +438,7 @@ msgstr "Traits Importantes"
 msgid "Iterator"
 msgstr "Iteradores"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -457,19 +462,19 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/generics.md:1
 msgid "Generics"
 msgstr "Genéricos"
 
-#: src/SUMMARY.md:140
+#: src/SUMMARY.md:140 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "Tipos de Datos Genéricos"
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "Métodos Genéricos"
 
-#: src/SUMMARY.md:142
+#: src/SUMMARY.md:142 src/generics/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "Límites Trait (Bounds)"
 
@@ -477,19 +482,20 @@ msgstr "Límites Trait (Bounds)"
 msgid "impl Trait"
 msgstr "impl Trait"
 
-#: src/SUMMARY.md:144
+#: src/SUMMARY.md:144 src/generics/closures.md:1
 msgid "Closures"
 msgstr "Cláusulas"
 
-#: src/SUMMARY.md:145
+#: src/SUMMARY.md:145 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "Monomorphization"
 
-#: src/SUMMARY.md:146
+#: src/SUMMARY.md:146 src/generics/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "Objetos Trait"
 
-#: src/SUMMARY.md:148
+#: src/SUMMARY.md:148 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "Una Libraría Simple GUI"
 
@@ -497,11 +503,11 @@ msgstr "Una Libraría Simple GUI"
 msgid "Day 3: Afternoon"
 msgstr "Día 3: Tarde"
 
-#: src/SUMMARY.md:152
+#: src/SUMMARY.md:152 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "Manejo de Errores"
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr ""
 
@@ -517,63 +523,64 @@ msgstr "Manejo de Errores de Estructura"
 msgid "Propagating Errors with ?"
 msgstr "Propagación de Errores con ?"
 
-#: src/SUMMARY.md:157
+#: src/SUMMARY.md:157 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "Convirtiendo Tipos de Errores"
 
-#: src/SUMMARY.md:159
+#: src/SUMMARY.md:159 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "Derivando Errores Enum"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "Tipos de Errores Dinámicos"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "Dando Contexto a los Errores"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/testing.md:1
 msgid "Testing"
 msgstr "Testeando"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "Testeo Unitario"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "Módulos de Test"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "Documentación de Test"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "Tests de Integración"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Rust No Seguro (Unsafe)"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "Desreferenciar Punteros Raw"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "Variables Mutables Estáticas"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "Unions"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "Llamando Funciones No Seguras"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "Escribiendo Funciones No Seguras"
 
@@ -581,11 +588,12 @@ msgstr "Escribiendo Funciones No Seguras"
 msgid "Extern Functions"
 msgstr "Funciones Externas"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "Implementando Traits No Seguros"
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "Wrappers FFI Seguros"
 
@@ -597,27 +605,27 @@ msgstr "Día 4: Mañana"
 msgid "Concurrency"
 msgstr "Concurrencia"
 
-#: src/SUMMARY.md:185
+#: src/SUMMARY.md:185 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "Hilos"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "Ámbito de los Hilos"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "Canales"
 
-#: src/SUMMARY.md:188
+#: src/SUMMARY.md:188 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Canales Ilimitados"
 
-#: src/SUMMARY.md:189
+#: src/SUMMARY.md:189 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Canales Limitados"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "Estado Compartido"
 
@@ -641,15 +649,16 @@ msgstr ""
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:197
+#: src/SUMMARY.md:197 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "Ejemplo"
 
-#: src/SUMMARY.md:199
+#: src/SUMMARY.md:199 src/exercises/day-4/dining-philosophers.md:1
+#: src/exercises/day-4/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "Filosofía de la Cena"
 
-#: src/SUMMARY.md:200
+#: src/SUMMARY.md:200 src/exercises/day-4/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "Chequeo de Links Multi-hilos"
 
@@ -657,15 +666,15 @@ msgstr "Chequeo de Links Multi-hilos"
 msgid "Day 4: Afternoon"
 msgstr "Día 4: Tarde"
 
-#: src/SUMMARY.md:206
+#: src/SUMMARY.md:206 src/android.md:1
 msgid "Android"
 msgstr ""
 
-#: src/SUMMARY.md:207
+#: src/SUMMARY.md:207 src/android/setup.md:1
 msgid "Setup"
 msgstr ""
 
-#: src/SUMMARY.md:208
+#: src/SUMMARY.md:208 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "Reglas de Compilación (Build)"
 
@@ -677,7 +686,7 @@ msgstr "Binarios"
 msgid "Library"
 msgstr "Librería"
 
-#: src/SUMMARY.md:211
+#: src/SUMMARY.md:211 src/android/aidl.md:1
 msgid "AIDL"
 msgstr ""
 
@@ -693,7 +702,7 @@ msgstr "Implementación"
 msgid "Server"
 msgstr "Servidor"
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr ""
 
@@ -701,15 +710,15 @@ msgstr ""
 msgid "Client"
 msgstr "Cliente"
 
-#: src/SUMMARY.md:217
+#: src/SUMMARY.md:217 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "Cambiando de API"
 
-#: src/SUMMARY.md:218
+#: src/SUMMARY.md:218 src/android/logging.md:1
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md:219
+#: src/SUMMARY.md:219 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "Interoperabilidad"
 
@@ -725,7 +734,7 @@ msgstr "Invocar C desde Bindgen"
 msgid "Calling Rust from C"
 msgstr "Invocar Rust desde C"
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "Con C++"
 
@@ -737,7 +746,7 @@ msgstr "Con Java"
 msgid "Final Words"
 msgstr "Palabras Finales"
 
-#: src/SUMMARY.md:229
+#: src/SUMMARY.md:229 src/thanks.md:1
 msgid "Thanks!"
 msgstr "Gracias!"
 
@@ -745,11 +754,11 @@ msgstr "Gracias!"
 msgid "Other Resources"
 msgstr "Otros Recursos"
 
-#: src/SUMMARY.md:231
+#: src/SUMMARY.md:231 src/credits.md:1
 msgid "Credits"
 msgstr "Créditos"
 
-#: src/SUMMARY.md:235
+#: src/SUMMARY.md:235 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "Soluciones"
 
@@ -781,215 +790,142 @@ msgstr "Día 3 Tarde"
 msgid "Day 4 Morning"
 msgstr "Día 4 Mañana"
 
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Bienvenido a Comprehensive Rust 🦀"
-
 #: src/welcome.md:3
 msgid ""
-"This is a four day Rust course developed by the Android team. The course covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like generics\n"
-"and error handling. It also includes Android-specific content on the last day."
+"This is a four day Rust course developed by the Android team. The course "
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
-"Este es un curso de Rust de cuatro días desarrollado por el team de Android. El curso cubre\n"
-"el espectro completo de Rust, desde la sintaxis básica a tópicos avanzados como genéricos\n"
-"y el manejo de errores. Para el último día también incluye contenido específico a Android."
+"Este es un curso de Rust de cuatro días desarrollado por el team de Android. "
+"El curso cubre el espectro completo de Rust, desde la sintaxis básica a "
+"tópicos avanzados como genéricos y el manejo de errores. Para el último día "
+"también incluye contenido específico a Android."
 
 #: src/welcome.md:7
 msgid ""
-"The goal of the course is to teach you Rust. We assume you don't know anything\n"
-"about Rust and hope to:"
+"The goal of the course is to teach you Rust. We assume you don't know "
+"anything about Rust and hope to:"
 msgstr ""
-"El objetivo del curso es enseñarte Rust. Asumimos que no sabes nada\n"
-"Acerca de Rust y esperamos que:"
+"El objetivo del curso es enseñarte Rust. Asumimos que no sabes nada Acerca "
+"de Rust y esperamos que:"
 
 #: src/welcome.md:10
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
-msgstr ""
-"* Darte un entendimiento comprensivo de la sintaxis y lenguaje Rust.\n"
-"* Permitirte modificar programas de Rust y escribir otros nuevos.\n"
-"* Brindarte idiomática propia de Rust."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
+msgstr "Darte un entendimiento comprensivo de la sintaxis y lenguaje Rust."
+
+#: src/welcome.md:11
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr "Permitirte modificar programas de Rust y escribir otros nuevos."
+
+#: src/welcome.md:12
+msgid "Show you common Rust idioms."
+msgstr "Brindarte idiomática propia de Rust."
 
 #: src/welcome.md:14
 msgid "On Day 4, we will cover Android-specific things such as:"
 msgstr "En el Día 4, cubriremos cosas específicas a Android como:"
 
 #: src/welcome.md:16
-msgid ""
-"* Building Android components in Rust.\n"
-"* AIDL servers and clients.\n"
-"* Interoperability with C, C++, and Java."
-msgstr ""
-"* Construir componentes en Rust.\n"
-"* Clientes y servidores AIDL. \n"
-"* Interoperabilidad con C, C++, y Java."
+msgid "Building Android components in Rust."
+msgstr "Construir componentes en Rust."
+
+#: src/welcome.md:17
+msgid "AIDL servers and clients."
+msgstr "Clientes y servidores AIDL. "
+
+#: src/welcome.md:18
+msgid "Interoperability with C, C++, and Java."
+msgstr "Interoperabilidad con C, C++, y Java."
 
 #: src/welcome.md:20
 msgid ""
-"It is important to note that this course does not cover Android **application** \n"
-"development in Rust, and that the Android-specific parts are specifically about\n"
-"writing code for Android itself, the operating system. "
+"It is important to note that this course does not cover Android "
+"**application**  development in Rust, and that the Android-specific parts "
+"are specifically about writing code for Android itself, the operating "
+"system. "
 msgstr ""
-"Es importante destacar que este curso no cubre desarrollo de **aplicaciones** \n"
-"Android en Rust, y que las partes específicas a Android son acerca de\n"
-"escribir código para Android en sí, el sistema operativo. "
+"Es importante destacar que este curso no cubre desarrollo de "
+"**aplicaciones**  Android en Rust, y que las partes específicas a Android "
+"son acerca de escribir código para Android en sí, el sistema operativo. "
 
 #: src/welcome.md:24
-msgid "## Non-Goals"
-msgstr "## No tiene por Objetivo"
+msgid "Non-Goals"
+msgstr "No tiene por Objetivo"
 
 #: src/welcome.md:26
 msgid ""
-"Rust is a large language and we won't be able to cover all of it in a few days.\n"
-"Some non-goals of this course are:"
+"Rust is a large language and we won't be able to cover all of it in a few "
+"days. Some non-goals of this course are:"
 msgstr ""
-"Rust es un lenguaje extenso y no podemos cubrir todo de él en algunos días.\n"
+"Rust es un lenguaje extenso y no podemos cubrir todo de él en algunos días. "
 "Algo de los No Objetivos es:"
 
 #: src/welcome.md:29
 msgid ""
-"* Learn how to use async Rust --- we'll only mention async Rust when\n"
-"  covering traditional concurrency primitives. Please see [Asynchronous\n"
-"  Programming in Rust](https://rust-lang.github.io/async-book/) instead for\n"
-"  details on this topic.\n"
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to use async Rust --- we'll only mention async Rust when covering "
+"traditional concurrency primitives. Please see [Asynchronous Programming in "
+"Rust](https://rust-lang.github.io/async-book/) instead for details on this "
+"topic."
 msgstr ""
-"* Aprender  cómo usar Rust asincrónico —solo mencionaremos Rust async cuando\n"
-"cubramos las primitivas de concurrencia tradicional. Por favor ver [Asynchronous\n"
-"  Programming in Rust](https://rust-lang.github.io/async-book/) para más detalles.\n"
-"* Aprender como escribir macros, en cambio por favor ver [Capítulo 19.5  en el Libro de\n"
-"Rust](https://doc.rust-lang.org/book/ch19-06-macros.html) y [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
+"Aprender  cómo usar Rust asincrónico —solo mencionaremos Rust async cuando "
+"cubramos las primitivas de concurrencia tradicional. Por favor ver "
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/) "
+"para más detalles."
+
+#: src/welcome.md:33
+msgid ""
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+msgstr ""
+"Aprender como escribir macros, en cambio por favor ver [Capítulo 19.5  en el "
+"Libro de Rust](https://doc.rust-lang.org/book/ch19-06-macros.html) y [Rust "
+"by Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
 
 #: src/welcome.md:37
-msgid "## Assumptions"
-msgstr "## Suposiciones"
+msgid "Assumptions"
+msgstr "Suposiciones"
 
 #: src/welcome.md:39
 msgid ""
-"The course assumes that you already know how to program. Rust is a statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to better\n"
-"explain or contrast the Rust approach."
+"The course assumes that you already know how to program. Rust is a "
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
-"El curso asume que ya sabes programar. Rust es un lenguaje de tipado estático y \n"
-"algunas veces trataremos comparaciones con C y C++ para explicar mejor o\n"
-"contrastar la aproximación de Rust."
+"El curso asume que ya sabes programar. Rust es un lenguaje de tipado "
+"estático y  algunas veces trataremos comparaciones con C y C++ para explicar "
+"mejor o contrastar la aproximación de Rust."
 
 #: src/welcome.md:43
 msgid ""
-"If you know how to program in a dynamically typed language such as Python or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
-"Si sabes como programar en un lenguaje de tapado dinámico como Python o\n"
+"Si sabes como programar en un lenguaje de tapado dinámico como Python o "
 "JavaScript, también podrás seguir el contenido a lo largo del curso."
-
-#: src/welcome.md:46 src/cargo/rust-ecosystem.md:19 src/cargo/code-samples.md:22
-#: src/cargo/running-locally.md:68 src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8 src/why-rust/modern.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/slices.md:18
-#: src/basic-syntax/string-slices.md:25 src/basic-syntax/functions.md:33
-#: src/basic-syntax/functions-interlude.md:25 src/exercises/day-1/morning.md:9
-#: src/exercises/day-1/for-loops.md:90 src/basic-syntax/variables.md:15
-#: src/basic-syntax/type-inference.md:24 src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27 src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums/variant-payloads.md:33 src/methods.md:28
-#: src/pattern-matching/destructuring-enums.md:33 src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:29 src/control-flow/if-let-expressions.md:19
-#: src/control-flow/while-let-expressions.md:25 src/control-flow/match-expressions.md:25
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35 src/std/hashmap.md:36
-#: src/std/box.md:32 src/std/box-recursive.md:31 src/std/rc.md:29 src/modules.md:26
-#: src/modules/visibility.md:37 src/modules/filesystem.md:24 src/exercises/day-2/afternoon.md:5
-#: src/traits.md:39 src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/operators.md:24 src/traits/drop.md:32 src/traits/default.md:38
-#: src/generics/methods.md:23 src/generics/trait-bounds.md:33 src/generics/impl-trait.md:22
-#: src/generics/closures.md:23 src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:48 src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37 src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26 src/unsafe/raw-pointers.md:24
-#: src/unsafe/mutable-static-variables.md:30 src/unsafe/unions.md:19
-#: src/unsafe/writing-unsafe-functions.md:31 src/unsafe/extern-functions.md:19
-#: src/unsafe/unsafe-traits.md:28 src/exercises/day-3/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/channels.md:25 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/example.md:21 src/concurrency/send-sync.md:18
-#: src/concurrency/send-sync/sync.md:12 src/exercises/day-4/morning.md:10
-#: src/android/interoperability/with-c/rust.md:81 src/exercises/day-4/afternoon.md:10
-msgid "<details>"
-msgstr "<details>"
 
 #: src/welcome.md:48
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
-"information to the slides. This could be key points which the instructor should\n"
-"cover as well as answers to typical questions which come up in class."
+"This is an example of a _speaker note_. We will use these to add additional "
+"information to the slides. This could be key points which the instructor "
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
-"Este es un ejemplo de _nota del speaker_. Usaremos esto para agregar información \n"
-"adicional a las diapositivas. Esto puede ser el punto clave en el cual el instructor podría\n"
-"cubrir respuestas a preguntas comunes."
-
-#: src/welcome.md:52 src/cargo/rust-ecosystem.md:67 src/cargo/code-samples.md:35
-#: src/cargo/running-locally.md:74 src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:36 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22 src/why-rust/modern.md:66
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:28
-#: src/basic-syntax/slices.md:36 src/basic-syntax/functions.md:54 src/exercises/day-1/morning.md:28
-#: src/exercises/day-1/for-loops.md:95 src/basic-syntax/variables.md:20
-#: src/basic-syntax/type-inference.md:48 src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/borrowing.md:51
-#: src/ownership/shared-unique-borrows.md:29 src/ownership/lifetimes-function-calls.md:60
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:103 src/structs.md:41
-#: src/enums/variant-payloads.md:41 src/enums/sizes.md:136 src/methods/example.md:53
-#: src/pattern-matching/destructuring-enums.md:39 src/pattern-matching/destructuring-arrays.md:46
-#: src/exercises/day-2/morning.md:15 src/exercises/day-2/points-polygons.md:125
-#: src/control-flow/if-let-expressions.md:26 src/control-flow/for-expressions.md:29
-#: src/control-flow/loop-expressions.md:27 src/std.md:31 src/std/option-result.md:25
-#: src/std/string.md:33 src/std/vec.md:49 src/std/hashmap.md:66 src/std/rc.md:66 src/modules.md:32
-#: src/modules/visibility.md:48 src/modules/filesystem.md:53 src/exercises/day-2/afternoon.md:11
-#: src/traits.md:54 src/traits/from-iterator.md:26 src/traits/operators.md:38 src/traits/drop.md:42
-#: src/traits/default.md:47 src/generics/methods.md:31 src/generics/closures.md:38
-#: src/exercises/day-3/morning.md:11 src/error-handling/try-operator.md:55
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45 src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32 src/unsafe/raw-pointers.md:42
-#: src/unsafe/mutable-static-variables.md:35 src/unsafe/unions.md:28
-#: src/unsafe/writing-unsafe-functions.md:38 src/unsafe/extern-functions.md:28
-#: src/unsafe/unsafe-traits.md:37 src/exercises/day-3/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/channels.md:32 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/example.md:60 src/concurrency/send-sync/sync.md:18
-#: src/exercises/day-4/morning.md:16 src/android/interoperability/with-c/rust.md:86
-#: src/exercises/day-4/afternoon.md:15
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# Ejecutar el Curso"
+"Este es un ejemplo de _nota del speaker_. Usaremos esto para agregar "
+"información  adicional a las diapositivas. Esto puede ser el punto clave en "
+"el cual el instructor podría cubrir respuestas a preguntas comunes."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> Esta página es para el instructor del curso."
+msgid "This page is for the course instructor."
+msgstr "Esta página es para el instructor del curso."
 
 #: src/running-the-course.md:5
 msgid ""
-"Here is a bit of background information about how we've been running the course\n"
-"internally at Google."
+"Here is a bit of background information about how we've been running the "
+"course internally at Google."
 msgstr ""
-"Aquí hay un poco de información de fondo acerca de como nosotros hemos llevado a cabo el curso\n"
-"Internamente en Google."
+"Aquí hay un poco de información de fondo acerca de como nosotros hemos "
+"llevado a cabo el curso Internamente en Google."
 
 #: src/running-the-course.md:8
 msgid "To run the course, you need to:"
@@ -997,290 +933,309 @@ msgstr "Para hacer el curso, necesitas:"
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker notes\n"
-"   on some of the pages to help highlight the key points (please help us by\n"
-"   contributing more speaker notes!). You should make sure to open the speaker\n"
-"   notes in a popup (click the link with a little arrow next to \"Speaker\n"
-"   Notes\"). This way you have a clean screen to present to the class."
+"Make yourself familiar with the course material. We've included speaker "
+"notes on some of the pages to help highlight the key points (please help us "
+"by contributing more speaker notes!). You should make sure to open the "
+"speaker notes in a popup (click the link with a little arrow next to "
+"\"Speaker Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. Estar familiarizado con el material del curso. Incluimos notas para el orador\n"
-"en algunas páginas para ayudar a destacar algunos puntos clave (por favor ayúdanos \n"
-"sumando con más notas!). Deberías estar seguro de abrir notas en un popup (click en el \n"
-"link con una pequeña flecha al lado de \"Speaker Notes\"). De esta manera tendrás\n"
-"la pantalla limpia para los oyentes de la clase."
+"Estar familiarizado con el material del curso. Incluimos notas para el "
+"orador en algunas páginas para ayudar a destacar algunos puntos clave (por "
+"favor ayúdanos  sumando con más notas!). Deberías estar seguro de abrir "
+"notas en un popup (click en el  link con una pequeña flecha al lado de "
+"\"Speaker Notes\"). De esta manera tendrás la pantalla limpia para los "
+"oyentes de la clase."
 
 #: src/running-the-course.md:16
 msgid ""
-"2. Decide on the dates. Since the course is large, we recommend that you\n"
-"   schedule the four days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them process\n"
-"   all the information we give them."
+"Decide on the dates. Since the course is large, we recommend that you "
+"schedule the four days over two weeks. Course participants have said that "
+"they find it helpful to have a gap in the course since it helps them process "
+"all the information we give them."
 msgstr ""
-"2. Determina las fechas. Debido que el curso es largo, recomendamos que\n"
-"planifiques un calendario de cuatro días en dos semanas. Los participantes del curso \n"
-"deben encontrar útil tener un espacio en el curso ya que ayuda a procesar\n"
-"toda la información que daremos."
+"Determina las fechas. Debido que el curso es largo, recomendamos que "
+"planifiques un calendario de cuatro días en dos semanas. Los participantes "
+"del curso  deben encontrar útil tener un espacio en el curso ya que ayuda a "
+"procesar toda la información que daremos."
 
 #: src/running-the-course.md:21
 msgid ""
-"3. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-20 people. That's small enough that people are comfortable\n"
-"   asking questions --- it's also small enough that one instructor will have\n"
-"   time to answer the questions."
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-20 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions."
 msgstr ""
-"3. Encuentra un lugar grande lo suficiente para los participantes. Recomendamos una \n"
-"clase del tamaño de 15-20 personas. Es lo mínimo necesario para estar cómodos \n"
-"respondiendo preguntas ---y también para que un instructor tenga tiempo \n"
-"para responder las preguntas."
+"Encuentra un lugar grande lo suficiente para los participantes. Recomendamos "
+"una  clase del tamaño de 15-20 personas. Es lo mínimo necesario para estar "
+"cómodos  respondiendo preguntas ---y también para que un instructor tenga "
+"tiempo  para responder las preguntas."
 
 #: src/running-the-course.md:26
 msgid ""
-"4. On the day of your course, show up to the room a little early to set things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on your\n"
-"   laptop (see the [installation instructions][5]). This ensures optimal performance with no lag "
-"as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them."
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
 msgstr ""
-"4. En el día del curso, llega al lugar antes para tener las cosas listas.\n"
-"   Recomendamos hacer la presentación usando directamente `mdbook serve` corriendo en tu\n"
-"   notebook (vea la [instrucción de instalación][5]). Esto asegura la mejor performance si lag al cambiar de página.\n"
-"   Usar tu laptop te permitirá corregir errores tipográficos que tú o los participantes encuentren en el curso."
+"En el día del curso, llega al lugar antes para tener las cosas listas. "
+"Recomendamos hacer la presentación usando directamente `mdbook serve` "
+"corriendo en tu notebook (vea la [instrucción de instalación](https://github."
+"com/google/comprehensive-rust#building)). Esto asegura la mejor performance "
+"si lag al cambiar de página. Usar tu laptop te permitirá corregir errores "
+"tipográficos que tú o los participantes encuentren en el curso."
 
 #: src/running-the-course.md:32
 msgid ""
-"5. Let people solve the exercises by themselves or in small groups. Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. When\n"
-"   you see that several people have the same problem, call it out to the class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Let people solve the exercises by themselves or in small groups. Make sure "
+"to ask people if they're stuck or if there is anything you can help with. "
+"When you see that several people have the same problem, call it out to the "
+"class and offer a solution, e.g., by showing people where to find the "
+"relevant information in the standard library."
 msgstr ""
-"5. Permite a las personas resolver los ejercicios ellos mismos o en grupos pequeños. Asegúrate de\n"
-"   preguntar a las personas si están trabadas o si hay algo en que puedas ayudarlos. Cuando\n"
-"   Veas varias personas tienen el mismo problema, háblalo con todos y ofrece una solución, por ejemplo, mostrando a las personas dónde encontrar información de librerías estándar."
+"Permite a las personas resolver los ejercicios ellos mismos o en grupos "
+"pequeños. Asegúrate de preguntar a las personas si están trabadas o si hay "
+"algo en que puedas ayudarlos. Cuando Veas varias personas tienen el mismo "
+"problema, háblalo con todos y ofrece una solución, por ejemplo, mostrando a "
+"las personas dónde encontrar información de librerías estándar."
 
 #: src/running-the-course.md:38
 msgid ""
-"6. If you don't skip the Android specific parts on Day 4, you will need an [AOSP\n"
-"   checkout][1]. Make a checkout of the [course repository][2] on the same\n"
-"   machine and move the `src/android/` directory into the root of your AOSP\n"
-"   checkout. This will ensure that the Android build system sees the\n"
-"   `Android.bp` files in `src/android/`."
+"If you don't skip the Android specific parts on Day 4, you will need an "
+"[AOSP checkout](https://source.android.com/docs/setup/download/downloading). "
+"Make a checkout of the [course repository](https://github.com/google/"
+"comprehensive-rust) on the same machine and move the `src/android/` "
+"directory into the root of your AOSP checkout. This will ensure that the "
+"Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"6. Si no saltas la parte del Día 4 específica de Android, necesitarás un [AOSP\n"
-"   checkout][1]. Haz un checkout del [repositorio del curso][2] en la misma\n"
-"   Máquina y moviendo el directorio `src/android/` a la raíz de tu archivos AOSP de ‘Android.bp’ en `src/android/`."
+"Si no saltas la parte del Día 4 específica de Android, necesitarás un [AOSP "
+"checkout](https://source.android.com/docs/setup/download/downloading). Haz "
+"un checkout del [repositorio del curso](https://github.com/google/"
+"comprehensive-rust) en la misma Máquina y moviendo el directorio `src/"
+"android/` a la raíz de tu archivos AOSP de ‘Android.bp’ en `src/android/`."
 
 #: src/running-the-course.md:44
 msgid ""
-"   Ensure that `adb sync` works with your emulator or real device and pre-build\n"
-"   all Android examples using `src/android/build_all.sh`. Read the script to see\n"
-"   the commands it runs and make sure they work when you run them by hand."
+"Ensure that `adb sync` works with your emulator or real device and pre-build "
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"   Asegúrate que `adb sync` funciona con tu emulador o en un dispositivo físico y haz pre-build\n"
-"   en todos los ejemplos de Android usando `src/android/build_all.sh`. Lee el script para ver\n"
-"   los comandos que corren y asegúrate que funcionan cuando lo corres a mano."
+"Asegúrate que `adb sync` funciona con tu emulador o en un dispositivo físico "
+"y haz pre-build en todos los ejemplos de Android usando `src/android/"
+"build_all.sh`. Lee el script para ver los comandos que corren y asegúrate "
+"que funcionan cuando lo corres a mano."
 
 #: src/running-the-course.md:48
 msgid ""
-"That is all, good luck running the course! We hope it will be as much fun for\n"
-"you as it has been for us!"
+"That is all, good luck running the course! We hope it will be as much fun "
+"for you as it has been for us!"
 msgstr ""
-"Esto es todo, buena suerte haciendo el curso! Esperamos que hacerlo sea tan placentero para\n"
-"ti como lo fue para nosotros!"
+"Esto es todo, buena suerte haciendo el curso! Esperamos que hacerlo sea tan "
+"placentero para ti como lo fue para nosotros!"
 
 #: src/running-the-course.md:51
 msgid ""
-"Please [provide feedback][3] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][4]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"Por favor luego [proporciona comentarios][3] para que podamos mejorar el curso.\n"
-"Nos encantaría saber cómo fue y qué podríamos hacer mejor.\n"
-"Los estudiantes también son bienvenidos para que [nos envíen feedback][4]!"
-
-#: src/running-the-course.md:55
-msgid ""
-"[1]: https://source.android.com/docs/setup/download/downloading\n"
-"[2]: https://github.com/google/comprehensive-rust\n"
-"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
-"[4]: https://github.com/google/comprehensive-rust/discussions/100\n"
-"[5]: https://github.com/google/comprehensive-rust#building"
-msgstr ""
-"[1]: https://source.android.com/docs/setup/download/downloading\n"
-"[2]: https://github.com/google/comprehensive-rust\n"
-"[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
-"[4]: https://github.com/google/comprehensive-rust/discussions/100\n"
-"[5]: https://github.com/google/comprehensive-rust#building"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# Estructura del Curso"
+"Por favor luego [proporciona comentarios](https://github.com/google/"
+"comprehensive-rust/discussions/86) para que podamos mejorar el curso. Nos "
+"encantaría saber cómo fue y qué podríamos hacer mejor. Los estudiantes "
+"también son bienvenidos para que [nos envíen feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "Este curso es acelerado y cubre muchos temas:"
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust.\n"
-"* Day 4: Concurrency in Rust and interoperability with other languages"
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "Día 1: Rust Básico, propiedad y chequeo de préstamos."
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
 msgstr ""
-"* Día 1: Rust Básico, propiedad y chequeo de préstamos.\n"
-"* Día 2: Tipos de datos compuestos, coincidencia de patrones, la librería estándar.\n"
-"* Día 3: Traits y Genéricos, manejo de errores, testing, Rust no seguro.\n"
-"* Día 4: Concurrencia en Rust e interoperatiblidad con otros lenguajes"
+"Día 2: Tipos de datos compuestos, coincidencia de patrones, la librería "
+"estándar."
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr "Día 3: Traits y Genéricos, manejo de errores, testing, Rust no seguro."
+
+#: src/running-the-course/course-structure.md:10
+msgid "Day 4: Concurrency in Rust and interoperability with other languages"
+msgstr "Día 4: Concurrencia en Rust e interoperatiblidad con otros lenguajes"
 
 #: src/running-the-course/course-structure.md:12
 msgid ""
-"> **Exercise for Day 4:** Do you interface with some C/C++ code in your project\n"
-"> which we could attempt to move to Rust? The fewer dependencies the better.\n"
-"> Parsing code would be ideal."
+"**Exercise for Day 4:** Do you interface with some C/C++ code in your "
+"project which we could attempt to move to Rust? The fewer dependencies the "
+"better. Parsing code would be ideal."
 msgstr ""
-"> **Ejecicio del Día 4:** Comunicarte con alegan código C/C++ en tu proyecto\n"
-"> que podrías migrar a Rust? Con menos dependencias es lo mejor.\n"
-"> Parsear el código sería lo ideal."
+"**Ejecicio del Día 4:** Comunicarte con alegan código C/C++ en tu proyecto "
+"que podrías migrar a Rust? Con menos dependencias es lo mejor. Parsear el "
+"código sería lo ideal."
 
 #: src/running-the-course/course-structure.md:16
-msgid "## Format"
-msgstr "## Formato"
+msgid "Format"
+msgstr "Formato"
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
-"El curso tiene la intención de ser muy interactivo y recomendamos dejar que las preguntas lleven a "
-"explorar Rust!"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# Atajos de Teclado"
+"El curso tiene la intención de ser muy interactivo y recomendamos dejar que "
+"las preguntas lleven a explorar Rust!"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Tenemos varios atajos de teclados útiles en mdBook:"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Arrow-Left</kbd>: Navigar a la página anterior.\n"
-"* <kbd>Arrow-Right</kbd>: Navigar a la página siguiente.\n"
-"* <kbd>Ctrl + Enter</kbd>: Ejecuta el código de ejemplo seleccionado.\n"
-"* <kbd>s</kbd>: Activa la barra de búsqueda."
+msgid "Arrow-Left"
+msgstr "Arrow-Left"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# Traducción"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr ": Navigar a la página anterior."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Arrow-Right"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr ": Navigar a la página siguiente."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr ": Ejecuta el código de ejemplo seleccionado."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr ": Activa la barra de búsqueda."
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
 msgstr ""
-"El curso ha sido traducido a otros lenguajes por una serie de maravillosos\n"
+"El curso ha sido traducido a otros lenguajes por una serie de maravillosos "
 "voluntarios:"
 
 #: src/running-the-course/translations.md:6
+#, fuzzy
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
 msgstr ""
-"* [Brazilian Portuguese][pt-BR] por [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] por [@keispace], [@jiyongp] and [@jooyunghan].\n"
-"* [Spanish][es] por [@wfranck]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"por [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
+
+#: src/running-the-course/translations.md:7
+#, fuzzy
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
+msgstr ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) por [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan).\n"
+"\n"
+"[Spanish](https://google.github.io/comprehensive-rust/es/) por [@wfranck]"
+"(https://github.com/wfranck)."
 
 #: src/running-the-course/translations.md:9
-msgid "Use the language picker in the top-right corner to switch between languages."
+msgid ""
+"Use the language picker in the top-right corner to switch between languages."
 msgstr ""
-"Selecciona el lenguaje en el globo en la esquina superior derecha para cambiar entre lenguajes."
+"Selecciona el lenguaje en el globo en la esquina superior derecha para "
+"cambiar entre lenguajes."
 
 #: src/running-the-course/translations.md:11
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"Si gustas contribuir con traducciones, por favor revisa [nuestras instrucciones] para \n"
-"saber cómo. Las traducciones son coordinadas en el [issue tracker]."
-
-#: src/running-the-course/translations.md:14
-msgid ""
-"[pt-BR]: https://google.github.io/comprehensive-rust/pt-BR/\n"
-"[ko]: https://google.github.io/comprehensive-rust/ko/\n"
-"[@rastringer]: https://github.com/rastringer\n"
-"[@hugojacob]: https://github.com/hugojacob\n"
-"[@keispace]: https://github.com/keispace\n"
-"[@jiyongp]: https://github.com/jiyongp\n"
-"[@jooyunghan]: https://github.com/jooyunghan\n"
-"[our instructions]: https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md\n"
-"[issue tracker]: https://github.com/google/comprehensive-rust/issues/282"
-msgstr ""
-"[es]: https://google.github.io/comprehensive-rust/es/\n"
-"[pt-BR]: https://google.github.io/comprehensive-rust/pt-BR/\n"
-"[ko]: https://google.github.io/comprehensive-rust/ko/\n"
-"[@wfranck]: https://github.com/wfranck\n"
-"[@rastringer]: https://github.com/rastringer\n"
-"[@hugojacob]: https://github.com/hugojacob\n"
-"[@keispace]: https://github.com/keispace\n"
-"[@jiyongp]: https://github.com/jiyongp\n"
-"[@jooyunghan]: https://github.com/jooyunghan\n"
-"[our instructions]: https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md\n"
-"[issue tracker]: https://github.com/google/comprehensive-rust/issues/282"
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# Usando Cargo"
+"Si gustas contribuir con traducciones, por favor revisa \\[nuestras "
+"instrucciones\\] para  saber cómo. Las traducciones son coordinadas en el "
+"[issue tracker](https://github.com/google/comprehensive-rust/issues/282)."
 
 #: src/cargo.md:3
 msgid ""
-"When you start reading about Rust, you will soon meet [Cargo](https://doc.rust-lang.org/cargo/), "
-"the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want to\n"
-"give a brief overview of what Cargo is and how it fits into the wider ecosystem\n"
-"and how it fits into this training."
+"When you start reading about Rust, you will soon meet [Cargo](https://doc."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
-"Cuando comienzas a leer acerca de Rust, descubrirás [Cargo](https://doc.rust-lang.org/cargo/), la herramienta estándar\n"
-"Usada en el ecosistema Rust para construir y correr aplicaciones Rust. Aquí queremos\n"
-"Dar una breve reseña de qué es Cargo y cómo forma parte del amplio ecosistema y\n"
-"como encaja en este curso."
+"Cuando comienzas a leer acerca de Rust, descubrirás [Cargo](https://doc.rust-"
+"lang.org/cargo/), la herramienta estándar Usada en el ecosistema Rust para "
+"construir y correr aplicaciones Rust. Aquí queremos Dar una breve reseña de "
+"qué es Cargo y cómo forma parte del amplio ecosistema y como encaja en este "
+"curso."
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## Instalación"
+msgid "Installation"
+msgstr "Instalación"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (Recomendado)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (Recomendado)"
 
 #: src/cargo.md:12
 msgid ""
-"You can follow the instructions to install cargo and rust compiler, among other standard ecosystem "
-"tools with the [rustup][3] tool, which is maintained by the Rust Foundation."
-msgstr "Puedes seguir las instrucciones para instalar cargo y el compilador de Rust, además de otras herramientas estándar con la herramienta [rustup][3], que es mantenida por la Fundación Rust."
+"You can follow the instructions to install cargo and rust compiler, among "
+"other standard ecosystem tools with the [rustup](https://rustup.rs/) tool, "
+"which is maintained by the Rust Foundation."
+msgstr ""
+"Puedes seguir las instrucciones para instalar cargo y el compilador de Rust, "
+"además de otras herramientas estándar con la herramienta [rustup](https://"
+"rust-analyzer.github.io/), que es mantenida por la Fundación Rust."
 
 #: src/cargo.md:14
 msgid ""
-"Along with cargo and rustc, Rustup will install itself as a command line utility that you can use "
-"to install/switch toolchains, setup cross compilation, etc."
-msgstr "Con cargo y rustc, Rustup por sí mismo se instalará como una utilidad de línea de comando que puedes usar para instalar/cambiar entre herramientas, configurar compilaciones cruzadas, etc."
+"Along with cargo and rustc, Rustup will install itself as a command line "
+"utility that you can use to install/switch toolchains, setup cross "
+"compilation, etc."
+msgstr ""
+"Con cargo y rustc, Rustup por sí mismo se instalará como una utilidad de "
+"línea de comando que puedes usar para instalar/cambiar entre herramientas, "
+"configurar compilaciones cruzadas, etc."
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### Package Managers"
+msgid "Package Managers"
+msgstr "Package Managers"
 
 #: src/cargo.md:18
-msgid "#### Debian"
+msgid "Debian"
 msgstr ""
 
 #: src/cargo.md:20
-msgid "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust formatter][6] with"
-msgstr "En Debian/Ubuntu, puedes instalar Cargo, el código fuente de Rust y el [Rust formatter][6] con"
+msgid ""
+"On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
+"formatter](https://github.com/rust-lang/rustfmt) with"
+msgstr ""
+"En Debian/Ubuntu, puedes instalar Cargo, el código fuente de Rust y el [Rust "
+"formatter](https://github.com/rust-lang/rustfmt) con"
 
 #: src/cargo.md:22
 msgid ""
@@ -1291,210 +1246,225 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow [rust-analyzer](https://rust-analyzer.github.io/) to jump to "
+"the definitions. We suggest using [VS Code](https://code.visualstudio.com/) "
+"to edit the code (but any LSP compatible editor works)."
 msgstr ""
-"Esto permitirá a [rust-analyzer][1] saltar a las definiciones. Sugerimos usar\n"
-"[VS Code][2] para editar código (pero cualquier editor LSP compatible funcionará)."
+"Esto permitirá a \\[rust-analyzer\\]\\[1\\] saltar a las definiciones. "
+"Sugerimos usar [VS Code](https://code.visualstudio.com/) para editar código "
+"(pero cualquier editor LSP compatible funcionará)."
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do their own analysis but "
-"have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take "
-"note that as of January 2023 debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"A algunos colegas también les gusta usar IDEs [JetBrains][4], que hacen su propio análisis y tienen diferentes ventajas. Si prefieres usarlos, puedes instalar el [Rust Plugin].\n"
-"Por favor tén en cuenta que a Enero 2023 el debugging solo funciona en la versión CLion de JetBrains IDEA."
-
-#: src/cargo.md:31
-msgid ""
-"[1]: https://rust-analyzer.github.io/\n"
-"[2]: https://code.visualstudio.com/\n"
-"[3]: https://rustup.rs/\n"
-"[4]: https://www.jetbrains.com/clion/\n"
-"[5]: https://www.jetbrains.com/rust/\n"
-"[6]: https://github.com/rust-lang/rustfmt"
-msgstr ""
+"A algunos colegas también les gusta usar IDEs [JetBrains](https://www."
+"jetbrains.com/clion/), que hacen su propio análisis y tienen diferentes "
+"ventajas. Si prefieres usarlos, puedes instalar el \\[Rust Plugin\\]. Por "
+"favor tén en cuenta que a Enero 2023 el debugging solo funciona en la "
+"versión CLion de JetBrains IDEA."
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# El Ecosistema Rust"
+msgid "The Rust Ecosystem"
+msgstr "El Ecosistema Rust"
 
 #: src/cargo/rust-ecosystem.md:3
-msgid "The Rust ecosystem consists of a number of tools, of which the main ones are:"
-msgstr "El ecosistema Rust consiste en un número de herramientas, entre las cuales contamos como principales:"
+msgid ""
+"The Rust ecosystem consists of a number of tools, of which the main ones are:"
+msgstr ""
+"El ecosistema Rust consiste en un número de herramientas, entre las cuales "
+"contamos como principales:"
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and other\n"
-"  intermediate formats."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc`: el compilador Rustque cambia archivos`.rs` a binarios y a otros\n"
-"  formatos intermedios."
+"`rustc`: el compilador Rustque cambia archivos`.rs` a binarios y a otros "
+"formatos intermedios."
 
 #: src/cargo/rust-ecosystem.md:8
 msgid ""
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests."
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
 msgstr ""
-"* `cargo`: la herramienta de manejo y build de Rust. Cargo sabe como \n"
-"descargar dependencias guardadas en <https://crates.io> y enviará ellas a\n"
-"`rustc` cuando arme tu proyecto. Cargo también trae incluida una herramienta de test \n"
-"que es usada para ejecutar test unitarios."
+"`cargo`: la herramienta de manejo y build de Rust. Cargo sabe como  "
+"descargar dependencias guardadas en <https://crates.io> y enviará ellas a "
+"`rustc` cuando arme tu proyecto. Cargo también trae incluida una herramienta "
+"de test  que es usada para ejecutar test unitarios."
 
 #: src/cargo/rust-ecosystem.md:13
 msgid ""
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and `rustup`\n"
-"  will let you switch between them as needed."
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
 msgstr ""
-"* `rustup`: es la herramienta Rust para hacer instalaciones y actualizaciones. Esta herramienta es "
-"usada para\n"
-"Instalar y actualizar `rustc` y `cargo` cuando salen nuevas versiones de Rust.\n"
-"Además, `rustup` también puede descargar documentación para las librerías estándar.\n"
-"Puedes tener múltiples versiones de Rust instaladas al mismo tiempo y `rustup`\n"
-"te dejará cambiar entre ellas cuando lo necesites."
+"`rustup`: es la herramienta Rust para hacer instalaciones y actualizaciones. "
+"Esta herramienta es usada para Instalar y actualizar `rustc` y `cargo` "
+"cuando salen nuevas versiones de Rust. Además, `rustup` también puede "
+"descargar documentación para las librerías estándar. Puedes tener múltiples "
+"versiones de Rust instaladas al mismo tiempo y `rustup` te dejará cambiar "
+"entre ellas cuando lo necesites."
 
-#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25 src/hello-world/small-example.md:27
-#: src/why-rust/runtime.md:10 src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:30
-#: src/error-handling/try-operator.md:50 src/error-handling/converting-error-types-example.md:50
-#: src/concurrency/threads.md:30
+#: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
+#: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
+#: src/why-rust/modern.md:21 src/basic-syntax/compound-types.md:30
+#: src/error-handling/try-operator.md:50
+#: src/error-handling/converting-error-types-example.md:50
+#: src/concurrency/threads.md:30 src/pattern-matching/destructuring-enums.md:35
 msgid "Key points:"
 msgstr "Puntos clave:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality."
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust tiene un programa de lanzamientos rápidos con una nueva versión \n"
-"cada seis semanas. Cada nuevo lanzamiento será retrocompatible con \n"
-"viejas versiones --- además que agregan nueva funcionalidad."
+"Rust tiene un programa de lanzamientos rápidos con una nueva versión  cada "
+"seis semanas. Cada nuevo lanzamiento será retrocompatible con  viejas "
+"versiones --- además que agregan nueva funcionalidad."
 
 #: src/cargo/rust-ecosystem.md:27
-msgid "* There are three release channels: \"stable\", \"beta\", and \"nightly\"."
-msgstr "* Para las raleases tenemos tres canales: \"estable\", \"beta\", y \"nightly\"."
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr ""
+"Para las raleases tenemos tres canales: \"estable\", \"beta\", y \"nightly\"."
 
 #: src/cargo/rust-ecosystem.md:29
 msgid ""
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks."
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
 msgstr ""
-"* Nuevas características se testean en \"nightly\" y \"beta\" pasa a \n"
+"Nuevas características se testean en \"nightly\" y \"beta\" pasa a  "
 "\"restable\" cada seis semanas."
 
 #: src/cargo/rust-ecosystem.md:32
 msgid ""
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018."
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
 msgstr ""
-"* Rust también tiene [ediciones]: la edición actual es Rust 2021. Las ediciones anteriores fueron "
-"Rust 2015 y Rust 2018."
+"Rust también tiene [ediciones](https://doc.rust-lang.org/edition-guide/): la "
+"edición actual es Rust 2021. Las ediciones anteriores fueron Rust 2015 y "
+"Rust 2018."
 
 #: src/cargo/rust-ecosystem.md:35
 msgid ""
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language."
-msgstr "  * Las ediciones nuevas introducen cambios al lenguaje que no son retrocompatibles."
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr ""
+"Las ediciones nuevas introducen cambios al lenguaje que no son "
+"retrocompatibles."
 
 #: src/cargo/rust-ecosystem.md:38
 msgid ""
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file."
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
 msgstr ""
-"  Para prevenir romper el código, se elige la versión: seleccionas la edición\n"
-"    para tu paquete vía el archivo `Cargo.toml`."
+"Para prevenir romper el código, se elige la versión: seleccionas la edición "
+"para tu paquete vía el archivo `Cargo.toml`."
 
 #: src/cargo/rust-ecosystem.md:41
 msgid ""
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions."
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
 msgstr ""
-"  * Para evitar dividir los ecosistemas, los compiladores de Rust pueden mezclar código\n"
-"    escrito para diferentes ediciones."
+"Para evitar dividir los ecosistemas, los compiladores de Rust pueden mezclar "
+"código escrito para diferentes ediciones."
 
 #: src/cargo/rust-ecosystem.md:44
 msgid ""
-"  * Mention that it is quite rare to ever use the compiler directly not through `cargo` (most "
-"users never do)."
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
 msgstr ""
-"  * Hay que decir que es raro necesitar usar el compilador directamente y no a travez de `cargo` "
-"(la mayoría de los usuarios jamás lo hace)."
+"Hay que decir que es raro necesitar usar el compilador directamente y no a "
+"travez de `cargo` (la mayoría de los usuarios jamás lo hace)."
 
 #: src/cargo/rust-ecosystem.md:46
 msgid ""
-"  * It might be worth alluding that Cargo itself is an extremely powerful and comprehensive tool.  "
-"It is capable of many advanced features including but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as [cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
 msgstr ""
-"  * Vale la pena mencionar que Cargo en sí es una herramienta extremadamente poderosa e integral.  "
-"Es capaz de hacer muchas cosas avanzadas y no limitadas a: \n"
-"      * Estructura del proyecto/package \n"
-"      * [workspaces] \n"
-"      * Manejo/Caché de Dependencias de Desarrollo y de Runtime \n"
-"      * [build scripting] \n"
-"      * [instalación global] \n"
-"      * También es extensible con plugins de subcomandos (como es [cargo clippy]). \n"
-"  * Lee más en el [Libro Oficial de Cargo]"
+"Vale la pena mencionar que Cargo en sí es una herramienta extremadamente "
+"poderosa e integral.  Es capaz de hacer muchas cosas avanzadas y no "
+"limitadas a: "
 
-#: src/cargo/rust-ecosystem.md:55
-msgid "[editions]: https://doc.rust-lang.org/edition-guide/"
-msgstr "[ediciones]: https://doc.rust-lang.org/edition-guide/"
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "Estructura del proyecto/package "
 
-#: src/cargo/rust-ecosystem.md:57
-msgid "[workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
 msgstr ""
+"[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html) "
 
-#: src/cargo/rust-ecosystem.md:59
-msgid "[build scripting]: https://doc.rust-lang.org/cargo/reference/build-scripts.html"
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr "Manejo/Caché de Dependencias de Desarrollo y de Runtime "
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
 msgstr ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html) "
 
-#: src/cargo/rust-ecosystem.md:61
-msgid "[global installation]: https://doc.rust-lang.org/cargo/commands/cargo-install.html"
-msgstr "[instalación global]: https://doc.rust-lang.org/cargo/commands/cargo-install.html"
-
-#: src/cargo/rust-ecosystem.md:63
-msgid "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
 msgstr ""
+"[instalación global](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html) "
 
-#: src/cargo/rust-ecosystem.md:65
-msgid "[official Cargo Book]: https://doc.rust-lang.org/cargo/"
-msgstr "[Libro Oficial de Cargo]: https://doc.rust-lang.org/cargo/"
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"También es extensible con plugins de subcomandos (como es [cargo clippy]"
+"(https://github.com/rust-lang/rust-clippy)). "
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr ""
+"Lee más en el [Libro Oficial de Cargo](https://doc.rust-lang.org/cargo/)"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# Códigos de Ejemplo en Esta Práctica"
+msgid "Code Samples in This Training"
+msgstr "Códigos de Ejemplo en Esta Práctica"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through examples\n"
-"which can be executed through your browser. This makes the setup much easier and\n"
-"ensures a consistent experience for everyone."
+"For this training, we will mostly explore the Rust language through examples "
+"which can be executed through your browser. This makes the setup much easier "
+"and ensures a consistent experience for everyone."
 msgstr ""
-"Para esta práctica, principalmente exploraremos el lenguaje Rust a través de ejemplos\n"
-"los cuales pueden correrse en el browser. Esto hace la configuración mucho mas fácil y\n"
-"asegura consistencia en la experiencia de cada uno."
+"Para esta práctica, principalmente exploraremos el lenguaje Rust a través de "
+"ejemplos los cuales pueden correrse en el browser. Esto hace la "
+"configuración mucho mas fácil y asegura consistencia en la experiencia de "
+"cada uno."
 
 #: src/cargo/code-samples.md:7
 msgid ""
-"Installing Cargo is still encouraged: it will make it easier for you to do the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how to\n"
-"work with dependencies and for that you need Cargo."
+"Installing Cargo is still encouraged: it will make it easier for you to do "
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
-"Claro que se sigue recomendando instalar Cargo: será más fácil para tí para hacer los\n"
-"ejercicios. En el último día haremos un ejercicio el cual te mostrará cómo\n"
-"Trabajar con dependencias y para eso necesitarás Cargo."
+"Claro que se sigue recomendando instalar Cargo: será más fácil para tí para "
+"hacer los ejercicios. En el último día haremos un ejercicio el cual te "
+"mostrará cómo Trabajar con dependencias y para eso necesitarás Cargo."
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -1515,54 +1485,57 @@ msgstr ""
 "```"
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in the\n"
-"text box."
-msgstr "Puedes usar <kbd>Ctrl + Enter</kbd> paraejecutar código cuando se hace foco en el text box."
+msgid "You can use "
+msgstr "Puedes usar "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr " paraejecutar código cuando se hace foco en el text box."
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
-"La mayor parte de los ejemplos son editables como se muestra arriba. Unos pocos ejemplos\n"
-"no son editables por varias razones:"
+"La mayor parte de los ejemplos son editables como se muestra arriba. Unos "
+"pocos ejemplos no son editables por varias razones:"
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* En los bloques de código embebido no pueden ejecutarse test unitarios. Copia y pega el código y "
-"ábrelo en un entorno real para comprobar test unitarios."
+"En los bloques de código embebido no pueden ejecutarse test unitarios. Copia "
+"y pega el código y ábrelo en un entorno real para comprobar test unitarios."
 
 #: src/cargo/code-samples.md:30
 msgid ""
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
 msgstr ""
-"* Los espacios de código embebido pierden su estado en el momento que navegas\n"
-"fuera de la página! Eta es la razón por la que los estudiantes deben\n"
-"resolver los ejercicios usando una instalación local de Rust o vía esos\n"
+"Los espacios de código embebido pierden su estado en el momento que navegas "
+"fuera de la página! Eta es la razón por la que los estudiantes deben "
+"resolver los ejercicios usando una instalación local de Rust o vía esos "
 "espacios de trabajo con código."
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# Correr Código Localmente con Cargo"
+msgid "Running Code Locally with Cargo"
+msgstr "Correr Código Localmente con Cargo"
 
 #: src/cargo/running-locally.md:3
 msgid ""
-"If you want to experiment with the code on your own system, then you will need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"If you want to experiment with the code on your own system, then you will "
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
-"Si quieres probar código en tu computadora, primero necesitarás \n"
-"instalar Rust. Para esto sigue las [instrucciones en el Libro de \n"
-"Rust][1]. Esto debería darte para usar un `rustc` y `cargo`. Al tiempo que se \n"
-"escribe esto, la última versión estable de Rust tiene estos números de versiones:"
+"Si quieres probar código en tu computadora, primero necesitarás  instalar "
+"Rust. Para esto sigue las [instrucciones en el Libro de  Rust](https://doc."
+"rust-lang.org/book/ch01-01-installation.html). Esto debería darte para usar "
+"un `rustc` y `cargo`. Al tiempo que se  escribe esto, la última versión "
+"estable de Rust tiene estos números de versiones:"
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -1576,163 +1549,189 @@ msgstr ""
 
 #: src/cargo/running-locally.md:15
 msgid ""
-"With this is in place, then follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this is in place, then follow these steps to build a Rust binary from "
+"one of the examples in this training:"
 msgstr ""
-"Con esto en su lugar, sigue las instrucciones para hacer un build de los binarios de Rust desde\n"
-"uno de los ejemplos de este curso:"
+"Con esto en su lugar, sigue las instrucciones para hacer un build de los "
+"binarios de Rust desde uno de los ejemplos de este curso:"
 
 #: src/cargo/running-locally.md:18
-msgid "1. Click the \"Copy to clipboard\" button on the example you want to copy."
-msgstr "1. Click sobre el botón \"Copy to clipboard\" en el ejemplo que quieres copiar."
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr ""
+"Click sobre el botón \"Copy to clipboard\" en el ejemplo que quieres copiar."
 
 #: src/cargo/running-locally.md:20
-msgid "2. Use `cargo new exercise` to create a new `exercise/` directory for your code:"
-msgstr "2. Usa `cargo new ejercicio` para crear una nueva carpeta `ejercicio/` para tu código:"
+msgid ""
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr ""
+"Usa `cargo new ejercicio` para crear una nueva carpeta `ejercicio/` para tu "
+"código:"
 
 #: src/cargo/running-locally.md:22
 msgid ""
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```\n"
+"```"
 msgstr ""
-"    ```shell\n"
-"    $ cargo new ejercicio\n"
-"         Created binary (application) `ejercicio` package\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo new ejercicio\n"
+"     Created binary (application) `ejercicio` package\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:27
-msgid "3. Navigate into `exercise/` and use `cargo run` to build and run your binary:"
-msgstr "3. Ve hasta `ejercicio/` y usa `cargo run` para hacer build y ejecutar tus binarios:"
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr ""
+"Ve hasta `ejercicio/` y usa `cargo run` para hacer build y ejecutar tus "
+"binarios:"
 
 #: src/cargo/running-locally.md:29
 msgid ""
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```\n"
+"```"
 msgstr ""
-"    ```shell\n"
-"    $ cd ejercicio\n"
-"    $ cargo run\n"
-"       Compiling ejercicio v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hola Mundo!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cd ejercicio\n"
+"$ cargo run\n"
+"   Compiling ejercicio v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hola Mundo!\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:38
 msgid ""
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look like"
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
 msgstr ""
-"4. Reemplaza el código base en `src/main.rs` con tu propio código. Por\n"
-"   ejemplo, usando el ejemplo de la página anterior, haciendo que `src/main.rs` quede como"
+"Reemplaza el código base en `src/main.rs` con tu propio código. Por ejemplo, "
+"usando el ejemplo de la página anterior, haciendo que `src/main.rs` quede "
+"como"
 
 #: src/cargo/running-locally.md:41
 msgid ""
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```"
+"```\n"
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```\n"
+"```"
 msgstr ""
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Modifícame!\");\n"
-"    }\n"
-"    ```"
+"```\n"
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Modifícame!\");\n"
+"}\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:47
-msgid "5. Use `cargo run` to build and run your updated binary:"
-msgstr "5. Usa `cargo run` para hacer build y ejecutar tu binario actualizado:"
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr "Usa `cargo run` para hacer build y ejecutar tu binario actualizado:"
 
 #: src/cargo/running-locally.md:49
 msgid ""
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```\n"
+"```"
 msgstr ""
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling ejercicio v0.1.0 (/home/mgeisler/tmp/ejercicio)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/ejercicio`\n"
-"    Modifícame!\n"
-"    ```"
+"```\n"
+"```shell\n"
+"$ cargo run\n"
+"   Compiling ejercicio v0.1.0 (/home/mgeisler/tmp/ejercicio)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/ejercicio`\n"
+"Modifícame!\n"
+"```\n"
+"```"
 
 #: src/cargo/running-locally.md:57
 msgid ""
-"6. Use `cargo check` to quickly check your project for errors, use `cargo build`\n"
-"   to compile it without running it. You will find the output in `target/debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an optimized\n"
-"   release build in `target/release/`."
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
 msgstr ""
-"6. Usa `cargo check` para controlar rápido tu proyecto por errores, usando `cargo build`\n"
-"para compilar sin ejecutarlo. Podrás encontrar el resultado en `target/debug/`\n"
-"para un debug de build normal. Usa `cargo build —release` para hacer un release\n"
-"optimizado del build en `target/release/`."
+"Usa `cargo check` para controlar rápido tu proyecto por errores, usando "
+"`cargo build` para compilar sin ejecutarlo. Podrás encontrar el resultado en "
+"`target/debug/` para un debug de build normal. Usa `cargo build —release` "
+"para hacer un release optimizado del build en `target/release/`."
 
 #: src/cargo/running-locally.md:62
 msgid ""
-"7. You can add dependencies for your project by editing `Cargo.toml`. When you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
 msgstr ""
-"7. Puedes agregar dependencias para trueque proyecto editando `cargo.toml`. Cuando corres\n"
-"el comando `cargo`, automáticamente descargará y compilará las dependencias faltantes."
-
-#: src/cargo/running-locally.md:66
-msgid "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
-msgstr ""
+"Puedes agregar dependencias para trueque proyecto editando `cargo.toml`. "
+"Cuando corres el comando `cargo`, automáticamente descargará y compilará las "
+"dependencias faltantes."
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
-"Trata de motivar a los participantes de la clase para instalar Cargo y usar un editor\n"
-"de código local. Esto hará que tu vida sea más fácil porque tienen un IDE normal."
+"Trata de motivar a los participantes de la clase para instalar Cargo y usar "
+"un editor de código local. Esto hará que tu vida sea más fácil porque tienen "
+"un IDE normal."
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# Bienvenido al Día 1"
+msgid "Welcome to Day 1"
+msgstr "Bienvenido al Día 1"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
-msgstr "Este es el primer día de Comprehensive Rust. Cubririemos un montón de contenido:"
+msgstr ""
+"Este es el primer día de Comprehensive Rust. Cubririemos un montón de "
+"contenido:"
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* sintaxis básica Rust: variables, scalar y tipos compuestos, enums, structs, \n"
-"  references, funciones, y métodos."
+"sintaxis básica Rust: variables, scalar y tipos compuestos, enums, structs,  "
+"references, funciones, y métodos."
 
 #: src/welcome-day-1.md:9
 msgid ""
-"* Memory management: stack vs heap, manual memory management, scope-based memory\n"
-"  management, and garbage collection."
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
 msgstr ""
-"* Manejo de memoria: stack vs heap, manejo manual de memoria, manejo de memoria \n"
-"scope-based, y garaje collection."
+"Manejo de memoria: stack vs heap, manejo manual de memoria, manejo de "
+"memoria  scope-based, y garaje collection."
 
 #: src/welcome-day-1.md:12
-msgid "* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
-msgstr "* Ownsership: manejo semántico, copiar y clonar, préstamos, y tiempo de vida."
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"Ownsership: manejo semántico, copiar y clonar, préstamos, y tiempo de vida."
 
 #: src/welcome-day-1.md:16
 msgid "Please remind the students that:"
@@ -1740,127 +1739,164 @@ msgstr "Por favor recuerda a los estudiantes que:"
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i.e.,\n"
-"    keep the related to how Rust does things vs some other language. It can be\n"
-"    hard to find the right balance, but err on the side of allowing discussions\n"
-"    since they engage people much more than one-way communication.\n"
-"* The questions will likely mean that we talk about things ahead of the slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
 msgstr ""
-"* Deben hacer las preguntas cuando surgen, no las guarden hasta el final.\n"
-"* La clase tiene la intención de ser interactiva y también para abrir espacios de debate.\n"
-"  * Como instructor, debes intentar llevar discusiones relevantes, por ejemplo,\n"
-"    mantener relación de cómo Rust hace las cosas vs otros lenguajes. Puede\n"
-"    costar encontrar un balance adecuado, pero permite llevar un debate\n"
-"    que atraiga la atención de la gente por sobre un discurso unidireccional.\n"
-"* Las preguntas deberían ser sobre cosas acerca del contenido de los slides.\n"
-"    * Esto está perfecto! Repetir es una parte importante del aprendizaje. Recuerda\n"
-"    que los slides son solo un soporte y tienes libertad de saltearlos cuando quieras."
+"Deben hacer las preguntas cuando surgen, no las guarden hasta el final."
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr ""
+"La clase tiene la intención de ser interactiva y también para abrir espacios "
+"de debate."
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the related to how Rust does things vs some other language. It can be "
+"hard to find the right balance, but err on the side of allowing discussions "
+"since they engage people much more than one-way communication."
+msgstr ""
+"Como instructor, debes intentar llevar discusiones relevantes, por ejemplo, "
+"mantener relación de cómo Rust hace las cosas vs otros lenguajes. Puede "
+"costar encontrar un balance adecuado, pero permite llevar un debate que "
+"atraiga la atención de la gente por sobre un discurso unidireccional."
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+"Las preguntas deberían ser sobre cosas acerca del contenido de los slides."
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"Esto está perfecto! Repetir es una parte importante del aprendizaje. "
+"Recuerda que los slides son solo un soporte y tienes libertad de saltearlos "
+"cuando quieras."
 
 #: src/welcome-day-1.md:29
 msgid ""
-"The idea for the first day is to show _just enough_ of Rust to be able to speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major feature\n"
-"and we should show students this right away."
+"The idea for the first day is to show _just enough_ of Rust to be able to "
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
-"La idea del primer día es mostar _solo lo necesario_ de Rust para permitir hablar\n"
-"sobre el famoso borrow checker. La manera que Rust maneja la memoria es la principal "
-"característica\n"
-"y debemos mostrar a los estudiantes la manera correcta."
+"La idea del primer día es mostar _solo lo necesario_ de Rust para permitir "
+"hablar sobre el famoso borrow checker. La manera que Rust maneja la memoria "
+"es la principal característica y debemos mostrar a los estudiantes la manera "
+"correcta."
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
-"Si estás enseñando esto en una clase, es un buen lugar para repasar el\n"
+"Si estás enseñando esto en una clase, es un buen lugar para repasar el "
 "horario. Sugerimos dividir el día en dos partes (guiándose por los slides):"
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* Mañana: 9:00 to 12:00,\n"
-"* Tarde: 13:00 to 16:00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "Mañana: 9:00 to 12:00,"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "Tarde: 13:00 to 16:00."
 
 #: src/welcome-day-1.md:39
 msgid ""
-"You can of course adjust this as necessary. Please make sure to include breaks,\n"
-"we recommend a break every hour!"
+"You can of course adjust this as necessary. Please make sure to include "
+"breaks, we recommend a break every hour!"
 msgstr ""
-"Claro que puedes modificarlo si es necesario. Por favor asegúrate de incluir breaks,\n"
-"Recomendamos un break cada hora!"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# Qué es Rust?"
+"Claro que puedes modificarlo si es necesario. Por favor asegúrate de incluir "
+"breaks, Recomendamos un break cada hora!"
 
 #: src/welcome-day-1/what-is-rust.md:3
-msgid "Rust is a new programming language which had its [1.0 release in 2015][1]:"
-msgstr "Rust es un nuevo lenguaje que tiene su [release 1.0 en 2015][1]:"
+msgid ""
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
+msgstr ""
+"Rust es un nuevo lenguaje que tiene su [release 1.0 en 2015](https://blog."
+"rust-lang.org/2015/05/15/Rust-1.0.html):"
 
 #: src/welcome-day-1/what-is-rust.md:5
+msgid "Rust is a statically compiled language in a similar role as C++"
+msgstr "Rust es un lenguaje compilado estático similar a C++"
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` usa LLVM como backend."
+
+#: src/welcome-day-1/what-is-rust.md:7
 msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
 msgstr ""
-"* Rust es un lenguaje compilado estático similar a C++\n"
-"  * `rustc` usa LLVM como backend.\n"
-"* Rust soporta muchas [platformas y\n"
-"  arquitecturas](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
-"  * x86, ARM, WebAssembly, …\n"
-"  * Linux, Mac, Windows, …\n"
-"* Rust es usado en muchos dispositivos:\n"
-"  * firmware y boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+"Rust soporta muchas [platformas y arquitecturas](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, …"
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, …"
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rust es usado en muchos dispositivos:"
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "firmware y boot loaders,"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "smart displays,"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "mobile phones,"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "desktops,"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "servers."
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust encaja en el mismo área de C++:"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* Alta flexibilidad.\n"
-"* Alto nivel de control.\n"
-"* Puede usarse en dispositivos limitados como teléfonos celulares\n"
-"* No tiene runtime o garbage colector.\n"
-"* Se enfoca en la confiabilidad y seguridad sin sacrificar performance."
+msgid "High flexibility."
+msgstr "Alta flexibilidad."
 
-#: src/welcome-day-1/what-is-rust.md:31
-msgid "[1]: https://blog.rust-lang.org/2015/05/15/Rust-1.0.html"
-msgstr ""
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "Alto nivel de control."
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr "# Hola Mundo!"
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr "Puede usarse en dispositivos limitados como teléfonos celulares"
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "No tiene runtime o garbage colector."
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr "Se enfoca en la confiabilidad y seguridad sin sacrificar performance."
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr "Vayamos al ejemplo de programa Rust más simple, un clásico Hola Mundo:"
 
@@ -1883,52 +1919,58 @@ msgid "What you see:"
 msgstr "Qué ves:"
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "Funciones agregadas con `fn`."
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "Bloques delimitados por llaves como en C y C++."
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "La función `main` que es el punto de entrada al programa."
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr "Rust tiene macros limpios, `println!` es un ejemplo de esto."
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
 msgstr ""
-"* Funciones agregadas con `fn`.\n"
-"* Bloques delimitados por llaves como en C y C++.\n"
-"* La función `main` que es el punto de entrada al programa.\n"
-"* Rust tiene macros limpios, `println!` es un ejemplo de esto.\n"
-"* Strings Rust son codificados UTF-8 y pueden contener cualquier carácter Unicode."
+"Strings Rust son codificados UTF-8 y pueden contener cualquier carácter "
+"Unicode."
 
 #: src/hello-world.md:22
 msgid ""
-"This slide tries to make the students comfortable with Rust code. They will see\n"
-"a ton of it over the next four days so we start small with something familiar."
+"This slide tries to make the students comfortable with Rust code. They will "
+"see a ton of it over the next four days so we start small with something "
+"familiar."
 msgstr ""
-"Este slide intenta que los estudiantes se sientan cómodos con código Rust. Verán\n"
-"mucho de esto los siguientes cuatro días ase que empezaremos con algo rápido y familiar."
+"Este slide intenta que los estudiantes se sientan cómodos con código Rust. "
+"Verán mucho de esto los siguientes cuatro días ase que empezaremos con algo "
+"rápido y familiar."
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rust es similar a otros lenguajes tradicionales como C/C++/Java. Es\n"
-"imperativo (no funcional) y no trata de reinventar cosas a menos que\n"
-"sea absolutamente necesario."
+"Rust es similar a otros lenguajes tradicionales como C/C++/Java. Es "
+"imperativo (no funcional) y no trata de reinventar cosas a menos que sea "
+"absolutamente necesario."
 
 #: src/hello-world.md:31
-msgid "* Rust is modern with full support for things like Unicode."
-msgstr "*Rust es moderno con soporte completo para cosas como Unicode."
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "\\*Rust es moderno con soporte completo para cosas como Unicode."
 
 #: src/hello-world.md:33
 msgid ""
-"* Rust uses macros for situations where you want to have a variable number of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
 msgstr ""
-"* Rust usa macros para situaciones donde quieres tener una variable number o\n"
+"Rust usa macros para situaciones donde quieres tener una variable number o "
 "arguments (no funciones [overloading](basic-syntax/functions-interlude.md))."
-
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# Ejemplo Rápido"
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -1970,404 +2012,490 @@ msgstr ""
 
 #: src/hello-world/small-example.md:23
 msgid ""
-"The code implements the Collatz conjecture: it is believed that the loop will\n"
-"always end, but this is not yet proved. Edit the code and play with different\n"
-"inputs."
+"The code implements the Collatz conjecture: it is believed that the loop "
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
-"El código implementa la conjetura de Collatz: que dice que un bucle\n"
-"siempre termina, pero no siempre se prueba. Modifica el código y prueba\n"
-"diferentes inputs."
+"El código implementa la conjetura de Collatz: que dice que un bucle siempre "
+"termina, pero no siempre se prueba. Modifica el código y prueba diferentes "
+"inputs."
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer overflow."
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* Explica que todas las variables son de tipo estáticas. Prueba removiendo `i32` para\n"
-"que se dispare la inferencia de tipos. Intenta con `i8` y ejecuta un overflow de integer."
+"Explica que todas las variables son de tipo estáticas. Prueba removiendo "
+"`i32` para que se dispare la inferencia de tipos. Intenta con `i8` y ejecuta "
+"un overflow de integer."
 
 #: src/hello-world/small-example.md:32
-msgid "* Change `let mut x` to `let x`, discuss the compiler error."
-msgstr "* Cambia `let mut x` a `let x`, debatan sobre el error de compilación."
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "Cambia `let mut x` a `let x`, debatan sobre el error de compilación."
 
 #: src/hello-world/small-example.md:34
 msgid ""
-"* Show how `print!` gives a compilation error if the arguments don't match the\n"
-"  format string."
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
 msgstr ""
-"* Muestra como `print!` da un error de compilación si el argumento no es el mismo del\n"
-"formato del string."
+"Muestra como `print!` da un error de compilación si el argumento no es el "
+"mismo del formato del string."
 
 #: src/hello-world/small-example.md:37
 msgid ""
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable."
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
 msgstr ""
-"* Muestra como necesitas usar `{}` como placeholder si quieres imprimir una\n"
-"  expresión la cual es más compleja que una simple variable."
+"Muestra como necesitas usar `{}` como placeholder si quieres imprimir una "
+"expresión la cual es más compleja que una simple variable."
 
 #: src/hello-world/small-example.md:40
 msgid ""
-"* Show the students the standard library, show them how to search for `std::fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that the\n"
-"  students become familiar with searching in the standard library."
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
 msgstr ""
-"* Muestra a los estudiantes la librería estándar, muestra como buscar con `std::fmt`\n"
-"  la cual quiene reglas de un mini-lenguaje de formato. Es importante que los\n"
-"  estudiantes se familiaricen con las búsquedas en la librería estándar."
-
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# ¿Por qué Rust?"
+"Muestra a los estudiantes la librería estándar, muestra como buscar con "
+"`std::fmt` la cual quiene reglas de un mini-lenguaje de formato. Es "
+"importante que los estudiantes se familiaricen con las búsquedas en la "
+"librería estándar."
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Algunas características únicas de Rust:"
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* Tiempo de compilación Garantizado.\n"
-"* Garantía en Tiempo de Ejecución.\n"
-"* Características Modernas."
+msgid "Compile time memory safety."
+msgstr "Tiempo de compilación Garantizado."
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "Garantía en Tiempo de Ejecución."
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "Características Modernas."
 
 #: src/why-rust.md:11
 msgid ""
-"Make sure to ask the class which languages they have experience with. Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Make sure to ask the class which languages they have experience with. "
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
-"Asegúrate de preguntar a la clase en qué lenguajes tienen experiencia. Dependiendo\n"
-"de la respuesta puedes destacar diferentes características de Rust:"
+"Asegúrate de preguntar a la clase en qué lenguajes tienen experiencia. "
+"Dependiendo de la respuesta puedes destacar diferentes características de "
+"Rust:"
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language with\n"
-"  constructs like pattern matching and built-in dependency management."
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* Experiencia con C o C++: Rust elimina todos los _runtime erorrs_\n"
-"vía el _borrow checker_. Puedes obtener misma performance de C y C++, pero no\n"
-"tienes errores con manejo de memoria no seguro. Además, tienes un lenguaje moderno con\n"
-"con constructores como patera matching y manejo de dependencias integrado."
+"Experiencia con C o C++: Rust elimina todos los _runtime erorrs_ vía el "
+"_borrow checker_. Puedes obtener misma performance de C y C++, pero no "
+"tienes errores con manejo de memoria no seguro. Además, tienes un lenguaje "
+"moderno con con constructores como patera matching y manejo de dependencias "
+"integrado."
 
 #: src/why-rust.md:19
 msgid ""
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory safety\n"
-"  as in those languages, plus a similar high-level language feeling. In addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
 msgstr ""
-"* Experiencia con Java, Go, Python, JavaScript…: Tienes el mismo manejo de memoria\n"
-"  seguro en esos lenguajes, más una sensación de performance similar a un lenguaje de alto nivel. "
-"Además\n"
-"  tienes la performance de C y C++ (sin garaje colector)\n"
-"  Así como acceso de bajo nivel a hardware (podrías necesitarlo)"
-
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# Tiempo de Compilación Garantizado"
+"Experiencia con Java, Go, Python, JavaScript…: Tienes el mismo manejo de "
+"memoria seguro en esos lenguajes, más una sensación de performance similar a "
+"un lenguaje de alto nivel. Además tienes la performance de C y C++ (sin "
+"garaje colector) Así como acceso de bajo nivel a hardware (podrías "
+"necesitarlo)"
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "Manejo de memoria estático en tiempo de compilación:"
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* No hay variables sin inicializar.\n"
-"* No hay memory leaks (_casi siempre_, ver notas).\n"
-"* No hay double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No puedes olvidar mutexes bloqueados.\n"
-"* No hay race-conditions por datos entre hilos.\n"
-"* No hay iteradores inválidos."
+msgid "No uninitialized variables."
+msgstr "No hay variables sin inicializar."
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "No hay memory leaks (_casi siempre_, ver notas)."
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "No hay double-frees."
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "No use-after-free."
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "No `NULL` pointers."
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "No puedes olvidar mutexes bloqueados."
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "No hay race-conditions por datos entre hilos."
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "No hay iteradores inválidos."
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
-msgstr ""
-"Es posible hacer memory learks en Rust (seguro). Algunos ejemplos\n"
-"son:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
+msgstr "Es posible hacer memory learks en Rust (seguro). Algunos ejemplos son:"
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can for use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can for use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* Puedes usar [`Box::leak`] para hacer un leak de un puntero. El uso de de esto puede\n"
-"ser para obtener variables inicializadas en tiempo de ejecución o modificando su tamaño.\n"
-"* Puedes usar [`std::mem::forget`] para hacer que el compilador \"olvide\" un valor (así no se corre el destructor).\n"
-"* También accidentalmente puedes crear un [ciclo de referencia] con `Rc` o `Arc`.\n"
-"* De hecho, algunos considerarán cargar datos infinitamente una colección un\n"
+"Puedes usar [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) para hacer un leak de un puntero. El uso de de esto puede "
+"ser para obtener variables inicializadas en tiempo de ejecución o "
+"modificando su tamaño."
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"Puedes usar [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) para hacer que el compilador \"olvide\" un valor (así no se corre el "
+"destructor)."
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"También accidentalmente puedes crear un [ciclo de referencia](https://doc."
+"rust-lang.org/book/ch15-06-reference-cycles.html) con `Rc` o `Arc`."
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"De hecho, algunos considerarán cargar datos infinitamente una colección un "
 "desbordamiento de memoria que Rust no protegerá."
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"Para el propósito de este curso, \"No memory leak\" debe entenderse\n"
-"como \"Ningún tipo de memory leak *accidental*\"."
-
-#: src/why-rust/compile-time.md:31
-msgid ""
-"[`Box::leak`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
-"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-"[reference cycle]: https://doc.rust-lang.org/book/ch15-06-reference-cycles.html"
-msgstr ""
-"[`Box::leak`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak\n"
-"[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-"[ciclo de referencia]: https://doc.rust-lang.org/book/ch15-06-reference-cycles.html"
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# Garantías en Tiempo de Ejecución"
+"Para el propósito de este curso, \"No memory leak\" debe entenderse como "
+"\"Ningún tipo de memory leak _accidental_\"."
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "Sin estados indefinidos en runtime:"
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
-msgstr ""
-"* Se verifican los límites de acceso a un Array.\n"
-"* Se define el overflow de Integer."
+msgid "Array access is bounds checked."
+msgstr "Se verifican los límites de acceso a un Array."
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
+msgstr "Se define el overflow de Integer."
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`)."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* El overflow en Integer es definido vía un flan en tiempo de compilación. Las opciones son\n"
-"alertas panic (un crash controlado del programa) o una semántica que lo envuelve. Por defecto, "
-"obtienes el alerta en modo depuración (`cargo build`) y envolviéndolo en el modo release (`cargo "
-"build —release`)."
+"El overflow en Integer es definido vía un flan en tiempo de compilación. Las "
+"opciones son alertas panic (un crash controlado del programa) o una "
+"semántica que lo envuelve. Por defecto, obtienes el alerta en modo "
+"depuración (`cargo build`) y envolviéndolo en el modo release (`cargo build —"
+"release`)."
 
 #: src/why-rust/runtime.md:17
 msgid ""
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
 msgstr ""
-"* El chequeo de límites no puede ser desactivado con el flag de compilador. Tampoco\n"
-"  puede deshabilitarse directamente usando `unsafe`. Sin embargo,\n"
-"  `unsafe` permite que llames a la función como `slice::get_unchecked`\n"
-"  que no brinda chequeos de límites."
-
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# Características Modernas"
+"El chequeo de límites no puede ser desactivado con el flag de compilador. "
+"Tampoco puede deshabilitarse directamente usando `unsafe`. Sin embargo, "
+"`unsafe` permite que llames a la función como `slice::get_unchecked` que no "
+"brinda chequeos de límites."
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
 msgstr "Rust está hecho con toda la experiencia ganada en 40 años."
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## Características del Lenguaje"
+msgid "Language Features"
+msgstr "Características del Lenguaje"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* Enums y pattern matching.\n"
-"* Genericos.\n"
-"* No overhead FFI.\n"
-"* Abstracciones Zero-cost."
+msgid "Enums and pattern matching."
+msgstr "Enums y pattern matching."
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "Genericos."
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "No overhead FFI."
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "Abstracciones Zero-cost."
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
-msgstr "## Herramientas"
+msgid "Tooling"
+msgstr "Herramientas"
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* Gran compilador de errores.\n"
-"* Manejador de Dependencias integrado.\n"
-"* Soporte de testing integrado.\n"
-"* Excelente soporte al Protocolo de Lenguaje de Servidor."
+msgid "Great compiler errors."
+msgstr "Gran compilador de errores."
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "Manejador de Dependencias integrado."
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "Soporte de testing integrado."
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "Excelente soporte al Protocolo de Lenguaje de Servidor."
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to 'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* Sin costo en abstracciones, similar a C++, quiere decir que no tienes que ‘pagar’\n"
-"  por tener un un lenguaje de alto nivel con memoria o CPU. Por ejemplo,\n"
-"  escribiendo un loop usando `for` debe resultar a bajo nivel\n"
-"  en una instrucción que usa `.iter().fold()`."
+"Sin costo en abstracciones, similar a C++, quiere decir que no tienes que "
+"‘pagar’ por tener un un lenguaje de alto nivel con memoria o CPU. Por "
+"ejemplo, escribiendo un loop usando `for` debe resultar a bajo nivel en una "
+"instrucción que usa `.iter().fold()`."
 
 #: src/why-rust/modern.md:28
 msgid ""
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`."
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
 msgstr ""
-"* Cabe mencionar que los enums de Rust son ‘Tipos de Datos Algebraicos’, también\n"
-"  conocidos como ‘tipos sumados’, los cuales permiten el tipo de sistema para expresas cosas como\n"
-"  `Option<T>` y `Result<T, E>`."
+"Cabe mencionar que los enums de Rust son ‘Tipos de Datos Algebraicos’, "
+"también conocidos como ‘tipos sumados’, los cuales permiten el tipo de "
+"sistema para expresas cosas como `Option<T>` y `Result<T, E>`."
 
 #: src/why-rust/modern.md:32
 msgid ""
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with _actionable_\n"
-"  feedback, ready to copy-paste into your code."
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
 msgstr ""
-"* Recuerda a las personas de leer los errores --- muchos programadores olvidan leer\n"
-"  la salida del compilador. El compilador de Rust es significativamente más\n"
-"  descriptivo que otros compiladores. Y frecuentemente provee un feedback\n"
-"  _para tomar acción_, con código listo para copiar y pegar."
+"Recuerda a las personas de leer los errores --- muchos programadores olvidan "
+"leer la salida del compilador. El compilador de Rust es significativamente "
+"más descriptivo que otros compiladores. Y frecuentemente provee un feedback "
+"_para tomar acción_, con código listo para copiar y pegar."
 
 #: src/why-rust/modern.md:37
 msgid ""
-"* The Rust standard library is small compared to languages like Java, Python,\n"
-"  and Go. Rust does not come with several things you might consider standard and\n"
-"  essential:"
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
 msgstr ""
-"* La librería estándar de Rust es pequeña comparada a otros lenguajes como Java, Python y Go.\n"
-"Rust no viene con varias cosas que puedes considerar estándar y\n"
-"esencial:"
+"La librería estándar de Rust es pequeña comparada a otros lenguajes como "
+"Java, Python y Go. Rust no viene con varias cosas que puedes considerar "
+"estándar y esencial:"
 
 #: src/why-rust/modern.md:41
-msgid ""
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json]."
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
 msgstr ""
-"  * un generador de número random, pero mira [rand].\n"
-"  * soporte para SSL o TLS, pero mira [rusttls].\n"
-"  * soporte para JSON, pero mira [serde_json]."
+"un generador de número random, pero mira [rand](https://docs.rs/rand/)."
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr "soporte para SSL o TLS, pero mira [rusttls](https://docs.rs/rustls/)."
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+"soporte para JSON, pero mira [serde_json](https://docs.rs/serde_json/)."
 
 #: src/why-rust/modern.md:45
+#, fuzzy
 msgid ""
-"  The reasoning behind this is that functionality in the standard library cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps there\n"
-"  isn't a single \"best solution\" for some of these things."
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
 msgstr ""
-"    Las razones detrás de esta funcionalidad es la librería estándar que no puede\n"
-"separarse, porque este tiene que ser muy estable. Para ejemplos de arriba, la comunidad\n"
-"Rust sigue trabajando en encontrar la mejor solución --- y por ejemplo no hay\n"
-"una única \"mejor solución\" para alguna de esas cosas."
+"```\n"
+"Las razones detrás de esta funcionalidad es la librería estándar que no "
+"puede\n"
+"```\n"
+"\n"
+"separarse, porque este tiene que ser muy estable. Para ejemplos de arriba, "
+"la comunidad Rust sigue trabajando en encontrar la mejor solución --- y por "
+"ejemplo no hay una única \"mejor solución\" para alguna de esas cosas."
 
 #: src/why-rust/modern.md:50
 msgid ""
-"  Rust comes with a built-in package manager in the form of Cargo and this makes\n"
-"  it trivial to download and compile third-party crates. A consequence of this\n"
-"  is that the standard library can be smaller."
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
 msgstr ""
-"  Rust trae incluido un package manager en la forma de Cargo y hace\n"
-"trivial descargar y compilador cosas autocontenidas. Como consecuencia\n"
-"la librería estándar puede ser pequeña."
+"Rust trae incluido un package manager en la forma de Cargo y hace trivial "
+"descargar y compilador cosas autocontenidas. Como consecuencia la librería "
+"estándar puede ser pequeña."
 
 #: src/why-rust/modern.md:54
 msgid ""
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
 msgstr ""
-"  Descubrir paquetes de terceros puede ser un problema. Sitios como\n"
-"  <https://lib.rs/> ayudará con esto permitiéndote comparar calidad de\n"
-"  paquetes para encontrar uno bueno y seguro.\n"
-"\n"
-"* [rust-analizer] es un LSP bien soportado e implementado usado en los \n"
-"  principales IDEs y editores."
+"Descubrir paquetes de terceros puede ser un problema. Sitios como <https://"
+"lib.rs/> ayudará con esto permitiéndote comparar calidad de paquetes para "
+"encontrar uno bueno y seguro."
 
-#: src/why-rust/modern.md:61
+#: src/why-rust/modern.md:58
 msgid ""
-"[rand]: https://docs.rs/rand/\n"
-"[rusttls]: https://docs.rs/rustls/\n"
-"[serde_json]: https://docs.rs/serde_json/\n"
-"[rust-analyzer]: https://rust-analyzer.github.io/"
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
 msgstr ""
-"[rand]: https://docs.rs/rand/\n"
-"[rusttls]: https://docs.rs/rustls/\n"
-"[serde_json]: https://docs.rs/serde_json/\n"
-"[rust-analyzer]: https://rust-analyzer.github.io/"
-
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
-msgstr "# Sintáxis Básica"
+"\\[rust-analizer\\] es un LSP bien soportado e implementado usado en los  "
+"principales IDEs y editores."
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr "Mucho de la sintaxis de Rust es parecido a C, C++ o Java:"
 
 #: src/basic-syntax.md:5
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "Bloques y ámbitos delimitados por llaves."
+
+#: src/basic-syntax.md:6
 msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"* Bloques y ámbitos delimitados por llaves.\n"
-"* Comentarios de línea que comienzan con `//`, bloques de comentarios delimitados por `/*…\n"
-"  */`.\n"
-"* Palabras claves como `if` y `while` funcionan igual.\n"
-"* Asignación de variables hechas con `=`, comparaciones con `==`."
+"Comentarios de línea que comienzan con `//`, bloques de comentarios "
+"delimitados por `/*… */`."
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
-msgstr "# Tipos Escalares"
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "Palabras claves como `if` y `while` funcionan igual."
 
-#: src/basic-syntax/scalar-types.md:3
-msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, `1_000`, "
-"`123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, `123`, "
-"`10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | `3.14`, `-10.0e20`, "
-"`2f32`    |\n"
-"| Strings                | `&str`                                     | `\"foo\"`, `r#\"\\\\"
-"\"#`            |\n"
-"| Unicode scalar values  | `char`                                     | `'a'`, `'α'`, "
-"`'∞'`           |\n"
-"| Byte strings           | `&[u8]`                                    | `b\"abc\"`, `br#\" \" "
-"\"#`         |\n"
-"| Booleans               | `bool`                                     | `true`, "
-"`false`               |"
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr "Asignación de variables hechas con `=`, comparaciones con `==`."
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Types"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `r#\"\\\\\"#`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Byte strings"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`&[u8]`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`b\"abc\"`, `br#\" \" \"#`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "Booleans"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`bool`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`true`, `false`"
 msgstr ""
 
 #: src/basic-syntax/scalar-types.md:13
@@ -2375,27 +2503,43 @@ msgid "The types have widths as follows:"
 msgstr "Los tipos tienen una capacidad así:"
 
 #: src/basic-syntax/scalar-types.md:15
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN`, and `fN` son _N_ bits de capacidad,"
+
+#: src/basic-syntax/scalar-types.md:16
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` y `usize` tienen el tamaño de un puntero,"
+
+#: src/basic-syntax/scalar-types.md:17
+msgid "`char` is 32 bit wide,"
+msgstr "`char` es 32 bit de grande,"
+
+#: src/basic-syntax/scalar-types.md:18
+msgid "`bool` is 8 bit wide."
+msgstr "`bool` es 8 bit de grande."
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
 msgstr ""
-"* `iN`, `uN`, and `fN` son _N_ bits de capacidad,\n"
-"* `isize` y `usize` tienen el tamaño de un puntero,\n"
-"* `char` es 32 bit de grande,\n"
-"* `bool` es 8 bit de grande."
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr "# Tipos Compuestos"
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr ""
 
-#: src/basic-syntax/compound-types.md:3
-msgid ""
-"|        | Types                         | Literals                          |\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          |\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... |"
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:8
@@ -2434,71 +2578,81 @@ msgstr ""
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that `[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
 msgstr ""
-"* Los Arrays tienen elementos del mismo tipo, `T`, y tamaño, `N` que es constante en compilación.\n"
-"  Nota que el tamaño del array es *parte del tipo*, lo que quiere decir que `[u8; 3]` y \n"
-"  `[u8; 4]`son considerados dos tipos diferentes."
+"Los Arrays tienen elementos del mismo tipo, `T`, y tamaño, `N` que es "
+"constante en compilación. Nota que el tamaño del array es _parte del tipo_, "
+"lo que quiere decir que `[u8; 3]` y  `[u8; 4]`son considerados dos tipos "
+"diferentes."
 
 #: src/basic-syntax/compound-types.md:38
-msgid "* We can use literals to assign values to arrays."
-msgstr "* Podemos usar literales para asignar valores a arreglos."
+msgid "We can use literals to assign values to arrays."
+msgstr "Podemos usar literales para asignar valores a arreglos."
 
 #: src/basic-syntax/compound-types.md:40
 msgid ""
-"* In the main function, the print statement asks for the debug implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after the\n"
-"  format string."
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
 msgstr ""
-"* En la función main, la palabra print pregunta por la implementación de debug con `?` para el "
-"formato de parámetro: `{}` que da una salida estándar, `{:?}`. También podemos usar `{a}` y `{a:?} "
-"sin especificar los valores luego del formato string."
+"En la función main, la palabra print pregunta por la implementación de debug "
+"con `?` para el formato de parámetro: `{}` que da una salida estándar, `{:?}"
+"`. También podemos usar `{a}` y \\`{a:?} sin especificar los valores luego "
+"del formato string."
 
 #: src/basic-syntax/compound-types.md:45
-msgid "* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be easier to read."
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
 msgstr ""
-"* Agregar `#`, por ejemplo `{a:#?}` invoca un formato para imprimir más lindo, más fácil de leer."
+"Agregar `#`, por ejemplo `{a:#?}` invoca un formato para imprimir más lindo, "
+"más fácil de leer."
 
 #: src/basic-syntax/compound-types.md:47
 msgid "Tuples:"
 msgstr "Tuplas:"
 
 #: src/basic-syntax/compound-types.md:49
-msgid "* Like arrays, tuples have a fixed length."
-msgstr "* Como los array, las duplas tienen un tamaño fijo."
+msgid "Like arrays, tuples have a fixed length."
+msgstr "Como los array, las duplas tienen un tamaño fijo."
 
 #: src/basic-syntax/compound-types.md:51
-msgid "* Tuples group together values of different types into a compound type."
-msgstr "* Las Tuplas es un grupo de valores con diferentes tipos formando un tipo compuesto."
+msgid "Tuples group together values of different types into a compound type."
+msgstr ""
+"Las Tuplas es un grupo de valores con diferentes tipos formando un tipo "
+"compuesto."
 
 #: src/basic-syntax/compound-types.md:53
 msgid ""
-"* Fields of a tuple can be accessed by the period and the index of the value, e.g. `t.0`, `t.1`."
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
 msgstr ""
-"* Los campos de una Tuplas se acceden con un punto y el índice del valor, por ejemplo: `t.0`, "
-"`t.1`."
+"Los campos de una Tuplas se acceden con un punto y el índice del valor, por "
+"ejemplo: `t.0`, `t.1`."
 
 #: src/basic-syntax/compound-types.md:55
 msgid ""
-"* The empty tuple `()` is also known as the \"unit type\". It is both a type, and\n"
-"  the only valid value of that type - that is to say both the type and its value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
 msgstr ""
-"* A una Tupla vacía `()` se la conoce también como \"unit type\". Ambos son tipos, y\n"
-"la única manera válida de valor de ese tipo es nombrar ambos tipos y sus valores\n"
-"que son expresados como `()`. Se usa para indicar, por ejemplo, que la función o\n"
-"expresión no devuelve valor, como veremos más adelante.\n"
-"    * Puedes pensar en este como un `void` de otros lenguajes de programación."
+"A una Tupla vacía `()` se la conoce también como \"unit type\". Ambos son "
+"tipos, y la única manera válida de valor de ese tipo es nombrar ambos tipos "
+"y sus valores que son expresados como `()`. Se usa para indicar, por "
+"ejemplo, que la función o expresión no devuelve valor, como veremos más "
+"adelante."
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
-msgstr "# Referencias"
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr ""
+"Puedes pensar en este como un `void` de otros lenguajes de programación."
 
 #: src/basic-syntax/references.md:3
 msgid "Like C++, Rust has references:"
@@ -2522,37 +2676,37 @@ msgstr "Algunos comentarios:"
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* Debemos referencias `ref_x` cuando lo asignamos, similar a los punteros de C o C++.\n"
-"* Rust puede auto-referencias en algunos casos, en particular cuando hace invoca \n"
-"métodos (intenta `ref_x.count_ones()`).\n"
-"* Las referencias se declaran como `mut` y pueden cambiar de valor."
+"Debemos referencias `ref_x` cuando lo asignamos, similar a los punteros de C "
+"o C++."
 
-#: src/basic-syntax/references.md:21
+#: src/basic-syntax/references.md:17
 msgid ""
-"<details>\n"
-"Key points:"
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
 msgstr ""
-"<details>\n"
-"Presta atención:"
+"Rust puede auto-referencias en algunos casos, en particular cuando hace "
+"invoca  métodos (intenta `ref_x.count_ones()`)."
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr "Las referencias se declaran como `mut` y pueden cambiar de valor."
 
 #: src/basic-syntax/references.md:24
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound to\n"
-"  different values, while the second represents a reference to a mutable value."
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
+"value."
 msgstr ""
-"* Asegúrate de poder diferenciar entre `let mut ref_x: &i32` y `let ref_x:\n"
-"  &mut i32`. El primero representa una referencia mutable que puede \n"
-"cambiar de valor, mientras que el segundo representa una referencia con un valor que puede cambiar."
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
-msgstr "# Referencias Colgantes"
+"Asegúrate de poder diferenciar entre `let mut ref_x: &i32` y `let ref_x: "
+"&mut i32`. El primero representa una referencia mutable que puede  cambiar "
+"de valor, mientras que el segundo representa una referencia con un valor que "
+"puede cambiar."
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -2573,19 +2727,21 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
+msgid "A reference is said to \"borrow\" the value it refers to."
 msgstr ""
-"* Se dice que una referencia \"toma prestado\" el valor al que se refiere.\n"
-"* Rust registra la vida de todas las referencias para asegurar que perduran lo necesario.\n"
-"* Hablaremos más de esto cuando veamos _ownership_."
+"Se dice que una referencia \"toma prestado\" el valor al que se refiere."
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
-msgstr "# Slices"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"Rust registra la vida de todas las referencias para asegurar que perduran lo "
+"necesario."
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr "Hablaremos más de esto cuando veamos _ownership_."
 
 #: src/basic-syntax/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
@@ -2596,73 +2752,246 @@ msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let a: [i32; 6] = [10, 20, 30, 40, 50, 60];\n"
-"    println!(\"a: {a:?}\");"
+"    println!(\"a: {a:?}\");\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/slices.md:10
 msgid ""
-"    let s: &[i32] = &a[2..4];\n"
-"    println!(\"s: {s:?}\");\n"
-"}\n"
+"```\n"
+"let s: &[i32] = &a[2..4];\n"
+"println!(\"s: {s:?}\");\n"
 "```"
 msgstr ""
 
-#: src/basic-syntax/slices.md:15
+#: src/basic-syntax/slices.md:12 src/basic-syntax/string-slices.md:17
+#: src/basic-syntax/methods.md:20
+#: src/exercises/day-1/implicit-conversions.md:16
+#: src/exercises/day-1/for-loops.md:35 src/exercises/day-1/for-loops.md:77
+#: src/basic-syntax/type-inference.md:21 src/basic-syntax/type-inference.md:43
+#: src/basic-syntax/scopes-shadowing.md:20
+#: src/ownership/shared-unique-borrows.md:20 src/std/rc.md:15
+#: src/exercises/day-1/book-library.md:74
+#: src/exercises/day-1/book-library.md:96
+#: src/exercises/day-1/iterators-and-ownership.md:31
+#: src/exercises/day-1/iterators-and-ownership.md:43
+#: src/exercises/day-1/iterators-and-ownership.md:80
+#: src/exercises/day-1/iterators-and-ownership.md:59
+#: src/exercises/day-1/iterators-and-ownership.md:100 src/structs.md:26
+#: src/enums/variant-payloads.md:30 src/enums/sizes.md:84
+#: src/enums/sizes.md:133 src/methods/example.md:30 src/pattern-matching.md:18
+#: src/exercises/day-2/health-statistics.md:47
+#: src/exercises/day-2/points-polygons.md:109
+#: src/control-flow/while-let-expressions.md:14
+#: src/control-flow/for-expressions.md:17 src/std/option-result.md:13
+#: src/std/string.md:19 src/std/vec.md:26 src/std/hashmap.md:33
+#: src/std/rc.md:63 src/modules/visibility.md:30
+#: src/exercises/day-2/strings-iterators.md:29
+#: src/exercises/day-2/solutions-afternoon.md:149
+#: src/exercises/day-2/strings-iterators.md:51 src/traits/iterator.md:20
+#: src/traits/read-write.md:20 src/traits/operators.md:15
+#: src/traits/default.md:34 src/generics/methods.md:15
+#: src/generics/trait-bounds.md:30 src/generics/closures.md:20
+#: src/exercises/day-3/simple-gui.md:35
+#: src/exercises/day-3/solutions-morning.md:36
+#: src/exercises/day-3/simple-gui.md:79
+#: src/exercises/day-3/solutions-morning.md:80
+#: src/exercises/day-3/simple-gui.md:90 src/exercises/day-3/simple-gui.md:100
+#: src/exercises/day-3/simple-gui.md:110 src/error-handling/try-operator.md:39
+#: src/testing/test-modules.md:23 src/unsafe/raw-pointers.md:21
+#: src/unsafe/mutable-static-variables.md:27
+#: src/unsafe/calling-unsafe-functions.md:23
+#: src/unsafe/writing-unsafe-functions.md:28
+#: src/exercises/day-3/safe-ffi-wrapper.md:54
+#: src/exercises/day-3/solutions-afternoon.md:48 src/concurrency/threads.md:21
+#: src/concurrency/scoped-threads.md:14 src/concurrency/scoped-threads.md:30
+#: src/concurrency/channels.md:22 src/concurrency/channels/unbounded.md:26
+#: src/concurrency/channels/bounded.md:26
+#: src/concurrency/shared_state/arc.md:22
+#: src/concurrency/shared_state/mutex.md:19
+#: src/concurrency/shared_state/example.md:18
+#: src/concurrency/shared_state/example.md:49
+#: src/exercises/day-4/dining-philosophers.md:44
+#: src/exercises/day-4/dining-philosophers.md:57
+#: src/exercises/day-4/link-checker.md:78 src/android/aidl/client.md:34
+#: src/android/interoperability/java.md:59
+#: src/exercises/day-1/solutions-morning.md:76
+#: src/exercises/day-1/solutions-afternoon.md:103
+#: src/exercises/day-1/solutions-afternoon.md:139
+#: src/exercises/day-1/solutions-afternoon.md:148
+#: src/exercises/day-1/solutions-afternoon.md:176
+#: src/exercises/day-2/solutions-morning.md:44
+#: src/exercises/day-2/solutions-morning.md:55
+#: src/exercises/day-2/solutions-morning.md:66
+#: src/exercises/day-2/solutions-morning.md:107
+#: src/exercises/day-2/solutions-morning.md:130
+#: src/exercises/day-2/solutions-afternoon.md:47
+#: src/exercises/day-2/solutions-afternoon.md:137
+#: src/exercises/day-3/solutions-morning.md:115
+#: src/exercises/day-3/solutions-morning.md:137
+#: src/exercises/day-3/solutions-morning.md:155
+#: src/exercises/day-4/solutions-morning.md:58
+#: src/exercises/day-4/solutions-morning.md:102
+msgid "}"
+msgstr "}"
+
+#: src/basic-syntax/slices.md:13 src/basic-syntax/string-slices.md:18
+#: src/basic-syntax/functions.md:31 src/basic-syntax/methods.md:28
+#: src/basic-syntax/functions-interlude.md:23
+#: src/exercises/day-1/implicit-conversions.md:17
+#: src/exercises/day-1/for-loops.md:36 src/exercises/day-1/for-loops.md:78
+#: src/basic-syntax/type-inference.md:22 src/basic-syntax/type-inference.md:44
+#: src/basic-syntax/static-and-const.md:25
+#: src/basic-syntax/static-and-const.md:39
+#: src/basic-syntax/scopes-shadowing.md:21 src/ownership.md:16
+#: src/ownership/moves-function-calls.md:16 src/ownership/copy-clone.md:28
+#: src/ownership/borrowing.md:20 src/ownership/shared-unique-borrows.md:21
+#: src/std/rc.md:16 src/ownership/lifetimes-function-calls.md:19
+#: src/exercises/day-1/book-library.md:97
+#: src/exercises/day-1/iterators-and-ownership.md:32
+#: src/exercises/day-1/iterators-and-ownership.md:44
+#: src/exercises/day-1/iterators-and-ownership.md:81
+#: src/exercises/day-1/iterators-and-ownership.md:60
+#: src/exercises/day-1/iterators-and-ownership.md:101 src/structs.md:27
+#: src/structs/tuple-structs.md:12 src/structs/tuple-structs.md:33
+#: src/traits/default.md:36 src/generics/trait-objects.md:86
+#: src/structs/field-shorthand.md:23 src/enums.md:29
+#: src/enums/variant-payloads.md:31 src/enums/sizes.md:35 src/enums/sizes.md:85
+#: src/enums/sizes.md:134 src/methods.md:26 src/methods/example.md:42
+#: src/pattern-matching.md:19 src/pattern-matching/destructuring-enums.md:27
+#: src/exercises/day-2/points-polygons.md:113 src/exercises/day-2/luhn.md:70
+#: src/control-flow/blocks.md:36 src/control-flow/while-let-expressions.md:15
+#: src/control-flow/for-expressions.md:18 src/std/option-result.md:14
+#: src/std/string.md:20 src/std/vec.md:27 src/std/hashmap.md:34
+#: src/std/box-recursive.md:16 src/std/box-niche.md:14 src/std/rc.md:64
+#: src/modules.md:24 src/modules/visibility.md:35
+#: src/exercises/day-2/strings-iterators.md:52 src/traits.md:37
+#: src/traits/deriving-traits.md:19 src/traits/default-methods.md:28
+#: src/traits/iterator.md:28 src/traits/read-write.md:21
+#: src/traits/read-write.md:40 src/traits/operators.md:22 src/traits/drop.md:30
+#: src/generics/data-types.md:17 src/generics/methods.md:21
+#: src/generics/trait-bounds.md:31 src/generics/impl-trait.md:17
+#: src/generics/closures.md:21 src/generics/monomorphization.md:29
+#: src/generics/trait-objects.md:16 src/generics/trait-objects.md:37
+#: src/exercises/day-3/simple-gui.md:121 src/exercises/day-3/simple-gui.md:133
+#: src/error-handling/panic-unwind.md:17 src/error-handling/result.md:23
+#: src/error-handling/try-operator.md:46
+#: src/error-handling/converting-error-types-example.md:46
+#: src/error-handling/deriving-error-enums.md:35
+#: src/error-handling/dynamic-errors.md:32
+#: src/error-handling/error-contexts.md:31 src/testing/test-modules.md:24
+#: src/unsafe/raw-pointers.md:22 src/unsafe/mutable-static-variables.md:11
+#: src/unsafe/mutable-static-variables.md:28 src/unsafe/unions.md:17
+#: src/unsafe/calling-unsafe-functions.md:28
+#: src/unsafe/writing-unsafe-functions.md:29 src/unsafe/extern-functions.md:17
+#: src/unsafe/unsafe-traits.md:26 src/exercises/day-3/safe-ffi-wrapper.md:93
+#: src/concurrency/threads.md:22 src/concurrency/scoped-threads.md:15
+#: src/concurrency/scoped-threads.md:31 src/concurrency/channels.md:23
+#: src/concurrency/channels/unbounded.md:27
+#: src/concurrency/channels/bounded.md:27
+#: src/concurrency/shared_state/arc.md:23
+#: src/concurrency/shared_state/mutex.md:20
+#: src/concurrency/shared_state/example.md:19
+#: src/exercises/day-4/dining-philosophers.md:58
+#: src/exercises/day-4/link-checker.md:88 src/android/build-rules/binary.md:25
+#: src/android/build-rules/library.md:46 src/android/build-rules/library.md:57
+#: src/android/aidl/interface.md:15 src/android/aidl/implementation.md:24
+#: src/android/aidl/server.md:26 src/android/aidl/client.md:35
+#: src/android/aidl/changing.md:14 src/android/logging.md:40
+#: src/android/interoperability/with-c.md:18
+#: src/android/interoperability/with-c/bindgen.md:17
+#: src/android/interoperability/with-c/bindgen.md:31
+#: src/android/interoperability/with-c/bindgen.md:96
+#: src/android/interoperability/with-c/rust.md:35
+#: src/android/interoperability/with-c/rust.md:60
+#: src/android/interoperability/java.md:60
+#: src/exercises/day-1/solutions-afternoon.md:177
+#: src/exercises/day-2/solutions-morning.md:234
+#: src/exercises/day-2/solutions-afternoon.md:175
+#: src/exercises/day-3/solutions-morning.md:168
+#: src/exercises/day-3/solutions-afternoon.md:118
+#: src/exercises/day-4/solutions-morning.md:103
 msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
+"```\n"
+"```"
 msgstr ""
-"* Slice toma prestado datos de un tipo _slice_.\n"
-"* Pregunta: ¿Qué pasa si modificas `a[3]`?"
+"```\n"
+"```"
+
+#: src/basic-syntax/slices.md:15
+msgid "Slices borrow data from the sliced type."
+msgstr "Slice toma prestado datos de un tipo _slice_."
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "Pregunta: ¿Qué pasa si modificas `a[3]`?"
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending indexes in brackets."
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
 msgstr ""
-"* Creamos un slice prestando `a` y especificando el comienzo y final de los índices entre "
-"corchetes."
+"Creamos un slice prestando `a` y especificando el comienzo y final de los "
+"índices entre corchetes."
 
 #: src/basic-syntax/slices.md:22
 msgid ""
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the starting index, "
-"meaning that `&a[0..a.len()]` and `&a[..a.len()]` are identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are identical."
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
 msgstr ""
-"* Si el slice empieza con índice 0, la sintaxis de rango de Rust nos permite borrar el índice del "
-"comienzo, generando que `&a[0..a.len()]` y `&a[..a.len()]` sean idénticos.\n"
-"\n"
-"* Lo mismo es para el último índice, así que `&a[2..a.len()]` y `&a[2..]` son lo mismo."
+"Si el slice empieza con índice 0, la sintaxis de rango de Rust nos permite "
+"borrar el índice del comienzo, generando que `&a[0..a.len()]` y `&a[..a."
+"len()]` sean idénticos."
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"Lo mismo es para el último índice, así que `&a[2..a.len()]` y `&a[2..]` son "
+"lo mismo."
 
 #: src/basic-syntax/slices.md:26
-msgid "* To easily create a slice of the full array, we can therefore use `&a[..]`."
-msgstr "* Para crear fácil un slice de un array completo, podemos usar &a[..]."
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+"Para crear fácil un slice de un array completo, podemos usar &a\\[..\\]."
 
 #: src/basic-syntax/slices.md:28
 msgid ""
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` (`&[i32]`) no longer "
-"mentions the array length. This allows us to perform computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to remain 'alive' (in scope) "
-"for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, but the answer is that "
-"for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read the data from both `a` "
-"and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
 msgstr ""
-"* `s` es una referencia a un slice de `i32`s. Tener en cuenta que en el tipo de `s` (`&[i32]`) no "
-"se menciona el tamaño del array. Esto permite realizar cálculos en silces de diferentes tamaños.\n"
-"* Los silbes siempre se prestan de otro objeto. En este ejemplo, `a` tiene que permanecer "
-"\"viva\" (en el scope) durante, al menos, el tiempo que dure nuestro segmento.\n"
-"* La pregunta sobre modificar `a[3]` puede darnos un punto para una interesante discusión, pero la "
-"respuesta es que por razones de memoria segura no puedes hacerlo a través de `a` luego de crear un "
-"slice, pero puedes leer los datos para ambos de `a` y `s` de forma segura.\n"
-"Se verá en más detalle en la sección de chequeo de préstamos."
+"`s` es una referencia a un slice de `i32`s. Tener en cuenta que en el tipo "
+"de `s` (`&[i32]`) no se menciona el tamaño del array. Esto permite realizar "
+"cálculos en silces de diferentes tamaños."
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"Los silbes siempre se prestan de otro objeto. En este ejemplo, `a` tiene que "
+"permanecer \"viva\" (en el scope) durante, al menos, el tiempo que dure "
+"nuestro segmento."
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
+"La pregunta sobre modificar `a[3]` puede darnos un punto para una "
+"interesante discusión, pero la respuesta es que por razones de memoria "
+"segura no puedes hacerlo a través de `a` luego de crear un slice, pero "
+"puedes leer los datos para ambos de `a` y `s` de forma segura. Se verá en "
+"más detalle en la sección de chequeo de préstamos."
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
+msgid "`String` vs `str`"
 msgstr ""
 
 #: src/basic-syntax/string-slices.md:3
@@ -2674,33 +3003,35 @@ msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let s1: &str = \"World\";\n"
-"    println!(\"s1: {s1}\");"
+"    println!(\"s1: {s1}\");\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let s1: &str = \"Mundo\";\n"
-"    println!(\"s1: {s1}\");"
+"    println!(\"s1: {s1}\");\n"
+"```"
 
 #: src/basic-syntax/string-slices.md:10
 msgid ""
-"    let mut s2: String = String::from(\"Hello \");\n"
-"    println!(\"s2: {s2}\");\n"
-"    s2.push_str(s1);\n"
-"    println!(\"s2: {s2}\");\n"
-"    \n"
-"    let s3: &str = &s2[6..];\n"
-"    println!(\"s3: {s3}\");\n"
-"}\n"
+"```\n"
+"let mut s2: String = String::from(\"Hello \");\n"
+"println!(\"s2: {s2}\");\n"
+"s2.push_str(s1);\n"
+"println!(\"s2: {s2}\");\n"
+"\n"
+"let s3: &str = &s2[6..];\n"
+"println!(\"s3: {s3}\");\n"
 "```"
 msgstr ""
-"    let mut s2: String = String::from(\"Hola \");\n"
-"    println!(\"s2: {s2}\");\n"
-"    s2.push_str(s1);\n"
-"    println!(\"s2: {s2}\");\n"
-"    \n"
-"    let s3: &str = &s2[6..];\n"
-"    println!(\"s3: {s3}\");\n"
-"}\n"
+"```\n"
+"let mut s2: String = String::from(\"Hola \");\n"
+"println!(\"s2: {s2}\");\n"
+"s2.push_str(s1);\n"
+"println!(\"s2: {s2}\");\n"
+"\n"
+"let s3: &str = &s2[6..];\n"
+"println!(\"s3: {s3}\");\n"
 "```"
 
 #: src/basic-syntax/string-slices.md:20
@@ -2708,191 +3039,195 @@ msgid "Rust terminology:"
 msgstr "Terminología Rust:"
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* `&str` es una referencia inmutable a un slice string.\n"
-"* `String` es un buffer de string mutable."
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str` es una referencia inmutable a un slice string."
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String` es un buffer de string mutable."
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in the program’s binary."
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* `&str` pone un string slice, que es una referencia inmutable a codificada con datos string "
-"UTF-8 \n"
-"guardados en un bloque de memoria. El literal String (`\"Hola\"`), se guarda en el binario del "
-"programa."
+"`&str` pone un string slice, que es una referencia inmutable a codificada "
+"con datos string UTF-8  guardados en un bloque de memoria. El literal String "
+"(`\"Hola\"`), se guarda en el binario del programa."
 
 #: src/basic-syntax/string-slices.md:30
 msgid ""
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a `Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string literal; `String::"
-"new()` \n"
-"  creates a new empty string, to which string data can be added using the `push()` and "
-"`push_str()` methods."
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
 msgstr ""
-"* El tipo `String` de Rust es un wrapper para un vector de bytes. Como con un `Vec<T>`, tiene "
-"dueño.\n"
-"* Como con otros tipos `String::from()` crea un string desde un string literal; `String::new()` \n"
-"  crea un string vacío, con datos que pueden usarse con métodos `push()` y `push_str()`."
+"El tipo `String` de Rust es un wrapper para un vector de bytes. Como con un "
+"`Vec<T>`, tiene dueño."
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"Como con otros tipos `String::from()` crea un string desde un string "
+"literal; `String::new()`  crea un string vacío, con datos que pueden usarse "
+"con métodos `push()` y `push_str()`."
 
 #: src/basic-syntax/string-slices.md:35
 msgid ""
-"* The `format!()` macro is a convenient way to generate an owned string from dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never use a small-string "
-"optimization).\n"
-"    \n"
-"</details>"
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
 msgstr ""
-"* El macro `format!()` es una manera conveniente de generar un string con dueño desde un valor "
-"dinámico. Esto\n"
-"  acepta los mismos formateo especificados como `println!()`.\n"
-"* Puedes prestar silces `&str` de `String` con `&` y opcionalmente un rango seleccionado.\n"
-"* Para programadores C++: piensa en `&str` como `const char` de C++, pero de una forma que los "
-"punteros siempre son string válidos en memoria. El `String` Rust es un equivalente tosco a `std::"
-"string` de C++ \n"
-"(La principal diferencia: solo puede contener bytes codificados UTF-8 y nunca usar optimización de "
-"small-string).\n"
-"\n"
-"</details>"
+"El macro `format!()` es una manera conveniente de generar un string con "
+"dueño desde un valor dinámico. Esto acepta los mismos formateo especificados "
+"como `println!()`."
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
-msgstr "# Funciones"
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+"Puedes prestar silces `&str` de `String` con `&` y opcionalmente un rango "
+"seleccionado."
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"Para programadores C++: piensa en `&str` como `const char` de C++, pero de "
+"una forma que los punteros siempre son string válidos en memoria. El "
+"`String` Rust es un equivalente tosco a `std::string` de C++  (La principal "
+"diferencia: solo puede contener bytes codificados UTF-8 y nunca usar "
+"optimización de small-string)."
 
 #: src/basic-syntax/functions.md:3
 msgid ""
-"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview "
-"question:"
+"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
+"Fizz_buzz) interview question:"
 msgstr ""
-"Una versión Rust de la famosa pregunta para entrevistas con [FizzBuzz](https://en.wikipedia.org/"
-"wiki/Fizz_buzz):"
+"Una versión Rust de la famosa pregunta para entrevistas con [FizzBuzz]"
+"(https://en.wikipedia.org/wiki/Fizz_buzz):"
 
 #: src/basic-syntax/functions.md:5
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    fizzbuzz_to(20);   // Defined below, no forward declaration needed\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
 "    fizzbuzz_to(20);   // Definida abajo, no necesitas declararla antes\n"
-"}"
+"}\n"
+"```"
 
 #: src/basic-syntax/functions.md:10
 msgid ""
-"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
-"    if rhs == 0 {\n"
-"        return false;  // Corner case, early return\n"
-"    }\n"
-"    lhs % rhs == 0     // The last expression in a block is the return value\n"
-"}"
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool { if rhs == 0 { return "
+"false;  // Corner case, early return } lhs % rhs == 0     // The last "
+"expression in a block is the return value }"
 msgstr ""
-"fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
-"    if rhs == 0 {\n"
-"        return false;  // Un caso extremo, vuelve rápido\n"
-"    }\n"
-"    lhs % rhs == 0     // La última expreción en el bloque es la que devuelve valor\n"
-"}"
+"fn is_divisible_by(lhs: u32, rhs: u32) -> bool { if rhs == 0 { return "
+"false;  // Un caso extremo, vuelve rápido } lhs % rhs == 0     // La última "
+"expreción en el bloque es la que devuelve valor }"
 
 #: src/basic-syntax/functions.md:17
 msgid ""
-"fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit type `()`\n"
-"    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
-"        (true,  true)  => println!(\"fizzbuzz\"),\n"
-"        (true,  false) => println!(\"fizz\"),\n"
-"        (false, true)  => println!(\"buzz\"),\n"
-"        (false, false) => println!(\"{n}\"),\n"
-"    }\n"
-"}"
+"fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit "
+"type `()` match (is_divisible_by(n, 3), is_divisible_by(n, 5)) { (true,  "
+"true)  => println!(\"fizzbuzz\"), (true,  false) => println!(\"fizz\"), "
+"(false, true)  => println!(\"buzz\"), (false, false) => println!"
+"(\"{n}\"), } }"
 msgstr ""
-"fn fizzbuzz(n: u32) -> () {  // No devolver valor implica devolver un tipo unit `()`\n"
-"    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
-"        (true,  true)  => println!(\"fizzbuzz\"),\n"
-"        (true,  false) => println!(\"fizz\"),\n"
-"        (false, true)  => println!(\"buzz\"),\n"
-"        (false, false) => println!(\"{n}\"),\n"
-"    }\n"
-"}"
+"fn fizzbuzz(n: u32) -> () {  // No devolver valor implica devolver un tipo "
+"unit `()` match (is_divisible_by(n, 3), is_divisible_by(n, 5)) { (true,  "
+"true)  => println!(\"fizzbuzz\"), (true,  false) => println!(\"fizz\"), "
+"(false, true)  => println!(\"buzz\"), (false, false) => println!"
+"(\"{n}\"), } }"
 
 #: src/basic-syntax/functions.md:26
 msgid ""
-"fn fizzbuzz_to(n: u32) {  // `-> ()` is normally omitted\n"
-"    for i in 1..=n {\n"
-"        fizzbuzz(i);\n"
-"    }\n"
-"}\n"
-"```"
+"fn fizzbuzz_to(n: u32) {  // `-> ()` is normally omitted for i in 1..=n "
+"{ fizzbuzz(i); } }"
 msgstr ""
-"fn fizzbuzz_to(n: u32) {  // `-> ()` por lo general se omite\n"
-"    for i in 1..=n {\n"
-"        fizzbuzz(i);\n"
-"    }\n"
-"}\n"
-"```"
+"fn fizzbuzz_to(n: u32) {  // `-> ()` por lo general se omite for i in 1..=n "
+"{ fizzbuzz(i); } }"
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward declarations nor headers are "
-"necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some programming languages), then "
-"a return type.\n"
-"* The last expression in a function body (or any block) becomes the return value. Simply omit the "
-"`;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The compiler will infer "
-"this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, which causes it to "
-"include the upper bound.\n"
-"* The `match` expression in `fizzbuzz()` is doing a lot of work. It is expanded below to show what "
-"is happening."
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
 msgstr ""
-"* En `main` invocamos a una función escrita debajo. No es necesario hacer declaraciones para referenciar.\n"
-"* La declaración de parámetros es por tipo (lo contrario a otros lenguajes), y devuelven tipo.\n"
-"* La última expresión en una función (u otro bloque) es el tipo que devuelve. Y omite el `;` al final.\n"
-"* Algunas funciones no devuelven valor y devuelven el `tipo unit`, `()`. El compilador va a inferir `->()` si es tipo a devolver es omitido.\n"
-"* Las expresiones `for` en `fizzbuzz_to()` contienen `=n`, que incluye el límite superior.\n"
-"* Los `match` en `fizzbuzz()` hacen mucho. Se detalla debajo."
+"En `main` invocamos a una función escrita debajo. No es necesario hacer "
+"declaraciones para referenciar."
+
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+"La declaración de parámetros es por tipo (lo contrario a otros lenguajes), y "
+"devuelven tipo."
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+"La última expresión en una función (u otro bloque) es el tipo que devuelve. "
+"Y omite el `;` al final."
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+"Algunas funciones no devuelven valor y devuelven el `tipo unit`, `()`. El "
+"compilador va a inferir `->()` si es tipo a devolver es omitido."
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
+"which causes it to include the upper bound."
+msgstr ""
+"Las expresiones `for` en `fizzbuzz_to()` contienen `=n`, que incluye el "
+"límite superior."
+
+#: src/basic-syntax/functions.md:40
+msgid ""
+"The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
+"expanded below to show what is happening."
+msgstr "Los `match` en `fizzbuzz()` hacen mucho. Se detalla debajo."
 
 #: src/basic-syntax/functions.md:42
-msgid "  (Type annotations added for clarity, but they can be elided.)"
-msgstr "  (Las anotaciones dan claridad, pero se pueden omitir)"
+msgid "(Type annotations added for clarity, but they can be elided.)"
+msgstr "(Las anotaciones dan claridad, pero se pueden omitir)"
 
 #: src/basic-syntax/functions.md:44
 msgid ""
-"  ```rust,ignore\n"
-"  let by_3: bool = is_divisible_by(n, 3);\n"
-"  let by_5: bool = is_divisible_by(n, 5);\n"
-"  let by_35: (bool, bool) = (by_3, by_5);\n"
-"  match by_35 {\n"
-"    // ...\n"
-"  ```"
+"```rust,ignore\n"
+"let by_3: bool = is_divisible_by(n, 3);\n"
+"let by_5: bool = is_divisible_by(n, 5);\n"
+"let by_35: (bool, bool) = (by_3, by_5);\n"
+"match by_35 {\n"
+"  // ...\n"
+"```"
 msgstr ""
-
-#: src/basic-syntax/functions.md:52
-msgid "  "
-msgstr ""
-
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
-msgstr "# Métodos"
 
 #: src/basic-syntax/methods.md:3
 msgid ""
-"Rust has methods, they are simply functions that are associated with a particular type. The\n"
-"first argument of a method is an instance of the type it is associated with:"
+"Rust has methods, they are simply functions that are associated with a "
+"particular type. The first argument of a method is an instance of the type "
+"it is associated with:"
 msgstr ""
-"Rust tiene métodos, pero simplemente son funciones que están asociadas a un tipo particular. El "
-"primer argumento de un método es una instancia de un tipo asociado con:"
+"Rust tiene métodos, pero simplemente son funciones que están asociadas a un "
+"tipo particular. El primer argumento de un método es una instancia de un "
+"tipo asociado con:"
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -2900,63 +3235,68 @@ msgid ""
 "struct Rectangle {\n"
 "    width: u32,\n"
 "    height: u32,\n"
-"}"
-msgstr ""
-
-#: src/basic-syntax/methods.md:12
-msgid ""
-"impl Rectangle {\n"
-"    fn area(&self) -> u32 {\n"
-"        self.width * self.height\n"
-"    }"
-msgstr ""
-
-#: src/basic-syntax/methods.md:17
-msgid ""
-"    fn inc_width(&mut self, delta: u32) {\n"
-"        self.width += delta;\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/basic-syntax/methods.md:22
-msgid ""
-"fn main() {\n"
-"    let mut rect = Rectangle { width: 10, height: 5 };\n"
-"    println!(\"old area: {}\", rect.area());\n"
-"    rect.inc_width(5);\n"
-"    println!(\"new area: {}\", rect.area());\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/basic-syntax/methods.md:12
+msgid "impl Rectangle { fn area(&self) -> u32 { self.width * self.height }"
+msgstr ""
+
+#: src/basic-syntax/methods.md:17
+msgid ""
+"```\n"
+"fn inc_width(&mut self, delta: u32) {\n"
+"    self.width += delta;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/methods.md:22
+msgid ""
+"fn main() { let mut rect = Rectangle { width: 10, height: 5 }; println!"
+"(\"old area: {}\", rect.area()); rect.inc_width(5); println!(\"new area: "
+"{}\", rect.area()); }"
+msgstr ""
+
 #: src/basic-syntax/methods.md:30
-msgid "* We will look much more at methods in today's exercise and in tomorrow's class."
-msgstr "* Observaremos mucho más acerca de métodos en la clase de hoy a la tarde."
+msgid ""
+"We will look much more at methods in today's exercise and in tomorrow's "
+"class."
+msgstr ""
+"Observaremos mucho más acerca de métodos en la clase de hoy a la tarde."
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
-msgstr "# Sobrecarga de Funciones"
+msgid "Function Overloading"
+msgstr "Sobrecarga de Funciones"
 
 #: src/basic-syntax/functions-interlude.md:3
 msgid "Overloading is not supported:"
 msgstr "La Sobrecarga no es soportada:"
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* Cada función tiene una implementación simple:\n"
-"  * Siempre tiene un número fijo de parámetros.\n"
-"  * Siempre tiene un único conjunto de tipos de parámetros.\n"
-"* Los valores por defecto no están soportados:\n"
-"  * Todas las llamadas tienen el mismo tipo de parámetro.\n"
-"  * Algunas veces como alternativa se usan macros."
+msgid "Each function has a single implementation:"
+msgstr "Cada función tiene una implementación simple:"
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "Siempre tiene un número fijo de parámetros."
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "Siempre tiene un único conjunto de tipos de parámetros."
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "Los valores por defecto no están soportados:"
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr "Todas las llamadas tienen el mismo tipo de parámetro."
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "Algunas veces como alternativa se usan macros."
 
 #: src/basic-syntax/functions-interlude.md:12
 msgid "However, function parameters can be generic:"
@@ -2967,54 +3307,47 @@ msgid ""
 "```rust,editable\n"
 "fn pick_one<T>(a: T, b: T) -> T {\n"
 "    if std::process::id() % 2 == 0 { a } else { b }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn elegir_uno<T>(a: T, b: T) -> T {\n"
 "    if std::process::id() % 2 == 0 { a } else { b }\n"
-"}"
+"}\n"
+"```"
 
 #: src/basic-syntax/functions-interlude.md:19
 msgid ""
-"fn main() {\n"
-"    println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\"));\n"
-"    println!(\"cash prize: {}\", pick_one(500, 1000));\n"
-"}\n"
-"```"
+"fn main() { println!(\"coin toss: {}\", pick_one(\"heads\", \"tails\")); "
+"println!(\"cash prize: {}\", pick_one(500, 1000)); }"
 msgstr ""
-"fn main() {\n"
-"    println!(\"arrojar la moneda: {}\", elegir_uno(\"cara\", \"cruz\"));\n"
-"    println!(\"premio: {}\", elegir_uno(500, 1000));\n"
-"}\n"
-"```"
+"fn main() { println!(\"arrojar la moneda: {}\", elegir_uno(\"cara\", "
+"\"cruz\")); println!(\"premio: {}\", elegir_uno(500, 1000)); }"
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind of limited\n"
-"  polymorphism on argument types. We will see more details in a later section."
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
+"section."
 msgstr ""
-"* Cuando usas genéricos, la librería estándar `Into<T>` puede dar un limitado \n"
-"  polimorfismo con tipo de parámetro. Lo veremos en detalle más adelante."
-
-#: src/basic-syntax/functions-interlude.md:30
-msgid "</defails>"
-msgstr ""
+"Cuando usas genéricos, la librería estándar `Into<T>` puede dar un limitado  "
+"polimorfismo con tipo de parámetro. Lo veremos en detalle más adelante."
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
-msgstr "# Día 1: Ejercicios de la Mañana"
+msgid "Day 1: Morning Exercises"
+msgstr "Día 1: Ejercicios de la Mañana"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
 msgstr "En estos ejercicios, exploraremos dos partes de Rust:"
 
 #: src/exercises/day-1/morning.md:5
-msgid "* Implicit conversions between types."
-msgstr "* Conversiones implícitas entre tipos."
+msgid "Implicit conversions between types."
+msgstr "Conversiones implícitas entre tipos."
 
 #: src/exercises/day-1/morning.md:7
-msgid "* Arrays and `for` loops."
-msgstr "* Arrays y loops `for`."
+msgid "Arrays and `for` loops."
+msgstr "Arrays y loops `for`."
 
 #: src/exercises/day-1/morning.md:11
 msgid "A few things to consider while solving the exercises:"
@@ -3022,140 +3355,131 @@ msgstr "Algunas cosas a considerar mientras resolvemos los ejercicios:"
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for details\n"
-"  on installing Rust."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* Usar una instalación de Rust local, si es posible. De esta manera puedes tener\n"
-"  auto-complete en el editor. Puedes ver la página [Usando Cargo] para más detalles\n"
-"  en la instalación de Rust."
+"Usar una instalación de Rust local, si es posible. De esta manera puedes "
+"tener auto-complete en el editor. Puedes ver la página [Usando Cargo](../../"
+"cargo.md) para más detalles en la instalación de Rust."
 
 #: src/exercises/day-1/morning.md:17
-msgid "* Alternatively, use the Rust Playground."
-msgstr "* Como alternativa, puedes usar el Rust embebido."
+msgid "Alternatively, use the Rust Playground."
+msgstr "Como alternativa, puedes usar el Rust embebido."
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
-"Los scnippets de código no son editables a propósito: el código de snippets inline pierden\n"
-"su estado si navegas fuera de la página."
+"Los scnippets de código no son editables a propósito: el código de snippets "
+"inline pierden su estado si navegas fuera de la página."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
 #: src/exercises/day-3/morning.md:7 src/exercises/day-4/morning.md:12
-msgid "After looking at the exercises, you can look at the [solutions] provided."
-msgstr "Luego de ver los ejercicios, puedes ver las [soluciones] que se brindan."
-
-#: src/exercises/day-1/morning.md:24 src/exercises/day-2/morning.md:13
-#: src/exercises/day-3/morning.md:9 src/exercises/day-4/morning.md:14
-msgid "[solutions]: solutions-morning.md"
-msgstr "[soluciones]: solutions-morning.md"
-
-#: src/exercises/day-1/morning.md:26
-msgid "[Using Cargo]: ../../cargo.md"
-msgstr "[Usando Cargo]: ../../cargo.md"
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
-msgstr "# Conversiones Implícitas"
+msgid ""
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
+msgstr ""
+"Luego de ver los ejercicios, puedes ver las \\[soluciones\\] que se brindan."
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
-"Rust will not automatically apply _implicit conversions_ between types ([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"Rust will not automatically apply _implicit conversions_ between types "
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
-"Rust no aplicará automáticamente _conversiones implícitas_ entre tipos ([como \n"
-"C++][3]). Puedes ver esto en programas como este:"
+"Rust no aplicará automáticamente _conversiones implícitas_ entre tipos "
+"([como  C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). Puedes ver esto en programas como este:"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn multiply(x: i16, y: i16) -> i16 {\n"
 "    x * y\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:11
-msgid ""
-"fn main() {\n"
-"    let x: i8 = 15;\n"
-"    let y: i16 = 1000;"
+msgid "fn main() { let x: i8 = 15; let y: i16 = 1000;"
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:15
 msgid ""
-"    println!(\"{x} * {y} = {}\", multiply(x, y));\n"
-"}\n"
+"```\n"
+"println!(\"{x} * {y} = {}\", multiply(x, y));\n"
 "```"
 msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single `from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"El tipo integer de Rust implementa el [`From<T>`][1] y [`Into<T>`][2]\n"
-"y trata de dejarnos para dejarnos convertir entre ellos. El `From<T>` se trata como un simple \n"
-"método `from()` y similar, el `Into<T>` se trata como un simple método `into()`.\n"
-"Implementando esto es como expresamos un tipo que puede convertirse a otro."
+"El tipo integer de Rust implementa el [`From<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.From.html) y [`Into<T>`](https://doc.rust-lang.org/std/"
+"convert/trait.Into.html) y trata de dejarnos para dejarnos convertir entre "
+"ellos. El `From<T>` se trata como un simple  método `from()` y similar, el "
+"`Into<T>` se trata como un simple método `into()`. Implementando esto es "
+"como expresamos un tipo que puede convertirse a otro."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
-"The standard library has an implementation of `From<i8> for i16`, which means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"The standard library has an implementation of `From<i8> for i16`, which "
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
-"La librería estándar tiene una implementación de `From<i8> para i16`, que significa\n"
-"Que podemos convertir la variable `x`de tipo `i8` a una `i16` llamando \n"
-"`i16::from(x)`. O, más simple, con `x.into()`, porque la implementación `From<i8> para i16`\n"
-"crea automáticamente una implementación de `Into<i16> para i8`."
+"La librería estándar tiene una implementación de `From<i8> para i16`, que "
+"significa Que podemos convertir la variable `x`de tipo `i8` a una `i16` "
+"llamando  `i16::from(x)`. O, más simple, con `x.into()`, porque la "
+"implementación `From<i8> para i16` crea automáticamente una implementación "
+"de `Into<i16> para i8`."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
-"The same applies for your own `From` implementations for your own types, so it is\n"
-"sufficient to only implement `From` to get a respective `Into` implementation automatically."
+"The same applies for your own `From` implementations for your own types, so "
+"it is sufficient to only implement `From` to get a respective `Into` "
+"implementation automatically."
 msgstr ""
-"Lo mismo aplica para tu propia implementación `From` para tus propios tipos, así es\n"
-"suficiente solo implementar `From` para obtener la respectiva implementación automática `Into`."
+"Lo mismo aplica para tu propia implementación `From` para tus propios tipos, "
+"así es suficiente solo implementar `From` para obtener la respectiva "
+"implementación automática `Into`."
 
 #: src/exercises/day-1/implicit-conversions.md:33
-msgid "1. Execute the above program and look at the compiler error."
-msgstr "1. Ejecuta el programa de arriba y mira el error de compilación."
+msgid "Execute the above program and look at the compiler error."
+msgstr "Ejecuta el programa de arriba y mira el error de compilación."
 
 #: src/exercises/day-1/implicit-conversions.md:35
-msgid "2. Update the code above to use `into()` to do the conversion."
-msgstr "2. Actualiza el código de arriba usando `into()` para hacer la conversión."
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr ""
+"Actualiza el código de arriba usando `into()` para hacer la conversión."
 
 #: src/exercises/day-1/implicit-conversions.md:37
 msgid ""
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented for\n"
-"   the pairs you check."
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
 msgstr ""
-"3. Cambia los tipos de `x` e `y` para otras cosas (como con `f32`, `bool`,\n"
-"`i128`) para ver qué tipos puedes convertir a otros tipos. Intenta\n"
-"convirtiendo tipos pequeños a grandes y a otros tipos disponibles. Revisa la\n"
-"[documentación de la librería estándar][1] para ver si `From<T>` se puede\n"
-"implementar."
-
-#: src/exercises/day-1/implicit-conversions.md:43
-msgid ""
-"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-"[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
-msgstr ""
+"Cambia los tipos de `x` e `y` para otras cosas (como con `f32`, `bool`, "
+"`i128`) para ver qué tipos puedes convertir a otros tipos. Intenta "
+"convirtiendo tipos pequeños a grandes y a otros tipos disponibles. Revisa la "
+"[documentación de la librería estándar](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) para ver si `From<T>` se puede implementar."
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
-msgstr "# Arrays y Loops `for`"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "Arrays y Loops `for`"
 
 #: src/exercises/day-1/for-loops.md:3
 msgid "We saw that an array can be declared like this:"
@@ -3169,7 +3493,9 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:9
-msgid "You can print such an array by asking for its debug representation with `{:?}`:"
+msgid ""
+"You can print such an array by asking for its debug representation with `{:?}"
+"`:"
 msgstr "Puedes imprimirlo para verlo y depurar código con `{:?}`:"
 
 #: src/exercises/day-1/for-loops.md:11
@@ -3184,7 +3510,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr "Rust permite iterar sobre cosas como array y arreglos usando `for`:"
 
@@ -3197,7 +3523,8 @@ msgid ""
 "    for n in array {\n"
 "        print!(\" {n}\");\n"
 "    }\n"
-"    println!();"
+"    println!();\n"
+"```"
 msgstr ""
 "```rust,editable\n"
 "fn main() {\n"
@@ -3206,33 +3533,36 @@ msgstr ""
 "    for n in array {\n"
 "        print!(\" {n}\");\n"
 "    }\n"
-"    println!();"
+"    println!();\n"
+"```"
 
 #: src/exercises/day-1/for-loops.md:30
 msgid ""
-"    print!(\"Iterating over range:\");\n"
-"    for i in 0..3 {\n"
-"        print!(\" {}\", array[i]);\n"
-"    }\n"
-"    println!();\n"
+"```\n"
+"print!(\"Iterating over range:\");\n"
+"for i in 0..3 {\n"
+"    print!(\" {}\", array[i]);\n"
 "}\n"
+"println!();\n"
 "```"
 msgstr ""
-"    print!(\"Iterando sobre el rango:\");\n"
-"    for i in 0..3 {\n"
-"        print!(\" {}\", array[i]);\n"
-"    }\n"
-"    println!();\n"
+"```\n"
+"print!(\"Iterando sobre el rango:\");\n"
+"for i in 0..3 {\n"
+"    print!(\" {}\", array[i]);\n"
 "}\n"
+"println!();\n"
 "```"
 
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
-"Use the above to write a function `pretty_print` which pretty-print a matrix and\n"
-"a function `transpose` which will transpose a matrix (turn rows into columns):"
+"Use the above to write a function `pretty_print` which pretty-print a matrix "
+"and a function `transpose` which will transpose a matrix (turn rows into "
+"columns):"
 msgstr ""
-"Usa lo de arriba para escribir la función `linda_impresion` que es una matriz y\n"
-"una función `trasponer` que trasponerá una matriz (cambia filas a columnas):"
+"Usa lo de arriba para escribir la función `linda_impresion` que es una "
+"matriz y una función `trasponer` que trasponerá una matriz (cambia filas a "
+"columnas):"
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3249,10 +3579,10 @@ msgstr "Hardcodea ambas funciones para operar con matrices 3 x 3."
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
-"Copia el código debajo para <https://play.rust-lang.org/> e implementa las\n"
+"Copia el código debajo para <https://play.rust-lang.org/> e implementa las "
 "funciones:"
 
 #: src/exercises/day-1/for-loops.md:52 src/exercises/day-1/book-library.md:20
@@ -3260,92 +3590,86 @@ msgstr ""
 msgid ""
 "```rust,should_panic\n"
 "// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]"
+"#![allow(unused_variables, dead_code)]\n"
+"```"
 msgstr ""
 "```rust,should_panic\n"
 "// TODO: borra esto cuando termines de implementarlo.\n"
-"#![allow(unused_variables, dead_code)]"
+"#![allow(unused_variables, dead_code)]\n"
+"```"
 
 #: src/exercises/day-1/for-loops.md:56
 msgid ""
-"fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
-"    unimplemented!()\n"
-"}"
+"fn transpose(matrix: \\[\\[i32; 3\\]; 3\\]) -> \\[\\[i32; 3\\]; 3\\] "
+"{ unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:60
-msgid ""
-"fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
-"    unimplemented!()\n"
-"}"
+msgid "fn pretty_print(matrix: &\\[\\[i32; 3\\]; 3\\]) { unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:64
 msgid ""
-"fn main() {\n"
-"    let matrix = [\n"
-"        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
-"        [201, 202, 203],\n"
-"        [301, 302, 303],\n"
-"    ];"
+"fn main() { let matrix = \\[ \\[101, 102, 103\\], // \\<\\-- the comment "
+"makes rustfmt add a newline \\[201, 202, 203\\], \\[301, 302, 303\\], \\];"
 msgstr ""
 
-#: src/exercises/day-1/for-loops.md:71 src/exercises/day-1/solutions-morning.md:70
+#: src/exercises/day-1/for-loops.md:71
+#: src/exercises/day-1/solutions-morning.md:70
 msgid ""
-"    println!(\"matrix:\");\n"
-"    pretty_print(&matrix);"
+"```\n"
+"println!(\"matrix:\");\n"
+"pretty_print(&matrix);\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:74
+#: src/exercises/day-1/solutions-morning.md:73
 msgid ""
-"    let transposed = transpose(matrix);\n"
-"    println!(\"transposed:\");\n"
-"    pretty_print(&transposed);\n"
-"}\n"
+"```\n"
+"let transposed = transpose(matrix);\n"
+"println!(\"transposed:\");\n"
+"pretty_print(&transposed);\n"
 "```"
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
-msgstr "## Preguntas Bonus"
+msgid "Bonus Question"
+msgstr "Preguntas Bonus"
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"Puedes usar silbes `&[i32]` en vez de hardcodear matrices 3 x 3 para tus\n"
-"parámetros y devolver tipos? Cosas como `&[&[i32]]` para dos dimensiones,\n"
+"Puedes usar silbes `&[i32]` en vez de hardcodear matrices 3 x 3 para tus "
+"parámetros y devolver tipos? Cosas como `&[&[i32]]` para dos dimensiones, "
 "slices de slices. Por qué sí o por qué no?"
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
-"Mira el [ crates `ndarray`](https://docs.rs/ndarray/) para implementación con calidad de producción\n"
-"de calidad."
+"Mira el [ crates `ndarray`](https://docs.rs/ndarray/) para implementación "
+"con calidad de producción de calidad."
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"Las soluciones y respuestas a la sección bonus están disponibles en\n"
-"la sección [Solución](solutions-morning.md#arrays-and-for-loops)."
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
-msgstr ""
+"Las soluciones y respuestas a la sección bonus están disponibles en la "
+"sección [Solución](solutions-morning.md#arrays-and-for-loops)."
 
 #: src/basic-syntax/variables.md:3
 msgid ""
-"Rust provides type safety via static typing. Variable bindings are immutable by\n"
-"default:"
+"Rust provides type safety via static typing. Variable bindings are immutable "
+"by default:"
 msgstr ""
-"Rust provee tipos seguros por tipado estático. El enlace a variables es inmutable\n"
-"por defecto:"
+"Rust provee tipos seguros por tipado estático. El enlace a variables es "
+"inmutable por defecto:"
 
 #: src/basic-syntax/variables.md:6
 msgid ""
@@ -3361,19 +3685,19 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the types less and less as "
-"the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the function like syntax of "
-"`println!(\"x: {}\", x)`"
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
 msgstr ""
-"* Dado a la inferencia de tipos `i32` es opcional. Poco a poco veremos los tipos a medida que "
-"avance el curso.\n"
-"* Nota que a partir que `println!` es una macro, `x` no se mueve, incluso usando una función como "
-"`println!(\"x: {}\", x)`"
+"Dado a la inferencia de tipos `i32` es opcional. Poco a poco veremos los "
+"tipos a medida que avance el curso."
 
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
-msgstr "# Tipo de inferencia"
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
+"function like syntax of `println!(\"x: {}\", x)`"
+msgstr ""
+"Nota que a partir que `println!` es una macro, `x` no se mueve, incluso "
+"usando una función como `println!(\"x: {}\", x)`"
 
 #: src/basic-syntax/type-inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
@@ -3384,57 +3708,59 @@ msgid ""
 "```rust,editable\n"
 "fn takes_u32(x: u32) {\n"
 "    println!(\"u32: {x}\");\n"
-"}"
-msgstr ""
-
-#: src/basic-syntax/type-inference.md:10
-msgid ""
-"fn takes_i8(y: i8) {\n"
-"    println!(\"i8: {y}\");\n"
-"}"
-msgstr ""
-
-#: src/basic-syntax/type-inference.md:14
-msgid ""
-"fn main() {\n"
-"    let x = 10;\n"
-"    let y = 20;"
-msgstr ""
-
-#: src/basic-syntax/type-inference.md:18
-msgid ""
-"    takes_u32(x);\n"
-"    takes_i8(y);\n"
-"    // takes_u32(y);\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/basic-syntax/type-inference.md:26
-msgid ""
-"This slide demonstrates how the Rust compiler infers types based on constraints given by variable "
-"declarations and usages.\n"
-"    \n"
-"It is very important to emphasize that variables declared like this are not of some sort of "
-"dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical to the explicit "
-"declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+#: src/basic-syntax/type-inference.md:10
+msgid "fn takes_i8(y: i8) { println!(\"i8: {y}\"); }"
 msgstr ""
-"Este slide demuestra cómo el compilador de Rust infiere tipos basados en constrainst dadas por la "
-"declaración de variables y los usos.\n"
-"Es importante enfatizar que las variables declaradas como esta no son un conjunto dinámico de "
-"\"cualquier tipo\" que puede contener todo tipo de datos. El código generado por esa declaración "
-"es idéntica a la declaración explícita de un tipo.\n"
-"El compilador hace el trabajo por nosotros y nos ayuda a escribir código más conciso."
+
+#: src/basic-syntax/type-inference.md:14
+msgid "fn main() { let x = 10; let y = 20;"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:18
+msgid ""
+"```\n"
+"takes_u32(x);\n"
+"takes_i8(y);\n"
+"// takes_u32(y);\n"
+"```"
+msgstr ""
+
+#: src/basic-syntax/type-inference.md:26
+#, fuzzy
+msgid ""
+"This slide demonstrates how the Rust compiler infers types based on "
+"constraints given by variable declarations and usages."
+msgstr ""
+"Este slide demuestra cómo el compilador de Rust infiere tipos basados en "
+"constrainst dadas por la declaración de variables y los usos. Es importante "
+"enfatizar que las variables declaradas como esta no son un conjunto dinámico "
+"de \"cualquier tipo\" que puede contener todo tipo de datos. El código "
+"generado por esa declaración es idéntica a la declaración explícita de un "
+"tipo. El compilador hace el trabajo por nosotros y nos ayuda a escribir "
+"código más conciso."
+
+#: src/basic-syntax/type-inference.md:28
+msgid ""
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
+msgstr ""
 
 #: src/basic-syntax/type-inference.md:32
 msgid ""
-"The following code tells the compiler to copy into a certain generic container without the code "
-"ever explicitly specifying the contained type, using `_` as a placeholder:"
+"The following code tells the compiler to copy into a certain generic "
+"container without the code ever explicitly specifying the contained type, "
+"using `_` as a placeholder:"
 msgstr ""
-"El siguiente código dice al compilador que copie en un contenedor genérico determinado sin que "
-"explicitar específicamente el tipo contenido, usando `_` como un placeholder:"
+"El siguiente código dice al compilador que copie en un contenedor genérico "
+"determinado sin que explicitar específicamente el tipo contenido, usando `_` "
+"como un placeholder:"
 
 #: src/basic-syntax/type-inference.md:34
 msgid ""
@@ -3443,37 +3769,38 @@ msgid ""
 "    let mut v = Vec::new();\n"
 "    v.push((10, false));\n"
 "    v.push((20, true));\n"
-"    println!(\"v: {v:?}\");"
+"    println!(\"v: {v:?}\");\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:41
 msgid ""
-"    let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
-"    println!(\"vv: {vv:?}\");\n"
-"}\n"
+"```\n"
+"let vv = v.iter().collect::<std::collections::HashSet<_>>();\n"
+"println!(\"vv: {vv:?}\");\n"
 "```"
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:46
 msgid ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) relies "
-"on `FromIterator`, which [`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
-"implements."
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) relies on `FromIterator`, which [`HashSet`](https://doc."
+"rust-lang.org/std/iter/trait.FromIterator.html) implements."
 msgstr ""
-"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) se basa "
-"en `FromIterator` que lo implementa el [`HashSet`](https://doc.rust-lang.org/std/iter/trait."
-"FromIterator.html)."
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) se basa en `FromIterator` que lo implementa el "
+"[`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html)."
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
-msgstr "# Variables Estáticas y Constantes"
+msgid "Static and Constant Variables"
+msgstr "Variables Estáticas y Constantes"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid "Global state is managed with static and constant variables."
 msgstr "El estado global es manejado con variables estáticas y constantes."
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
+msgid "`const`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:7
@@ -3484,40 +3811,36 @@ msgstr "Puedes declarar constantes en tiempo de compilación:"
 msgid ""
 "```rust,editable\n"
 "const DIGEST_SIZE: usize = 3;\n"
-"const ZERO: Option<u8> = Some(42);"
+"const ZERO: Option<u8> = Some(42);\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:13
 msgid ""
-"fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
-"    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
-"    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
-"        digest[idx % DIGEST_SIZE] = digest[idx % DIGEST_SIZE].wrapping_add(b);\n"
-"    }\n"
-"    digest\n"
-"}"
+"fn compute_digest(text: &str) -> \\[u8; DIGEST_SIZE\\] { let mut digest = "
+"\\[ZERO.unwrap_or(0); DIGEST_SIZE\\]; for (idx, &b) in text.as_bytes()."
+"iter().enumerate() { digest\\[idx % DIGEST_SIZE\\] = digest\\[idx % "
+"DIGEST_SIZE\\].wrapping_add(b); } digest }"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:21
 msgid ""
-"fn main() {\n"
-"    let digest = compute_digest(\"Hello\");\n"
-"    println!(\"Digest: {digest:?}\");\n"
-"}\n"
-"```"
+"fn main() { let digest = compute_digest(\"Hello\"); println!(\"Digest: "
+"{digest:?}\"); }"
 msgstr ""
-"fn main() {\n"
-"    let digest = compute_digest(\"Hola\");\n"
-"    println!(\"Digest: {digest:?}\");\n"
-"}\n"
-"```"
+"fn main() { let digest = compute_digest(\"Hola\"); println!(\"Digest: "
+"{digest:?}\"); }"
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According the the [Rust RFC Book][1] these are inlined upon use."
-msgstr "De acuerdo con [Rust RFC Book][1] eso está en línea del uso."
+msgid ""
+"According the the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-"
+"const-vs-static.html) these are inlined upon use."
+msgstr ""
+"De acuerdo con [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) eso está en línea del uso."
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
+msgid "`static`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:31
@@ -3527,105 +3850,130 @@ msgstr "También puedes declarar variables estáticas:"
 #: src/basic-syntax/static-and-const.md:33
 msgid ""
 "```rust,editable\n"
-"static BANNER: &str = \"Welcome to RustOS 3.14\";"
+"static BANNER: &str = \"Welcome to RustOS 3.14\";\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:36
-msgid ""
-"fn main() {\n"
-"    println!(\"{BANNER}\");\n"
-"}\n"
-"```"
+msgid "fn main() { println!(\"{BANNER}\"); }"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:41
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have an actual associated "
-"memory location.  This is useful for unsafe and embedded code, and the variable lives through the "
-"entirety of the program execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
-"Como se ve en [Rust RFC Book][1], esto no está en línea del uso y puede estar asociado a una "
-"locación de memoria. Es útil para código no seguro o embebido, y las variables viven enteramente "
-"dentro de la ejecución del programa."
+"Como se ve en [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-"
+"static.html), esto no está en línea del uso y puede estar asociado a una "
+"locación de memoria. Es útil para código no seguro o embebido, y las "
+"variables viven enteramente dentro de la ejecución del programa."
 
 #: src/basic-syntax/static-and-const.md:44
-msgid "We will look at mutating static data in the [chapter on Unsafe Rust](../unsafe.md)."
-msgstr "Veremos cambiar datos estáticos en el [capítulo Rust No Seguro](../unsafe.md)."
+msgid ""
+"We will look at mutating static data in the [chapter on Unsafe Rust](../"
+"unsafe.md)."
+msgstr ""
+"Veremos cambiar datos estáticos en el [capítulo Rust No Seguro](../unsafe."
+"md)."
 
 #: src/basic-syntax/static-and-const.md:48
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
+msgstr ""
+"Aclaremos que `const` semánticamente se comporta similar a `constexpr` de C+"
+"+."
+
+#: src/basic-syntax/static-and-const.md:49
 msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable global variable in C+"
-"+.\n"
-"* It isn't super common that one would need a runtime evaluated constant, but it is helpful and "
-"safer than using a static."
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
 msgstr ""
-"* Aclaremos que `const` semánticamente se comporta similar a `constexpr` de C++.\n"
-"* `static`, por lo contrario, es mucho más similar a `const` o una variable mutable global de C+"
-"+.\n"
-"* No es muy común que necesitemos evaluar contantes en runtime, pero ayuda y es más seguro que "
-"usando un _static_."
+"`static`, por lo contrario, es mucho más similar a `const` o una variable "
+"mutable global de C++."
 
-#: src/basic-syntax/static-and-const.md:54
-msgid "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
 msgstr ""
-
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
-msgstr "# Scopes y Shadowing"
+"No es muy común que necesitemos evaluar contantes en runtime, pero ayuda y "
+"es más seguro que usando un _static_."
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
-"You can shadow variables, both those from outer scopes and variables from the\n"
-"same scope:"
-msgstr "Puedes hacer seguimiento de variables, esto se puede hacer para variables dentro y fuera del scope actual:"
+"You can shadow variables, both those from outer scopes and variables from "
+"the same scope:"
+msgstr ""
+"Puedes hacer seguimiento de variables, esto se puede hacer para variables "
+"dentro y fuera del scope actual:"
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let a = 10;\n"
-"    println!(\"before: {a}\");"
+"    println!(\"before: {a}\");\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:11
 msgid ""
-"    {\n"
-"        let a = \"hello\";\n"
-"        println!(\"inner scope: {a}\");"
+"```\n"
+"{\n"
+"    let a = \"hello\";\n"
+"    println!(\"inner scope: {a}\");\n"
+"```"
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:15
 msgid ""
-"        let a = true;\n"
-"        println!(\"shadowed in inner scope: {a}\");\n"
-"    }"
-msgstr ""
-
-#: src/basic-syntax/scopes-shadowing.md:19
-msgid ""
-"    println!(\"after: {a}\");\n"
+"```\n"
+"    let a = true;\n"
+"    println!(\"shadowed in inner scope: {a}\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:25
+#: src/basic-syntax/scopes-shadowing.md:19
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing both variable's memory "
-"locations exist at the same time. Both are available under the same name, depending where you use "
-"it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory locations when "
-"shadowing an immutable variable in a scope, even if the type does not change."
+"```\n"
+"println!(\"after: {a}\");\n"
+"```"
 msgstr ""
-"* Definición: Shadowing es diferente de mutación, porque luego de shadowing ambos espacio de "
-"memorias de las variables existen al mismo tiempo. Ambas están disponibles bajo el mismo nombre, "
-"dependiendo donde uses el código.\n"
-"* Un shadowing de variable puede tener un tipo diferente.\n"
-"* El siguiente código demuestra por qué el compilador no puede simplemente reutilizar las "
-"locaciones de memoria mientras hacemos shadowing a una variable inmutable en un cope, incluso si "
-"el tipo no cambia."
+
+#: src/basic-syntax/scopes-shadowing.md:25
+#, fuzzy
+msgid ""
+"Definition: Shadowing is different from mutation, because after shadowing "
+"both variable's memory locations exist at the same time. Both are available "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"Definición: Shadowing es diferente de mutación, porque luego de shadowing "
+"ambos espacio de memorias de las variables existen al mismo tiempo. Ambas "
+"están disponibles bajo el mismo nombre, dependiendo donde uses el código."
+
+#: src/basic-syntax/scopes-shadowing.md:26
+#, fuzzy
+msgid "A shadowing variable can have a different type. "
+msgstr "Un shadowing de variable puede tener un tipo diferente."
+
+#: src/basic-syntax/scopes-shadowing.md:27
+#, fuzzy
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+"El siguiente código demuestra por qué el compilador no puede simplemente "
+"reutilizar las locaciones de memoria mientras hacemos shadowing a una "
+"variable inmutable en un cope, incluso si el tipo no cambia."
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
+"locations when shadowing an immutable variable in a scope, even if the type "
+"does not change."
+msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:30
 msgid ""
@@ -3639,22 +3987,21 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr "# Manejo de memoria"
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr "Por lo general, los lenguajes caen en dos amplias categorías:"
 
 #: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr "Control total manual del manejo de memoria: C, C++, Pascal, …"
+
+#: src/memory-management.md:6
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, Haskell, ..."
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Haskell, ..."
 msgstr ""
-"* Control total manual del manejo de memoria: C, C++, Pascal, …\n"
-"* Total Seguridad vía manejo automático de memoria en tiempo de ejecución: Java, Python, Go, "
-"Haskell, …"
+"Total Seguridad vía manejo automático de memoria en tiempo de ejecución: "
+"Java, Python, Go, Haskell, …"
 
 #: src/memory-management.md:8
 msgid "Rust offers a new mix:"
@@ -3662,11 +4009,11 @@ msgstr "Rust ofrece un nuevo mix:"
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
-"> Control total y seguro vía tiempo de compilación con aseguramiento del correcto\n"
-"> manejo de memoria."
+"Control total y seguro vía tiempo de compilación con aseguramiento del "
+"correcto manejo de memoria."
 
 #: src/memory-management.md:13
 msgid "It does this with an explicit ownership concept."
@@ -3677,45 +4024,53 @@ msgid "First, let's refresh how memory management works."
 msgstr "Empecemos refrescando cómo funciona el manejo de memoria."
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
+msgid "The Stack vs The Heap"
 msgstr ""
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality."
-msgstr ""
-"* Stack: Es un área de memoria continua para variables locales.\n"
-"  * Los valores son de tamaño fijo conocidos en tiempo de compilación.\n"
-"  * Extremadamente rápido:  solo mueve un puntero de Stack.\n"
-"  * Fácil de manejar: sigue funciones de llamada.\n"
-"  * Mucha memoria local."
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "Stack: Es un área de memoria continua para variables locales."
+
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr "Los valores son de tamaño fijo conocidos en tiempo de compilación."
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr "Extremadamente rápido:  solo mueve un puntero de Stack."
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr "Fácil de manejar: sigue funciones de llamada."
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr "Mucha memoria local."
 
 #: src/memory-management/stack-vs-heap.md:9
-msgid ""
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* Heap: Guardar valores fuera de llamadas de funciones.\n"
-"  * Los valores tienen tamaños dinámicos determinados en tiempo de ejecución.\n"
-"  * Algo más lento que Stack: son necesarios algunos índices.\n"
-"  * No se garantiza memoria local."
+msgid "Heap: Storage of values outside of function calls."
+msgstr "Heap: Guardar valores fuera de llamadas de funciones."
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
 msgstr ""
+"Los valores tienen tamaños dinámicos determinados en tiempo de ejecución."
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "Algo más lento que Stack: son necesarios algunos índices."
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr "No se garantiza memoria local."
 
 #: src/memory-management/stack.md:3
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
-"Crear un `String` pune datos de tamaño fijo en el stack y con tamaño dado dinámicamente en el heap:"
+"Crear un `String` pune datos de tamaño fijo en el stack y con tamaño dado "
+"dinámicamente en el heap:"
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -3745,28 +4100,32 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and length and can grow if "
-"mutable via reallocation on the heap."
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
-"* Ve que un `String` es respaldado por un `Vec`, así tiene capacidad y tamaño que puede "
-"incrementarse si la mutable por relocalicación en el _heap_."
+"Ve que un `String` es respaldado por un `Vec`, así tiene capacidad y tamaño "
+"que puede incrementarse si la mutable por relocalicación en el _heap_."
 
 #: src/memory-management/stack.md:30
 msgid ""
-"* If students ask about it, you can mention that the underlying memory is heap allocated using the "
-"[System Allocator] and custom allocators can be implemented using the [Allocator API]"
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
 msgstr ""
-"* Si los estudiantes preguntan sobre esto, puedes mencionar que por debajo la memoria es colocada "
-"por _heap_ usando el [Sistema de Colocación] y la colocación personalizada puede ser implementada "
-"usando la [Allocator API]"
+"Si los estudiantes preguntan sobre esto, puedes mencionar que por debajo la "
+"memoria es colocada por _heap_ usando el [Sistema de Colocación](https://doc."
+"rust-lang.org/std/alloc/struct.System.html) y la colocación personalizada "
+"puede ser implementada usando la [Allocator API](https://doc.rust-lang.org/"
+"std/alloc/index.html)"
 
 #: src/memory-management/stack.md:32
 msgid ""
-"* We can inspect the memory layout with `unsafe` code. However, you should point out that this is "
-"rightfully unsafe!"
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
 msgstr ""
-"* Podemos inspeccionar el layout de memoria con la cláusula `unsafe`. Sin embargo, debes aclarar "
-"que esto no es seguro!"
+"Podemos inspeccionar el layout de memoria con la cláusula `unsafe`. Sin "
+"embargo, debes aclarar que esto no es seguro!"
 
 #: src/memory-management/stack.md:34
 msgid ""
@@ -3776,10 +4135,12 @@ msgid ""
 "    s1.push(' ');\n"
 "    s1.push_str(\"world\");\n"
 "    // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"    // String provides no guarantees about its layout, so this could lead to\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
 "    // undefined behavior.\n"
 "    unsafe {\n"
-"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
@@ -3794,23 +4155,12 @@ msgstr ""
 "    // El String no provee garantías en su layout, esto puede derivar en\n"
 "    // comportamientos no deseados.\n"
 "    unsafe {\n"
-"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
 "        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
 "    }\n"
 "}\n"
 "```"
-
-#: src/memory-management/stack.md:51
-msgid ""
-"[System Allocator]: https://doc.rust-lang.org/std/alloc/struct.System.html\n"
-"[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
-msgstr ""
-"[Sistema de Colocación]: https://doc.rust-lang.org/std/alloc/struct.System.html\n"
-"[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
-
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
-msgstr "# Manejo Manual de Memoria"
 
 #: src/memory-management/manual.md:3
 msgid "You allocate and deallocate heap memory yourself."
@@ -3818,14 +4168,15 @@ msgstr "Tú mismo puedes asignar o desasignar pilas (_heap_) de memoria."
 
 #: src/memory-management/manual.md:5
 msgid ""
-"If not done with care, this can lead to crashes, bugs, security vulnerabilities, and memory leaks."
+"If not done with care, this can lead to crashes, bugs, security "
+"vulnerabilities, and memory leaks."
 msgstr ""
-"Si no lo haces con cuidado, puede derivar en crasheo, errores, vulnerabilidad de seguridad, memory "
-"leaks."
+"Si no lo haces con cuidado, puede derivar en crasheo, errores, "
+"vulnerabilidad de seguridad, memory leaks."
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
-msgstr "# Ejemplo en C"
+msgid "C Example"
+msgstr "Ejemplo en C"
 
 #: src/memory-management/manual.md:9
 msgid "You must call `free` on every pointer you allocate with `malloc`:"
@@ -3846,41 +4197,40 @@ msgstr ""
 
 #: src/memory-management/manual.md:21
 msgid ""
-"Memory is leaked if the function returns early between `malloc` and `free`: the\n"
-"pointer is lost and we cannot deallocate the memory."
+"Memory is leaked if the function returns early between `malloc` and `free`: "
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
-"La memoria es _leaked_ si la función vuelve rápido entre `malloc` y `free`: se pierde el puntero y "
-"no podemos desasignar la memoria."
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
-msgstr "# Ámbitos de Manejo de Memoria"
+"La memoria es _leaked_ si la función vuelve rápido entre `malloc` y `free`: "
+"se pierde el puntero y no podemos desasignar la memoria."
 
 #: src/memory-management/scope-based.md:3
-msgid "Constructors and destructors let you hook into the lifetime of an object."
-msgstr "Los constructores y destructores te permiten mantener en _lifetime_ un objeto."
+msgid ""
+"Constructors and destructors let you hook into the lifetime of an object."
+msgstr ""
+"Los constructores y destructores te permiten mantener en _lifetime_ un "
+"objeto."
 
 #: src/memory-management/scope-based.md:5
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
-"destroyed. The compiler guarantees that this happens, even if an exception is\n"
-"raised."
+"By wrapping a pointer in an object, you can free memory when the object is "
+"destroyed. The compiler guarantees that this happens, even if an exception "
+"is raised."
 msgstr ""
-"Envolviendo un puntero con un objeto, puedes liberar memoria cuando el objeto es\n"
-"destruido. El compilador garantiza que eso pase, incluso si se alcanzó una excepción."
+"Envolviendo un puntero con un objeto, puedes liberar memoria cuando el "
+"objeto es destruido. El compilador garantiza que eso pase, incluso si se "
+"alcanzó una excepción."
 
 #: src/memory-management/scope-based.md:9
 msgid ""
-"This is often called _resource acquisition is initialization_ (RAII) and gives\n"
-"you smart pointers."
+"This is often called _resource acquisition is initialization_ (RAII) and "
+"gives you smart pointers."
 msgstr ""
-"A menudo se dice que la adquisición de recursos es inicializada ó, _resource acquisition is "
-"initialization_ (RAII),\n"
-"y brinda punteros inteligentes."
+"A menudo se dice que la adquisición de recursos es inicializada ó, _resource "
+"acquisition is initialization_ (RAII), y brinda punteros inteligentes."
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
-msgstr "## Ejemplo C++"
+msgid "C++ Example"
+msgstr "Ejemplo C++"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -3898,19 +4248,26 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:20
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
 msgstr ""
-"* El objeto `std::unique_ptr` se ubica en el stack, y los punteros a \n"
-"  memoria apuntando a el heap.\n"
-"* Al final de `say_hello`, correrá el destructor `std::unique_ptr`.\n"
-"* El destructor libera el objeto `Person`que apunta a él."
+"El objeto `std::unique_ptr` se ubica en el stack, y los punteros a  memoria "
+"apuntando a el heap."
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr "Al final de `say_hello`, correrá el destructor `std::unique_ptr`."
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
+msgstr "El destructor libera el objeto `Person`que apunta a él."
 
 #: src/memory-management/scope-based.md:25
-msgid "Special move constructors are used when passing ownership to a function:"
-msgstr "Un movimiento especial de constructor es usado cuando se pasa la propiedad a una función:"
+msgid ""
+"Special move constructors are used when passing ownership to a function:"
+msgstr ""
+"Un movimiento especial de constructor es usado cuando se pasa la propiedad a "
+"una función:"
 
 #: src/memory-management/scope-based.md:27
 msgid ""
@@ -3921,26 +4278,30 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
-msgstr "# Manejo Automático de Memoria"
+msgid "Automatic Memory Management"
+msgstr "Manejo Automático de Memoria"
 
 #: src/memory-management/garbage-collection.md:3
 msgid ""
-"An alternative to manual and scope-based memory management is automatic memory\n"
-"management:"
+"An alternative to manual and scope-based memory management is automatic "
+"memory management:"
 msgstr "Una alternativa al manejo manual es el automático:"
 
 #: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "El programador nunca asigna o desasgan memoria explícitamente."
+
+#: src/memory-management/garbage-collection.md:7
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the programmer."
+"A garbage collector finds unused memory and deallocates it for the "
+"programmer."
 msgstr ""
-"* El programador nunca asigna o desasgan memoria explícitamente.\n"
-"* Un garbage collector encuentra memoria sin usar y la libera para el programador."
+"Un garbage collector encuentra memoria sin usar y la libera para el "
+"programador."
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
-msgstr "## Ejemplo Java"
+msgid "Java Example"
+msgstr "Ejemplo Java"
 
 #: src/memory-management/garbage-collection.md:11
 msgid "The `person` object is not deallocated after `sayHello` returns:"
@@ -3961,28 +4322,39 @@ msgstr ""
 "```"
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
-msgstr "# Manejo de la Memoria en Rust"
+msgid "Memory Management in Rust"
+msgstr "Manejo de la Memoria en Rust"
 
 #: src/memory-management/rust.md:3
 msgid "Memory management in Rust is a mix:"
 msgstr "El manejo de memoria en Rust es una mezcla:"
 
 #: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "Segura y correcta como en Java, pero sin un Garbage Collector."
+
+#: src/memory-management/rust.md:6
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you choose, can be a single "
-"unique pointer, reference counted, or atomically reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even have no cost at "
-"runtime like C."
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
 msgstr ""
-"* Segura y correcta como en Java, pero sin un Garbage Collector.\n"
-"* Dependiendo qué abstracción (o combinación de abstracción) eliges, puedes ser un puntero simple, "
-"referencia contada, o atómicamente referencia contada.\n"
-"* El ámbito basado en C++, pero que el compilador fuerza a incluirlo por completo.\n"
-"* Un usuario de Rust puede elegir la abstracción correcta para la situación, algunos incluso no "
-"tienen costo en runtime como C++."
+"Dependiendo qué abstracción (o combinación de abstracción) eliges, puedes "
+"ser un puntero simple, referencia contada, o atómicamente referencia contada."
+
+#: src/memory-management/rust.md:7
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+"El ámbito basado en C++, pero que el compilador fuerza a incluirlo por "
+"completo."
+
+#: src/memory-management/rust.md:8
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
+"have no cost at runtime like C."
+msgstr ""
+"Un usuario de Rust puede elegir la abstracción correcta para la situación, "
+"algunos incluso no tienen costo en runtime como C++."
 
 #: src/memory-management/rust.md:10
 msgid "It achieves this by modeling _ownership_ explicitly."
@@ -3990,144 +4362,154 @@ msgstr "Esto se logra modelando el _ownership_ explícitamente."
 
 #: src/memory-management/rust.md:14
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually handled by RAII wrapper "
-"types such as [Box], [Vec], [Rc], or [Arc]. These encapsulate ownership and memory allocation via "
-"various means, and prevent the potential errors in C."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* Si en este punto preguntas, puedes decir que Rust usualmente es tomado por tipos wrapper RAII "
-"como [Box], [Vec], [Rc], or [Arc]. Esto encapsula el _ownsership_ y la ubicación de memoria con "
-"varios significados, y previene potenciales errores en C."
+"Si en este punto preguntas, puedes decir que Rust usualmente es tomado por "
+"tipos wrapper RAII como [Box](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html), [Rc]"
+"(https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc](https://doc.rust-"
+"lang.org/std/sync/struct.Arc.html). Esto encapsula el _ownsership_ y la "
+"ubicación de memoria con varios significados, y previene potenciales errores "
+"en C."
 
 #: src/memory-management/rust.md:16
-msgid "* You may be asked about destructors here, the [Drop] trait is the Rust equivalent."
-msgstr "* Puedes preguntar acerca de destructores, el [Drop] es el equivalente de Rust."
-
-#: src/memory-management/rust.md:20
 msgid ""
-"[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-"[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-"[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-"[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-"[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
 msgstr ""
-
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
-msgstr "# Comparación"
+"Puedes preguntar acerca de destructores, el [Drop](https://doc.rust-lang.org/"
+"std/ops/trait.Drop.html) es el equivalente de Rust."
 
 #: src/memory-management/comparison.md:3
 msgid "Here is a rough comparison of the memory management techniques."
 msgstr "Aquí una rústica comparación de técnicas de manejo de memoria."
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## Ventajas de las Diferentes Técnicas de Manejo de Memoria"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "Ventajas de las Diferentes Técnicas de Manejo de Memoria"
 
-#: src/memory-management/comparison.md:7
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* Manual como en C:\n"
-"  * No runtime overhead.\n"
-"* Automático como en Java:\n"
-"  * Totalmente automático.\n"
-"  * Correcto y Seguro.\n"
-"* Scope-based como en C++:\n"
-"  * Parcialmente automático.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced y scope-based como en Rust:\n"
-"  * Asgurado por el compilador.\n"
-"  * No runtime overhead.\n"
-"  * Correcto y Seguro."
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
+msgid "Manual like C:"
+msgstr "Manual como en C:"
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+msgid "No runtime overhead."
+msgstr "No runtime overhead."
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+msgid "Automatic like Java:"
+msgstr "Automático como en Java:"
+
+#: src/memory-management/comparison.md:10
+msgid "Fully automatic."
+msgstr "Totalmente automático."
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+msgid "Safe and correct."
+msgstr "Correcto y Seguro."
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+msgid "Scope-based like C++:"
+msgstr "Scope-based como en C++:"
+
+#: src/memory-management/comparison.md:13
+msgid "Partially automatic."
+msgstr "Parcialmente automático."
+
+#: src/memory-management/comparison.md:15
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "Compiler-enforced y scope-based como en Rust:"
+
+#: src/memory-management/comparison.md:16
+msgid "Enforced by compiler."
+msgstr "Asgurado por el compilador."
 
 #: src/memory-management/comparison.md:20
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## Contras de las Diferentes Técnicas de Manejo de Memoria"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "Contras de las Diferentes Técnicas de Manejo de Memoria"
 
-#: src/memory-management/comparison.md:22
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* Manual como en C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automático como en Java:\n"
-"  * Pausas en Garbage Colletion.\n"
-"  * Destructor delays.\n"
-"* Scope-based como en C++:\n"
-"  * Complejo, a elección del programador.\n"
-"  * Potencial de use-after-free.\n"
-"* Compiler-enforced y scope-based como Rust:\n"
-"  * Alguna upfront complexity.\n"
-"  * Puede denegar programas válidos."
+#: src/memory-management/comparison.md:23
+msgid "Use-after-free."
+msgstr "Use-after-free."
 
-#: src/ownership.md:1
-msgid "# Ownership"
-msgstr ""
+#: src/memory-management/comparison.md:24
+msgid "Double-frees."
+msgstr "Double-frees."
+
+#: src/memory-management/comparison.md:25
+msgid "Memory leaks."
+msgstr "Memory leaks."
+
+#: src/memory-management/comparison.md:27
+msgid "Garbage collection pauses."
+msgstr "Pausas en Garbage Colletion."
+
+#: src/memory-management/comparison.md:28
+msgid "Destructor delays."
+msgstr "Destructor delays."
+
+#: src/memory-management/comparison.md:30
+msgid "Complex, opt-in by programmer."
+msgstr "Complejo, a elección del programador."
+
+#: src/memory-management/comparison.md:31
+msgid "Potential for use-after-free."
+msgstr "Potencial de use-after-free."
+
+#: src/memory-management/comparison.md:32
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "Compiler-enforced y scope-based como Rust:"
+
+#: src/memory-management/comparison.md:33
+msgid "Some upfront complexity."
+msgstr "Alguna upfront complexity."
+
+#: src/memory-management/comparison.md:34
+msgid "Can reject valid programs."
+msgstr "Puede denegar programas válidos."
 
 #: src/ownership.md:3
 msgid ""
-"All variable bindings have a _scope_ where they are valid and it is an error to\n"
-"use a variable outside its scope:"
+"All variable bindings have a _scope_ where they are valid and it is an error "
+"to use a variable outside its scope:"
 msgstr ""
-"Todos los enlaces de variables tienen un _scope_ donde son válidas y es un error\n"
-"usar la variable fuera de este _scope_:"
+"Todos los enlaces de variables tienen un _scope_ donde son válidas y es un "
+"error usar la variable fuera de este _scope_:"
 
 #: src/ownership.md:6
 msgid ""
 "```rust,editable,compile_fail\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
 
 #: src/ownership.md:9
 msgid ""
-"fn main() {\n"
-"    {\n"
-"        let p = Point(3, 4);\n"
-"        println!(\"x: {}\", p.0);\n"
-"    }\n"
-"    println!(\"y: {}\", p.1);\n"
-"}\n"
-"```"
+"fn main() { { let p = Point(3, 4); println!(\"x: {}\", p.0); } println!(\"y: "
+"{}\", p.1); }"
 msgstr ""
 
 #: src/ownership.md:18
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
-msgstr ""
-"* Al final del _scope_, se borra la variable y se liberan los datos.\n"
-"* Un destructor puede correr aquí y liberar los recursos.\n"
-"* Podemos decir que la variable es dueña del valor."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
+msgstr "Al final del _scope_, se borra la variable y se liberan los datos."
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
-msgstr ""
+#: src/ownership.md:19
+msgid "A destructor can run here to free up resources."
+msgstr "Un destructor puede correr aquí y liberar los recursos."
+
+#: src/ownership.md:20
+msgid "We say that the variable _owns_ the value."
+msgstr "Podemos decir que la variable es dueña del valor."
 
 #: src/ownership/move-semantics.md:3
 msgid "An assignment will transfer ownership between variables:"
@@ -4154,34 +4536,38 @@ msgstr ""
 "```"
 
 #: src/ownership/move-semantics.md:14
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "La asignación de `s1` a `s2` transfiere el _ownership_."
+
+#: src/ownership/move-semantics.md:15
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr "Los datos se mueven de `s1` y `s2` si no se accede más."
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr "Cuando `s1` sale del ámbito, no sucede nada: no tiene dueño."
+
+#: src/ownership/move-semantics.md:17
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr "Cuando `s2` sale del ámbito, el dato del string es liberado."
+
+#: src/ownership/move-semantics.md:18
+msgid "There is always _exactly_ one variable binding which owns a value."
 msgstr ""
-"* La asignación de `s1` a `s2` transfiere el _ownership_.\n"
-"* Los datos se mueven de `s1` y `s2` si no se accede más.\n"
-"* Cuando `s1` sale del ámbito, no sucede nada: no tiene dueño.\n"
-"* Cuando `s2` sale del ámbito, el dato del string es liberado.\n"
-"* Allí siempre hay _exactamente_ una variable enlazada que es dueña del valor."
+"Allí siempre hay _exactamente_ una variable enlazada que es dueña del valor."
 
 #: src/ownership/move-semantics.md:22
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by value unless you use "
-"`std::move` (and the move constructor is defined!)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* Hay que destacar que el contrario de los defaults en C++, que copia por valor a menos que uses "
-"`std::move` (y el movimiento del constructor está definido!)."
+"Hay que destacar que el contrario de los defaults en C++, que copia por "
+"valor a menos que uses `std::move` (y el movimiento del constructor está "
+"definido!)."
 
 #: src/ownership/move-semantics.md:24
-msgid "* In Rust, clones are explicit (by using `clone`)."
-msgstr "* En Rust los clones son explícitos (usando `clone`)."
-
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
-msgstr "# Mover Strings en Rust"
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr "En Rust los clones son explícitos (usando `clone`)."
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4194,12 +4580,12 @@ msgid ""
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:10
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
-msgstr ""
-"* La pila (heap) de datos de `s1` es rehusado para `s2`.\n"
-"* Cuando `s1` sale del scope, no sucede nada (se movió de)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "La pila (heap) de datos de `s1` es rehusado para `s2`."
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgstr "Cuando `s1` sale del scope, no sucede nada (se movió de)."
 
 #: src/ownership/moved-strings-rust.md:13
 msgid "Before move to `s2`:"
@@ -4251,10 +4637,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr "# Liberar Doble en C++ moderno"
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr "El C++ moderno lo resuelve diferente:"
@@ -4273,11 +4655,15 @@ msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
-"* La pila de datos de `s1` duplicada en `s2` obtiene su copia de datos independiente.\n"
-"* Cuando `s1` y `s2` salen del scope, cada uno liberan su propia memoria."
+"La pila de datos de `s1` duplicada en `s2` obtiene su copia de datos "
+"independiente."
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"Cuando `s1` y `s2` salen del scope, cada uno liberan su propia memoria."
 
 #: src/ownership/double-free-modern-cpp.md:13
 msgid "Before copy-assignment:"
@@ -4328,16 +4714,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:1
-msgid "# Moves in Function Calls"
-msgstr "# Movimientos en Llamadas de Funciones"
-
 #: src/ownership/moves-function-calls.md:3
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
-"Cuando pasas un valor a una función, el valor es asignado al parámetro de la\n"
+"Cuando pasas un valor a una función, el valor es asignado al parámetro de la "
 "función. Esto transfiere el ownership:"
 
 #: src/ownership/moves-function-calls.md:6
@@ -4345,46 +4727,63 @@ msgid ""
 "```rust,editable\n"
 "fn say_hello(name: String) {\n"
 "    println!(\"Hello {name}\")\n"
-"}"
-msgstr ""
-
-#: src/ownership/moves-function-calls.md:11
-msgid ""
-"fn main() {\n"
-"    let name = String::from(\"Alice\");\n"
-"    say_hello(name);\n"
-"    // say_hello(name);\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/ownership/moves-function-calls.md:11
+msgid ""
+"fn main() { let name = String::from(\"Alice\"); say_hello(name); // "
+"say_hello(name); }"
+msgstr ""
+
 #: src/ownership/moves-function-calls.md:20
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. Afterwards, `name` "
-"cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the `say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) and if `say_hello` "
-"accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name.clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making move semantics the "
-"default, and by forcing programmers to make clones explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* Con la primer llamada a `say_hello`, `main` da propiedad de `name`. Después de todo, `name` no "
-"puede usarse meas dentro de `main`.\n"
-"* La pila de memoria se asigna para `name` y será liberada al final de la función `say_hello`.\n"
-"* `main` puede mantener la propiedad si pasa `name` como referencia (`&name`) y si `say_hello` "
-"acepta una referencia como un parámetro.\n"
-"* Alternativamente, `main` puede pasar un clon de `name` in la primer llamada (`name.clone()`).\n"
-"* Rust hace esto más duro que C++ para crear copias automáticas mediante mover semánticas por "
-"defecto, y forzando a los programadores a hacer clones explícitos."
+"Con la primer llamada a `say_hello`, `main` da propiedad de `name`. Después "
+"de todo, `name` no puede usarse meas dentro de `main`."
 
-#: src/ownership/copy-clone.md:1
-msgid "# Copying and Cloning"
-msgstr "# Copiar y Clonar"
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+"La pila de memoria se asigna para `name` y será liberada al final de la "
+"función `say_hello`."
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"`main` puede mantener la propiedad si pasa `name` como referencia (`&name`) "
+"y si `say_hello` acepta una referencia como un parámetro."
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+"Alternativamente, `main` puede pasar un clon de `name` in la primer llamada "
+"(`name.clone()`)."
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"Rust hace esto más duro que C++ para crear copias automáticas mediante mover "
+"semánticas por defecto, y forzando a los programadores a hacer clones "
+"explícitos."
 
 #: src/ownership/copy-clone.md:3
-msgid "While move semantics are the default, certain types are copied by default:"
-msgstr "Mientras mover semántica es por defecto, en otros casos los tipos son copiados:"
+msgid ""
+"While move semantics are the default, certain types are copied by default:"
+msgstr ""
+"Mientras mover semántica es por defecto, en otros casos los tipos son "
+"copiados:"
 
 #: src/ownership/copy-clone.md:5
 msgid ""
@@ -4410,27 +4809,23 @@ msgstr "Puedes elegir tu propio tipo para usar copias semánticas:"
 msgid ""
 "```rust,editable\n"
 "#[derive(Copy, Clone, Debug)]\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
 
 #: src/ownership/copy-clone.md:22
 msgid ""
-"fn main() {\n"
-"    let p1 = Point(3, 4);\n"
-"    let p2 = p1;\n"
-"    println!(\"p1: {p1:?}\");\n"
-"    println!(\"p2: {p2:?}\");\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point(3, 4); let p2 = p1; println!(\"p1: {p1:?}\"); "
+"println!(\"p2: {p2:?}\"); }"
 msgstr ""
 
 #: src/ownership/copy-clone.md:30
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
-msgstr ""
-"* Luego de la asignación, ambos `p1` y `p2` obtienen su propio dato.\n"
-"* También podemos usar `p1.clone()` para explícitamente copiar datos."
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr "Luego de la asignación, ambos `p1` y `p2` obtienen su propio dato."
+
+#: src/ownership/copy-clone.md:31
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr "También podemos usar `p1.clone()` para explícitamente copiar datos."
 
 #: src/ownership/copy-clone.md:35
 msgid "Copying and cloning are not the same thing:"
@@ -4438,17 +4833,30 @@ msgstr "Copiar datos y clonar no es la misma cosa:"
 
 #: src/ownership/copy-clone.md:37
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C++).\n"
-"* Cloning is a more general operation and also allows for custom behavior by implementing the "
-"`Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
 msgstr ""
-"* Copiar refiere a copias bit a bit de regiones de memoria y no funciona con objetos arbitrarios.\n"
-"* Copiar no permite por lógica personalizada (como copiar constructores en C++).\n"
-"* Clonar es una operación más general y también permite estados personalizados implementando el "
-"trato de `Clon`.\n"
-"* Copiar no funciona en tipos que implementan el trato `Drop`."
+"Copiar refiere a copias bit a bit de regiones de memoria y no funciona con "
+"objetos arbitrarios."
+
+#: src/ownership/copy-clone.md:38
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+"Copiar no permite por lógica personalizada (como copiar constructores en C+"
+"+)."
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+"Clonar es una operación más general y también permite estados personalizados "
+"implementando el trato de `Clon`."
+
+#: src/ownership/copy-clone.md:40
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr "Copiar no funciona en tipos que implementan el trato `Drop`."
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 msgid "In the above example, try the following:"
@@ -4456,359 +4864,417 @@ msgstr "En el ejemplo de arriba, intenta lo siguiente:"
 
 #: src/ownership/copy-clone.md:44
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because `String` is not a `Copy` "
-"type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in the `println!` for  "
-"`p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* Agrega el campo `String` a `struct Point`. Esto no compilará porque `String` no es un tipo de "
-"`Copia`.\n"
-"* Remueve la `Copia` de el atributo `resultante`. El error del compilador es ahora `println!` para "
-"`p1`.\n"
-"* Muestra que en cambio funciona si clonas `p1`."
+"Agrega el campo `String` a `struct Point`. Esto no compilará porque `String` "
+"no es un tipo de `Copia`."
+
+#: src/ownership/copy-clone.md:45
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"Remueve la `Copia` de el atributo `resultante`. El error del compilador es "
+"ahora `println!` para `p1`."
+
+#: src/ownership/copy-clone.md:46
+msgid "Show that it works if you clone `p1` instead."
+msgstr "Muestra que en cambio funciona si clonas `p1`."
 
 #: src/ownership/copy-clone.md:48
 msgid ""
-"If students ask about `derive`, it is sufficient to say that this is a way to generate code in "
-"Rust\n"
-"at compile time. In this case the default implementations of `Copy` and `Clone` traits are "
-"generated.\n"
-"    \n"
-"</details>"
+"If students ask about `derive`, it is sufficient to say that this is a way "
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
-"Si un estudiante pregunta sobre `derive`, es suficiente decir que esta es la forma que se genera "
-"el código en Rust\n"
-"en tiempo de compilación. En este caso la implementación del trato por defecto de `Copiar` y "
-"`Clonar` los genera.\n"
-"    \n"
-"</details>"
-
-#: src/ownership/borrowing.md:1
-msgid "# Borrowing"
-msgstr ""
+"Si un estudiante pregunta sobre `derive`, es suficiente decir que esta es la "
+"forma que se genera el código en Rust en tiempo de compilación. En este caso "
+"la implementación del trato por defecto de `Copiar` y `Clonar` los genera."
 
 #: src/ownership/borrowing.md:3
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
-"En vez de transferir la propiedad cuando llamamos a una función, puedes _prestar_\n"
-"el valor a una función:"
+"En vez de transferir la propiedad cuando llamamos a una función, puedes "
+"_prestar_ el valor a una función:"
 
 #: src/ownership/borrowing.md:6 src/ownership/lifetimes-function-calls.md:5
+#: src/ownership/borrowing.md:30
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
 
 #: src/ownership/borrowing.md:10
 msgid ""
-"fn add(p1: &Point, p2: &Point) -> Point {\n"
-"    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
-"}"
+"fn add(p1: &Point, p2: &Point) -> Point { Point(p1.0 + p2.0, p1.1 + p2.1) }"
 msgstr ""
 
 #: src/ownership/borrowing.md:14
 msgid ""
-"fn main() {\n"
-"    let p1 = Point(3, 4);\n"
-"    let p2 = Point(10, 20);\n"
-"    let p3 = add(&p1, &p2);\n"
-"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point(3, 4); let p2 = Point(10, 20); let p3 = add(&p1, "
+"&p2); println!(\"{p1:?} + {p2:?} = {p3:?}\"); }"
 msgstr ""
 
 #: src/ownership/borrowing.md:22
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
-msgstr ""
-"* El `add` de la función presta dos puntos y devuelve uno nuevo.\n"
-"* El llamador mantiene la propiedad de sus inputs."
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr "El `add` de la función presta dos puntos y devuelve uno nuevo."
+
+#: src/ownership/borrowing.md:23
+msgid "The caller retains ownership of the inputs."
+msgstr "El llamador mantiene la propiedad de sus inputs."
 
 #: src/ownership/borrowing.md:27
-msgid ""
-"Notes on stack returns:\n"
-"* Demonstrate that the return from `add` is cheap because the compiler can eliminate the copy "
-"operation. Change the above code to print stack addresses and run it on the [Playground]. In the "
-"\"DEBUG\" optimization level, the addresses should change, while the stay the same when changing "
-"to the \"RELEASE\" setting:"
-msgstr ""
-"Notas acerca de la pila devuelta:\n"
-"* Demuestra que el return de `add` es adecuado porque le compilador puede eliminar la operación de "
-"copia. Cambia el código de arriba para imprimir una pila de direcciones y corre esto en "
-"[Playground]. En nivel de optimización \"DEBUG\", las direcciones pueden cambiar, mientras que se "
-"mantienen igual cuando se cambia el seteo a \"RELEASE\":"
+msgid "Notes on stack returns:"
+msgstr "Notas acerca de la pila devuelta:"
 
-#: src/ownership/borrowing.md:30
+#: src/ownership/borrowing.md:28
 msgid ""
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);"
+"Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while the stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
+"Demuestra que el return de `add` es adecuado porque le compilador puede "
+"eliminar la operación de copia. Cambia el código de arriba para imprimir una "
+"pila de direcciones y corre esto en [Playground](https://play.rust-lang."
+"org/). En nivel de optimización \"DEBUG\", las direcciones pueden cambiar, "
+"mientras que se mantienen igual cuando se cambia el seteo a \"RELEASE\":"
 
 #: src/ownership/borrowing.md:34
 msgid ""
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }"
+"fn add(p1: &Point, p2: &Point) -> Point { let p = Point(p1.0 + p2.0, p1.1 + "
+"p2.1); println!(\"&p.0: {:p}\", &p.0); p }"
 msgstr ""
 
 #: src/ownership/borrowing.md:40
 msgid ""
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
+"fn main() { let p1 = Point(3, 4); let p2 = Point(10, 20); let p3 = add(&p1, "
+"&p2); println!(\"&p3.0: {:p}\", &p3.0); println!(\"{p1:?} + {p2:?} = "
+"{p3:?}\"); }"
+msgstr ""
+"fn main() { let p1 = Point(3, 4); let p2 = Point(10, 20); let p3 = add(&p1, "
+"&p2); println!(\"&p3.0: {:p}\", &p3.0); println!(\"{p1:?} + {p2:?} = "
+"{p3:?}\"); }"
+
+#: src/ownership/borrowing.md:47
+msgid ""
+"```\n"
 "* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification because constructors can "
-"have side effects. In Rust, this is not an issue at all. If RVO did not happen, Rust will always "
-"performs a simple and efficient `memcpy` copy."
+"* In C++, copy elision has to be defined in the language specification "
+"because constructors can have side effects. In Rust, this is not an issue at "
+"all. If RVO did not happen, Rust will always performs a simple and efficient "
+"`memcpy` copy.\n"
+"```"
 msgstr ""
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
+"```\n"
 "* El compilador de Rust puede devolver optimización de valor (RVO).\n"
-"* En C++, la copia elisión tiene que estar definida en la especificación porque los contructores "
-"pueden tener efectos secundarios. En Rust, esto para nada es un issue. Si no sucede RVO, Rust "
-"siempre hará que corre de forma simple y eficiente con una copia `memcpy`."
-
-#: src/ownership/borrowing.md:53
-msgid "[Playground]: https://play.rust-lang.org/"
-msgstr ""
-
-#: src/ownership/shared-unique-borrows.md:1
-msgid "# Shared and Unique Borrows"
-msgstr "# Shared y Unique Borrows"
+"* En C++, la copia elisión tiene que estar definida en la especificación "
+"porque los contructores pueden tener efectos secundarios. En Rust, esto para "
+"nada es un issue. Si no sucede RVO, Rust siempre hará que corre de forma "
+"simple y eficiente con una copia `memcpy`.\n"
+"```"
 
 #: src/ownership/shared-unique-borrows.md:3
 msgid "Rust puts constraints on the ways you can borrow values:"
 msgstr "Rust restringe la forma que puedes estar calores:"
 
 #: src/ownership/shared-unique-borrows.md:5
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* A lo largo del tiempo puedes tener diferentes valores `&T`, _o_\n"
-"* Puedes tener exactamente el mismo valor `&mud T`."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "A lo largo del tiempo puedes tener diferentes valores `&T`, _o_"
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
+msgstr "Puedes tener exactamente el mismo valor `&mud T`."
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
 "    let mut a: i32 = 10;\n"
-"    let b: &i32 = &a;"
+"    let b: &i32 = &a;\n"
+"```"
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:13
 msgid ""
-"    {\n"
-"        let c: &mut i32 = &mut a;\n"
-"        *c = 20;\n"
-"    }"
+"```\n"
+"{\n"
+"    let c: &mut i32 = &mut a;\n"
+"    *c = 20;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:18 src/std/rc.md:13
 msgid ""
-"    println!(\"a: {a}\");\n"
-"    println!(\"b: {b}\");\n"
-"}\n"
+"```\n"
+"println!(\"a: {a}\");\n"
+"println!(\"b: {b}\");\n"
 "```"
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:25
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable (through `c`) and as "
-"immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` to make the code "
-"compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before the new mutable "
-"borrow of `a` through `c`. This is a feature of the borrow checker called \"non-lexical "
-"lifetimes\"."
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
 msgstr ""
-"* El código de arriba no compila porque `a` es prestado como mutable (a través de `c`) y es "
-"inmutable (a través de `b`) al mismo tiempo.\n"
-"* Mueve el `println!` para `b` antes del scope que dice a `c` hacer que el código compile.\n"
-"* Luego de ese cambio, el compilados hace que `b` sea usado solo antes de un préstamo mutable de "
-"`a` a través de `c`. Esta es una característica para chequear los préstamos llamada \"non-lexical "
-"lifetimes\"."
+"El código de arriba no compila porque `a` es prestado como mutable (a través "
+"de `c`) y es inmutable (a través de `b`) al mismo tiempo."
 
-#: src/ownership/lifetimes.md:1
-msgid "# Lifetimes"
-msgstr "# Tiempo de Vida"
+#: src/ownership/shared-unique-borrows.md:26
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"Mueve el `println!` para `b` antes del scope que dice a `c` hacer que el "
+"código compile."
+
+#: src/ownership/shared-unique-borrows.md:27
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
+msgstr ""
+"Luego de ese cambio, el compilados hace que `b` sea usado solo antes de un "
+"préstamo mutable de `a` a través de `c`. Esta es una característica para "
+"chequear los préstamos llamada \"non-lexical lifetimes\"."
 
 #: src/ownership/lifetimes.md:3
 msgid "A borrowed value has a _lifetime_:"
 msgstr "Un valor prestado tiene un tiempo de vida:"
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that there is\n"
-"    a valid solution."
+msgid "The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`."
 msgstr ""
-"* El tiempo de vida puede ser otorgado: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* El tiempo también puede ser explícito: `&’a Point`, `&’document str`.\n"
-"* Leer `&’a Point` como un \"`Point` prestado\" que es válido para al menos el tiempo de `a`\".\n"
-"* Los tiempos de vida siempre son inferidos por el compilador: no puedes asignar uno tú mismo.\n"
-"* Las anotaciones de tiempo de vida crea dependencias; el compilador verifica que allí haya una "
-"solución válida."
+"El tiempo de vida puede ser otorgado: `add(p1: &Point, p2: &Point) -> Point`."
 
-#: src/ownership/lifetimes-function-calls.md:1
-msgid "# Lifetimes in Function Calls"
-msgstr "# Tiempo de Vida en Llamada a Funciones"
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr "El tiempo también puede ser explícito: `&’a Point`, `&’document str`."
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+"Leer `&’a Point` como un \"`Point` prestado\" que es válido para al menos el "
+"tiempo de `a`\"."
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+"Los tiempos de vida siempre son inferidos por el compilador: no puedes "
+"asignar uno tú mismo."
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+"Las anotaciones de tiempo de vida crea dependencias; el compilador verifica "
+"que allí haya una solución válida."
 
 #: src/ownership/lifetimes-function-calls.md:3
-msgid "In addition to borrowing its arguments, a function can return a borrowed value:"
-msgstr "Además, para prestar estos argumentos, una función puede devolver un valor prestado:"
+msgid ""
+"In addition to borrowing its arguments, a function can return a borrowed "
+"value:"
+msgstr ""
+"Además, para prestar estos argumentos, una función puede devolver un valor "
+"prestado:"
 
 #: src/ownership/lifetimes-function-calls.md:9
+#: src/ownership/lifetimes-function-calls.md:36
 msgid ""
-"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"    if p1.0 < p2.0 { p1 } else { p2 }\n"
-"}"
+"fn left_most\\<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point { if p1.0 \\< "
+"p2.0 { p1 } else { p2 } }"
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:13
 msgid ""
-"fn main() {\n"
-"    let p1: Point = Point(10, 10);\n"
-"    let p2: Point = Point(20, 20);\n"
-"    let p3: &Point = left_most(&p1, &p2);\n"
-"    println!(\"left-most point: {:?}\", p3);\n"
-"}\n"
-"```"
+"fn main() { let p1: Point = Point(10, 10); let p2: Point = Point(20, 20); "
+"let p3: &Point = left_most(&p1, &p2); println!(\"left-most point: {:?}\", "
+"p3); }"
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:21
-msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "`’a` es un parámetro genérico, inferido por el compilador."
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
 msgstr ""
-"* `’a` es un parámetro genérico, inferido por el compilador.\n"
-"* Los tiempos de vida empiezan con `’` y `’a` es el nombre típico por default.\n"
-"* Lee `&’ un Point` es \"un `Point` prestado que es válido por al menos el ciclo de vida de "
-"`a`\".\n"
-"* El _al menos_ es importante cuando los parámetros están en diferentes scopes."
+"Los tiempos de vida empiezan con `’` y `’a` es el nombre típico por default."
+
+#: src/ownership/lifetimes-function-calls.md:25
+msgid ""
+"The _at least_ part is important when parameters are in different scopes."
+msgstr ""
+"El _al menos_ es importante cuando los parámetros están en diferentes scopes."
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), resulting in the following "
-"code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);"
+"Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
-"* Mueve la declaración de `p2` y `p3` a un nuevo scope (`{ … }`), resultando en este código:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);"
+"Mueve la declaración de `p2` y `p3` a un nuevo scope (`{ … }`), resultando "
+"en este código:"
 
-#: src/ownership/lifetimes-function-calls.md:36
+#: src/ownership/lifetimes-function-calls.md:32
 msgid ""
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }"
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"```"
 
 #: src/ownership/lifetimes-function-calls.md:40
 msgid ""
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`."
+"fn main() { let p1: Point = Point(10, 10); let p3: &Point; { let p2: Point = "
+"Point(20, 20); p3 = left_most(&p1, &p2); } println!(\"left-most point: "
+"{:?}\", p3); }"
 msgstr ""
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Nota como no compila desde que `p3` persiste `p2`."
+"fn main() { let p1: Point = Point(10, 10); let p3: &Point; { let p2: Point = "
+"Point(20, 20); p3 = left_most(&p1, &p2); } println!(\"left-most point: "
+"{:?}\", p3); }"
+
+#: src/ownership/lifetimes-function-calls.md:49
+msgid ""
+"```\n"
+"Note how this does not compile since `p3` outlives `p2`.\n"
+"```"
+msgstr ""
+"```\n"
+"Nota como no compila desde que `p3` persiste `p2`.\n"
+"```"
 
 #: src/ownership/lifetimes-function-calls.md:52
+#, fuzzy
 msgid ""
-"* Reset the workspace and change the function signature to `fn left_most<'a, 'b>(p1: &'a Point, "
-"p2: &'a Point) -> &'b Point`. This will not compile because the relationship between the lifetimes "
-"`'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global variable).\n"
-"  * Which one is it? The compiler needs to to know, so at the call site the returned reference is "
-"not used\n"
-"    for longer than a variable from where the reference came from."
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
 msgstr ""
-"* Resetea el workspace y cambia el signo de la función a `fn left_most<‘a, ‘b>(p1: &’a Point, p2: "
-"&’a Point) -> &’b Point`. Esto no compilará porque la relación entre los ciclos de vida `’a` y "
-"`’b` no es clara.\n"
-"* Otra forma de explicar esto:\n"
-"  *Dos referencias para dos valores son prestados por una función y la función devuelve otra "
-"referencia.\n"
-"  * esto debe venir desde uno de esos dos inputs (o de una variable global).\n"
-"  * Cuál es esta? El compilador necesita saber, que la llamada para volver al sitio de referencia "
-"no se usa más que como variable de donde viene la referencia."
+"Resetea el workspace y cambia el signo de la función a `fn left_most<‘a, "
+"‘b>(p1: &’a Point, p2: &’a Point) -> &’b Point`. Esto no compilará porque la "
+"relación entre los ciclos de vida `’a` y `’b` no es clara."
 
-#: src/ownership/lifetimes-data-structures.md:1
-msgid "# Lifetimes in Data Structures"
-msgstr "# Ciclos de Vida y Estructura de Datos"
+#: src/ownership/lifetimes-function-calls.md:53
+#, fuzzy
+msgid "Another way to explain it:"
+msgstr ""
+"Otra forma de explicar esto: \\*Dos referencias para dos valores son "
+"prestados por una función y la función devuelve otra referencia."
+
+#: src/ownership/lifetimes-function-calls.md:54
+#, fuzzy
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+"esto debe venir desde uno de esos dos inputs (o de una variable global)."
+
+#: src/ownership/lifetimes-function-calls.md:56
+#, fuzzy
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+"Cuál es esta? El compilador necesita saber, que la llamada para volver al "
+"sitio de referencia no se usa más que como variable de donde viene la "
+"referencia."
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
-msgid "If a data type stores borrowed data, it must be annotated with a lifetime:"
-msgstr "SI un tipo de datos presta data, debe ser anotado como un ciclo de vida:"
+msgid ""
+"If a data type stores borrowed data, it must be annotated with a lifetime:"
+msgstr ""
+"SI un tipo de datos presta data, debe ser anotado como un ciclo de vida:"
 
 #: src/ownership/lifetimes-data-structures.md:5
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Highlight<'doc>(&'doc str);"
+"struct Highlight<'doc>(&'doc str);\n"
+"```"
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:9
-msgid ""
-"fn erase(text: String) {\n"
-"    println!(\"Bye {text}!\");\n"
-"}"
+msgid "fn erase(text: String) { println!(\"Bye {text}!\"); }"
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:13
 msgid ""
+"fn main() { let text = String::from(\"The quick brown fox jumps over the "
+"lazy dog.\"); let fox = Highlight(&text\\[4..19\\]); let dog = "
+"Highlight(&text\\[35..43\\]); // erase(text); println!(\"{fox:?}\"); println!"
+"(\"{dog:?}\"); }"
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:21
+msgid ""
+"```\n"
+"\n"
+"# Lifetimes in Data Structures\n"
+"\n"
+"If a data type stores borrowed data, it must be annotated with a lifetime:\n"
+"\n"
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
+"<details>\n"
+"\n"
+"* In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data.\n"
+"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error.\n"
+"* Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use.\n"
+"* When possible, make data structures own their data directly.\n"
+"* Some structs with multiple references inside can have more than one "
+"lifetime annotation. This can be necessary if there is a need to describe "
+"lifetime relationships between the references themselves, in addition to the "
+"lifetime of the struct itself. Those are very advanced use cases.\n"
+"</details>\n"
+"\n"
+"# Lifetimes in Data Structures\n"
+"\n"
+"If a data type stores borrowed data, it must be annotated with a lifetime:\n"
+"\n"
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Highlight<'doc>(&'doc str);\n"
+"\n"
+"fn erase(text: String) {\n"
+"    println!(\"Bye {text}!\");\n"
+"}\n"
+"\n"
 "fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy dog.\");\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
 "    let fox = Highlight(&text[4..19]);\n"
 "    let dog = Highlight(&text[35..43]);\n"
 "    // erase(text);\n"
@@ -4820,62 +5286,73 @@ msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data underlying the "
-"contained `&str` lives at least as long as any instance of `Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), the borrow checker "
-"throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This can be useful for "
-"creating lightweight views, but it generally makes them somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one lifetime annotation. This "
-"can be necessary if there is a need to describe lifetime relationships between the references "
-"themselves, in addition to the lifetime of the struct itself. Those are very advanced use cases.\n"
-"</details>"
+"In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data."
 msgstr ""
-"* En el ejemplo de arriba, las anotaciones `resaltadlas` fuerzan que los datos contenidos en "
-"`&str` viven al menos a lo largo de todas las instancias `resaltadlas` que usan esos datos.\n"
-"* Si el `texto` es usado antes del final del ciclo de vida de `fox` (o `dog`), el chequeado de "
-"préstamos arrojará error.\n"
-"* Los tipos que prestan datos fuerzan a los usuarios a mantener el dato original. Esto puede ser "
-"útil para crear vistas ligeras, pero generalmente hace que sea difícil de usar.\n"
-"* Cuando sea posible, haz estructuras de datos tengan su dato directamente.\n"
-"* Algunas estructuras con múltiples referencias dentro pueden tener más de una anotación de ciclo "
-"de vida. Esto puede ser necesario si allí quiere describir un a relación de ciclo de vida entre "
-"las referencias, ademas del ciclo de vida de las estructuras en sí mismo. Aquellas son casos de "
-"uso más avanzado.\n"
-"</details>"
+"En el ejemplo de arriba, las anotaciones `resaltadlas` fuerzan que los datos "
+"contenidos en `&str` viven al menos a lo largo de todas las instancias "
+"`resaltadlas` que usan esos datos."
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"Si el `texto` es usado antes del final del ciclo de vida de `fox` (o `dog`), "
+"el chequeado de préstamos arrojará error."
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"Los tipos que prestan datos fuerzan a los usuarios a mantener el dato "
+"original. Esto puede ser útil para crear vistas ligeras, pero generalmente "
+"hace que sea difícil de usar."
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+"Cuando sea posible, haz estructuras de datos tengan su dato directamente."
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"Algunas estructuras con múltiples referencias dentro pueden tener más de una "
+"anotación de ciclo de vida. Esto puede ser necesario si allí quiere "
+"describir un a relación de ciclo de vida entre las referencias, ademas del "
+"ciclo de vida de las estructuras en sí mismo. Aquellas son casos de uso más "
+"avanzado."
 
 #: src/exercises/day-1/afternoon.md:1
-msgid "# Day 1: Afternoon Exercises"
-msgstr "# Día 1: Ejercicios de la Tarde"
+msgid "Day 1: Afternoon Exercises"
+msgstr "Día 1: Ejercicios de la Tarde"
 
 #: src/exercises/day-1/afternoon.md:3
 msgid "We will look at two things:"
 msgstr "Veremos todas estas cosas:"
 
 #: src/exercises/day-1/afternoon.md:5
-msgid "* A small book library,"
-msgstr "* Un pequeño libro de biblioteca,"
+msgid "A small book library,"
+msgstr "Un pequeño libro de biblioteca,"
 
 #: src/exercises/day-1/afternoon.md:7
-msgid "* Iterators and ownership (hard)."
-msgstr "* Iteradores y propiedad (difícil)."
-
-#: src/exercises/day-1/afternoon.md:13 src/exercises/day-2/afternoon.md:9
-msgid "[solutions]: solutions-afternoon.md"
-msgstr "[soluciones]: solutions-afternoon.md"
-
-#: src/exercises/day-1/book-library.md:1
-msgid "# Designing a Library"
-msgstr "# Diseñar una Librería"
+msgid "Iterators and ownership (hard)."
+msgstr "Iteradores y propiedad (difícil)."
 
 #: src/exercises/day-1/book-library.md:3
 msgid ""
-"We will learn much more about structs and the `Vec<T>` type tomorrow. For now,\n"
-"you just need to know part of its API:"
+"We will learn much more about structs and the `Vec<T>` type tomorrow. For "
+"now, you just need to know part of its API:"
 msgstr ""
-"Mañana aprenderemos mucho mas acerca de estructuras y tipos `Vec<T>`. Por ahora,\n"
-"solo necesitas conocer parte de esta API:"
+"Mañana aprenderemos mucho mas acerca de estructuras y tipos `Vec<T>`. Por "
+"ahora, solo necesitas conocer parte de esta API:"
 
 #: src/exercises/day-1/book-library.md:6
 msgid ""
@@ -4893,176 +5370,156 @@ msgstr ""
 
 #: src/exercises/day-1/book-library.md:17
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
-"Usa esto para crear una librería de aplicación. Copia el código debajo a\n"
+"Usa esto para crear una librería de aplicación. Copia el código debajo a "
 "<https://play.rust-lang.org/> y actualiza los tipos para hacer que compile:"
 
 #: src/exercises/day-1/book-library.md:24
-msgid ""
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}"
+msgid "struct Library { books: Vec"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:28 src/exercises/day-1/solutions-afternoon.md:27
-msgid ""
-"struct Book {\n"
-"    title: String,\n"
-"    year: u16,\n"
-"}"
+#: src/exercises/day-1/book-library.md:25
+#: src/exercises/day-1/solutions-afternoon.md:24
+#: src/exercises/day-2/solutions-morning.md:71
+#: src/exercises/day-4/solutions-morning.md:35
+msgid ", }"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:33 src/exercises/day-1/solutions-afternoon.md:32
-msgid ""
-"impl Book {\n"
-"    // This is a constructor, used below.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}"
+#: src/exercises/day-1/book-library.md:28
+#: src/exercises/day-1/solutions-afternoon.md:27
+msgid "struct Book { title: String, year: u16, }"
 msgstr ""
-"impl Book {\n"
-"    // Este es el constructor, usado debajo.\n"
-"    fn new(title: &str, year: u16) -> Book {\n"
-"        Book {\n"
-"            title: String::from(title),\n"
-"            year,\n"
-"        }\n"
-"    }\n"
-"}"
+
+#: src/exercises/day-1/book-library.md:33
+#: src/exercises/day-1/solutions-afternoon.md:32
+msgid ""
+"impl Book { // This is a constructor, used below. fn new(title: &str, year: "
+"u16) -> Book { Book { title: String::from(title), year, } } }"
+msgstr ""
+"impl Book { // Este es el constructor, usado debajo. fn new(title: &str, "
+"year: u16) -> Book { Book { title: String::from(title), year, } } }"
 
 #: src/exercises/day-1/book-library.md:43
 msgid ""
-"// This makes it possible to print Book values with {}.\n"
-"impl std::fmt::Display for Book {\n"
-"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-"        write!(f, \"{} ({})\", self.title, self.year)\n"
-"    }\n"
-"}"
+"// This makes it possible to print Book values with {}. impl std::fmt::"
+"Display for Book { fn fmt(&self, f: &mut std::fmt::Formatter\\<'\\_\\>) -> "
+"std::fmt::Result { write!(f, \"{} ({})\", self.title, self.year) } }"
 msgstr ""
-"// Esto hace posible imprimir valores del libro con {}.\n"
-"impl std::fmt::Display for Book {\n"
-"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-"        write!(f, \"{} ({})\", self.title, self.year)\n"
-"    }\n"
-"}"
+"// Esto hace posible imprimir valores del libro con {}. impl std::fmt::"
+"Display for Book { fn fmt(&self, f: &mut std::fmt::Formatter\\<'\\_\\>) -> "
+"std::fmt::Result { write!(f, \"{} ({})\", self.title, self.year) } }"
 
 #: src/exercises/day-1/book-library.md:50
-msgid ""
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Library { fn new() -> Library { unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:55
 msgid ""
-"    //fn len(self) -> usize {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn len(self) -> usize {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:59
 msgid ""
-"    //fn is_empty(self) -> bool {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn is_empty(self) -> bool {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:63
 msgid ""
-"    //fn add_book(self, book: Book) {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn add_book(self, book: Book) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:67
 msgid ""
-"    //fn print_books(self) {\n"
-"    //    unimplemented!()\n"
-"    //}"
+"```\n"
+"//fn print_books(self) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:71
 msgid ""
-"    //fn oldest_book(self) -> Option<&Book> {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"}"
+"```\n"
+"//fn oldest_book(self) -> Option<&Book> {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:76
 msgid ""
-"// This shows the desired behavior. Uncomment the code below and\n"
-"// implement the missing methods. You will need to update the\n"
-"// method signatures, including the \"self\" parameter! You may\n"
-"// also need to update the variable bindings within main.\n"
-"fn main() {\n"
-"    let library = Library::new();"
+"// This shows the desired behavior. Uncomment the code below and // "
+"implement the missing methods. You will need to update the // method "
+"signatures, including the \"self\" parameter! You may // also need to update "
+"the variable bindings within main. fn main() { let library = Library::new();"
 msgstr ""
-"// Esto muestra el estado deseado. Descomenta el código debajo e\n"
-"// implementa el método que falta. Puedes necesitar actualizar el \n"
-"// signo del método, incluyendo el parámetro \"self\". También\n"
-"fn main() {\n"
-"    let library = Library::new();"
+"// Esto muestra el estado deseado. Descomenta el código debajo e // "
+"implementa el método que falta. Puedes necesitar actualizar el  // signo del "
+"método, incluyendo el parámetro \"self\". También fn main() { let library = "
+"Library::new();"
 
 #: src/exercises/day-1/book-library.md:83
+#: src/exercises/day-1/solutions-afternoon.md:113
 msgid ""
-"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
-"    //\n"
-"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
-"    //\n"
-"    //library.print_books();\n"
-"    //\n"
-"    //match library.oldest_book() {\n"
-"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
-"    //    None => println!(\"My library is empty!\"),\n"
-"    //}\n"
-"    //\n"
-"    //println!(\"Our library has {} books\", library.len());\n"
-"}\n"
+"```\n"
+"//println!(\"Our library is empty: {}\", library.is_empty());\n"
+"//\n"
+"//library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"//library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"//\n"
+"//library.print_books();\n"
+"//\n"
+"//match library.oldest_book() {\n"
+"//    Some(book) => println!(\"My oldest book is {book}\"),\n"
+"//    None => println!(\"My library is empty!\"),\n"
+"//}\n"
+"//\n"
+"//println!(\"Our library has {} books\", library.len());\n"
 "```"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:99
-msgid ""
-"<details>\n"
-"    \n"
-"[Solution](solutions-afternoon.md#designing-a-library)"
+#: src/exercises/day-1/book-library.md:101
+msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr ""
-
-#: src/exercises/day-1/iterators-and-ownership.md:1
-msgid "# Iterators and Ownership"
-msgstr "# Iteratoradores y Propiedad"
 
 #: src/exercises/day-1/iterators-and-ownership.md:3
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
-"El modelo de propiedad de Rust afecta muchas APIs. Un ejemplo de esto es\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) y\n"
+"El modelo de propiedad de Rust afecta muchas APIs. Un ejemplo de esto es "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) y "
 "[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)."
 
 #: src/exercises/day-1/iterators-and-ownership.md:8
-msgid "## `Iterator`"
+msgid "`Iterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. The\n"
-"`Iterator` trait simply says that you can call `next` until you get `None` back:"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
+"`Iterator` trait simply says that you can call `next` until you get `None` "
+"back:"
 msgstr ""
-"Estos son como interfaces: ellas describen un estado (método) para un tipo. El\n"
-"`Iterador` simplemente dice que puedes llamar al `siguiente` hasta que se devuelve `ninguno`:"
+"Estos son como interfaces: ellas describen un estado (método) para un tipo. "
+"El `Iterador` simplemente dice que puedes llamar al `siguiente` hasta que se "
+"devuelve `ninguno`:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
 msgid ""
@@ -5083,16 +5540,17 @@ msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();"
+"    let mut iter = v.iter();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:27
 msgid ""
-"    println!(\"v[0]: {:?}\", iter.next());\n"
-"    println!(\"v[1]: {:?}\", iter.next());\n"
-"    println!(\"v[2]: {:?}\", iter.next());\n"
-"    println!(\"No more items: {:?}\", iter.next());\n"
-"}\n"
+"```\n"
+"println!(\"v[0]: {:?}\", iter.next());\n"
+"println!(\"v[1]: {:?}\", iter.next());\n"
+"println!(\"v[2]: {:?}\", iter.next());\n"
+"println!(\"No more items: {:?}\", iter.next());\n"
 "```"
 msgstr ""
 
@@ -5105,15 +5563,16 @@ msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
 "    let v: Vec<i8> = vec![10, 20, 30];\n"
-"    let mut iter = v.iter();"
+"    let mut iter = v.iter();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:41
 #: src/exercises/day-1/iterators-and-ownership.md:78
 msgid ""
-"    let v0: Option<..> = iter.next();\n"
-"    println!(\"v0: {v0:?}\");\n"
-"}\n"
+"```\n"
+"let v0: Option<..> = iter.next();\n"
+"println!(\"v0: {v0:?}\");\n"
 "```"
 msgstr ""
 
@@ -5122,52 +5581,56 @@ msgid "Why is this type used?"
 msgstr "Por qué es usado este tipo?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
-msgid "## `IntoIterator`"
+msgid "`IntoIterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
-"iterator. The related trait `IntoIterator` tells you how to create the iterator:"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
+"iterator. The related trait `IntoIterator` tells you how to create the "
+"iterator:"
 msgstr ""
-"El `Iterator` te dice cómo _iterarP una vez que creas un\n"
-"iterado. La relación `IntoIterator` dice cómo crear un iterador:"
+"El `Iterator` te dice cómo \\_iterarP una vez que creas un iterado. La "
+"relación `IntoIterator` dice cómo crear un iterador:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:53
 msgid ""
 "```rust\n"
 "pub trait IntoIterator {\n"
 "    type Item;\n"
-"    type IntoIter: Iterator<Item = Self::Item>;"
+"    type IntoIter: Iterator<Item = Self::Item>;\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:58
 msgid ""
-"    fn into_iter(self) -> Self::IntoIter;\n"
-"}\n"
+"```\n"
+"fn into_iter(self) -> Self::IntoIter;\n"
 "```"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:62
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
-msgstr "La sintaxis aquí dice que cada implementación de `IntoIterator` debe declarar dos tipos:"
+msgstr ""
+"La sintaxis aquí dice que cada implementación de `IntoIterator` debe "
+"declarar dos tipos:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
-msgstr ""
-"* `Item`: el tipo que iteramos, como `i8`,\n"
-"* `IntoIter`: el tipo `Iterator` devuelto por el método `into_iter`."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr "`Item`: el tipo que iteramos, como `i8`,"
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgstr "`IntoIter`: el tipo `Iterator` devuelto por el método `into_iter`."
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
-"Nota que `IntoIter` e `Item` están linkeados: el iterado debe tener el mismo\n"
+"Nota que `IntoIter` e `Item` están linkeados: el iterado debe tener el mismo "
 "tipo `Item`, que quiere decir que retorna `Option<item>`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:71
@@ -5178,42 +5641,49 @@ msgstr "Como antes, qué es el tipo devuelto por el iterador?"
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];\n"
-"    let mut iter = v.into_iter();"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"    let mut iter = v.into_iter();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
-msgid "## `for` Loops"
-msgstr "## Loops `for`"
+msgid "`for` Loops"
+msgstr "Loops `for`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 msgid ""
-"Now that we know both `Iterator` and `IntoIterator`, we can build `for` loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
-"Ahora que sabemos de ambos `Iterator` y `Intolterator`, podemos hacer loops `for`.\n"
-"Ellos llaman `into_iter()` en una expresión e iterados sobre el iterado resultante:"
+"Ahora que sabemos de ambos `Iterator` y `Intolterator`, podemos hacer loops "
+"`for`. Ellos llaman `into_iter()` en una expresión e iterados sobre el "
+"iterado resultante:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:93
 msgid ""
-"    for word in &v {\n"
-"        println!(\"word: {word}\");\n"
-"    }"
+"```\n"
+"for word in &v {\n"
+"    println!(\"word: {word}\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:97
 msgid ""
-"    for word in v {\n"
-"        println!(\"word: {word}\");\n"
-"    }\n"
+"```\n"
+"for word in v {\n"
+"    println!(\"word: {word}\");\n"
 "}\n"
 "```"
 msgstr ""
@@ -5224,58 +5694,48 @@ msgstr "Qué es el tipo `word` en cada loop?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:105
 msgid ""
-"Experiment with the code above and then consult the documentation for [`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
-"%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
-"Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
-"Experimenta con el código de arriba y luego consultas por [`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
-"%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"y [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
-"Vec%3CT%2C%20A%3E)\n"
-"para verificar tus respuestas."
+"Experimenta con el código de arriba y luego consultas por [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) y [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) para verificar tus respuestas."
 
 #: src/welcome-day-2.md:1
-msgid "# Welcome to Day 2"
-msgstr "# Bienvenido al Día 2"
+msgid "Welcome to Day 2"
+msgstr "Bienvenido al Día 2"
 
 #: src/welcome-day-2.md:3
 msgid "Now that we have seen a fair amount of Rust, we will continue with:"
 msgstr ""
 
 #: src/welcome-day-2.md:5
-msgid "* Structs, enums, methods."
+msgid "Structs, enums, methods."
 msgstr ""
 
 #: src/welcome-day-2.md:7
-msgid "* Pattern matching: destructuring enums, structs, and arrays."
+msgid "Pattern matching: destructuring enums, structs, and arrays."
 msgstr ""
 
 #: src/welcome-day-2.md:9
 msgid ""
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and\n"
-"  `continue`."
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
 msgstr ""
 
 #: src/welcome-day-2.md:12
 msgid ""
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, `Rc`\n"
-"  and `Arc`."
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
 msgstr ""
 
 #: src/welcome-day-2.md:15
-msgid "* Modules: visibility, paths, and filesystem hierarchy."
-msgstr ""
-
-#: src/structs.md:1
-msgid "# Structs"
+msgid "Modules: visibility, paths, and filesystem hierarchy."
 msgstr ""
 
 #: src/structs.md:3
@@ -5288,52 +5748,72 @@ msgid ""
 "struct Person {\n"
 "    name: String,\n"
 "    age: u8,\n"
-"}"
-msgstr ""
-
-#: src/structs.md:11
-msgid ""
-"fn main() {\n"
-"    let mut peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    peter.age = 28;\n"
-"    println!(\"{} is {} years old\", peter.name, peter.age);\n"
-"    \n"
-"    let jackie = Person {\n"
-"        name: String::from(\"Jackie\"),\n"
-"        ..peter\n"
-"    };\n"
-"    println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/structs.md:29
+#: src/structs.md:11
 msgid ""
-"<details>\n"
-"Key Points: "
+"fn main() { let mut peter = Person { name: String::from(\"Peter\"), age: "
+"27, }; println!(\"{} is {} years old\", peter.name, peter.age);"
+msgstr ""
+
+#: src/structs.md:18
+msgid ""
+"```\n"
+"peter.age = 28;\n"
+"println!(\"{} is {} years old\", peter.name, peter.age);\n"
+"\n"
+"let jackie = Person {\n"
+"    name: String::from(\"Jackie\"),\n"
+"    ..peter\n"
+"};\n"
+"println!(\"{} is {} years old\", jackie.name, jackie.age);\n"
+"```"
 msgstr ""
 
 #: src/structs.md:32
-msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following slides.\n"
-"* This may be a good time to let people know there are different types of structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a trait on some type "
-"but don’t have any data that you want to store in the value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the old struct without "
-"having to explicitly type it all out. It must always be the last element."
+msgid "Structs work like in C or C++."
 msgstr ""
 
-#: src/structs/tuple-structs.md:1
-msgid "# Tuple Structs"
+#: src/structs.md:33
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:35
+msgid ""
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:36
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
+"old struct without having to explicitly type it all out. It must always be "
+"the last element."
 msgstr ""
 
 #: src/structs/tuple-structs.md:3
@@ -5343,16 +5823,12 @@ msgstr ""
 #: src/structs/tuple-structs.md:5
 msgid ""
 "```rust,editable\n"
-"struct Point(i32, i32);"
+"struct Point(i32, i32);\n"
+"```"
 msgstr ""
 
 #: src/structs/tuple-structs.md:8
-msgid ""
-"fn main() {\n"
-"    let p = Point(17, 23);\n"
-"    println!(\"({}, {})\", p.0, p.1);\n"
-"}\n"
-"```"
+msgid "fn main() { let p = Point(17, 23); println!(\"({}, {})\", p.0, p.1); }"
 msgstr ""
 
 #: src/structs/tuple-structs.md:14
@@ -5363,57 +5839,61 @@ msgstr ""
 msgid ""
 "```rust,editable,compile_fail\n"
 "struct PoundOfForce(f64);\n"
-"struct Newtons(f64);"
+"struct Newtons(f64);\n"
+"```"
 msgstr ""
 
 #: src/structs/tuple-structs.md:20
 msgid ""
-"fn compute_thruster_force() -> PoundOfForce {\n"
-"    todo!(\"Ask a rocket scientist at NASA\")\n"
-"}"
+"fn compute_thruster_force() -> PoundOfForce { todo!(\"Ask a rocket scientist "
+"at NASA\") }"
 msgstr ""
 
 #: src/structs/tuple-structs.md:24
-msgid ""
-"fn set_thruster_force(force: Newtons) {\n"
-"    // ...\n"
-"}"
+msgid "fn set_thruster_force(force: Newtons) { // ... }"
 msgstr ""
 
 #: src/structs/tuple-structs.md:28
 msgid ""
-"fn main() {\n"
-"    let force = compute_thruster_force();\n"
-"    set_thruster_force(force);\n"
-"}"
-msgstr ""
-
-#: src/structs/tuple-structs.md:33 src/traits/default.md:36 src/generics/trait-objects.md:86
-msgid "```"
+"fn main() { let force = compute_thruster_force(); "
+"set_thruster_force(force); }"
 msgstr ""
 
 #: src/structs/tuple-structs.md:37
 msgid ""
-"* Newtypes are a great way to encode additional information about the value in a primitive type, "
-"for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer have to validate it "
-"again at every use: 'PhoneNumber(String)` or `OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the single field in the "
-"newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic unwrapping or for instance "
-"using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). \n"
-"</details>"
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
 
-#: src/structs/field-shorthand.md:1
-msgid "# Field Shorthand Syntax"
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics). "
 msgstr ""
 
 #: src/structs/field-shorthand.md:3
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
 
@@ -5424,31 +5904,26 @@ msgid ""
 "struct Person {\n"
 "    name: String,\n"
 "    age: u8,\n"
-"}"
-msgstr ""
-
-#: src/structs/field-shorthand.md:13
-msgid ""
-"impl Person {\n"
-"    fn new(name: String, age: u8) -> Person {\n"
-"        Person { name, age }\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/structs/field-shorthand.md:19
-msgid ""
-"fn main() {\n"
-"    let peter = Person::new(String::from(\"Peter\"), 27);\n"
-"    println!(\"{peter:?}\");\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/structs/field-shorthand.md:13
+msgid ""
+"impl Person { fn new(name: String, age: u8) -> Person { Person { name, "
+"age } } }"
+msgstr ""
+
+#: src/structs/field-shorthand.md:19
+msgid ""
+"fn main() { let peter = Person::new(String::from(\"Peter\"), 27); println!"
+"(\"{peter:?}\"); }"
+msgstr ""
+
 #: src/structs/field-shorthand.md:27
 msgid ""
-"The `new` function could be written using `Self` as a type, as it is interchangeable with the "
-"struct type name"
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
 #: src/structs/field-shorthand.md:29
@@ -5459,19 +5934,13 @@ msgid ""
 "        Self { name, age }\n"
 "    }\n"
 "}\n"
-"```\n"
-"    \n"
-"</details>"
-msgstr ""
-
-#: src/enums.md:1
-msgid "# Enums"
+"```"
 msgstr ""
 
 #: src/enums.md:3
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
 
 #: src/enums.md:6
@@ -5479,67 +5948,66 @@ msgid ""
 "```rust,editable\n"
 "fn generate_random_number() -> i32 {\n"
 "    4  // Chosen by fair dice roll. Guaranteed to be random.\n"
-"}"
-msgstr ""
-
-#: src/enums.md:11
-msgid ""
-"#[derive(Debug)]\n"
-"enum CoinFlip {\n"
-"    Heads,\n"
-"    Tails,\n"
-"}"
-msgstr ""
-
-#: src/enums.md:17
-msgid ""
-"fn flip_coin() -> CoinFlip {\n"
-"    let random_number = generate_random_number();\n"
-"    if random_number % 2 == 0 {\n"
-"        return CoinFlip::Heads;\n"
-"    } else {\n"
-"        return CoinFlip::Tails;\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/enums.md:26
-msgid ""
-"fn main() {\n"
-"    println!(\"You got: {:?}\", flip_coin());\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/enums.md:31
+#: src/enums.md:11
+msgid "\\#\\[derive(Debug)\\] enum CoinFlip { Heads, Tails, }"
+msgstr ""
+
+#: src/enums.md:17
 msgid ""
-"<details>\n"
-"    \n"
-"Key Points:"
+"fn flip_coin() -> CoinFlip { let random_number = generate_random_number(); "
+"if random_number % 2 == 0 { return CoinFlip::Heads; } else { return "
+"CoinFlip::Tails; } }"
+msgstr ""
+
+#: src/enums.md:26
+msgid "fn main() { println!(\"You got: {:?}\", flip_coin()); }"
+msgstr ""
+
+#: src/enums.md:33 src/methods.md:30 src/methods/example.md:46
+#: src/pattern-matching.md:25 src/pattern-matching/match-guards.md:22
+#: src/control-flow/blocks.md:42
+msgid "Key Points:"
 msgstr ""
 
 #: src/enums.md:35
-msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and `Tail`. You might note "
-"the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or one with different "
-"types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate structs but then they "
-"wouldn’t be the same type as they would if they were all defined in an enum. \n"
-"</details>"
+msgid "Enumerations allow you to collect a set of values under one type"
 msgstr ""
 
-#: src/enums/variant-payloads.md:1
-msgid "# Variant Payloads"
+#: src/enums.md:36
+msgid ""
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+
+#: src/enums.md:37
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr ""
+
+#: src/enums.md:38
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+
+#: src/enums.md:39
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr ""
+
+#: src/enums.md:40
+msgid ""
+"You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. "
 msgstr ""
 
 #: src/enums/variant-payloads.md:3
 msgid ""
-"You can define richer enums where the variants carry data. You can then use the\n"
-"`match` statement to extract the data from each variant:"
+"You can define richer enums where the variants carry data. You can then use "
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 
 #: src/enums/variant-payloads.md:6
@@ -5549,196 +6017,212 @@ msgid ""
 "    PageLoad,                 // Variant without payload\n"
 "    KeyPress(char),           // Tuple struct variant\n"
 "    Click { x: i64, y: i64 }, // Full struct variant\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/enums/variant-payloads.md:13
 msgid ""
-"#[rustfmt::skip]\n"
-"fn inspect(event: WebEvent) {\n"
-"    match event {\n"
-"        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
-"        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
-"        WebEvent::Click { x, y } => println!(\"clicked at x={x}, y={y}\"),\n"
-"    }\n"
-"}"
+"\\#\\[rustfmt::skip\\] fn inspect(event: WebEvent) { match event { WebEvent::"
+"PageLoad       => println!(\"page loaded\"), WebEvent::KeyPress(c)    => "
+"println!(\"pressed '{c}'\"), WebEvent::Click { x, y } => println!(\"clicked "
+"at x={x}, y={y}\"), } }"
 msgstr ""
 
 #: src/enums/variant-payloads.md:22
 msgid ""
-"fn main() {\n"
-"    let load = WebEvent::PageLoad;\n"
-"    let press = WebEvent::KeyPress('x');\n"
-"    let click = WebEvent::Click { x: 20, y: 80 };"
+"fn main() { let load = WebEvent::PageLoad; let press = WebEvent::"
+"KeyPress('x'); let click = WebEvent::Click { x: 20, y: 80 };"
 msgstr ""
 
 #: src/enums/variant-payloads.md:27
 msgid ""
-"    inspect(load);\n"
-"    inspect(press);\n"
-"    inspect(click);\n"
-"}\n"
+"```\n"
+"inspect(load);\n"
+"inspect(press);\n"
+"inspect(click);\n"
 "```"
 msgstr ""
 
 #: src/enums/variant-payloads.md:35
 msgid ""
-"* In the above example, accessing the `char` in `KeyPress`, or `x` and `y` in `Click` only works "
-"within a `match` or an `if let` statement.\n"
-"* `match` and `if let` inspect a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs where comparing field "
-"values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::Click(Click)` with a top level "
-"`struct Click { ... }`. The inlined version cannot implement traits, for example."
+"In the above example, accessing the `char` in `KeyPress`, or `x` and `y` in "
+"`Click` only works within a `match` or an `if let` statement."
 msgstr ""
 
-#: src/enums/sizes.md:1
-msgid "# Enum Sizes"
+#: src/enums/variant-payloads.md:36
+msgid "`match` and `if let` inspect a hidden discriminant field in the `enum`."
+msgstr ""
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
 msgstr ""
 
 #: src/enums/sizes.md:3
-msgid "Rust enums are packed tightly, taking constraints due to alignment into account:"
+msgid ""
+"Rust enums are packed tightly, taking constraints due to alignment into "
+"account:"
 msgstr ""
 
 #: src/enums/sizes.md:5
 msgid ""
 "```rust,editable\n"
-"use std::mem::{align_of, size_of};"
+"use std::mem::{align_of, size_of};\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:8
 msgid ""
-"macro_rules! dbg_size {\n"
-"    ($t:ty) => {\n"
-"        println!(\"{}: size {} bytes, align: {} bytes\",\n"
-"                 stringify!($t), size_of::<$t>(), align_of::<$t>());\n"
-"    };\n"
-"}"
+"macro_rules! dbg_size { ($t:ty) => { println!(\"{}: size {} bytes, align: {} "
+"bytes\", stringify!($t), size_of::\\<$t>(), align_of::\\<$t>()); }; }"
 msgstr ""
 
 #: src/enums/sizes.md:15
-msgid ""
-"enum Foo {\n"
-"    A,\n"
-"    B,\n"
-"}"
+msgid "enum Foo { A, B, }"
 msgstr ""
 
 #: src/enums/sizes.md:20
-msgid ""
-"#[repr(u32)]\n"
-"enum Bar {\n"
-"    A,  // 0\n"
-"    B = 10000,\n"
-"    C,  // 10001\n"
-"}"
+msgid "\\#\\[repr(u32)\\] enum Bar { A,  // 0 B = 10000, C,  // 10001 }"
 msgstr ""
 
 #: src/enums/sizes.md:27
 msgid ""
-"fn main() {\n"
-"    dbg_size!(Foo);\n"
-"    dbg_size!(Bar);\n"
-"    dbg_size!(bool);\n"
-"    dbg_size!(Option<bool>);\n"
-"    dbg_size!(&i32);\n"
-"    dbg_size!(Option<&i32>);\n"
-"}\n"
-"```"
+"fn main() { dbg_size!(Foo); dbg_size!(Bar); dbg_size!(bool); dbg_size!(Option"
+msgstr ""
+
+#: src/enums/sizes.md:31
+msgid "); dbg_size!(&i32); dbg_size!(Option\\<&i32>); }"
 msgstr ""
 
 #: src/enums/sizes.md:37
-msgid "* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout.html)."
+msgid ""
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"html)."
 msgstr ""
 
-#: src/enums/sizes.md:39
+#: src/enums/sizes.md:41
+msgid "Key Points: "
+msgstr ""
+
+#: src/enums/sizes.md:42
 msgid ""
-"<details>\n"
-"    \n"
-"Key Points: \n"
-" * Internally Rust is using a field (discriminant) to keep track of the enum variant.\n"
-" * `Bar` enum demonstrates that there is a way to control the discriminant value and type. If "
-"`repr` is removed, the discriminant type takes 2 bytes, becuase 10001 fits 2 bytes.\n"
-" * As a niche optimization an enum discriminant is merged with the pointer so that `Option<&Foo>` "
-"is the same size as `&Foo`.\n"
-" * `Option<bool>` is another example of tight packing.\n"
-" * For [some types](https://doc.rust-lang.org/std/option/#representation), Rust guarantees that "
-"`size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-" * Zero-sized types allow for efficient implementation of `HashSet` using `HashMap` with `()` as "
-"the value."
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+
+#: src/enums/sizes.md:43
+msgid ""
+"`Bar` enum demonstrates that there is a way to control the discriminant "
+"value and type. If `repr` is removed, the discriminant type takes 2 bytes, "
+"becuase 10001 fits 2 bytes."
+msgstr ""
+
+#: src/enums/sizes.md:44
+msgid ""
+"As a niche optimization an enum discriminant is merged with the pointer so "
+"that `Option<&Foo>` is the same size as `&Foo`."
+msgstr ""
+
+#: src/enums/sizes.md:45
+msgid "`Option<bool>` is another example of tight packing."
+msgstr ""
+
+#: src/enums/sizes.md:46
+msgid ""
+"For [some types](https://doc.rust-lang.org/std/option/#representation), Rust "
+"guarantees that `size_of::<T>()` equals `size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:47
+msgid ""
+"Zero-sized types allow for efficient implementation of `HashSet` using "
+"`HashMap` with `()` as the value."
 msgstr ""
 
 #: src/enums/sizes.md:49
 msgid ""
-"Example code if you want to show how the bitwise representation *may* look like in practice.\n"
-"It's important to note that the compiler provides no guarantees regarding this representation, "
-"therefore this is totally unsafe."
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
 msgstr ""
 
 #: src/enums/sizes.md:52
 msgid ""
 "```rust,editable\n"
-"use std::mem::transmute;"
+"use std::mem::transmute;\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:55 src/enums/sizes.md:94
 msgid ""
-"macro_rules! dbg_bits {\n"
-"    ($e:expr, $bit_type:ty) => {\n"
-"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, $bit_type>($e));\n"
-"    };\n"
-"}"
+"macro_rules! dbg_bits { ($e:expr, $bit_type:ty) => { println!(\"- {}: {:"
+"#x}\", stringify!($e), transmute::\\<\\_, $bit_type>($e)); }; }"
 msgstr ""
 
 #: src/enums/sizes.md:61
 msgid ""
-"fn main() {\n"
-"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"    // representation of types.\n"
-"    unsafe {\n"
-"        println!(\"Bitwise representation of bool\");\n"
-"        dbg_bits!(false, u8);\n"
-"        dbg_bits!(true, u8);"
+"fn main() { // TOTALLY UNSAFE. Rust provides no guarantees about the "
+"bitwise // representation of types. unsafe { println!(\"Bitwise "
+"representation of bool\"); dbg_bits!(false, u8); dbg_bits!(true, u8);"
 msgstr ""
 
 #: src/enums/sizes.md:69
 msgid ""
-"        println!(\"Bitwise representation of Option<bool>\");\n"
-"        dbg_bits!(None::<bool>, u8);\n"
-"        dbg_bits!(Some(false), u8);\n"
-"        dbg_bits!(Some(true), u8);"
+"```\n"
+"    println!(\"Bitwise representation of Option<bool>\");\n"
+"    dbg_bits!(None::<bool>, u8);\n"
+"    dbg_bits!(Some(false), u8);\n"
+"    dbg_bits!(Some(true), u8);\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:74
 msgid ""
-"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"        dbg_bits!(Some(Some(false)), u8);\n"
-"        dbg_bits!(Some(Some(true)), u8);\n"
-"        dbg_bits!(Some(None::<bool>), u8);\n"
-"        dbg_bits!(None::<Option<bool>>, u8);"
+"```\n"
+"    println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"    dbg_bits!(Some(Some(false)), u8);\n"
+"    dbg_bits!(Some(Some(true)), u8);\n"
+"    dbg_bits!(Some(None::<bool>), u8);\n"
+"    dbg_bits!(None::<Option<bool>>, u8);\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:80
 msgid ""
-"        println!(\"Bitwise representation of Option<&i32>\");\n"
-"        dbg_bits!(None::<&i32>, usize);\n"
-"        dbg_bits!(Some(&0i32), usize);\n"
-"    }\n"
+"```\n"
+"    println!(\"Bitwise representation of Option<&i32>\");\n"
+"    dbg_bits!(None::<&i32>, usize);\n"
+"    dbg_bits!(Some(&0i32), usize);\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/enums/sizes.md:87
 msgid ""
-"More complex example if you want to discuss what happens when we chain more than 256 `Option`s "
-"together."
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
 msgstr ""
 
 #: src/enums/sizes.md:89
 msgid ""
 "```rust,editable\n"
-"#![recursion_limit = \"1000\"]"
+"#![recursion_limit = \"1000\"]\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:92
@@ -5747,157 +6231,171 @@ msgstr ""
 
 #: src/enums/sizes.md:100
 msgid ""
-"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" signs.\n"
-"// Increasing the recursion limit is required to evaluate this macro.\n"
-"macro_rules! many_options {\n"
-"    ($value:expr) => { Some($value) };\n"
-"    ($value:expr, @) => {\n"
-"        Some(Some($value))\n"
-"    };\n"
-"    ($value:expr, @ $($more:tt)+) => {\n"
-"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"    };\n"
-"}"
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"signs. // Increasing the recursion limit is required to evaluate this macro. "
+"macro_rules! many_options { ($value:expr) => { Some($value) }; ($value:expr, "
+"@) => { Some(Some($value)) }; ($value:expr, @ $($more:tt)+) => "
+"{ many_options!(many_options!($value, $($more)+), $($more)+) }; }"
 msgstr ""
 
 #: src/enums/sizes.md:112
 msgid ""
-"fn main() {\n"
-"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"    // representation of types.\n"
-"    unsafe {\n"
-"        assert_eq!(many_options!(false), Some(false));\n"
-"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"        assert_eq!(many_options!(false, @@), Some(Some(Some(Some(false)))));"
+"fn main() { // TOTALLY UNSAFE. Rust provides no guarantees about the "
+"bitwise // representation of types. unsafe { assert_eq!(many_options!"
+"(false), Some(false)); assert_eq!(many_options!(false, @), "
+"Some(Some(false))); assert_eq!(many_options!(false, @@), "
+"Some(Some(Some(Some(false)))));"
 msgstr ""
 
 #: src/enums/sizes.md:120
 msgid ""
-"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
-"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"        dbg_bits!(many_options!(true, @@@@@@@), u8);"
+"```\n"
+"    println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"    dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"    dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:124
 msgid ""
-"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
-"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(true, @@@@@@@@), u16);"
+"```\n"
+"    println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"    dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"```"
 msgstr ""
 
 #: src/enums/sizes.md:128
 msgid ""
-"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
-"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"    }\n"
+"```\n"
+"    println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"    dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"    dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/methods.md:3
 msgid ""
-"Rust allows you to associate functions with your new types. You do this with an\n"
-"`impl` block:"
+"Rust allows you to associate functions with your new types. You do this with "
+"an `impl` block:"
 msgstr ""
 
 #: src/methods.md:13
 msgid ""
-"impl Person {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Hello, my name is {}\", self.name);\n"
-"    }\n"
-"}"
+"impl Person { fn say_hello(&self) { println!(\"Hello, my name is {}\", self."
+"name); } }"
 msgstr ""
-"impl Person {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Hola, mi nombre es {}\", self.name);\n"
-"    }\n"
-"}"
+"impl Person { fn say_hello(&self) { println!(\"Hola, mi nombre es {}\", self."
+"name); } }"
 
 #: src/methods.md:19
 msgid ""
-"fn main() {\n"
-"    let peter = Person {\n"
-"        name: String::from(\"Peter\"),\n"
-"        age: 27,\n"
-"    };\n"
-"    peter.say_hello();\n"
-"}\n"
-"```"
+"fn main() { let peter = Person { name: String::from(\"Peter\"), age: 27, }; "
+"peter.say_hello(); }"
 msgstr ""
 
-#: src/methods.md:30
+#: src/methods.md:31
+msgid "It can be helpful to introduce methods by comparing them to functions."
+msgstr ""
+
+#: src/methods.md:32
 msgid ""
-"Key Points:\n"
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), the first parameter "
-"represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method receiver syntax and to help "
-"keep them more organized. By using methods we can keep all the implementation code in one "
-"predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show how the struct name "
-"could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in and can be used "
-"elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used to refer to individual "
-"fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from `self` by modifying the "
-"code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   \n"
-"</details>"
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
 msgstr ""
 
-#: src/methods/receiver.md:1
-msgid "# Method Receiver"
+#: src/methods.md:33
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+
+#: src/methods.md:34
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr ""
+
+#: src/methods.md:35
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+
+#: src/methods.md:36
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+
+#: src/methods.md:37
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+
+#: src/methods.md:38
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+
+#: src/methods.md:39
+msgid "We describe the distinction between method receivers next."
 msgstr ""
 
 #: src/methods/receiver.md:3
 msgid ""
-"The `&self` above indicates that the method borrows the object immutably. There\n"
-"are other possible receivers for a method:"
+"The `&self` above indicates that the method borrows the object immutably. "
+"There are other possible receivers for a method:"
 msgstr ""
 
 #: src/methods/receiver.md:6
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. The\n"
-"  method becomes the owner of the object. The object will be dropped (deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted.\n"
-"* `mut self`: same as above, but while the method owns the object, it can\n"
-"  mutate it too. Complete ownership does not automatically mean mutability.\n"
-"* No receiver: this becomes a static method on the struct. Typically used to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:8
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:10
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted."
+msgstr ""
+
+#: src/methods/receiver.md:14
+msgid ""
+"`mut self`: same as above, but while the method owns the object, it can "
+"mutate it too. Complete ownership does not automatically mean mutability."
+msgstr ""
+
+#: src/methods/receiver.md:16
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
 msgstr ""
 
 #: src/methods/receiver.md:19
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
 
-#: src/methods/receiver.md:23
+#: src/methods/receiver.md:25
 msgid ""
-"<details>\n"
-"  \n"
-"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". These constraints always "
-"come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) method on it.\n"
-"  \n"
-"</details>"
-msgstr ""
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "# Example"
+"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 
 #: src/methods/example.md:3
@@ -5907,83 +6405,89 @@ msgid ""
 "struct Race {\n"
 "    name: String,\n"
 "    laps: Vec<i32>,\n"
-"}"
-msgstr ""
-
-#: src/methods/example.md:10
-msgid ""
-"impl Race {\n"
-"    fn new(name: &str) -> Race {  // No receiver, a static method\n"
-"        Race { name: String::from(name), laps: Vec::new() }\n"
-"    }"
-msgstr ""
-
-#: src/methods/example.md:15
-msgid ""
-"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write access to self\n"
-"        self.laps.push(lap);\n"
-"    }"
-msgstr ""
-
-#: src/methods/example.md:19
-msgid ""
-"    fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
-"        println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
-"        for (idx, lap) in self.laps.iter().enumerate() {\n"
-"            println!(\"Lap {idx}: {lap} sec\");\n"
-"        }\n"
-"    }"
-msgstr ""
-
-#: src/methods/example.md:26
-msgid ""
-"    fn finish(self) {  // Exclusive ownership of self\n"
-"        let total = self.laps.iter().sum::<i32>();\n"
-"        println!(\"Race {} is finished, total lap time: {}\", self.name, total);\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/methods/example.md:32
-msgid ""
-"fn main() {\n"
-"    let mut race = Race::new(\"Monaco Grand Prix\");\n"
-"    race.add_lap(70);\n"
-"    race.add_lap(68);\n"
-"    race.print_laps();\n"
-"    race.add_lap(71);\n"
-"    race.print_laps();\n"
-"    race.finish();\n"
-"    // race.add_lap(42);\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/methods/example.md:44
+#: src/methods/example.md:10
 msgid ""
-"<details>\n"
-"    \n"
-"Key Points:\n"
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the variable values and if/"
-"how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` twice.\n"
-"* Note that although the method receivers are different, the non-static functions are called the "
-"same way in the main body. Rust enables automatic referencing and dereferencing when calling "
-"methods. Rust automatically adds in the `&`, `*`, `muts` so that that object matches the method "
-"signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated over. We describe "
-"vectors in more detail in the afternoon. "
+"impl Race { fn new(name: &str) -> Race {  // No receiver, a static method "
+"Race { name: String::from(name), laps: Vec::new() } }"
 msgstr ""
 
-#: src/pattern-matching.md:1
-msgid "# Pattern Matching"
+#: src/methods/example.md:15
+msgid ""
+"```\n"
+"fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write access "
+"to self\n"
+"    self.laps.push(lap);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/methods/example.md:19
+msgid ""
+"```\n"
+"fn print_laps(&self) {  // Shared and read-only borrowed access to self\n"
+"    println!(\"Recorded {} laps for {}:\", self.laps.len(), self.name);\n"
+"    for (idx, lap) in self.laps.iter().enumerate() {\n"
+"        println!(\"Lap {idx}: {lap} sec\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/methods/example.md:26
+msgid ""
+"```\n"
+"fn finish(self) {  // Exclusive ownership of self\n"
+"    let total = self.laps.iter().sum::<i32>();\n"
+"    println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"total);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/methods/example.md:32
+msgid ""
+"fn main() { let mut race = Race::new(\"Monaco Grand Prix\"); race."
+"add_lap(70); race.add_lap(68); race.print_laps(); race.add_lap(71); race."
+"print_laps(); race.finish(); // race.add_lap(42); }"
+msgstr ""
+
+#: src/methods/example.md:47
+msgid "All four methods here use a different method receiver."
+msgstr ""
+
+#: src/methods/example.md:48
+msgid ""
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+
+#: src/methods/example.md:49
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+
+#: src/methods/example.md:50
+msgid ""
+"Note that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+
+#: src/methods/example.md:51
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
 msgstr ""
 
 #: src/pattern-matching.md:3
 msgid ""
-"The `match` keyword let you match a value against one or more _patterns_. The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The `match` keyword let you match a value against one or more _patterns_. "
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
 #: src/pattern-matching.md:6
@@ -5994,17 +6498,18 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let input = 'x';"
+"    let input = 'x';\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching.md:12
 msgid ""
-"    match input {\n"
-"        'q'                   => println!(\"Quitting\"),\n"
-"        'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
-"        '0'..='9'             => println!(\"Number input\"),\n"
-"        _                     => println!(\"Something else\"),\n"
-"    }\n"
+"```\n"
+"match input {\n"
+"    'q'                   => println!(\"Quitting\"),\n"
+"    'a' | 's' | 'w' | 'd' => println!(\"Moving around\"),\n"
+"    '0'..='9'             => println!(\"Number input\"),\n"
+"    _                     => println!(\"Something else\"),\n"
 "}\n"
 "```"
 msgstr ""
@@ -6013,33 +6518,49 @@ msgstr ""
 msgid "The `_` pattern is a wildcard pattern which matches any value."
 msgstr ""
 
-#: src/pattern-matching.md:23
+#: src/pattern-matching.md:26
 msgid ""
-"<details>\n"
-"    \n"
-"Key Points:\n"
-"* You might point out how some specific characters are being used when in a pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a wildcard character with "
-"a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, as the term can show "
-"up in error messages.\n"
-"   \n"
-"</details>"
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:1
-msgid "# Destructuring Enums"
+#: src/pattern-matching.md:27
+msgid "`|` as an `or`"
+msgstr ""
+
+#: src/pattern-matching.md:28
+msgid "`..` can expand as much as it needs to be"
+msgstr ""
+
+#: src/pattern-matching.md:29
+msgid "`1..=5` represents an inclusive range"
+msgstr ""
+
+#: src/pattern-matching.md:30
+msgid "`_` is a wild card"
+msgstr ""
+
+#: src/pattern-matching.md:31
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+
+#: src/pattern-matching.md:32
+msgid "You can demonstrate matching on a reference."
+msgstr ""
+
+#: src/pattern-matching.md:33
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:3
 msgid ""
-"Patterns can also be used to bind variables to parts of your values. This is how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` type:"
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:6
@@ -6048,50 +6569,41 @@ msgid ""
 "enum Result {\n"
 "    Ok(i32),\n"
 "    Err(String),\n"
-"}"
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:12
-msgid ""
-"fn divide_in_two(n: i32) -> Result {\n"
-"    if n % 2 == 0 {\n"
-"        Result::Ok(n / 2)\n"
-"    } else {\n"
-"        Result::Err(format!(\"cannot divide {n} into two equal parts\"))\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/pattern-matching/destructuring-enums.md:20
-msgid ""
-"fn main() {\n"
-"    let n = 100;\n"
-"    match divide_in_two(n) {\n"
-"        Result::Ok(half) => println!(\"{n} divided in two is {half}\"),\n"
-"        Result::Err(msg) => println!(\"sorry, an error happened: {msg}\"),\n"
-"    }\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/pattern-matching/destructuring-enums.md:12
+msgid ""
+"fn divide_in_two(n: i32) -> Result { if n % 2 == 0 { Result::Ok(n / 2) } "
+"else { Result::Err(format!(\"cannot divide {n} into two equal parts\")) } }"
+msgstr ""
+
+#: src/pattern-matching/destructuring-enums.md:20
+msgid ""
+"fn main() { let n = 100; match divide_in_two(n) { Result::Ok(half) => "
+"println!(\"{n} divided in two is {half}\"), Result::Err(msg) => println!"
+"(\"sorry, an error happened: {msg}\"), } }"
+msgstr ""
+
 #: src/pattern-matching/destructuring-enums.md:29
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the first\n"
-"arm, `half` is bound to the value inside the `Ok` variant. In the second arm,\n"
-"`msg` is bound to the error message."
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm, `msg` is bound to the error message."
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:35
+#: src/pattern-matching/destructuring-enums.md:36
 msgid ""
-"Key points:\n"
-"* The `if`/`else` expression is returning an enum that is later unpacked with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying the errors when running "
-"the code. Point out the places where your code is now inexhaustive and how the compiler tries to "
-"give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:1
-msgid "# Destructuring Structs"
+#: src/pattern-matching/destructuring-enums.md:37
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:3
@@ -6104,37 +6616,57 @@ msgid ""
 "struct Foo {\n"
 "    x: (u32, u32),\n"
 "    y: u32,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:11
 msgid ""
-"#[rustfmt::skip]\n"
-"fn main() {\n"
-"    let foo = Foo { x: (1, 2), y: 3 };\n"
-"    match foo {\n"
-"        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
-"        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were ignored\"),\n"
-"    }\n"
-"}\n"
+"\\#\\[rustfmt::skip\\] fn main() { let foo = Foo { x: (1, 2), y: 3 }; match "
+"foo { Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"), Foo "
+"{ y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"), Foo { y, .. }        => "
+"println!(\"y = {y}, other fields were ignored\"), } }"
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:20
+msgid ""
 "```\n"
-"<details>"
+"<details>\n"
+"\n"
+"# Destructuring Structs\n"
+"\n"
+"You can also destructure `structs`:\n"
+"\n"
+"```rust,editable\n"
+"struct Foo {\n"
+"    x: (u32, u32),\n"
+"    y: u32,\n"
+"}\n"
+"\n"
+"* Change the literal values in `foo` to match with the other patterns.\n"
+"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
+"</details>\n"
+"\n"
+"# Destructuring Structs\n"
+"\n"
+"You can also destructure `structs`:\n"
+"\n"
+"```rust,editable\n"
+"{{#include ../../third_party/rust-by-example/destructuring-structs.rs}}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"</details>"
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-msgid "# Destructuring Arrays"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
-msgid "You can destructure arrays, tuples, and slices by matching on their elements:"
+msgid ""
+"You can destructure arrays, tuples, and slices by matching on their elements:"
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:5
@@ -6154,7 +6686,9 @@ msgid ""
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
-msgid "* Destructuring of slices of unknown length also works with patterns of fixed length."
+msgid ""
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:24
@@ -6163,36 +6697,51 @@ msgid ""
 "fn main() {\n"
 "    inspect(&[0, -2, 3]);\n"
 "    inspect(&[0, -2, 3, 4]);\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:30
 msgid ""
-"#[rustfmt::skip]\n"
-"fn inspect(slice: &[i32]) {\n"
-"    println!(\"Tell me about {slice:?}\");\n"
-"    match slice {\n"
-"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"        _          => println!(\"All elements were ignored\"),\n"
-"    }\n"
-"}\n"
+"\\#\\[rustfmt::skip\\] fn inspect(slice: &\\[i32\\]) { println!(\"Tell me "
+"about {slice:?}\"); match slice { &\\[0, y, z\\] => println!(\"First is 0, y "
+"= {y}, and z = {z}\"), &\\[1, ..\\]   => println!(\"First is 1 and the rest "
+"were ignored\"), \\_          => println!(\"All elements were ignored\"), } }"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:39
+msgid ""
 "```\n"
 "  \n"
 "* Create a new pattern using `_` to represent an element. \n"
 "* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
-msgstr ""
-
-#: src/pattern-matching/match-guards.md:1
-msgid "# Match Guards"
+"* Point out that how `..` will expand to account for different number of "
+"elements.\n"
+"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`\n"
+"\n"
+"# Destructuring Arrays\n"
+"\n"
+"You can destructure arrays, tuples, and slices by matching on their "
+"elements:\n"
+"\n"
+"```rust,editable\n"
+"#[rustfmt::skip]\n"
+"fn main() {\n"
+"    let triple = [0, -2, 3];\n"
+"    println!(\"Tell me about {triple:?}\");\n"
+"    match triple {\n"
+"        [0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        [1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _         => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 msgid ""
-"When matching, you can add a _guard_ to a pattern. This is an arbitrary Boolean\n"
-"expression which will be executed if the pattern matches:"
+"When matching, you can add a _guard_ to a pattern. This is an arbitrary "
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:6
@@ -6212,22 +6761,33 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:22
+#: src/pattern-matching/match-guards.md:23
 msgid ""
-"Key Points:\n"
-"* Match guards as a separate syntax feature are important and necessary when we wish to concisely "
-"express more complex ideas than patterns alone would allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. An `if` expression "
-"inside of the branch block (after `=>`) happens after the match arm is selected. Failing the `if` "
-"condition inside of that block won't result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a pattern with an `|`.\n"
-"</details>"
+"Match guards as a separate syntax feature are important and necessary when "
+"we wish to concisely express more complex ideas than patterns alone would "
+"allow."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:24
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
+"An `if` expression inside of the branch block (after `=>`) happens after the "
+"match arm is selected. Failing the `if` condition inside of that block won't "
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:26
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:27
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
 msgstr ""
 
 #: src/exercises/day-2/morning.md:1
-msgid "# Day 2: Morning Exercises"
+msgid "Day 2: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:3
@@ -6235,108 +6795,197 @@ msgid "We will look at implementing methods in two contexts:"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:5
-msgid "* Simple struct which tracks health statistics."
+msgid "Simple struct which tracks health statistics."
 msgstr ""
 
 #: src/exercises/day-2/morning.md:7
-msgid "* Multiple structs and enums for a drawing library."
-msgstr ""
-
-#: src/exercises/day-2/health-statistics.md:1
-msgid "# Health Statistics"
+msgid "Multiple structs and enums for a drawing library."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
 msgid ""
-"You're working on implementing a health-monitoring system. As part of that, you\n"
-"need to keep track of users' health statistics."
+"You're working on implementing a health-monitoring system. As part of that, "
+"you need to keep track of users' health statistics."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
-"You'll start with some stubbed functions in an `impl` block as well as a `User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:17
-msgid ""
-"struct User {\n"
-"    name: String,\n"
-"    age: u32,\n"
-"    weight: f32,\n"
-"}"
+msgid "struct User { name: String, age: u32, weight: f32, }"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:23
 msgid ""
-"impl User {\n"
-"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
-"        unimplemented!()\n"
-"    }"
+"impl User { pub fn new(name: String, age: u32, weight: f32) -> Self "
+"{ unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:28
 msgid ""
-"    pub fn name(&self) -> &str {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn name(&self) -> &str {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:32
 msgid ""
-"    pub fn age(&self) -> u32 {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn age(&self) -> u32 {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:36
 msgid ""
-"    pub fn weight(&self) -> f32 {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn weight(&self) -> f32 {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:40
 msgid ""
-"    pub fn set_age(&mut self, new_age: u32) {\n"
-"        unimplemented!()\n"
-"    }"
+"```\n"
+"pub fn set_age(&mut self, new_age: u32) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:44
 msgid ""
-"    pub fn set_weight(&mut self, new_weight: f32) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn set_weight(&mut self, new_weight: f32) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:49
 msgid ""
-"fn main() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
-"}"
+"fn main() { let bob = User::new(String::from(\"Bob\"), 32, 155.2); println!"
+"(\"I'm {} and my age is {}\", bob.name(), bob.age()); }"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:54
 msgid ""
-"#[test]\n"
-"fn test_weight() {\n"
-"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
-"    assert_eq!(bob.weight(), 155.2);\n"
-"}"
+"\\#\\[test\\] fn test_weight() { let bob = User::new(String::from(\"Bob\"), "
+"32, 155.2); assert_eq!(bob.weight(), 155.2); }"
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:60
 msgid ""
+"\\#\\[test\\] fn test_set_age() { let mut bob = User::new(String::"
+"from(\"Bob\"), 32, 155.2); assert_eq!(bob.age(), 32); bob.set_age(33); "
+"assert_eq!(bob.age(), 33); }"
+msgstr ""
+
+#: src/exercises/day-2/health-statistics.md:67
+msgid ""
+"```\n"
+"\n"
+"# Health Statistics\n"
+"\n"
+"You're working on implementing a health-monitoring system. As part of that, "
+"you\n"
+"need to keep track of users' health statistics.\n"
+"\n"
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User`\n"
+"struct definition. Your goal is to implement the stubbed out methods on the\n"
+"`User` `struct` defined in the `impl` block.\n"
+"\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"methods:\n"
+"\n"
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"struct User {\n"
+"    name: String,\n"
+"    age: u32,\n"
+"    weight: f32,\n"
+"}\n"
+"\n"
+"impl User {\n"
+"    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn name(&self) -> &str {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn age(&self) -> u32 {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn weight(&self) -> f32 {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn set_age(&mut self, new_age: u32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"\n"
+"    pub fn set_weight(&mut self, new_weight: f32) {\n"
+"        unimplemented!()\n"
+"    }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_weight() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.weight(), 155.2);\n"
+"}\n"
+"\n"
+"# Health Statistics\n"
+"\n"
+"{{#include ../../../third_party/rust-on-exercism/health-statistics.md}}\n"
+"\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the "
+"missing\n"
+"methods:\n"
+"\n"
+"```rust,should_panic\n"
+"// TODO: remove this when you're done with your implementation.\n"
+"#![allow(unused_variables, dead_code)]\n"
+"\n"
+"{{#include ../../../third_party/rust-on-exercism/health-statistics.rs}}\n"
+"\n"
+"fn main() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    println!(\"I'm {} and my age is {}\", bob.name(), bob.age());\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_height() {\n"
+"    let bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.height(), 155.2);\n"
+"}\n"
+"\n"
 "#[test]\n"
 "fn test_set_age() {\n"
 "    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
@@ -6344,18 +6993,39 @@ msgid ""
 "    bob.set_age(33);\n"
 "    assert_eq!(bob.age(), 33);\n"
 "}\n"
+"\n"
+"#[test]\n"
+"fn test_visit() {\n"
+"    let mut bob = User::new(String::from(\"Bob\"), 32, 155.2);\n"
+"    assert_eq!(bob.doctor_visits(), 0);\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (120, 80),\n"
+"    });\n"
+"    assert_eq!(report.patient_name, \"Bob\");\n"
+"    assert_eq!(report.visit_count, 1);\n"
+"    assert_eq!(report.blood_pressure_change, None);\n"
+"\n"
+"    let report = bob.visit_doctor(Measurements {\n"
+"        height: 156.1,\n"
+"        blood_pressure: (115, 76),\n"
+"    });\n"
+"\n"
+"    assert_eq!(report.visit_count, 2);\n"
+"    assert_eq!(report.blood_pressure_change, Some((-5, -4)));\n"
+"}\n"
 "```"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
-msgid "# Polygon Struct"
+msgid "Polygon Struct"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:3
 msgid ""
-"We will create a `Polygon` struct which contain some points. Copy the code below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make the\n"
-"tests pass:"
+"We will create a `Polygon` struct which contain some points. Copy the code "
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:7 src/exercises/day-2/luhn.md:23
@@ -6363,206 +7033,207 @@ msgstr ""
 msgid ""
 "```rust\n"
 "// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_variables, dead_code)]"
+"#![allow(unused_variables, dead_code)]\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:11
-msgid ""
-"pub struct Point {\n"
-"    // add fields\n"
-"}"
+msgid "pub struct Point { // add fields }"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:15
-msgid ""
-"impl Point {\n"
-"    // add methods\n"
-"}"
+msgid "impl Point { // add methods }"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:19
-msgid ""
-"pub struct Polygon {\n"
-"    // add fields\n"
-"}"
+msgid "pub struct Polygon { // add fields }"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:23
-msgid ""
-"impl Polygon {\n"
-"    // add methods\n"
-"}"
+msgid "impl Polygon { // add methods }"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:27
-msgid ""
-"pub struct Circle {\n"
-"    // add fields\n"
-"}"
+msgid "pub struct Circle { // add fields }"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:31
-msgid ""
-"impl Circle {\n"
-"    // add methods\n"
-"}"
+msgid "impl Circle { // add methods }"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:35
-msgid ""
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}"
+msgid "pub enum Shape { Polygon(Polygon), Circle(Circle), }"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:40 src/testing/test-modules.md:15
-msgid ""
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;"
+msgid "\\#\\[cfg(test)\\] mod tests { use super::\\*;"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:44 src/exercises/day-2/solutions-morning.md:165
+#: src/exercises/day-2/points-polygons.md:44
+#: src/exercises/day-2/solutions-morning.md:165
 msgid ""
-"    fn round_two_digits(x: f64) -> f64 {\n"
-"        (x * 100.0).round() / 100.0\n"
-"    }"
+"```\n"
+"fn round_two_digits(x: f64) -> f64 {\n"
+"    (x * 100.0).round() / 100.0\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:48 src/exercises/day-2/solutions-morning.md:169
+#: src/exercises/day-2/points-polygons.md:48
+#: src/exercises/day-2/solutions-morning.md:169
 msgid ""
-"    #[test]\n"
-"    fn test_point_magnitude() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_magnitude() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    assert_eq!(round_two_digits(p1.magnitude()), 17.69);\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:54 src/exercises/day-2/solutions-morning.md:175
+#: src/exercises/day-2/points-polygons.md:54
+#: src/exercises/day-2/solutions-morning.md:175
 msgid ""
-"    #[test]\n"
-"    fn test_point_dist() {\n"
-"        let p1 = Point::new(10, 10);\n"
-"        let p2 = Point::new(14, 13);\n"
-"        assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_dist() {\n"
+"    let p1 = Point::new(10, 10);\n"
+"    let p2 = Point::new(14, 13);\n"
+"    assert_eq!(round_two_digits(p1.dist(p2)), 5.00);\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:61 src/exercises/day-2/solutions-morning.md:182
+#: src/exercises/day-2/points-polygons.md:61
+#: src/exercises/day-2/solutions-morning.md:182
 msgid ""
-"    #[test]\n"
-"    fn test_point_add() {\n"
-"        let p1 = Point::new(16, 16);\n"
-"        let p2 = p1 + Point::new(-4, 3);\n"
-"        assert_eq!(p2, Point::new(12, 19));\n"
-"    }"
+"```\n"
+"#[test]\n"
+"fn test_point_add() {\n"
+"    let p1 = Point::new(16, 16);\n"
+"    let p2 = p1 + Point::new(-4, 3);\n"
+"    assert_eq!(p2, Point::new(12, 19));\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:68 src/exercises/day-2/solutions-morning.md:189
+#: src/exercises/day-2/points-polygons.md:68
+#: src/exercises/day-2/solutions-morning.md:189
 msgid ""
-"    #[test]\n"
-"    fn test_polygon_left_most_point() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);"
+"```\n"
+"#[test]\n"
+"fn test_polygon_left_most_point() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    let p2 = Point::new(16, 16);\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:73 src/exercises/day-2/solutions-morning.md:194
+#: src/exercises/day-2/points-polygons.md:73
+#: src/exercises/day-2/solutions-morning.md:194
 msgid ""
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);\n"
-"        assert_eq!(poly.left_most_point(), Some(p1));\n"
-"    }"
+"```\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(p1);\n"
+"    poly.add_point(p2);\n"
+"    assert_eq!(poly.left_most_point(), Some(p1));\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:79 src/exercises/day-2/solutions-morning.md:200
+#: src/exercises/day-2/points-polygons.md:79
+#: src/exercises/day-2/solutions-morning.md:200
 msgid ""
-"    #[test]\n"
-"    fn test_polygon_iter() {\n"
-"        let p1 = Point::new(12, 13);\n"
-"        let p2 = Point::new(16, 16);"
+"```\n"
+"#[test]\n"
+"fn test_polygon_iter() {\n"
+"    let p1 = Point::new(12, 13);\n"
+"    let p2 = Point::new(16, 16);\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:84 src/exercises/day-2/solutions-morning.md:205
+#: src/exercises/day-2/points-polygons.md:84
+#: src/exercises/day-2/solutions-morning.md:205
 msgid ""
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(p1);\n"
-"        poly.add_point(p2);"
+"```\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(p1);\n"
+"    poly.add_point(p2);\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/points-polygons.md:88 src/exercises/day-2/solutions-morning.md:209
+#: src/exercises/day-2/points-polygons.md:88
+#: src/exercises/day-2/solutions-morning.md:209
 msgid ""
-"        let points = poly.iter().cloned().collect::<Vec<_>>();\n"
-"        assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
-"    }"
+"```\n"
+"    let points = poly.iter().cloned().collect::<Vec<_>>();\n"
+"    assert_eq!(points, vec![Point::new(12, 13), Point::new(16, 16)]);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:92
+#: src/exercises/day-2/solutions-morning.md:213
 msgid ""
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}"
+"```\n"
+"#[test]\n"
+"fn test_shape_perimeters() {\n"
+"    let mut poly = Polygon::new();\n"
+"    poly.add_point(Point::new(12, 13));\n"
+"    poly.add_point(Point::new(17, 11));\n"
+"    poly.add_point(Point::new(16, 16));\n"
+"    let shapes = vec![\n"
+"        Shape::from(poly),\n"
+"        Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
+"    ];\n"
+"    let perimeters = shapes\n"
+"        .iter()\n"
+"        .map(Shape::perimeter)\n"
+"        .map(round_two_digits)\n"
+"        .collect::<Vec<_>>();\n"
+"    assert_eq!(perimeters, vec![15.48, 31.42]);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:111 src/exercises/day-2/luhn.md:68
-msgid ""
-"#[allow(dead_code)]\n"
-"fn main() {}\n"
-"```"
+msgid "\\#\\[allow(dead_code)\\] fn main() {}"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:117
 msgid ""
-"Since the method signatures are missing from the problem statements, the key part\n"
-"of the exercise is to specify those correctly. You don't have to modify the tests."
+"Since the method signatures are missing from the problem statements, the key "
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:120
-msgid ""
-"Other interesting parts of the exercise:\n"
-"    \n"
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes don't borrow their "
-"arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be addable via \"+\". Note that "
-"we do not discuss generics until Day 3."
+msgid "Other interesting parts of the exercise:"
 msgstr ""
 
-#: src/control-flow.md:1
-msgid "# Control Flow"
+#: src/exercises/day-2/points-polygons.md:122
+msgid ""
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
+msgstr ""
+
+#: src/exercises/day-2/points-polygons.md:123
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
 msgstr ""
 
 #: src/control-flow.md:3
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
-"evaluate one of two blocks, but the blocks can have a value which then becomes\n"
-"the value of the `if` expression. Other control flow expressions work similarly\n"
-"in Rust."
-msgstr ""
-
-#: src/control-flow/blocks.md:1
-msgid "# Blocks"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
+"evaluate one of two blocks, but the blocks can have a value which then "
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
 
 #: src/control-flow/blocks.md:3
 msgid ""
-"A block in Rust has a value and a type: the value is the last expression of the\n"
-"block:"
+"A block in Rust has a value and a type: the value is the last expression of "
+"the block:"
 msgstr ""
 
 #: src/control-flow/blocks.md:6
@@ -6589,7 +7260,7 @@ msgstr ""
 
 #: src/control-flow/blocks.md:25
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
 
@@ -6598,33 +7269,34 @@ msgid ""
 "```rust,editable\n"
 "fn double(x: i32) -> i32 {\n"
 "    x + x\n"
-"}"
-msgstr ""
-
-#: src/control-flow/blocks.md:33
-msgid ""
-"fn main() {\n"
-"    println!(\"doubled: {}\", double(7));\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/control-flow/blocks.md:38
-msgid "However if the last expression ends with `;`, then the resulting value and type is `()`."
+#: src/control-flow/blocks.md:33
+msgid "fn main() { println!(\"doubled: {}\", double(7)); }"
 msgstr ""
 
-#: src/control-flow/blocks.md:42
+#: src/control-flow/blocks.md:38
 msgid ""
-"Key Points:\n"
-"* The point of this slide is to show that blocks have a type and value in Rust. \n"
-"* You can show how the value of the block changes by changing the last line in the block. For "
-"instance, adding/removing a semicolon or using a `return`.\n"
-"   \n"
-"</details>"
+"However if the last expression ends with `;`, then the resulting value and "
+"type is `()`."
+msgstr ""
+
+#: src/control-flow/blocks.md:43
+msgid ""
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr ""
+
+#: src/control-flow/blocks.md:44
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
 
 #: src/control-flow/if-expressions.md:1
-msgid "# `if` expressions"
+msgid "`if` expressions"
 msgstr ""
 
 #: src/control-flow/if-expressions.md:3
@@ -6646,7 +7318,8 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/if-expressions.md:16
-msgid "In addition, you can use it as an expression. This does the same as above:"
+msgid ""
+"In addition, you can use it as an expression. This does the same as above:"
 msgstr ""
 
 #: src/control-flow/if-expressions.md:18
@@ -6665,14 +7338,13 @@ msgstr ""
 
 #: src/control-flow/if-expressions.md:31
 msgid ""
-"Because `if` is an expression and must have a particular type, both of its branch blocks must have "
-"the same type. Consider showing what happens if you add `;` after `x / 2` in the second example.\n"
-"    \n"
-"</details>"
+"Because `if` is an expression and must have a particular type, both of its "
+"branch blocks must have the same type. Consider showing what happens if you "
+"add `;` after `x / 2` in the second example."
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:1
-msgid "# `if let` expressions"
+msgid "`if let` expressions"
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:3
@@ -6693,25 +7365,37 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/control-flow/if-let-expressions.md:16 src/control-flow/while-let-expressions.md:21
+#: src/control-flow/if-let-expressions.md:16
+#: src/control-flow/while-let-expressions.md:21
 #: src/control-flow/match-expressions.md:22
 msgid ""
-"See [pattern matching](../pattern-matching.md) for more details on patterns in\n"
-"Rust."
+"See [pattern matching](../pattern-matching.md) for more details on patterns "
+"in Rust."
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:21
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is interesting. In contrast, "
-"`match` requires all branches to be covered.\n"
-"    * For the similar use case consider demonstrating a newly stabilized [`let else`](https://"
-"github.com/rust-lang/rust/pull/93628) feature.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern matching."
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:22
+msgid ""
+"For the similar use case consider demonstrating a newly stabilized [`let "
+"else`](https://github.com/rust-lang/rust/pull/93628) feature."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:23
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:24
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
 msgstr ""
 
 #: src/control-flow/while-expressions.md:1
-msgid "# `while` expressions"
+msgid "`while` expressions"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:3
@@ -6736,13 +7420,13 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
-msgid "# `while let` expressions"
+msgid "`while let` expressions"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
-"Like with `if`, there is a `while let` variant which repeatedly tests a value\n"
-"against a pattern:"
+"Like with `if`, there is a `while let` variant which repeatedly tests a "
+"value against a pattern:"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:6
@@ -6750,61 +7434,68 @@ msgid ""
 "```rust,editable\n"
 "fn main() {\n"
 "    let v = vec![10, 20, 30];\n"
-"    let mut iter = v.into_iter();"
+"    let mut iter = v.into_iter();\n"
+"```"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:11
 msgid ""
-"    while let Some(x) = iter.next() {\n"
-"        println!(\"x: {x}\");\n"
-"    }\n"
+"```\n"
+"while let Some(x) = iter.next() {\n"
+"    println!(\"x: {x}\");\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:17
 msgid ""
-"Here the iterator returned by `v.iter()` will return a `Option<i32>` on every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:27
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if statement that breaks when "
-"there is no value to unwrap for `iter.next()`. The `while let` provides syntactic sugar for the "
-"above scenario.\n"
-"    \n"
-"</details>"
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
+msgstr ""
+
+#: src/control-flow/while-let-expressions.md:28
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
 
 #: src/control-flow/for-expressions.md:1
-msgid "# `for` expressions"
+msgid "`for` expressions"
 msgstr ""
 
 #: src/control-flow/for-expressions.md:3
 msgid ""
-"The `for` expression is closely related to the `while let` expression. It will\n"
-"automatically call `into_iter()` on the expression and then iterate over it:"
+"The `for` expression is closely related to the `while let` expression. It "
+"will automatically call `into_iter()` on the expression and then iterate "
+"over it:"
 msgstr ""
 
 #: src/control-flow/for-expressions.md:6
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v = vec![10, 20, 30];"
+"    let v = vec![10, 20, 30];\n"
+"```"
 msgstr ""
 
 #: src/control-flow/for-expressions.md:10
 msgid ""
-"    for x in v {\n"
-"        println!(\"x: {x}\");\n"
-"    }\n"
-"    \n"
-"    for i in (0..10).step_by(2) {\n"
-"        println!(\"i: {i}\");\n"
-"    }\n"
+"```\n"
+"for x in v {\n"
+"    println!(\"x: {x}\");\n"
+"}\n"
+"\n"
+"for i in (0..10).step_by(2) {\n"
+"    println!(\"i: {i}\");\n"
 "}\n"
 "```"
 msgstr ""
@@ -6813,25 +7504,34 @@ msgstr ""
 msgid "You can use `break` and `continue` here as usual."
 msgstr ""
 
-#: src/control-flow/for-expressions.md:22
+#: src/control-flow/for-expressions.md:24
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr ""
+
+#: src/control-flow/for-expressions.md:25
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr ""
+
+#: src/control-flow/for-expressions.md:26
 msgid ""
-"<details>\n"
-"    \n"
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change vector `v` to be "
-"mutable and the for loop to `for x in v.iter_mut()`."
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+
+#: src/control-flow/for-expressions.md:27
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
+"vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:1
-msgid "# `loop` expressions"
+msgid "`loop` expressions"
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
-"Finally, there is a `loop` keyword which creates an endless loop. Here you must\n"
-"either `break` or `return` to stop the loop:"
+"Finally, there is a `loop` keyword which creates an endless loop. Here you "
+"must either `break` or `return` to stop the loop:"
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:6
@@ -6854,21 +7554,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/control-flow/loop-expressions.md:23
-msgid ""
-"<details>\n"
-"    \n"
-"* Break the `loop` with a value (e.g. `break 8`) and print it out."
+#: src/control-flow/loop-expressions.md:25
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:1
-msgid "# `match` expressions"
+msgid "`match` expressions"
 msgstr ""
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
-"The `match` keyword is used to match a value against one or more patterns. In\n"
-"that sense, it works like a series of `if let` expressions:"
+"The `match` keyword is used to match a value against one or more patterns. "
+"In that sense, it works like a series of `if let` expressions:"
 msgstr ""
 
 #: src/control-flow/match-expressions.md:6
@@ -6889,31 +7586,44 @@ msgstr ""
 
 #: src/control-flow/match-expressions.md:19
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:27
+msgid "Save the match expression to a variable and print it out."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:28
+msgid "Remove `.as_deref()` and explain the error."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:29
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot match against "
-"`String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, this turns "
-"`Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside `Option`.\n"
-"</details>"
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:30
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
 msgstr ""
 
 #: src/control-flow/break-continue.md:1
-msgid "# `break` and `continue`"
+msgid "`break` and `continue`"
 msgstr ""
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"If you want to exit a loop early, use `break`, if you want to immediately start\n"
-"the next iteration use `continue`. Both `continue` and `break` can optionally\n"
-"take a label argument which is used to break out of nested loops:"
+"If you want to exit a loop early, use `break`, if you want to immediately "
+"start the next iteration use `continue`. Both `continue` and `break` can "
+"optionally take a label argument which is used to break out of nested loops:"
 msgstr ""
 
 #: src/control-flow/break-continue.md:7
@@ -6938,18 +7648,15 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/break-continue.md:25
-msgid "In this case we break the outer loop after 3 iterations of the inner loop."
-msgstr ""
-
-#: src/std.md:1
-msgid "# Standard Library"
+msgid ""
+"In this case we break the outer loop after 3 iterations of the inner loop."
 msgstr ""
 
 #: src/std.md:3
 msgid ""
-"Rust comes with a standard library which helps establish a set of common types\n"
-"used by Rust library and programs. This way, two libraries can work together\n"
-"smoothly because they both use the same `String` type."
+"Rust comes with a standard library which helps establish a set of common "
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 
 #: src/std.md:7
@@ -6958,45 +7665,59 @@ msgstr ""
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional values\n"
-"  and [error handling](error-handling.md)."
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
 msgstr ""
 
 #: src/std.md:12
-msgid "* [`String`](std/string.md): the default string type used for owned data."
+msgid "[`String`](std/string.md): the default string type used for owned data."
 msgstr ""
 
 #: src/std.md:14
-msgid "* [`Vec`](std/vec.md): a standard extensible vector."
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
 msgstr ""
 
 #: src/std.md:16
 msgid ""
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm."
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
 msgstr ""
 
 #: src/std.md:19
-msgid "* [`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
 msgstr ""
 
 #: src/std.md:21
-msgid "* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated data."
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
 msgstr ""
 
-#: src/std.md:23
+#: src/std.md:25
 msgid ""
-"<details>\n"
-"  \n"
-"  * In fact, Rust contains several layers of the Standard Library: `core`, `alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on `libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as `Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
+msgstr ""
+
+#: src/std.md:26
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+
+#: src/std.md:28
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+
+#: src/std.md:29
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
 
 #: src/std/option-result.md:1
-msgid "# `Option` and `Result`"
+msgid "`Option` and `Result`"
 msgstr ""
 
 #: src/std/option-result.md:3
@@ -7009,33 +7730,50 @@ msgid ""
 "fn main() {\n"
 "    let numbers = vec![10, 20, 30];\n"
 "    let first: Option<&i8> = numbers.first();\n"
-"    println!(\"first: {first:?}\");"
+"    println!(\"first: {first:?}\");\n"
+"```"
 msgstr ""
 
 #: src/std/option-result.md:11
 msgid ""
-"    let idx: Result<usize, usize> = numbers.binary_search(&10);\n"
-"    println!(\"idx: {idx:?}\");\n"
-"}\n"
+"```\n"
+"let idx: Result<usize, usize> = numbers.binary_search(&10);\n"
+"println!(\"idx: {idx:?}\");\n"
 "```"
 msgstr ""
 
 #: src/std/option-result.md:18
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
 
-#: src/std/string.md:1
-msgid "# String"
+#: src/std/option-result.md:19
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr ""
+
+#: src/std/option-result.md:20
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+
+#: src/std/option-result.md:21
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr ""
+
+#: src/std/option-result.md:22
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr ""
+
+#: src/std/option-result.md:23
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
 msgstr ""
 
 #: src/std/string.md:3
-msgid "[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+msgid ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
 
 #: src/std/string.md:5
@@ -7044,50 +7782,54 @@ msgid ""
 "fn main() {\n"
 "    let mut s1 = String::new();\n"
 "    s1.push_str(\"Hello\");\n"
-"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());"
+"    println!(\"s1: len = {}, capacity = {}\", s1.len(), s1.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/string.md:11
 msgid ""
-"    let mut s2 = String::with_capacity(s1.len() + 1);\n"
-"    s2.push_str(&s1);\n"
-"    s2.push('!');\n"
-"    println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());"
+"```\n"
+"let mut s2 = String::with_capacity(s1.len() + 1);\n"
+"s2.push_str(&s1);\n"
+"s2.push('!');\n"
+"println!(\"s2: len = {}, capacity = {}\", s2.len(), s2.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/string.md:16
 msgid ""
-"    let s3 = String::from(\"🇨🇭\");\n"
-"    println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
-"             s3.chars().count());\n"
-"}\n"
+"```\n"
+"let s3 = String::from(\"🇨🇭\");\n"
+"println!(\"s3: len = {}, number of chars = {}\", s3.len(),\n"
+"         s3.chars().count());\n"
 "```"
 msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can call all\n"
-"`str` methods on a `String`."
-msgstr ""
-
-#: src/std/string.md:25
-msgid ""
-"[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
-"[2]: https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str"
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
 
 #: src/std/string.md:30
 msgid ""
-"* `len()` returns the size of the `String` in bytes, not its length in characters.\n"
-"* `chars()` returns an iterator over the actual characters."
+"`len()` returns the size of the `String` in bytes, not its length in "
+"characters."
+msgstr ""
+
+#: src/std/string.md:31
+msgid "`chars()` returns an iterator over the actual characters."
 msgstr ""
 
 #: src/std/vec.md:1
-msgid "# `Vec`"
+msgid "`Vec`"
 msgstr ""
 
 #: src/std/vec.md:3
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
 msgstr ""
 
 #: src/std/vec.md:5
@@ -7096,71 +7838,88 @@ msgid ""
 "fn main() {\n"
 "    let mut v1 = Vec::new();\n"
 "    v1.push(42);\n"
-"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());"
+"    println!(\"v1: len = {}, capacity = {}\", v1.len(), v1.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:11
 msgid ""
-"    let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
-"    v2.extend(v1.iter());\n"
-"    v2.push(9999);\n"
-"    println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());"
+"```\n"
+"let mut v2 = Vec::with_capacity(v1.len() + 1);\n"
+"v2.extend(v1.iter());\n"
+"v2.push(9999);\n"
+"println!(\"v2: len = {}, capacity = {}\", v2.len(), v2.capacity());\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:16
 msgid ""
-"    // Canonical macro to initialize a vector with elements.\n"
-"    let mut v3 = vec![0, 0, 1, 2, 3, 4];"
+"```\n"
+"// Canonical macro to initialize a vector with elements.\n"
+"let mut v3 = vec![0, 0, 1, 2, 3, 4];\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:19
 msgid ""
-"    // Retain only the even elements.\n"
-"    v3.retain(|x| x % 2 == 0);\n"
-"    println!(\"{v3:?}\");"
+"```\n"
+"// Retain only the even elements.\n"
+"v3.retain(|x| x % 2 == 0);\n"
+"println!(\"{v3:?}\");\n"
+"```"
 msgstr ""
 
 #: src/std/vec.md:23
 msgid ""
-"    // Remove consecutive duplicates.\n"
-"    v3.dedup();\n"
-"    println!(\"{v3:?}\");\n"
-"}\n"
+"```\n"
+"// Remove consecutive duplicates.\n"
+"v3.dedup();\n"
+"println!(\"{v3:?}\");\n"
 "```"
 msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-[T]), which means that you can call slice "
 "methods on a `Vec`."
-msgstr ""
-
-#: src/std/vec.md:32
-msgid ""
-"[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-"[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
 msgstr ""
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data it contains is "
-"stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at compile time. It can "
-"grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` explicitly. As "
-"always\n"
-"  with Rust type inference, the `T` was established during the first `push` call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
+msgstr ""
+
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
 msgstr ""
 
 #: src/std/hashmap.md:1
-msgid "# `HashMap`"
+msgid "`HashMap`"
 msgstr ""
 
 #: src/std/hashmap.md:3
@@ -7170,107 +7929,135 @@ msgstr ""
 #: src/std/hashmap.md:5
 msgid ""
 "```rust,editable\n"
-"use std::collections::HashMap;"
+"use std::collections::HashMap;\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:8
 msgid ""
-"fn main() {\n"
-"    let mut page_counts = HashMap::new();\n"
-"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), 207);\n"
-"    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
-"    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);"
+"fn main() { let mut page_counts = HashMap::new(); page_counts."
+"insert(\"Adventures of Huckleberry Finn\".to_string(), 207); page_counts."
+"insert(\"Grimms' Fairy Tales\".to_string(), 751); page_counts.insert(\"Pride "
+"and Prejudice\".to_string(), 303);"
 msgstr ""
 
 #: src/std/hashmap.md:14
 msgid ""
-"    if !page_counts.contains_key(\"Les Misérables\") {\n"
-"        println!(\"We know about {} books, but not Les Misérables.\",\n"
-"                 page_counts.len());\n"
-"    }"
+"```\n"
+"if !page_counts.contains_key(\"Les Misérables\") {\n"
+"    println!(\"We know about {} books, but not Les Misérables.\",\n"
+"             page_counts.len());\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:19
 msgid ""
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] {\n"
-"        match page_counts.get(book) {\n"
-"            Some(count) => println!(\"{book}: {count} pages\"),\n"
-"            None => println!(\"{book} is unknown.\")\n"
-"        }\n"
-"    }"
+"```\n"
+"for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] "
+"{\n"
+"    match page_counts.get(book) {\n"
+"        Some(count) => println!(\"{book}: {count} pages\"),\n"
+"        None => println!(\"{book} is unknown.\")\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:26
 msgid ""
-"    // Use the .entry() method to insert a value if nothing is found.\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] {\n"
-"        let page_count: &mut i32 = page_counts.entry(book.to_string()).or_insert(0);\n"
-"        *page_count += 1;\n"
-"    }"
+"```\n"
+"// Use the .entry() method to insert a value if nothing is found.\n"
+"for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] "
+"{\n"
+"    let page_count: &mut i32 = page_counts.entry(book.to_string())."
+"or_insert(0);\n"
+"    *page_count += 1;\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:32
 msgid ""
-"    println!(\"{page_counts:#?}\");\n"
-"}\n"
+"```\n"
+"println!(\"{page_counts:#?}\");\n"
 "```"
 msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into scope.\n"
-"* Try the following lines of code. The first line will see if a book is in the hashmap and if not "
-"return an alternative value. The second line will insert the alternative value in the hashmap if "
-"the book is not found."
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
 msgstr ""
 
 #: src/std/hashmap.md:41
 msgid ""
-"  ```rust,ignore\n"
-"  let pc1 = page_counts\n"
-"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"      .unwrap_or(&336);\n"
-"  let pc2 = page_counts\n"
-"      .entry(\"The Hunger Games\".to_string())\n"
-"      .or_insert(374);\n"
-"  ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], which allows us to "
-"easily initialize a hash map from a literal array:"
+"```rust,ignore\n"
+"let pc1 = page_counts\n"
+"    .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"    .unwrap_or(&336);\n"
+"let pc2 = page_counts\n"
+"    .entry(\"The Hunger Games\".to_string())\n"
+"    .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K%2C%20V)%3B%20N%5D%3E-for-"
+"HashMap%3CK%2C%20V%2C%20RandomState%3E), which allows us to easily "
+"initialize a hash map from a literal array:"
 msgstr ""
 
 #: src/std/hashmap.md:52
 msgid ""
-"  ```rust,ignore\n"
-"  let page_counts = HashMap::from([\n"
-"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"    (\"The Hunger Games\".to_string(), 374),\n"
-"  ]);\n"
-"  ```"
+"```rust,ignore\n"
+"let page_counts = HashMap::from([\n"
+"  (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"  (\"The Hunger Games\".to_string(), 374),\n"
+"]);\n"
+"```"
 msgstr ""
 
 #: src/std/hashmap.md:59
 msgid ""
-" * Alternatively HashMap can be built from any `Iterator` which yields key-value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make examples easier. "
-"Using references in collections can, of course, be done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still compiles. Where do you "
-"think we might run into issues?"
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
 msgstr ""
 
-#: src/std/hashmap.md:64
+#: src/std/hashmap.md:60
 msgid ""
-"[1]: https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
-"From%3C%5B(K%2C%20V)%3B%20N%5D%3E-for-HashMap%3CK%2C%20V%2C%20RandomState%3E"
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
+"compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
-msgid "# `Box`"
+msgid "`Box`"
 msgstr ""
 
 #: src/std/box.md:3
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
 msgstr ""
 
 #: src/std/box.md:5
@@ -7301,35 +8088,45 @@ msgstr ""
 
 #: src/std/box.md:26
 msgid ""
-"`Box<T>` implements `Deref<Target = T>`, which means that you can [call methods\n"
-"from `T` directly on a `Box<T>`][2]."
-msgstr ""
-
-#: src/std/box.md:29
-msgid ""
-"[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-"[2]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion"
+"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 
 #: src/std/box.md:34
+msgid "`Box` is like `std::unique_ptr` in C++. "
+msgstr ""
+
+#: src/std/box.md:35
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++. \n"
-"* In the above example, you can even leave out the `*` in the `println!` statement thanks to "
-"`Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the Rust compiler wants to "
-"know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying large amounts of data "
-"on the stack, instead store the data on the heap in a `Box` so only the pointer is moved.\n"
-"</details>"
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr ""
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
 msgstr ""
 
 #: src/std/box-recursive.md:1
-msgid "# Box with Recursive Data Structures"
+msgid "Box with Recursive Data Structures"
 msgstr ""
 
 #: src/std/box-recursive.md:3
-msgid "Recursive data types or data types with dynamic sizes need to use a `Box`:"
+msgid ""
+"Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
 #: src/std/box-recursive.md:5 src/std/box-niche.md:3
@@ -7339,63 +8136,65 @@ msgid ""
 "enum List<T> {\n"
 "    Cons(T, Box<List<T>>),\n"
 "    Nil,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/std/box-recursive.md:12 src/std/box-niche.md:10
+msgid "fn main() { let list: List"
+msgstr ""
+
+#: src/std/box-recursive.md:13 src/std/box-niche.md:11
 msgid ""
-"fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil))));\n"
-"    println!(\"{list:?}\");\n"
-"}\n"
-"```"
+" = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil)))); println!"
+"(\"{list:?}\"); }"
 msgstr ""
 
 #: src/std/box-recursive.md:18
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
 ":                         :     :                                               :\n"
-":    list                 :     :                                               :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
-":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // |   :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
+":    "
+"list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
+":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
+"|   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
 ":                         :     :                                               :\n"
 ":                         :     :                                               :\n"
-"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
+"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
 "```"
 msgstr ""
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it would look infinite."
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
 
 #: src/std/box-recursive.md:36
 msgid ""
-"* `Box` solves this problem as it has the same size as a regular pointer and just points at the "
-"next\n"
-"element of the `List` in the heap."
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
 msgstr ""
 
 #: src/std/box-recursive.md:39
 msgid ""
-"* Remove the `Box` in the List definition and show the compiler error. \"Recursive with "
-"indirection\" is a hint you might want to use a Box or reference of some kind, instead of storing "
-"a value directly.   \n"
-"    \n"
-"</details>"
-msgstr ""
-
-#: src/std/box-niche.md:1
-msgid "# Niche Optimization"
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
 msgstr ""
 
 #: src/std/box-niche.md:16
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 
@@ -7403,111 +8202,123 @@ msgstr ""
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"-.\n"
 ":                         :     :                                             :\n"
-":    list                 :     :                                             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
+":    "
+"list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
+"|             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
 ":                         :     :                                             :\n"
 ":                         :     :                                             :\n"
-"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
 "```"
 msgstr ""
 
 #: src/std/rc.md:1
-msgid "# `Rc`"
+msgid "`Rc`"
 msgstr ""
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
 
 #: src/std/rc.md:6
 msgid ""
 "```rust,editable\n"
-"use std::rc::Rc;"
+"use std::rc::Rc;\n"
+"```"
 msgstr ""
 
 #: src/std/rc.md:9
-msgid ""
-"fn main() {\n"
-"    let mut a = Rc::new(10);\n"
-"    let mut b = a.clone();"
+msgid "fn main() { let mut a = Rc::new(10); let mut b = a.clone();"
 msgstr ""
 
 #: src/std/rc.md:18
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](https://doc.rust-lang.org/std/"
+"cell/index.html)."
 msgstr ""
 
-#: src/std/rc.md:24
+#: src/std/rc.md:20
 msgid ""
-"[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-"[2]: https://doc.rust-lang.org/std/cell/index.html\n"
-"[3]: ../concurrency/shared_state/arc.md\n"
-"[4]: https://doc.rust-lang.org/std/rc/struct.Weak.html"
+"See [`Arc`](../concurrency/shared_state/arc.md) if you are in a multi-"
+"threaded context."
+msgstr ""
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
 
 #: src/std/rc.md:31
+msgid "Like C++'s `std::shared_ptr`."
+msgstr ""
+
+#: src/std/rc.md:32
 msgid ""
-"* Like C++'s `std::shared_ptr`.\n"
-"* `clone` is cheap: creates a pointer to the same allocation and increases the reference count.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-write\") and returns a "
-"mutable reference.\n"
-"* You can `downgrade()` a `Rc` into a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"`clone` is cheap: creates a pointer to the same allocation and increases the "
+"reference count."
+msgstr ""
+
+#: src/std/rc.md:33
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+
+#: src/std/rc.md:34
+msgid ""
+"You can `downgrade()` a `Rc` into a _weakly reference-counted_ object to "
+"create cycles that will be dropped properly (likely in combination with "
+"`RefCell`)."
 msgstr ""
 
 #: src/std/rc.md:38
 msgid ""
 "```rust,editable\n"
 "use std::rc::{Rc, Weak};\n"
-"use std::cell::RefCell;"
+"use std::cell::RefCell;\n"
+"```"
 msgstr ""
 
 #: src/std/rc.md:42
 msgid ""
-"#[derive(Debug)]\n"
-"struct Node {\n"
-"    value: i64,\n"
-"    parent: Option<Weak<RefCell<Node>>>,\n"
-"    children: Vec<Rc<RefCell<Node>>>,\n"
-"}"
+"\\#\\[derive(Debug)\\] struct Node { value: i64, parent: "
+"Option\\<Weak\\<RefCell"
+msgstr ""
+
+#: src/std/rc.md:45
+msgid "\\>>, children: Vec\\<Rc\\<RefCell"
+msgstr ""
+
+#: src/std/rc.md:46
+msgid "\\>>, }"
 msgstr ""
 
 #: src/std/rc.md:49
 msgid ""
-"fn main() {\n"
-"    let mut root = Rc::new(RefCell::new(Node {\n"
-"        value: 42,\n"
-"        parent: None,\n"
-"        children: vec![],\n"
-"    }));\n"
-"    let child = Rc::new(RefCell::new(Node {\n"
-"        value: 43,\n"
-"        children: vec![],\n"
-"        parent: Some(Rc::downgrade(&root))\n"
-"    }));\n"
-"    root.borrow_mut().children.push(child);"
+"fn main() { let mut root = Rc::new(RefCell::new(Node { value: 42, parent: "
+"None, children: vec![\\], })); let child = Rc::new(RefCell::new(Node "
+"{ value: 43, children: vec![\\], parent: Some(Rc::downgrade(&root)) })); "
+"root.borrow_mut().children.push(child);"
 msgstr ""
 
 #: src/std/rc.md:62
 msgid ""
-"    println!(\"graph: {root:#?}\");\n"
-"}\n"
+"```\n"
+"println!(\"graph: {root:#?}\");\n"
 "```"
-msgstr ""
-
-#: src/modules.md:1
-msgid "# Modules"
 msgstr ""
 
 #: src/modules.md:3
@@ -7525,38 +8336,32 @@ msgid ""
 "    pub fn do_something() {\n"
 "        println!(\"In the foo module\");\n"
 "    }\n"
-"}"
-msgstr ""
-
-#: src/modules.md:14
-msgid ""
-"mod bar {\n"
-"    pub fn do_something() {\n"
-"        println!(\"In the bar module\");\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/modules.md:20
-msgid ""
-"fn main() {\n"
-"    foo::do_something();\n"
-"    bar::do_something();\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/modules.md:28
-msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that describes how to build a "
-"bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable and a library crate "
-"compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+#: src/modules.md:14
+msgid "mod bar { pub fn do_something() { println!(\"In the bar module\"); } }"
 msgstr ""
 
-#: src/modules/visibility.md:1
-msgid "# Visibility"
+#: src/modules.md:20
+msgid "fn main() { foo::do_something(); bar::do_something(); }"
+msgstr ""
+
+#: src/modules.md:28
+msgid ""
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
+msgstr ""
+
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
 #: src/modules/visibility.md:3
@@ -7564,11 +8369,17 @@ msgid "Modules are a privacy boundary:"
 msgstr ""
 
 #: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr ""
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr ""
+
+#: src/modules/visibility.md:7
 msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all the\n"
-"  descendants of `foo`."
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
 msgstr ""
 
 #: src/modules/visibility.md:10
@@ -7577,62 +8388,72 @@ msgid ""
 "mod outer {\n"
 "    fn private() {\n"
 "        println!(\"outer::private\");\n"
-"    }"
+"    }\n"
+"```"
 msgstr ""
 
 #: src/modules/visibility.md:16
 msgid ""
-"    pub fn public() {\n"
-"        println!(\"outer::public\");\n"
-"    }"
-msgstr ""
-
-#: src/modules/visibility.md:20
-msgid ""
-"    mod inner {\n"
-"        fn private() {\n"
-"            println!(\"outer::inner::private\");\n"
-"        }"
-msgstr ""
-
-#: src/modules/visibility.md:25
-msgid ""
-"        pub fn public() {\n"
-"            println!(\"outer::inner::public\");\n"
-"            super::private();\n"
-"        }\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/modules/visibility.md:32
-msgid ""
-"fn main() {\n"
-"    outer::public();\n"
+"```\n"
+"pub fn public() {\n"
+"    println!(\"outer::public\");\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/modules/visibility.md:20
+msgid ""
+"```\n"
+"mod inner {\n"
+"    fn private() {\n"
+"        println!(\"outer::inner::private\");\n"
+"    }\n"
+"```"
+msgstr ""
+
+#: src/modules/visibility.md:25
+msgid ""
+"```\n"
+"    pub fn public() {\n"
+"        println!(\"outer::inner::public\");\n"
+"        super::private();\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/modules/visibility.md:32
+msgid "fn main() { outer::public(); }"
+msgstr ""
+
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
+msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
 #: src/modules/visibility.md:41
 msgid ""
-"Additionally, there are advanced `pub(...)` specifiers to restrict the scope of public visibility."
+"Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
+"of public visibility."
 msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-"
-"path-pubcrate-pubsuper-and-pubself)).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself))."
 msgstr ""
 
-#: src/modules/paths.md:1
-msgid "# Paths"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
 msgstr ""
 
 #: src/modules/paths.md:3
@@ -7640,21 +8461,27 @@ msgid "Paths are resolved as follows:"
 msgstr ""
 
 #: src/modules/paths.md:5
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module."
+msgid "As a relative path:"
+msgstr ""
+
+#: src/modules/paths.md:6
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+
+#: src/modules/paths.md:7
+msgid "`super::foo` refers to `foo` in the parent module."
 msgstr ""
 
 #: src/modules/paths.md:9
-msgid ""
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgid "As an absolute path:"
 msgstr ""
 
-#: src/modules/filesystem.md:1
-msgid "# Filesystem Hierarchy"
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
 #: src/modules/filesystem.md:3
@@ -7673,9 +8500,11 @@ msgid "The `garden` module content is found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:11
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:12
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:14
@@ -7683,9 +8512,11 @@ msgid "Similarly, a `garden::vegetables` module can be found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:16
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:17
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:19
@@ -7693,244 +8524,207 @@ msgid "The `crate` root is in:"
 msgstr ""
 
 #: src/modules/filesystem.md:21
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:22
+msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
 #: src/modules/filesystem.md:26
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of submodules in Rust "
-"2018.\n"
-"  (It was mandatory in Rust 2015.)"
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
 msgstr ""
 
 #: src/modules/filesystem.md:29
-msgid "  The following is valid:"
+msgid "The following is valid:"
 msgstr ""
 
 #: src/modules/filesystem.md:31
 msgid ""
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```"
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
 msgstr ""
 
 #: src/modules/filesystem.md:39
 msgid ""
-"* The main reason for the change is to prevent many files named `mod.rs`, which can be hard\n"
-"  to distinguish in IDEs."
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
 msgstr ""
 
 #: src/modules/filesystem.md:42
 msgid ""
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but this can be changed\n"
-"  with a compiler directive:"
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
 msgstr ""
 
 #: src/modules/filesystem.md:45
 msgid ""
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```"
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
 msgstr ""
 
 #: src/modules/filesystem.md:50
 msgid ""
-"  This is useful, for example, if you would like to place tests for a module in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
-msgid "# Day 2: Afternoon Exercises"
+msgid "Day 2: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:3
 msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr ""
 
-#: src/exercises/day-2/luhn.md:1
-msgid "# Luhn Algorithm"
-msgstr ""
-
 #: src/exercises/day-2/luhn.md:3
 msgid ""
-"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used to\n"
-"validate credit card numbers. The algorithm takes a string as input and does the\n"
-"following to validate the credit card number:"
+"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:7
-msgid "* Ignore all spaces. Reject number with less than two digits."
+msgid "Ignore all spaces. Reject number with less than two digits."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Moving from right to left, double every second digit: for the number `1234`,\n"
-"  we double `3` and `1`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:12
 msgid ""
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` which\n"
-"  becomes `5`."
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:15
-msgid "* Sum all the undoubled and doubled digits."
+msgid "Sum all the undoubled and doubled digits."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:17
-msgid "* The credit card number is valid if the sum ends with `0`."
+msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:19
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:27
-msgid ""
-"pub fn luhn(cc_number: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}"
+msgid "pub fn luhn(cc_number: &str) -> bool { unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:31
 msgid ""
-"#[test]\n"
-"fn test_non_digit_cc_number() {\n"
-"    assert!(!luhn(\"foo\"));\n"
-"}"
+"\\#\\[test\\] fn test_non_digit_cc_number() { assert!(!luhn(\"foo\")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:36 src/exercises/day-2/solutions-afternoon.md:64
 msgid ""
-"#[test]\n"
-"fn test_empty_cc_number() {\n"
-"    assert!(!luhn(\"\"));\n"
-"    assert!(!luhn(\" \"));\n"
-"    assert!(!luhn(\"  \"));\n"
-"    assert!(!luhn(\"    \"));\n"
-"}"
+"\\#\\[test\\] fn test_empty_cc_number() { assert!(!luhn(\"\")); assert!(!"
+"luhn(\" \")); assert!(!luhn(\"  \")); assert!(!luhn(\"    \")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:44 src/exercises/day-2/solutions-afternoon.md:72
 msgid ""
-"#[test]\n"
-"fn test_single_digit_cc_number() {\n"
-"    assert!(!luhn(\"0\"));\n"
-"}"
+"\\#\\[test\\] fn test_single_digit_cc_number() { assert!(!luhn(\"0\")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:49 src/exercises/day-2/solutions-afternoon.md:77
 msgid ""
-"#[test]\n"
-"fn test_two_digit_cc_number() {\n"
-"    assert!(luhn(\" 0 0 \"));\n"
-"}"
+"\\#\\[test\\] fn test_two_digit_cc_number() { assert!(luhn(\" 0 0 \")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:54 src/exercises/day-2/solutions-afternoon.md:82
 msgid ""
-"#[test]\n"
-"fn test_valid_cc_number() {\n"
-"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
-"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
-"    assert!(luhn(\"7992 7398 713\"));\n"
-"}"
+"\\#\\[test\\] fn test_valid_cc_number() { assert!(luhn(\"4263 9826 4026 "
+"9299\")); assert!(luhn(\"4539 3195 0343 6467\")); assert!(luhn(\"7992 7398 "
+"713\")); }"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:61
 msgid ""
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-2/strings-iterators.md:1
-msgid "# Strings and Iterators"
+"\\#\\[test\\] fn test_invalid_cc_number() { assert!(!luhn(\"4223 9826 4026 "
+"9299\")); assert!(!luhn(\"4539 3195 0343 6476\")); assert!(!luhn(\"8273 1232 "
+"7352 0569\")); }"
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:3
 msgid ""
-"In this exercise, you are implementing a routing component of a web server. The\n"
-"server is configured with a number of _path prefixes_ which are matched against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"In this exercise, you are implementing a routing component of a web server. "
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:8
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:16
 msgid ""
-"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-"    unimplemented!()\n"
-"}"
+"pub fn prefix_matches(prefix: &str, request_path: &str) -> bool "
+"{ unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:20
 msgid ""
-"#[test]\n"
-"fn test_matches_without_wildcard() {\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));"
+"\\#\\[test\\] fn test_matches_without_wildcard() { assert!(prefix_matches(\"/"
+"v1/publishers\", \"/v1/publishers\")); assert!(prefix_matches(\"/v1/"
+"publishers\", \"/v1/publishers/abc-123\")); assert!(prefix_matches(\"/v1/"
+"publishers\", \"/v1/publishers/abc/books\"));"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:26 src/exercises/day-2/solutions-afternoon.md:146
+#: src/exercises/day-2/strings-iterators.md:26
+#: src/exercises/day-2/solutions-afternoon.md:146
 msgid ""
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
-"}"
+"```\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:31 src/exercises/day-2/solutions-afternoon.md:151
+#: src/exercises/day-2/strings-iterators.md:31
+#: src/exercises/day-2/solutions-afternoon.md:151
 msgid ""
-"#[test]\n"
-"fn test_matches_with_wildcard() {\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/bar/books\"\n"
-"    ));\n"
-"    assert!(prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/books/book1\"\n"
-"    ));"
+"\\#\\[test\\] fn test_matches_with_wildcard() { assert!(prefix_matches( \"/"
+"v1/publishers/_/books\", \"/v1/publishers/foo/books\" )); assert!"
+"(prefix_matches( \"/v1/publishers/_/books\", \"/v1/publishers/bar/"
+"books\" )); assert!(prefix_matches( \"/v1/publishers/\\*/books\", \"/v1/"
+"publishers/foo/books/book1\" ));"
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:46
+#: src/exercises/day-2/solutions-afternoon.md:166
 msgid ""
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
-"    assert!(!prefix_matches(\n"
-"        \"/v1/publishers/*/books\",\n"
-"        \"/v1/publishers/foo/booksByAuthor\"\n"
-"    ));\n"
-"}\n"
+"```\n"
+"assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"assert!(!prefix_matches(\n"
+"    \"/v1/publishers/*/books\",\n"
+"    \"/v1/publishers/foo/booksByAuthor\"\n"
+"));\n"
 "```"
 msgstr ""
 
 #: src/welcome-day-3.md:1
-msgid "# Welcome to Day 3"
-msgstr "# Bienvenido al Día 3"
+msgid "Welcome to Day 3"
+msgstr "Bienvenido al Día 3"
 
 #: src/welcome-day-3.md:3
 msgid "Today, we will cover some more advanced topics of Rust:"
@@ -7938,36 +8732,33 @@ msgstr ""
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
 
 #: src/welcome-day-3.md:8
 msgid ""
-"* Generics: generic data types, generic methods, monomorphization, and trait\n"
-"  objects."
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
 msgstr ""
 
 #: src/welcome-day-3.md:11
-msgid "* Error handling: panics, `Result`, and the try operator `?`."
+msgid "Error handling: panics, `Result`, and the try operator `?`."
 msgstr ""
 
 #: src/welcome-day-3.md:13
-msgid "* Testing: unit tests, documentation tests, and integration tests."
+msgid "Testing: unit tests, documentation tests, and integration tests."
 msgstr ""
 
 #: src/welcome-day-3.md:15
 msgid ""
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
-msgstr ""
-
-#: src/traits.md:1
-msgid "# Traits"
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
 msgstr ""
 
 #: src/traits.md:3
-msgid "Rust lets you abstract over types with traits. They're similar to interfaces:"
+msgid ""
+"Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
 #: src/traits.md:5
@@ -7975,14 +8766,12 @@ msgid ""
 "```rust,editable\n"
 "trait Greet {\n"
 "    fn say_hello(&self);\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits.md:10
-msgid ""
-"struct Dog {\n"
-"    name: String,\n"
-"}"
+msgid "struct Dog { name: String, }"
 msgstr ""
 
 #: src/traits.md:14
@@ -7991,62 +8780,65 @@ msgstr ""
 
 #: src/traits.md:16
 msgid ""
-"impl Greet for Dog {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Wuf, my name is {}!\", self.name);\n"
-"    }\n"
-"}"
+"impl Greet for Dog { fn say_hello(&self) { println!(\"Wuf, my name is {}!\", "
+"self.name); } }"
 msgstr ""
 
 #: src/traits.md:22
-msgid ""
-"impl Greet for Cat {\n"
-"    fn say_hello(&self) {\n"
-"        println!(\"Miau!\");\n"
-"    }\n"
-"}"
+msgid "impl Greet for Cat { fn say_hello(&self) { println!(\"Miau!\"); } }"
 msgstr ""
 
 #: src/traits.md:28
+msgid "fn main() { let pets: Vec\\<Box"
+msgstr ""
+
+#: src/traits.md:29
 msgid ""
-"fn main() {\n"
-"    let pets: Vec<Box<dyn Greet>> = vec![\n"
-"        Box::new(Dog { name: String::from(\"Fido\") }),\n"
-"        Box::new(Cat),\n"
-"    ];\n"
-"    for pet in pets {\n"
-"        pet.say_hello();\n"
-"    }\n"
-"}\n"
-"```"
+"\\> = vec![ Box::new(Dog { name: String::from(\"Fido\") }), Box::new(Cat), "
+"\\]; for pet in pets { pet.say_hello(); } }"
 msgstr ""
 
 #: src/traits.md:41
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that users are required to "
-"implement themselves. Methods with default implementations can rely on required methods.\n"
-"* Types that implement a given trait may be of different sizes. This makes it impossible to have "
-"things like `Vec<Greet>` in the example above.\n"
-"* `dyn Greet` is a way to tell the compiler about a dynamically sized type that implements "
-"`Greet`.\n"
-"* In the example, `pets` holds Fat Pointers to objects that implement `Greet`. The Fat Pointer "
-"consists of two components, a pointer to the actual object and a pointer to the virtual method "
-"table for the `Greet` implementation of that particular object."
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
+msgstr ""
+
+#: src/traits.md:42
+msgid ""
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Greet>` in the example above."
+msgstr ""
+
+#: src/traits.md:43
+msgid ""
+"`dyn Greet` is a way to tell the compiler about a dynamically sized type "
+"that implements `Greet`."
+msgstr ""
+
+#: src/traits.md:44
+msgid ""
+"In the example, `pets` holds Fat Pointers to objects that implement `Greet`. "
+"The Fat Pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Greet` implementation of "
+"that particular object."
 msgstr ""
 
 #: src/traits.md:46
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits.md:47
 msgid ""
-"Compare these outputs in the above example:\n"
 "```rust,ignore\n"
-"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::<Cat>());\n"
-"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::<&Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
 "    println!(\"{}\", std::mem::size_of::<&dyn Greet>());\n"
 "    println!(\"{}\", std::mem::size_of::<Box<dyn Greet>>());\n"
 "```"
-msgstr ""
-
-#: src/traits/deriving-traits.md:1
-msgid "# Deriving Traits"
 msgstr ""
 
 #: src/traits/deriving-traits.md:3
@@ -8061,22 +8853,15 @@ msgid ""
 "    name: String,\n"
 "    strength: u8,\n"
 "    hit_points: u8,\n"
-"}"
-msgstr ""
-
-#: src/traits/deriving-traits.md:13
-msgid ""
-"fn main() {\n"
-"    let p1 = Player::default();\n"
-"    let p2 = p1.clone();\n"
-"    println!(\"Is {:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2,\n"
-"             if p1 == p2 { \"yes\" } else { \"no\" });\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/traits/default-methods.md:1
-msgid "# Default Methods"
+#: src/traits/deriving-traits.md:13
+msgid ""
+"fn main() { let p1 = Player::default(); let p2 = p1.clone(); println!(\"Is "
+"{:?}\\nequal to {:?}?\\nThe answer is {}!\", &p1, &p2, if p1 == p2 "
+"{ \"yes\" } else { \"no\" }); }"
 msgstr ""
 
 #: src/traits/default-methods.md:3
@@ -8091,73 +8876,80 @@ msgid ""
 "    fn not_equal(&self, other: &Self) -> bool {\n"
 "        !self.equal(other)\n"
 "    }\n"
-"}"
-msgstr ""
-
-#: src/traits/default-methods.md:13
-msgid ""
-"#[derive(Debug)]\n"
-"struct Centimeter(i16);"
-msgstr ""
-
-#: src/traits/default-methods.md:16
-msgid ""
-"impl Equals for Centimeter {\n"
-"    fn equal(&self, other: &Centimeter) -> bool {\n"
-"        self.0 == other.0\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/traits/default-methods.md:22
-msgid ""
-"fn main() {\n"
-"    let a = Centimeter(10);\n"
-"    let b = Centimeter(20);\n"
-"    println!(\"{a:?} equals {b:?}: {}\", a.equal(&b));\n"
-"    println!(\"{a:?} not_equals {b:?}: {}\", a.not_equal(&b));\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/traits/important-traits.md:1
-msgid "# Important Traits"
+#: src/traits/default-methods.md:13
+msgid "\\#\\[derive(Debug)\\] struct Centimeter(i16);"
+msgstr ""
+
+#: src/traits/default-methods.md:16
+msgid ""
+"impl Equals for Centimeter { fn equal(&self, other: &Centimeter) -> bool "
+"{ self.0 == other.0 } }"
+msgstr ""
+
+#: src/traits/default-methods.md:22
+msgid ""
+"fn main() { let a = Centimeter(10); let b = Centimeter(20); println!(\"{a:?} "
+"equals {b:?}: {}\", a.equal(&b)); println!(\"{a:?} not_equals {b:?}: {}\", a."
+"not_equal(&b)); }"
 msgstr ""
 
 #: src/traits/important-traits.md:3
-msgid "We will now look at some of the most common traits of the Rust standard library:"
+msgid ""
+"We will now look at some of the most common traits of the Rust standard "
+"library:"
 msgstr ""
 
 #: src/traits/important-traits.md:5
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
 msgstr ""
 
-#: src/traits/important-traits.md:12
+#: src/traits/important-traits.md:6
 msgid ""
-"[1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html\n"
-"[2]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html\n"
-"[3]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[4]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-"[5]: https://doc.rust-lang.org/std/io/trait.Read.html\n"
-"[6]: https://doc.rust-lang.org/std/io/trait.Write.html\n"
-"[7]: https://doc.rust-lang.org/std/ops/trait.Add.html\n"
-"[8]: https://doc.rust-lang.org/std/ops/trait.Mul.html\n"
-"[9]: https://doc.rust-lang.org/std/ops/trait.Drop.html\n"
-"[10]: https://doc.rust-lang.org/std/default/trait.Default.html"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+
+#: src/traits/important-traits.md:7
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+
+#: src/traits/important-traits.md:8
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+
+#: src/traits/important-traits.md:9
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
 msgstr ""
 
 #: src/traits/iterator.md:1
-msgid "# Iterators"
+msgid "Iterators"
 msgstr ""
 
 #: src/traits/iterator.md:3
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
 
 #: src/traits/iterator.md:5
@@ -8166,62 +8958,53 @@ msgid ""
 "struct Fibonacci {\n"
 "    curr: u32,\n"
 "    next: u32,\n"
-"}"
-msgstr ""
-
-#: src/traits/iterator.md:11
-msgid ""
-"impl Iterator for Fibonacci {\n"
-"    type Item = u32;"
-msgstr ""
-
-#: src/traits/iterator.md:14
-msgid ""
-"    fn next(&mut self) -> Option<Self::Item> {\n"
-"        let new_next = self.curr + self.next;\n"
-"        self.curr = self.next;\n"
-"        self.next = new_next;\n"
-"        Some(self.curr)\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/traits/iterator.md:22
-msgid ""
-"fn main() {\n"
-"    let fib = Fibonacci { curr: 0, next: 1 };\n"
-"    for (i, n) in fib.enumerate().take(5) {\n"
-"        println!(\"fib({i}): {n}\");\n"
-"    }\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/traits/iterator.md:11
+msgid "impl Iterator for Fibonacci { type Item = u32;"
+msgstr ""
+
+#: src/traits/iterator.md:14
+msgid ""
+"```\n"
+"fn next(&mut self) -> Option<Self::Item> {\n"
+"    let new_next = self.curr + self.next;\n"
+"    self.curr = self.next;\n"
+"    self.next = new_next;\n"
+"    Some(self.curr)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/iterator.md:22
+msgid ""
+"fn main() { let fib = Fibonacci { curr: 0, next: 1 }; for (i, n) in fib."
+"enumerate().take(5) { println!(\"fib({i}): {n}\"); } }"
+msgstr ""
+
 #: src/traits/iterator.md:32
 msgid ""
-"* `IntoIterator` is the trait that makes for loops work. It is implemented by collection types "
-"such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also implement it.\n"
-"* The `Iterator` trait implements many common functional programming operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can find all the "
-"documentation\n"
-"  about them. In Rust these functions should produce the code as efficient as equivalent "
-"imperative\n"
-"  implementations.\n"
-"    \n"
-"</details>"
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it."
 msgstr ""
 
-#: src/traits/iterator.md:41
-msgid "[1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
-msgstr ""
-
-#: src/traits/from-iterator.md:1
-msgid "# FromIterator"
+#: src/traits/iterator.md:34
+msgid ""
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
 
 #: src/traits/from-iterator.md:3
-msgid "[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
+msgid ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
 
 #: src/traits/from-iterator.md:5
@@ -8239,31 +9022,25 @@ msgstr ""
 
 #: src/traits/from-iterator.md:17
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
 
 #: src/traits/from-iterator.md:23
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 
-#: src/traits/from-iterator.md:28
-msgid ""
-"[1]: https://doc.rust-lang.org/std/iter/trait.FromIterator.html\n"
-"[2]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
-msgstr ""
-
 #: src/traits/from-into.md:1
-msgid "# `From` and `Into`"
+msgid "`From` and `Into`"
 msgstr ""
 
 #: src/traits/from-into.md:3
-msgid "Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+msgid ""
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
 
 #: src/traits/from-into.md:5
@@ -8280,7 +9057,10 @@ msgid ""
 msgstr ""
 
 #: src/traits/from-into.md:15
-msgid "[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+msgid ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
 
 #: src/traits/from-into.md:17
@@ -8296,137 +9076,120 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/traits/from-into.md:27
+#: src/traits/from-into.md:29
 msgid ""
-"<details>\n"
-"  \n"
-"* That's why it is common to only implement `From`, as your type will get `Into` implementation "
-"too.\n"
-"* When declaring a function argument input type like \"anything that can be converted into a "
-"`String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that _only_ implement `Into`.\n"
-"    \n"
-"</details>"
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
 msgstr ""
 
-#: src/traits/from-into.md:35
+#: src/traits/from-into.md:30
 msgid ""
-"[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-"[2]: https://doc.rust-lang.org/std/convert/trait.Into.html"
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
 msgstr ""
 
 #: src/traits/read-write.md:1
-msgid "# `Read` and `Write`"
+msgid "`Read` and `Write`"
 msgstr ""
 
 #: src/traits/read-write.md:3
-msgid "Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
+msgid ""
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
 msgstr ""
 
 #: src/traits/read-write.md:5
 msgid ""
 "```rust,editable\n"
-"use std::io::{BufRead, BufReader, Read, Result};"
+"use std::io::{BufRead, BufReader, Read, Result};\n"
+"```"
 msgstr ""
 
 #: src/traits/read-write.md:8
 msgid ""
-"fn count_lines<R: Read>(reader: R) -> usize {\n"
-"    let buf_reader = BufReader::new(reader);\n"
-"    buf_reader.lines().count()\n"
-"}"
+"fn count_lines\\<R: Read>(reader: R) -> usize { let buf_reader = BufReader::"
+"new(reader); buf_reader.lines().count() }"
 msgstr ""
 
 #: src/traits/read-write.md:13
 msgid ""
-"fn main() -> Result<()> {\n"
-"    let slice: &[u8] = b\"foo\\nbar\\nbaz\\n\";\n"
-"    println!(\"lines in slice: {}\", count_lines(slice));"
+"fn main() -> Result\\<()> { let slice: &\\[u8\\] = b\"foo\\nbar\\nbaz\\n\"; "
+"println!(\"lines in slice: {}\", count_lines(slice));"
 msgstr ""
 
 #: src/traits/read-write.md:17
 msgid ""
-"    let file = std::fs::File::open(std::env::current_exe()?)?;\n"
-"    println!(\"lines in file: {}\", count_lines(file));\n"
-"    Ok(())\n"
-"}\n"
+"```\n"
+"let file = std::fs::File::open(std::env::current_exe()?)?;\n"
+"println!(\"lines in file: {}\", count_lines(file));\n"
+"Ok(())\n"
 "```"
 msgstr ""
 
 #: src/traits/read-write.md:23
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
 msgstr ""
 
 #: src/traits/read-write.md:25
 msgid ""
 "```rust,editable\n"
-"use std::io::{Result, Write};"
+"use std::io::{Result, Write};\n"
+"```"
 msgstr ""
 
 #: src/traits/read-write.md:28
 msgid ""
-"fn log<W: Write>(writer: &mut W, msg: &str) -> Result<()> {\n"
-"    writer.write_all(msg.as_bytes())?;\n"
-"    writer.write_all(\"\\n\".as_bytes())\n"
-"}"
+"fn log\\<W: Write>(writer: &mut W, msg: &str) -> Result\\<()> { writer."
+"write_all(msg.as_bytes())?; writer.write_all(\"\\n\".as_bytes()) }"
 msgstr ""
 
 #: src/traits/read-write.md:33
 msgid ""
-"fn main() -> Result<()> {\n"
-"    let mut buffer = Vec::new();\n"
-"    log(&mut buffer, \"Hello\")?;\n"
-"    log(&mut buffer, \"World\")?;\n"
-"    println!(\"Logged: {:?}\", buffer);\n"
-"    Ok(())\n"
-"}\n"
-"```"
-msgstr ""
-
-#: src/traits/read-write.md:42
-msgid ""
-"[1]: https://doc.rust-lang.org/std/io/trait.Read.html\n"
-"[2]: https://doc.rust-lang.org/std/io/trait.BufRead.html\n"
-"[3]: https://doc.rust-lang.org/std/io/trait.Write.html"
+"fn main() -> Result\\<()> { let mut buffer = Vec::new(); log(&mut buffer, "
+"\"Hello\")?; log(&mut buffer, \"World\")?; println!(\"Logged: {:?}\", "
+"buffer); Ok(()) }"
 msgstr ""
 
 #: src/traits/operators.md:1
-msgid "# `Add`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
 msgstr ""
 
 #: src/traits/operators.md:3
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
 
 #: src/traits/operators.md:5
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug, Copy, Clone)]\n"
-"struct Point { x: i32, y: i32 }"
+"struct Point { x: i32, y: i32 }\n"
+"```"
 msgstr ""
 
 #: src/traits/operators.md:9 src/exercises/day-2/solutions-morning.md:46
-msgid ""
-"impl std::ops::Add for Point {\n"
-"    type Output = Self;"
+msgid "impl std::ops::Add for Point { type Output = Self;"
 msgstr ""
 
 #: src/traits/operators.md:12
 msgid ""
-"    fn add(self, other: Self) -> Self {\n"
-"        Self {x: self.x + other.x, y: self.y + other.y}\n"
-"    }\n"
-"}"
+"```\n"
+"fn add(self, other: Self) -> Self {\n"
+"    Self {x: self.x + other.x, y: self.y + other.y}\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/operators.md:17
 msgid ""
-"fn main() {\n"
-"    let p1 = Point { x: 10, y: 20 };\n"
-"    let p2 = Point { x: 100, y: 200 };\n"
-"    println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2);\n"
-"}\n"
-"```"
+"fn main() { let p1 = Point { x: 10, y: 20 }; let p2 = Point { x: 100, y: "
+"200 }; println!(\"{:?} + {:?} = {:?}\", p1, p2, p1 + p2); }"
 msgstr ""
 
 #: src/traits/operators.md:26 src/traits/drop.md:34
@@ -8435,27 +9198,34 @@ msgstr ""
 
 #: src/traits/operators.md:28
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter?\n"
-"    * Short answer: Type parameters are controlled by the caller, but\n"
-"        associated types (like `Output`) are controlled by the implementor of a\n"
-"        trait."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
 msgstr ""
 
-#: src/traits/operators.md:40
-msgid "[1]: https://doc.rust-lang.org/std/ops/index.html"
+#: src/traits/operators.md:29
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+
+#: src/traits/operators.md:33
+msgid "Why is `Output` an associated type? Could it be made a type parameter?"
+msgstr ""
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Type parameters are controlled by the caller, but associated "
+"types (like `Output`) are controlled by the implementor of a trait."
 msgstr ""
 
 #: src/traits/drop.md:1
-msgid "# The `Drop` Trait"
+msgid "The `Drop` Trait"
 msgstr ""
 
 #: src/traits/drop.md:3
-msgid "Values which implement [`Drop`][1] can specify code to run when they go out of scope:"
+msgid ""
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
 
 #: src/traits/drop.md:5
@@ -8463,56 +9233,46 @@ msgid ""
 "```rust,editable\n"
 "struct Droppable {\n"
 "    name: &'static str,\n"
-"}"
-msgstr ""
-
-#: src/traits/drop.md:10
-msgid ""
-"impl Drop for Droppable {\n"
-"    fn drop(&mut self) {\n"
-"        println!(\"Dropping {}\", self.name);\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/traits/drop.md:16
-msgid ""
-"fn main() {\n"
-"    let a = Droppable { name: \"a\" };\n"
-"    {\n"
-"        let b = Droppable { name: \"b\" };\n"
-"        {\n"
-"            let c = Droppable { name: \"c\" };\n"
-"            let d = Droppable { name: \"d\" };\n"
-"            println!(\"Exiting block B\");\n"
-"        }\n"
-"        println!(\"Exiting block A\");\n"
-"    }\n"
-"    drop(a);\n"
-"    println!(\"Exiting main\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/traits/drop.md:36
+#: src/traits/drop.md:10
 msgid ""
-"* Why does not `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"impl Drop for Droppable { fn drop(&mut self) { println!(\"Dropping {}\", "
+"self.name); } }"
 msgstr ""
 
-#: src/traits/drop.md:44
-msgid "[1]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
+#: src/traits/drop.md:16
+msgid ""
+"fn main() { let a = Droppable { name: \"a\" }; { let b = Droppable { name: "
+"\"b\" }; { let c = Droppable { name: \"c\" }; let d = Droppable { name: "
+"\"d\" }; println!(\"Exiting block B\"); } println!(\"Exiting block A\"); } "
+"drop(a); println!(\"Exiting main\"); }"
+msgstr ""
+
+#: src/traits/drop.md:36
+msgid "Why does not `Drop::drop` take `self`?"
+msgstr ""
+
+#: src/traits/drop.md:37
+msgid ""
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
+msgstr ""
+
+#: src/traits/drop.md:40
+msgid "Try replacing `drop(a)` with `a.drop()`."
 msgstr ""
 
 #: src/traits/default.md:1
-msgid "# The `Default` Trait"
+msgid "The `Default` Trait"
 msgstr ""
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait provides a default implementation of a trait."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"provides a default implementation of a trait."
 msgstr ""
 
 #: src/traits/default.md:5
@@ -8523,75 +9283,80 @@ msgid ""
 "    x: u32,\n"
 "    y: String,\n"
 "    z: Implemented,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/traits/default.md:13
-msgid ""
-"#[derive(Debug)]\n"
-"struct Implemented(String);"
+msgid "\\#\\[derive(Debug)\\] struct Implemented(String);"
 msgstr ""
 
 #: src/traits/default.md:16
 msgid ""
-"impl Default for Implemented {\n"
-"    fn default() -> Self {\n"
-"        Self(\"John Smith\".into())\n"
-"    }\n"
-"}"
+"impl Default for Implemented { fn default() -> Self { Self(\"John Smith\"."
+"into()) } }"
 msgstr ""
 
 #: src/traits/default.md:22
 msgid ""
-"fn main() {\n"
-"    let default_struct: Derived = Default::default();\n"
-"    println!(\"{default_struct:#?}\");"
+"fn main() { let default_struct: Derived = Default::default(); println!"
+"(\"{default_struct:#?}\");"
 msgstr ""
 
 #: src/traits/default.md:26
 msgid ""
-"    let almost_default_struct = Derived {\n"
-"        y: \"Y is set!\".into(),\n"
-"        ..Default::default()\n"
-"    };\n"
-"    println!(\"{almost_default_struct:#?}\");"
+"```\n"
+"let almost_default_struct = Derived {\n"
+"    y: \"Y is set!\".into(),\n"
+"    ..Default::default()\n"
+"};\n"
+"println!(\"{almost_default_struct:#?}\");\n"
+"```"
 msgstr ""
 
 #: src/traits/default.md:32
 msgid ""
-"    let nothing: Option<Derived> = None;\n"
-"    println!(\"{:#?}\", nothing.unwrap_or_default());\n"
-"}"
+"```\n"
+"let nothing: Option<Derived> = None;\n"
+"println!(\"{:#?}\", nothing.unwrap_or_default());\n"
+"```"
 msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via `#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set to their default "
-"values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e.g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and provides convenience "
-"methods that use it."
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
 msgstr ""
 
-#: src/traits/default.md:49
-msgid "[1]: https://doc.rust-lang.org/std/default/trait.Default.html"
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
 msgstr ""
 
-#: src/generics.md:1
-msgid "# Generics"
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr ""
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
+"provides convenience methods that use it."
 msgstr ""
 
 #: src/generics.md:3
 msgid ""
-"Rust support generics, which lets you abstract an algorithm (such as sorting)\n"
-"over the types used in the algorithm."
-msgstr ""
-
-#: src/generics/data-types.md:1
-msgid "# Generic Data Types"
+"Rust support generics, which lets you abstract an algorithm (such as "
+"sorting) over the types used in the algorithm."
 msgstr ""
 
 #: src/generics/data-types.md:3
@@ -8605,21 +9370,14 @@ msgid ""
 "struct Point<T> {\n"
 "    x: T,\n"
 "    y: T,\n"
-"}"
-msgstr ""
-
-#: src/generics/data-types.md:12
-msgid ""
-"fn main() {\n"
-"    let integer = Point { x: 5, y: 10 };\n"
-"    let float = Point { x: 1.0, y: 4.0 };\n"
-"    println!(\"{integer:?} and {float:?}\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/generics/methods.md:1
-msgid "# Generic Methods"
+#: src/generics/data-types.md:12
+msgid ""
+"fn main() { let integer = Point { x: 5, y: 10 }; let float = Point { x: 1.0, "
+"y: 4.0 }; println!(\"{integer:?} and {float:?}\"); }"
 msgstr ""
 
 #: src/generics/methods.md:3
@@ -8630,50 +9388,62 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "#[derive(Debug)]\n"
-"struct Point<T>(T, T);"
+"struct Point<T>(T, T);\n"
+"```"
 msgstr ""
 
 #: src/generics/methods.md:9
-msgid ""
-"impl<T> Point<T> {\n"
-"    fn x(&self) -> &T {\n"
-"        &self.0  // + 10\n"
-"    }"
+msgid "impl"
+msgstr ""
+
+#: src/generics/methods.md:9
+msgid " Point"
+msgstr ""
+
+#: src/generics/methods.md:9
+msgid " { fn x(&self) -> &T { &self.0  // + 10 }"
 msgstr ""
 
 #: src/generics/methods.md:14
 msgid ""
-"    // fn set_x(&mut self, x: T)\n"
-"}"
+"```\n"
+"// fn set_x(&mut self, x: T)\n"
+"```"
 msgstr ""
 
 #: src/generics/methods.md:17
-msgid ""
-"fn main() {\n"
-"    let p = Point(5, 10);\n"
-"    println!(\"p.x = {}\", p.x());\n"
-"}\n"
-"```"
+msgid "fn main() { let p = Point(5, 10); println!(\"p.x = {}\", p.x()); }"
 msgstr ""
 
 #: src/generics/methods.md:25
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that redundant?\n"
-"    * This is because it is a generic implementation section for generic type. They are "
-"independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods in this block will only "
-"be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
 
-#: src/generics/trait-bounds.md:1
-msgid "# Trait Bounds"
+#: src/generics/methods.md:26
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+
+#: src/generics/methods.md:27
+msgid "It means these methods are defined for any `T`."
+msgstr ""
+
+#: src/generics/methods.md:28
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr ""
+
+#: src/generics/methods.md:29
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
 msgstr ""
 
 #: src/generics/trait-bounds.md:3
 msgid ""
-"When working with generics, you often want to require the types to implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 
@@ -8686,16 +9456,20 @@ msgid ""
 "```rust,editable\n"
 "fn duplicate<T: Clone>(a: T) -> (T, T) {\n"
 "    (a.clone(), a.clone())\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/trait-bounds.md:13
-msgid ""
-"// Syntactic sugar for:\n"
-"//   fn add_42_millions<T: Into<i32>>(x: T) -> i32 {\n"
-"fn add_42_millions(x: impl Into<i32>) -> i32 {\n"
-"    x.into() + 42_000_000\n"
-"}"
+msgid "// Syntactic sugar for: //   fn add_42_millions\\<T: Into"
+msgstr ""
+
+#: src/generics/trait-bounds.md:14
+msgid "\\>(x: T) -> i32 { fn add_42_millions(x: impl Into"
+msgstr ""
+
+#: src/generics/trait-bounds.md:15
+msgid ") -> i32 { x.into() + 42_000_000 }"
 msgstr ""
 
 #: src/generics/trait-bounds.md:19
@@ -8704,26 +9478,26 @@ msgstr ""
 
 #: src/generics/trait-bounds.md:21
 msgid ""
-"fn main() {\n"
-"    let foo = String::from(\"foo\");\n"
-"    let pair = duplicate(foo);\n"
-"    println!(\"{pair:?}\");"
+"fn main() { let foo = String::from(\"foo\"); let pair = duplicate(foo); "
+"println!(\"{pair:?}\");"
 msgstr ""
 
 #: src/generics/trait-bounds.md:26
 msgid ""
-"    let many = add_42_millions(42_i8);\n"
-"    println!(\"{many}\");\n"
-"    let many_more = add_42_millions(10_000_000);\n"
-"    println!(\"{many_more}\");\n"
-"}\n"
+"```\n"
+"let many = add_42_millions(42_i8);\n"
+"println!(\"{many}\");\n"
+"let many_more = add_42_millions(10_000_000);\n"
+"println!(\"{many_more}\");\n"
 "```"
 msgstr ""
 
 #: src/generics/trait-bounds.md:35
+msgid "Show a `where` clause, students will encounter it when reading code."
+msgstr ""
+
+#: src/generics/trait-bounds.md:37
 msgid ""
-"Show a `where` clause, students will encounter it when reading code.\n"
-"    \n"
 "```rust,ignore\n"
 "fn duplicate<T>(a: T) -> (T, T)\n"
 "where\n"
@@ -8735,89 +9509,88 @@ msgid ""
 msgstr ""
 
 #: src/generics/trait-bounds.md:46
+msgid "It declutters the function signature if you have many parameters."
+msgstr ""
+
+#: src/generics/trait-bounds.md:47
+msgid "It has additional features making it more powerful."
+msgstr ""
+
+#: src/generics/trait-bounds.md:48
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":\" can be arbitrary, "
-"like `Option<T>`.\n"
-"    \n"
-"</details>"
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
 
 #: src/generics/impl-trait.md:1
-msgid "# `impl Trait`"
+msgid "`impl Trait`"
 msgstr ""
 
 #: src/generics/impl-trait.md:3
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 
-#: src/generics/impl-trait.md:6 src/generics/trait-objects.md:5 src/generics/trait-objects.md:28
+#: src/generics/impl-trait.md:6 src/generics/trait-objects.md:5
+#: src/generics/trait-objects.md:28
 msgid ""
 "```rust,editable\n"
-"use std::fmt::Display;"
+"use std::fmt::Display;\n"
+"```"
 msgstr ""
 
 #: src/generics/impl-trait.md:9
 msgid ""
-"fn get_x(name: impl Display) -> impl Display {\n"
-"    format!(\"Hello {name}\")\n"
-"}"
+"fn get_x(name: impl Display) -> impl Display { format!(\"Hello {name}\") }"
 msgstr ""
 
 #: src/generics/impl-trait.md:13
-msgid ""
-"fn main() {\n"
-"    let x = get_x(\"foo\");\n"
-"    println!(\"{x}\");\n"
-"}\n"
-"```"
+msgid "fn main() { let x = get_x(\"foo\"); println!(\"{x}\"); }"
 msgstr ""
 
 #: src/generics/impl-trait.md:19
-msgid ""
-"* `impl Trait` cannot be used with the `::<>` turbo fish syntax.\n"
-"* `impl Trait` allows you to work with types which you cannot name."
+msgid "`impl Trait` cannot be used with the `::<>` turbo fish syntax."
+msgstr ""
+
+#: src/generics/impl-trait.md:20
+msgid "`impl Trait` allows you to work with types which you cannot name."
 msgstr ""
 
 #: src/generics/impl-trait.md:24
-msgid "The meaning of `impl Trait` is a bit different in the different positions."
+msgid ""
+"The meaning of `impl Trait` is a bit different in the different positions."
 msgstr ""
 
 #: src/generics/impl-trait.md:26
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with a trait bound.\n"
-"* For a return type, it means that the return type is some concrete type that implements the "
-"trait,\n"
-"  without naming the type. This can be useful when you don't want to expose the concrete type in "
-"a\n"
-"  public API."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
+msgstr ""
+
+#: src/generics/impl-trait.md:27
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
 msgstr ""
 
 #: src/generics/impl-trait.md:31
 msgid ""
-"This example is great, because it uses `impl Display` twice. It helps to explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` type are the same "
-"type.\n"
-"It would not work for this particular function, as the type we expect as input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, we'd need two\n"
-"independent generic parameters.\n"
-"    \n"
-"</details>"
-msgstr ""
-
-#: src/generics/closures.md:1
-msgid "# Closures"
+"This example is great, because it uses `impl Display` twice. It helps to "
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 
 #: src/generics/closures.md:3
 msgid ""
-"Closures or lambda expressions have types which cannot be named. However, they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"Closures or lambda expressions have types which cannot be named. However, "
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
@@ -8827,54 +9600,49 @@ msgid ""
 "fn apply_with_log(func: impl FnOnce(i32) -> i32, input: i32) -> i32 {\n"
 "    println!(\"Calling function on {input}\");\n"
 "    func(input)\n"
-"}"
-msgstr ""
-
-#: src/generics/closures.md:14
-msgid ""
-"fn main() {\n"
-"    let add_3 = |x| x + 3;\n"
-"    let mul_5 = |x| x * 5;"
-msgstr ""
-
-#: src/generics/closures.md:18
-msgid ""
-"    println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
-"    println!(\"mul_5: {}\", apply_with_log(mul_5, 20));\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/generics/closures.md:14
+msgid "fn main() { let add_3 = |x| x + 3; let mul_5 = |x| x * 5;"
+msgstr ""
+
+#: src/generics/closures.md:18
+msgid ""
+"```\n"
+"println!(\"add_3: {}\", apply_with_log(add_3, 10));\n"
+"println!(\"mul_5: {}\", apply_with_log(mul_5, 20));\n"
+"```"
+msgstr ""
+
 #: src/generics/closures.md:25
-msgid "If you have an `FnOnce`, you may only call it once. It might consume captured values."
+msgid ""
+"If you have an `FnOnce`, you may only call it once. It might consume "
+"captured values."
 msgstr ""
 
 #: src/generics/closures.md:27
 msgid ""
-"An `FnMut` might mutate captured values, so you can call it multiple times but not concurrently."
+"An `FnMut` might mutate captured values, so you can call it multiple times "
+"but not concurrently."
 msgstr ""
 
 #: src/generics/closures.md:29
 msgid ""
-"An `Fn` neither consumes nor mutates captured values, or perhaps captures nothing at all, so it "
-"can\n"
-"be called multiple times concurrently."
+"An `Fn` neither consumes nor mutates captured values, or perhaps captures "
+"nothing at all, so it can be called multiple times concurrently."
 msgstr ""
 
 #: src/generics/closures.md:32
 msgid ""
-"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever an `FnMut` or "
-"`FnOnce`\n"
-"is called for."
+"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 
 #: src/generics/closures.md:36
 msgid "`move` closures only implement `FnOnce`."
-msgstr ""
-
-#: src/generics/monomorphization.md:1
-msgid "# Monomorphization"
 msgstr ""
 
 #: src/generics/monomorphization.md:3
@@ -8901,34 +9669,24 @@ msgid ""
 "enum Option_i32 {\n"
 "    Some(i32),\n"
 "    None,\n"
-"}"
-msgstr ""
-
-#: src/generics/monomorphization.md:20
-msgid ""
-"enum Option_f64 {\n"
-"    Some(f64),\n"
-"    None,\n"
-"}"
-msgstr ""
-
-#: src/generics/monomorphization.md:25
-msgid ""
-"fn main() {\n"
-"    let integer = Option_i32::Some(5);\n"
-"    let float = Option_f64::Some(5.0);\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/generics/monomorphization.md:31
-msgid ""
-"This is a zero-cost abstraction: you get exactly the same result as if you had\n"
-"hand-coded the data structures without the abstraction."
+#: src/generics/monomorphization.md:20
+msgid "enum Option_f64 { Some(f64), None, }"
 msgstr ""
 
-#: src/generics/trait-objects.md:1
-msgid "# Trait Objects"
+#: src/generics/monomorphization.md:25
+msgid ""
+"fn main() { let integer = Option_i32::Some(5); let float = Option_f64::"
+"Some(5.0); }"
+msgstr ""
+
+#: src/generics/monomorphization.md:31
+msgid ""
+"This is a zero-cost abstraction: you get exactly the same result as if you "
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 
 #: src/generics/trait-objects.md:3
@@ -8936,23 +9694,17 @@ msgid "We've seen how a function can take arguments which implement a trait:"
 msgstr ""
 
 #: src/generics/trait-objects.md:8
-msgid ""
-"fn print<T: Display>(x: T) {\n"
-"    println!(\"Your value: {x}\");\n"
-"}"
+msgid "fn print\\<T: Display>(x: T) { println!(\"Your value: {x}\"); }"
 msgstr ""
 
 #: src/generics/trait-objects.md:12
-msgid ""
-"fn main() {\n"
-"    print(123);\n"
-"    print(\"Hello\");\n"
-"}\n"
-"```"
+msgid "fn main() { print(123); print(\"Hello\"); }"
 msgstr ""
 
 #: src/generics/trait-objects.md:18
-msgid "However, how can we store a collection of mixed types which implement `Display`?"
+msgid ""
+"However, how can we store a collection of mixed types which implement "
+"`Display`?"
 msgstr ""
 
 #: src/generics/trait-objects.md:20
@@ -8969,14 +9721,13 @@ msgid "For this, we need _trait objects_:"
 msgstr ""
 
 #: src/generics/trait-objects.md:31
+msgid "fn main() { let xs: Vec\\<Box"
+msgstr ""
+
+#: src/generics/trait-objects.md:32
 msgid ""
-"fn main() {\n"
-"    let xs: Vec<Box<dyn Display>> = vec![Box::new(123), Box::new(\"Hello\")];\n"
-"    for x in xs {\n"
-"        println!(\"x: {x}\");\n"
-"    }\n"
-"}\n"
-"```"
+"\\> = vec![Box::new(123), Box::new(\"Hello\")\\]; for x in xs { println!"
+"(\"x: {x}\"); } }"
 msgstr ""
 
 #: src/generics/trait-objects.md:39
@@ -8987,36 +9738,57 @@ msgstr ""
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- - -.\n"
 ":                           :     :                                               :\n"
-":    xs                     :     :                                               :\n"
-":   +-----------+-------+   :     :   +-----+-----+                               :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |                               :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+                               :\n"
-":   | capacity  |     2 |   :     :     | |   | |   +----+----+----+----+----+    :\n"
-":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  |    :\n"
-":                           :     :     | |   |     +----+----+----+----+----+    :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |                                   :\n"
-"                                  :     | |   |     +-------------------------+   :\n"
-"                                  :     | |   '---->| \"<str as Display>::fmt\" |   :\n"
-"                                  :     | |         +-------------------------+   :\n"
-"                                  :     | |                                       :\n"
-"                                  :     | |   +----+----+----+----+               :\n"
-"                                  :     | '-->| 7b | 00 | 00 | 00 |               :\n"
-"                                  :     |     +----+----+----+----+               :\n"
-"                                  :     |                                         :\n"
-"                                  :     |     +-------------------------+         :\n"
-"                                  :     '---->| \"<i32 as Display>::fmt\" |         :\n"
-"                                  :           +-------------------------+         :\n"
+":    "
+"xs                     :     :                                               :\n"
+":   +-----------+-------+   :     :   +-----+-----"
+"+                               :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o "
+"|                               :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-"
+"+                               :\n"
+":   | capacity  |     2 |   :     :     | |   | |   +----+----+----+----+----"
+"+    :\n"
+":   +-----------+-------+   :     :     | |   | '-->| H  | e  | l  | l  | o  "
+"|    :\n"
+":                           :     :     | |   |     +----+----+----+----+----"
+"+    :\n"
+"`- - - - - - - - - - - - - -'     :     | |   "
+"|                                   :\n"
+"                                  :     | |   |     "
+"+-------------------------+   :\n"
+"                                  :     | |   '---->| \"<str as Display>::"
+"fmt\" |   :\n"
+"                                  :     | |         "
+"+-------------------------+   :\n"
+"                                  :     | "
+"|                                       :\n"
+"                                  :     | |   +----+----+----+----"
+"+               :\n"
+"                                  :     | '-->| 7b | 00 | 00 | 00 "
+"|               :\n"
+"                                  :     |     +----+----+----+----"
+"+               :\n"
+"                                  :     "
+"|                                         :\n"
+"                                  :     |     +-------------------------"
+"+         :\n"
+"                                  :     '---->| \"<i32 as Display>::fmt\" "
+"|         :\n"
+"                                  :           +-------------------------"
+"+         :\n"
 "                                  :                                               :\n"
 "                                  :                                               :\n"
-"                                  '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- - -'\n"
 "```"
 msgstr ""
 
 #: src/generics/trait-objects.md:69
 msgid ""
-"Similarly, you need a trait object if you want to return different types\n"
+"Similarly, you need a trait object if you want to return different types "
 "implementing a trait:"
 msgstr ""
 
@@ -9029,32 +9801,27 @@ msgid ""
 "    } else {\n"
 "        Box::new((n..0).rev())\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/generics/trait-objects.md:81
 msgid ""
-"fn main() {\n"
-"    println!(\"{:?}\", numbers(-5).collect::<Vec<_>>());\n"
-"    println!(\"{:?}\", numbers(5).collect::<Vec<_>>());\n"
-"}"
+"fn main() { println!(\"{:?}\", numbers(-5).collect::\\<Vec\\<_\\>>()); "
+"println!(\"{:?}\", numbers(5).collect::\\<Vec\\<_\\>>()); }"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
-msgid "# Day 3: Morning Exercises"
+msgid "Day 3: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:3
 msgid "We will design a classical GUI library traits and trait objects."
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:1
-msgid "# A Simple GUI Library"
-msgstr ""
-
 #: src/exercises/day-3/simple-gui.md:3
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 
@@ -9063,11 +9830,17 @@ msgid "We will have a number of widgets in our library:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:8
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:9
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:11
+msgid "`Label`: has a `label`."
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:13
@@ -9076,151 +9849,125 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:15
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:18 src/exercises/day-3/safe-ffi-wrapper.md:25
+#: src/exercises/day-3/simple-gui.md:18
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
 "```rust,should_panic\n"
 "// TODO: remove this when you're done with your implementation.\n"
-"#![allow(unused_imports, unused_variables, dead_code)]"
+"#![allow(unused_imports, unused_variables, dead_code)]\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:22
 msgid ""
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;"
+"pub trait Widget { /// Natural width of `self`. fn width(&self) -> usize;"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:26 src/exercises/day-3/solutions-morning.md:27
+#: src/exercises/day-3/simple-gui.md:26
+#: src/exercises/day-3/solutions-morning.md:27
 msgid ""
-"    /// Draw the widget into a buffer.\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write);"
+"```\n"
+"/// Draw the widget into a buffer.\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write);\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:29 src/exercises/day-3/solutions-morning.md:30
+#: src/exercises/day-3/simple-gui.md:29
+#: src/exercises/day-3/solutions-morning.md:30
 msgid ""
-"    /// Draw the widget on standard output.\n"
-"    fn draw(&self) {\n"
-"        let mut buffer = String::new();\n"
-"        self.draw_into(&mut buffer);\n"
-"        println!(\"{buffer}\");\n"
-"    }\n"
-"}"
+"```\n"
+"/// Draw the widget on standard output.\n"
+"fn draw(&self) {\n"
+"    let mut buffer = String::new();\n"
+"    self.draw_into(&mut buffer);\n"
+"    println!(\"{buffer}\");\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:37 src/exercises/day-3/solutions-morning.md:38
-msgid ""
-"pub struct Label {\n"
-"    label: String,\n"
-"}"
+#: src/exercises/day-3/simple-gui.md:37
+#: src/exercises/day-3/solutions-morning.md:38
+msgid "pub struct Label { label: String, }"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:41 src/exercises/day-3/solutions-morning.md:42
+#: src/exercises/day-3/simple-gui.md:41
+#: src/exercises/day-3/solutions-morning.md:42
 msgid ""
-"impl Label {\n"
-"    fn new(label: &str) -> Label {\n"
-"        Label {\n"
-"            label: label.to_owned(),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Label { fn new(label: &str) -> Label { Label { label: label."
+"to_owned(), } } }"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:49 src/exercises/day-3/solutions-morning.md:50
-msgid ""
-"pub struct Button {\n"
-"    label: Label,\n"
-"    callback: Box<dyn FnMut()>,\n"
-"}"
+#: src/exercises/day-3/simple-gui.md:49
+#: src/exercises/day-3/solutions-morning.md:50
+msgid "pub struct Button { label: Label, callback: Box\\<dyn FnMut()>, }"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:54 src/exercises/day-3/solutions-morning.md:55
+#: src/exercises/day-3/simple-gui.md:54
+#: src/exercises/day-3/solutions-morning.md:55
 msgid ""
-"impl Button {\n"
-"    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
-"        Button {\n"
-"            label: Label::new(label),\n"
-"            callback,\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Button { fn new(label: &str, callback: Box\\<dyn FnMut()>) -> Button "
+"{ Button { label: Label::new(label), callback, } } }"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:63 src/exercises/day-3/solutions-morning.md:64
-msgid ""
-"pub struct Window {\n"
-"    title: String,\n"
-"    widgets: Vec<Box<dyn Widget>>,\n"
-"}"
+#: src/exercises/day-3/simple-gui.md:63
+#: src/exercises/day-3/solutions-morning.md:64
+msgid "pub struct Window { title: String, widgets: Vec\\<Box"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:68 src/exercises/day-3/solutions-morning.md:69
-msgid ""
-"impl Window {\n"
-"    fn new(title: &str) -> Window {\n"
-"        Window {\n"
-"            title: title.to_owned(),\n"
-"            widgets: Vec::new(),\n"
-"        }\n"
-"    }"
+#: src/exercises/day-3/simple-gui.md:65
+#: src/exercises/day-3/solutions-morning.md:66
+msgid "\\>, }"
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:76 src/exercises/day-3/solutions-morning.md:77
+#: src/exercises/day-3/simple-gui.md:68
+#: src/exercises/day-3/solutions-morning.md:69
 msgid ""
-"    fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
-"        self.widgets.push(widget);\n"
-"    }\n"
-"}"
+"impl Window { fn new(title: &str) -> Window { Window { title: title."
+"to_owned(), widgets: Vec::new(), } }"
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:76
+#: src/exercises/day-3/solutions-morning.md:77
+msgid ""
+"```\n"
+"fn add_widget(&mut self, widget: Box<dyn Widget>) {\n"
+"    self.widgets.push(widget);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:82
-msgid ""
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Widget for Label { fn width(&self) -> usize { unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:87 src/exercises/day-3/simple-gui.md:97
 #: src/exercises/day-3/simple-gui.md:107
 msgid ""
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
+"```\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    unimplemented!()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:92
-msgid ""
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Widget for Button { fn width(&self) -> usize { unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:102
-msgid ""
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        unimplemented!()\n"
-"    }"
+msgid "impl Widget for Window { fn width(&self) -> usize { unimplemented!() }"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:112
 msgid ""
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo.\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\",\n"
-"        Box::new(|| println!(\"You clicked the button!\")),\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"```"
+"fn main() { let mut window = Window::new(\"Rust GUI Demo 1.23\"); window."
+"add_widget(Box::new(Label::new(\"This is a small text GUI demo.\"))); window."
+"add_widget(Box::new(Button::new( \"Click me!\", Box::new(|| println!(\"You "
+"clicked the button!\")), ))); window.draw(); }"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:123
@@ -9232,7 +9979,8 @@ msgid ""
 "```text\n"
 "========\n"
 "Rust GUI Demo 1.23\n"
-"========"
+"========\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:130
@@ -9240,17 +9988,15 @@ msgid "This is a small text GUI demo."
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:132
-msgid ""
-"| Click me! |\n"
-"```"
+msgid "\\| Click me! |"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:135
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:140
@@ -9266,7 +10012,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:149
-msgid "Using such alignment tricks, you can for example produce output like this:"
+msgid ""
+"Using such alignment tricks, you can for example produce output like this:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:151
@@ -9283,22 +10030,16 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-msgid "# Error Handling"
-msgstr ""
-
 #: src/error-handling.md:3
 msgid "Error handling in Rust is done using explicit control flow:"
 msgstr ""
 
 #: src/error-handling.md:5
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
+msgid "Functions that can have errors list this in their return type,"
 msgstr ""
 
-#: src/error-handling/panics.md:1
-msgid "# Panics"
+#: src/error-handling.md:6
+msgid "There are no exceptions."
 msgstr ""
 
 #: src/error-handling/panics.md:3
@@ -9316,107 +10057,106 @@ msgid ""
 msgstr ""
 
 #: src/error-handling/panics.md:12
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr ""
+
+#: src/error-handling/panics.md:13
+msgid "Panics are symptoms of bugs in the program."
+msgstr ""
+
+#: src/error-handling/panics.md:14
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:1
-msgid "# Catching the Stack Unwinding"
+msgid "Catching the Stack Unwinding"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:3
-msgid "By default, a panic will cause the stack to unwind. The unwinding can be caught:"
+msgid ""
+"By default, a panic will cause the stack to unwind. The unwinding can be "
+"caught:"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:5
 msgid ""
 "```rust\n"
-"use std::panic;"
+"use std::panic;\n"
+"```"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:8
 msgid ""
-"let result = panic::catch_unwind(|| {\n"
-"    println!(\"hello!\");\n"
-"});\n"
-"assert!(result.is_ok());"
+"let result = panic::catch_unwind(|| { println!(\"hello!\"); }); assert!"
+"(result.is_ok());"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:13
 msgid ""
-"let result = panic::catch_unwind(|| {\n"
-"    panic!(\"oh no!\");\n"
-"});\n"
-"assert!(result.is_err());\n"
-"```"
+"let result = panic::catch_unwind(|| { panic!(\"oh no!\"); }); assert!(result."
+"is_err());"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:19
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:21
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
 msgstr ""
 
 #: src/error-handling/result.md:1
-msgid "# Structured Error Handling with `Result`"
+msgid "Structured Error Handling with `Result`"
 msgstr ""
 
 #: src/error-handling/result.md:3
 msgid ""
-"We have already seen the `Result` enum. This is used pervasively when errors are\n"
-"expected as part of normal operation:"
+"We have already seen the `Result` enum. This is used pervasively when errors "
+"are expected as part of normal operation:"
 msgstr ""
 
 #: src/error-handling/result.md:6
 msgid ""
 "```rust\n"
 "use std::fs::File;\n"
-"use std::io::Read;"
+"use std::io::Read;\n"
+"```"
 msgstr ""
 
 #: src/error-handling/result.md:10
 msgid ""
-"fn main() {\n"
-"    let file = File::open(\"diary.txt\");\n"
-"    match file {\n"
-"        Ok(mut file) => {\n"
-"            let mut contents = String::new();\n"
-"            file.read_to_string(&mut contents);\n"
-"            println!(\"Dear diary: {contents}\");\n"
-"        },\n"
-"        Err(err) => {\n"
-"            println!(\"The diary could not be opened: {err}\");\n"
-"        }\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let file = File::open(\"diary.txt\"); match file { Ok(mut file) "
+"=> { let mut contents = String::new(); file.read_to_string(&mut contents); "
+"println!(\"Dear diary: {contents}\"); }, Err(err) => { println!(\"The diary "
+"could not be opened: {err}\"); } } }"
 msgstr ""
 
 #: src/error-handling/result.md:27
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where an error should never "
-"happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but it is worth "
-"mentioning. \n"
-"    It contains a lot of convenience methods and functions that help functional-style "
-"programming. \n"
-"    \n"
-"</details>"
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
+msgstr ""
+
+#: src/error-handling/result.md:30
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
 msgstr ""
 
 #: src/error-handling/try-operator.md:1
-msgid "# Propagating Errors with `?`"
+msgid "Propagating Errors with `?`"
 msgstr ""
 
 #: src/error-handling/try-operator.md:3
 msgid ""
-"The try-operator `?` is used to return errors to the caller. It lets you turn\n"
-"the common"
+"The try-operator `?` is used to return errors to the caller. It lets you "
+"turn the common"
 msgstr ""
 
 #: src/error-handling/try-operator.md:6
@@ -9448,60 +10188,66 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "use std::fs;\n"
-"use std::io::{self, Read};"
+"use std::io::{self, Read};\n"
+"```"
 msgstr ""
 
 #: src/error-handling/try-operator.md:25
 msgid ""
-"fn read_username(path: &str) -> Result<String, io::Error> {\n"
-"    let username_file_result = fs::File::open(path);"
+"fn read_username(path: &str) -> Result\\<String, io::Error> { let "
+"username_file_result = fs::File::open(path);"
 msgstr ""
 
 #: src/error-handling/try-operator.md:28
 msgid ""
-"    let mut username_file = match username_file_result {\n"
-"        Ok(file) => file,\n"
-"        Err(e) => return Err(e),\n"
-"    };"
+"```\n"
+"let mut username_file = match username_file_result {\n"
+"    Ok(file) => file,\n"
+"    Err(e) => return Err(e),\n"
+"};\n"
+"```"
 msgstr ""
 
 #: src/error-handling/try-operator.md:33
-msgid "    let mut username = String::new();"
+msgid ""
+"```\n"
+"let mut username = String::new();\n"
+"```"
 msgstr ""
 
 #: src/error-handling/try-operator.md:35
 msgid ""
-"    match username_file.read_to_string(&mut username) {\n"
-"        Ok(_) => Ok(username),\n"
-"        Err(e) => Err(e),\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/error-handling/try-operator.md:41
-msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"alice\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
+"```\n"
+"match username_file.read_to_string(&mut username) {\n"
+"    Ok(_) => Ok(username),\n"
+"    Err(e) => Err(e),\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/error-handling/try-operator.md:52 src/error-handling/converting-error-types-example.md:52
+#: src/error-handling/try-operator.md:41
 msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, empty file, file with "
-"username."
+"fn main() { //fs::write(\"config.dat\", \"alice\").unwrap(); let username = "
+"read_username(\"config.dat\"); println!(\"username or error: "
+"{username:?}\"); }"
 msgstr ""
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-msgid "# Converting Error Types"
+#: src/error-handling/try-operator.md:52
+#: src/error-handling/converting-error-types-example.md:52
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
+msgstr ""
+
+#: src/error-handling/try-operator.md:53
+#: src/error-handling/converting-error-types-example.md:53
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
 msgstr ""
 
 #: src/error-handling/converting-error-types.md:3
-msgid "The effective expansion of `?` is a little more complicated than previously indicated:"
+msgid ""
+"The effective expansion of `?` is a little more complicated than previously "
+"indicated:"
 msgstr ""
 
 #: src/error-handling/converting-error-types.md:5
@@ -9527,7 +10273,7 @@ msgstr ""
 
 #: src/error-handling/converting-error-types.md:18
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
 
@@ -9537,16 +10283,14 @@ msgid ""
 "use std::error::Error;\n"
 "use std::fmt::{self, Display, Formatter};\n"
 "use std::fs::{self, File};\n"
-"use std::io::{self, Read};"
+"use std::io::{self, Read};\n"
+"```"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:9
 msgid ""
-"#[derive(Debug)]\n"
-"enum ReadUsernameError {\n"
-"    IoError(io::Error),\n"
-"    EmptyUsername(String),\n"
-"}"
+"\\#\\[derive(Debug)\\] enum ReadUsernameError { IoError(io::Error), "
+"EmptyUsername(String), }"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:15
@@ -9555,65 +10299,46 @@ msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:17
 msgid ""
-"impl Display for ReadUsernameError {\n"
-"    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-"        match self {\n"
-"            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Found no username in {}\", filename),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Display for ReadUsernameError { fn fmt(&self, f: &mut Formatter) -> "
+"fmt::Result { match self { Self::IoError(e) => write!(f, \"IO error: {}\", "
+"e), Self::EmptyUsername(filename) => write!(f, \"Found no username in {}\", "
+"filename), } } }"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:26
 msgid ""
-"impl From<io::Error> for ReadUsernameError {\n"
-"    fn from(err: io::Error) -> ReadUsernameError {\n"
-"        ReadUsernameError::IoError(err)\n"
-"    }\n"
-"}"
+"impl From<io::Error> for ReadUsernameError { fn from(err: io::Error) -> "
+"ReadUsernameError { ReadUsernameError::IoError(err) } }"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:32
 msgid ""
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+"fn read_username(path: &str) -> Result\\<String, ReadUsernameError> { let "
+"mut username = String::with_capacity(100); File::open(path)?."
+"read_to_string(&mut username)?; if username.is_empty() { return "
+"Err(ReadUsernameError::EmptyUsername(String::from(path))); } Ok(username) }"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:41
 msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    let username = read_username(\"config.dat\");\n"
-"    println!(\"username or error: {username:?}\");\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"\").unwrap(); let username = "
+"read_username(\"config.dat\"); println!(\"username or error: "
+"{username:?}\"); }"
 msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:55
 msgid ""
-"It is good practice for all error types to implement `std::error::Error`, which requires `Debug` "
-"and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too where possible, to "
-"make\n"
-"life easier for tests and consumers of your library. In this case we can't easily do so, because\n"
+"It is good practice for all error types to implement `std::error::Error`, "
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:1
-msgid "# Deriving Error Enums"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
-"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create an\n"
-"error enum like we did on the previous page:"
+"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
+"an error enum like we did on the previous page:"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:6
@@ -9621,64 +10346,49 @@ msgid ""
 "```rust,editable,compile_fail\n"
 "use std::{fs, io};\n"
 "use std::io::Read;\n"
-"use thiserror::Error;"
+"use thiserror::Error;\n"
+"```"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:11
 msgid ""
-"#[derive(Debug, Error)]\n"
-"enum ReadUsernameError {\n"
-"    #[error(\"Could not read: {0}\")]\n"
-"    IoError(#[from] io::Error),\n"
-"    #[error(\"Found no username in {0}\")]\n"
-"    EmptyUsername(String),\n"
-"}"
+"\\#\\[derive(Debug, Error)\\] enum ReadUsernameError { \\#\\[error(\"Could "
+"not read: {0}\")\\] IoError(#\\[from\\] io::Error), \\#\\[error(\"Found no "
+"username in {0}\")\\] EmptyUsername(String), }"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:19
 msgid ""
-"fn read_username(path: &str) -> Result<String, ReadUsernameError> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    fs::File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(ReadUsernameError::EmptyUsername(String::from(path)));\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+"fn read_username(path: &str) -> Result\\<String, ReadUsernameError> { let "
+"mut username = String::with_capacity(100); fs::File::open(path)?."
+"read_to_string(&mut username)?; if username.is_empty() { return "
+"Err(ReadUsernameError::EmptyUsername(String::from(path))); } Ok(username) }"
 msgstr ""
 
-#: src/error-handling/deriving-error-enums.md:28 src/error-handling/dynamic-errors.md:25
+#: src/error-handling/deriving-error-enums.md:28
+#: src/error-handling/dynamic-errors.md:25
 msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err}\"),\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"\").unwrap(); match "
+"read_username(\"config.dat\") { Ok(username) => println!(\"Username: "
+"{username}\"), Err(err)     => println!(\"Error: {err}\"), } }"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:39
 msgid ""
-"`thiserror`'s derive macro automatically implements `std::error::Error`, and optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the `#[from]` attribute is "
-"added).\n"
-"It also works for structs."
+"`thiserror`'s derive macro automatically implements `std::error::Error`, and "
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:1
-msgid "# Dynamic Error Types"
-msgstr ""
-
 #: src/error-handling/dynamic-errors.md:3
 msgid ""
-"Sometimes we want to allow any type of error to be returned without writing our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"Sometimes we want to allow any type of error to be returned without writing "
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:6
@@ -9687,48 +10397,41 @@ msgid ""
 "use std::fs::{self, File};\n"
 "use std::io::Read;\n"
 "use thiserror::Error;\n"
-"use std::error::Error;"
+"use std::error::Error;\n"
+"```"
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:12
 msgid ""
-"#[derive(Clone, Debug, Eq, Error, PartialEq)]\n"
-"#[error(\"Found no username in {0}\")]\n"
-"struct EmptyUsernameError(String);"
+"\\#\\[derive(Clone, Debug, Eq, Error, PartialEq)\\] \\#\\[error(\"Found no "
+"username in {0}\")\\] struct EmptyUsernameError(String);"
+msgstr ""
+
+#: src/error-handling/dynamic-errors.md:16
+msgid "fn read_username(path: &str) -> Result\\<String, Box"
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:16
 msgid ""
-"fn read_username(path: &str) -> Result<String, Box<dyn Error>> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    File::open(path)?.read_to_string(&mut username)?;\n"
-"    if username.is_empty() {\n"
-"        return Err(EmptyUsernameError(String::from(path)).into());\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+"\\> { let mut username = String::with_capacity(100); File::open(path)?."
+"read_to_string(&mut username)?; if username.is_empty() { return "
+"Err(EmptyUsernameError(String::from(path)).into()); } Ok(username) }"
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
-"This saves on code, but gives up the ability to cleanly handle different error cases differently "
-"in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` in the public API of "
-"a\n"
-"library, but it can be a good option in a program where you just want to display the error "
-"message\n"
+"This saves on code, but gives up the ability to cleanly handle different "
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
-msgstr ""
-
-#: src/error-handling/error-contexts.md:1
-msgid "# Adding Context to Errors"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:3
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:7
@@ -9736,49 +10439,50 @@ msgid ""
 "```rust,editable,compile_fail\n"
 "use std::{fs, io};\n"
 "use std::io::Read;\n"
-"use anyhow::{Context, Result, bail};"
+"use anyhow::{Context, Result, bail};\n"
+"```"
+msgstr ""
+
+#: src/error-handling/error-contexts.md:12
+msgid "fn read_username(path: &str) -> Result"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:12
 msgid ""
-"fn read_username(path: &str) -> Result<String> {\n"
-"    let mut username = String::with_capacity(100);\n"
-"    fs::File::open(path)\n"
-"        .context(format!(\"Failed to open {path}\"))?\n"
-"        .read_to_string(&mut username)\n"
-"        .context(\"Failed to read\")?;\n"
-"    if username.is_empty() {\n"
-"        bail!(\"Found no username in {path}\");\n"
-"    }\n"
-"    Ok(username)\n"
-"}"
+" { let mut username = String::with_capacity(100); fs::File::open(path) ."
+"context(format!(\"Failed to open {path}\"))? .read_to_string(&mut username) ."
+"context(\"Failed to read\")?; if username.is_empty() { bail!(\"Found no "
+"username in {path}\"); } Ok(username) }"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:24
 msgid ""
-"fn main() {\n"
-"    //fs::write(\"config.dat\", \"\").unwrap();\n"
-"    match read_username(\"config.dat\") {\n"
-"        Ok(username) => println!(\"Username: {username}\"),\n"
-"        Err(err)     => println!(\"Error: {err:?}\"),\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { //fs::write(\"config.dat\", \"\").unwrap(); match "
+"read_username(\"config.dat\") { Ok(username) => println!(\"Username: "
+"{username}\"), Err(err)     => println!(\"Error: {err:?}\"), } }"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such it's again generally "
-"not\n"
-"  a good choice for the public API of a library, but is widely used in applications.\n"
-"* Actual error type inside of it can be extracted for examination if necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
 
-#: src/testing.md:1
-msgid "# Testing"
+#: src/error-handling/error-contexts.md:36
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:38
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:39
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
 msgstr ""
 
 #: src/testing.md:3
@@ -9786,15 +10490,11 @@ msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr ""
 
 #: src/testing.md:5
-msgid "* Unit tests are supported throughout your code."
+msgid "Unit tests are supported throughout your code."
 msgstr ""
 
 #: src/testing.md:7
-msgid "* Integration tests are supported via the `tests/` directory."
-msgstr ""
-
-#: src/testing/unit-tests.md:1
-msgid "# Unit Tests"
+msgid "Integration tests are supported via the `tests/` directory."
 msgstr ""
 
 #: src/testing/unit-tests.md:3
@@ -9809,27 +10509,76 @@ msgid ""
 "        Some(idx) => &text[..idx],\n"
 "        None => &text,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/testing/unit-tests.md:13
-msgid ""
-"#[test]\n"
-"fn test_empty() {\n"
-"    assert_eq!(first_word(\"\"), \"\");\n"
-"}"
+msgid "\\#\\[test\\] fn test_empty() { assert_eq!(first_word(\"\"), \"\"); }"
 msgstr ""
 
 #: src/testing/unit-tests.md:18
 msgid ""
-"#[test]\n"
-"fn test_single_word() {\n"
-"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
-"}"
+"\\#\\[test\\] fn test_single_word() { assert_eq!(first_word(\"Hello\"), "
+"\"Hello\"); }"
 msgstr ""
 
 #: src/testing/unit-tests.md:23
 msgid ""
+"\\#\\[test\\] fn test_multiple_words() { assert_eq!(first_word(\"Hello "
+"World\"), \"Hello\"); }"
+msgstr ""
+
+#: src/testing/unit-tests.md:27
+msgid ""
+"```\n"
+"\n"
+"# Unit Tests\n"
+"\n"
+"Mark unit tests with `#[test]`:\n"
+"\n"
+"```rust,editable\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}\n"
+"\n"
+"Use `cargo test` to find and run the unit tests.\n"
+"\n"
+"# Unit Tests\n"
+"\n"
+"Mark unit tests with `#[test]`:\n"
+"\n"
+"```rust,editable,ignore\n"
+"fn first_word(text: &str) -> &str {\n"
+"    match text.find(' ') {\n"
+"        Some(idx) => &text[..idx],\n"
+"        None => &text,\n"
+"    }\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_empty() {\n"
+"    assert_eq!(first_word(\"\"), \"\");\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_word() {\n"
+"    assert_eq!(first_word(\"Hello\"), \"Hello\");\n"
+"}\n"
+"\n"
 "#[test]\n"
 "fn test_multiple_words() {\n"
 "    assert_eq!(first_word(\"Hello World\"), \"Hello\");\n"
@@ -9841,14 +10590,10 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr ""
 
-#: src/testing/test-modules.md:1
-msgid "# Test Modules"
-msgstr ""
-
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 
 #: src/testing/test-modules.md:6
@@ -9856,34 +10601,30 @@ msgid ""
 "```rust,editable\n"
 "fn helper(a: &str, b: &str) -> String {\n"
 "    format!(\"{a} {b}\")\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/testing/test-modules.md:11
-msgid ""
-"pub fn main() {\n"
-"    println!(\"{}\", helper(\"Hello\", \"World\"));\n"
-"}"
+msgid "pub fn main() { println!(\"{}\", helper(\"Hello\", \"World\")); }"
 msgstr ""
 
 #: src/testing/test-modules.md:19
 msgid ""
-"    #[test]\n"
-"    fn test_helper() {\n"
-"        assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
-"    }\n"
+"```\n"
+"#[test]\n"
+"fn test_helper() {\n"
+"    assert_eq!(helper(\"foo\", \"bar\"), \"foo bar\");\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/testing/test-modules.md:26
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgid "This lets you unit test private helpers."
 msgstr ""
 
-#: src/testing/doc-tests.md:1
-msgid "# Documentation Tests"
+#: src/testing/test-modules.md:27
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
 
 #: src/testing/doc-tests.md:3
@@ -9907,15 +10648,17 @@ msgid ""
 msgstr ""
 
 #: src/testing/doc-tests.md:18
-msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
-"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
 
-#: src/testing/integration-tests.md:1
-msgid "# Integration Tests"
+#: src/testing/doc-tests.md:19
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr ""
+
+#: src/testing/doc-tests.md:20
+msgid ""
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
 
 #: src/testing/integration-tests.md:3
@@ -9929,11 +10672,38 @@ msgstr ""
 #: src/testing/integration-tests.md:7
 msgid ""
 "```rust,ignore\n"
-"use my_library::init;"
+"use my_library::init;\n"
+"```"
 msgstr ""
 
 #: src/testing/integration-tests.md:10
+msgid "\\#\\[test\\] fn test_init() { assert!(init().is_ok()); }"
+msgstr ""
+
+#: src/testing/integration-tests.md:14
 msgid ""
+"```\n"
+"\n"
+"# Integration Tests\n"
+"\n"
+"If you want to test your library as a client, use an integration test.\n"
+"\n"
+"Create a `.rs` file under `tests/`:\n"
+"\n"
+"```rust,ignore\n"
+"use my_library::init;\n"
+"\n"
+"These tests only have access to the public API of your crate.\n"
+"\n"
+"# Integration Tests\n"
+"\n"
+"If you want to test your library as a client, use an integration test.\n"
+"\n"
+"Create a `.rs` file under `tests/`:\n"
+"\n"
+"```rust,ignore\n"
+"use my_library::init;\n"
+"\n"
 "#[test]\n"
 "fn test_init() {\n"
 "    assert!(init().is_ok());\n"
@@ -9945,30 +10715,30 @@ msgstr ""
 msgid "These tests only have access to the public API of your crate."
 msgstr ""
 
-#: src/unsafe.md:1
-msgid "# Unsafe Rust"
-msgstr ""
-
 #: src/unsafe.md:3
 msgid "The Rust language has two parts:"
 msgstr ""
 
 #: src/unsafe.md:5
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr ""
+
+#: src/unsafe.md:6
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are violated."
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"violated."
 msgstr ""
 
 #: src/unsafe.md:8
 msgid ""
-"We will be seeing mostly safe Rust in this course, but it's important to know\n"
-"what Unsafe Rust is."
+"We will be seeing mostly safe Rust in this course, but it's important to "
+"know what Unsafe Rust is."
 msgstr ""
 
 #: src/unsafe.md:11
 msgid ""
-"Unsafe code is usually small and isolated, and its correctness should be carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"Unsafe code is usually small and isolated, and its correctness should be "
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 
 #: src/unsafe.md:14
@@ -9976,30 +10746,38 @@ msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr ""
 
 #: src/unsafe.md:16
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
+msgid "Dereference raw pointers."
+msgstr ""
+
+#: src/unsafe.md:17
+msgid "Access or modify mutable static variables."
+msgstr ""
+
+#: src/unsafe.md:18
+msgid "Access `union` fields."
+msgstr ""
+
+#: src/unsafe.md:19
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr ""
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
 msgstr ""
 
 #: src/unsafe.md:22
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please see\n"
-"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"We will briefly cover unsafe capabilities next. For full details, please see "
+"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 
 #: src/unsafe.md:28
 msgid ""
-"Unsafe Rust does not mean the code is incorrect. It means that developers have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety rules."
-msgstr ""
-
-#: src/unsafe/raw-pointers.md:1
-msgid "# Dereferencing Raw Pointers"
+"Unsafe Rust does not mean the code is incorrect. It means that developers "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
+"rules."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:3
@@ -10010,60 +10788,75 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let mut num = 5;"
+"    let mut num = 5;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:9
 msgid ""
-"    let r1 = &mut num as *mut i32;\n"
-"    let r2 = &num as *const i32;"
+"```\n"
+"let r1 = &mut num as *mut i32;\n"
+"let r2 = &num as *const i32;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:12
 msgid ""
-"    // Safe because r1 and r2 were obtained from references and so are guaranteed to be non-null "
-"and\n"
-"    // properly aligned, the objects underlying the references from which they were obtained are\n"
-"    // live throughout the whole unsafe block, and they are not accessed either through the\n"
-"    // references or concurrently through any other pointers.\n"
-"    unsafe {\n"
-"        println!(\"r1 is: {}\", *r1);\n"
-"        *r1 = 10;\n"
-"        println!(\"r2 is: {}\", *r2);\n"
-"    }\n"
+"```\n"
+"// Safe because r1 and r2 were obtained from references and so are "
+"guaranteed to be non-null and\n"
+"// properly aligned, the objects underlying the references from which they "
+"were obtained are\n"
+"// live throughout the whole unsafe block, and they are not accessed either "
+"through the\n"
+"// references or concurrently through any other pointers.\n"
+"unsafe {\n"
+"    println!(\"r1 is: {}\", *r1);\n"
+"    *r1 = 10;\n"
+"    println!(\"r2 is: {}\", *r2);\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:26
 msgid ""
-"It is good practice (and required by the Android Rust style guide) to write a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety requirements of the unsafe\n"
-"operations it is doing."
+"It is good practice (and required by the Android Rust style guide) to write "
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:30
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:33
+msgid "The pointer must be non-null."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:34
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:35
+msgid "The object must not have been deallocated."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:36
+msgid "There must not be concurrent accesses to the same location."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:37
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:40
 msgid "In most cases the pointer must also be properly aligned."
-msgstr ""
-
-#: src/unsafe/mutable-static-variables.md:1
-msgid "# Mutable Static Variables"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:3
@@ -10073,58 +10866,49 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:5
 msgid ""
 "```rust,editable\n"
-"static HELLO_WORLD: &str = \"Hello, world!\";"
+"static HELLO_WORLD: &str = \"Hello, world!\";\n"
+"```"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:8
-msgid ""
-"fn main() {\n"
-"    println!(\"HELLO_WORLD: {HELLO_WORLD}\");\n"
-"}\n"
-"```"
+msgid "fn main() { println!(\"HELLO_WORLD: {HELLO_WORLD}\"); }"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:16
 msgid ""
 "```rust,editable\n"
-"static mut COUNTER: u32 = 0;"
+"static mut COUNTER: u32 = 0;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:19
 msgid ""
-"fn add_to_counter(inc: u32) {\n"
-"    unsafe { COUNTER += inc; }  // Potential data race!\n"
-"}"
+"fn add_to_counter(inc: u32) { unsafe { COUNTER += inc; }  // Potential data "
+"race! }"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:23
-msgid ""
-"fn main() {\n"
-"    add_to_counter(42);"
+msgid "fn main() { add_to_counter(42);"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:26
 msgid ""
-"    unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
-"}\n"
+"```\n"
+"unsafe { println!(\"COUNTER: {COUNTER}\"); }  // Potential data race!\n"
 "```"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:32
 msgid ""
-"Using a mutable static is generally a bad idea, but there are some cases where it might make "
-"sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working with some C APIs."
-msgstr ""
-
-#: src/unsafe/unions.md:1
-msgid "# Unions"
+"Using a mutable static is generally a bad idea, but there are some cases "
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 
 #: src/unsafe/unions.md:3
@@ -10138,90 +10922,83 @@ msgid ""
 "union MyUnion {\n"
 "    i: u8,\n"
 "    b: bool,\n"
-"}"
-msgstr ""
-
-#: src/unsafe/unions.md:12
-msgid ""
-"fn main() {\n"
-"    let u = MyUnion { i: 42 };\n"
-"    println!(\"int: {}\", unsafe { u.i });\n"
-"    println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior!\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/unsafe/unions.md:12
+msgid ""
+"fn main() { let u = MyUnion { i: 42 }; println!(\"int: {}\", unsafe { u."
+"i }); println!(\"bool: {}\", unsafe { u.b });  // Undefined behavior! }"
+msgstr ""
+
 #: src/unsafe/unions.md:21
 msgid ""
-"Unions are very rarely needed in Rust as you can usually use an enum. They are occasionally "
-"needed\n"
-"for interacting with C library APIs."
+"Unions are very rarely needed in Rust as you can usually use an enum. They "
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 
 #: src/unsafe/unions.md:24
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably want\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:1
-msgid "# Calling Unsafe Functions"
+"If you just want to reinterpret bytes as a different type, you probably want "
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
-"A function or method can be marked `unsafe` if it has extra preconditions you\n"
-"must uphold to avoid undefined behaviour:"
+"A function or method can be marked `unsafe` if it has extra preconditions "
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let emojis = \"🗻∈🌏\";"
+"    let emojis = \"🗻∈🌏\";\n"
+"```"
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:10
 msgid ""
-"    // Safe because the indices are in the correct order, within the bounds of\n"
-"    // the string slice, and lie on UTF-8 sequence boundaries.\n"
-"    unsafe {\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
-"        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
-"    }"
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:18
-msgid "    println!(\"char count: {}\", count_chars(unsafe { emojis.get_unchecked(0..7) }));"
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:20
-msgid ""
-"    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
-"    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe { emojis.get_unchecked(0..3) }));\n"
-"}"
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:25
-msgid ""
-"fn count_chars(s: &str) -> usize {\n"
-"    s.chars().map(|_| 1).sum()\n"
+"```\n"
+"// Safe because the indices are in the correct order, within the bounds of\n"
+"// the string slice, and lie on UTF-8 sequence boundaries.\n"
+"unsafe {\n"
+"    println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
+"    println!(\"emoji: {}\", emojis.get_unchecked(4..7));\n"
+"    println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-msgid "# Writing Unsafe Functions"
+#: src/unsafe/calling-unsafe-functions.md:18
+msgid ""
+"```\n"
+"println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..7) }));\n"
+"```"
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:20
+msgid ""
+"```\n"
+"// Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
+"// println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
+"// println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..3) }));\n"
+"```"
+msgstr ""
+
+#: src/unsafe/calling-unsafe-functions.md:25
+msgid "fn count_chars(s: &str) -> usize { s.chars().map(|\\_\\| 1).sum() }"
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:3
 msgid ""
-"You can mark your own functions as `unsafe` if they require particular conditions to avoid "
-"undefined\n"
-"behaviour."
+"You can mark your own functions as `unsafe` if they require particular "
+"conditions to avoid undefined behaviour."
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:6
@@ -10236,48 +11013,51 @@ msgid ""
 "    let temp = *a;\n"
 "    *a = *b;\n"
 "    *b = temp;\n"
-"}"
-msgstr ""
-
-#: src/unsafe/writing-unsafe-functions.md:18
-msgid ""
-"fn main() {\n"
-"    let mut a = 42;\n"
-"    let mut b = 66;"
-msgstr ""
-
-#: src/unsafe/writing-unsafe-functions.md:22
-msgid ""
-"    // Safe because ...\n"
-"    unsafe {\n"
-"        swap(&mut a, &mut b);\n"
-"    }"
-msgstr ""
-
-#: src/unsafe/writing-unsafe-functions.md:27
-msgid ""
-"    println!(\"a = {}, b = {}\", a, b);\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/unsafe/writing-unsafe-functions.md:18
+msgid "fn main() { let mut a = 42; let mut b = 66;"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:22
+msgid ""
+"```\n"
+"// Safe because ...\n"
+"unsafe {\n"
+"    swap(&mut a, &mut b);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/unsafe/writing-unsafe-functions.md:27
+msgid ""
+"```\n"
+"println!(\"a = {}, b = {}\", a, b);\n"
+"```"
+msgstr ""
+
 #: src/unsafe/writing-unsafe-functions.md:33
-msgid "We wouldn't actually use pointers for this because it can be done safely with references."
+msgid ""
+"We wouldn't actually use pointers for this because it can be done safely "
+"with references."
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:35
 msgid ""
-"Note that unsafe code is allowed within an unsafe function without an `unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see what happens."
+"Note that unsafe code is allowed within an unsafe function without an "
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 
 #: src/unsafe/extern-functions.md:1
-msgid "# Calling External Code"
+msgid "Calling External Code"
 msgstr ""
 
 #: src/unsafe/extern-functions.md:3
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
 
@@ -10286,86 +11066,73 @@ msgid ""
 "```rust,editable\n"
 "extern \"C\" {\n"
 "    fn abs(input: i32) -> i32;\n"
-"}"
-msgstr ""
-
-#: src/unsafe/extern-functions.md:11
-msgid ""
-"fn main() {\n"
-"    unsafe {\n"
-"        // Undefined behavior if abs misbehaves.\n"
-"        println!(\"Absolute value of -3 according to C: {}\", abs(-3));\n"
-"    }\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/unsafe/extern-functions.md:11
+msgid ""
+"fn main() { unsafe { // Undefined behavior if abs misbehaves. println!"
+"(\"Absolute value of -3 according to C: {}\", abs(-3)); } }"
+msgstr ""
+
 #: src/unsafe/extern-functions.md:21
 msgid ""
-"This is usually only a problem for extern functions which do things with pointers which might\n"
-"violate Rust's memory model, but in general any C function might have undefined behaviour under "
-"any\n"
-"arbitrary circumstances."
+"This is usually only a problem for extern functions which do things with "
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
-msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-msgid "# Implementing Unsafe Traits"
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
-"Like with functions, you can mark a trait as `unsafe` if the implementation must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"Like with functions, you can mark a trait as `unsafe` if the implementation "
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:9
 msgid ""
 "```rust,editable\n"
 "use std::mem::size_of_val;\n"
-"use std::slice;"
+"use std::slice;\n"
+"```"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:13
 msgid ""
-"/// ...\n"
-"/// # Safety\n"
-"/// The type must have a defined representation and no padding.\n"
-"pub unsafe trait AsBytes {\n"
-"    fn as_bytes(&self) -> &[u8] {\n"
-"        unsafe {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, size_of_val(self))\n"
-"        }\n"
-"    }\n"
-"}"
+"/// ... /// # Safety /// The type must have a defined representation and no "
+"padding. pub unsafe trait AsBytes { fn as_bytes(&self) -> &\\[u8\\] { unsafe "
+"{ slice::from_raw_parts(self as \\*const Self as \\*const u8, "
+"size_of_val(self)) } } }"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:24
 msgid ""
-"// Safe because u32 has a defined representation and no padding.\n"
-"unsafe impl AsBytes for u32 {}\n"
-"```"
+"// Safe because u32 has a defined representation and no padding. unsafe impl "
+"AsBytes for u32 {}"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:30
 msgid ""
-"There should be a `# Safety` section on the Rustdoc for the trait explaining the requirements for\n"
-"the trait to be safely implemented."
+"There should be a `# Safety` section on the Rustdoc for the trait explaining "
+"the requirements for the trait to be safely implemented."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:33
-msgid "The actual safety section for `AsBytes` is rather longer and more complicated."
+msgid ""
+"The actual safety section for `AsBytes` is rather longer and more "
+"complicated."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:35
@@ -10373,7 +11140,7 @@ msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:1
-msgid "# Day 3: Afternoon Exercises"
+msgid "Day 3: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:3
@@ -10381,21 +11148,15 @@ msgid "Let us build a safe wrapper for reading directory content!"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:7
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr ""
-
-#: src/exercises/day-3/afternoon.md:9
-msgid "[solution]: solutions-afternoon.md"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-msgid "# Safe FFI Wrapper"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 
@@ -10404,174 +11165,165 @@ msgid "You will want to consult the manual pages:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module, particular for [`CStr`]\n"
-"and [`CString`] types which are used to hold NUL-terminated strings coming from\n"
-"C. The [Nomicon] also has a very useful chapter about FFI."
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:17
-msgid ""
-"[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
-"[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
-"[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
-"[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module, particular for [`CStr`](https://doc.rust-lang.org/std/ffi/"
+"struct.CStr.html) and [`CString`](https://doc.rust-lang.org/std/ffi/struct."
+"CString.html) types which are used to hold NUL-terminated strings coming "
+"from C. The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a "
+"very useful chapter about FFI."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:29
-msgid ""
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+msgid "mod ffi { use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
 msgstr ""
 
-#: src/exercises/day-3/safe-ffi-wrapper.md:32 src/exercises/day-3/solutions-afternoon.md:26
+#: src/exercises/day-3/safe-ffi-wrapper.md:32
+#: src/exercises/day-3/solutions-afternoon.md:26
 msgid ""
-"    // Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
-"    #[repr(C)]\n"
-"    pub struct DIR {\n"
-"        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:39 src/exercises/day-3/solutions-afternoon.md:33
-msgid ""
-"    // Layout as per readdir(3) and definitions in /usr/include/x86_64-linux-gnu.\n"
-"    #[repr(C)]\n"
-"    pub struct dirent {\n"
-"        pub d_ino: c_long,\n"
-"        pub d_off: c_ulong,\n"
-"        pub d_reclen: c_ushort,\n"
-"        pub d_type: c_char,\n"
-"        pub d_name: [c_char; 256],\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:49 src/exercises/day-3/solutions-afternoon.md:43
-msgid ""
-"    extern \"C\" {\n"
-"        pub fn opendir(s: *const c_char) -> *mut DIR;\n"
-"        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
-"        pub fn closedir(s: *mut DIR) -> c_int;\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:56 src/exercises/day-3/solutions-afternoon.md:50
-msgid ""
-"use std::ffi::{CStr, CString, OsStr, OsString};\n"
-"use std::os::unix::ffi::OsStrExt;"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:59
-msgid ""
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:65
-msgid ""
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:73
-msgid ""
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:81
-msgid ""
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        unimplemented!()\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:88
-msgid ""
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
+"```\n"
+"// Opaque type. See https://doc.rust-lang.org/nomicon/ffi.html.\n"
+"#[repr(C)]\n"
+"pub struct DIR {\n"
+"    _data: [u8; 0],\n"
+"    _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/exercises/day-3/safe-ffi-wrapper.md:39
+#: src/exercises/day-3/solutions-afternoon.md:33
+msgid ""
+"```\n"
+"// Layout as per readdir(3) and definitions in /usr/include/x86_64-linux-"
+"gnu.\n"
+"#[repr(C)]\n"
+"pub struct dirent {\n"
+"    pub d_ino: c_long,\n"
+"    pub d_off: c_ulong,\n"
+"    pub d_reclen: c_ushort,\n"
+"    pub d_type: c_char,\n"
+"    pub d_name: [c_char; 256],\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:49
+#: src/exercises/day-3/solutions-afternoon.md:43
+msgid ""
+"```\n"
+"extern \"C\" {\n"
+"    pub fn opendir(s: *const c_char) -> *mut DIR;\n"
+"    pub fn readdir(s: *mut DIR) -> *const dirent;\n"
+"    pub fn closedir(s: *mut DIR) -> c_int;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:56
+#: src/exercises/day-3/solutions-afternoon.md:50
+msgid ""
+"use std::ffi::{CStr, CString, OsStr, OsString}; use std::os::unix::ffi::"
+"OsStrExt;"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:59
+msgid ""
+"\\#\\[derive(Debug)\\] struct DirectoryIterator { path: CString, dir: \\*mut "
+"ffi::DIR, }"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:65
+msgid ""
+"impl DirectoryIterator { fn new(path: &str) -> Result\\<DirectoryIterator, "
+"String> { // Call opendir and return a Ok value if that worked, // otherwise "
+"return Err with a message. unimplemented!() } }"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:73
+msgid ""
+"impl Iterator for DirectoryIterator { type Item = OsString; fn next(&mut "
+"self) -> Option"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:75
+msgid ""
+" { // Keep calling readdir until we get a NULL pointer back. unimplemented!"
+"() } }"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:81
+msgid ""
+"impl Drop for DirectoryIterator { fn drop(&mut self) { // Call closedir as "
+"needed. unimplemented!() } }"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:88
+msgid ""
+"fn main() -> Result\\<(), String> { let iter = DirectoryIterator::new(\"."
+"\")?; println!(\"files: {:#?}\", iter.collect::\\<Vec\\<\\_\\>>()); Ok(()) }"
+msgstr ""
+
 #: src/welcome-day-4.md:1
-msgid "# Welcome to Day 4"
-msgstr "# Bienvenido al Día 4"
+msgid "Welcome to Day 4"
+msgstr "Bienvenido al Día 4"
 
 #: src/welcome-day-4.md:3
 msgid "Today we will look at two main topics:"
 msgstr ""
 
 #: src/welcome-day-4.md:5
-msgid "* Concurrency: threads, channels, shared state, `Send` and `Sync`."
+msgid "Concurrency: threads, channels, shared state, `Send` and `Sync`."
 msgstr ""
 
 #: src/welcome-day-4.md:7
 msgid ""
-"* Android: building binaries and libraries, using AIDL, logging, and\n"
-"  interoperability with C, C++, and Java."
+"Android: building binaries and libraries, using AIDL, logging, and "
+"interoperability with C, C++, and Java."
 msgstr ""
 
 #: src/welcome-day-4.md:10
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try to\n"
-"> find a little corner of your code base where we can move some lines of code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something that\n"
-"> parses some raw bytes would be ideal."
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
 
 #: src/concurrency.md:1
-msgid "# Fearless Concurrency"
+msgid "Fearless Concurrency"
 msgstr ""
 
 #: src/concurrency.md:3
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 
 #: src/concurrency.md:6
 msgid ""
-"The Rust type system plays an important role in making many concurrency bugs\n"
-"compile time bugs. This is often referred to as _fearless concurrency_ since you\n"
-"can rely on the compiler to ensure correctness at runtime."
-msgstr ""
-
-#: src/concurrency/threads.md:1
-msgid "# Threads"
+"The Rust type system plays an important role in making many concurrency bugs "
+"compile time bugs. This is often referred to as _fearless concurrency_ since "
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 
 #: src/concurrency/threads.md:3
@@ -10582,65 +11334,59 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "use std::thread;\n"
-"use std::time::Duration;"
+"use std::time::Duration;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/threads.md:9
 msgid ""
-"fn main() {\n"
-"    thread::spawn(|| {\n"
-"        for i in 1..10 {\n"
-"            println!(\"Count in thread: {i}!\");\n"
-"            thread::sleep(Duration::from_millis(5));\n"
-"        }\n"
-"    });"
+"fn main() { thread::spawn(|| { for i in 1..10 { println!(\"Count in thread: "
+"{i}!\"); thread::sleep(Duration::from_millis(5)); } });"
 msgstr ""
 
 #: src/concurrency/threads.md:17
 msgid ""
-"    for i in 1..5 {\n"
-"        println!(\"Main thread: {i}\");\n"
-"        thread::sleep(Duration::from_millis(5));\n"
-"    }\n"
+"```\n"
+"for i in 1..5 {\n"
+"    println!(\"Main thread: {i}\");\n"
+"    thread::sleep(Duration::from_millis(5));\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/concurrency/threads.md:24
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
+msgstr ""
+
+#: src/concurrency/threads.md:25
+msgid "Thread panics are independent of each other."
+msgstr ""
+
+#: src/concurrency/threads.md:26
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
 msgstr ""
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread is\n"
-"  not waiting."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
 
 #: src/concurrency/threads.md:35
 msgid ""
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for\n"
-"  the thread to finish."
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
 msgstr ""
 
 #: src/concurrency/threads.md:38
-msgid "* Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
 msgstr ""
 
 #: src/concurrency/threads.md:40
 msgid ""
-"* Use the `Result` return value from `handle.join()` to get access to the panic\n"
-"  payload. This is a good time to talk about [`Any`]."
-msgstr ""
-
-#: src/concurrency/threads.md:43
-msgid "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
-msgstr ""
-
-#: src/concurrency/scoped-threads.md:1
-msgid "# Scoped Threads"
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:3
@@ -10650,155 +11396,152 @@ msgstr ""
 #: src/concurrency/scoped-threads.md:5
 msgid ""
 "```rust,editable,compile_fail\n"
-"use std::thread;"
+"use std::thread;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:8 src/concurrency/scoped-threads.md:22
-msgid ""
-"fn main() {\n"
-"    let s = String::from(\"Hello\");"
+msgid "fn main() { let s = String::from(\"Hello\");"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:11
 msgid ""
-"    thread::spawn(|| {\n"
-"        println!(\"Length: {}\", s.len());\n"
-"    });\n"
-"}\n"
+"```\n"
+"thread::spawn(|| {\n"
+"    println!(\"Length: {}\", s.len());\n"
+"});\n"
 "```"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
-msgid "However, you can use a [scoped thread][1] for this:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
 "```rust,editable\n"
-"use std::thread;"
+"use std::thread;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:25
 msgid ""
-"    thread::scope(|scope| {\n"
-"        scope.spawn(|| {\n"
-"            println!(\"Length: {}\", s.len());\n"
-"        });\n"
+"```\n"
+"thread::scope(|scope| {\n"
+"    scope.spawn(|| {\n"
+"        println!(\"Length: {}\", s.len());\n"
 "    });\n"
-"}\n"
+"});\n"
 "```"
 msgstr ""
 
-#: src/concurrency/scoped-threads.md:33
-msgid "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
-msgstr ""
-
-#: src/concurrency/scoped-threads.md:35
+#: src/concurrency/scoped-threads.md:37
 msgid ""
-"<details>\n"
-"    \n"
-"* The reason for that is that when the `thread::scope` function completes, all the threads are "
-"guaranteed to be joined, so they can return borrowed data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one thread, or immutably by "
-"any number of threads.\n"
-"    \n"
-"</details>"
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/channels.md:1
-msgid "# Channels"
+#: src/concurrency/scoped-threads.md:38
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
 msgstr ""
 
 #: src/concurrency/channels.md:3
 msgid ""
-"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two parts\n"
-"are connected via the channel, but you only see the end-points."
+"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
 
 #: src/concurrency/channels.md:6
 msgid ""
 "```rust,editable\n"
 "use std::sync::mpsc;\n"
-"use std::thread;"
+"use std::thread;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels.md:10 src/concurrency/channels/unbounded.md:10
-msgid ""
-"fn main() {\n"
-"    let (tx, rx) = mpsc::channel();"
+msgid "fn main() { let (tx, rx) = mpsc::channel();"
 msgstr ""
 
 #: src/concurrency/channels.md:13
 msgid ""
-"    tx.send(10).unwrap();\n"
-"    tx.send(20).unwrap();"
+"```\n"
+"tx.send(10).unwrap();\n"
+"tx.send(20).unwrap();\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels.md:16
 msgid ""
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"    println!(\"Received: {:?}\", rx.recv());"
+"```\n"
+"println!(\"Received: {:?}\", rx.recv());\n"
+"println!(\"Received: {:?}\", rx.recv());\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels.md:19
 msgid ""
-"    let tx2 = tx.clone();\n"
-"    tx2.send(30).unwrap();\n"
-"    println!(\"Received: {:?}\", rx.recv());\n"
-"}\n"
+"```\n"
+"let tx2 = tx.clone();\n"
+"tx2.send(30).unwrap();\n"
+"println!(\"Received: {:?}\", rx.recv());\n"
 "```"
 msgstr ""
 
 #: src/concurrency/channels.md:27
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` implement `Clone` "
-"(so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the counterpart `Sender` "
-"or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:1
-msgid "# Unbounded Channels"
+#: src/concurrency/channels.md:29
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
 msgstr ""
 
 #: src/concurrency/channels/unbounded.md:3
 msgid "You get an unbounded and asynchronous channel with `mpsc::channel()`:"
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:5 src/concurrency/channels/bounded.md:5
+#: src/concurrency/channels/unbounded.md:5
+#: src/concurrency/channels/bounded.md:5
 msgid ""
 "```rust,editable\n"
 "use std::sync::mpsc;\n"
 "use std::thread;\n"
-"use std::time::Duration;"
+"use std::time::Duration;\n"
+"```"
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:13 src/concurrency/channels/bounded.md:13
+#: src/concurrency/channels/unbounded.md:13
+#: src/concurrency/channels/bounded.md:13
 msgid ""
-"    thread::spawn(move || {\n"
-"        let thread_id = thread::current().id();\n"
-"        for i in 1..10 {\n"
-"            tx.send(format!(\"Message {i}\")).unwrap();\n"
-"            println!(\"{thread_id:?}: sent Message {i}\");\n"
-"        }\n"
-"        println!(\"{thread_id:?}: done\");\n"
-"    });\n"
-"    thread::sleep(Duration::from_millis(100));"
+"```\n"
+"thread::spawn(move || {\n"
+"    let thread_id = thread::current().id();\n"
+"    for i in 1..10 {\n"
+"        tx.send(format!(\"Message {i}\")).unwrap();\n"
+"        println!(\"{thread_id:?}: sent Message {i}\");\n"
+"    }\n"
+"    println!(\"{thread_id:?}: done\");\n"
+"});\n"
+"thread::sleep(Duration::from_millis(100));\n"
+"```"
 msgstr ""
 
 #: src/concurrency/channels/unbounded.md:23
 msgid ""
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {}\", msg);\n"
-"    }\n"
+"```\n"
+"for msg in rx.iter() {\n"
+"    println!(\"Main: got {}\", msg);\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/concurrency/channels/bounded.md:1
-msgid "# Bounded Channels"
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:3
@@ -10806,173 +11549,184 @@ msgid "Bounded and synchronous channels make `send` block the current thread:"
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:10
-msgid ""
-"fn main() {\n"
-"    let (tx, rx) = mpsc::sync_channel(3);"
+msgid "fn main() { let (tx, rx) = mpsc::sync_channel(3);"
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:23
 msgid ""
-"    for msg in rx.iter() {\n"
-"        println!(\"Main: got {msg}\");\n"
-"    }\n"
+"```\n"
+"for msg in rx.iter() {\n"
+"    println!(\"Main: got {msg}\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/concurrency/shared_state.md:1
-msgid "# Shared State"
-msgstr ""
-
 #: src/concurrency/shared_state.md:3
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 
 #: src/concurrency/shared_state.md:6
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
 
-#: src/concurrency/shared_state.md:10
+#: src/concurrency/shared_state.md:8
 msgid ""
-"[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:1
-msgid "# `Arc`"
+msgid "`Arc`"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:3
-msgid "[`Arc<T>`][1] allows shared read-only access via its `clone` method:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via its `clone` method:"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
 "```rust,editable\n"
 "use std::thread;\n"
-"use std::sync::Arc;"
+"use std::sync::Arc;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:9
 msgid ""
-"fn main() {\n"
-"    let v = Arc::new(vec![10, 20, 30]);\n"
-"    let mut handles = Vec::new();\n"
-"    for _ in 1..5 {\n"
-"        let v = v.clone();\n"
-"        handles.push(thread::spawn(move || {\n"
-"            let thread_id = thread::current().id();\n"
-"            println!(\"{thread_id:?}: {v:?}\");\n"
-"        }));\n"
-"    }"
+"fn main() { let v = Arc::new(vec![10, 20, 30\\]); let mut handles = Vec::"
+"new(); for _ in 1..5 { let v = v.clone(); handles.push(thread::spawn(move || "
+"{ let thread_id = thread::current().id(); println!(\"{thread_id:?}: "
+"{v:?}\"); })); }"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:20
 msgid ""
-"    handles.into_iter().for_each(|h| h.join().unwrap());\n"
-"    println!(\"v: {v:?}\");\n"
-"}\n"
+"```\n"
+"handles.into_iter().for_each(|h| h.join().unwrap());\n"
+"println!(\"v: {v:?}\");\n"
 "```"
-msgstr ""
-
-#: src/concurrency/shared_state/arc.md:25
-msgid "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but after that the use of "
-"the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:31
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:33
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:35
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:36
+msgid "`std::sync::Weak` can help."
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:1
-msgid "# `Mutex`"
+msgid "`Mutex`"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:3
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
 "```rust,editable\n"
-"use std::sync::Mutex;"
+"use std::sync::Mutex;\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:9
 msgid ""
-"fn main() {\n"
-"    let v = Mutex::new(vec![10, 20, 30]);\n"
-"    println!(\"v: {:?}\", v.lock().unwrap());"
+"fn main() { let v = Mutex::new(vec![10, 20, 30\\]); println!(\"v: {:?}\", v."
+"lock().unwrap());"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:13
 msgid ""
-"    {\n"
-"        let mut guard = v.lock().unwrap();\n"
-"        guard.push(40);\n"
-"    }"
+"```\n"
+"{\n"
+"    let mut guard = v.lock().unwrap();\n"
+"    guard.push(40);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:18
 msgid ""
-"    println!(\"v: {:?}\", v.lock().unwrap());\n"
-"}\n"
+"```\n"
+"println!(\"v: {:?}\", v.lock().unwrap());\n"
 "```"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:25
+#: src/concurrency/shared_state/mutex.md:31
 msgid ""
-"[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-"[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E\n"
-"[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:29
+#: src/concurrency/shared_state/mutex.md:32
 msgid ""
-"<details>\n"
-"    \n"
-"* `Mutex` in Rust looks like a collection with just one element - the protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The `MutexGuard` ensures that "
-"the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes \"poisoned\" to signal "
-"that\n"
-"      the data it protected might be in an inconsistent state. Calling `lock()` on a poisoned "
-"mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error to recover the data\n"
-"      regardless."
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
 msgstr ""
 
-#: src/concurrency/shared_state/mutex.md:43
+#: src/concurrency/shared_state/mutex.md:33
 msgid ""
-"[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError.html  \n"
-"    \n"
-"</details>"
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:35
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:36
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:37
+msgid "Why does `lock()` return a `Result`? "
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:38
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:3
@@ -10983,152 +11737,179 @@ msgstr ""
 msgid ""
 "```rust,editable,compile_fail\n"
 "use std::thread;\n"
-"// use std::sync::{Arc, Mutex};"
+"// use std::sync::{Arc, Mutex};\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:9
 msgid ""
-"fn main() {\n"
-"    let mut v = vec![10, 20, 30];\n"
-"    let handle = thread::spawn(|| {\n"
-"        v.push(10);\n"
-"    });\n"
-"    v.push(1000);"
+"fn main() { let mut v = vec![10, 20, 30\\]; let handle = thread::spawn(|| "
+"{ v.push(10); }); v.push(1000);"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:16
 msgid ""
-"    handle.join().unwrap();\n"
+"```\n"
+"handle.join().unwrap();\n"
+"println!(\"v: {v:?}\");\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:23
+msgid "Possible solution:"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:25
+msgid ""
+"```rust,editable\n"
+"use std::sync::{Arc, Mutex};\n"
+"use std::thread;\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:29
+msgid "fn main() { let v = Arc::new(Mutex::new(vec![10, 20, 30\\]));"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:32
+msgid ""
+"```\n"
+"let v2 = v.clone();\n"
+"let handle = thread::spawn(move || {\n"
+"    let mut v2 = v2.lock().unwrap();\n"
+"    v2.push(10);\n"
+"});\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:38
+msgid ""
+"```\n"
+"{\n"
+"    let mut v = v.lock().unwrap();\n"
+"    v.push(1000);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:43
+msgid ""
+"```\n"
+"handle.join().unwrap();\n"
+"```"
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:45
+msgid ""
+"```\n"
+"{\n"
+"    let v = v.lock().unwrap();\n"
 "    println!(\"v: {v:?}\");\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/concurrency/shared_state/example.md:23
+#: src/concurrency/shared_state/example.md:50
 msgid ""
-"Possible solution:\n"
-"    \n"
-"```rust,editable\n"
-"use std::sync::{Arc, Mutex};\n"
-"use std::thread;"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:29
-msgid ""
-"fn main() {\n"
-"    let v = Arc::new(Mutex::new(vec![10, 20, 30]));"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:32
-msgid ""
-"    let v2 = v.clone();\n"
-"    let handle = thread::spawn(move || {\n"
-"        let mut v2 = v2.lock().unwrap();\n"
-"        v2.push(10);\n"
-"    });"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:38
-msgid ""
-"    {\n"
-"        let mut v = v.lock().unwrap();\n"
-"        v.push(1000);\n"
-"    }"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:43
-msgid "    handle.join().unwrap();"
-msgstr ""
-
-#: src/concurrency/shared_state/example.md:45
-msgid ""
-"    {\n"
-"        let v = v.lock().unwrap();\n"
-"        println!(\"v: {v:?}\");\n"
-"    }\n"
-"}\n"
 "```\n"
 "    \n"
-"Notable parts:"
+"Notable parts:\n"
+"```"
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:54
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another thread. Note `move` "
-"was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as possible.\n"
-"* We still need to acquire the `Mutex` to print our `Vec`."
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:55
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:56
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:57
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:58
+msgid "We still need to acquire the `Mutex` to print our `Vec`."
 msgstr ""
 
 #: src/concurrency/send-sync.md:1
-msgid "# `Send` and `Sync`"
+msgid "`Send` and `Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync.md:3
-msgid "How does Rust know to forbid shared access across thread? The answer is in two traits:"
+msgid ""
+"How does Rust know to forbid shared access across thread? The answer is in "
+"two traits:"
 msgstr ""
 
 #: src/concurrency/send-sync.md:5
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
+msgstr ""
+
+#: src/concurrency/send-sync.md:7
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
 msgstr ""
 
 #: src/concurrency/send-sync.md:10
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically derive them for your "
-"types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement them manually when "
-"you\n"
-"know it is valid."
-msgstr ""
-
-#: src/concurrency/send-sync.md:14
-msgid ""
-"[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
-"[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
-"[3]: ../unsafe/unsafe-traits.md"
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  \n"
-"</details>"
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
+msgstr ""
+
+#: src/concurrency/send-sync.md:21
+msgid "They can be used in the generic constraints as normal traits."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:1
-msgid "# `Send`"
+msgid "`Send`"
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:3
-msgid "> A type `T` is [`Send`][1] if it is safe to move a `T` value to another thread."
+msgid ""
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
-"The effect of moving ownership to another thread is that _destructors_ will run\n"
-"in that thread. So the question is when you can allocate a value in one thread\n"
-"and deallocate it in another."
-msgstr ""
-
-#: src/concurrency/send-sync/send.md:9
-msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
+"The effect of moving ownership to another thread is that _destructors_ will "
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:1
-msgid "# `Sync`"
+msgid "`Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:6
@@ -11136,33 +11917,27 @@ msgid "More precisely, the definition is:"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:8
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
-msgstr ""
-
-#: src/concurrency/send-sync/sync.md:10
-msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:14
 msgid ""
-"This statement is essentially a shorthand way of saying that if a type is thread-safe for shared "
-"use, it is also thread-safe to pass references of it across threads."
+"This statement is essentially a shorthand way of saying that if a type is "
+"thread-safe for shared use, it is also thread-safe to pass references of it "
+"across threads."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:16
 msgid ""
-"This is because if a type is Sync it means that it can be shared across multiple threads without "
-"the risk of data races or other synchronization issues, so it is safe to move it to another "
-"thread. A reference to the type is also safe to move to another thread, because the data it "
-"references can be accessed from any thread safely."
-msgstr ""
-
-#: src/concurrency/send-sync/examples.md:1
-msgid "# Examples"
+"This is because if a type is Sync it means that it can be shared across "
+"multiple threads without the risk of data races or other synchronization "
+"issues, so it is safe to move it to another thread. A reference to the type "
+"is also safe to move to another thread, because the data it references can "
+"be accessed from any thread safely."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:3
-msgid "## `Send + Sync`"
+msgid "`Send + Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:5
@@ -11170,55 +11945,78 @@ msgid "Most types you come across are `Send + Sync`:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:17
-msgid "## `Send + !Sync`"
+msgid "`Send + !Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:19
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:22
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:23
+msgid "`mpsc::Receiver<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:24
+msgid "`Cell<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:25
+msgid "`RefCell<T>`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:27
-msgid "## `!Send + Sync`"
+msgid "`!Send + Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:29
-msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgid ""
+"These types are thread-safe, but they cannot be moved to another thread:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:34
-msgid "## `!Send + !Sync`"
+msgid "`!Send + !Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:36
@@ -11227,14 +12025,14 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
 
-#: src/exercises/day-4/morning.md:1 src/exercises/day-4/afternoon.md:1
-msgid "# Exercises"
+#: src/concurrency/send-sync/examples.md:40
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
 msgstr ""
 
 #: src/exercises/day-4/morning.md:3
@@ -11242,17 +12040,13 @@ msgid "Let us practice our new concurrency skills with"
 msgstr ""
 
 #: src/exercises/day-4/morning.md:5
-msgid "* Dining philosophers: a classic problem in concurrency."
+msgid "Dining philosophers: a classic problem in concurrency."
 msgstr ""
 
 #: src/exercises/day-4/morning.md:7
 msgid ""
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:1
-msgid "# Dining Philosophers"
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:3
@@ -11261,20 +12055,21 @@ msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:5
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has their\n"
-"> own place at the table. There is a fork between each plate. The dish served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will only\n"
-"> be available when their two nearest neighbors are thinking, not eating. After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:13
 msgid ""
-"You will need a local [Cargo installation](../../cargo/running-locally.md) for\n"
-"this exercise. Copy the code below to `src/main.rs` file, fill out the blanks,\n"
-"and test that `cargo run` does not deadlock:"
+"You will need a local [Cargo installation](../../cargo/running-locally.md) "
+"for this exercise. Copy the code below to `src/main.rs` file, fill out the "
+"blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:17
@@ -11283,86 +12078,82 @@ msgid ""
 "use std::sync::mpsc;\n"
 "use std::sync::{Arc, Mutex};\n"
 "use std::thread;\n"
-"use std::time::Duration;"
+"use std::time::Duration;\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-4/dining-philosophers.md:23 src/exercises/day-4/solutions-morning.md:28
+#: src/exercises/day-4/dining-philosophers.md:23
+#: src/exercises/day-4/solutions-morning.md:28
 msgid "struct Fork;"
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:25
 msgid ""
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // left_fork: ...\n"
-"    // right_fork: ...\n"
-"    // thoughts: ...\n"
-"}"
+"struct Philosopher { name: String, // left_fork: ... // right_fork: ... // "
+"thoughts: ... }"
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:32
 msgid ""
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }"
+"impl Philosopher { fn think(&self) { self.thoughts .send(format!(\"Eureka! "
+"{} has a new idea!\", &self.name)) .unwrap(); }"
 msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:39
 msgid ""
-"    fn eat(&self) {\n"
-"        // Pick up forks...\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:46 src/exercises/day-4/solutions-morning.md:60
-msgid ""
-"static PHILOSOPHERS: &[&str] =\n"
-"    &[\"Socrates\", \"Plato\", \"Aristotle\", \"Thales\", \"Pythagoras\"];"
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:49
-msgid ""
-"fn main() {\n"
-"    // Create forks"
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:52
-msgid "    // Create philosophers"
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:54
-msgid "    // Make them think and eat"
-msgstr ""
-
-#: src/exercises/day-4/dining-philosophers.md:56
-msgid ""
-"    // Output their thoughts\n"
+"```\n"
+"fn eat(&self) {\n"
+"    // Pick up forks...\n"
+"    println!(\"{} is eating...\", &self.name);\n"
+"    thread::sleep(Duration::from_millis(10));\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/exercises/day-4/link-checker.md:1
-msgid "# Multi-threaded Link Checker"
+#: src/exercises/day-4/dining-philosophers.md:46
+#: src/exercises/day-4/solutions-morning.md:60
+msgid ""
+"static PHILOSOPHERS: &\\[&str\\] = &\\[\"Socrates\", \"Plato\", "
+"\"Aristotle\", \"Thales\", \"Pythagoras\"\\];"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:49
+msgid "fn main() { // Create forks"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:52
+msgid ""
+"```\n"
+"// Create philosophers\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:54
+msgid ""
+"```\n"
+"// Make them think and eat\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-4/dining-philosophers.md:56
+msgid ""
+"```\n"
+"// Output their thoughts\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:3
 msgid ""
-"Let us use our new knowledge to create a multi-threaded link checker. It should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until all\n"
-"pages have been validated."
+"Let us use our new knowledge to create a multi-threaded link checker. It "
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:11
@@ -11376,12 +12167,14 @@ msgstr ""
 
 #: src/exercises/day-4/link-checker.md:17
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:20
-msgid "You will also need a way to find links. We can use [`scraper`][2] for that:"
+msgid ""
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:22
@@ -11393,8 +12186,8 @@ msgstr ""
 
 #: src/exercises/day-4/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:29
@@ -11405,14 +12198,16 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:33
-msgid "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
+msgid ""
+"The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:35
 msgid ""
 "```toml\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] }\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -11420,8 +12215,8 @@ msgstr ""
 
 #: src/exercises/day-4/link-checker.md:42
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:45
@@ -11434,59 +12229,58 @@ msgid ""
 "use reqwest::blocking::{get, Response};\n"
 "use reqwest::Url;\n"
 "use scraper::{Html, Selector};\n"
-"use thiserror::Error;"
+"use thiserror::Error;\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:53
 msgid ""
-"#[derive(Error, Debug)]\n"
-"enum Error {\n"
-"    #[error(\"request error: {0}\")]\n"
-"    ReqwestError(#[from] reqwest::Error),\n"
-"}"
+"\\#\\[derive(Error, Debug)\\] enum Error { \\#\\[error(\"request error: "
+"{0}\")\\] ReqwestError(#\\[from\\] reqwest::Error), }"
+msgstr ""
+
+#: src/exercises/day-4/link-checker.md:59
+msgid "fn extract_links(response: Response) -> Result\\<Vec"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:59
 msgid ""
-"fn extract_links(response: Response) -> Result<Vec<Url>, Error> {\n"
-"    let base_url = response.url().to_owned();\n"
-"    let document = response.text()?;\n"
-"    let html = Html::parse_document(&document);\n"
-"    let selector = Selector::parse(\"a\").unwrap();"
+", Error> { let base_url = response.url().to_owned(); let document = response."
+"text()?; let html = Html::parse_document(&document); let selector = "
+"Selector::parse(\"a\").unwrap();"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:65
 msgid ""
-"    let mut valid_urls = Vec::new();\n"
-"    for element in html.select(&selector) {\n"
-"        if let Some(href) = element.value().attr(\"href\") {\n"
-"            match base_url.join(href) {\n"
-"                Ok(url) => valid_urls.push(url),\n"
-"                Err(err) => {\n"
-"                    println!(\"On {base_url}: could not parse {href:?}: {err} (ignored)\",);\n"
-"                }\n"
+"```\n"
+"let mut valid_urls = Vec::new();\n"
+"for element in html.select(&selector) {\n"
+"    if let Some(href) = element.value().attr(\"href\") {\n"
+"        match base_url.join(href) {\n"
+"            Ok(url) => valid_urls.push(url),\n"
+"            Err(err) => {\n"
+"                println!(\"On {base_url}: could not parse {href:?}: {err} "
+"(ignored)\",);\n"
 "            }\n"
 "        }\n"
-"    }"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:77
 msgid ""
-"    Ok(valid_urls)\n"
-"}"
+"```\n"
+"Ok(valid_urls)\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:80
 msgid ""
-"fn main() {\n"
-"    let start_url = Url::parse(\"https://www.google.org\").unwrap();\n"
-"    let response = get(start_url).unwrap();\n"
-"    match extract_links(response) {\n"
-"        Ok(links) => println!(\"Links: {links:#?}\"),\n"
-"        Err(err) => println!(\"Could not extract links: {err:#}\"),\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let start_url = Url::parse(\"https://www.google.org\").unwrap(); "
+"let response = get(start_url).unwrap(); match extract_links(response) "
+"{ Ok(links) => println!(\"Links: {links:#?}\"), Err(err) => println!(\"Could "
+"not extract links: {err:#}\"), } }"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:90
@@ -11501,44 +12295,33 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:96
-msgid "## Tasks"
+msgid "Tasks"
 msgstr ""
 
 #: src/exercises/day-4/link-checker.md:98
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
 msgstr ""
 
-#: src/exercises/day-4/link-checker.md:104
+#: src/exercises/day-4/link-checker.md:100
 msgid ""
-"[1]: https://docs.rs/reqwest/\n"
-"[2]: https://docs.rs/scraper/\n"
-"[3]: https://docs.rs/thiserror/"
-msgstr ""
-
-#: src/android.md:1
-msgid "# Android"
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
 
 #: src/android.md:3
 msgid ""
-"Rust is supported for native platform development on Android. This means that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
-msgstr ""
-
-#: src/android/setup.md:1
-msgid "# Setup"
+"Rust is supported for native platform development on Android. This means "
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 
 #: src/android/setup.md:3
 msgid ""
-"We will be using an Android Virtual Device to test our code. Make sure you have\n"
-"access to one or create a new one with:"
+"We will be using an Android Virtual Device to test our code. Make sure you "
+"have access to one or create a new one with:"
 msgstr ""
 
 #: src/android/setup.md:6
@@ -11552,12 +12335,8 @@ msgstr ""
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
-msgstr ""
-
-#: src/android/build-rules.md:1
-msgid "# Build Rules"
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
 
 #: src/android/build-rules.md:3
@@ -11565,27 +12344,83 @@ msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr ""
 
 #: src/android/build-rules.md:5
+msgid "Module Type"
+msgstr ""
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr ""
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr ""
+
+#: src/android/build-rules.md:9
 msgid ""
-"| Module Type       | "
-"Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust "
-"binary.                                                                            |\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and `dylib` "
-"variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and provides both static "
-"and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are analogous to compiler "
-"plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard Rust test "
-"harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging "
-"`libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that provides an interface for "
-"a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library containing Rust bindings to C "
-"libraries.              |"
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
 msgstr ""
 
 #: src/android/build-rules.md:16
@@ -11593,13 +12428,13 @@ msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr ""
 
 #: src/android/build-rules/binary.md:1
-msgid "# Rust Binaries"
+msgid "Rust Binaries"
 msgstr ""
 
 #: src/android/build-rules/binary.md:3
 msgid ""
-"Let us start with a simple application. At the root of an AOSP checkout, create\n"
-"the following files:"
+"Let us start with a simple application. At the root of an AOSP checkout, "
+"create the following files:"
 msgstr ""
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
@@ -11624,16 +12459,14 @@ msgstr ""
 #: src/android/build-rules/binary.md:18
 msgid ""
 "```rust\n"
-"//! Rust demo."
+"//! Rust demo.\n"
+"```"
 msgstr ""
 
 #: src/android/build-rules/binary.md:21
 msgid ""
-"/// Prints a greeting to standard output.\n"
-"fn main() {\n"
-"    println!(\"Hello from Rust!\");\n"
-"}\n"
-"```"
+"/// Prints a greeting to standard output. fn main() { println!(\"Hello from "
+"Rust!\"); }"
 msgstr ""
 
 #: src/android/build-rules/binary.md:27
@@ -11651,7 +12484,7 @@ msgid ""
 msgstr ""
 
 #: src/android/build-rules/library.md:1
-msgid "# Rust Libraries"
+msgid "Rust Libraries"
 msgstr ""
 
 #: src/android/build-rules/library.md:3
@@ -11663,14 +12496,14 @@ msgid "Here we declare a dependency on two libraries:"
 msgstr ""
 
 #: src/android/build-rules/library.md:7
-msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+msgid "`libgreeting`, which we define below,"
 msgstr ""
 
-#: src/android/build-rules/library.md:11
-msgid "[crates]: https://cs.android.com/android/platform/superproject/+/master:external/rust/crates/"
+#: src/android/build-rules/library.md:8
+msgid ""
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
 
 #: src/android/build-rules/library.md:15
@@ -11685,15 +12518,58 @@ msgid ""
 "        \"libtextwrap\",\n"
 "    ],\n"
 "    prefer_rlib: true,\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/build-rules/library.md:27
 msgid ""
-"rust_library {\n"
-"    name: \"libgreetings\",\n"
-"    crate_name: \"greetings\",\n"
-"    srcs: [\"src/lib.rs\"],\n"
+"rust_library { name: \"libgreetings\", crate_name: \"greetings\", srcs: "
+"\\[\"src/lib.rs\"\\], }"
+msgstr ""
+
+#: src/android/build-rules/library.md:32
+msgid ""
+"```\n"
+"\n"
+"# Rust Libraries\n"
+"\n"
+"You use `rust_library` to create a new Rust library for Android.\n"
+"\n"
+"Here we declare a dependency on two libraries:\n"
+"\n"
+"* `libgreeting`, which we define below,\n"
+"* `libtextwrap`, which is a crate already vendored in\n"
+"  [`external/rust/crates/`][crates].\n"
+"\n"
+"[crates]: https://cs.android.com/android/platform/superproject/+/master:"
+"external/rust/crates/\n"
+"\n"
+"_hello_rust/Android.bp_:\n"
+"\n"
+"```javascript\n"
+"rust_binary {\n"
+"    name: \"hello_rust_with_dep\",\n"
+"    crate_name: \"hello_rust_with_dep\",\n"
+"    srcs: [\"src/main.rs\"],\n"
+"    rustlibs: [\n"
+"        \"libgreetings\",\n"
+"        \"libtextwrap\",\n"
+"    ],\n"
+"    prefer_rlib: true,\n"
+"}\n"
+"\n"
+"_hello_rust/src/main.rs_:\n"
+"\n"
+"```rust,ignore\n"
+"//! Rust demo.\n"
+"\n"
+"use greetings::greeting;\n"
+"use textwrap::fill;\n"
+"\n"
+"/// Prints a greeting to standard output.\n"
+"fn main() {\n"
+"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
 "}\n"
 "```"
 msgstr ""
@@ -11701,22 +12577,18 @@ msgstr ""
 #: src/android/build-rules/library.md:36
 msgid ""
 "```rust,ignore\n"
-"//! Rust demo."
+"//! Rust demo.\n"
+"```"
 msgstr ""
 
 #: src/android/build-rules/library.md:39
-msgid ""
-"use greetings::greeting;\n"
-"use textwrap::fill;"
+msgid "use greetings::greeting; use textwrap::fill;"
 msgstr ""
 
 #: src/android/build-rules/library.md:42
 msgid ""
-"/// Prints a greeting to standard output.\n"
-"fn main() {\n"
-"    println!(\"{}\", fill(&greeting(\"Bob\"), 24));\n"
-"}\n"
-"```"
+"/// Prints a greeting to standard output. fn main() { println!(\"{}\", "
+"fill(&greeting(\"Bob\"), 24)); }"
 msgstr ""
 
 #: src/android/build-rules/library.md:48
@@ -11726,16 +12598,14 @@ msgstr ""
 #: src/android/build-rules/library.md:50
 msgid ""
 "```rust,ignore\n"
-"//! Greeting library."
+"//! Greeting library.\n"
+"```"
 msgstr ""
 
 #: src/android/build-rules/library.md:53
 msgid ""
-"/// Greet `name`.\n"
-"pub fn greeting(name: &str) -> String {\n"
-"    format!(\"Hello {name}, it is very nice to meet you!\")\n"
-"}\n"
-"```"
+"/// Greet `name`. pub fn greeting(name: &str) -> String { format!(\"Hello "
+"{name}, it is very nice to meet you!\") }"
 msgstr ""
 
 #: src/android/build-rules/library.md:59
@@ -11746,31 +12616,30 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m hello_rust_with_dep\n"
-"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/tmp\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
+"tmp\n"
 "$ adb shell /data/local/tmp/hello_rust_with_dep\n"
 "Hello Bob, it is very\n"
 "nice to meet you!\n"
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-msgid "# AIDL"
-msgstr ""
-
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
 #: src/android/aidl.md:6
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr ""
+
+#: src/android/aidl.md:7
+msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
 #: src/android/aidl/interface.md:1
-msgid "# AIDL Interfaces"
+msgid "AIDL Interfaces"
 msgstr ""
 
 #: src/android/aidl/interface.md:3
@@ -11778,27 +12647,26 @@ msgid "You declare the API of your service using an AIDL interface:"
 msgstr ""
 
 #: src/android/aidl/interface.md:5
-msgid "*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+msgid ""
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:7 src/android/aidl/changing.md:6
 msgid ""
 "```java\n"
-"package com.example.birthdayservice;"
+"package com.example.birthdayservice;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/interface.md:10
 msgid ""
-"/** Birthday service interface. */\n"
-"interface IBirthdayService {\n"
-"    /** Generate a Happy Birthday message. */\n"
-"    String wishHappyBirthday(String name, int years);\n"
-"}\n"
-"```"
+"/\\*\\* Birthday service interface. _/ interface IBirthdayService { /_\\* "
+"Generate a Happy Birthday message. \\*/ String wishHappyBirthday(String "
+"name, int years); }"
 msgstr ""
 
 #: src/android/aidl/interface.md:17
-msgid "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:19
@@ -11819,12 +12687,12 @@ msgstr ""
 
 #: src/android/aidl/interface.md:32
 msgid ""
-"Add `vendor_available: true` if your AIDL file is used by a binary in the vendor\n"
-"partition."
+"Add `vendor_available: true` if your AIDL file is used by a binary in the "
+"vendor partition."
 msgstr ""
 
 #: src/android/aidl/implementation.md:1
-msgid "# Service Implementation"
+msgid "Service Implementation"
 msgstr ""
 
 #: src/android/aidl/implementation.md:3
@@ -11832,22 +12700,21 @@ msgid "We can now implement the AIDL service:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:5
-msgid "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::"
-"IBirthdayService;\n"
-"use com_example_birthdayservice::binder;"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/implementation.md:12
-msgid ""
-"/// The `IBirthdayService` implementation.\n"
-"pub struct BirthdayService;"
+msgid "/// The `IBirthdayService` implementation. pub struct BirthdayService;"
 msgstr ""
 
 #: src/android/aidl/implementation.md:15
@@ -11856,18 +12723,19 @@ msgstr ""
 
 #: src/android/aidl/implementation.md:17
 msgid ""
-"impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::Result<String> {\n"
-"        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} years!\"\n"
-"        ))\n"
-"    }\n"
-"}\n"
-"```"
+"impl IBirthdayService for BirthdayService { fn wishHappyBirthday(&self, "
+"name: &str, years: i32) -> binder::Result"
 msgstr ""
 
-#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28 src/android/aidl/client.md:37
-msgid "*birthday_service/Android.bp*:"
+#: src/android/aidl/implementation.md:18
+msgid ""
+" { Ok(format!( \"Happy Birthday {name}, congratulations with the {years} "
+"years!\" )) } }"
+msgstr ""
+
+#: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
+#: src/android/aidl/client.md:37
+msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:28
@@ -11886,7 +12754,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/server.md:1
-msgid "# AIDL Server"
+msgid "AIDL Server"
 msgstr ""
 
 #: src/android/aidl/server.md:3
@@ -11894,7 +12762,7 @@ msgid "Finally, we can create a server which exposes the service:"
 msgstr ""
 
 #: src/android/aidl/server.md:5
-msgid "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
 #: src/android/aidl/server.md:7
@@ -11902,9 +12770,10 @@ msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
 "use birthdayservice::BirthdayService;\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::"
-"BnBirthdayService;\n"
-"use com_example_birthdayservice::binder;"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/server.md:13 src/android/aidl/client.md:12
@@ -11913,18 +12782,12 @@ msgstr ""
 
 #: src/android/aidl/server.md:15
 msgid ""
-"/// Entry point for birthday service.\n"
-"fn main() {\n"
-"    let birthday_service = BirthdayService;\n"
-"    let birthday_service_binder = BnBirthdayService::new_binder(\n"
-"        birthday_service,\n"
-"        binder::BinderFeatures::default(),\n"
-"    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder.as_binder())\n"
-"        .expect(\"Failed to register service\");\n"
-"    binder::ProcessState::join_thread_pool()\n"
-"}\n"
-"```"
+"/// Entry point for birthday service. fn main() { let birthday_service = "
+"BirthdayService; let birthday_service_binder = BnBirthdayService::"
+"new_binder( birthday_service, binder::BinderFeatures::default(), ); binder::"
+"add_service(SERVICE_IDENTIFIER, birthday_service_binder.as_binder()) ."
+"expect(\"Failed to register service\"); binder::ProcessState::"
+"join_thread_pool() }"
 msgstr ""
 
 #: src/android/aidl/server.md:30
@@ -11942,10 +12805,6 @@ msgid ""
 "    prefer_rlib: true,\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/android/aidl/deploy.md:1
-msgid "# Deploy"
 msgstr ""
 
 #: src/android/aidl/deploy.md:3
@@ -11994,7 +12853,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/client.md:1
-msgid "# AIDL Client"
+msgid "AIDL Client"
 msgstr ""
 
 #: src/android/aidl/client.md:3
@@ -12002,47 +12861,49 @@ msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
 #: src/android/aidl/client.md:5
-msgid "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
 #: src/android/aidl/client.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::"
-"IBirthdayService;\n"
-"use com_example_birthdayservice::binder;"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::binder;\n"
+"```"
 msgstr ""
 
 #: src/android/aidl/client.md:14
 msgid ""
-"/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::StatusCode> {\n"
-"    binder::get_interface(SERVICE_IDENTIFIER)\n"
-"}"
+"/// Connect to the BirthdayService. pub fn connect() -> Result\\<binder::"
+"Strong"
+msgstr ""
+
+#: src/android/aidl/client.md:15
+msgid ", binder::StatusCode> { binder::get_interface(SERVICE_IDENTIFIER) }"
 msgstr ""
 
 #: src/android/aidl/client.md:19
 msgid ""
-"/// Call the birthday service.\n"
-"fn main() -> Result<(), binder::Status> {\n"
-"    let name = std::env::args()\n"
-"        .nth(1)\n"
-"        .unwrap_or_else(|| String::from(\"Bob\"));\n"
-"    let years = std::env::args()\n"
-"        .nth(2)\n"
-"        .and_then(|arg| arg.parse::<i32>().ok())\n"
-"        .unwrap_or(42);"
+"/// Call the birthday service. fn main() -> Result\\<(), binder::Status> "
+"{ let name = std::env::args() .nth(1) .unwrap_or_else(|| String::"
+"from(\"Bob\")); let years = std::env::args() .nth(2) .and_then(|arg| arg."
+"parse::"
+msgstr ""
+
+#: src/android/aidl/client.md:26
+msgid "().ok()) .unwrap_or(42);"
 msgstr ""
 
 #: src/android/aidl/client.md:29
 msgid ""
-"    binder::ProcessState::start_thread_pool();\n"
-"    let service = connect().expect(\"Failed to connect to BirthdayService\");\n"
-"    let msg = service.wishHappyBirthday(&name, years)?;\n"
-"    println!(\"{msg}\");\n"
-"    Ok(())\n"
-"}\n"
+"```\n"
+"binder::ProcessState::start_thread_pool();\n"
+"let service = connect().expect(\"Failed to connect to BirthdayService\");\n"
+"let msg = service.wishHappyBirthday(&name, years)?;\n"
+"println!(\"{msg}\");\n"
+"Ok(())\n"
 "```"
 msgstr ""
 
@@ -12080,34 +12941,23 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-msgid "# Changing API"
-msgstr ""
-
 #: src/android/aidl/changing.md:3
 msgid ""
-"Let us extend the API with more functionality: we want to let clients specify a\n"
-"list of lines for the birthday card:"
+"Let us extend the API with more functionality: we want to let clients "
+"specify a list of lines for the birthday card:"
 msgstr ""
 
 #: src/android/aidl/changing.md:9
 msgid ""
-"/** Birthday service interface. */\n"
-"interface IBirthdayService {\n"
-"    /** Generate a Happy Birthday message. */\n"
-"    String wishHappyBirthday(String name, int years, in String[] text);\n"
-"}\n"
-"```"
-msgstr ""
-
-#: src/android/logging.md:1
-msgid "# Logging"
+"/\\*\\* Birthday service interface. _/ interface IBirthdayService { /_\\* "
+"Generate a Happy Birthday message. \\*/ String wishHappyBirthday(String "
+"name, int years, in String\\[\\] text); }"
 msgstr ""
 
 #: src/android/logging.md:3
 msgid ""
-"You should use the `log` crate to automatically log to `logcat` (on-device) or\n"
-"`stdout` (on-host):"
+"You should use the `log` crate to automatically log to `logcat` (on-device) "
+"or `stdout` (on-host):"
 msgstr ""
 
 #: src/android/logging.md:6
@@ -12138,7 +12988,8 @@ msgstr ""
 #: src/android/logging.md:24
 msgid ""
 "```rust,ignore\n"
-"//! Rust logging demo."
+"//! Rust logging demo.\n"
+"```"
 msgstr ""
 
 #: src/android/logging.md:27
@@ -12147,18 +12998,10 @@ msgstr ""
 
 #: src/android/logging.md:29
 msgid ""
-"/// Logs a greeting.\n"
-"fn main() {\n"
-"    logger::init(\n"
-"        logger::Config::default()\n"
-"            .with_tag_on_device(\"rust\")\n"
-"            .with_min_level(log::Level::Trace),\n"
-"    );\n"
-"    debug!(\"Starting program.\");\n"
-"    info!(\"Things are going fine.\");\n"
-"    error!(\"Something went wrong!\");\n"
-"}\n"
-"```"
+"/// Logs a greeting. fn main() { logger::init( logger::Config::default() ."
+"with_tag_on_device(\"rust\") .with_min_level(log::Level::Trace), ); debug!"
+"(\"Starting program.\"); info!(\"Things are going fine.\"); error!"
+"(\"Something went wrong!\"); }"
 msgstr ""
 
 #: src/android/logging.md:42 src/android/interoperability/with-c/bindgen.md:98
@@ -12184,40 +13027,40 @@ msgid ""
 "```shell\n"
 "$ adb logcat -s rust\n"
 "09-08 08:38:32.454  2420  2420 D rust: hello_rust_logs: Starting program.\n"
-"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going fine.\n"
-"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went wrong!\n"
+"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going "
+"fine.\n"
+"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went "
+"wrong!\n"
 "```"
-msgstr ""
-
-#: src/android/interoperability.md:1
-msgid "# Interoperability"
 msgstr ""
 
 #: src/android/interoperability.md:3
 msgid ""
-"Rust has excellent support for interoperability with other languages. This means\n"
-"that you can:"
+"Rust has excellent support for interoperability with other languages. This "
+"means that you can:"
 msgstr ""
 
 #: src/android/interoperability.md:6
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
+msgid "Call Rust functions from other languages."
+msgstr ""
+
+#: src/android/interoperability.md:7
+msgid "Call functions written in other languages from Rust."
 msgstr ""
 
 #: src/android/interoperability.md:9
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:1
-msgid "# Interoperability with C"
+msgid "Interoperability with C"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:3
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
@@ -12230,29 +13073,26 @@ msgid ""
 "```rust\n"
 "extern \"C\" {\n"
 "    fn abs(x: i32) -> i32;\n"
-"}"
-msgstr ""
-
-#: src/android/interoperability/with-c.md:13
-msgid ""
-"fn main() {\n"
-"    let x = -42;\n"
-"    let abs_x = unsafe { abs(x) };\n"
-"    println!(\"{x}, {abs_x}\");\n"
 "}\n"
 "```"
 msgstr ""
 
+#: src/android/interoperability/with-c.md:13
+msgid ""
+"fn main() { let x = -42; let abs_x = unsafe { abs(x) }; println!(\"{x}, "
+"{abs_x}\"); }"
+msgstr ""
+
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:23
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:26
@@ -12260,13 +13100,13 @@ msgid "We will look at better options next."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:1
-msgid "# Using Bindgen"
+msgid "Using Bindgen"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:3
 msgid ""
-"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) tool\n"
-"can auto-generate bindings from a C header file."
+"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:6
@@ -12283,13 +13123,12 @@ msgid ""
 "typedef struct card {\n"
 "  const char* name;\n"
 "  int years;\n"
-"} card;"
+"} card;\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:16
-msgid ""
-"void print_card(const card* card);\n"
-"```"
+msgid "void print_card(const card\\* card);"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:19
@@ -12300,18 +13139,15 @@ msgstr ""
 msgid ""
 "```c\n"
 "#include <stdio.h>\n"
-"#include \"libbirthday.h\""
+"#include \"libbirthday.h\"\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:25
 msgid ""
-"void print_card(const card* card) {\n"
-"  printf(\"+--------------\\n\");\n"
-"  printf(\"| Happy Birthday %s!\\n\", card->name);\n"
-"  printf(\"| Congratulations with the %i years!\\n\", card->years);\n"
-"  printf(\"+--------------\\n\");\n"
-"}\n"
-"```"
+"void print_card(const card\\* card) { printf(\"+--------------\\n\"); "
+"printf(\"| Happy Birthday %s!\\n\", card->name); printf(\"| Congratulations "
+"with the %i years!\\n\", card->years); printf(\"+--------------\\n\"); }"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:33
@@ -12337,7 +13173,7 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
@@ -12391,7 +13227,8 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:81
 msgid ""
 "```rust,compile_fail\n"
-"//! Bindgen demo."
+"//! Bindgen demo.\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:84
@@ -12400,24 +13237,17 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:86
 msgid ""
-"fn main() {\n"
-"    let name = std::ffi::CString::new(\"Peter\").unwrap();\n"
-"    let card = card {\n"
-"        name: name.as_ptr(),\n"
-"        years: 42,\n"
-"    };\n"
-"    unsafe {\n"
-"        print_card(&card as *const card);\n"
-"    }\n"
-"}\n"
-"```"
+"fn main() { let name = std::ffi::CString::new(\"Peter\").unwrap(); let card "
+"= card { name: name.as_ptr(), years: 42, }; unsafe { print_card(&card as "
+"\\*const card); } }"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:100
 msgid ""
 "```shell\n"
 "$ m print_birthday_card\n"
-"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/tmp\n"
+"$ adb push $ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/"
+"tmp\n"
 "$ adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
@@ -12449,7 +13279,7 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
-msgid "# Calling Rust"
+msgid "Calling Rust"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:3
@@ -12464,7 +13294,8 @@ msgstr ""
 msgid ""
 "```rust,editable\n"
 "//! Rust FFI demo.\n"
-"#![deny(improper_ctypes_definitions)]"
+"#![deny(improper_ctypes_definitions)]\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:11
@@ -12473,15 +13304,39 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:13
 msgid ""
-"/// Analyze the numbers.\n"
-"#[no_mangle]\n"
-"pub extern \"C\" fn analyze_numbers(x: c_int, y: c_int) {\n"
-"    if x < y {\n"
-"        println!(\"x ({x}) is smallest!\");\n"
-"    } else {\n"
-"        println!(\"y ({y}) is probably larger than x ({x})\");\n"
-"    }\n"
+"/// Analyze the numbers. \\#\\[no_mangle\\] pub extern \"C\" fn "
+"analyze_numbers(x: c_int, y: c_int) { if x \\< y { println!(\"x ({x}) is "
+"smallest!\"); } else { println!(\"y ({y}) is probably larger than x "
+"({x})\"); } }"
+msgstr ""
+
+#: src/android/interoperability/with-c/rust.md:22
+msgid ""
+"```\n"
+"\n"
+"# Calling Rust\n"
+"\n"
+"Exporting Rust functions and types to C is easy:\n"
+"\n"
+"_interoperability/rust/libanalyze/analyze.rs_\n"
+"\n"
+"```rust,editable\n"
+"//! Rust FFI demo.\n"
+"#![deny(improper_ctypes_definitions)]\n"
+"\n"
+"use std::os::raw::c_int;\n"
+"\n"
+"_interoperability/rust/libanalyze/analyze.h_\n"
+"\n"
+"```c\n"
+"#ifndef ANALYSE_H\n"
+"#define ANALYSE_H\n"
+"\n"
+"extern \"C\" {\n"
+"void analyze_numbers(int x, int y);\n"
 "}\n"
+"\n"
+"#endif\n"
 "```"
 msgstr ""
 
@@ -12493,20 +13348,16 @@ msgstr ""
 msgid ""
 "```c\n"
 "#ifndef ANALYSE_H\n"
-"#define ANALYSE_H"
+"#define ANALYSE_H\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:30
-msgid ""
-"extern \"C\" {\n"
-"void analyze_numbers(int x, int y);\n"
-"}"
+msgid "extern \"C\" { void analyze_numbers(int x, int y); }"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:34
-msgid ""
-"#endif\n"
-"```"
+msgid "\\#endif"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:37
@@ -12536,17 +13387,13 @@ msgstr ""
 #: src/android/interoperability/with-c/rust.md:52
 msgid ""
 "```c\n"
-"#include \"analyze.h\""
+"#include \"analyze.h\"\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:55
 msgid ""
-"int main() {\n"
-"  analyze_numbers(10, 20);\n"
-"  analyze_numbers(123, 123);\n"
-"  return 0;\n"
-"}\n"
-"```"
+"int main() { analyze_numbers(10, 20); analyze_numbers(123, 123); return 0; }"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:62
@@ -12575,48 +13422,36 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:83
 msgid ""
-"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol will just be the name "
-"of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify whatever name you want."
-msgstr ""
-
-#: src/android/interoperability/cpp.md:1
-msgid "# With C++"
+"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:3
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:8
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr ""
-
 #: src/android/interoperability/cpp.md:10
-msgid "See the [CXX tutorial][2] for an full example of using this."
-msgstr ""
-
-#: src/android/interoperability/cpp.md:12
 msgid ""
-"[1]: https://cxx.rs/\n"
-"[2]: https://cxx.rs/tutorial.html"
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
 
 #: src/android/interoperability/java.md:1
-msgid "# Interoperability with Java"
+msgid "Interoperability with Java"
 msgstr ""
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 
 #: src/android/interoperability/java.md:7
@@ -12630,34 +13465,59 @@ msgstr ""
 #: src/android/interoperability/java.md:11
 msgid ""
 "```rust,compile_fail\n"
-"//! Rust <-> Java FFI demo."
+"//! Rust <-> Java FFI demo.\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:14
 msgid ""
-"use jni::objects::{JClass, JString};\n"
-"use jni::sys::jstring;\n"
-"use jni::JNIEnv;"
+"use jni::objects::{JClass, JString}; use jni::sys::jstring; use jni::JNIEnv;"
 msgstr ""
 
 #: src/android/interoperability/java.md:18
 msgid ""
-"/// HelloWorld::hello method implementation.\n"
-"#[no_mangle]\n"
-"pub extern \"system\" fn Java_HelloWorld_hello(\n"
-"    env: JNIEnv,\n"
-"    _class: JClass,\n"
-"    name: JString,\n"
-") -> jstring {\n"
-"    let input: String = env.get_string(name).unwrap().into();\n"
-"    let greeting = format!(\"Hello, {input}!\");\n"
-"    let output = env.new_string(greeting).unwrap();\n"
-"    output.into_inner()\n"
+"/// HelloWorld::hello method implementation. \\#\\[no_mangle\\] pub extern "
+"\"system\" fn Java_HelloWorld_hello( env: JNIEnv, \\_class: JClass, name: "
+"JString, ) -> jstring { let input: String = env.get_string(name).unwrap()."
+"into(); let greeting = format!(\"Hello, {input}!\"); let output = env."
+"new_string(greeting).unwrap(); output.into_inner() }"
+msgstr ""
+
+#: src/android/interoperability/java.md:30
+msgid ""
+"```\n"
+"\n"
+"# Interoperability with Java\n"
+"\n"
+"Java can load shared objects via [Java Native Interface\n"
+"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
+"crate](https://docs.rs/jni/) allows you to create a compatible library.\n"
+"\n"
+"First, we create a Rust function to export to Java:\n"
+"\n"
+"_interoperability/java/src/lib.rs_:\n"
+"\n"
+"```rust,compile_fail\n"
+"//! Rust <-> Java FFI demo.\n"
+"\n"
+"use jni::objects::{JClass, JString};\n"
+"use jni::sys::jstring;\n"
+"use jni::JNIEnv;\n"
+"\n"
+"_interoperability/java/Android.bp_:\n"
+"\n"
+"```javascript\n"
+"rust_ffi_shared {\n"
+"    name: \"libhello_jni\",\n"
+"    crate_name: \"hello_jni\",\n"
+"    srcs: [\"src/lib.rs\"],\n"
+"    rustlibs: [\"libjni\"],\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/android/interoperability/java.md:32 src/android/interoperability/java.md:62
+#: src/android/interoperability/java.md:32
+#: src/android/interoperability/java.md:62
 msgid "_interoperability/java/Android.bp_:"
 msgstr ""
 
@@ -12685,22 +13545,25 @@ msgstr ""
 msgid ""
 "```java\n"
 "class HelloWorld {\n"
-"    private static native String hello(String name);"
+"    private static native String hello(String name);\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:51
 msgid ""
-"    static {\n"
-"        System.loadLibrary(\"hello_jni\");\n"
-"    }"
+"```\n"
+"static {\n"
+"    System.loadLibrary(\"hello_jni\");\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/android/interoperability/java.md:55
 msgid ""
-"    public static void main(String[] args) {\n"
-"        String output = HelloWorld.hello(\"Alice\");\n"
-"        System.out.println(output);\n"
-"    }\n"
+"```\n"
+"public static void main(String[] args) {\n"
+"    String output = HelloWorld.hello(\"Alice\");\n"
+"    System.out.println(output);\n"
 "}\n"
 "```"
 msgstr ""
@@ -12732,55 +13595,50 @@ msgstr ""
 
 #: src/exercises/day-4/afternoon.md:3
 msgid ""
-"For the last exercise, we will look at one of the projects you work with. Let us\n"
-"group up and do this together. Some suggestions:"
+"For the last exercise, we will look at one of the projects you work with. "
+"Let us group up and do this together. Some suggestions:"
 msgstr ""
 
 #: src/exercises/day-4/afternoon.md:6
-msgid "* Call your AIDL service with a client written in Rust."
+msgid "Call your AIDL service with a client written in Rust."
 msgstr ""
 
 #: src/exercises/day-4/afternoon.md:8
-msgid "* Move a function from your project to Rust and call it."
+msgid "Move a function from your project to Rust and call it."
 msgstr ""
 
 #: src/exercises/day-4/afternoon.md:12
 msgid ""
-"No solution is provided here since this is open-ended: it relies on someone in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
-msgstr ""
-
-#: src/thanks.md:1
-msgid "# Thanks!"
+"No solution is provided here since this is open-ended: it relies on someone "
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
 #: src/thanks.md:3
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that it\n"
-"was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
 msgstr ""
 
 #: src/thanks.md:6
 msgid ""
-"We've had a lot of fun putting the course together. The course is not perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would love\n"
-"to hear from you."
+"We've had a lot of fun putting the course together. The course is not "
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 
 #: src/other-resources.md:1
-msgid "# Other Rust Resources"
+msgid "Other Rust Resources"
 msgstr ""
 
 #: src/other-resources.md:3
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 
 #: src/other-resources.md:6
-msgid "## Official Documentation"
+msgid "Official Documentation"
 msgstr ""
 
 #: src/other-resources.md:8
@@ -12789,17 +13647,29 @@ msgstr ""
 
 #: src/other-resources.md:10
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the Rust\n"
-"  syntax via a series of examples which showcase different constructs. Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
+msgstr ""
+
+#: src/other-resources.md:13
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+
+#: src/other-resources.md:17
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+
+#: src/other-resources.md:19
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
 msgstr ""
 
 #: src/other-resources.md:22
@@ -12808,18 +13678,27 @@ msgstr ""
 
 #: src/other-resources.md:24
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/):\n"
-"  covers the new asynchronous programming model which was introduced after the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
+msgstr ""
+
+#: src/other-resources.md:27
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+
+#: src/other-resources.md:30
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
 msgstr ""
 
 #: src/other-resources.md:33
-msgid "## Unofficial Learning Material"
+msgid "Unofficial Learning Material"
 msgstr ""
 
 #: src/other-resources.md:35
@@ -12828,93 +13707,105 @@ msgstr ""
 
 #: src/other-resources.md:37
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): a\n"
-"  series of small presentations covering both basic and advanced part of the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
+msgstr ""
+
+#: src/other-resources.md:39
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+
+#: src/other-resources.md:42
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+
+#: src/other-resources.md:45
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+
+#: src/other-resources.md:47
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+
+#: src/other-resources.md:52
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
 msgstr ""
 
 #: src/other-resources.md:63
 msgid ""
-"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) for\n"
-"even more Rust books."
-msgstr ""
-
-#: src/credits.md:1
-msgid "# Credits"
+"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
+"for even more Rust books."
 msgstr ""
 
 #: src/credits.md:3
 msgid ""
-"The material here builds on top of the many great sources of Rust documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of useful\n"
-"resources."
+"The material here builds on top of the many great sources of Rust "
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
 
 #: src/credits.md:7
 msgid ""
-"The material of Comprehensive Rust is licensed under the terms of the Apache 2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
+"The material of Comprehensive Rust is licensed under the terms of the Apache "
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
 msgstr ""
 
 #: src/credits.md:10
-msgid "## Rust by Example"
+msgid "Rust by Example"
 msgstr ""
 
 #: src/credits.md:12
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
 
 #: src/credits.md:17
-msgid "## Rust on Exercism"
+msgid "Rust on Exercism"
 msgstr ""
 
 #: src/credits.md:19
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
 
 #: src/credits.md:24
-msgid "## CXX"
+msgid "CXX"
 msgstr ""
 
 #: src/credits.md:26
 msgid ""
-"The [Interoperability with C++](android/interoperability/cpp.md) section uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` directory\n"
-"for details, including the license terms."
-msgstr ""
-
-#: src/exercises/solutions.md:1
-msgid "# Solutions"
+"The [Interoperability with C++](android/interoperability/cpp.md) section "
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 
 #: src/exercises/solutions.md:3
@@ -12923,34 +13814,34 @@ msgstr ""
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
 
 #: src/exercises/solutions.md:10
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:1
-msgid "# Day 1 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:3
-msgid "## Arrays and `for` Loops"
+msgid "Day 1 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:5
 msgid "([back to exercise](for-loops.md))"
 msgstr ""
 
-#: src/exercises/day-1/solutions-morning.md:7 src/exercises/day-1/solutions-afternoon.md:7
-#: src/exercises/day-2/solutions-morning.md:7 src/exercises/day-2/solutions-afternoon.md:7
-#: src/exercises/day-2/solutions-afternoon.md:102 src/exercises/day-3/solutions-morning.md:7
-#: src/exercises/day-3/solutions-afternoon.md:7 src/exercises/day-4/solutions-morning.md:7
+#: src/exercises/day-1/solutions-morning.md:7
+#: src/exercises/day-1/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-morning.md:7
+#: src/exercises/day-2/solutions-afternoon.md:7
+#: src/exercises/day-2/solutions-afternoon.md:102
+#: src/exercises/day-3/solutions-morning.md:7
+#: src/exercises/day-3/solutions-afternoon.md:7
+#: src/exercises/day-4/solutions-morning.md:7
 msgid ""
 "```rust\n"
 "// Copyright 2022 Google LLC\n"
@@ -12965,11 +13856,121 @@ msgid ""
 "// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
 "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
 "// See the License for the specific language governing permissions and\n"
-"// limitations under the License."
+"// limitations under the License.\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:22
 msgid ""
+"// ANCHOR: transpose fn transpose(matrix: \\[\\[i32; 3\\]; 3\\]) -> "
+"\\[\\[i32; 3\\]; 3\\] { // ANCHOR_END: transpose let mut result = \\[\\[0; "
+"3\\]; 3\\]; for i in 0..3 { for j in 0..3 { result\\[j\\]\\[i\\] = "
+"matrix\\[i\\]\\[j\\]; } } return result; }"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:34
+msgid ""
+"// ANCHOR: pretty_print fn pretty_print(matrix: &\\[\\[i32; 3\\]; 3\\]) { // "
+"ANCHOR_END: pretty_print for row in matrix { println!(\"{row:?}\"); } }"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:42
+msgid ""
+"// ANCHOR: tests \\#\\[test\\] fn test_transpose() { let matrix = "
+"\\[ \\[101, 102, 103\\], // \\[201, 202, 203\\], \\[301, 302, 303\\], \\]; "
+"let transposed = transpose(matrix); assert_eq!( transposed, \\[ \\[101, 201, "
+"301\\], // \\[102, 202, 302\\], \\[103, 203, 303\\], \\] ); } // ANCHOR_END: "
+"tests"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:62
+msgid ""
+"// ANCHOR: main fn main() { let matrix = \\[ \\[101, 102, 103\\], // \\<\\-- "
+"the comment makes rustfmt add a newline \\[201, 202, 203\\], \\[301, 302, "
+"303\\], \\];"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:77
+msgid ""
+"```\n"
+"### Bonus question\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:80
+msgid ""
+"It requires more advanced concepts. It might seem that we could use a slice-"
+"of-slices (`&[&[i32]]`) as the input type to transpose and thus make our "
+"function handle any size of matrix. However, this quickly breaks down: the "
+"return type cannot be `&[&[i32]]` since it needs to own the data you return."
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:82
+msgid ""
+"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work "
+"out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to "
+"`&[&[i32]]` so now you cannot easily use `pretty_print` either."
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:84
+msgid ""
+"Once we get to traits and generics, we'll be able to use the [`std::convert::"
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:86
+msgid ""
+"```rust\n"
+"use std::convert::AsRef;\n"
+"use std::fmt::Debug;\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:90
+msgid ""
+"fn pretty_print\\<T, Line, Matrix>(matrix: Matrix) where T: Debug, // A line "
+"references a slice of items Line: AsRef\\<\\[T\\]\\>, // A matrix references "
+"a slice of lines Matrix: AsRef\\<\\[Line\\]\\> { for row in matrix.as_ref() "
+"{ println!(\"{:?}\", row.as_ref()); } }"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:103
+msgid ""
+"fn main() { // &\\[&\\[i32\\]\\] pretty_print(&\\[&\\[1, 2, 3\\], &\\[4, 5, "
+"6\\], &\\[7, 8, 9\\]\\]); // \\[\\[&str; 2\\]; 2\\] "
+"pretty_print(\\[\\[\"a\", \"b\"\\], \\[\"c\", \"d\"\\]\\]); // Vec\\<Vec"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:108
+msgid "\\> pretty_print(vec![vec![1, 2\\], vec![3, 4\\]\\]); }"
+msgstr ""
+
+#: src/exercises/day-1/solutions-morning.md:111
+msgid ""
+"```\n"
+"\n"
+"# Day 1 Morning Exercises\n"
+"\n"
+"## Arrays and `for` Loops\n"
+"\n"
+"([back to exercise](for-loops.md))\n"
+"\n"
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
 "// ANCHOR: transpose\n"
 "fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {\n"
 "    // ANCHOR_END: transpose\n"
@@ -12980,22 +13981,16 @@ msgid ""
 "        }\n"
 "    }\n"
 "    return result;\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:34
-msgid ""
+"}\n"
+"\n"
 "// ANCHOR: pretty_print\n"
 "fn pretty_print(matrix: &[[i32; 3]; 3]) {\n"
 "    // ANCHOR_END: pretty_print\n"
 "    for row in matrix {\n"
 "        println!(\"{row:?}\");\n"
 "    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:42
-msgid ""
+"}\n"
+"\n"
 "// ANCHOR: tests\n"
 "#[test]\n"
 "fn test_transpose() {\n"
@@ -13014,103 +14009,34 @@ msgid ""
 "        ]\n"
 "    );\n"
 "}\n"
-"// ANCHOR_END: tests"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:62
-msgid ""
+"// ANCHOR_END: tests\n"
+"\n"
 "// ANCHOR: main\n"
 "fn main() {\n"
 "    let matrix = [\n"
 "        [101, 102, 103], // <-- the comment makes rustfmt add a newline\n"
 "        [201, 202, 203],\n"
 "        [301, 302, 303],\n"
-"    ];"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:73
-msgid ""
+"    ];\n"
+"\n"
+"    println!(\"matrix:\");\n"
+"    pretty_print(&matrix);\n"
+"\n"
 "    let transposed = transpose(matrix);\n"
 "    println!(\"transposed:\");\n"
 "    pretty_print(&transposed);\n"
-"}\n"
-"```\n"
-"### Bonus question"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:80
-msgid ""
-"It requires more advanced concepts. It might seem that we could use a slice-of-slices "
-"(`&[&[i32]]`) as the input type to transpose and thus make our function handle any size of matrix. "
-"However, this quickly breaks down: the return type cannot be `&[&[i32]]` since it needs to own the "
-"data you return."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:82
-msgid ""
-"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work out-of-the-box "
-"either: it's hard to convert from `Vec<Vec<i32>>` to `&[&[i32]]` so now you cannot easily use "
-"`pretty_print` either."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:84
-msgid ""
-"Once we get to traits and generics, we'll be able to use the [`std::convert::AsRef`][1] trait to "
-"abstract over anything that can be referenced as a slice."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:86
-msgid ""
-"```rust\n"
-"use std::convert::AsRef;\n"
-"use std::fmt::Debug;"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:90
-msgid ""
-"fn pretty_print<T, Line, Matrix>(matrix: Matrix)\n"
-"where\n"
-"    T: Debug,\n"
-"    // A line references a slice of items\n"
-"    Line: AsRef<[T]>,\n"
-"    // A matrix references a slice of lines\n"
-"    Matrix: AsRef<[Line]>\n"
-"{\n"
-"    for row in matrix.as_ref() {\n"
-"        println!(\"{:?}\", row.as_ref());\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:103
-msgid ""
-"fn main() {\n"
-"    // &[&[i32]]\n"
-"    pretty_print(&[&[1, 2, 3], &[4, 5, 6], &[7, 8, 9]]);\n"
-"    // [[&str; 2]; 2]\n"
-"    pretty_print([[\"a\", \"b\"], [\"c\", \"d\"]]);\n"
-"    // Vec<Vec<i32>>\n"
-"    pretty_print(vec![vec![1, 2], vec![3, 4]]);\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:113
 msgid ""
-"In addition, the type itself would not enforce that the child slices are of the same length, so "
-"such variable could contain an invalid matrix."
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:115
-msgid "[1]: https://doc.rust-lang.org/std/convert/trait.AsRef.html"
+"In addition, the type itself would not enforce that the child slices are of "
+"the same length, so such variable could contain an invalid matrix."
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
-msgid "# Day 1 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-msgid "## Designing a Library"
+msgid "Day 1 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:5
@@ -13118,207 +14044,176 @@ msgid "([back to exercise](book-library.md))"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:22
-msgid ""
-"// ANCHOR: setup\n"
-"struct Library {\n"
-"    books: Vec<Book>,\n"
-"}"
+msgid "// ANCHOR: setup struct Library { books: Vec"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:42
 msgid ""
-"// This makes it possible to print Book values with {}.\n"
-"impl std::fmt::Display for Book {\n"
-"    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-"        write!(f, \"{} ({})\", self.title, self.year)\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: setup"
+"// This makes it possible to print Book values with {}. impl std::fmt::"
+"Display for Book { fn fmt(&self, f: &mut std::fmt::Formatter\\<'\\_\\>) -> "
+"std::fmt::Result { write!(f, \"{} ({})\", self.title, self.year) } } // "
+"ANCHOR_END: setup"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:50
 msgid ""
-"// ANCHOR: Library_new\n"
-"impl Library {\n"
-"    fn new() -> Library {\n"
-"        // ANCHOR_END: Library_new\n"
-"        Library { books: Vec::new() }\n"
-"    }"
+"// ANCHOR: Library_new impl Library { fn new() -> Library { // ANCHOR_END: "
+"Library_new Library { books: Vec::new() } }"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:57
 msgid ""
-"    // ANCHOR: Library_len\n"
-"    //fn len(self) -> usize {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_len\n"
-"    fn len(&self) -> usize {\n"
-"        self.books.len()\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:66
-msgid ""
-"    // ANCHOR: Library_is_empty\n"
-"    //fn is_empty(self) -> bool {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_is_empty\n"
-"    fn is_empty(&self) -> bool {\n"
-"        self.books.is_empty()\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:75
-msgid ""
-"    // ANCHOR: Library_add_book\n"
-"    //fn add_book(self, book: Book) {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_add_book\n"
-"    fn add_book(&mut self, book: Book) {\n"
-"        self.books.push(book)\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:84
-msgid ""
-"    // ANCHOR: Library_print_books\n"
-"    //fn print_books(self) {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_print_books\n"
-"    fn print_books(&self) {\n"
-"        for book in &self.books {\n"
-"            println!(\"{}\", book);\n"
-"        }\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:95
-msgid ""
-"    // ANCHOR: Library_oldest_book\n"
-"    //fn oldest_book(self) -> Option<&Book> {\n"
-"    //    unimplemented!()\n"
-"    //}\n"
-"    // ANCHOR_END: Library_oldest_book\n"
-"    fn oldest_book(&self) -> Option<&Book> {\n"
-"        self.books.iter().min_by_key(|book| book.year)\n"
-"    }\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:105
-msgid ""
-"// ANCHOR: main\n"
-"// This shows the desired behavior. Uncomment the code below and\n"
-"// implement the missing methods. You will need to update the\n"
-"// method signatures, including the \"self\" parameter! You may\n"
-"// also need to update the variable bindings within main.\n"
-"fn main() {\n"
-"    let library = Library::new();"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:113
-msgid ""
-"    //println!(\"Our library is empty: {}\", library.is_empty());\n"
-"    //\n"
-"    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
-"    //\n"
-"    //library.print_books();\n"
-"    //\n"
-"    //match library.oldest_book() {\n"
-"    //    Some(book) => println!(\"My oldest book is {book}\"),\n"
-"    //    None => println!(\"My library is empty!\"),\n"
-"    //}\n"
-"    //\n"
-"    //println!(\"Our library has {} books\", library.len());\n"
-"}\n"
-"// ANCHOR_END: main"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:129
-msgid ""
-"#[test]\n"
-"fn test_library_len() {\n"
-"    let mut library = Library::new();\n"
-"    assert_eq!(library.len(), 0);\n"
-"    assert!(library.is_empty());"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:135
-msgid ""
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
-"    assert_eq!(library.len(), 2);\n"
-"    assert!(!library.is_empty());\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:141
-msgid ""
-"#[test]\n"
-"fn test_library_is_empty() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.is_empty());"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:146
-msgid ""
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert!(!library.is_empty());\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:150
-msgid ""
-"#[test]\n"
-"fn test_library_print_books() {\n"
-"    let mut library = Library::new();\n"
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
-"    // We could try and capture stdout, but let us just call the\n"
-"    // method to start with.\n"
-"    library.print_books();\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:160
-msgid ""
-"#[test]\n"
-"fn test_library_oldest_book() {\n"
-"    let mut library = Library::new();\n"
-"    assert!(library.oldest_book().is_none());"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:165
-msgid ""
-"    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Lord of the Rings\")\n"
-"    );"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:171
-msgid ""
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
-"    assert_eq!(\n"
-"        library.oldest_book().map(|b| b.title.as_str()),\n"
-"        Some(\"Alice's Adventures in Wonderland\")\n"
-"    );\n"
+"```\n"
+"// ANCHOR: Library_len\n"
+"//fn len(self) -> usize {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_len\n"
+"fn len(&self) -> usize {\n"
+"    self.books.len()\n"
 "}\n"
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-morning.md:1
-msgid "# Day 2 Morning Exercises"
+#: src/exercises/day-1/solutions-afternoon.md:66
+msgid ""
+"```\n"
+"// ANCHOR: Library_is_empty\n"
+"//fn is_empty(self) -> bool {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_is_empty\n"
+"fn is_empty(&self) -> bool {\n"
+"    self.books.is_empty()\n"
+"}\n"
+"```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-morning.md:3
-msgid "## Points and Polygons"
+#: src/exercises/day-1/solutions-afternoon.md:75
+msgid ""
+"```\n"
+"// ANCHOR: Library_add_book\n"
+"//fn add_book(self, book: Book) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_add_book\n"
+"fn add_book(&mut self, book: Book) {\n"
+"    self.books.push(book)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:84
+msgid ""
+"```\n"
+"// ANCHOR: Library_print_books\n"
+"//fn print_books(self) {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_print_books\n"
+"fn print_books(&self) {\n"
+"    for book in &self.books {\n"
+"        println!(\"{}\", book);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:95
+msgid ""
+"```\n"
+"// ANCHOR: Library_oldest_book\n"
+"//fn oldest_book(self) -> Option<&Book> {\n"
+"//    unimplemented!()\n"
+"//}\n"
+"// ANCHOR_END: Library_oldest_book\n"
+"fn oldest_book(&self) -> Option<&Book> {\n"
+"    self.books.iter().min_by_key(|book| book.year)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:105
+msgid ""
+"// ANCHOR: main // This shows the desired behavior. Uncomment the code below "
+"and // implement the missing methods. You will need to update the // method "
+"signatures, including the \"self\" parameter! You may // also need to update "
+"the variable bindings within main. fn main() { let library = Library::new();"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:126
+msgid "} // ANCHOR_END: main"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:129
+msgid ""
+"\\#\\[test\\] fn test_library_len() { let mut library = Library::new(); "
+"assert_eq!(library.len(), 0); assert!(library.is_empty());"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:135
+msgid ""
+"```\n"
+"library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"assert_eq!(library.len(), 2);\n"
+"assert!(!library.is_empty());\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:141
+msgid ""
+"\\#\\[test\\] fn test_library_is_empty() { let mut library = Library::new(); "
+"assert!(library.is_empty());"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:146
+msgid ""
+"```\n"
+"library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"assert!(!library.is_empty());\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:150
+msgid ""
+"\\#\\[test\\] fn test_library_print_books() { let mut library = Library::"
+"new(); library.add_book(Book::new(\"Lord of the Rings\", 1954)); library."
+"add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865)); // We could "
+"try and capture stdout, but let us just call the // method to start with. "
+"library.print_books(); }"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:160
+msgid ""
+"\\#\\[test\\] fn test_library_oldest_book() { let mut library = Library::"
+"new(); assert!(library.oldest_book().is_none());"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:165
+msgid ""
+"```\n"
+"library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
+"assert_eq!(\n"
+"    library.oldest_book().map(|b| b.title.as_str()),\n"
+"    Some(\"Lord of the Rings\")\n"
+");\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-1/solutions-afternoon.md:171
+msgid ""
+"```\n"
+"library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"assert_eq!(\n"
+"    library.oldest_book().map(|b| b.title.as_str()),\n"
+"    Some(\"Alice's Adventures in Wonderland\")\n"
+");\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:1
+msgid "Day 2 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:5
@@ -13327,248 +14222,198 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:22
 msgid ""
-"#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-"// ANCHOR: Point\n"
-"pub struct Point {\n"
-"    // ANCHOR_END: Point\n"
-"    x: i32,\n"
-"    y: i32,\n"
-"}"
+"\\#\\[derive(Debug, Copy, Clone, PartialEq, Eq)\\] // ANCHOR: Point pub "
+"struct Point { // ANCHOR_END: Point x: i32, y: i32, }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:30
 msgid ""
-"// ANCHOR: Point-impl\n"
-"impl Point {\n"
-"    // ANCHOR_END: Point-impl\n"
-"    pub fn new(x: i32, y: i32) -> Point {\n"
-"        Point { x, y }\n"
-"    }"
+"// ANCHOR: Point-impl impl Point { // ANCHOR_END: Point-impl pub fn new(x: "
+"i32, y: i32) -> Point { Point { x, y } }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:37
 msgid ""
-"    pub fn magnitude(self) -> f64 {\n"
-"        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-"    }"
+"```\n"
+"pub fn magnitude(self) -> f64 {\n"
+"    f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:41
 msgid ""
-"    pub fn dist(self, other: Point) -> f64 {\n"
-"        (self - other).magnitude()\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn dist(self, other: Point) -> f64 {\n"
+"    (self - other).magnitude()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:49
 msgid ""
-"    fn add(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x + other.x,\n"
-"            y: self.y + other.y,\n"
-"        }\n"
+"```\n"
+"fn add(self, other: Self) -> Self::Output {\n"
+"    Self {\n"
+"        x: self.x + other.x,\n"
+"        y: self.y + other.y,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:57
-msgid ""
-"impl std::ops::Sub for Point {\n"
-"    type Output = Self;"
+msgid "impl std::ops::Sub for Point { type Output = Self;"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:60
 msgid ""
-"    fn sub(self, other: Self) -> Self::Output {\n"
-"        Self {\n"
-"            x: self.x - other.x,\n"
-"            y: self.y - other.y,\n"
-"        }\n"
+"```\n"
+"fn sub(self, other: Self) -> Self::Output {\n"
+"    Self {\n"
+"        x: self.x - other.x,\n"
+"        y: self.y - other.y,\n"
 "    }\n"
-"}"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:68
 msgid ""
-"// ANCHOR: Polygon\n"
-"pub struct Polygon {\n"
-"    // ANCHOR_END: Polygon\n"
-"    points: Vec<Point>,\n"
-"}"
+"// ANCHOR: Polygon pub struct Polygon { // ANCHOR_END: Polygon points: Vec"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:74
 msgid ""
-"// ANCHOR: Polygon-impl\n"
-"impl Polygon {\n"
-"    // ANCHOR_END: Polygon-impl\n"
-"    pub fn new() -> Polygon {\n"
-"        Polygon { points: Vec::new() }\n"
-"    }"
+"// ANCHOR: Polygon-impl impl Polygon { // ANCHOR_END: Polygon-impl pub fn "
+"new() -> Polygon { Polygon { points: Vec::new() } }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:81
 msgid ""
-"    pub fn add_point(&mut self, point: Point) {\n"
-"        self.points.push(point);\n"
-"    }"
+"```\n"
+"pub fn add_point(&mut self, point: Point) {\n"
+"    self.points.push(point);\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:85
 msgid ""
-"    pub fn left_most_point(&self) -> Option<Point> {\n"
-"        self.points.iter().min_by_key(|p| p.x).copied()\n"
-"    }"
+"```\n"
+"pub fn left_most_point(&self) -> Option<Point> {\n"
+"    self.points.iter().min_by_key(|p| p.x).copied()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:89
 msgid ""
-"    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-"        self.points.iter()\n"
-"    }"
+"```\n"
+"pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
+"    self.points.iter()\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:93
 msgid ""
-"    pub fn length(&self) -> f64 {\n"
-"        if self.points.is_empty() {\n"
-"            return 0.0;\n"
-"        }"
+"```\n"
+"pub fn length(&self) -> f64 {\n"
+"    if self.points.is_empty() {\n"
+"        return 0.0;\n"
+"    }\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:98
 msgid ""
-"        let mut result = 0.0;\n"
-"        let mut last_point = self.points[0];\n"
-"        for point in &self.points[1..] {\n"
-"            result += last_point.dist(*point);\n"
-"            last_point = *point;\n"
-"        }\n"
-"        result += last_point.dist(self.points[0]);\n"
-"        result\n"
+"```\n"
+"    let mut result = 0.0;\n"
+"    let mut last_point = self.points[0];\n"
+"    for point in &self.points[1..] {\n"
+"        result += last_point.dist(*point);\n"
+"        last_point = *point;\n"
 "    }\n"
-"}"
+"    result += last_point.dist(self.points[0]);\n"
+"    result\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:109
 msgid ""
-"// ANCHOR: Circle\n"
-"pub struct Circle {\n"
-"    // ANCHOR_END: Circle\n"
-"    center: Point,\n"
-"    radius: i32,\n"
-"}"
+"// ANCHOR: Circle pub struct Circle { // ANCHOR_END: Circle center: Point, "
+"radius: i32, }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:116
 msgid ""
-"// ANCHOR: Circle-impl\n"
-"impl Circle {\n"
-"    // ANCHOR_END: Circle-impl\n"
-"    pub fn new(center: Point, radius: i32) -> Circle {\n"
-"        Circle { center, radius }\n"
-"    }"
+"// ANCHOR: Circle-impl impl Circle { // ANCHOR_END: Circle-impl pub fn "
+"new(center: Point, radius: i32) -> Circle { Circle { center, radius } }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:123
 msgid ""
-"    pub fn circumference(&self) -> f64 {\n"
-"        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-"    }"
+"```\n"
+"pub fn circumference(&self) -> f64 {\n"
+"    2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:127
 msgid ""
-"    pub fn dist(&self, other: &Self) -> f64 {\n"
-"        self.center.dist(other.center)\n"
-"    }\n"
-"}"
+"```\n"
+"pub fn dist(&self, other: &Self) -> f64 {\n"
+"    self.center.dist(other.center)\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:132
 msgid ""
-"// ANCHOR: Shape\n"
-"pub enum Shape {\n"
-"    Polygon(Polygon),\n"
-"    Circle(Circle),\n"
-"}\n"
-"// ANCHOR_END: Shape"
+"// ANCHOR: Shape pub enum Shape { Polygon(Polygon), Circle(Circle), } // "
+"ANCHOR_END: Shape"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:139
-msgid ""
-"impl From<Polygon> for Shape {\n"
-"    fn from(poly: Polygon) -> Self {\n"
-"        Shape::Polygon(poly)\n"
-"    }\n"
-"}"
+#: src/exercises/day-2/solutions-morning.md:145
+msgid "impl From"
+msgstr ""
+
+#: src/exercises/day-2/solutions-morning.md:139
+msgid " for Shape { fn from(poly: Polygon) -> Self { Shape::Polygon(poly) } }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:145
 msgid ""
-"impl From<Circle> for Shape {\n"
-"    fn from(circle: Circle) -> Self {\n"
-"        Shape::Circle(circle)\n"
-"    }\n"
-"}"
+" for Shape { fn from(circle: Circle) -> Self { Shape::Circle(circle) } }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:151
 msgid ""
-"impl Shape {\n"
-"    pub fn perimeter(&self) -> f64 {\n"
-"        match self {\n"
-"            Shape::Polygon(poly) => poly.length(),\n"
-"            Shape::Circle(circle) => circle.circumference(),\n"
-"        }\n"
-"    }\n"
-"}"
+"impl Shape { pub fn perimeter(&self) -> f64 { match self { Shape::"
+"Polygon(poly) => poly.length(), Shape::Circle(circle) => circle."
+"circumference(), } } }"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:160
-msgid ""
-"// ANCHOR: unit-tests\n"
-"#[cfg(test)]\n"
-"mod tests {\n"
-"    use super::*;"
+msgid "// ANCHOR: unit-tests \\#\\[cfg(test)\\] mod tests { use super::\\*;"
 msgstr ""
 
-#: src/exercises/day-2/solutions-morning.md:213
-msgid ""
-"    #[test]\n"
-"    fn test_shape_perimeters() {\n"
-"        let mut poly = Polygon::new();\n"
-"        poly.add_point(Point::new(12, 13));\n"
-"        poly.add_point(Point::new(17, 11));\n"
-"        poly.add_point(Point::new(16, 16));\n"
-"        let shapes = vec![\n"
-"            Shape::from(poly),\n"
-"            Shape::from(Circle::new(Point::new(10, 20), 5)),\n"
-"        ];\n"
-"        let perimeters = shapes\n"
-"            .iter()\n"
-"            .map(Shape::perimeter)\n"
-"            .map(round_two_digits)\n"
-"            .collect::<Vec<_>>();\n"
-"        assert_eq!(perimeters, vec![15.48, 31.42]);\n"
-"    }\n"
-"}\n"
-"// ANCHOR_END: unit-tests"
+#: src/exercises/day-2/solutions-morning.md:230
+#: src/exercises/day-2/solutions-afternoon.md:171
+msgid "} // ANCHOR_END: unit-tests"
 msgstr ""
 
-#: src/exercises/day-2/solutions-morning.md:233 src/exercises/day-2/solutions-afternoon.md:174
-msgid ""
-"fn main() {}\n"
-"```"
+#: src/exercises/day-2/solutions-morning.md:233
+#: src/exercises/day-2/solutions-afternoon.md:174
+msgid "fn main() {}"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
-msgid "# Day 2 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-msgid "## Luhn Algorithm"
+msgid "Day 2 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:5
@@ -13577,12 +14422,81 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:22
 msgid ""
+"// ANCHOR: luhn pub fn luhn(cc_number: &str) -> bool { // ANCHOR_END: luhn "
+"let mut digits_seen = 0; let mut sum = 0; for (i, ch) in cc_number.chars()."
+"rev().filter(|&ch| ch != ' ').enumerate() { match ch.to_digit(10) { Some(d) "
+"=> { sum += if i % 2 == 1 { let dd = d * 2; dd / 10 + dd % 10 } else { d }; "
+"digits_seen += 1; } None => return false, } }"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:42
+msgid ""
+"```\n"
+"if digits_seen < 2 {\n"
+"    return false;\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:46
+msgid ""
+"```\n"
+"sum % 10 == 0\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:49
+msgid ""
+"fn main() { let cc_number = \"1234 5678 1234 5670\"; println!( \"Is {} a "
+"valid credit card number? {}\", cc_number, if luhn(cc_number) { \"yes\" } "
+"else { \"no\" } ); }"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:58
+msgid ""
+"// ANCHOR: unit-tests \\#\\[test\\] fn test_non_digit_cc_number() { assert!(!"
+"luhn(\"foo\")); }"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:89
+msgid ""
+"\\#\\[test\\] fn test_invalid_cc_number() { assert!(!luhn(\"4223 9826 4026 "
+"9299\")); assert!(!luhn(\"4539 3195 0343 6476\")); assert!(!luhn(\"8273 1232 "
+"7352 0569\")); } // ANCHOR_END: unit-tests"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:96
+msgid ""
+"```\n"
+"\n"
+"# Day 2 Afternoon Exercises\n"
+"\n"
+"## Luhn Algorithm\n"
+"\n"
+"([back to exercise](luhn.md))\n"
+"\n"
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
 "// ANCHOR: luhn\n"
 "pub fn luhn(cc_number: &str) -> bool {\n"
 "    // ANCHOR_END: luhn\n"
 "    let mut digits_seen = 0;\n"
 "    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ').enumerate() {\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
 "        match ch.to_digit(10) {\n"
 "            Some(d) => {\n"
 "                sum += if i % 2 == 1 {\n"
@@ -13595,24 +14509,15 @@ msgid ""
 "            }\n"
 "            None => return false,\n"
 "        }\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:42
-msgid ""
+"    }\n"
+"\n"
 "    if digits_seen < 2 {\n"
 "        return false;\n"
-"    }"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:46
-msgid ""
+"    }\n"
+"\n"
 "    sum % 10 == 0\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:49
-msgid ""
+"}\n"
+"\n"
 "fn main() {\n"
 "    let cc_number = \"1234 5678 1234 5670\";\n"
 "    println!(\n"
@@ -13620,40 +14525,58 @@ msgid ""
 "        cc_number,\n"
 "        if luhn(cc_number) { \"yes\" } else { \"no\" }\n"
 "    );\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:58
-msgid ""
+"}\n"
+"\n"
 "// ANCHOR: unit-tests\n"
 "#[test]\n"
 "fn test_non_digit_cc_number() {\n"
 "    assert!(!luhn(\"foo\"));\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:89
-msgid ""
-"#[test]\n"
-"fn test_invalid_cc_number() {\n"
-"    assert!(!luhn(\"4223 9826 4026 9299\"));\n"
-"    assert!(!luhn(\"4539 3195 0343 6476\"));\n"
-"    assert!(!luhn(\"8273 1232 7352 0569\"));\n"
 "}\n"
-"// ANCHOR_END: unit-tests\n"
-"```"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:98
-msgid "## Strings and Iterators"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:100
-msgid "([back to exercise](strings-iterators.md))"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:117
-msgid ""
+"\n"
+"#[test]\n"
+"fn test_empty_cc_number() {\n"
+"    assert!(!luhn(\"\"));\n"
+"    assert!(!luhn(\" \"));\n"
+"    assert!(!luhn(\"  \"));\n"
+"    assert!(!luhn(\"    \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_single_digit_cc_number() {\n"
+"    assert!(!luhn(\"0\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_two_digit_cc_number() {\n"
+"    assert!(luhn(\" 0 0 \"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_valid_cc_number() {\n"
+"    assert!(luhn(\"4263 9826 4026 9299\"));\n"
+"    assert!(luhn(\"4539 3195 0343 6467\"));\n"
+"    assert!(luhn(\"7992 7398 713\"));\n"
+"}\n"
+"\n"
+"## Strings and Iterators\n"
+"\n"
+"([back to exercise](strings-iterators.md))\n"
+"\n"
+"```rust\n"
+"// Copyright 2022 Google LLC\n"
+"//\n"
+"// Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+"// you may not use this file except in compliance with the License.\n"
+"// You may obtain a copy of the License at\n"
+"//\n"
+"//      http://www.apache.org/licenses/LICENSE-2.0\n"
+"//\n"
+"// Unless required by applicable law or agreed to in writing, software\n"
+"// distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+"// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+"// See the License for the specific language governing permissions and\n"
+"// limitations under the License.\n"
+"\n"
 "// ANCHOR: prefix_matches\n"
 "pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
 "    // ANCHOR_END: prefix_matches\n"
@@ -13661,11 +14584,8 @@ msgid ""
 "    let request_paths = request_path\n"
 "        .split('/')\n"
 "        .map(|p| Some(p))\n"
-"        .chain(std::iter::once(None));"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:126
-msgid ""
+"        .chain(std::iter::once(None));\n"
+"\n"
 "    for (prefix, request_path) in prefixes.zip(request_paths) {\n"
 "        match request_path {\n"
 "            Some(request_path) => {\n"
@@ -13677,36 +14597,90 @@ msgid ""
 "        }\n"
 "    }\n"
 "    true\n"
-"}"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:139
-msgid ""
+"}\n"
+"\n"
 "// ANCHOR: unit-tests\n"
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:166
-msgid ""
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
+"}\n"
+"\n"
+"#[test]\n"
+"fn test_matches_with_wildcard() {\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/bar/books\"\n"
+"    ));\n"
+"    assert!(prefix_matches(\n"
+"        \"/v1/publishers/*/books\",\n"
+"        \"/v1/publishers/foo/books/book1\"\n"
+"    ));\n"
+"\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
 "    ));\n"
 "}\n"
-"// ANCHOR_END: unit-tests"
+"// ANCHOR_END: unit-tests\n"
+"\n"
+"fn main() {}\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:100
+msgid "([back to exercise](strings-iterators.md))"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:117
+msgid ""
+"// ANCHOR: prefix_matches pub fn prefix_matches(prefix: &str, request_path: "
+"&str) -> bool { // ANCHOR_END: prefix_matches let prefixes = prefix."
+"split('/'); let request_paths = request_path .split('/') .map(|p| Some(p)) ."
+"chain(std::iter::once(None));"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:126
+msgid ""
+"```\n"
+"for (prefix, request_path) in prefixes.zip(request_paths) {\n"
+"    match request_path {\n"
+"        Some(request_path) => {\n"
+"            if (prefix != \"*\") && (prefix != request_path) {\n"
+"                return false;\n"
+"            }\n"
+"        }\n"
+"        None => return false,\n"
+"    }\n"
+"}\n"
+"true\n"
+"```"
+msgstr ""
+
+#: src/exercises/day-2/solutions-afternoon.md:139
+msgid ""
+"// ANCHOR: unit-tests \\#\\[test\\] fn test_matches_without_wildcard() "
+"{ assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\")); assert!"
+"(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\")); assert!"
+"(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
-msgid "# Day 3 Morning Exercise"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:3
-msgid "## A Simple GUI Library"
+msgid "Day 3 Morning Exercise"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:5
@@ -13715,10 +14689,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:22
 msgid ""
-"// ANCHOR: setup\n"
-"pub trait Widget {\n"
-"    /// Natural width of `self`.\n"
-"    fn width(&self) -> usize;"
+"// ANCHOR: setup pub trait Widget { /// Natural width of `self`. fn "
+"width(&self) -> usize;"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:82
@@ -13727,125 +14699,108 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:84
 msgid ""
-"// ANCHOR: Window-width\n"
-"impl Widget for Window {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Window-width\n"
-"        std::cmp::max(\n"
-"            self.title.chars().count(),\n"
-"            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-"        )\n"
-"    }"
+"// ANCHOR: Window-width impl Widget for Window { fn width(&self) -> usize "
+"{ // ANCHOR_END: Window-width std::cmp::max( self.title.chars().count(), "
+"self.widgets.iter().map(|w| w.width()).max().unwrap_or(0), ) }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:94
 msgid ""
-"    // ANCHOR: Window-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Window-draw_into\n"
-"        let mut inner = String::new();\n"
-"        for widget in &self.widgets {\n"
-"            widget.draw_into(&mut inner);\n"
-"        }"
+"```\n"
+"// ANCHOR: Window-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Window-draw_into\n"
+"    let mut inner = String::new();\n"
+"    for widget in &self.widgets {\n"
+"        widget.draw_into(&mut inner);\n"
+"    }\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:102
-msgid "        let window_width = self.width();"
+msgid ""
+"```\n"
+"    let window_width = self.width();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:104
 msgid ""
-"        // TODO: after learning about error handling, you can change\n"
-"        // draw_into to return Result<(), std::fmt::Error>. Then use\n"
-"        // the ?-operator here instead of .unwrap().\n"
-"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
-"        writeln!(buffer, \"| {:^window_width$} |\", &self.title).unwrap();\n"
-"        writeln!(buffer, \"+={:=<window_width$}=+\", \"\").unwrap();\n"
-"        for line in inner.lines() {\n"
-"            writeln!(buffer, \"| {:window_width$} |\", line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"```\n"
+"    // TODO: after learning about error handling, you can change\n"
+"    // draw_into to return Result<(), std::fmt::Error>. Then use\n"
+"    // the ?-operator here instead of .unwrap().\n"
+"    writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"    writeln!(buffer, \"| {:^window_width$} |\", &self.title).unwrap();\n"
+"    writeln!(buffer, \"+={:=<window_width$}=+\", \"\").unwrap();\n"
+"    for line in inner.lines() {\n"
+"        writeln!(buffer, \"| {:window_width$} |\", line).unwrap();\n"
 "    }\n"
-"}"
+"    writeln!(buffer, \"+-{:-<window_width$}-+\", \"\").unwrap();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:117
 msgid ""
-"// ANCHOR: Button-width\n"
-"impl Widget for Button {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Button-width\n"
-"        self.label.width() + 8 // add a bit of padding\n"
-"    }"
+"// ANCHOR: Button-width impl Widget for Button { fn width(&self) -> usize "
+"{ // ANCHOR_END: Button-width self.label.width() + 8 // add a bit of "
+"padding }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:124
 msgid ""
-"    // ANCHOR: Button-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Button-draw_into\n"
-"        let width = self.width();\n"
-"        let mut label = String::new();\n"
-"        self.label.draw_into(&mut label);"
+"```\n"
+"// ANCHOR: Button-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Button-draw_into\n"
+"    let width = self.width();\n"
+"    let mut label = String::new();\n"
+"    self.label.draw_into(&mut label);\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:131
 msgid ""
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
-"        for line in label.lines() {\n"
-"            writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
-"        }\n"
-"        writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"```\n"
+"    writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"    for line in label.lines() {\n"
+"        writeln!(buffer, \"|{:^width$}|\", &line).unwrap();\n"
 "    }\n"
-"}"
+"    writeln!(buffer, \"+{:-<width$}+\", \"\").unwrap();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:139
 msgid ""
-"// ANCHOR: Label-width\n"
-"impl Widget for Label {\n"
-"    fn width(&self) -> usize {\n"
-"        // ANCHOR_END: Label-width\n"
-"        self.label\n"
-"            .lines()\n"
-"            .map(|line| line.chars().count())\n"
-"            .max()\n"
-"            .unwrap_or(0)\n"
-"    }"
+"// ANCHOR: Label-width impl Widget for Label { fn width(&self) -> usize { // "
+"ANCHOR_END: Label-width self.label .lines() .map(|line| line.chars()."
+"count()) .max() .unwrap_or(0) }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:150
 msgid ""
-"    // ANCHOR: Label-draw_into\n"
-"    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-"        // ANCHOR_END: Label-draw_into\n"
-"        writeln!(buffer, \"{}\", &self.label).unwrap();\n"
-"    }\n"
-"}"
+"```\n"
+"// ANCHOR: Label-draw_into\n"
+"fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
+"    // ANCHOR_END: Label-draw_into\n"
+"    writeln!(buffer, \"{}\", &self.label).unwrap();\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:157
 msgid ""
-"// ANCHOR: main\n"
-"fn main() {\n"
-"    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo.\")));\n"
-"    window.add_widget(Box::new(Button::new(\n"
-"        \"Click me!\",\n"
-"        Box::new(|| println!(\"You clicked the button!\")),\n"
-"    )));\n"
-"    window.draw();\n"
-"}\n"
-"// ANCHOR_END: main\n"
-"```"
+"// ANCHOR: main fn main() { let mut window = Window::new(\"Rust GUI Demo "
+"1.23\"); window.add_widget(Box::new(Label::new(\"This is a small text GUI "
+"demo.\"))); window.add_widget(Box::new(Button::new( \"Click me!\", Box::"
+"new(|| println!(\"You clicked the button!\")), ))); window.draw(); } // "
+"ANCHOR_END: main"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
-msgid "# Day 3 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-msgid "## Safe FFI Wrapper"
+msgid "Day 3 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:5
@@ -13854,99 +14809,62 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:22
 msgid ""
-"// ANCHOR: ffi\n"
-"mod ffi {\n"
-"    use std::os::raw::{c_char, c_int, c_long, c_ulong, c_ushort};"
+"// ANCHOR: ffi mod ffi { use std::os::raw::{c_char, c_int, c_long, c_ulong, "
+"c_ushort};"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:53
 msgid ""
-"#[derive(Debug)]\n"
-"struct DirectoryIterator {\n"
-"    path: CString,\n"
-"    dir: *mut ffi::DIR,\n"
-"}\n"
-"// ANCHOR_END: ffi"
+"\\#\\[derive(Debug)\\] struct DirectoryIterator { path: CString, dir: \\*mut "
+"ffi::DIR, } // ANCHOR_END: ffi"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:60
 msgid ""
-"// ANCHOR: DirectoryIterator\n"
-"impl DirectoryIterator {\n"
-"    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-"        // Call opendir and return a Ok value if that worked,\n"
-"        // otherwise return Err with a message.\n"
-"        // ANCHOR_END: DirectoryIterator\n"
-"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: {err}\"))?;\n"
-"        // SAFETY: path.as_ptr() cannot be NULL.\n"
-"        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
-"        if dir.is_null() {\n"
-"            Err(format!(\"Could not open {:?}\", path))\n"
-"        } else {\n"
-"            Ok(DirectoryIterator { path, dir })\n"
-"        }\n"
-"    }\n"
-"}"
+"// ANCHOR: DirectoryIterator impl DirectoryIterator { fn new(path: &str) -> "
+"Result\\<DirectoryIterator, String> { // Call opendir and return a Ok value "
+"if that worked, // otherwise return Err with a message. // ANCHOR_END: "
+"DirectoryIterator let path = CString::new(path).map_err(|err| format!"
+"(\"Invalid path: {err}\"))?; // SAFETY: path.as_ptr() cannot be NULL. let "
+"dir = unsafe { ffi::opendir(path.as_ptr()) }; if dir.is_null() { Err(format!"
+"(\"Could not open {:?}\", path)) } else { Ok(DirectoryIterator { path, "
+"dir }) } } }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:77
 msgid ""
-"// ANCHOR: Iterator\n"
-"impl Iterator for DirectoryIterator {\n"
-"    type Item = OsString;\n"
-"    fn next(&mut self) -> Option<OsString> {\n"
-"        // Keep calling readdir until we get a NULL pointer back.\n"
-"        // ANCHOR_END: Iterator\n"
-"        // SAFETY: self.dir is never NULL.\n"
-"        let dirent = unsafe { ffi::readdir(self.dir) };\n"
-"        if dirent.is_null() {\n"
-"            // We have reached the end of the directory.\n"
-"            return None;\n"
-"        }\n"
-"        // SAFETY: dirent is not NULL and dirent.d_name is NUL\n"
-"        // terminated.\n"
-"        let d_name = unsafe { CStr::from_ptr((*dirent).d_name.as_ptr()) };\n"
-"        let os_str = OsStr::from_bytes(d_name.to_bytes());\n"
-"        Some(os_str.to_owned())\n"
-"    }\n"
-"}"
+"// ANCHOR: Iterator impl Iterator for DirectoryIterator { type Item = "
+"OsString; fn next(&mut self) -> Option"
+msgstr ""
+
+#: src/exercises/day-3/solutions-afternoon.md:80
+msgid ""
+" { // Keep calling readdir until we get a NULL pointer back. // ANCHOR_END: "
+"Iterator // SAFETY: self.dir is never NULL. let dirent = unsafe { ffi::"
+"readdir(self.dir) }; if dirent.is_null() { // We have reached the end of the "
+"directory. return None; } // SAFETY: dirent is not NULL and dirent.d_name is "
+"NUL // terminated. let d_name = unsafe { CStr::from_ptr((\\*dirent).d_name."
+"as_ptr()) }; let os_str = OsStr::from_bytes(d_name.to_bytes()); Some(os_str."
+"to_owned()) } }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:97
 msgid ""
-"// ANCHOR: Drop\n"
-"impl Drop for DirectoryIterator {\n"
-"    fn drop(&mut self) {\n"
-"        // Call closedir as needed.\n"
-"        // ANCHOR_END: Drop\n"
-"        if !self.dir.is_null() {\n"
-"            // SAFETY: self.dir is not NULL.\n"
-"            if unsafe { ffi::closedir(self.dir) } != 0 {\n"
-"                panic!(\"Could not close {:?}\", self.path);\n"
-"            }\n"
-"        }\n"
-"    }\n"
-"}"
+"// ANCHOR: Drop impl Drop for DirectoryIterator { fn drop(&mut self) { // "
+"Call closedir as needed. // ANCHOR_END: Drop if !self.dir.is_null() { // "
+"SAFETY: self.dir is not NULL. if unsafe { ffi::closedir(self.dir) } != 0 "
+"{ panic!(\"Could not close {:?}\", self.path); } } } }"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:111
 msgid ""
-"// ANCHOR: main\n"
-"fn main() -> Result<(), String> {\n"
-"    let iter = DirectoryIterator::new(\".\")?;\n"
-"    println!(\"files: {:#?}\", iter.collect::<Vec<_>>());\n"
-"    Ok(())\n"
-"}\n"
-"// ANCHOR_END: main\n"
-"```"
+"// ANCHOR: main fn main() -> Result\\<(), String> { let iter = "
+"DirectoryIterator::new(\".\")?; println!(\"files: {:#?}\", iter.collect::"
+"\\<Vec\\<\\_\\>>()); Ok(()) } // ANCHOR_END: main"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:1
-msgid "# Day 4 Morning Exercise"
-msgstr ""
-
-#: src/exercises/day-4/solutions-morning.md:3
-msgid "## Dining Philosophers"
+msgid "Day 4 Morning Exercise"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:5
@@ -13955,114 +14873,121 @@ msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:22
 msgid ""
-"// ANCHOR: Philosopher\n"
-"use std::sync::mpsc;\n"
-"use std::sync::{Arc, Mutex};\n"
-"use std::thread;\n"
-"use std::time::Duration;"
+"// ANCHOR: Philosopher use std::sync::mpsc; use std::sync::{Arc, Mutex}; use "
+"std::thread; use std::time::Duration;"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:30
 msgid ""
-"struct Philosopher {\n"
-"    name: String,\n"
-"    // ANCHOR_END: Philosopher\n"
-"    left_fork: Arc<Mutex<Fork>>,\n"
-"    right_fork: Arc<Mutex<Fork>>,\n"
-"    thoughts: mpsc::SyncSender<String>,\n"
-"}"
+"struct Philosopher { name: String, // ANCHOR_END: Philosopher left_fork: "
+"Arc\\<Mutex"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:33
+msgid "\\>, right_fork: Arc\\<Mutex"
+msgstr ""
+
+#: src/exercises/day-4/solutions-morning.md:34
+msgid "\\>, thoughts: mpsc::SyncSender"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:38
 msgid ""
-"// ANCHOR: Philosopher-think\n"
-"impl Philosopher {\n"
-"    fn think(&self) {\n"
-"        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))\n"
-"            .unwrap();\n"
-"    }\n"
-"    // ANCHOR_END: Philosopher-think"
+"// ANCHOR: Philosopher-think impl Philosopher { fn think(&self) { self."
+"thoughts .send(format!(\"Eureka! {} has a new idea!\", &self.name)) ."
+"unwrap(); } // ANCHOR_END: Philosopher-think"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:47
 msgid ""
-"    // ANCHOR: Philosopher-eat\n"
-"    fn eat(&self) {\n"
-"        // ANCHOR_END: Philosopher-eat\n"
-"        println!(\"{} is trying to eat\", &self.name);\n"
-"        let left = self.left_fork.lock().unwrap();\n"
-"        let right = self.right_fork.lock().unwrap();"
+"```\n"
+"// ANCHOR: Philosopher-eat\n"
+"fn eat(&self) {\n"
+"    // ANCHOR_END: Philosopher-eat\n"
+"    println!(\"{} is trying to eat\", &self.name);\n"
+"    let left = self.left_fork.lock().unwrap();\n"
+"    let right = self.right_fork.lock().unwrap();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:54
 msgid ""
-"        // ANCHOR: Philosopher-eat-end\n"
-"        println!(\"{} is eating...\", &self.name);\n"
-"        thread::sleep(Duration::from_millis(10));\n"
-"    }\n"
-"}"
+"```\n"
+"    // ANCHOR: Philosopher-eat-end\n"
+"    println!(\"{} is eating...\", &self.name);\n"
+"    thread::sleep(Duration::from_millis(10));\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:63
 msgid ""
-"fn main() {\n"
-"    // ANCHOR_END: Philosopher-eat-end\n"
-"    let (tx, rx) = mpsc::sync_channel(10);"
+"fn main() { // ANCHOR_END: Philosopher-eat-end let (tx, rx) = mpsc::"
+"sync_channel(10);"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:67
 msgid ""
-"    let forks = (0..PHILOSOPHERS.len())\n"
-"        .map(|_| Arc::new(Mutex::new(Fork)))\n"
-"        .collect::<Vec<_>>();"
+"```\n"
+"let forks = (0..PHILOSOPHERS.len())\n"
+"    .map(|_| Arc::new(Mutex::new(Fork)))\n"
+"    .collect::<Vec<_>>();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:71
 msgid ""
-"    for i in 0..forks.len() {\n"
-"        let tx = tx.clone();\n"
-"        let mut left_fork = forks[i].clone();\n"
-"        let mut right_fork = forks[(i + 1) % forks.len()].clone();"
+"```\n"
+"for i in 0..forks.len() {\n"
+"    let tx = tx.clone();\n"
+"    let mut left_fork = forks[i].clone();\n"
+"    let mut right_fork = forks[(i + 1) % forks.len()].clone();\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:76
 msgid ""
-"        // To avoid a deadlock, we have to break the symmetry\n"
-"        // somewhere. This will swap the forks without deinitializing\n"
-"        // either of them.\n"
-"        if i == forks.len() - 1 {\n"
-"            std::mem::swap(&mut left_fork, &mut right_fork);\n"
-"        }"
+"```\n"
+"    // To avoid a deadlock, we have to break the symmetry\n"
+"    // somewhere. This will swap the forks without deinitializing\n"
+"    // either of them.\n"
+"    if i == forks.len() - 1 {\n"
+"        std::mem::swap(&mut left_fork, &mut right_fork);\n"
+"    }\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:83
 msgid ""
-"        let philosopher = Philosopher {\n"
-"            name: PHILOSOPHERS[i].to_string(),\n"
-"            thoughts: tx,\n"
-"            left_fork,\n"
-"            right_fork,\n"
-"        };"
+"```\n"
+"    let philosopher = Philosopher {\n"
+"        name: PHILOSOPHERS[i].to_string(),\n"
+"        thoughts: tx,\n"
+"        left_fork,\n"
+"        right_fork,\n"
+"    };\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:90
 msgid ""
-"        thread::spawn(move || {\n"
-"            for _ in 0..100 {\n"
-"                philosopher.eat();\n"
-"                philosopher.think();\n"
-"            }\n"
-"        });\n"
-"    }"
+"```\n"
+"    thread::spawn(move || {\n"
+"        for _ in 0..100 {\n"
+"            philosopher.eat();\n"
+"            philosopher.think();\n"
+"        }\n"
+"    });\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:98
 msgid ""
-"    drop(tx);\n"
-"    for thought in rx {\n"
-"        println!(\"{thought}\");\n"
-"    }\n"
+"```\n"
+"drop(tx);\n"
+"for thought in rx {\n"
+"    println!(\"{thought}\");\n"
 "}\n"
 "```"
 msgstr ""


### PR DESCRIPTION
Before, po/es.po had these statistics:

    386 translated messages, 133 fuzzy translations, 1262 untranslated messages.

Afterwards, the statistics for po/es.po is:

    585 translated messages, 142 fuzzy translations, 1740 untranslated messages.

The number of translated messages changed from 22% to 24%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.