### PR TITLE
ru: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -5,34 +5,33 @@ msgstr ""
 "PO-Revision-Date: 2023-07-04 21:36+0200\n"
 "Last-Translator: Yauheni Baltukha <evgenii.boltuho@gmail.com>\n"
 "Language-Team: \n"
-"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ru\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.2\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Добро пожаловать в Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Проведение курса"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Структура курса"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Горячие клавиши"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Переводы"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Использование Cargo"
 
@@ -57,55 +56,55 @@ msgstr "День 1: Утро"
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Что такое Rust?"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Привет, мир!"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "Небольшой пример"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "Почему Rust?"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "Гарантии времени компиляции"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "Гарантии времени выполнения"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "Современные возможности"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "Базовый синтаксис"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "Скалярные типы"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "Составные типы"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "Ссылки"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "Висячие ссылки"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "Срезы"
 
@@ -113,15 +112,16 @@ msgstr "Срезы"
 msgid "String vs str"
 msgstr "String и str"
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "Функции"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
 msgstr "Rustdoc"
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "Методы"
 
@@ -132,10 +132,14 @@ msgstr "Перегрузка"
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
 #: src/SUMMARY.md:253 src/SUMMARY.md:275 src/SUMMARY.md:296
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
+#: src/exercises/concurrency/morning.md:1
+#: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "Упражнения"
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "Неявные преобразования"
 
@@ -147,11 +151,11 @@ msgstr "Массивы и циклы for"
 msgid "Day 1: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr ""
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr ""
 
@@ -159,11 +163,11 @@ msgstr ""
 msgid "static & const"
 msgstr ""
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr ""
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
 msgstr ""
 
@@ -171,15 +175,15 @@ msgstr ""
 msgid "Stack vs Heap"
 msgstr ""
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr ""
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr ""
 
@@ -191,59 +195,60 @@ msgstr ""
 msgid "Rust Memory Management"
 msgstr ""
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr ""
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
 msgstr ""
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr ""
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr ""
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr ""
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr ""
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr ""
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr ""
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr ""
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr ""
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr ""
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr ""
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr ""
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr ""
 
@@ -251,63 +256,64 @@ msgstr ""
 msgid "Day 2: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
 msgstr ""
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr ""
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr ""
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
 msgstr ""
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr ""
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr ""
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr ""
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:274
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr ""
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr ""
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr ""
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr ""
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr ""
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr ""
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr ""
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr ""
 
@@ -315,11 +321,11 @@ msgstr ""
 msgid "Day 2: Afternoon"
 msgstr "День 2: Вторая половина дня"
 
-#: src/SUMMARY.md:96 src/SUMMARY.md:288
+#: src/SUMMARY.md:96 src/SUMMARY.md:288 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "Поток управления"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "Блоки"
 
@@ -355,7 +361,7 @@ msgstr ""
 msgid "break & continue"
 msgstr ""
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
 msgstr ""
 
@@ -363,7 +369,7 @@ msgstr ""
 msgid "Option and Result"
 msgstr ""
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
 msgstr ""
 
@@ -383,7 +389,7 @@ msgstr ""
 msgid "Recursive Data Types"
 msgstr ""
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr ""
 
@@ -391,27 +397,29 @@ msgstr ""
 msgid "Rc"
 msgstr ""
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr ""
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr ""
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr ""
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr ""
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr ""
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:97
 msgid "Strings and Iterators"
 msgstr ""
 
@@ -419,39 +427,39 @@ msgstr ""
 msgid "Day 3: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/generics.md:1
 msgid "Generics"
 msgstr ""
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr ""
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr ""
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr ""
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits.md:1
 msgid "Traits"
 msgstr ""
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr ""
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr ""
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md:136 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr ""
 
-#: src/SUMMARY.md:137
+#: src/SUMMARY.md:137 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr ""
 
@@ -459,7 +467,7 @@ msgstr ""
 msgid "impl Trait"
 msgstr ""
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr ""
 
@@ -467,7 +475,7 @@ msgstr ""
 msgid "Iterator"
 msgstr ""
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr ""
 
@@ -495,7 +503,8 @@ msgstr ""
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr ""
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr ""
 
@@ -503,11 +512,11 @@ msgstr ""
 msgid "Day 3: Afternoon"
 msgstr ""
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
 msgstr ""
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr ""
 
@@ -523,67 +532,68 @@ msgstr ""
 msgid "Propagating Errors with ?"
 msgstr ""
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr ""
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr ""
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr ""
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr ""
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
 msgstr ""
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr ""
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr ""
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr ""
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr ""
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr ""
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr ""
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr ""
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr ""
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr ""
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr ""
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr ""
 
@@ -591,23 +601,25 @@ msgstr ""
 msgid "Extern Functions"
 msgstr ""
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr ""
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr ""
 
 #: src/SUMMARY.md:181 src/SUMMARY.md:251
+#: src/running-the-course/course-structure.md:16 src/bare-metal/android.md:1
 msgid "Android"
 msgstr ""
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/android/setup.md:1
 msgid "Setup"
 msgstr ""
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr ""
 
@@ -619,7 +631,7 @@ msgstr ""
 msgid "Library"
 msgstr ""
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/android/aidl.md:1
 msgid "AIDL"
 msgstr ""
 
@@ -635,7 +647,7 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:194 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr ""
 
@@ -643,15 +655,16 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:196 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr ""
 
-#: src/SUMMARY.md:197 src/SUMMARY.md:241
+#: src/SUMMARY.md:197 src/SUMMARY.md:241 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr ""
 
@@ -667,7 +680,7 @@ msgstr ""
 msgid "Calling Rust from C"
 msgstr ""
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr ""
 
@@ -691,11 +704,11 @@ msgstr ""
 msgid "alloc"
 msgstr ""
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr ""
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr ""
 
@@ -723,7 +736,7 @@ msgstr ""
 msgid "probe-rs, cargo-embed"
 msgstr ""
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr ""
 
@@ -731,7 +744,8 @@ msgstr ""
 msgid "Other Projects"
 msgstr ""
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:226 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Application Processors"
 msgstr ""
 
-#: src/SUMMARY.md:231
+#: src/SUMMARY.md:231 src/bare-metal/aps/entry-point.md:1
 msgid "Getting Ready to Rust"
 msgstr ""
 
@@ -767,7 +781,7 @@ msgstr ""
 msgid "A Better UART Driver"
 msgstr ""
 
-#: src/SUMMARY.md:237
+#: src/SUMMARY.md:237 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr ""
 
@@ -775,7 +789,7 @@ msgstr ""
 msgid "Multiple Registers"
 msgstr ""
 
-#: src/SUMMARY.md:239
+#: src/SUMMARY.md:239 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr ""
 
@@ -783,7 +797,7 @@ msgstr ""
 msgid "Using It"
 msgstr ""
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md:243 src/bare-metal/aps/exceptions.md:1
 msgid "Exceptions"
 msgstr ""
 
@@ -811,7 +825,7 @@ msgstr ""
 msgid "spin"
 msgstr ""
 
-#: src/SUMMARY.md:252
+#: src/SUMMARY.md:252 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr ""
 
@@ -823,23 +837,23 @@ msgstr ""
 msgid "Concurrency: Morning"
 msgstr ""
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:262 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr ""
 
-#: src/SUMMARY.md:263
+#: src/SUMMARY.md:263 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr ""
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr ""
 
-#: src/SUMMARY.md:265
+#: src/SUMMARY.md:265 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr ""
 
-#: src/SUMMARY.md:266
+#: src/SUMMARY.md:266 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr ""
 
@@ -855,11 +869,11 @@ msgstr ""
 msgid "Sync"
 msgstr ""
 
-#: src/SUMMARY.md:270
+#: src/SUMMARY.md:270 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr ""
 
-#: src/SUMMARY.md:271
+#: src/SUMMARY.md:271 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr ""
 
@@ -872,10 +886,12 @@ msgid "Mutex"
 msgstr ""
 
 #: src/SUMMARY.md:276 src/SUMMARY.md:297
+#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr ""
 
-#: src/SUMMARY.md:277
+#: src/SUMMARY.md:277 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr ""
 
@@ -891,31 +907,32 @@ msgstr ""
 msgid "async/await"
 msgstr ""
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md:283 src/async/futures.md:1
 msgid "Futures"
 msgstr ""
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr ""
 
-#: src/SUMMARY.md:285
+#: src/SUMMARY.md:285 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr ""
 
-#: src/SUMMARY.md:286
+#: src/SUMMARY.md:286 src/exercises/concurrency/link-checker.md:106
+#: src/exercises/concurrency/chat-app.md:140 src/async/tasks.md:1
 msgid "Tasks"
 msgstr ""
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:287 src/async/channels.md:1
 msgid "Async Channels"
 msgstr ""
 
-#: src/SUMMARY.md:289
+#: src/SUMMARY.md:289 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:290
+#: src/SUMMARY.md:290 src/async/control-flow/select.md:1
 msgid "Select"
 msgstr ""
 
@@ -927,20 +944,21 @@ msgstr ""
 msgid "Blocking the Executor"
 msgstr ""
 
-#: src/SUMMARY.md:293
+#: src/SUMMARY.md:293 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr ""
 
-#: src/SUMMARY.md:294
+#: src/SUMMARY.md:294 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr ""
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md:295 src/async/pitfalls/cancellation.md:1
 #, fuzzy
 msgid "Cancellation"
-msgstr ""
+msgstr "Переводы"
 
-#: src/SUMMARY.md:298
+#: src/SUMMARY.md:298 src/exercises/concurrency/chat-app.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:113
 msgid "Broadcast Chat Application"
 msgstr ""
 
@@ -948,7 +966,7 @@ msgstr ""
 msgid "Final Words"
 msgstr ""
 
-#: src/SUMMARY.md:305
+#: src/SUMMARY.md:305 src/thanks.md:1
 msgid "Thanks!"
 msgstr ""
 
@@ -956,11 +974,11 @@ msgstr ""
 msgid "Other Resources"
 msgstr ""
 
-#: src/SUMMARY.md:307
+#: src/SUMMARY.md:307 src/credits.md:1
 msgid "Credits"
 msgstr ""
 
-#: src/SUMMARY.md:310
+#: src/SUMMARY.md:310 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr ""
 
@@ -992,7 +1010,7 @@ msgstr ""
 msgid "Bare Metal Rust Morning"
 msgstr ""
 
-#: src/SUMMARY.md:322
+#: src/SUMMARY.md:322 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr ""
 
@@ -1004,12 +1022,11 @@ msgstr ""
 msgid "Concurrency Afternoon"
 msgstr ""
 
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Добро пожаловать в Comprehensive Rust 🦀"
-
 #: src/welcome.md:3
-msgid "[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)"
+msgid ""
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)"
 msgstr ""
 
 #: src/welcome.md:3
@@ -1018,8 +1035,12 @@ msgstr ""
 
 #: src/welcome.md:3
 msgid ""
-"[![Build workflow](https://img.shields.io/github/actions/workflow/status/google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)"
+"[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
+"google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors)"
 msgstr ""
 
 #: src/welcome.md:4
@@ -1028,8 +1049,11 @@ msgstr ""
 
 #: src/welcome.md:4
 msgid ""
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
+"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"comprehensive-rust?style=flat-square)](https://github.com/google/"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
 #: src/welcome.md:5
@@ -1037,337 +1061,150 @@ msgid "GitHub stars"
 msgstr ""
 
 #: src/welcome.md:5
-msgid "[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-rust?style=flat-square)](https://github.com/google/comprehensive-rust/stargazers)"
+msgid ""
+"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
+"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
+"stargazers)"
 msgstr ""
 
 #: src/welcome.md:7
 msgid ""
-"This is a three day Rust course developed by the Android team. The course covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like generics\n"
-"and error handling. It also includes Android-specific content on the last day."
+"This is a three day Rust course developed by the Android team. The course "
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
-"Это трехдневный курс по языку Rust, разработанный командой Android. Курс\n"
-"охватывает весь спектр Rust, от базового синтаксиса до сложных тем, таких как обобщения (generics)\n"
-"и обработка ошибок. Последний день курса также затрагивает вопросы разработки для Android."
+"Это трехдневный курс по языку Rust, разработанный командой Android. Курс "
+"охватывает весь спектр Rust, от базового синтаксиса до сложных тем, таких "
+"как обобщения (generics) и обработка ошибок. Последний день курса также "
+"затрагивает вопросы разработки для Android."
 
 #: src/welcome.md:11
 msgid ""
-"The goal of the course is to teach you Rust. We assume you don't know anything\n"
-"about Rust and hope to:"
+"The goal of the course is to teach you Rust. We assume you don't know "
+"anything about Rust and hope to:"
 msgstr ""
-"Цель курса --- научить вас языку Rust. Мы предполагаем, что вы ничего не знаете\n"
-"о Rust и надеемся:"
+"Цель курса --- научить вас языку Rust. Мы предполагаем, что вы ничего не "
+"знаете о Rust и надеемся:"
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
+msgstr "Дать достаточно хорошее представление о синтаксисе и семантике Rust."
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
 msgstr ""
-"* Дать достаточно хорошее представление о синтаксисе и семантике Rust.\n"
-"* Научить работать с существующим кодом и писать новые программы на Rust.\n"
-"* Показать распространённые идиомы языка Rust."
+"Научить работать с существующим кодом и писать новые программы на Rust."
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
+msgstr "Показать распространённые идиомы языка Rust."
 
 #: src/welcome.md:18
 msgid ""
-"The first three days show you the fundamentals of Rust. Following this, you're\n"
-"invited to dive into one or more specialized topics:"
+"The first three days show you the fundamentals of Rust. Following this, "
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
-"Первые три дня познакомят вас с основами Rust. После этого вам \n"
-"предлагается углубиться в одну или несколько специализированных тем:"
+"Первые три дня познакомят вас с основами Rust. После этого вам  предлагается "
+"углубиться в одну или несколько специализированных тем:"
 
 #: src/welcome.md:21
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a full day class on using Rust for bare-metal\n"
-"  (embedded) development. Both microcontrollers and application processors are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a full day class on concurrency in Rust. We\n"
-"  cover both classical concurrency (preemptively scheduling using threads and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"* [Android](android.md): рассчитанный на полдня курс по использованию Rust для разработки на\n"
-"платформе Android (AOSP).\n"
-"Сюда входит взаимодействие с C, C++ и Java.\n"
-"* [Bare-metal](bare-metal.md): однодневное занятие по использованию Rust для низкоуровневой\n"
-"(embedded) разработки, охватывающее как микроконтроллеры, так и обычные процессоры.\n"
-"* [Concurrency](concurrency.md): полный день занятий по изучению многозадачности в Rust.\n"
-"Мы рассмотрим как классический подход, использующий потоки и мьютексы,\n"
-"так и асинхронный подход с использованием фьючерсов (future)."
+"[Android](android.md): рассчитанный на полдня курс по использованию Rust для "
+"разработки на платформе Android (AOSP). Сюда входит взаимодействие с C, C++ "
+"и Java."
+
+#: src/welcome.md:23
+msgid ""
+"[Bare-metal](bare-metal.md): a full day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+"[Bare-metal](bare-metal.md): однодневное занятие по использованию Rust для "
+"низкоуровневой (embedded) разработки, охватывающее как микроконтроллеры, так "
+"и обычные процессоры."
+
+#: src/welcome.md:26
+msgid ""
+"[Concurrency](concurrency.md): a full day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
+msgstr ""
+"[Concurrency](concurrency.md): полный день занятий по изучению "
+"многозадачности в Rust. Мы рассмотрим как классический подход, использующий "
+"потоки и мьютексы, так и асинхронный подход с использованием фьючерсов "
+"(future)."
 
 #: src/welcome.md:32
-msgid "## Non-Goals"
-msgstr "## За рамками курса"
+msgid "Non-Goals"
+msgstr "За рамками курса"
 
 #: src/welcome.md:34
 msgid ""
-"Rust is a large language and we won't be able to cover all of it in a few days.\n"
-"Some non-goals of this course are:"
+"Rust is a large language and we won't be able to cover all of it in a few "
+"days. Some non-goals of this course are:"
 msgstr ""
-"Rust --- это объёмный язык, и мы не сможем охватить его целиком за несколько дней.\n"
-"Темы, выходящие за рамки курса:"
+"Rust --- это объёмный язык, и мы не сможем охватить его целиком за несколько "
+"дней. Темы, выходящие за рамки курса:"
 
 #: src/welcome.md:37
 msgid ""
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
-"* Написание макросов, см. [Глава 19.5 в The Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) и [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
+"Написание макросов, см. [Глава 19.5 в The Rust Book](https://doc.rust-lang."
+"org/book/ch19-06-macros.html) и [Rust by Example](https://doc.rust-lang.org/"
+"rust-by-example/macros.html)."
 
 #: src/welcome.md:41
-msgid "## Assumptions"
-msgstr "## Предположения"
+msgid "Assumptions"
+msgstr "Предположения"
 
 #: src/welcome.md:43
 msgid ""
-"The course assumes that you already know how to program. Rust is a statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to better\n"
-"explain or contrast the Rust approach."
+"The course assumes that you already know how to program. Rust is a "
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
-"Предполагается, что вы уже умеете программировать. Rust --- это\n"
-"статически типизированный язык, и иногда мы будем сравнивать его с C и C++, чтобы\n"
-"лучше объяснить или подчеркнуть разницу в подходах к написанию кода на Rust."
+"Предполагается, что вы уже умеете программировать. Rust --- это статически "
+"типизированный язык, и иногда мы будем сравнивать его с C и C++, чтобы лучше "
+"объяснить или подчеркнуть разницу в подходах к написанию кода на Rust."
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically typed language such as Python or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
-"Если вы знаете, как программировать на языке с динамической типизацией,\n"
+"Если вы знаете, как программировать на языке с динамической типизацией, "
 "таком как Python или JavaScript, вы сможете успешно пройти этот курс."
-
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/scalar-types.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/references.md:21
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/methods.md:32 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:100
-#: src/structs.md:29 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums.md:32
-#: src/enums/variant-payloads.md:33 src/enums/sizes.md:27 src/methods.md:28
-#: src/methods/receiver.md:22 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:21
-#: src/control-flow/while-let-expressions.md:24
-#: src/control-flow/for-expressions.md:23
-#: src/control-flow/loop-expressions.md:25
-#: src/control-flow/match-expressions.md:26 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:42 src/exercises/day-2/afternoon.md:5
-#: src/generics/data-types.md:19 src/generics/methods.md:23
-#: src/traits/trait-objects.md:70 src/traits/default-methods.md:30
-#: src/traits/trait-bounds.md:33 src/traits/impl-trait.md:21
-#: src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/drop.md:32 src/traits/default.md:38
-#: src/traits/operators.md:24 src/traits/closures.md:32
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:46
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:25 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:12
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/android/morning.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:37 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/entry-point.md:75
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart.md:53 src/bare-metal/aps/uart/traits.md:22
-#: src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:49 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:44 src/bare-metal/aps/exceptions.md:62
-#: src/bare-metal/aps/other-projects.md:15
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/scoped-threads.md:35 src/concurrency/channels.md:25
-#: src/concurrency/channels/bounded.md:29 src/concurrency/send-sync.md:18
-#: src/concurrency/send-sync/send.md:11 src/concurrency/send-sync/sync.md:12
-#: src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21
-#: src/exercises/concurrency/morning.md:10 src/async/async-await.md:23
-#: src/async/futures.md:30 src/async/runtimes.md:18
-#: src/async/runtimes/tokio.md:31 src/async/tasks.md:50
-#: src/async/channels.md:33 src/async/control-flow/join.md:34
-#: src/async/control-flow/select.md:60
-#: src/async/pitfalls/blocking-executor.md:27 src/async/pitfalls/pin.md:66
-#: src/async/pitfalls/cancellation.md:70
-#: src/exercises/concurrency/afternoon.md:11
-#: src/exercises/concurrency/dining-philosophers-async.md:75
-msgid "<details>"
-msgstr ""
 
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
-"information to the slides. This could be key points which the instructor should\n"
-"cover as well as answers to typical questions which come up in class."
+"This is an example of a _speaker note_. We will use these to add additional "
+"information to the slides. This could be key points which the instructor "
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
-"Это пример _заметок для преподавателя_. Мы будем использовать их для добавления\n"
-"дополнительной информации к слайдам. Это могут быть ключевые моменты, которые преподаватель\n"
-"должен осветить, а также ответы на типичные вопросы, которые возникают в ходе прохождения курса."
-
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:46 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
-#: src/why-rust/modern.md:66 src/basic-syntax/scalar-types.md:43
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:29
-#: src/basic-syntax/slices.md:36 src/basic-syntax/string-slices.md:44
-#: src/basic-syntax/functions.md:41 src/basic-syntax/rustdoc.md:33
-#: src/basic-syntax/methods.md:45 src/basic-syntax/functions-interlude.md:30
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:104
-#: src/structs.md:42 src/structs/tuple-structs.md:44
-#: src/structs/field-shorthand.md:72 src/enums.md:42
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:28 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:29
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:46
-#: src/control-flow/if-expressions.md:37
-#: src/control-flow/if-let-expressions.md:41
-#: src/control-flow/while-let-expressions.md:29
-#: src/control-flow/for-expressions.md:30
-#: src/control-flow/loop-expressions.md:32
-#: src/control-flow/match-expressions.md:33 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:42 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:71 src/exercises/day-2/afternoon.md:11
-#: src/generics/data-types.md:25 src/generics/methods.md:31
-#: src/traits/trait-objects.md:83 src/traits/default-methods.md:60
-#: src/traits/trait-bounds.md:50 src/traits/impl-trait.md:44
-#: src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/drop.md:42 src/traits/default.md:47
-#: src/traits/operators.md:40 src/traits/closures.md:63
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:53
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:43 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:18
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/android/morning.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:49
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/entry-point.md:101
-#: src/bare-metal/aps/inline-assembly.md:58 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:55 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:49 src/bare-metal/aps/exceptions.md:75
-#: src/bare-metal/aps/other-projects.md:29
-#: src/bare-metal/useful-crates/zerocopy.md:53
-#: src/bare-metal/useful-crates/aarch64-paging.md:33
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
-#: src/bare-metal/useful-crates/tinyvec.md:26
-#: src/bare-metal/useful-crates/spin.md:30 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/scoped-threads.md:40 src/concurrency/channels.md:32
-#: src/concurrency/channels/bounded.md:35 src/concurrency/send-sync.md:23
-#: src/concurrency/send-sync/send.md:16 src/concurrency/send-sync/sync.md:18
-#: src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56
-#: src/exercises/concurrency/morning.md:16 src/async/async-await.md:48
-#: src/async/futures.md:45 src/async/runtimes.md:29
-#: src/async/runtimes/tokio.md:49 src/async/tasks.md:63
-#: src/async/channels.md:49 src/async/control-flow/join.md:50
-#: src/async/control-flow/select.md:79
-#: src/async/pitfalls/blocking-executor.md:50 src/async/pitfalls/pin.md:112
-#: src/async/pitfalls/async-traits.md:63 src/async/pitfalls/cancellation.md:114
-#: src/exercises/concurrency/afternoon.md:17
-#: src/exercises/concurrency/dining-philosophers-async.md:79
-msgid "</details>"
-msgstr ""
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# Проведение курса"
+"Это пример _заметок для преподавателя_. Мы будем использовать их для "
+"добавления дополнительной информации к слайдам. Это могут быть ключевые "
+"моменты, которые преподаватель должен осветить, а также ответы на типичные "
+"вопросы, которые возникают в ходе прохождения курса."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> Эта страница предназначена для преподавателя курса."
+msgid "This page is for the course instructor."
+msgstr "Эта страница предназначена для преподавателя курса."
 
 #: src/running-the-course.md:5
 msgid ""
-"Here is a bit of background information about how we've been running the course\n"
-"internally at Google."
-msgstr "Вот краткая справочная информация о том, как мы проводили курс внутри компании Google."
+"Here is a bit of background information about how we've been running the "
+"course internally at Google."
+msgstr ""
+"Вот краткая справочная информация о том, как мы проводили курс внутри "
+"компании Google."
 
 #: src/running-the-course.md:8
 msgid "Before you run the course, you will want to:"
@@ -1375,190 +1212,217 @@ msgstr "Перед проведением курса желательно:"
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker notes\n"
-"   to help highlight the key points (please help us by contributing more speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Decide on the dates. Since the course takes at least three full days, we recommend that you\n"
-"   schedule the days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-25 people. That's small enough that people are comfortable\n"
-"   asking questions --- it's also small enough that one instructor will have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself and for the\n"
-"   students: you will all need to be able to sit and work with your laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups.\n"
-"   We typically spend 30-45 minutes on exercises in the morning and in the afternoon (including time to review the solutions).\n"
-"   Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. When\n"
-"   you see that several people have the same problem, call it out to the class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. Ознакомиться с материалами курса. Мы добавили заметки для преподавателя на некоторых страницах,\n"
-"чтобы выделить ключевые моменты (пожалуйста, помогайте нам, добавляя свои заметки для преподавателей!).\n"
-"Убедитесь в том, что открыли заметки для преподавателя во всплывающем окне (нажмите на ссылку с маленькой стрелкой рядом\n"
-"с ”Заметки для преподавателя”). У вас откроется отдельное окно с заметками для преподавателя,\n"
-"в то время как основное окно вы можете демонстрировать классу.\n"
-"\n"
-"1. Определиться с датами. Поскольку курс требует как минимум три дня, мы рекомендуем вам запланировать три дня на протяжении двух недель.\n"
-"По нашему опыту, слушатели предпочитают иметь перерывы в течение курса, так как это помогает им лучше осмыслить информацию.\n"
-"\n"
-"1. Найти помещение, достаточно просторное для очного участия.\n"
-"Мы рекомендуем, чтобы в классе было 15-20 человек.\n"
-"Это довольно немного для того, чтобы людям было комфортно задавать вопросы,\n"
-"а у преподавателя было время на то, чтобы на них отвечать.\n"
-"\n"
-"1. В день занятия приходите в аудиторию немного раньше, чтобы всё подготовить.\n"
-"Мы рекомендуем показывать слайды используя `mdbook serve`, запущенного на вашем ноутбуке (см. [installation instructions][3]).\n"
-"Это обеспечивает оптимальную производительность без задержек при смене страниц.\n"
-"Использование ноутбука также позволит вам исправлять опечатки по мере их обнаружения вами или участниками курса.\n"
-"\n"
-"1. Позвольте участникам решать упражнения самостоятельно или в небольших группах.\n"
-"Обычно мы уделяем упражнениям по 30-45 минут утром и во второй половине дня (включая время на разбор решений).\n"
-"Обязательно спросите, не испытывают ли слушатели трудности и нужно ли с чем-то помочь.\n"
-"Когда вы видите, что у нескольких человек одна и та же проблема, сообщите об этом классу и предложите решение,\n"
-"например, показав, как найти нужную информацию в стандартной библиотеке."
+"Ознакомиться с материалами курса. Мы добавили заметки для преподавателя на "
+"некоторых страницах, чтобы выделить ключевые моменты (пожалуйста, помогайте "
+"нам, добавляя свои заметки для преподавателей!). Убедитесь в том, что "
+"открыли заметки для преподавателя во всплывающем окне (нажмите на ссылку с "
+"маленькой стрелкой рядом с ”Заметки для преподавателя”). У вас откроется "
+"отдельное окно с заметками для преподавателя, в то время как основное окно "
+"вы можете демонстрировать классу."
+
+#: src/running-the-course.md:16
+msgid ""
+"Decide on the dates. Since the course takes at least three full days, we "
+"recommend that you schedule the days over two weeks. Course participants "
+"have said that they find it helpful to have a gap in the course since it "
+"helps them process all the information we give them."
+msgstr ""
+"Определиться с датами. Поскольку курс требует как минимум три дня, мы "
+"рекомендуем вам запланировать три дня на протяжении двух недель. По нашему "
+"опыту, слушатели предпочитают иметь перерывы в течение курса, так как это "
+"помогает им лучше осмыслить информацию."
+
+#: src/running-the-course.md:21
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-25 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"Найти помещение, достаточно просторное для очного участия. Мы рекомендуем, "
+"чтобы в классе было 15-20 человек. Это довольно немного для того, чтобы "
+"людям было комфортно задавать вопросы, а у преподавателя было время на то, "
+"чтобы на них отвечать."
+
+#: src/running-the-course.md:29
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"В день занятия приходите в аудиторию немного раньше, чтобы всё подготовить. "
+"Мы рекомендуем показывать слайды используя `mdbook serve`, запущенного на "
+"вашем ноутбуке (см. [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). Это обеспечивает оптимальную "
+"производительность без задержек при смене страниц. Использование ноутбука "
+"также позволит вам исправлять опечатки по мере их обнаружения вами или "
+"участниками курса."
+
+#: src/running-the-course.md:35
+msgid ""
+"Let people solve the exercises by themselves or in small groups. We "
+"typically spend 30-45 minutes on exercises in the morning and in the "
+"afternoon (including time to review the solutions). Make sure to ask people "
+"if they're stuck or if there is anything you can help with. When you see "
+"that several people have the same problem, call it out to the class and "
+"offer a solution, e.g., by showing people where to find the relevant "
+"information in the standard library."
+msgstr ""
+"Позвольте участникам решать упражнения самостоятельно или в небольших "
+"группах. Обычно мы уделяем упражнениям по 30-45 минут утром и во второй "
+"половине дня (включая время на разбор решений). Обязательно спросите, не "
+"испытывают ли слушатели трудности и нужно ли с чем-то помочь. Когда вы "
+"видите, что у нескольких человек одна и та же проблема, сообщите об этом "
+"классу и предложите решение, например, показав, как найти нужную информацию "
+"в стандартной библиотеке."
 
 #: src/running-the-course.md:43
 msgid ""
-"That is all, good luck running the course! We hope it will be as much fun for\n"
-"you as it has been for us!"
-msgstr "На этом всё, удачи в прохождении курса! Мы надеемся, что вам будет так же весело, как и нам!"
+"That is all, good luck running the course! We hope it will be as much fun "
+"for you as it has been for us!"
+msgstr ""
+"На этом всё, удачи в прохождении курса! Мы надеемся, что вам будет так же "
+"весело, как и нам!"
 
 #: src/running-the-course.md:46
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"Пожалуйста, [оставьте отзыв][1],\n"
-"чтобы мы могли продолжать совершенствовать курс.\n"
-"Мы хотели бы услышать, что было хорошо и что можно сделать лучше.\n"
-"Ваши студенты также могут [присылать нам свои отзывы][2]!"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# Структура курса"
+"Пожалуйста, [оставьте отзыв](https://github.com/google/comprehensive-rust/"
+"discussions/86), чтобы мы могли продолжать совершенствовать курс. Мы хотели "
+"бы услышать, что было хорошо и что можно сделать лучше. Ваши студенты также "
+"могут [присылать нам свои отзывы](https://github.com/google/comprehensive-"
+"rust/discussions/100)!"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "Курс проходит в быстром темпе и охватывает много вопросов:"
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "День 1: Базовый Rust, владение и анализатор заимствований."
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
 msgstr ""
-"* День 1: Базовый Rust, владение и анализатор заимствований.\n"
-"* День 2: Составные типы данных, шаблоны (patterns), стандартная библиотека.\n"
-"* День 3: Типажи (traits) и обобщения (generics), обработка ошибок, тестирование, небезопасный Rust."
+"День 2: Составные типы данных, шаблоны (patterns), стандартная библиотека."
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr ""
+"День 3: Типажи (traits) и обобщения (generics), обработка ошибок, "
+"тестирование, небезопасный Rust."
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
-msgstr "## Глубокое погружение"
+msgid "Deep Dives"
+msgstr "Глубокое погружение"
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
 msgstr ""
-"В дополнение к 3-дневному курсу по основам Rust,\n"
-"мы рассмотрим ещё несколько специализированных тем:"
-
-#: src/running-the-course/course-structure.md:16
-msgid "### Android"
-msgstr ""
+"В дополнение к 3-дневному курсу по основам Rust, мы рассмотрим ещё несколько "
+"специализированных тем:"
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
-"The [Android Deep Dive](../android.md) is a half-day course on using Rust for\n"
-"Android platform development. This includes interoperability with C, C++, and\n"
-"Java."
+"The [Android Deep Dive](../android.md) is a half-day course on using Rust "
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
-"[Android Deep Dive](../android.md) --- это полудневный курс по использованию Rust\n"
-"для разработки на платформе Android. Сюда входит взаимодействие с C, C++ и Java."
+"[Android Deep Dive](../android.md) --- это полудневный курс по использованию "
+"Rust для разработки на платформе Android. Сюда входит взаимодействие с C, C+"
+"+ и Java."
 
 #: src/running-the-course/course-structure.md:22
 msgid ""
-"You will need an [AOSP checkout][1]. Make a checkout of the [course\n"
-"repository][2] on the same machine and move the `src/android/` directory into\n"
-"the root of your AOSP checkout. This will ensure that the Android build system\n"
-"sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"Вам потребуется [AOSP][1]. Загрузите [репозиторий курса][2]\n"
-"на тот же компьютер, что и курс и переместите каталог `src/android/` в\n"
-"корневой каталог вашего AOSP.\n"
-"Это гарантирует, что система сборки Android увидит файлы `Android.bp` в `src/android/`."
+"Вам потребуется [AOSP](https://source.android.com/docs/setup/download/"
+"downloading). Загрузите [репозиторий курса](https://github.com/google/"
+"comprehensive-rust) на тот же компьютер, что и курс и переместите каталог "
+"`src/android/` в корневой каталог вашего AOSP. Это гарантирует, что система "
+"сборки Android увидит файлы `Android.bp` в `src/android/`."
 
 #: src/running-the-course/course-structure.md:27
 msgid ""
-"Ensure that `adb sync` works with your emulator or real device and pre-build all\n"
-"Android examples using `src/android/build_all.sh`. Read the script to see the\n"
-"commands it runs and make sure they work when you run them by hand."
+"Ensure that `adb sync` works with your emulator or real device and pre-build "
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"Убедитесь, что `adb sync` работает с вашим эмулятором или реальным устройством,\n"
-"и предварительно соберите все примеры Android, используя `src/android/build_all.sh`.\n"
-"Прочтите скрипт, чтобы увидеть команды, которые он запускает,\n"
-"и убедитесь, что они работают, когда вы запускаете их вручную."
+"Убедитесь, что `adb sync` работает с вашим эмулятором или реальным "
+"устройством, и предварительно соберите все примеры Android, используя `src/"
+"android/build_all.sh`. Прочтите скрипт, чтобы увидеть команды, которые он "
+"запускает, и убедитесь, что они работают, когда вы запускаете их вручную."
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
+msgid "Bare-Metal"
 msgstr ""
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
-"The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
-"[Bare-Metal Deep Dive](../bare-metal.md): занятие на полный день по использованию Rust для\n"
-"низкоуровневой (embedded) разработки. Рассматриваются как микроконтроллеры, так и прикладные процессоры."
+"[Bare-Metal Deep Dive](../bare-metal.md): занятие на полный день по "
+"использованию Rust для низкоуровневой (embedded) разработки. Рассматриваются "
+"как микроконтроллеры, так и прикладные процессоры."
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
-"Что касается части микроконтроллеров, то вам нужно будет заранее приобрести плату разработки [BBC\n"
-"micro:bit](https://microbit.org/) v2. Всем нужно будет установить несколько пакетов, как описано на [странице приветствия](../bare-metal.md)."
+"Что касается части микроконтроллеров, то вам нужно будет заранее приобрести "
+"плату разработки [BBC micro:bit](https://microbit.org/) v2. Всем нужно будет "
+"установить несколько пакетов, как описано на [странице приветствия](../bare-"
+"metal.md)."
 
 #: src/running-the-course/course-structure.md:45
-msgid "### Concurrency"
-msgstr "### Конкурентность"
+msgid "Concurrency"
+msgstr "Конкурентность"
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
-"The [Concurrency Deep Dive](../concurrency.md) is a full day class on classical\n"
-"as well as `async`/`await` concurrency."
+"The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
+"classical as well as `async`/`await` concurrency."
 msgstr ""
-"[Concurrency Deep Dive](../concurrency.md) это целый день занятий по классической,\n"
-"а также `async`/`await` конкурентности."
+"[Concurrency Deep Dive](../concurrency.md) это целый день занятий по "
+"классической, а также `async`/`await` конкурентности."
 
 #: src/running-the-course/course-structure.md:50
 msgid ""
-"You will need a fresh crate set up and the dependencies downloaded and ready to\n"
-"go. You can then copy/paste the examples into `src/main.rs` to experiment with\n"
-"them:"
+"You will need a fresh crate set up and the dependencies downloaded and ready "
+"to go. You can then copy/paste the examples into `src/main.rs` to experiment "
+"with them:"
 msgstr ""
-"Вам понадобится настроенный новый крейт, а также загруженные зависимости, готовые к работе.\n"
-"Затем вы можете скопировать примеры в `src/main.rs`, чтобы поэкспериментировать с ними:"
+"Вам понадобится настроенный новый крейт, а также загруженные зависимости, "
+"готовые к работе. Затем вы можете скопировать примеры в `src/main.rs`, чтобы "
+"поэкспериментировать с ними:"
 
 #: src/running-the-course/course-structure.md:54
 msgid ""
@@ -1571,137 +1435,190 @@ msgid ""
 msgstr ""
 
 #: src/running-the-course/course-structure.md:61
-msgid "## Format"
-msgstr "## Формат"
+msgid "Format"
+msgstr "Формат"
 
 #: src/running-the-course/course-structure.md:63
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
-"Курс задуман весьма интерактивным, и мы рекомендуем,\n"
-"чтобы вопросы содействовали изучению Rust!"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# Горячие клавиши"
+"Курс задуман весьма интерактивным, и мы рекомендуем, чтобы вопросы "
+"содействовали изучению Rust!"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "В mdBook есть несколько полезных сочетаний клавиш:"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Стрелка-влево</kbd>: Переход на предыдущую страницу.\n"
-"* <kbd>Стрелка-вправо</kbd>: Переход на следующую страницу.\n"
-"* <kbd>Ctrl + Enter</kbd>: Выполнение примера кода, находящегося в фокусе.\n"
-"* <kbd>s</kbd>: Активировать панель поиска."
+msgid "Arrow-Left"
+msgstr "Стрелка-влево"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# Переводы"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr ": Переход на предыдущую страницу."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Стрелка-вправо"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr ": Переход на следующую страницу."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr ": Выполнение примера кода, находящегося в фокусе."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr ": Активировать панель поиска."
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
-msgstr ""
-"Курс был переведен на другие языки группой замечательных\n"
-"волонтёров:"
+msgstr "Курс был переведен на другие языки группой замечательных волонтёров:"
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
 msgstr ""
-"* [Бразильский португальский][pt-BR] от [@rastringer] и [@hugojacob].\n"
-"* [Корейский][ko] от [@keispace], [@jiyongp] и [@jooyunghan]."
+"[Бразильский португальский](https://google.github.io/comprehensive-rust/pt-"
+"BR/) от [@rastringer](https://github.com/rastringer) и [@hugojacob](https://"
+"github.com/hugojacob)."
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
+msgstr ""
+"[Корейский](https://google.github.io/comprehensive-rust/ko/) от [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) и "
+"[@jooyunghan](https://github.com/jooyunghan)."
 
 #: src/running-the-course/translations.md:9
-msgid "Use the language picker in the top-right corner to switch between languages."
-msgstr "Используйте кнопку выбора языка в правом верхнем углу для переключения между языками."
+msgid ""
+"Use the language picker in the top-right corner to switch between languages."
+msgstr ""
+"Используйте кнопку выбора языка в правом верхнем углу для переключения между "
+"языками."
 
 #: src/running-the-course/translations.md:11
-#, fuzzy
-msgid "## Incomplete Translations"
+msgid "Incomplete Translations"
 msgstr ""
 
 #: src/running-the-course/translations.md:13
 msgid ""
-"There is a large number of in-progress translations. We link to the most\n"
+"There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
 
 #: src/running-the-course/translations.md:16
 msgid ""
-"* [Bengali][bn] by [@raselmandol].\n"
-"* [French][fr] by [@KookaS] and [@vcaen].\n"
-"* [German][de] by [@Throvn] and [@ronaldfw].\n"
-"* [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105]."
+"[Bengali](https://google.github.io/comprehensive-rust/bn/) by [@raselmandol]"
+"(https://github.com/raselmandol)."
+msgstr ""
+
+#: src/running-the-course/translations.md:17
+msgid ""
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+msgstr ""
+
+#: src/running-the-course/translations.md:18
+msgid ""
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+msgstr ""
+
+#: src/running-the-course/translations.md:19
+msgid ""
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
 msgstr ""
 
 #: src/running-the-course/translations.md:21
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"Если вы хотите помочь в этом, пожалуйста, ознакомьтесь с [our instructions] о том, как приступить к работе.\n"
-"Переводы координируются с помощью [issue tracker]."
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# Использование Cargo"
+"Если вы хотите помочь в этом, пожалуйста, ознакомьтесь с [our instructions]"
+"(https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) о "
+"том, как приступить к работе. Переводы координируются с помощью [issue "
+"tracker](https://github.com/google/comprehensive-rust/issues/282)."
 
 #: src/cargo.md:3
 msgid ""
-"When you start reading about Rust, you will soon meet [Cargo](https://doc.rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want to\n"
-"give a brief overview of what Cargo is and how it fits into the wider ecosystem\n"
-"and how it fits into this training."
+"When you start reading about Rust, you will soon meet [Cargo](https://doc."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
-"Когда вы начнете читать о Rust, то вскоре познакомитесь с [Cargo](https://doc.rust-lang.org/cargo/),\n"
-"стандартным инструментом, используемым в экосистеме Rust для создания и запуска приложений.\n"
-"Здесь мы хотим дать краткий обзор того, что такое Cargo и как он вписывается в более широкую экосистему\n"
-"и в этот курс."
+"Когда вы начнете читать о Rust, то вскоре познакомитесь с [Cargo](https://"
+"doc.rust-lang.org/cargo/), стандартным инструментом, используемым в "
+"экосистеме Rust для создания и запуска приложений. Здесь мы хотим дать "
+"краткий обзор того, что такое Cargo и как он вписывается в более широкую "
+"экосистему и в этот курс."
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## Установка"
+msgid "Installation"
+msgstr "Установка"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (рекомендуется)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (рекомендуется)"
 
 #: src/cargo.md:12
-msgid "You can follow the instructions to install cargo and rust compiler, among other standard ecosystem tools with the [rustup][3] tool, which is maintained by the Rust Foundation."
+msgid ""
+"You can follow the instructions to install cargo and rust compiler, among "
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
-"Вы можете следовать инструкции для установки Cargo, компилятора Rust и\n"
-"других стандартных инструментов экосистемы с помощью инструмента\n"
-"[rustup][3], который поддерживается Rust Foundation."
+"Вы можете следовать инструкции для установки Cargo, компилятора Rust и "
+"других стандартных инструментов экосистемы с помощью инструмента [rustup]"
+"(https://rust-analyzer.github.io/), который поддерживается Rust Foundation."
 
 #: src/cargo.md:14
-msgid "Along with cargo and rustc, Rustup will install itself as a command line utility that you can use to install/switch toolchains, setup cross compilation, etc."
+msgid ""
+"Along with cargo and rustc, Rustup will install itself as a command line "
+"utility that you can use to install/switch toolchains, setup cross "
+"compilation, etc."
 msgstr ""
-"Наряду с Cargo и rustc, Rustup будет установлен как утилита командной\n"
-"строки, которую вы можете использовать для установки/переключения наборов\n"
+"Наряду с Cargo и rustc, Rustup будет установлен как утилита командной "
+"строки, которую вы можете использовать для установки/переключения наборов "
 "инструментов, настройки кросс-компиляции и т. д."
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### Менеджеры пакетов"
+msgid "Package Managers"
+msgstr "Менеджеры пакетов"
 
 #: src/cargo.md:18
-msgid "#### Debian"
+msgid "Debian"
 msgstr ""
 
 #: src/cargo.md:20
-msgid "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust formatter][6] with"
-msgstr "В Debian/Ubuntu вы можете установить Cargo, исходный код Rust и [Rust formatter][6] с помощью"
+msgid ""
+"On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
+"formatter](https://github.com/rust-lang/rustfmt) with"
+msgstr ""
+"В Debian/Ubuntu вы можете установить Cargo, исходный код Rust и [Rust "
+"formatter](https://github.com/rust-lang/rustfmt) с помощью"
 
 #: src/cargo.md:22
 msgid ""
@@ -1712,57 +1629,73 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"Это позволит [rust-analyzer][1] переходить к определениям в исходном коде.\n"
-"Мы предлагаем использовать [VS Code][2] для редактирования кода (поддерживается любой совместимый с LSP редактор)."
+"Это позволит \\[rust-analyzer\\]\\[1\\] переходить к определениям в исходном "
+"коде. Мы предлагаем использовать [VS Code](https://code.visualstudio.com/) "
+"для редактирования кода (поддерживается любой совместимый с LSP редактор)."
 
 #: src/cargo.md:29
-msgid "Some folks also like to use the [JetBrains][4] family of IDEs, which do their own analysis but have their own tradeoffs. If you prefer them, you can install the [Rust Plugin][5]. Please take note that as of January 2023 debugging only works on the CLion version of the JetBrains IDEA suite."
+msgid ""
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"Некоторым также нравится использовать семейство IDE [JetBrains][4], которые\n"
-"выполняют собственный анализ, но имеют свои особенности. Если вы\n"
-"предпочитаете их, вы можете установить [Rust Plugin][5]. Обратите внимание,\n"
-"что по состоянию на январь 2023 года отладка работает только в CLion."
+"Некоторым также нравится использовать семейство IDE [JetBrains](https://www."
+"jetbrains.com/clion/), которые выполняют собственный анализ, но имеют свои "
+"особенности. Если вы предпочитаете их, вы можете установить [Rust Plugin]"
+"(https://www.jetbrains.com/rust/). Обратите внимание, что по состоянию на "
+"январь 2023 года отладка работает только в CLion."
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# Экосистема Rust"
+msgid "The Rust Ecosystem"
+msgstr "Экосистема Rust"
 
 #: src/cargo/rust-ecosystem.md:3
-msgid "The Rust ecosystem consists of a number of tools, of which the main ones are:"
-msgstr "Экосистема Rust состоит из ряда инструментов, основными из которых являются:"
+msgid ""
+"The Rust ecosystem consists of a number of tools, of which the main ones are:"
+msgstr ""
+"Экосистема Rust состоит из ряда инструментов, основными из которых являются:"
 
 #: src/cargo/rust-ecosystem.md:5
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and `rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc`: компилятор Rust, который превращает файлы `.rs` в исполняемые файлы\n"
-"и другие промежуточные форматы.\n"
-"\n"
-"* `cargo`: менеджер зависимостей Rust и инструмент сборки. Cargo знает, как\n"
-"загрузить зависимости, размещённые на <https://crates.io>, и передать их\n"
-"`rustc` при сборке вашего проекта. Cargo также поставляется со\n"
-"встроенным иструментом запуска тестов, который используется для выполнения модульных тестов.\n"
-"\n"
-"* `rustup`: программа установки и обновления набора инструментов Rust. Этот\n"
-"инструмент используется для установки и обновления rustc и cargo при выходе новых версий Rust.\n"
-"Кроме того, `rustup` также может загружать документацию стандартной библиотеки.\n"
-"У вас может быть установлено несколько версий Rust одновременно и `rustup`\n"
-"позволит вам переключаться между ними по мере необходимости."
+"`rustc`: компилятор Rust, который превращает файлы `.rs` в исполняемые файлы "
+"и другие промежуточные форматы."
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
+msgstr ""
+"`cargo`: менеджер зависимостей Rust и инструмент сборки. Cargo знает, как "
+"загрузить зависимости, размещённые на <https://crates.io>, и передать их "
+"`rustc` при сборке вашего проекта. Cargo также поставляется со встроенным "
+"иструментом запуска тестов, который используется для выполнения модульных "
+"тестов."
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
+"`rustup`: программа установки и обновления набора инструментов Rust. Этот "
+"инструмент используется для установки и обновления rustc и cargo при выходе "
+"новых версий Rust. Кроме того, `rustup` также может загружать документацию "
+"стандартной библиотеки. У вас может быть установлено несколько версий Rust "
+"одновременно и `rustup` позволит вам переключаться между ними по мере "
+"необходимости."
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1777,92 +1710,142 @@ msgstr "Ключевые моменты:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful and comprehensive tool.  It is capable of many advanced features including but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as [cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* У Rust стремительный график релизов: новая версия выходит каждые шесть недель.\n"
-"Новые версии поддерживают обратную совместимость со старыми версиями ---\n"
-"в дополнение они предоставляют новые функциональные возможности.\n"
-"\n"
-"* Существует три вида релизов: ”stable”, ”beta” и ”nightly”.\n"
-"\n"
-"* Новые функции тестируются на ”nightly”, ”beta” --- это то, что становится\n"
-"”stable” каждые шесть недель.\n"
-"\n"
-"* У Rust также есть [редакции]: текущая редакция --- Rust 2021. Предыдущими\n"
-"редакциями были Rust 2015 и Rust 2018.\n"
-"\n"
-"   * Редакциями позволено вносить обратно--несовместимые изменения в язык.\n"
-"\n"
-"  * Чтобы избежать сбоев, редакцию для своего пакета можно явно указать в файле `Cargo.toml`.\n"
-"\n"
-"  * Чтобы избежать разделения экосистемы, компилятор Rust может смешивать код,\n"
-"написанный для разных редакций.\n"
-"\n"
-"  * Стоит упомянуть, что использование компилятора напрямую, а не через `cargo`, является редким явлением\n"
-"(большинство пользователей никогда этого не делают).\n"
-"\n"
-"  * Cargo сам по себе является чрезвычайно\n"
-"мощным и всеобъемлющим инструментом. Он поддерживает множество дополнительных функций, включая, помимо прочего:\n"
-"      * Структура проекта/пакета\n"
-"      * [workspaces]\n"
-"      * Управление зависимостями для разработки (dev) и времени выполнения (runtime)\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * Он также расширяем с помощью плагинов подкоманд (таких как [cargo clippy]).\n"
-"  * Подробнее читайте в [official Cargo Book]"
+"У Rust стремительный график релизов: новая версия выходит каждые шесть "
+"недель. Новые версии поддерживают обратную совместимость со старыми версиями "
+"--- в дополнение они предоставляют новые функциональные возможности."
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "Существует три вида релизов: ”stable”, ”beta” и ”nightly”."
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr ""
+"Новые функции тестируются на ”nightly”, ”beta” --- это то, что становится "
+"”stable” каждые шесть недель."
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"У Rust также есть \\[редакции\\]: текущая редакция --- Rust 2021. "
+"Предыдущими редакциями были Rust 2015 и Rust 2018."
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "Редакциями позволено вносить обратно--несовместимые изменения в язык."
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"Чтобы избежать сбоев, редакцию для своего пакета можно явно указать в файле "
+"`Cargo.toml`."
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr ""
+"Чтобы избежать разделения экосистемы, компилятор Rust может смешивать код, "
+"написанный для разных редакций."
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+"Стоит упомянуть, что использование компилятора напрямую, а не через `cargo`, "
+"является редким явлением (большинство пользователей никогда этого не делают)."
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+"Cargo сам по себе является чрезвычайно мощным и всеобъемлющим инструментом. "
+"Он поддерживает множество дополнительных функций, включая, помимо прочего:"
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "Структура проекта/пакета"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr ""
+"[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr ""
+"Управление зависимостями для разработки (dev) и времени выполнения (runtime)"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"Он также расширяем с помощью плагинов подкоманд (таких как [cargo clippy]"
+"(https://github.com/rust-lang/rust-clippy))."
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr ""
+"Подробнее читайте в [official Cargo Book](https://doc.rust-lang.org/cargo/)"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# Примеры кода в этом курсе"
+msgid "Code Samples in This Training"
+msgstr "Примеры кода в этом курсе"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through examples\n"
-"which can be executed through your browser. This makes the setup much easier and\n"
-"ensures a consistent experience for everyone."
+"For this training, we will mostly explore the Rust language through examples "
+"which can be executed through your browser. This makes the setup much easier "
+"and ensures a consistent experience for everyone."
 msgstr ""
-"В этом курсе мы в основном будем изучать язык Rust на примерах, которые могут быть выполнены в вашем браузере.\n"
-"Это значительно упрощает настройку и обеспечивает единообразный опыт для всех."
+"В этом курсе мы в основном будем изучать язык Rust на примерах, которые "
+"могут быть выполнены в вашем браузере. Это значительно упрощает настройку и "
+"обеспечивает единообразный опыт для всех."
 
 #: src/cargo/code-samples.md:7
 msgid ""
-"Installing Cargo is still encouraged: it will make it easier for you to do the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how to\n"
-"work with dependencies and for that you need Cargo."
+"Installing Cargo is still encouraged: it will make it easier for you to do "
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
-"Установка Cargo по-прежнему рекомендуется: это облегчит вам выполнение упражнений.\n"
-"В последний день мы выполним более масштабное упражнение, которое покажет вам,\n"
-"как работать с зависимостями, и для этого вам понадобится Cargo."
+"Установка Cargo по-прежнему рекомендуется: это облегчит вам выполнение "
+"упражнений. В последний день мы выполним более масштабное упражнение, "
+"которое покажет вам, как работать с зависимостями, и для этого вам "
+"понадобится Cargo."
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -1878,49 +1861,57 @@ msgid ""
 msgstr ""
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in the\n"
-"text box."
-msgstr "Вы можете использовать <kbd>Ctrl + Enter</kbd> для выполнения кода, когда фокус ввода находится в текстовом поле."
+msgid "You can use "
+msgstr "Вы можете использовать "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
+msgstr " для выполнения кода, когда фокус ввода находится в текстовом поле."
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
-"Большинство примеров кода доступны для редактирования, как показано выше.\n"
+"Большинство примеров кода доступны для редактирования, как показано выше. "
 "Несколько примеров кода недоступны для редактирования по разным причинам:"
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* Встроенный в страницу редактор кода не может запускать модульные тесты.\n"
-"Скопируйте код и откройте его в Rust Playground, чтобы продемонстрировать модульные тесты.\n"
-"\n"
-"* Встроенные в страницу редакторы кода теряют своё состояние в тот момент, когда вы уходите со страницы!\n"
-"Именно по этой причине учащиеся должны выполнять упражнения, используя локальную установку Rust или Rust Playground."
+"Встроенный в страницу редактор кода не может запускать модульные тесты. "
+"Скопируйте код и откройте его в Rust Playground, чтобы продемонстрировать "
+"модульные тесты."
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"Встроенные в страницу редакторы кода теряют своё состояние в тот момент, "
+"когда вы уходите со страницы! Именно по этой причине учащиеся должны "
+"выполнять упражнения, используя локальную установку Rust или Rust Playground."
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# Запуск кода локально с помощью Cargo"
+msgid "Running Code Locally with Cargo"
+msgstr "Запуск кода локально с помощью Cargo"
 
 #: src/cargo/running-locally.md:3
 msgid ""
-"If you want to experiment with the code on your own system, then you will need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"If you want to experiment with the code on your own system, then you will "
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
-"Если вы хотите поэкспериментировать с кодом на своей системе, то вам нужно будет сначала установить Rust.\n"
-"Сделайте это, следуя [инструкциям в The Rust Book][1]. В вашей системе появятся инструменты `rustc` и `cargo`.\n"
-"На момент написания статьи последний стабильный выпуск Rust имеет следующие версии:"
+"Если вы хотите поэкспериментировать с кодом на своей системе, то вам нужно "
+"будет сначала установить Rust. Сделайте это, следуя [инструкциям в The Rust "
+"Book](https://doc.rust-lang.org/book/ch01-01-installation.html). В вашей "
+"системе появятся инструменты `rustc` и `cargo`. На момент написания статьи "
+"последний стабильный выпуск Rust имеет следующие версии:"
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -1934,144 +1925,173 @@ msgstr ""
 
 #: src/cargo/running-locally.md:15
 msgid ""
-"With this in place, follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this in place, follow these steps to build a Rust binary from one of "
+"the examples in this training:"
 msgstr ""
-"После этого выполните следующие шаги, чтобы собрать исполняемый файл\n"
-"на основе одного из примеров в этом курсе:"
+"После этого выполните следующие шаги, чтобы собрать исполняемый файл на "
+"основе одного из примеров в этом курсе:"
 
 #: src/cargo/running-locally.md:18
-msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo build`\n"
-"   to compile it without running it. You will find the output in `target/debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr ""
-"1. Нажмите кнопку ”Copy to clipboard” на примере кода, который вы хотите скопировать.\n"
-"\n"
-"2. Используйте `cargo new exercise`, чтобы создать новую директорию `exercise/` для вашего кода:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3.  Перейдите в директорию `exercise/` и выполните `cargo run` для сборки и запуска исполняемого файла:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Замените шаблонный код в `src/main.rs` своим кодом. Например, используя пример кода с предыдущей страницы,\n"
-"сделайте `src/main.rs` похожим на\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Используйте `cargo run` для сборки и запуска обновленного исполняемого файла:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Используйте `cargo check` для быстрой проверки проекта на наличие ошибок и `cargo build` для\n"
-"компиляции проекта без его запуска. Вы найдете результат в директории `target/debug/` для отладочной сборки.\n"
-"Используйте `cargo build --release` для создания оптимизированной финальной сборки в `target/release/`.\n"
-"\n"
-"7. Вы можете добавить зависимости для вашего проекта, отредактировав файл `Cargo.toml`.\n"
-"Когда вы запустите команду `cargo`, она автоматически загрузит и скомпилирует недостающие зависимости для вас."
+"Нажмите кнопку ”Copy to clipboard” на примере кода, который вы хотите "
+"скопировать."
+
+#: src/cargo/running-locally.md:20
+msgid ""
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr ""
+"Используйте `cargo new exercise`, чтобы создать новую директорию `exercise/` "
+"для вашего кода:"
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr ""
+"Перейдите в директорию `exercise/` и выполните `cargo run` для сборки и "
+"запуска исполняемого файла:"
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+"Замените шаблонный код в `src/main.rs` своим кодом. Например, используя "
+"пример кода с предыдущей страницы, сделайте `src/main.rs` похожим на"
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr ""
+"Используйте `cargo run` для сборки и запуска обновленного исполняемого файла:"
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+"Используйте `cargo check` для быстрой проверки проекта на наличие ошибок и "
+"`cargo build` для компиляции проекта без его запуска. Вы найдете результат в "
+"директории `target/debug/` для отладочной сборки. Используйте `cargo build --"
+"release` для создания оптимизированной финальной сборки в `target/release/`."
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
+msgstr ""
+"Вы можете добавить зависимости для вашего проекта, отредактировав файл "
+"`Cargo.toml`. Когда вы запустите команду `cargo`, она автоматически загрузит "
+"и скомпилирует недостающие зависимости для вас."
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
-"Предложите участникам занятия установить Cargo и использовать локальный редактор.\n"
-"Это облегчит им жизнь, так как у них будет подходящая среда разработки."
+"Предложите участникам занятия установить Cargo и использовать локальный "
+"редактор. Это облегчит им жизнь, так как у них будет подходящая среда "
+"разработки."
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# Добро пожаловать в День 1"
+msgid "Welcome to Day 1"
+msgstr "Добро пожаловать в День 1"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr "Это первый день курса. Сегодня мы пройдёмся по многим темам:"
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* Базовый синтаксис Rust: переменные, скалярные и составные типы, перечисления,\n"
-"структуры, ссылки, функции и методы.\n"
-"\n"
-"* Управление памятью: стек и куча, ручное управление памятью,\n"
-"управление памятью на основе области видимости и сборка мусора.\n"
-"\n"
-"* Владение: семантика перемещения, копирование и клонирование, заимствование и время жизни."
+"Базовый синтаксис Rust: переменные, скалярные и составные типы, "
+"перечисления, структуры, ссылки, функции и методы."
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+"Управление памятью: стек и куча, ручное управление памятью, управление "
+"памятью на основе области видимости и сборка мусора."
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"Владение: семантика перемещения, копирование и клонирование, заимствование и "
+"время жизни."
 
 #: src/welcome-day-1.md:16
 msgid "Please remind the students that:"
@@ -2079,123 +2099,174 @@ msgstr "Пожалуйста, напомните студентам, что:"
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i.e.,\n"
-"    keep the discussions related to how Rust does things vs some other language. \n"
-"    It can be hard to find the right balance, but err on the side of allowing \n"
-"    discussions since they engage people much more than one-way communication.\n"
-"* The questions will likely mean that we talk about things ahead of the slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
 msgstr ""
-"* Они могут задавать вопросы по мере их появления, не откладывая их до конца.\n"
-"* Занятие задумано как интерактивное, и дискуссии крайне приветствуются!\n"
-"  * Как преподаватель, вы должны стараться поддерживать релевантность дискуссий,\n"
-"например, поддерживать обсуждения, связанные с тем, как в Rust делается что-либо в сравнении с каким--либо другим языком. \n"
-"Бывает трудно найти правильный баланс, но все же сделайте выбор в пользу наличия дискуссий,\n"
-"поскольку они вовлекают учащихся гораздо больше, чем одностороннее общение.\n"
-"* Часто вопросы будут приводить к обсуждениям, опережающим порядок показа слайдов.\n"
-"  * Это совершенно нормально! Повторение --- важная часть обучения.\n"
-"Помните, что слайды --- это всего лишь вспомогательный материал, и вы вольны пропускать их по \n"
-"своему усмотрению."
+"Они могут задавать вопросы по мере их появления, не откладывая их до конца."
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr "Занятие задумано как интерактивное, и дискуссии крайне приветствуются!"
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
+msgstr ""
+"Как преподаватель, вы должны стараться поддерживать релевантность дискуссий, "
+"например, поддерживать обсуждения, связанные с тем, как в Rust делается что-"
+"либо в сравнении с каким--либо другим языком.  Бывает трудно найти "
+"правильный баланс, но все же сделайте выбор в пользу наличия дискуссий, "
+"поскольку они вовлекают учащихся гораздо больше, чем одностороннее общение."
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+"Часто вопросы будут приводить к обсуждениям, опережающим порядок показа "
+"слайдов."
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"Это совершенно нормально! Повторение --- важная часть обучения. Помните, что "
+"слайды --- это всего лишь вспомогательный материал, и вы вольны пропускать "
+"их по  своему усмотрению."
 
 #: src/welcome-day-1.md:29
 msgid ""
-"The idea for the first day is to show _just enough_ of Rust to be able to speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major feature\n"
-"and we should show students this right away."
+"The idea for the first day is to show _just enough_ of Rust to be able to "
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
-"Идея первого дня состоит в том, чтобы показать Rust _достаточно_, чтобы\n"
-"иметь возможность говорить о знаменитом анализаторе заимствований. То, как Rust работает с памятью ---\n"
-"важная особенность языка и мы должны показать её студентам с самого начала."
+"Идея первого дня состоит в том, чтобы показать Rust _достаточно_, чтобы "
+"иметь возможность говорить о знаменитом анализаторе заимствований. То, как "
+"Rust работает с памятью --- важная особенность языка и мы должны показать её "
+"студентам с самого начала."
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
-msgstr "Если вы преподаете в классе, то стоит проработать расписание. Мы предлагаем разбить день на две части (по слайдам):"
+msgstr ""
+"Если вы преподаете в классе, то стоит проработать расписание. Мы предлагаем "
+"разбить день на две части (по слайдам):"
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* Утро: с 9:00 до 12:00,\n"
-"* Вторая половина дня: с 13:00 до 16:00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "Утро: с 9:00 до 12:00,"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "Вторая половина дня: с 13:00 до 16:00."
 
 #: src/welcome-day-1.md:39
 msgid ""
-"You can of course adjust this as necessary. Please make sure to include breaks,\n"
-"we recommend a break every hour!"
+"You can of course adjust this as necessary. Please make sure to include "
+"breaks, we recommend a break every hour!"
 msgstr ""
-"Вы, конечно, можете изменять расписание по мере необходимости.\n"
-"Пожалуйста, не забудьте добавить перерывы. Мы рекомендуем делать перерыв каждый час!"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# Что такое Rust?"
+"Вы, конечно, можете изменять расписание по мере необходимости. Пожалуйста, "
+"не забудьте добавить перерывы. Мы рекомендуем делать перерыв каждый час!"
 
 #: src/welcome-day-1/what-is-rust.md:3
-msgid "Rust is a new programming language which had its [1.0 release in 2015][1]:"
-msgstr "Rust --- это новый язык программирования, [версия 1.0][1] которого была выпущена в 2015 году:"
+msgid ""
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
+msgstr ""
+"Rust --- это новый язык программирования, [версия 1.0](https://blog.rust-"
+"lang.org/2015/05/15/Rust-1.0.html) которого была выпущена в 2015 году:"
 
 #: src/welcome-day-1/what-is-rust.md:5
-msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+msgid "Rust is a statically compiled language in a similar role as C++"
 msgstr ""
-"* Rust --- это статически компилируемый язык, выступающий в той же роли, что и C++.\n"
-"  * `rustc` использует LLVM в качестве бэкенда.\n"
-"* Rust поддерживает множество [платформ и\n"
-"архитектур](https://doc.rust-lang.org/nightly/rustc/platform-support.html):\n"
-"  * x86, ARM, WebAssembly, …\n"
-"  * Linux, Mac, Windows, …\n"
-"* Rust используется для широкого спектра устройств:\n"
-"  * прошивки и загрузчики,\n"
-"  * смарт-экраны,\n"
-"  * мобильные устройства,\n"
-"  * настольные компьютеры,\n"
-"  * серверы."
+"Rust --- это статически компилируемый язык, выступающий в той же роли, что и "
+"C++."
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` использует LLVM в качестве бэкенда."
+
+#: src/welcome-day-1/what-is-rust.md:7
+msgid ""
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+msgstr ""
+"Rust поддерживает множество [платформ и архитектур](https://doc.rust-lang."
+"org/nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, …"
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, …"
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rust используется для широкого спектра устройств:"
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "прошивки и загрузчики,"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "смарт-экраны,"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "мобильные устройства,"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "настольные компьютеры,"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "серверы."
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust подходит для той же области, что и C++:"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* Высокая гибкость.\n"
-"* Высокий уровень контроля.\n"
-"* Может использоваться на очень ограниченных устройствах, таких как мобильные телефоны.\n"
-"* Не имеет среды выполнения или сборки мусора.\n"
-"* Ориентирован на надежность и безопасность без ущерба для производительности."
+msgid "High flexibility."
+msgstr "Высокая гибкость."
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr "# Привет, мир!"
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "Высокий уровень контроля."
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr ""
+"Может использоваться на очень ограниченных устройствах, таких как мобильные "
+"телефоны."
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "Не имеет среды выполнения или сборки мусора."
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"Ориентирован на надежность и безопасность без ущерба для производительности."
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
-msgstr "Давайте перейдём к самой простой из возможных программ на Rust, классической программе Привет, мир!"
+msgstr ""
+"Давайте перейдём к самой простой из возможных программ на Rust, классической "
+"программе Привет, мир!"
 
 #: src/hello-world.md:6
 msgid ""
@@ -2216,55 +2287,70 @@ msgid "What you see:"
 msgstr "Что вы видите:"
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
-msgstr ""
-"* Функции объявляются с помощью `fn`.\n"
-"* Блоки разделяются фигурными скобками, как в C и C++.\n"
-"* Функция `main` является точкой входа в программу.\n"
-"* В Rust есть макросы, например `println!`.\n"
-"* Строки закодированы в UTF-8 и могут содержать любой символ Юникода."
+msgid "Functions are introduced with `fn`."
+msgstr "Функции объявляются с помощью `fn`."
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "Блоки разделяются фигурными скобками, как в C и C++."
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "Функция `main` является точкой входа в программу."
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
+msgstr "В Rust есть макросы, например `println!`."
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr "Строки закодированы в UTF-8 и могут содержать любой символ Юникода."
 
 #: src/hello-world.md:22
 msgid ""
-"This slide tries to make the students comfortable with Rust code. They will see\n"
-"a ton of it over the next four days so we start small with something familiar."
+"This slide tries to make the students comfortable with Rust code. They will "
+"see a ton of it over the next four days so we start small with something "
+"familiar."
 msgstr ""
-"На этом слайде мы пытаемся помочь студентам ознакомиться с кодом на Rust.\n"
-"В течение следующих четырёх дней они увидят его в большом количестве, поэтому мы начинаем с чего-то знакомого."
+"На этом слайде мы пытаемся помочь студентам ознакомиться с кодом на Rust. В "
+"течение следующих четырёх дней они увидят его в большом количестве, поэтому "
+"мы начинаем с чего-то знакомого."
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude.md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rust очень похож на другие языки, такие как C/C++/Java.\n"
-"Rust императивный (не функциональный), и он не пытается что--то изобретать заново без крайней необходимости.\n"
-"\n"
-"* Rust --- это современный язык с полной поддержкой таких вещей, как Юникод.\n"
-"\n"
-"* Rust использует макросы для ситуаций, когда вы хотите иметь переменное количество аргументов\n"
-"(без [перегрузки](basic-syntax/functions-interlude.md) функций).\n"
-"\n"
-"* „Гигиеничность“ макросов означает, что они случайно не захватывают идентификаторы из области, в которой они используются. Макросы в Rust на самом деле гигиеничны лишь [частично](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+"Rust очень похож на другие языки, такие как C/C++/Java. Rust императивный "
+"(не функциональный), и он не пытается что--то изобретать заново без крайней "
+"необходимости."
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# Небольшой пример"
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr ""
+"Rust --- это современный язык с полной поддержкой таких вещей, как Юникод."
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"Rust использует макросы для ситуаций, когда вы хотите иметь переменное "
+"количество аргументов (без [перегрузки](basic-syntax/functions-interlude.md) "
+"функций)."
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
+msgstr ""
+"„Гигиеничность“ макросов означает, что они случайно не захватывают "
+"идентификаторы из области, в которой они используются. Макросы в Rust на "
+"самом деле гигиеничны лишь [частично](https://veykril.github.io/tlborm/decl-"
+"macros/minutiae/hygiene.html)."
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2306,372 +2392,509 @@ msgstr ""
 
 #: src/hello-world/small-example.md:23
 msgid ""
-"The code implements the Collatz conjecture: it is believed that the loop will\n"
-"always end, but this is not yet proved. Edit the code and play with different\n"
-"inputs."
+"The code implements the Collatz conjecture: it is believed that the loop "
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
-"Код реализует гипотезу Коллатца: считается, что цикл всегда будет заканчиваться,\n"
-"но это еще не доказано. Отредактируйте код и поэкспериментируйте с разными входными данными."
+"Код реализует гипотезу Коллатца: считается, что цикл всегда будет "
+"заканчиваться, но это еще не доказано. Отредактируйте код и "
+"поэкспериментируйте с разными входными данными."
 
 #: src/hello-world/small-example.md:29
+#, fuzzy
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that the\n"
-"  students become familiar with searching in the standard library.\n"
-"    \n"
-"    * In a shell `rustup doc std::fmt` will open a browser on the local std::fmt documentation"
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* Объясните, что все переменные статически типизированы. Попробуйте убрать\n"
-"`i32` чтобы инициировать вывод типа.\n"
-"Попробуйте использовать `i8` и получить целочисленное переполнение.\n"
-"\n"
-"* Измените `let mut x` на `let x`, обсудите ошибку компилятора.\n"
-"\n"
-"* Покажите, как `print!` выдает ошибку компиляции, если аргументы не соответствуют строке формата.\n"
-"\n"
-"* Покажите, как нужно использовать `{}` в качестве заполнителя, если вы\n"
-"хотите напечатать выражение, которое сложнее, чем просто одна переменная.\n"
-"\n"
-"* Продемонстрируйте студентам стандартную библиотеку, покажите им, как найти `std::fmt`,\n"
-"который содержит правила мини--языка форматирования.\n"
-"Важно, чтобы учащиеся ознакомились с поиском по стандартной библиотеке."
+"Объясните, что все переменные статически типизированы. Попробуйте убрать "
+"`i32` чтобы инициировать вывод типа. Попробуйте использовать `i8` и получить "
+"целочисленное переполнение."
 
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# Почему Rust?"
+#: src/hello-world/small-example.md:32
+#, fuzzy
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "Измените `let mut x` на `let x`, обсудите ошибку компилятора."
+
+#: src/hello-world/small-example.md:34
+#, fuzzy
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+"Покажите, как `print!` выдает ошибку компиляции, если аргументы не "
+"соответствуют строке формата."
+
+#: src/hello-world/small-example.md:37
+#, fuzzy
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+"Покажите, как нужно использовать `{}` в качестве заполнителя, если вы хотите "
+"напечатать выражение, которое сложнее, чем просто одна переменная."
+
+#: src/hello-world/small-example.md:40
+#, fuzzy
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"Продемонстрируйте студентам стандартную библиотеку, покажите им, как найти "
+"`std::fmt`, который содержит правила мини--языка форматирования. Важно, "
+"чтобы учащиеся ознакомились с поиском по стандартной библиотеке."
+
+#: src/hello-world/small-example.md:44
+msgid ""
+"In a shell `rustup doc std::fmt` will open a browser on the local std::fmt "
+"documentation"
+msgstr ""
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Некоторые уникальные преимущества Rust:"
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* Безопасность памяти во время компиляции.\n"
-"* Отсутствие неопределенного поведения во время выполнения.\n"
-"* Современные возможности."
+msgid "Compile time memory safety."
+msgstr "Безопасность памяти во время компиляции."
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "Отсутствие неопределенного поведения во время выполнения."
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "Современные возможности."
 
 #: src/why-rust.md:11
 msgid ""
-"Make sure to ask the class which languages they have experience with. Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Make sure to ask the class which languages they have experience with. "
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
-"Обязательно спросите учащихся, с какими языками у них есть опыт работы.\n"
-"В зависимости от ответа вы можете подчеркнуть различные особенности Rust:"
+"Обязательно спросите учащихся, с какими языками у них есть опыт работы. В "
+"зависимости от ответа вы можете подчеркнуть различные особенности Rust:"
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory safety\n"
-"  as in those languages, plus a similar high-level language feeling. In addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* Опыт работы с C или C++: Rust устраняет целый класс _ошибок времени выполнения_\n"
-"с помощью анализатора заимствований. Вы получаете производительность, как в C и C++,\n"
-"минуя проблем с безопасностью памяти. Кроме того, вы получаете современный язык\n"
-"с такими конструкциями, как сопоставление с образцом и встроенное управление зависимостями.\n"
-"\n"
-"* Опыт работы с Java, Go, Python, JavaScript…: Вы получаете ту же безопасность\n"
-"памяти, что и в этих языках, плюс схожее чувство языка высокого уровня.\n"
-"В дополнение к этому, вы получаете высокую и предсказуемую производительность, такую\n"
-"как в C и C++ (без сборщика мусора), а также доступ к аппаратному обеспечению\n"
-"(если он понадобится)."
+"Опыт работы с C или C++: Rust устраняет целый класс _ошибок времени "
+"выполнения_ с помощью анализатора заимствований. Вы получаете "
+"производительность, как в C и C++, минуя проблем с безопасностью памяти. "
+"Кроме того, вы получаете современный язык с такими конструкциями, как "
+"сопоставление с образцом и встроенное управление зависимостями."
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# Гарантии времени компиляции"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"Опыт работы с Java, Go, Python, JavaScript…: Вы получаете ту же безопасность "
+"памяти, что и в этих языках, плюс схожее чувство языка высокого уровня. В "
+"дополнение к этому, вы получаете высокую и предсказуемую производительность, "
+"такую как в C и C++ (без сборщика мусора), а также доступ к аппаратному "
+"обеспечению (если он понадобится)."
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "Управление статической памятью во время компиляции:"
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* Нет неинициализированных переменных.\n"
-"* Нет утечек памяти (_в основном_, см. примечания).\n"
-"* Нет двойных освобождений.\n"
-"* Нет использования-после-освобождения (use-after-free).\n"
-"* Нет `NULL` указателей.\n"
-"* Нет забытых заблокированных мьютексов.\n"
-"* Нет гонок данных между потоками.\n"
-"* Нет инвалидации итераторов."
+msgid "No uninitialized variables."
+msgstr "Нет неинициализированных переменных."
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "Нет утечек памяти (_в основном_, см. примечания)."
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "Нет двойных освобождений."
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "Нет использования-после-освобождения (use-after-free)."
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "Нет `NULL` указателей."
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "Нет забытых заблокированных мьютексов."
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "Нет гонок данных между потоками."
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "Нет инвалидации итераторов."
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr "В (безопасном) Rust возможны утечки памяти. Вот некоторые примеры:"
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* Вы можете использовать [`Box::leak`] для утечки указателя.\n"
-"Это может быть использовано для получения инициализированных статических переменных, размерность которых определяется во время выполнения.\n"
-"* Вы можете использовать [`std::mem::forget`], чтобы заставить компилятор “забыть” о значении\n"
-"(значит, что деструктор никогда не будет вызван).\n"
-"* Вы также можете случайно создать ссылочный цикл ([reference cycle]) с помощью `Rc` или `Arc`.\n"
-"* Некоторые могут счесть неограниченное заполнение коллекции утечкой памяти, и Rust не защищает от этого."
+"Вы можете использовать [`Box::leak`](https://doc.rust-lang.org/std/boxed/"
+"struct.Box.html#method.leak) для утечки указателя. Это может быть "
+"использовано для получения инициализированных статических переменных, "
+"размерность которых определяется во время выполнения."
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"Вы можете использовать [`std::mem::forget`](https://doc.rust-lang.org/std/"
+"mem/fn.forget.html), чтобы заставить компилятор “забыть” о значении (значит, "
+"что деструктор никогда не будет вызван)."
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"Вы также можете случайно создать ссылочный цикл ([reference cycle](https://"
+"doc.rust-lang.org/book/ch15-06-reference-cycles.html)) с помощью `Rc` или "
+"`Arc`."
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"Некоторые могут счесть неограниченное заполнение коллекции утечкой памяти, и "
+"Rust не защищает от этого."
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"В рамках данного курса ”Отсутствие утечек памяти” следует понимать как\n"
-"”Практически полное отсутствие *случайных* утечек памяти”."
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# Гарантии времени выполнения"
+"В рамках данного курса ”Отсутствие утечек памяти” следует понимать как "
+"”Практически полное отсутствие _случайных_ утечек памяти”."
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "Отсутствие неопределенного поведения во время выполнения:"
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
-msgstr ""
-"* Проверка границ массива.\n"
-"* Определено целочисленное переполнение."
+msgid "Array access is bounds checked."
+msgstr "Проверка границ массива."
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
+msgstr "Определено целочисленное переполнение."
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* Целочисленное переполнение определяется с помощью флага времени компиляции.\n"
-"Варианты --- это либо паника (управляемый сбой программы), либо переполнение (wrap-around).\n"
-"По умолчанию вы получаете панику в режиме отладочной сборки (`cargo build`)\n"
-"и переполнение в режиме финальной (`cargo build --release`).\n"
-"\n"
-"* Проверка границ не может быть отключена с помощью флага компилятора.\n"
-"Ее также нельзя отключить напрямую с помощью ключевого слова `unsafe`.\n"
-"Однако `unsafe` позволяет вызывать функции, такие как `slice::get_unchecked`,\n"
-"которые не проверяют границы."
+"Целочисленное переполнение определяется с помощью флага времени компиляции. "
+"Варианты --- это либо паника (управляемый сбой программы), либо переполнение "
+"(wrap-around). По умолчанию вы получаете панику в режиме отладочной сборки "
+"(`cargo build`) и переполнение в режиме финальной (`cargo build --release`)."
 
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# Современные возможности"
+#: src/why-rust/runtime.md:17
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"Проверка границ не может быть отключена с помощью флага компилятора. Ее "
+"также нельзя отключить напрямую с помощью ключевого слова `unsafe`. Однако "
+"`unsafe` позволяет вызывать функции, такие как `slice::get_unchecked`, "
+"которые не проверяют границы."
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
 msgstr "Rust создан с учетом опыта, накопленного за последние 40 лет."
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## Особенности языка"
+msgid "Language Features"
+msgstr "Особенности языка"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* Перечисления и сопоставление с образцом.\n"
-"* Обобщения (generics).\n"
-"* Нет накладных расходов для FFI.\n"
-"* Абстракции с нулевой стоимостью (zero-cost abstractions)."
+msgid "Enums and pattern matching."
+msgstr "Перечисления и сопоставление с образцом."
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "Обобщения (generics)."
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "Нет накладных расходов для FFI."
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "Абстракции с нулевой стоимостью (zero-cost abstractions)."
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
-msgstr "## Набор инструментов"
+msgid "Tooling"
+msgstr "Набор инструментов"
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* Отличные ошибки компилятора.\n"
-"* Встроенный менеджер зависимостей.\n"
-"* Встроенная поддержка тестирования.\n"
-"* Великолепная поддержка протокола языкового сервера (LSP)."
+msgid "Great compiler errors."
+msgstr "Отличные ошибки компилятора."
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "Встроенный менеджер зависимостей."
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "Встроенная поддержка тестирования."
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "Великолепная поддержка протокола языкового сервера (LSP)."
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to 'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with _actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, Python,\n"
-"  and Go. Rust does not come with several things you might consider standard and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this makes\n"
-"  it trivial to download and compile third-party crates. A consequence of this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* Абстракции с нулевой стоимостью, аналогичные C++, означают,\n"
-"  что вам не нужно ‘платить’ за высокоуровневые программные конструкции\n"
-"  памятью или процессорным временем. Например, написание цикла с использованием\n"
-"  `for` должно порождать примерно те же низкоуровневые инструкции,\n"
-"  что и при использовании конструкции `.iter().fold()`.\n"
-"\n"
-"* Пожалуй, стоит упомянуть, что перечисления в Rust ---\n"
-"  это ‘Алгебраические типы данных’, также известные как ‘тип-сумма’,\n"
-"  которые позволяют системе типов выражать такие вещи, как `Option<T>` и `Result<T, E>`.\n"
-"\n"
-"* Обратите внимание учащихся на важность чтения ошибок компилятора --- многие разработчики\n"
-"  привыкли игнорировать длинные выходные сигналы компилятора.\n"
-"  Компилятор Rust значительно более многословен, чем другие компиляторы.\n"
-"  Он часто предоставляет _полезную_ обратную связь, готовую к копированию и\n"
-"  вставке в ваш код.\n"
-"\n"
-"* Стандартная библиотека Rust невелика по сравнению с такими языками,\n"
-"  как Java, Python и Go. Rust не содержит некоторых компонентов,\n"
-"  которые вы могли бы счесть стандартными и неотъемлемыми:\n"
-"\n"
-"  * генератор случайных чисел, но см. [rand].\n"
-"  * поддержка SSL или TLS, но см. [rusttls].\n"
-"  * поддержка JSON, но см. [serde_json].\n"
-"\n"
-"  Причина этого заключается в том, что функциональность из стандартной библиотеки не может просто исчезнуть,\n"
-"  поэтому она должна быть чрезвычайно стабильной. В приведённых выше примерах сообщество Rust всё ещё работает над\n"
-"  поиском наилучшего решения --- и, возможно, для некоторых из этих вещей не существует единого ”наилучшего решения”.\n"
-"\n"
-"  Rust поставляется со встроенным менеджером пакетов Cargo,\n"
-"  что значительно упрощает загрузку и компиляцию сторонних пакетов.\n"
-"  Вследствие этого стандартная библиотека может быть меньше.\n"
-"\n"
-"  Поиск хороших покетов от сторонних разработчиков может стать проблемой.\n"
-"  Сайты, такие как <https://lib.rs/> помогают в этом, позволяя сравнивать\n"
-"  показатели состояния пакетов, чтобы отыскать подходящие и заслуживающие доверия.\n"
-"  \n"
-"* [rust-analyzer] --- это хорошо поддерживаемая реализация LSP, используемая во многих IDE и текстовых редакторах."
+"Абстракции с нулевой стоимостью, аналогичные C++, означают, что вам не нужно "
+"‘платить’ за высокоуровневые программные конструкции памятью или "
+"процессорным временем. Например, написание цикла с использованием `for` "
+"должно порождать примерно те же низкоуровневые инструкции, что и при "
+"использовании конструкции `.iter().fold()`."
 
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
-msgstr "# Базовый синтаксис"
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+"Пожалуй, стоит упомянуть, что перечисления в Rust --- это ‘Алгебраические "
+"типы данных’, также известные как ‘тип-сумма’, которые позволяют системе "
+"типов выражать такие вещи, как `Option<T>` и `Result<T, E>`."
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"Обратите внимание учащихся на важность чтения ошибок компилятора --- многие "
+"разработчики привыкли игнорировать длинные выходные сигналы компилятора. "
+"Компилятор Rust значительно более многословен, чем другие компиляторы. Он "
+"часто предоставляет _полезную_ обратную связь, готовую к копированию и "
+"вставке в ваш код."
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+"Стандартная библиотека Rust невелика по сравнению с такими языками, как "
+"Java, Python и Go. Rust не содержит некоторых компонентов, которые вы могли "
+"бы счесть стандартными и неотъемлемыми:"
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr "генератор случайных чисел, но см. [rand](https://docs.rs/rand/)."
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr "поддержка SSL или TLS, но см. [rusttls](https://docs.rs/rustls/)."
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr "поддержка JSON, но см. [serde_json](https://docs.rs/serde_json/)."
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+"Причина этого заключается в том, что функциональность из стандартной "
+"библиотеки не может просто исчезнуть, поэтому она должна быть чрезвычайно "
+"стабильной. В приведённых выше примерах сообщество Rust всё ещё работает над "
+"поиском наилучшего решения --- и, возможно, для некоторых из этих вещей не "
+"существует единого ”наилучшего решения”."
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+"Rust поставляется со встроенным менеджером пакетов Cargo, что значительно "
+"упрощает загрузку и компиляцию сторонних пакетов. Вследствие этого "
+"стандартная библиотека может быть меньше."
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+"Поиск хороших покетов от сторонних разработчиков может стать проблемой. "
+"Сайты, такие как <https://lib.rs/> помогают в этом, позволяя сравнивать "
+"показатели состояния пакетов, чтобы отыскать подходящие и заслуживающие "
+"доверия."
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/) --- это хорошо "
+"поддерживаемая реализация LSP, используемая во многих IDE и текстовых "
+"редакторах."
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr "Большая часть синтаксиса Rust будет знакома вам по C, C++ или Java:"
 
 #: src/basic-syntax.md:5
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
-msgstr ""
-"* Блоки и области видимости разделены фигурными скобками.\n"
-"* Строковые комментарии начинаются с `//`, блочные комментарии заключены в `/* …*/`.\n"
-"* Ключевые слова, такие как `if` и `while`, работают так же.\n"
-"* Присваивание переменной выполняется с помощью `=`, сравнение выполняется с помощью `==`."
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "Блоки и области видимости разделены фигурными скобками."
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
-msgstr "# Скалярные типы"
-
-#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax.md:6
 msgid ""
-"|                        | Types                                      | Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, `123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | `3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | `\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode scalar values  | `char`                                     | `'a'`, `'α'`, `'∞'`           |\n"
-"| Booleans               | `bool`                                     | `true`, `false`               |"
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"|                           | Типы                                       | Литералы                      |\n"
-"|---------------------------|--------------------------------------------|-------------------------------|\n"
-"| Знаковые целые числа      | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, `1_000`, `123i64` |\n"
-"| Беззнаковые целые числа   | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, `123`, `10u16`           |\n"
-"| Числа с плавающей запятой | `f32`, `f64`                               | `3.14`, `-10.0e20`, `2f32`    |\n"
-"| Строки                    | `&str`                                     | `\"foo\"`, `\"two\\nlines\"`  |\n"
-"| Символы Юникода           | `char`                                     | `'a'`, `'α'`, `'∞'`           |\n"
-"| Логические значения       | `bool`                                     | `true`, `false`               |"
+"Строковые комментарии начинаются с `//`, блочные комментарии заключены в `/* "
+"…*/`."
+
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "Ключевые слова, такие как `if` и `while`, работают так же."
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr ""
+"Присваивание переменной выполняется с помощью `=`, сравнение выполняется с "
+"помощью `==`."
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Types"
+msgstr "Типы"
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr "Литералы"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr "Знаковые целые числа"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr "Беззнаковые целые числа"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr "Числа с плавающей запятой"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr "Строки"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr "`\"foo\"`, `\"two\\nlines\"`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr "Символы Юникода"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr "`char`"
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Booleans"
+msgstr "Логические значения"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`bool`"
+msgstr "`bool`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`true`, `false`"
+msgstr "`true`, `false`"
 
 #: src/basic-syntax/scalar-types.md:12
 msgid "The types have widths as follows:"
 msgstr "Типы имеют следующие размеры:"
 
 #: src/basic-syntax/scalar-types.md:14
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
-msgstr ""
-"* `iN`, `uN` и `fN` -- _N_ бит,\n"
-"* `isize` и `usize` -- размерность указателя,\n"
-"* `char` -- 32 бита,\n"
-"* `bool` -- 8 бит."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN` и `fN` -- _N_ бит,"
+
+#: src/basic-syntax/scalar-types.md:15
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` и `usize` -- размерность указателя,"
+
+#: src/basic-syntax/scalar-types.md:16
+msgid "`char` is 32 bit wide,"
+msgstr "`char` -- 32 бита,"
+
+#: src/basic-syntax/scalar-types.md:17
+msgid "`bool` is 8 bit wide."
+msgstr "`bool` -- 8 бит."
 
 #: src/basic-syntax/scalar-types.md:21
 msgid "There are a few syntaxes which are not shown above:"
@@ -2679,61 +2902,73 @@ msgstr "Существует несколько вариантов синтак�
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: `r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of `#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
-"- Сырые строки позволяют создавать значение `&str` с отключенным экранированием: `r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. Вы можете поставить двойные кавычки, используя равное количество\n"
-"символов `#` с обеих сторон кавычек:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Байтовые строки позволяют создать значение `&[u8]`:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Сырые строки позволяют создавать значение `&str` с отключенным "
+"экранированием: `r\"\\n\" == \"\\\\n\"`. Вы можете поставить двойные "
+"кавычки, используя равное количество символов `#` с обеих сторон кавычек:"
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr "# Составные типы"
-
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:27
 msgid ""
-"|        | Types                         | Literals                          |\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          |\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... |"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
 msgstr ""
-"|         | Типы                          | Литералы                          |\n"
-"|---------|-------------------------------|-----------------------------------|\n"
-"| Массивы | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          |\n"
-"| Кортежи | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... |"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr "Байтовые строки позволяют создать значение `&[u8]`:"
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr "Массивы"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr "`[T; N]`"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr "`[20, 30, 40]`, `[0; 3]`"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr "Кортежи"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
 
 #: src/basic-syntax/compound-types.md:8
 msgid "Array assignment and access:"
@@ -2778,68 +3013,80 @@ msgstr "Массивы:"
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that `[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
 msgstr ""
-"* Массивы содержат элементы одного типа `T`, и имеют длину `N`,\n"
-"которая является константой времени компиляции.\n"
-"Обратите внимание, что длина массива является *частью его типа*, это значит, что\n"
-"`[u8; 3]` и `[u8; 4]` являются двумя разными типами.\n"
-"\n"
-"* Мы можем использовать литералы для присваивания значений массивам.\n"
-"\n"
-"* В функции main оператор print запрашивает отладочную реализацию используя параметр форматирования `?`:\n"
-"`{}` выдает представление по умолчанию, `{:?}` выдает отладочное представление.\n"
-"Мы также могли бы использовать `{a}` и `{a:?}` без указания значений после строки формата.\n"
-"\n"
-"* Добавление `#`, например `{a:#?}`, позволяет использовать формат ”красивой печати”,\n"
-"который может облегчить чтение."
+"Массивы содержат элементы одного типа `T`, и имеют длину `N`, которая "
+"является константой времени компиляции. Обратите внимание, что длина массива "
+"является _частью его типа_, это значит, что `[u8; 3]` и `[u8; 4]` являются "
+"двумя разными типами."
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr "Мы можем использовать литералы для присваивания значений массивам."
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+"В функции main оператор print запрашивает отладочную реализацию используя "
+"параметр форматирования `?`: `{}` выдает представление по умолчанию, `{:?}` "
+"выдает отладочное представление. Мы также могли бы использовать `{a}` и "
+"`{a:?}` без указания значений после строки формата."
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
+msgstr ""
+"Добавление `#`, например `{a:#?}`, позволяет использовать формат ”красивой "
+"печати”, который может облегчить чтение."
 
 #: src/basic-syntax/compound-types.md:47
 msgid "Tuples:"
 msgstr "Кортежи:"
 
 #: src/basic-syntax/compound-types.md:49
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a type, and\n"
-"  the only valid value of that type - that is to say both the type and its value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
-msgstr ""
-"* Как и массивы, кортежи имеют фиксированную длину.\n"
-"\n"
-"* Кортежи группируют значения разных типов в составной тип.\n"
-"\n"
-"* Доступ к полям кортежа можно получить используя точку и индекс значения, например `t.0`, `t.1`.\n"
-"\n"
-"* Пустой кортеж `()` также известен как ”единичный тип”.\n"
-"Это одновременно и тип, и единственное допустимое значение этого типа ---\n"
-"и тип, и его значение выражаются как `()`.\n"
-"Он используется, например, для указания того, что функция или выражение не имеет возвращаемого значения,\n"
-"как мы увидим на следующем слайде.\n"
-"  * Вы можете думать о нем как о `void`, который может быть знаком вам по другим языкам программирования."
+msgid "Like arrays, tuples have a fixed length."
+msgstr "Как и массивы, кортежи имеют фиксированную длину."
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
-msgstr "# Ссылки"
+#: src/basic-syntax/compound-types.md:51
+msgid "Tuples group together values of different types into a compound type."
+msgstr "Кортежи группируют значения разных типов в составной тип."
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr ""
+"Доступ к полям кортежа можно получить используя точку и индекс значения, "
+"например `t.0`, `t.1`."
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+"Пустой кортеж `()` также известен как ”единичный тип”. Это одновременно и "
+"тип, и единственное допустимое значение этого типа --- и тип, и его значение "
+"выражаются как `()`. Он используется, например, для указания того, что "
+"функция или выражение не имеет возвращаемого значения, как мы увидим на "
+"следующем слайде."
+
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr ""
+"Вы можете думать о нем как о `void`, который может быть знаком вам по другим "
+"языкам программирования."
 
 #: src/basic-syntax/references.md:3
 msgid "Like C++, Rust has references:"
@@ -2863,29 +3110,39 @@ msgstr "Примечания:"
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* Мы должны разыменовывать `ref_x` при присваивании значения, аналогично указателям в C и C++.\n"
-"* В некоторых случаях Rust будет автоматически разыменовывать ссылки, в\n"
-"частности, при вызове методов (попробуйте `ref_x.count_ones()`).\n"
-"* Ссылки, объявленные как `mut`, могут быть привязаны к разным значениям в течение срока жизни."
+"Мы должны разыменовывать `ref_x` при присваивании значения, аналогично "
+"указателям в C и C++."
+
+#: src/basic-syntax/references.md:17
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+"В некоторых случаях Rust будет автоматически разыменовывать ссылки, в "
+"частности, при вызове методов (попробуйте `ref_x.count_ones()`)."
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"Ссылки, объявленные как `mut`, могут быть привязаны к разным значениям в "
+"течение срока жизни."
 
 #: src/basic-syntax/references.md:25
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound to\n"
-"  different values, while the second represents a reference to a mutable value."
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
+"value."
 msgstr ""
-"* Обратите внимание на разницу между `let mut ref_x: &i32` и `let ref_x: &mut i32`.\n"
-"Первая представляет собой изменяемую ссылку, которая может быть привязана к разным значениям,\n"
-"в то время как вторая --- ссылку на изменяемое значение."
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
-msgstr "# Висячие ссылки"
+"Обратите внимание на разницу между `let mut ref_x: &i32` и `let ref_x: &mut "
+"i32`. Первая представляет собой изменяемую ссылку, которая может быть "
+"привязана к разным значениям, в то время как вторая --- ссылку на изменяемое "
+"значение."
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -2906,23 +3163,26 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
-msgstr ""
-"* Говорят, что ссылка ”заимствует” значение, на которое она ссылается.\n"
-"* Rust отслеживает время жизни всех ссылок, чтобы убедиться, что они живут достаточно долго.\n"
-"* Мы подробнее поговорим о заимствовании, когда перейдем к владению."
+msgid "A reference is said to \"borrow\" the value it refers to."
+msgstr "Говорят, что ссылка ”заимствует” значение, на которое она ссылается."
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
-msgstr "# Срезы"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"Rust отслеживает время жизни всех ссылок, чтобы убедиться, что они живут "
+"достаточно долго."
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr "Мы подробнее поговорим о заимствовании, когда перейдем к владению."
 
 #: src/basic-syntax/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
-msgstr "Срезы позволяют ссылаться на непрерывную последовательность элементов в коллекции:"
+msgstr ""
+"Срезы позволяют ссылаться на непрерывную последовательность элементов в "
+"коллекции:"
 
 #: src/basic-syntax/slices.md:5
 msgid ""
@@ -2938,57 +3198,79 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
-msgstr ""
-"* Срезы заимствуют данные у коллекции.\n"
-"* Вопрос: Что произойдет, если вы измените значение в `a[3]`?"
+msgid "Slices borrow data from the sliced type."
+msgstr "Срезы заимствуют данные у коллекции."
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "Вопрос: Что произойдет, если вы измените значение в `a[3]`?"
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use `&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` (`&[i32]`) no longer mentions the array length. This allows us to perform computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
 msgstr ""
-"* Мы создаем срез, заимствуя `a` и указывая начальный и конечный индексы в скобках.\n"
-"\n"
-"* Если срез начинается с индекса 0, синтаксис Rust позволяет отбросить начальный индекс,\n"
-"таким образом, `&a[0..a.len()]` и `&a[..a.len()]` идентичны .\n"
-"    \n"
-"* То же верно и для последнего индекса, поэтому `&a[2..a.len()]` и `&a[2..]` идентичны.\n"
-"\n"
-"* Чтобы создать срез всего массива, можно использовать `&a[..]`.\n"
-"\n"
-"* `s` --- это ссылка на срез элементов типа `i32`. Обратите внимание, что тип `s`\n"
-"(`&[i32]`) больше не указывает длину массива. Это позволяет выполнять\n"
-"вычисления на срезах разных размеров.\n"
-" \n"
-"* Срезы всегда заимствуют у другого объекта.\n"
-"В этом примере `a` должен оставаться ‘живым’ (в области видимости) по крайней\n"
-"мере столько же, сколько и срез.\n"
-"    \n"
-"* Вопрос об изменении `a[3]` может породить интересную дискуссию, но ответ\n"
-"заключается в том, что по соображениям безопасности памяти\n"
-"вы не можете сделать это через `a` после создания среза, но можете\n"
-"безопасно читать данные как из `a`, так и из `s`.\n"
-"  Более подробная информация будет изложена в разделе анализатора заимствований."
+"Мы создаем срез, заимствуя `a` и указывая начальный и конечный индексы в "
+"скобках."
+
+#: src/basic-syntax/slices.md:22
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"Если срез начинается с индекса 0, синтаксис Rust позволяет отбросить "
+"начальный индекс, таким образом, `&a[0..a.len()]` и `&a[..a.len()]` "
+"идентичны ."
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"То же верно и для последнего индекса, поэтому `&a[2..a.len()]` и `&a[2..]` "
+"идентичны."
+
+#: src/basic-syntax/slices.md:26
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr "Чтобы создать срез всего массива, можно использовать `&a[..]`."
+
+#: src/basic-syntax/slices.md:28
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+"`s` --- это ссылка на срез элементов типа `i32`. Обратите внимание, что тип "
+"`s` (`&[i32]`) больше не указывает длину массива. Это позволяет выполнять "
+"вычисления на срезах разных размеров."
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"Срезы всегда заимствуют у другого объекта. В этом примере `a` должен "
+"оставаться ‘живым’ (в области видимости) по крайней мере столько же, сколько "
+"и срез."
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
+"Вопрос об изменении `a[3]` может породить интересную дискуссию, но ответ "
+"заключается в том, что по соображениям безопасности памяти вы не можете "
+"сделать это через `a` после создания среза, но можете безопасно читать "
+"данные как из `a`, так и из `s`. Более подробная информация будет изложена в "
+"разделе анализатора заимствований."
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
-msgstr "# String и str"
+msgid "`String` vs `str`"
+msgstr "String и str"
 
 #: src/basic-syntax/string-slices.md:3
 msgid "We can now understand the two string types in Rust:"
@@ -3017,63 +3299,75 @@ msgid "Rust terminology:"
 msgstr "Терминология Rust:"
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* `&str` --- неизменяемая ссылка на срез строки.\n"
-"* `String` --- изменяемый строковый буфер."
+msgid "`&str` an immutable reference to a string slice."
+msgstr "`&str` --- неизменяемая ссылка на срез строки."
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String` --- изменяемый строковый буфер."
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a `Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the `push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* `&str` представляет срез строки, который является неизменяемой ссылкой на\n"
-"строковые данные в кодировке UTF-8, хранящиеся в памяти.\n"
-"Строковые литералы (`”Hello”`) хранятся в исполняемом файле программы.\n"
-"\n"
-"* Тип `String` в Rust --- это обертка вокруг вектора байтов.\n"
-"    \n"
-"* Как и во многих других типах, `String::from()` создает строку из строкового литерала;\n"
-"`String::new()` создает новую пустую строку, в которую строковые данные могут быть\n"
-"добавлены с помощью методов `push()` и `push_str()`.\n"
-"\n"
-"* Макрос `format!()` --- это удобный способ сгенерировать строку из динамических\n"
-"значений. Он принимает ту же строку формата, что и `println!()`.\n"
-"    \n"
-"* Вы можете заимствовать `&str` срезы из `String` с помощью оператора `&`\n"
-"и , при необходимости, указывать диапазон среза.\n"
-"    \n"
-"* Для программистов на C++: думайте о `&str` как о `const char*`\n"
-"из C++, но таком, который всегда указывает на корректную строку в памяти.\n"
-"`String` в Rust --- это примерный эквивалент `std::string` из C++\n"
-"(основное отличие: она может содержать только байты в кодировке UTF-8\n"
-"и не будет использовать оптимизацию для небольших строк).\n"
-"    "
+"`&str` представляет срез строки, который является неизменяемой ссылкой на "
+"строковые данные в кодировке UTF-8, хранящиеся в памяти. Строковые литералы "
+"(`”Hello”`) хранятся в исполняемом файле программы."
 
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
-msgstr "# Функции"
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr "Тип `String` в Rust --- это обертка вокруг вектора байтов."
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"Как и во многих других типах, `String::from()` создает строку из строкового "
+"литерала; `String::new()` создает новую пустую строку, в которую строковые "
+"данные могут быть добавлены с помощью методов `push()` и `push_str()`."
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+"Макрос `format!()` --- это удобный способ сгенерировать строку из "
+"динамических значений. Он принимает ту же строку формата, что и `println!()`."
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+"Вы можете заимствовать `&str` срезы из `String` с помощью оператора `&` и , "
+"при необходимости, указывать диапазон среза."
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"Для программистов на C++: думайте о `&str` как о `const char*` из C++, но "
+"таком, который всегда указывает на корректную строку в памяти. `String` в "
+"Rust --- это примерный эквивалент `std::string` из C++ (основное отличие: "
+"она может содержать только байты в кодировке UTF-8 и не будет использовать "
+"оптимизацию для небольших строк)."
 
 #: src/basic-syntax/functions.md:3
-msgid "A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) interview question:"
-msgstr "Rust--версия знаменитого вопроса для интервью [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz):"
+msgid ""
+"A Rust version of the famous [FizzBuzz](https://en.wikipedia.org/wiki/"
+"Fizz_buzz) interview question:"
+msgstr ""
+"Rust--версия знаменитого вопроса для интервью [FizzBuzz](https://en."
+"wikipedia.org/wiki/Fizz_buzz):"
 
 #: src/basic-syntax/functions.md:5
 msgid ""
@@ -3108,37 +3402,64 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `print_fizzbuzz_to()` contains `=n`, which causes it to include the upper bound."
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
 msgstr ""
-"* В `main` мы ссылаемся на функцию, которая определена ниже. При этом ни предварительные объявления, ни заголовки не требуются.\n"
-"* В объявлении функции за каждым параметром следует его тип (противоположно некоторым языкам программирования), затем тип возвращаемого значения.\n"
-"* Последнее выражение в теле функции (или любом блоке) становится возвращаемым значением. Просто отбросьте символ `;` в конце выражения.\n"
-"* Некоторые функции не имеют возвращаемого значения и возвращают ‘тип unit’, `()`. Компилятор определит это, если возвращаемый тип `-> ()` не указан.\n"
-"* Выражение диапазона в цикле `for` в `fizzbuzz_to()` содержит `=n`, что ведет к включению верхней границы диапазона."
+"В `main` мы ссылаемся на функцию, которая определена ниже. При этом ни "
+"предварительные объявления, ни заголовки не требуются."
 
-#: src/basic-syntax/rustdoc.md:1
-msgid "# Rustdoc"
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
 msgstr ""
+"В объявлении функции за каждым параметром следует его тип (противоположно "
+"некоторым языкам программирования), затем тип возвращаемого значения."
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+"Последнее выражение в теле функции (или любом блоке) становится возвращаемым "
+"значением. Просто отбросьте символ `;` в конце выражения."
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+"Некоторые функции не имеют возвращаемого значения и возвращают ‘тип unit’, "
+"`()`. Компилятор определит это, если возвращаемый тип `-> ()` не указан."
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"`=n`, which causes it to include the upper bound."
+msgstr ""
+"Выражение диапазона в цикле `for` в `fizzbuzz_to()` содержит `=n`, что ведет "
+"к включению верхней границы диапазона."
 
 #: src/basic-syntax/rustdoc.md:3
-msgid "All language items in Rust can be documented using special `///` syntax."
-msgstr "Все языковые элементы в Rust могут быть задокументированы с использованием особого синтаксиса `///`."
+msgid ""
+"All language items in Rust can be documented using special `///` syntax."
+msgstr ""
+"Все языковые элементы в Rust могут быть задокументированы с использованием "
+"особого синтаксиса `///`."
 
 #: src/basic-syntax/rustdoc.md:5
 msgid ""
 "```rust,editable\n"
-"/// Determine whether the first argument is divisible by the second argument.\n"
+"/// Determine whether the first argument is divisible by the second "
+"argument.\n"
 "///\n"
 "/// If the second argument is zero, the result is false.\n"
 "fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
 "    if rhs == 0 {\n"
 "        return false;  // Corner case, early return\n"
 "    }\n"
-"    lhs % rhs == 0     // The last expression in a block is the return value\n"
+"    lhs % rhs == 0     // The last expression in a block is the return "
+"value\n"
 "}\n"
 "```"
 msgstr ""
@@ -3150,50 +3471,53 @@ msgstr ""
 "    if rhs == 0 {\n"
 "        return false;  // Особый случай, досрочное возвращение\n"
 "    }\n"
-"    lhs % rhs == 0     // Последнее выражение в блоке - это возвращаемое значение\n"
+"    lhs % rhs == 0     // Последнее выражение в блоке - это возвращаемое "
+"значение\n"
 "}\n"
 "```"
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
-"Содержимое интерпретируется как Markdown. Все опубликованные крейты\n"
-"библиотек Rust автоматически документируются на [`docs.rs`](https://docs.rs)\n"
-"с помощью инструмента [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html).\n"
-"Документирование всех общедоступных элементов API используя этот подход является идиоматичным."
+"Содержимое интерпретируется как Markdown. Все опубликованные крейты "
+"библиотек Rust автоматически документируются на [`docs.rs`](https://docs.rs) "
+"с помощью инструмента [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-"
+"rustdoc.html). Документирование всех общедоступных элементов API используя "
+"этот подход является идиоматичным."
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
-"* Покажите стедентам сгенерированную документацию для крейта `rand` в [`docs.rs/rand`](https://docs.rs/rand) .\n"
-"\n"
-"* Этот курс не включает rustdoc на слайдах, просто для экономии места, но в реальном коде они должны присутствовать.\n"
-"\n"
-"* Inner doc комментарии будут рассмотрены позже (на странице о модулях)."
+"Покажите стедентам сгенерированную документацию для крейта `rand` в [`docs."
+"rs/rand`](https://docs.rs/rand) ."
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
-msgstr "# Методы"
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+"Этот курс не включает rustdoc на слайдах, просто для экономии места, но в "
+"реальном коде они должны присутствовать."
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr "Inner doc комментарии будут рассмотрены позже (на странице о модулях)."
 
 #: src/basic-syntax/methods.md:3
 msgid ""
-"Methods are functions associated with a type. The `self` argument of a method is\n"
-"an instance of the type it is associated with:"
+"Methods are functions associated with a type. The `self` argument of a "
+"method is an instance of the type it is associated with:"
 msgstr ""
-"Методы это функции, связанные с типом.\n"
-"Аргумент `self` в методе --- это экземпляр типа, с которым он связан:"
+"Методы это функции, связанные с типом. Аргумент `self` в методе --- это "
+"экземпляр типа, с которым он связан:"
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3246,56 +3570,70 @@ msgstr ""
 "```"
 
 #: src/basic-syntax/methods.md:30
-msgid "* We will look much more at methods in today's exercise and in tomorrow's class."
-msgstr "* Мы подробнее рассмотрим методы в сегодняшнем упражнении и на завтрашнем занятии."
+msgid ""
+"We will look much more at methods in today's exercise and in tomorrow's "
+"class."
+msgstr ""
+"Мы подробнее рассмотрим методы в сегодняшнем упражнении и на завтрашнем "
+"занятии."
 
 #: src/basic-syntax/methods.md:34
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
+msgstr "Добавьте конструктор `Rectangle::new` и вызовите его из `main`:"
+
+#: src/basic-syntax/methods.md:36
 msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
 msgstr ""
-"- Добавьте конструктор `Rectangle::new` и вызовите его из `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Добавьте конструктор `Rectangle::new_square(width: u32)`,\n"
-"чтобы показать, что конструкторы могут принимать произвольные параметры."
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
+msgstr ""
+"Добавьте конструктор `Rectangle::new_square(width: u32)`, чтобы показать, "
+"что конструкторы могут принимать произвольные параметры."
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
-msgstr "# Перегрузка функций"
+msgid "Function Overloading"
+msgstr "Перегрузка функций"
 
 #: src/basic-syntax/functions-interlude.md:3
 msgid "Overloading is not supported:"
 msgstr "Перегрузка не поддерживается:"
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* Каждая функция имеет единственную реализацию:\n"
-"  * Всегда принимает фиксированное количество параметров.\n"
-"  * Всегда принимает один набор типов параметров.\n"
-"* Значения по умолчанию не поддерживаются:\n"
-"  * Все вызовы имеют одинаковое количество аргументов.\n"
-"  * В качестве альтернативы иногда используются макросы."
+msgid "Each function has a single implementation:"
+msgstr "Каждая функция имеет единственную реализацию:"
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "Всегда принимает фиксированное количество параметров."
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "Всегда принимает один набор типов параметров."
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "Значения по умолчанию не поддерживаются:"
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
+msgstr "Все вызовы имеют одинаковое количество аргументов."
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "В качестве альтернативы иногда используются макросы."
 
 #: src/basic-syntax/functions-interlude.md:12
 msgid "However, function parameters can be generic:"
@@ -3327,30 +3665,29 @@ msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind of limited\n"
-"  polymorphism on argument types. We will see more details in a later section."
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
+"section."
 msgstr ""
-"* При использовании обобщений тип `Into<T>` из стандартной библиотеки может\n"
-"обеспечить своего рода ограниченный полиморфизм в отношении типов аргументов.\n"
-"Мы увидим более подробную информацию в следующих разделах."
+"При использовании обобщений тип `Into<T>` из стандартной библиотеки может "
+"обеспечить своего рода ограниченный полиморфизм в отношении типов "
+"аргументов. Мы увидим более подробную информацию в следующих разделах."
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
-msgstr "# День 1: Утренние упражнения"
+msgid "Day 1: Morning Exercises"
+msgstr "День 1: Утренние упражнения"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
 msgstr "В этих упражнениях мы рассмотрим две составляющие Rust:"
 
 #: src/exercises/day-1/morning.md:5
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
-msgstr ""
-"* Неявные преобразования между типами.\n"
-"\n"
-"* Массивы и циклы `for`."
+msgid "Implicit conversions between types."
+msgstr "Неявные преобразования между типами."
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
+msgstr "Массивы и циклы `for`."
 
 #: src/exercises/day-1/morning.md:11
 msgid "A few things to consider while solving the exercises:"
@@ -3358,25 +3695,25 @@ msgstr "Несколько вещей, которые следует учиты�
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* Используйте локальную установку Rust, если это возможно. Таким образом вы\n"
-"можете получить автодополнение в вашем редакторе. Смотрите страницу\n"
-"[Using Cargo] для получения подробной информации об установке Rust.\n"
-"\n"
-"* В качестве альтернативы используйте Rust Playground."
+"Используйте локальную установку Rust, если это возможно. Таким образом вы "
+"можете получить автодополнение в вашем редакторе. Смотрите страницу [Using "
+"Cargo](../../cargo.md) для получения подробной информации об установке Rust."
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
+msgstr "В качестве альтернативы используйте Rust Playground."
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
-"Фрагменты кода намеренно недоступны для редактирования:\n"
-"встроенные фрагменты кода теряют свое состояние, если вы уходите со страницы."
+"Фрагменты кода намеренно недоступны для редактирования: встроенные фрагменты "
+"кода теряют свое состояние, если вы уходите со страницы."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
@@ -3384,20 +3721,21 @@ msgstr ""
 #: src/exercises/bare-metal/afternoon.md:7
 #: src/exercises/concurrency/morning.md:12
 #: src/exercises/concurrency/afternoon.md:13
-msgid "After looking at the exercises, you can look at the [solutions] provided."
-msgstr "Ознакомившись с упражнениями, вы можете изучить предоставленные [solutions]."
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
-msgstr "# Неявные преобразования"
+msgid ""
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
+msgstr ""
+"Ознакомившись с упражнениями, вы можете изучить предоставленные "
+"\\[solutions\\]."
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
-"Rust will not automatically apply _implicit conversions_ between types ([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"Rust will not automatically apply _implicit conversions_ between types "
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
-"Rust не применяет автоматически _неявные преобразования_ между типами ([в отличие от C++][3]).\n"
-"Это можно увидеть в следующей программе:"
+"Rust не применяет автоматически _неявные преобразования_ между типами ([в "
+"отличие от C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). Это можно увидеть в следующей программе:"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
@@ -3417,63 +3755,72 @@ msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single `from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Все целочисленные типы в Rust реализуют типажи [`From<T>`][1] и [`Into<T>`][2],\n"
-"что позволяет выполнять преобразования между ними. Типаж `From<T>` имеет\n"
-"единственный метод `from()` и аналогично, типаж `Into<T>` имеет единственный метод `into()`.\n"
-"Реализация этих типажей --- это то, как тип выражает, что он может быть преобразован в другой тип."
+"Все целочисленные типы в Rust реализуют типажи [`From<T>`](https://doc.rust-"
+"lang.org/std/convert/trait.From.html) и [`Into<T>`](https://doc.rust-lang."
+"org/std/convert/trait.Into.html), что позволяет выполнять преобразования "
+"между ними. Типаж `From<T>` имеет единственный метод `from()` и аналогично, "
+"типаж `Into<T>` имеет единственный метод `into()`. Реализация этих типажей "
+"--- это то, как тип выражает, что он может быть преобразован в другой тип."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
-"The standard library has an implementation of `From<i8> for i16`, which means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"The standard library has an implementation of `From<i8> for i16`, which "
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
-"В стандартной библиотеке есть реализация `From<i8> для i16`, что значит,\n"
-"что мы можем преобразовать переменную `x` типа `i8` в `i16`, вызвав\n"
-"`i16::from(x)`. Или, проще, с помощью `x.into()`, потому что реализация `From<i8> для i16`\n"
-"автоматически создает реализацию `Into<i16> для i8`."
+"В стандартной библиотеке есть реализация `From<i8> для i16`, что значит, что "
+"мы можем преобразовать переменную `x` типа `i8` в `i16`, вызвав `i16::"
+"from(x)`. Или, проще, с помощью `x.into()`, потому что реализация `From<i8> "
+"для i16` автоматически создает реализацию `Into<i16> для i8`."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
-"The same applies for your own `From` implementations for your own types, so it is\n"
-"sufficient to only implement `From` to get a respective `Into` implementation automatically."
+"The same applies for your own `From` implementations for your own types, so "
+"it is sufficient to only implement `From` to get a respective `Into` "
+"implementation automatically."
 msgstr ""
-"То же самое относится к реализациям `From` для ваших\n"
-"собственных типов, поэтому достаточно реализовать только `From`,\n"
-"чтобы автоматически получить соответствующую реализацию `Into`."
+"То же самое относится к реализациям `From` для ваших собственных типов, "
+"поэтому достаточно реализовать только `From`, чтобы автоматически получить "
+"соответствующую реализацию `Into`."
 
 #: src/exercises/day-1/implicit-conversions.md:33
-msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented for\n"
-"   the pairs you check."
+msgid "Execute the above program and look at the compiler error."
 msgstr ""
-"1. Запустите приведенную выше программу и посмотрите на ошибку компилятора.\n"
-"\n"
-"2. Измените приведенный выше код, чтобы использовать `into()` для выполнения преобразования.\n"
-"\n"
-"3. Измените типы `x` и `y` на другие (такие как `f32`, `bool`, `i128`),\n"
-"чтобы увидеть, из каких и в какие типы можно выполнить преобразование.\n"
-"Попробуйте преобразовать малые типы в большие и наоборот.\n"
-"Ознакомьтесь c [документацией стандартной библиотеки][1], чтобы узнать, реализован ли\n"
-"`From<T>` для проверяемых пар."
+"Запустите приведенную выше программу и посмотрите на ошибку компилятора."
+
+#: src/exercises/day-1/implicit-conversions.md:35
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr ""
+"Измените приведенный выше код, чтобы использовать `into()` для выполнения "
+"преобразования."
+
+#: src/exercises/day-1/implicit-conversions.md:37
+msgid ""
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
+msgstr ""
+"Измените типы `x` и `y` на другие (такие как `f32`, `bool`, `i128`), чтобы "
+"увидеть, из каких и в какие типы можно выполнить преобразование. Попробуйте "
+"преобразовать малые типы в большие и наоборот. Ознакомьтесь c [документацией "
+"стандартной библиотеки](https://doc.rust-lang.org/std/convert/trait.From."
+"html), чтобы узнать, реализован ли `From<T>` для проверяемых пар."
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
-msgstr "# Массивы и циклы `for`"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "Массивы и циклы `for`"
 
 #: src/exercises/day-1/for-loops.md:3
 msgid "We saw that an array can be declared like this:"
@@ -3487,8 +3834,12 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:9
-msgid "You can print such an array by asking for its debug representation with `{:?}`:"
-msgstr "Вы можете распечатать массив, запросив его отладочное представление используя `{:?}`:"
+msgid ""
+"You can print such an array by asking for its debug representation with `{:?}"
+"`:"
+msgstr ""
+"Вы можете распечатать массив, запросив его отладочное представление "
+"используя `{:?}`:"
 
 #: src/exercises/day-1/for-loops.md:11
 msgid ""
@@ -3508,9 +3859,11 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
-msgstr "Rust позволяет итерироваться по массивам и диапазонам используя ключевое слово `for`:"
+msgstr ""
+"Rust позволяет итерироваться по массивам и диапазонам используя ключевое "
+"слово `for`:"
 
 #: src/exercises/day-1/for-loops.md:21
 msgid ""
@@ -3550,11 +3903,12 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
-"Use the above to write a function `pretty_print` which pretty-print a matrix and\n"
-"a function `transpose` which will transpose a matrix (turn rows into columns):"
+"Use the above to write a function `pretty_print` which pretty-print a matrix "
+"and a function `transpose` which will transpose a matrix (turn rows into "
+"columns):"
 msgstr ""
-"Используя приведенное выше, напишите функцию `pretty_print`, которая\n"
-"красиво печатает матрицу и функцию `transpose`, которая транспонирует матрицу\n"
+"Используя приведенное выше, напишите функцию `pretty_print`, которая красиво "
+"печатает матрицу и функцию `transpose`, которая транспонирует матрицу "
 "(превращает строки в столбцы):"
 
 #: src/exercises/day-1/for-loops.md:41
@@ -3568,13 +3922,17 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:47
 msgid "Hard-code both functions to operate on 3 × 3 matrices."
-msgstr "Запрограммируйте обе функции так, чтобы они работали с матрицами размером 3 × 3."
+msgstr ""
+"Запрограммируйте обе функции так, чтобы они работали с матрицами размером 3 "
+"× 3."
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
-msgstr "Скопируйте приведенный ниже код в <https://play.rust-lang.org/> и реализуйте функции:"
+msgstr ""
+"Скопируйте приведенный ниже код в <https://play.rust-lang.org/> и реализуйте "
+"функции:"
 
 #: src/exercises/day-1/for-loops.md:52
 msgid ""
@@ -3620,7 +3978,8 @@ msgstr ""
 "\n"
 "fn main() {\n"
 "    let matrix = [\n"
-"        [101, 102, 103], // <-- комментарий заставляет rustfmt добавить переход на новую строку\n"
+"        [101, 102, 103], // <-- комментарий заставляет rustfmt добавить "
+"переход на новую строку\n"
 "        [201, 202, 203],\n"
 "        [301, 302, 303],\n"
 "    ];\n"
@@ -3635,41 +3994,39 @@ msgstr ""
 "```"
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
-msgstr "## Бонусный вопрос"
+msgid "Bonus Question"
+msgstr "Бонусный вопрос"
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"Могли бы вы использовать срезы `&[i32]`, вместо жестко закодированных\n"
-"матриц 3 × 3, как тип аргументов и возвращаемых значений?\n"
-"Что-то вроде `&[&[i32]]` для двумерного среза срезов. Почему или почему нет?"
+"Могли бы вы использовать срезы `&[i32]`, вместо жестко закодированных матриц "
+"3 × 3, как тип аргументов и возвращаемых значений? Что-то вроде `&[&[i32]]` "
+"для двумерного среза срезов. Почему или почему нет?"
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
-msgstr "Смотрите [пакет `ndarray`](https://docs.rs/ndarray/), чтобы узнать больше о реализации многомерных контейнеров."
+msgstr ""
+"Смотрите [пакет `ndarray`](https://docs.rs/ndarray/), чтобы узнать больше о "
+"реализации многомерных контейнеров."
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"Решение и ответ на бонусный вопрос доступны в разделе\n"
-"[Решение](solutions-morning.md#arrays-and-for-loops)."
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
-msgstr ""
+"Решение и ответ на бонусный вопрос доступны в разделе [Решение](solutions-"
+"morning.md#arrays-and-for-loops)."
 
 #: src/basic-syntax/variables.md:3
 msgid ""
-"Rust provides type safety via static typing. Variable bindings are immutable by\n"
-"default:"
+"Rust provides type safety via static typing. Variable bindings are immutable "
+"by default:"
 msgstr ""
 
 #: src/basic-syntax/variables.md:6
@@ -3686,12 +4043,14 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the function like syntax of `println!(\"x: {}\", x)`"
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
 msgstr ""
 
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
+"function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:3
@@ -3721,18 +4080,25 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:26
-msgid "This slide demonstrates how the Rust compiler infers types based on constraints given by variable declarations and usages."
+msgid ""
+"This slide demonstrates how the Rust compiler infers types based on "
+"constraints given by variable declarations and usages."
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:28
 msgid ""
-"It is very important to emphasize that variables declared like this are not of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"It is very important to emphasize that variables declared like this are not "
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:32
-msgid "The following code tells the compiler to copy into a certain generic container without the code ever explicitly specifying the contained type, using `_` as a placeholder:"
+msgid ""
+"The following code tells the compiler to copy into a certain generic "
+"container without the code ever explicitly specifying the contained type, "
+"using `_` as a placeholder:"
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:34
@@ -3751,11 +4117,14 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/type-inference.md:46
-msgid "[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect) relies on `FromIterator`, which [`HashSet`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) implements."
+msgid ""
+"[`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
+"html#method.collect) relies on `FromIterator`, which [`HashSet`](https://doc."
+"rust-lang.org/std/iter/trait.FromIterator.html) implements."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
+msgid "Static and Constant Variables"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:3
@@ -3763,7 +4132,7 @@ msgid "Global state is managed with static and constant variables."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
+msgid "`const`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:7
@@ -3779,7 +4148,8 @@ msgid ""
 "fn compute_digest(text: &str) -> [u8; DIGEST_SIZE] {\n"
 "    let mut digest = [ZERO.unwrap_or(0); DIGEST_SIZE];\n"
 "    for (idx, &b) in text.as_bytes().iter().enumerate() {\n"
-"        digest[idx % DIGEST_SIZE] = digest[idx % DIGEST_SIZE].wrapping_add(b);\n"
+"        digest[idx % DIGEST_SIZE] = digest[idx % DIGEST_SIZE]."
+"wrapping_add(b);\n"
 "    }\n"
 "    digest\n"
 "}\n"
@@ -3792,11 +4162,13 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According to the [Rust RFC Book][1] these are inlined upon use."
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
+msgid "`static`"
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:31
@@ -3815,28 +4187,39 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:41
-msgid "As noted in the [Rust RFC Book][1], these are not inlined upon use and have an actual associated memory location.  This is useful for unsafe and embedded code, and the variable lives through the entirety of the program execution."
+msgid ""
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:44
-msgid "We will look at mutating static data in the [chapter on Unsafe Rust](../unsafe.md)."
+msgid ""
+"We will look at mutating static data in the [chapter on Unsafe Rust](../"
+"unsafe.md)."
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:48
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
 
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
+#: src/basic-syntax/static-and-const.md:49
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
-"You can shadow variables, both those from outer scopes and variables from the\n"
-"same scope:"
+"You can shadow variables, both those from outer scopes and variables from "
+"the same scope:"
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:6
@@ -3861,10 +4244,26 @@ msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing both variable's memory locations exist at the same time. Both are available under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory locations when shadowing an immutable variable in a scope, even if the type does not change."
+"Definition: Shadowing is different from mutation, because after shadowing "
+"both variable's memory locations exist at the same time. Both are available "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
+"locations when shadowing an immutable variable in a scope, even if the type "
+"does not change."
 msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:30
@@ -3879,18 +4278,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr ""
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr ""
 
 #: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr ""
+
+#: src/memory-management.md:6
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, Haskell, ..."
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Haskell, ..."
 msgstr ""
 
 #: src/memory-management.md:8
@@ -3899,8 +4298,8 @@ msgstr ""
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
 
 #: src/memory-management.md:13
@@ -3912,30 +4311,48 @@ msgid "First, let's refresh how memory management works."
 msgstr ""
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
+msgid "The Stack vs The Heap"
 msgstr ""
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
+msgid "Stack: Continuous area of memory for local variables."
 msgstr ""
 
-#: src/memory-management/stack.md:1
-msgid "# Stack Memory"
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
 msgstr ""
 
 #: src/memory-management/stack.md:3
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 
@@ -3967,30 +4384,42 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is heap allocated using the [System Allocator] and custom allocators can be implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/manual.md:1
-msgid "# Manual Memory Management"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/memory-management/manual.md:3
@@ -3998,11 +4427,13 @@ msgid "You allocate and deallocate heap memory yourself."
 msgstr ""
 
 #: src/memory-management/manual.md:5
-msgid "If not done with care, this can lead to crashes, bugs, security vulnerabilities, and memory leaks."
+msgid ""
+"If not done with care, this can lead to crashes, bugs, security "
+"vulnerabilities, and memory leaks."
 msgstr ""
 
 #: src/memory-management/manual.md:7
-msgid "## C Example"
+msgid "C Example"
 msgstr ""
 
 #: src/memory-management/manual.md:9
@@ -4024,33 +4455,30 @@ msgstr ""
 
 #: src/memory-management/manual.md:21
 msgid ""
-"Memory is leaked if the function returns early between `malloc` and `free`: the\n"
-"pointer is lost and we cannot deallocate the memory."
-msgstr ""
-
-#: src/memory-management/scope-based.md:1
-msgid "# Scope-Based Memory Management"
+"Memory is leaked if the function returns early between `malloc` and `free`: "
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
 
 #: src/memory-management/scope-based.md:3
-msgid "Constructors and destructors let you hook into the lifetime of an object."
+msgid ""
+"Constructors and destructors let you hook into the lifetime of an object."
 msgstr ""
 
 #: src/memory-management/scope-based.md:5
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
-"destroyed. The compiler guarantees that this happens, even if an exception is\n"
-"raised."
+"By wrapping a pointer in an object, you can free memory when the object is "
+"destroyed. The compiler guarantees that this happens, even if an exception "
+"is raised."
 msgstr ""
 
 #: src/memory-management/scope-based.md:9
 msgid ""
-"This is often called _resource acquisition is initialization_ (RAII) and gives\n"
-"you smart pointers."
+"This is often called _resource acquisition is initialization_ (RAII) and "
+"gives you smart pointers."
 msgstr ""
 
 #: src/memory-management/scope-based.md:12
-msgid "## C++ Example"
+msgid "C++ Example"
 msgstr ""
 
 #: src/memory-management/scope-based.md:14
@@ -4064,14 +4492,21 @@ msgstr ""
 
 #: src/memory-management/scope-based.md:20
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
+msgstr ""
+
+#: src/memory-management/scope-based.md:22
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr ""
+
+#: src/memory-management/scope-based.md:23
+msgid "The destructor frees the `Person` object it points to."
 msgstr ""
 
 #: src/memory-management/scope-based.md:25
-msgid "Special move constructors are used when passing ownership to a function:"
+msgid ""
+"Special move constructors are used when passing ownership to a function:"
 msgstr ""
 
 #: src/memory-management/scope-based.md:27
@@ -4083,23 +4518,27 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:1
-msgid "# Automatic Memory Management"
+msgid "Automatic Memory Management"
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:3
 msgid ""
-"An alternative to manual and scope-based memory management is automatic memory\n"
-"management:"
+"An alternative to manual and scope-based memory management is automatic "
+"memory management:"
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:6
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr ""
+
+#: src/memory-management/garbage-collection.md:7
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the programmer."
+"A garbage collector finds unused memory and deallocates it for the "
+"programmer."
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:9
-msgid "## Java Example"
+msgid "Java Example"
 msgstr ""
 
 #: src/memory-management/garbage-collection.md:11
@@ -4116,7 +4555,7 @@ msgid ""
 msgstr ""
 
 #: src/memory-management/rust.md:1
-msgid "# Memory Management in Rust"
+msgid "Memory Management in Rust"
 msgstr ""
 
 #: src/memory-management/rust.md:3
@@ -4124,11 +4563,24 @@ msgid "Memory management in Rust is a mix:"
 msgstr ""
 
 #: src/memory-management/rust.md:5
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr ""
+
+#: src/memory-management/rust.md:6
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you choose, can be a single unique pointer, reference counted, or atomically reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even have no cost at runtime like C."
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+
+#: src/memory-management/rust.md:7
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+
+#: src/memory-management/rust.md:8
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
+"have no cost at runtime like C."
 msgstr ""
 
 #: src/memory-management/rust.md:10
@@ -4137,13 +4589,19 @@ msgstr ""
 
 #: src/memory-management/rust.md:14
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These encapsulate ownership and memory allocation via various means, and prevent the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
 
-#: src/memory-management/comparison.md:1
-msgid "# Comparison"
+#: src/memory-management/rust.md:16
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
 msgstr ""
 
 #: src/memory-management/comparison.md:3
@@ -4151,54 +4609,96 @@ msgid "Here is a rough comparison of the memory management techniques."
 msgstr ""
 
 #: src/memory-management/comparison.md:5
-msgid "## Pros of Different Memory Management Techniques"
+msgid "Pros of Different Memory Management Techniques"
 msgstr ""
 
-#: src/memory-management/comparison.md:7
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
+msgid "Manual like C:"
+msgstr ""
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+msgid "No runtime overhead."
+msgstr ""
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+msgid "Automatic like Java:"
+msgstr ""
+
+#: src/memory-management/comparison.md:10
+msgid "Fully automatic."
+msgstr ""
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+msgid "Safe and correct."
+msgstr ""
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+msgid "Scope-based like C++:"
+msgstr ""
+
+#: src/memory-management/comparison.md:13
+msgid "Partially automatic."
+msgstr ""
+
+#: src/memory-management/comparison.md:15
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr ""
+
+#: src/memory-management/comparison.md:16
+msgid "Enforced by compiler."
 msgstr ""
 
 #: src/memory-management/comparison.md:20
-msgid "## Cons of Different Memory Management Techniques"
+msgid "Cons of Different Memory Management Techniques"
 msgstr ""
 
-#: src/memory-management/comparison.md:22
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
+#: src/memory-management/comparison.md:23
+msgid "Use-after-free."
 msgstr ""
 
-#: src/ownership.md:1
-msgid "# Ownership"
+#: src/memory-management/comparison.md:24
+msgid "Double-frees."
+msgstr ""
+
+#: src/memory-management/comparison.md:25
+msgid "Memory leaks."
+msgstr ""
+
+#: src/memory-management/comparison.md:27
+msgid "Garbage collection pauses."
+msgstr ""
+
+#: src/memory-management/comparison.md:28
+msgid "Destructor delays."
+msgstr ""
+
+#: src/memory-management/comparison.md:30
+msgid "Complex, opt-in by programmer."
+msgstr ""
+
+#: src/memory-management/comparison.md:31
+msgid "Potential for use-after-free."
+msgstr ""
+
+#: src/memory-management/comparison.md:32
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr ""
+
+#: src/memory-management/comparison.md:33
+msgid "Some upfront complexity."
+msgstr ""
+
+#: src/memory-management/comparison.md:34
+msgid "Can reject valid programs."
 msgstr ""
 
 #: src/ownership.md:3
 msgid ""
-"All variable bindings have a _scope_ where they are valid and it is an error to\n"
-"use a variable outside its scope:"
+"All variable bindings have a _scope_ where they are valid and it is an error "
+"to use a variable outside its scope:"
 msgstr ""
 
 #: src/ownership.md:6
@@ -4218,13 +4718,15 @@ msgstr ""
 
 #: src/ownership.md:18
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr ""
 
-#: src/ownership/move-semantics.md:1
-msgid "# Move Semantics"
+#: src/ownership.md:19
+msgid "A destructor can run here to free up resources."
+msgstr ""
+
+#: src/ownership.md:20
+msgid "We say that the variable _owns_ the value."
 msgstr ""
 
 #: src/ownership/move-semantics.md:3
@@ -4244,23 +4746,33 @@ msgid ""
 msgstr ""
 
 #: src/ownership/move-semantics.md:14
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr ""
+
+#: src/ownership/move-semantics.md:15
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
+msgstr ""
+
+#: src/ownership/move-semantics.md:16
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr ""
+
+#: src/ownership/move-semantics.md:17
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr ""
+
+#: src/ownership/move-semantics.md:18
+msgid "There is always _exactly_ one variable binding which owns a value."
 msgstr ""
 
 #: src/ownership/move-semantics.md:22
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
 
-#: src/ownership/moved-strings-rust.md:1
-msgid "# Moved Strings in Rust"
+#: src/ownership/move-semantics.md:24
+msgid "In Rust, clones are explicit (by using `clone`)."
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:3
@@ -4274,9 +4786,11 @@ msgid ""
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:10
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr ""
+
+#: src/ownership/moved-strings-rust.md:11
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
 msgstr ""
 
 #: src/ownership/moved-strings-rust.md:13
@@ -4329,10 +4843,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:1
-msgid "# Double Frees in Modern C++"
-msgstr ""
-
 #: src/ownership/double-free-modern-cpp.md:3
 msgid "Modern C++ solves this differently:"
 msgstr ""
@@ -4347,8 +4857,11 @@ msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:10
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
+msgstr ""
+
+#: src/ownership/double-free-modern-cpp.md:11
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
 msgstr ""
 
 #: src/ownership/double-free-modern-cpp.md:13
@@ -4400,13 +4913,9 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:1
-msgid "# Moves in Function Calls"
-msgstr ""
-
 #: src/ownership/moves-function-calls.md:3
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 
@@ -4427,19 +4936,37 @@ msgstr ""
 
 #: src/ownership/moves-function-calls.md:20
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the `say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name.clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making move semantics the default, and by forcing programmers to make clones explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
 
-#: src/ownership/copy-clone.md:1
-msgid "# Copying and Cloning"
+#: src/ownership/moves-function-calls.md:21
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:22
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:23
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+
+#: src/ownership/moves-function-calls.md:24
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
 msgstr ""
 
 #: src/ownership/copy-clone.md:3
-msgid "While move semantics are the default, certain types are copied by default:"
+msgid ""
+"While move semantics are the default, certain types are copied by default:"
 msgstr ""
 
 #: src/ownership/copy-clone.md:5
@@ -4478,9 +5005,11 @@ msgid ""
 msgstr ""
 
 #: src/ownership/copy-clone.md:30
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
+msgid "After the assignment, both `p1` and `p2` own their own data."
+msgstr ""
+
+#: src/ownership/copy-clone.md:31
+msgid "We can also use `p1.clone()` to explicitly copy the data."
 msgstr ""
 
 #: src/ownership/copy-clone.md:35
@@ -4489,10 +5018,23 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:37
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C++).\n"
-"* Cloning is a more general operation and also allows for custom behavior by implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
+msgstr ""
+
+#: src/ownership/copy-clone.md:38
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+
+#: src/ownership/copy-clone.md:39
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+
+#: src/ownership/copy-clone.md:40
+msgid "Copying does not work on types that implement the `Drop` trait."
 msgstr ""
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
@@ -4501,24 +5043,30 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:44
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because `String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
+msgstr ""
+
+#: src/ownership/copy-clone.md:45
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+
+#: src/ownership/copy-clone.md:46
+msgid "Show that it works if you clone `p1` instead."
 msgstr ""
 
 #: src/ownership/copy-clone.md:48
 msgid ""
-"If students ask about `derive`, it is sufficient to say that this is a way to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and `Clone` traits are generated."
-msgstr ""
-
-#: src/ownership/borrowing.md:1
-msgid "# Borrowing"
+"If students ask about `derive`, it is sufficient to say that this is a way "
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 
 #: src/ownership/borrowing.md:3
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
 
@@ -4542,9 +5090,11 @@ msgid ""
 msgstr ""
 
 #: src/ownership/borrowing.md:22
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
+msgid "The `add` function _borrows_ two points and returns a new point."
+msgstr ""
+
+#: src/ownership/borrowing.md:23
+msgid "The caller retains ownership of the inputs."
 msgstr ""
 
 #: src/ownership/borrowing.md:27
@@ -4553,32 +5103,45 @@ msgstr ""
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can eliminate the copy operation. Change the above code to print stack addresses and run it on the [Playground]. In the \"DEBUG\" optimization level, the addresses should change, while they stay the same when changing to the \"RELEASE\" setting:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification because constructors can have side effects. In Rust, this is not an issue at all. If RVO did not happen, Rust will always perform a simple and efficient `memcpy` copy."
+"Demonstrate that the return from `add` is cheap because the compiler can "
+"eliminate the copy operation. Change the above code to print stack addresses "
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/ownership/shared-unique-borrows.md:1
-msgid "# Shared and Unique Borrows"
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr ""
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always perform a simple and efficient `memcpy` "
+"copy."
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:3
@@ -4586,9 +5149,11 @@ msgid "Rust puts constraints on the ways you can borrow values:"
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:5
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr ""
+
+#: src/ownership/shared-unique-borrows.md:6
+msgid "You can have exactly one `&mut T` value."
 msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:8
@@ -4611,13 +5176,21 @@ msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:25
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable (through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before the new mutable borrow of `a` through `c`. This is a feature of the borrow checker called \"non-lexical lifetimes\"."
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
 msgstr ""
 
-#: src/ownership/lifetimes.md:1
-msgid "# Lifetimes"
+#: src/ownership/shared-unique-borrows.md:26
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+
+#: src/ownership/shared-unique-borrows.md:27
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
+"the new mutable borrow of `a` through `c`. This is a feature of the borrow "
+"checker called \"non-lexical lifetimes\"."
 msgstr ""
 
 #: src/ownership/lifetimes.md:3
@@ -4625,26 +5198,42 @@ msgid "A borrowed value has a _lifetime_:"
 msgstr ""
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully specified,\n"
-"  but Rust allows lifetimes to be elided in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
 msgstr ""
 
-#: src/ownership/lifetimes-function-calls.md:1
-msgid "# Lifetimes in Function Calls"
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr ""
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+
+#: src/ownership/lifetimes.md:13
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows lifetimes to be elided in most cases with [a few simple "
+"rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:3
-msgid "In addition to borrowing its arguments, a function can return a borrowed value:"
+msgid ""
+"In addition to borrowing its arguments, a function can return a borrowed "
+"value:"
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:5
@@ -4667,52 +5256,82 @@ msgid ""
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:21
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:22
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:25
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+"The _at least_ part is important when parameters are in different scopes."
 msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:31
 msgid ""
-"* Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global variable).\n"
-"  * Which one is it? The compiler needs to know, so at the call site the returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
 
-#: src/ownership/lifetimes-data-structures.md:1
-msgid "# Lifetimes in Data Structures"
+#: src/ownership/lifetimes-function-calls.md:32
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:50
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:52
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:53
+msgid "Another way to explain it:"
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
-msgid "If a data type stores borrowed data, it must be annotated with a lifetime:"
+msgid ""
+"If a data type stores borrowed data, it must be annotated with a lifetime:"
 msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:5
@@ -4726,7 +5345,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let text = String::from(\"The quick brown fox jumps over the lazy dog.\");\n"
+"    let text = String::from(\"The quick brown fox jumps over the lazy dog."
+"\");\n"
 "    let fox = Highlight(&text[4..19]);\n"
 "    let dog = Highlight(&text[35..43]);\n"
 "    // erase(text);\n"
@@ -4738,15 +5358,38 @@ msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:25
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data underlying the contained `&str` lives at least as long as any instance of `Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This can be useful for creating lightweight views, but it generally makes them somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one lifetime annotation. This can be necessary if there is a need to describe lifetime relationships between the references themselves, in addition to the lifetime of the struct itself. Those are very advanced use cases."
+"In the above example, the annotation on `Highlight` enforces that the data "
+"underlying the contained `&str` lives at least as long as any instance of "
+"`Highlight` that uses that data."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:26
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:27
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:28
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+
+#: src/ownership/lifetimes-data-structures.md:29
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:1
-msgid "# Day 1: Afternoon Exercises"
+msgid "Day 1: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:3
@@ -4754,20 +5397,17 @@ msgid "We will look at two things:"
 msgstr ""
 
 #: src/exercises/day-1/afternoon.md:5
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
+msgid "A small book library,"
 msgstr ""
 
-#: src/exercises/day-1/book-library.md:1
-msgid "# Designing a Library"
+#: src/exercises/day-1/afternoon.md:7
+msgid "Iterators and ownership (hard)."
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:3
 msgid ""
-"We will learn much more about structs and the `Vec<T>` type tomorrow. For now,\n"
-"you just need to know part of its API:"
+"We will learn much more about structs and the `Vec<T>` type tomorrow. For "
+"now, you just need to know part of its API:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:6
@@ -4787,8 +5427,8 @@ msgstr ""
 
 #: src/exercises/day-1/book-library.md:18
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 
 #: src/exercises/day-1/book-library.md:21
@@ -4837,7 +5477,8 @@ msgid ""
 "    //}\n"
 "\n"
 "    //fn print_books(self) {\n"
-"    //    todo!(\"Iterate over `self.books` and each book's title and year\")\n"
+"    //    todo!(\"Iterate over `self.books` and each book's title and "
+"year\")\n"
 "    //}\n"
 "\n"
 "    //fn oldest_book(self) -> Option<&Book> {\n"
@@ -4852,12 +5493,15 @@ msgid ""
 "fn main() {\n"
 "    let library = Library::new();\n"
 "\n"
-"    //println!(\"The library is empty: library.is_empty() -> {}\", library.is_empty());\n"
+"    //println!(\"The library is empty: library.is_empty() -> {}\", library."
+"is_empty());\n"
 "    //\n"
 "    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    //\n"
-"    //println!(\"The library is no longer empty: library.is_empty() -> {}\", library.is_empty());\n"
+"    //println!(\"The library is no longer empty: library.is_empty() -> {}\", "
+"library.is_empty());\n"
 "    //\n"
 "    //\n"
 "    //library.print_books();\n"
@@ -4877,26 +5521,23 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-msgid "# Iterators and Ownership"
-msgstr ""
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
-msgid "## `Iterator`"
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
+msgid "`Iterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. The\n"
-"`Iterator` trait simply says that you can call `next` until you get `None` back:"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
+"`Iterator` trait simply says that you can call `next` until you get `None` "
+"back:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
@@ -4950,13 +5591,14 @@ msgid "Why is this type used?"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
-msgid "## `IntoIterator`"
+msgid "`IntoIterator`"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
-"iterator. The related trait `IntoIterator` tells you how to create the iterator:"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
+"iterator. The related trait `IntoIterator` tells you how to create the "
+"iterator:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:53
@@ -4973,19 +5615,21 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:62
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr ""
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 
@@ -4997,7 +5641,8 @@ msgstr ""
 msgid ""
 "```rust,editable,compile_fail\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "    let mut iter = v.into_iter();\n"
 "\n"
 "    let v0: Option<..> = iter.next();\n"
@@ -5007,21 +5652,22 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
-msgid "## `for` Loops"
+msgid "`for` Loops"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 msgid ""
-"Now that we know both `Iterator` and `IntoIterator`, we can build `for` loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
 "```rust,editable\n"
 "fn main() {\n"
-"    let v: Vec<String> = vec![String::from(\"foo\"), String::from(\"bar\")];\n"
+"    let v: Vec<String> = vec![String::from(\"foo\"), String::"
+"from(\"bar\")];\n"
 "\n"
 "    for word in &v {\n"
 "        println!(\"word: {word}\");\n"
@@ -5040,16 +5686,15 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:105
 msgid ""
-"Experiment with the code above and then consult the documentation for [`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 
 #: src/welcome-day-2.md:1
-msgid "# Welcome to Day 2"
+msgid "Welcome to Day 2"
 msgstr ""
 
 #: src/welcome-day-2.md:3
@@ -5057,22 +5702,27 @@ msgid "Now that we have seen a fair amount of Rust, we will continue with:"
 msgstr ""
 
 #: src/welcome-day-2.md:5
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, `Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
+msgid "Structs, enums, methods."
 msgstr ""
 
-#: src/structs.md:1
-msgid "# Structs"
+#: src/welcome-day-2.md:7
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr ""
+
+#: src/welcome-day-2.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
 msgstr ""
 
 #: src/structs.md:3
@@ -5113,19 +5763,47 @@ msgid "Key Points:"
 msgstr ""
 
 #: src/structs.md:33
-msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following slides.\n"
-"* This may be a good time to let people know there are different types of structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a trait on some type but don’t have any data that you want to store in the value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the old struct without having to explicitly type it all out. It must always be the last element."
+msgid "Structs work like in C or C++."
 msgstr ""
 
-#: src/structs/tuple-structs.md:1
-msgid "# Tuple Structs"
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
+msgid ""
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"trait on some type but don’t have any data that you want to store in the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
+"old struct without having to explicitly type it all out. It must always be "
+"the last element."
 msgstr ""
 
 #: src/structs/tuple-structs.md:3
@@ -5172,22 +5850,45 @@ msgstr ""
 
 #: src/structs/tuple-structs.md:37
 msgid ""
-"* Newtypes are a great way to encode additional information about the value in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer have to validate it again at every use: 'PhoneNumber(String)` or `OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics).\n"
-"* The example is a subtle reference to the [Mars Climate Orbiter](https://en.wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
 
-#: src/structs/field-shorthand.md:1
-msgid "# Field Shorthand Syntax"
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics)."
+msgstr ""
+
+#: src/structs/tuple-structs.md:43
+msgid ""
+"The example is a subtle reference to the [Mars Climate Orbiter](https://en."
+"wikipedia.org/wiki/Mars_Climate_Orbiter) failure."
 msgstr ""
 
 #: src/structs/field-shorthand.md:3
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
 
@@ -5215,60 +5916,79 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-msgid "# Enums"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
 msgstr ""
 
 #: src/enums.md:3
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
 
 #: src/enums.md:6
@@ -5301,23 +6021,40 @@ msgid ""
 msgstr ""
 
 #: src/enums.md:36
-msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and `Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate structs but then they wouldn’t be the same type as they would if they were all defined in an enum. "
+msgid "Enumerations allow you to collect a set of values under one type"
 msgstr ""
 
-#: src/enums/variant-payloads.md:1
-msgid "# Variant Payloads"
+#: src/enums.md:37
+msgid ""
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+
+#: src/enums.md:38
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr ""
+
+#: src/enums.md:39
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+
+#: src/enums.md:40
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr ""
+
+#: src/enums.md:41
+msgid ""
+"You could even implement the different variants of an enum with separate "
+"structs but then they wouldn’t be the same type as they would if they were "
+"all defined in an enum. "
 msgstr ""
 
 #: src/enums/variant-payloads.md:3
 msgid ""
-"You can define richer enums where the variants carry data. You can then use the\n"
-"`match` statement to extract the data from each variant:"
+"You can define richer enums where the variants carry data. You can then use "
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 
 #: src/enums/variant-payloads.md:6
@@ -5352,24 +6089,62 @@ msgstr ""
 
 #: src/enums/variant-payloads.md:35
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern matched. The pattern binds references to the fields in the \"match arm\" after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the advantage the Rust compiler provides by confirming when all cases are handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::Click(Click)` with a top level `struct Click { ... }`. The inlined version cannot implement traits, for example.  \n"
-"  "
+"The values in the enum variants can only be accessed after being pattern "
+"matched. The pattern binds references to the fields in the \"match arm\" "
+"after the `=>`."
 msgstr ""
 
-#: src/enums/sizes.md:1
-msgid "# Enum Sizes"
+#: src/enums/variant-payloads.md:36
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr ""
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
 msgstr ""
 
 #: src/enums/sizes.md:3
-msgid "Rust enums are packed tightly, taking constraints due to alignment into account:"
+msgid ""
+"Rust enums are packed tightly, taking constraints due to alignment into "
+"account:"
 msgstr ""
 
 #: src/enums/sizes.md:5
@@ -5396,140 +6171,192 @@ msgid ""
 msgstr ""
 
 #: src/enums/sizes.md:25
-msgid "* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout.html)."
+msgid ""
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"html)."
 msgstr ""
 
 #: src/enums/sizes.md:31
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+
+#: src/enums/sizes.md:33
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr ""
+
+#: src/enums/sizes.md:35
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:50
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+
+#: src/enums/sizes.md:54
+msgid "Try out other types such as"
+msgstr ""
+
+#: src/enums/sizes.md:56
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr ""
+
+#: src/enums/sizes.md:57
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+
+#: src/enums/sizes.md:58
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+
+#: src/enums/sizes.md:59
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+
+#: src/enums/sizes.md:61
+msgid ""
+"Niche optimization: Rust will merge unused bit patterns for the enum "
+"discriminant."
+msgstr ""
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2\n"
-"    bytes.\n"
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"    };\n"
+"}\n"
 "\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer optimization, see below).\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-" * Niche optimization: Rust will merge unused bit patterns for the enum\n"
-"   discriminant.\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
 "\n"
-"     Example code if you want to show how the bitwise representation *may* look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees regarding this representation, therefore this is totally unsafe.\n"
+"use std::mem::transmute;\n"
 "\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"$bit_type>($e));\n"
+"    };\n"
+"}\n"
 "\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, $bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"signs.\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
+"Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"\n"
-"     More complex example if you want to discuss what happens when we chain more than 256 `Option`s together.\n"
-"\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, $bit_type>($e));\n"
-"         };\n"
-"     }\n"
-"\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
-"\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), Some(Some(Some(Some(false)))));\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
-"\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods.md:3
 msgid ""
-"Rust allows you to associate functions with your new types. You do this with an\n"
-"`impl` block:"
+"Rust allows you to associate functions with your new types. You do this with "
+"an `impl` block:"
 msgstr ""
 
 #: src/methods.md:6
@@ -5558,60 +6385,103 @@ msgid ""
 msgstr ""
 
 #: src/methods.md:31
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method receiver syntax and to help keep them more organized. By using methods we can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from `self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
 
-#: src/methods/receiver.md:1
-msgid "# Method Receiver"
+#: src/methods.md:32
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+
+#: src/methods.md:33
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+
+#: src/methods.md:34
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr ""
+
+#: src/methods.md:35
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+
+#: src/methods.md:36
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+
+#: src/methods.md:37
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+
+#: src/methods.md:38
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+
+#: src/methods.md:39
+msgid "We describe the distinction between method receivers next."
 msgstr ""
 
 #: src/methods/receiver.md:3
 msgid ""
-"The `&self` above indicates that the method borrows the object immutably. There\n"
-"are other possible receivers for a method:"
+"The `&self` above indicates that the method borrows the object immutably. "
+"There are other possible receivers for a method:"
 msgstr ""
 
 #: src/methods/receiver.md:6
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. The\n"
-"  method becomes the owner of the object. The object will be dropped (deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted. Complete ownership does not automatically mean mutability.\n"
-"* `mut self`: same as above, but the method can mutate the object. \n"
-"* No receiver: this becomes a static method on the struct. Typically used to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:8
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+
+#: src/methods/receiver.md:10
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+
+#: src/methods/receiver.md:14
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+
+#: src/methods/receiver.md:15
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
 msgstr ""
 
 #: src/methods/receiver.md:18
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
 
 #: src/methods/receiver.md:24
 msgid ""
-"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) method on it."
-msgstr ""
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-msgid "# Example"
+"Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 
 #: src/methods/example.md:3
@@ -5628,7 +6498,8 @@ msgid ""
 "        Race { name: String::from(name), laps: Vec::new() }\n"
 "    }\n"
 "\n"
-"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write access to self\n"
+"    fn add_lap(&mut self, lap: i32) {  // Exclusive borrowed read-write "
+"access to self\n"
 "        self.laps.push(lap);\n"
 "    }\n"
 "\n"
@@ -5641,7 +6512,8 @@ msgid ""
 "\n"
 "    fn finish(self) {  // Exclusive ownership of self\n"
 "        let total = self.laps.iter().sum::<i32>();\n"
-"        println!(\"Race {} is finished, total lap time: {}\", self.name, total);\n"
+"        println!(\"Race {} is finished, total lap time: {}\", self.name, "
+"total);\n"
 "    }\n"
 "}\n"
 "\n"
@@ -5659,22 +6531,38 @@ msgid ""
 msgstr ""
 
 #: src/methods/example.md:47
-msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` twice.\n"
-"* Note that although the method receivers are different, the non-static functions are called the same way in the main body. Rust enables automatic referencing and dereferencing when calling methods. Rust automatically adds in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated over. We describe vectors in more detail in the afternoon. "
+msgid "All four methods here use a different method receiver."
 msgstr ""
 
-#: src/pattern-matching.md:1
-msgid "# Pattern Matching"
+#: src/methods/example.md:48
+msgid ""
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+
+#: src/methods/example.md:49
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+
+#: src/methods/example.md:50
+msgid ""
+"Note that although the method receivers are different, the non-static "
+"functions are called the same way in the main body. Rust enables automatic "
+"referencing and dereferencing when calling methods. Rust automatically adds "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+
+#: src/methods/example.md:51
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
 msgstr ""
 
 #: src/pattern-matching.md:3
 msgid ""
-"The `match` keyword let you match a value against one or more _patterns_. The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The `match` keyword let you match a value against one or more _patterns_. "
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 
 #: src/pattern-matching.md:6
@@ -5703,25 +6591,47 @@ msgstr ""
 
 #: src/pattern-matching.md:26
 msgid ""
-"* You might point out how some specific characters are being used when in a pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
 
-#: src/pattern-matching/destructuring-enums.md:1
-msgid "# Destructuring Enums"
+#: src/pattern-matching.md:27
+msgid "`|` as an `or`"
+msgstr ""
+
+#: src/pattern-matching.md:28
+msgid "`..` can expand as much as it needs to be"
+msgstr ""
+
+#: src/pattern-matching.md:29
+msgid "`1..=5` represents an inclusive range"
+msgstr ""
+
+#: src/pattern-matching.md:30
+msgid "`_` is a wild card"
+msgstr ""
+
+#: src/pattern-matching.md:31
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+
+#: src/pattern-matching.md:32
+msgid "You can demonstrate matching on a reference."
+msgstr ""
+
+#: src/pattern-matching.md:33
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:3
 msgid ""
-"Patterns can also be used to bind variables to parts of your values. This is how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` type:"
+"Patterns can also be used to bind variables to parts of your values. This is "
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:6
@@ -5752,19 +6662,22 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:29
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the first\n"
-"arm, `half` is bound to the value inside the `Ok` variant. In the second arm,\n"
-"`msg` is bound to the error message."
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
+"arm, `half` is bound to the value inside the `Ok` variant. In the second "
+"arm, `msg` is bound to the error message."
 msgstr ""
 
 #: src/pattern-matching/destructuring-enums.md:36
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying the errors when running the code. Point out the places where your code is now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
 
-#: src/pattern-matching/destructuring-structs.md:1
-msgid "# Destructuring Structs"
+#: src/pattern-matching/destructuring-enums.md:37
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:3
@@ -5785,27 +6698,31 @@ msgid ""
 "    match foo {\n"
 "        Foo { x: (1, b), y } => println!(\"x.0 = 1, b = {b}, y = {y}\"),\n"
 "        Foo { y: 2, x: i }   => println!(\"y = 2, x = {i:?}\"),\n"
-"        Foo { y, .. }        => println!(\"y = {y}, other fields were ignored\"),\n"
+"        Foo { y, .. }        => println!(\"y = {y}, other fields were "
+"ignored\"),\n"
 "    }\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-msgid "# Destructuring Arrays"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:25
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
-msgid "You can destructure arrays, tuples, and slices by matching on their elements:"
+msgid ""
+"You can destructure arrays, tuples, and slices by matching on their elements:"
 msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:5
@@ -5826,40 +6743,52 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:1
-msgid "# Match Guards"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 msgid ""
-"When matching, you can add a _guard_ to a pattern. This is an arbitrary Boolean\n"
-"expression which will be executed if the pattern matches:"
+"When matching, you can add a _guard_ to a pattern. This is an arbitrary "
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 
 #: src/pattern-matching/match-guards.md:6
@@ -5881,15 +6810,31 @@ msgstr ""
 
 #: src/pattern-matching/match-guards.md:23
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when we wish to concisely express more complex ideas than patterns alone would allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. An `if` expression inside of the branch block (after `=>`) happens after the match arm is selected. Failing the `if` condition inside of that block won't result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a pattern with an `|`."
+"Match guards as a separate syntax feature are important and necessary when "
+"we wish to concisely express more complex ideas than patterns alone would "
+"allow."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:24
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
+"An `if` expression inside of the branch block (after `=>`) happens after the "
+"match arm is selected. Failing the `if` condition inside of that block won't "
+"result in other arms of the original `match` expression being considered."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:26
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+
+#: src/pattern-matching/match-guards.md:27
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
 msgstr ""
 
 #: src/exercises/day-2/morning.md:1
-msgid "# Day 2: Morning Exercises"
+msgid "Day 2: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:3
@@ -5897,32 +6842,29 @@ msgid "We will look at implementing methods in two contexts:"
 msgstr ""
 
 #: src/exercises/day-2/morning.md:5
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
+msgid "Simple struct which tracks health statistics."
 msgstr ""
 
-#: src/exercises/day-2/health-statistics.md:1
-msgid "# Health Statistics"
+#: src/exercises/day-2/morning.md:7
+msgid "Multiple structs and enums for a drawing library."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
 msgid ""
-"You're working on implementing a health-monitoring system. As part of that, you\n"
-"need to keep track of users' health statistics."
+"You're working on implementing a health-monitoring system. As part of that, "
+"you need to keep track of users' health statistics."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:6
 msgid ""
-"You'll start with some stubbed functions in an `impl` block as well as a `User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"You'll start with some stubbed functions in an `impl` block as well as a "
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:10
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 
@@ -5986,14 +6928,14 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
-msgid "# Polygon Struct"
+msgid "Polygon Struct"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:3
 msgid ""
-"We will create a `Polygon` struct which contain some points. Copy the code below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make the\n"
-"tests pass:"
+"We will create a `Polygon` struct which contain some points. Copy the code "
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:7
@@ -6109,8 +7051,9 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:117
 msgid ""
-"Since the method signatures are missing from the problem statements, the key part\n"
-"of the exercise is to specify those correctly. You don't have to modify the tests."
+"Since the method signatures are missing from the problem statements, the key "
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:120
@@ -6119,36 +7062,37 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:122
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
 
-#: src/control-flow.md:1
-msgid "# Control Flow"
-msgstr "# Поток управления"
+#: src/exercises/day-2/points-polygons.md:123
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
 
 #: src/control-flow.md:3
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
-"evaluate one of two blocks, but the blocks can have a value which then becomes\n"
-"the value of the `if` expression. Other control flow expressions work similarly\n"
-"in Rust."
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
+"evaluate one of two blocks, but the blocks can have a value which then "
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
-"Как мы уже заметили, выражение `if` может использоваться для \n"
-"условного выполнения одного из двух блоков. Однако, в Rust сами блоки могут \n"
-"иметь значения. Значение одного из двух блоков (в зависимости от значения условия) \n"
-"и станет значением всего выражения `if`. Другие выражения управления потоком\n"
-"(такие как `while`, `for` и `match`), работают схожим образом."
-
-#: src/control-flow/blocks.md:1
-msgid "# Blocks"
-msgstr "# Блоки"
+"Как мы уже заметили, выражение `if` может использоваться для  условного "
+"выполнения одного из двух блоков. Однако, в Rust сами блоки могут  иметь "
+"значения. Значение одного из двух блоков (в зависимости от значения "
+"условия)  и станет значением всего выражения `if`. Другие выражения "
+"управления потоком (такие как `while`, `for` и `match`), работают схожим "
+"образом."
 
 #: src/control-flow/blocks.md:3
 msgid ""
-"A block in Rust has a value and a type: the value is the last expression of the\n"
-"block:"
-msgstr "Блоки в языке Rust имеют тип и значение, которые равны типу и значению последнего выражения в блоке. Например:"
+"A block in Rust has a value and a type: the value is the last expression of "
+"the block:"
+msgstr ""
+"Блоки в языке Rust имеют тип и значение, которые равны типу и значению "
+"последнего выражения в блоке. Например:"
 
 #: src/control-flow/blocks.md:6
 msgid ""
@@ -6174,10 +7118,10 @@ msgstr ""
 
 #: src/control-flow/blocks.md:25
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
-"То же правило работает и для функций: функция возвращает значение \n"
+"То же правило работает и для функций: функция возвращает значение  "
 "последнего выражения в теле:"
 
 #: src/control-flow/blocks.md:28
@@ -6203,31 +7147,39 @@ msgstr ""
 "```"
 
 #: src/control-flow/blocks.md:38
-msgid "However if the last expression ends with `;`, then the resulting value and type is `()`."
+msgid ""
+"However if the last expression ends with `;`, then the resulting value and "
+"type is `()`."
 msgstr ""
-"Однако, если за последним выражением в блоке следует `;`, то результатом такого \n"
-"блока (а также его тип) будет `()`."
+"Однако, если за последним выражением в блоке следует `;`, то результатом "
+"такого  блока (а также его тип) будет `()`."
 
 #: src/control-flow/blocks.md:43
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in Rust. \n"
-"* You can show how the value of the block changes by changing the last line in the block. For instance, adding/removing a semicolon or using a `return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr "Этот слайд показывает, что в языке Rust у блоков есть тип и значение. "
+
+#: src/control-flow/blocks.md:44
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
-"* Этот слайд показывает, что в языке Rust у блоков есть тип и значение. \n"
-"* Можно показать, как меняется значение блока при изменении последней строки \n"
-"в блоке. Например, можно добавить/убрать точку с запятой или использовать `return`."
+"Можно показать, как меняется значение блока при изменении последней строки  "
+"в блоке. Например, можно добавить/убрать точку с запятой или использовать "
+"`return`."
 
 #: src/control-flow/if-expressions.md:1
-msgid "# `if` expressions"
-msgstr "# Выражение `if`"
+msgid "`if` expressions"
+msgstr "Выражение `if`"
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions)\n"
-"exactly like `if` statements in other languages:"
-msgstr "[Выражение `if`](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-expressions) работает так же, как и оператор `if` в других языках:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
+msgstr ""
+"[Выражение `if`](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-expressions) работает так же, как и оператор `if` в других языках:"
 
 #: src/control-flow/if-expressions.md:7
 msgid ""
@@ -6245,11 +7197,11 @@ msgstr ""
 
 #: src/control-flow/if-expressions.md:18
 msgid ""
-"In addition, you can use `if` as an expression. The last expression of each\n"
+"In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
-"Помимо этого, можно использовать `if` как выражение. Последнее выражение \n"
-"внутри одного из блоков (в зависимости от значения условия) становится \n"
+"Помимо этого, можно использовать `if` как выражение. Последнее выражение  "
+"внутри одного из блоков (в зависимости от значения условия) становится  "
 "значением всего выражения `if`:"
 
 #: src/control-flow/if-expressions.md:22
@@ -6267,22 +7219,27 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/if-expressions.md:35
-msgid "Because `if` is an expression and must have a particular type, both of its branch blocks must have the same type. Consider showing what happens if you add `;` after `x / 2` in the second example."
-msgstr "Обе ветки выражения `if` должны быть одинакового типа. Попробуйте показать, что происходит, если добавить `;` после `x / 2` во втором примере."
+msgid ""
+"Because `if` is an expression and must have a particular type, both of its "
+"branch blocks must have the same type. Consider showing what happens if you "
+"add `;` after `x / 2` in the second example."
+msgstr ""
+"Обе ветки выражения `if` должны быть одинакового типа. Попробуйте показать, "
+"что происходит, если добавить `;` после `x / 2` во втором примере."
 
 #: src/control-flow/if-let-expressions.md:1
-msgid "# `if let` expressions"
-msgstr "# Выражение `if let`"
+msgid "`if let` expressions"
+msgstr "Выражение `if let`"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions)\n"
-"lets you execute different code depending on whether a value matches a pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
-"[Выражение `if let`](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions)\n"
-"позволяет выполнять разные ветки кода в зависимости от того, соответствует ли какое-либо \n"
-"значение шаблону или нет:"
+"[Выражение `if let`](https://doc.rust-lang.org/reference/expressions/if-expr."
+"html#if-let-expressions) позволяет выполнять разные ветки кода в зависимости "
+"от того, соответствует ли какое-либо  значение шаблону или нет:"
 
 #: src/control-flow/if-let-expressions.md:7
 msgid ""
@@ -6312,58 +7269,84 @@ msgstr ""
 #: src/control-flow/while-let-expressions.md:21
 #: src/control-flow/match-expressions.md:23
 msgid ""
-"See [pattern matching](../pattern-matching.md) for more details on patterns in\n"
-"Rust."
+"See [pattern matching](../pattern-matching.md) for more details on patterns "
+"in Rust."
 msgstr ""
-"Больше информации об использовании шаблонов в языке Rust можно найти на\n"
+"Больше информации об использовании шаблонов в языке Rust можно найти на "
 "[странице про сопоставление с шаблоном](../pattern-matching.md)."
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* Unlike `match`, `if let` does not have to cover all branches. This can make it more concise than `match`.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) construct allows to do a destructuring assignment, or if it fails, have a non-returning block branch (panic/return/break/continue):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"Unlike `match`, `if let` does not have to cover all branches. This can make "
+"it more concise than `match`."
 msgstr ""
-"* `if let` может быть более лаконично, чем `match`. Например, когда нужно проверить только один вариант. Выражение `match`, напротив, требует проверки всех вариантов.\n"
-"* Типичным случаем использования является проверка на значение `Some` при работе с типом `Option`.\n"
-"* В отличие от выражения `match`, `if let` не позволяет использовать охранные выражения.\n"
-"* Начиная с версии 1.65, похожая конструкция [`let-else`](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) позволяет проводить деструктурирующее присвоение, а при ошибке исполнить ветку с не возвращающим блоком (`panic`/`return`/`break`/`continue`). Например:\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"`if let` может быть более лаконично, чем `match`. Например, когда нужно "
+"проверить только один вариант. Выражение `match`, напротив, требует проверки "
+"всех вариантов."
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+"Типичным случаем использования является проверка на значение `Some` при "
+"работе с типом `Option`."
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr ""
+"В отличие от выражения `match`, `if let` не позволяет использовать охранные "
+"выражения."
+
+#: src/control-flow/if-let-expressions.md:26
+msgid ""
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"flow_control/let_else.html) construct allows to do a destructuring "
+"assignment, or if it fails, have a non-returning block branch (panic/return/"
+"break/continue):"
+msgstr ""
+"Начиная с версии 1.65, похожая конструкция [`let-else`](https://doc.rust-"
+"lang.org/rust-by-example/flow_control/let_else.html) позволяет проводить "
+"деструктурирующее присвоение, а при ошибке исполнить ветку с не возвращающим "
+"блоком (`panic`/`return`/`break`/`continue`). Например:"
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 
 #: src/control-flow/while-expressions.md:1
-msgid "# `while` loops"
+msgid "`while` loops"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
-"The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:6
@@ -6384,13 +7367,14 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
-msgid "# `while let` loops"
+msgid "`while let` loops"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:3
 msgid ""
-"Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variant which repeatedly tests a value against a pattern:"
+"Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:6
@@ -6409,26 +7393,33 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:17
 msgid ""
-"Here the iterator returned by `v.iter()` will return a `Option<i32>` on every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 
 #: src/control-flow/while-let-expressions.md:26
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if statement that breaks when there is no value to unwrap for `iter.next()`. The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
+msgstr ""
+
+#: src/control-flow/while-let-expressions.md:27
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
 msgstr ""
 
 #: src/control-flow/for-expressions.md:1
-msgid "# `for` loops"
+msgid "`for` loops"
 msgstr ""
 
 #: src/control-flow/for-expressions.md:3
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely\n"
-"related to the [`while let` loop](while-let-expressions.md). It will\n"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expressions.md). It will "
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
 
@@ -6454,21 +7445,33 @@ msgid "You can use `break` and `continue` here as usual."
 msgstr ""
 
 #: src/control-flow/for-expressions.md:25
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr ""
+
+#: src/control-flow/for-expressions.md:26
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr ""
+
+#: src/control-flow/for-expressions.md:27
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+
+#: src/control-flow/for-expressions.md:28
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
+"vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:1
-msgid "# `loop` expressions"
+msgid "`loop` expressions"
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
-"Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:6
@@ -6496,22 +7499,25 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:27
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr ""
+
+#: src/control-flow/loop-expressions.md:28
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-trivial\n"
-"  value. This is because it's guaranteed to be entered at least once (unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:1
-msgid "# `match` expressions"
+msgid "`match` expressions"
 msgstr ""
 
 #: src/control-flow/match-expressions.md:3
 msgid ""
-"The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-expr.html)\n"
-"is used to match a value against one or more patterns. In that sense, it works\n"
-"like a series of `if let` expressions:"
+"The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
 
 #: src/control-flow/match-expressions.md:7
@@ -6532,34 +7538,55 @@ msgstr ""
 
 #: src/control-flow/match-expressions.md:20
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:28
+msgid "Save the match expression to a variable and print it out."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:29
+msgid "Remove `.as_deref()` and explain the error."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:30
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside `Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:32
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
 msgstr ""
 
 #: src/control-flow/break-continue.md:1
-msgid "# `break` and `continue`"
+msgid "`break` and `continue`"
 msgstr ""
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
+msgstr ""
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
 msgstr ""
 
 #: src/control-flow/break-continue.md:7
 msgid ""
-"Both `continue` and `break` can optionally take a label argument which is used\n"
-"to break out of nested loops:"
+"Both `continue` and `break` can optionally take a label argument which is "
+"used to break out of nested loops:"
 msgstr ""
 
 #: src/control-flow/break-continue.md:10
@@ -6584,18 +7611,15 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/break-continue.md:28
-msgid "In this case we break the outer loop after 3 iterations of the inner loop."
-msgstr ""
-
-#: src/std.md:1
-msgid "# Standard Library"
+msgid ""
+"In this case we break the outer loop after 3 iterations of the inner loop."
 msgstr ""
 
 #: src/std.md:3
 msgid ""
-"Rust comes with a standard library which helps establish a set of common types\n"
-"used by Rust library and programs. This way, two libraries can work together\n"
-"smoothly because they both use the same `String` type."
+"Rust comes with a standard library which helps establish a set of common "
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 
 #: src/std.md:7
@@ -6604,32 +7628,59 @@ msgstr ""
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated data."
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
+msgstr ""
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr ""
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr ""
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr ""
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"data."
 msgstr ""
 
 #: src/std.md:25
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, `alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on `libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as `Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
+msgstr ""
+
+#: src/std.md:26
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+
+#: src/std.md:28
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+
+#: src/std.md:29
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
 msgstr ""
 
 #: src/std/option-result.md:1
-msgid "# `Option` and `Result`"
+msgid "`Option` and `Result`"
 msgstr ""
 
 #: src/std/option-result.md:3
@@ -6651,21 +7702,37 @@ msgid ""
 msgstr ""
 
 #: src/std/option-result.md:18
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
 
-#: src/std/string.md:1
-msgid "# String"
+#: src/std/option-result.md:19
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr ""
+
+#: src/std/option-result.md:20
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+
+#: src/std/option-result.md:21
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr ""
+
+#: src/std/option-result.md:22
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr ""
+
+#: src/std/option-result.md:23
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
 msgstr ""
 
 #: src/std/string.md:3
-msgid "[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+msgid ""
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
 
 #: src/std/string.md:5
@@ -6690,31 +7757,84 @@ msgstr ""
 
 #: src/std/string.md:22
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that a `char` can be different from what a human will consider a \"character\" due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or `String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the operations you see supported on vectors are also supported on `String`, but with some extra guarantees.\n"
-"* Compare the different ways to index a `String`:\n"
-"    * To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, out-of-bounds.\n"
-"    * To a substring by using `s3[0..4]`, where that slice is on character boundaries or not."
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
+"operations you see supported on vectors are also supported on `String`, but "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
+"boundaries or not."
 msgstr ""
 
 #: src/std/vec.md:1
-msgid "# `Vec`"
+msgid "`Vec`"
 msgstr ""
 
 #: src/std/vec.md:3
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
 msgstr ""
 
 #: src/std/vec.md:5
@@ -6746,27 +7866,46 @@ msgstr ""
 
 #: src/std/vec.md:29
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
-msgid "# `HashMap`"
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
+msgid "`HashMap`"
 msgstr ""
 
 #: src/std/hashmap.md:3
@@ -6780,7 +7919,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut page_counts = HashMap::new();\n"
-"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), 207);\n"
+"    page_counts.insert(\"Adventures of Huckleberry Finn\".to_string(), "
+"207);\n"
 "    page_counts.insert(\"Grimms' Fairy Tales\".to_string(), 751);\n"
 "    page_counts.insert(\"Pride and Prejudice\".to_string(), 303);\n"
 "\n"
@@ -6789,7 +7929,8 @@ msgid ""
 "                 page_counts.len());\n"
 "    }\n"
 "\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] {\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
 "        match page_counts.get(book) {\n"
 "            Some(count) => println!(\"{book}: {count} pages\"),\n"
 "            None => println!(\"{book} is unknown.\")\n"
@@ -6797,8 +7938,10 @@ msgid ""
 "    }\n"
 "\n"
 "    // Use the .entry() method to insert a value if nothing is found.\n"
-"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in Wonderland\"] {\n"
-"        let page_count: &mut i32 = page_counts.entry(book.to_string()).or_insert(0);\n"
+"    for book in [\"Pride and Prejudice\", \"Alice's Adventure in "
+"Wonderland\"] {\n"
+"        let page_count: &mut i32 = page_counts.entry(book.to_string())."
+"or_insert(0);\n"
 "        *page_count += 1;\n"
 "    }\n"
 "\n"
@@ -6809,39 +7952,77 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into scope.\n"
-"* Try the following lines of code. The first line will see if a book is in the hashmap and if not return an alternative value. The second line will insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make examples easier. Using references in collections can, of course, be done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still compiles. Where do you think we might run into issues?"
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
+"compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
-msgid "# `Box`"
+msgid "`Box`"
 msgstr ""
 
 #: src/std/box.md:3
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
 msgstr ""
 
 #: src/std/box.md:5
@@ -6872,25 +8053,47 @@ msgstr ""
 
 #: src/std/box.md:26
 msgid ""
-"`Box<T>` implements `Deref<Target = T>`, which means that you can [call methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 
 #: src/std/box.md:34
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying large amounts of data on the stack, instead store the data on the heap in a `Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
+msgstr ""
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr ""
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
 msgstr ""
 
 #: src/std/box-recursive.md:1
-msgid "# Box with Recursive Data Structures"
+msgid "Box with Recursive Data Structures"
 msgstr ""
 
 #: src/std/box-recursive.md:3
-msgid "Recursive data types or data types with dynamic sizes need to use a `Box`:"
+msgid ""
+"Recursive data types or data types with dynamic sizes need to use a `Box`:"
 msgstr ""
 
 #: src/std/box-recursive.md:5 src/std/box-niche.md:3
@@ -6903,7 +8106,8 @@ msgid ""
 "}\n"
 "\n"
 "fn main() {\n"
-"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil))));\n"
+"    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::"
+"new(List::Nil))));\n"
 "    println!(\"{list:?}\");\n"
 "}\n"
 "```"
@@ -6913,37 +8117,47 @@ msgstr ""
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
 ":                         :     :                                               :\n"
-":    list                 :     :                                               :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
-":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // |   :\n"
-":   +------+----+----+    :     :    +------+----+----+    +------+----+----+   :\n"
+":    "
+"list                 :     :                                               :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
+":   | Cons | 1  | o--+----+-----+--->| Cons | 2  | o--+--->| Nil  | // | // "
+"|   :\n"
+":   +------+----+----+    :     :    +------+----+----+    +------+----+----"
+"+   :\n"
 ":                         :     :                                               :\n"
 ":                         :     :                                               :\n"
-"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - - -'\n"
+"'- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
 "```"
 msgstr ""
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it would look infinite.\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. \"Recursive with indirection\" is a hint you might want to use a Box or reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
 
-#: src/std/box-niche.md:1
-msgid "# Niche Optimization"
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
 msgstr ""
 
 #: src/std/box-niche.md:16
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 
@@ -6951,26 +8165,33 @@ msgstr ""
 msgid ""
 "```bob\n"
 " Stack                           Heap\n"
-".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - "
+"-.\n"
 ":                         :     :                                             :\n"
-":    list                 :     :                                             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
-":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null |             :\n"
-":   +----+----+           :     :    +----+----+    +----+------+             :\n"
+":    "
+"list                 :     :                                             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
+":   | 1  | o--+-----------+-----+--->| 2  | o--+--->| // | null "
+"|             :\n"
+":   +----+----+           :     :    +----+----+    +----+------"
+"+             :\n"
 ":                         :     :                                             :\n"
 ":                         :     :                                             :\n"
-"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - -'\n"
+"`- - - - - - - - - - - - -'     '- - - - - - - - - - - - - - - - - - - - - - "
+"-'\n"
 "```"
 msgstr ""
 
 #: src/std/rc.md:1
-msgid "# `Rc`"
+msgid "`Rc`"
 msgstr ""
 
 #: src/std/rc.md:3
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
 
 #: src/std/rc.md:6
@@ -6990,24 +8211,61 @@ msgstr ""
 
 #: src/std/rc.md:18
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
+msgstr ""
+
+#: src/std/rc.md:20
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
 msgstr ""
 
 #: src/std/rc.md:31
 msgid ""
-"* `Rc`'s count ensures that its contained value is valid for as long as there are references.\n"
-"* Like C++'s `std::shared_ptr`.\n"
-"* `Rc::clone` is cheap: it creates a pointer to the same allocation and increases the reference count. Does not make a deep clone and can generally be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable borrows that are enforced at compile time. `RefCell` enables (im)mutable borrows that are enforced at run time and will panic if it fails at runtime.\n"
-"* `Rc::downgrade` gives you a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr ""
+
+#: src/std/rc.md:32
+msgid "Like C++'s `std::shared_ptr`."
+msgstr ""
+
+#: src/std/rc.md:33
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"increases the reference count. Does not make a deep clone and can generally "
+"be ignored when looking for performance issues in code."
+msgstr ""
+
+#: src/std/rc.md:34
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+
+#: src/std/rc.md:35
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr ""
+
+#: src/std/rc.md:36
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+
+#: src/std/rc.md:37
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
 msgstr ""
 
 #: src/std/rc.md:41
@@ -7039,10 +8297,6 @@ msgid ""
 "    println!(\"graph: {root:#?}\");\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/modules.md:1
-msgid "# Modules"
 msgstr ""
 
 #: src/modules.md:3
@@ -7077,13 +8331,18 @@ msgstr ""
 
 #: src/modules.md:28
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/visibility.md:1
-msgid "# Visibility"
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
 msgstr ""
 
 #: src/modules/visibility.md:3
@@ -7091,11 +8350,17 @@ msgid "Modules are a privacy boundary:"
 msgstr ""
 
 #: src/modules/visibility.md:5
+msgid "Module items are private by default (hides implementation details)."
+msgstr ""
+
+#: src/modules/visibility.md:6
+msgid "Parent and sibling items are always visible."
+msgstr ""
+
+#: src/modules/visibility.md:7
 msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all the\n"
-"  descendants of `foo`."
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
 msgstr ""
 
 #: src/modules/visibility.md:10
@@ -7129,23 +8394,33 @@ msgid ""
 msgstr ""
 
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
+msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
 #: src/modules/visibility.md:41
-msgid "Additionally, there are advanced `pub(...)` specifiers to restrict the scope of public visibility."
+msgid ""
+"Additionally, there are advanced `pub(...)` specifiers to restrict the scope "
+"of public visibility."
 msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/paths.md:1
-msgid "# Paths"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
 msgstr ""
 
 #: src/modules/paths.md:3
@@ -7153,20 +8428,33 @@ msgid "Paths are resolved as follows:"
 msgstr ""
 
 #: src/modules/paths.md:5
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgid "As a relative path:"
+msgstr ""
+
+#: src/modules/paths.md:6
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+
+#: src/modules/paths.md:7
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr ""
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
 msgstr ""
 
 #: src/modules/paths.md:13
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
 
 #: src/modules/paths.md:16
@@ -7175,10 +8463,6 @@ msgid ""
 "use std::collections::HashSet;\n"
 "use std::mem::transmute;\n"
 "```"
-msgstr ""
-
-#: src/modules/filesystem.md:1
-msgid "# Filesystem Hierarchy"
 msgstr ""
 
 #: src/modules/filesystem.md:3
@@ -7197,9 +8481,11 @@ msgid "The `garden` module content is found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:11
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:12
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:14
@@ -7207,9 +8493,11 @@ msgid "Similarly, a `garden::vegetables` module can be found at:"
 msgstr ""
 
 #: src/modules/filesystem.md:16
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr ""
+
+#: src/modules/filesystem.md:17
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
 msgstr ""
 
 #: src/modules/filesystem.md:19
@@ -7217,21 +8505,25 @@ msgid "The `crate` root is in:"
 msgstr ""
 
 #: src/modules/filesystem.md:21
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr ""
+
+#: src/modules/filesystem.md:22
+msgid "`src/main.rs` (for a binary crate)"
 msgstr ""
 
 #: src/modules/filesystem.md:24
 msgid ""
-"Modules defined in files can be documented, too, using \"inner doc comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"Modules defined in files can be documented, too, using \"inner doc "
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 
 #: src/modules/filesystem.md:27
 msgid ""
 "```rust,editable,compile_fail\n"
-"//! This module implements the garden, including a highly performant germination\n"
+"//! This module implements the garden, including a highly performant "
+"germination\n"
 "//! implementation.\n"
 "\n"
 "// Re-export types from this module.\n"
@@ -7248,71 +8540,93 @@ msgstr ""
 
 #: src/modules/filesystem.md:44
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:47
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:57
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:60
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:63
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:68
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
-msgid "# Day 2: Afternoon Exercises"
+msgid "Day 2: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:3
 msgid "The exercises for this afternoon will focus on strings and iterators."
 msgstr ""
 
-#: src/exercises/day-2/luhn.md:1
-msgid "# Luhn Algorithm"
-msgstr ""
-
 #: src/exercises/day-2/luhn.md:3
 msgid ""
-"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used to\n"
-"validate credit card numbers. The algorithm takes a string as input and does the\n"
-"following to validate the credit card number:"
+"The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number `1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:19
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 
@@ -7368,21 +8682,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-msgid "# Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/strings-iterators.md:3
 msgid ""
-"In this exercise, you are implementing a routing component of a web server. The\n"
-"server is configured with a number of _path prefixes_ which are matched against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"In this exercise, you are implementing a routing component of a web server. "
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 
 #: src/exercises/day-2/strings-iterators.md:8
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 
@@ -7399,12 +8709,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -7422,7 +8735,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -7432,7 +8746,7 @@ msgid ""
 msgstr ""
 
 #: src/welcome-day-3.md:1
-msgid "# Welcome to Day 3"
+msgid "Welcome to Day 3"
 msgstr ""
 
 #: src/welcome-day-3.md:3
@@ -7441,32 +8755,34 @@ msgstr ""
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
 
-#: src/generics.md:1
-msgid "# Generics"
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
 msgstr ""
 
 #: src/generics.md:3
 msgid ""
-"Rust support generics, which lets you abstract an algorithm (such as sorting)\n"
-"over the types used in the algorithm."
-msgstr ""
-
-#: src/generics/data-types.md:1
-msgid "# Generic Data Types"
+"Rust support generics, which lets you abstract an algorithm (such as "
+"sorting) over the types used in the algorithm."
 msgstr ""
 
 #: src/generics/data-types.md:3
@@ -7491,14 +8807,11 @@ msgid ""
 msgstr ""
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
 msgstr ""
 
-#: src/generics/methods.md:1
-msgid "# Generic Methods"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
 msgstr ""
 
 #: src/generics/methods.md:3
@@ -7528,15 +8841,28 @@ msgstr ""
 
 #: src/generics/methods.md:25
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that redundant?\n"
-"    * This is because it is a generic implementation section for generic type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
 
-#: src/generics/monomorphization.md:1
-msgid "# Monomorphization"
+#: src/generics/methods.md:26
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+
+#: src/generics/methods.md:27
+msgid "It means these methods are defined for any `T`."
+msgstr ""
+
+#: src/generics/methods.md:28
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr ""
+
+#: src/generics/methods.md:29
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
 msgstr ""
 
 #: src/generics/monomorphization.md:3
@@ -7579,16 +8905,13 @@ msgstr ""
 
 #: src/generics/monomorphization.md:31
 msgid ""
-"This is a zero-cost abstraction: you get exactly the same result as if you had\n"
-"hand-coded the data structures without the abstraction."
-msgstr ""
-
-#: src/traits.md:1
-msgid "# Traits"
+"This is a zero-cost abstraction: you get exactly the same result as if you "
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 
 #: src/traits.md:3
-msgid "Rust lets you abstract over types with traits. They're similar to interfaces:"
+msgid ""
+"Rust lets you abstract over types with traits. They're similar to interfaces:"
 msgstr ""
 
 #: src/traits.md:5
@@ -7612,7 +8935,8 @@ msgid ""
 "\n"
 "impl Pet for Cat {\n"
 "    fn name(&self) -> String {\n"
-"        String::from(\"The cat\") // No name, cats won't respond to it anyway.\n"
+"        String::from(\"The cat\") // No name, cats won't respond to it "
+"anyway.\n"
 "    }\n"
 "}\n"
 "\n"
@@ -7630,12 +8954,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/traits/trait-objects.md:1
-msgid "# Trait Objects"
-msgstr ""
-
 #: src/traits/trait-objects.md:3
-msgid "Trait objects allow for values of different types, for instance in a collection:"
+msgid ""
+"Trait objects allow for values of different types, for instance in a "
+"collection:"
 msgstr ""
 
 #: src/traits/trait-objects.md:5
@@ -7659,7 +8981,8 @@ msgid ""
 "\n"
 "impl Pet for Cat {\n"
 "    fn name(&self) -> String {\n"
-"        String::from(\"The cat\") // No name, cats won't respond to it anyway.\n"
+"        String::from(\"The cat\") // No name, cats won't respond to it "
+"anyway.\n"
 "    }\n"
 "}\n"
 "\n"
@@ -7683,49 +9006,88 @@ msgstr ""
 msgid ""
 "```bob\n"
 " Stack                             Heap\n"
-".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - - -.\n"
+".- - - - - - - - - - - - - -.     .- - - - - - - - - - - - - - - - - - - - - "
+"- -.\n"
 ":                           :     :                                             :\n"
-":    pets                   :     :                                             :\n"
-":   +-----------+-------+   :     :   +-----+-----+                             :\n"
-":   | ptr       |   o---+---+-----+-->| o o | o o |                             :\n"
-":   | len       |     2 |   :     :   +-|-|-+-|-|-+                             :\n"
-":   | capacity  |     2 |   :     :     | |   | |   +---------------+           :\n"
-":   +-----------+-------+   :     :     | |   | '-->| name: \"Fido\"  |           :\n"
-":                           :     :     | |   |     +---------------+           :\n"
-"`- - - - - - - - - - - - - -'     :     | |   |                                 :\n"
-"                                  :     | |   |     +----------------------+    :   \n"
-"                                  :     | |   '---->| \"<Dog as Pet>::name\" |    :\n"
-"                                  :     | |         +----------------------+    : \n"
-"                                  :     | |                                     : \n"
-"                                  :     | |   +-+                               :   \n"
-"                                  :     | '-->|\\|                               :     \n"
-"                                  :     |     +-+                               :    \n"
-"                                  :     |                                       : \n"
-"                                  :     |     +----------------------+          : \n"
-"                                  :     '---->| \"<Cat as Pet>::name\" |          : \n"
-"                                  :           +----------------------+          :\n"
+":    "
+"pets                   :     :                                             :\n"
+":   +-----------+-------+   :     :   +-----+-----"
+"+                             :\n"
+":   | ptr       |   o---+---+-----+-->| o o | o o "
+"|                             :\n"
+":   | len       |     2 |   :     :   +-|-|-+-|-|-"
+"+                             :\n"
+":   | capacity  |     2 |   :     :     | |   | |   +---------------"
+"+           :\n"
+":   +-----------+-------+   :     :     | |   | '-->| name: \"Fido\"  "
+"|           :\n"
+":                           :     :     | |   |     +---------------"
+"+           :\n"
+"`- - - - - - - - - - - - - -'     :     | |   "
+"|                                 :\n"
+"                                  :     | |   |     +----------------------"
+"+    :   \n"
+"                                  :     | |   '---->| \"<Dog as Pet>::name\" "
+"|    :\n"
+"                                  :     | |         +----------------------"
+"+    : \n"
+"                                  :     | "
+"|                                     : \n"
+"                                  :     | |   +-"
+"+                               :   \n"
+"                                  :     | '-->|"
+"\\|                               :     \n"
+"                                  :     |     +-"
+"+                               :    \n"
+"                                  :     "
+"|                                       : \n"
+"                                  :     |     +----------------------"
+"+          : \n"
+"                                  :     '---->| \"<Cat as Pet>::name\" "
+"|          : \n"
+"                                  :           +----------------------"
+"+          :\n"
 "                                  :                                             :\n"
-"                                  '- - - - - - - - - - - - - - - - - - - - - - -'\n"
+"                                  '- - - - - - - - - - - - - - - - - - - - - "
+"- -'\n"
 "\n"
 "```"
 msgstr ""
 
 #: src/traits/trait-objects.md:72
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes it impossible to have things like `Vec<Pet>` in the example above.\n"
-"* `dyn Pet` is a way to tell the compiler about a dynamically sized type that implements `Pet`.\n"
-"* In the example, `pets` holds *fat pointers* to objects that implement `Pet`. The fat pointer consists of two components, a pointer to the actual object and a pointer to the virtual method table for the `Pet` implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"     ```"
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Pet>` in the example above."
 msgstr ""
 
-#: src/traits/deriving-traits.md:1
-msgid "# Deriving Traits"
+#: src/traits/trait-objects.md:73
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+
+#: src/traits/trait-objects.md:74
+msgid ""
+"In the example, `pets` holds _fat pointers_ to objects that implement `Pet`. "
+"The fat pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Pet` implementation of "
+"that particular object."
+msgstr ""
+
+#: src/traits/trait-objects.md:75
+msgid "Compare these outputs in the above example:"
+msgstr ""
+
+#: src/traits/trait-objects.md:76
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
 msgstr ""
 
 #: src/traits/deriving-traits.md:3
@@ -7749,10 +9111,6 @@ msgid ""
 "             if p1 == p2 { \"yes\" } else { \"no\" });\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/traits/default-methods.md:1
-msgid "# Default Methods"
 msgstr ""
 
 #: src/traits/default-methods.md:3
@@ -7789,43 +9147,58 @@ msgstr ""
 
 #: src/traits/default-methods.md:32
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that users are required to\n"
-"  implement themselves. Methods with default implementations can rely on required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `Equals` a super trait for `NotEqual`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `Equals` as a super trait for `NotEqual`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
 
-#: src/traits/trait-bounds.md:1
-msgid "# Trait Bounds"
+#: src/traits/default-methods.md:35
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr ""
+
+#: src/traits/default-methods.md:37
+msgid "Make `Equals` a super trait for `NotEqual`."
+msgstr ""
+
+#: src/traits/default-methods.md:38
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:46
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `Equals` as a super "
+"trait for `NotEqual`."
 msgstr ""
 
 #: src/traits/trait-bounds.md:3
 msgid ""
-"When working with generics, you often want to require the types to implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 
@@ -7878,20 +9251,26 @@ msgid ""
 msgstr ""
 
 #: src/traits/trait-bounds.md:46
+msgid "It declutters the function signature if you have many parameters."
+msgstr ""
+
+#: src/traits/trait-bounds.md:47
+msgid "It has additional features making it more powerful."
+msgstr ""
+
+#: src/traits/trait-bounds.md:48
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":\" can be arbitrary, like `Option<T>`.\n"
-"    "
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
 
 #: src/traits/impl-trait.md:1
-msgid "# `impl Trait`"
+msgid "`impl Trait`"
 msgstr ""
 
 #: src/traits/impl-trait.md:3
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 
@@ -7912,62 +9291,101 @@ msgid ""
 msgstr ""
 
 #: src/traits/impl-trait.md:19
-msgid "* `impl Trait` allows you to work with types which you cannot name."
+msgid "`impl Trait` allows you to work with types which you cannot name."
 msgstr ""
 
 #: src/traits/impl-trait.md:23
-msgid "The meaning of `impl Trait` is a bit different in the different positions."
+msgid ""
+"The meaning of `impl Trait` is a bit different in the different positions."
 msgstr ""
 
 #: src/traits/impl-trait.md:25
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` picks\n"
-"  the concrete type it returns, without writing it out in the source. A function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
+msgstr ""
+
+#: src/traits/impl-trait.md:27
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+
+#: src/traits/impl-trait.md:31
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
 msgstr ""
 
 #: src/traits/impl-trait.md:37
 msgid ""
-"This example is great, because it uses `impl Display` twice. It helps to explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` type are the same type.\n"
-"It would not work for this particular function, as the type we expect as input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, we'd need two\n"
-"independent generic parameters."
-msgstr ""
-
-#: src/traits/important-traits.md:1
-msgid "# Important Traits"
+"This example is great, because it uses `impl Display` twice. It helps to "
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 
 #: src/traits/important-traits.md:3
-msgid "We will now look at some of the most common traits of the Rust standard library:"
+msgid ""
+"We will now look at some of the most common traits of the Rust standard "
+"library:"
 msgstr ""
 
 #: src/traits/important-traits.md:5
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
+msgstr ""
+
+#: src/traits/important-traits.md:6
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr ""
+
+#: src/traits/important-traits.md:7
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr ""
+
+#: src/traits/important-traits.md:8
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr ""
+
+#: src/traits/important-traits.md:9
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr ""
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
 msgstr ""
 
 #: src/traits/iterator.md:1
-msgid "# Iterators"
+msgid "Iterators"
 msgstr ""
 
 #: src/traits/iterator.md:3
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
 
 #: src/traits/iterator.md:5
@@ -8000,23 +9418,26 @@ msgstr ""
 
 #: src/traits/iterator.md:32
 msgid ""
-"* The `Iterator` trait implements many common functional programming operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
 
-#: src/traits/from-iterator.md:1
-msgid "# FromIterator"
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
 msgstr ""
 
 #: src/traits/from-iterator.md:3
-msgid "[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
+msgid ""
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
 
 #: src/traits/from-iterator.md:5
@@ -8034,25 +9455,25 @@ msgstr ""
 
 #: src/traits/from-iterator.md:17
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
 
 #: src/traits/from-iterator.md:23
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 
 #: src/traits/from-into.md:1
-msgid "# `From` and `Into`"
+msgid "`From` and `Into`"
 msgstr ""
 
 #: src/traits/from-into.md:3
-msgid "Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+msgid ""
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
 
 #: src/traits/from-into.md:5
@@ -8069,7 +9490,10 @@ msgid ""
 msgstr ""
 
 #: src/traits/from-into.md:15
-msgid "[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+msgid ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr ""
 
 #: src/traits/from-into.md:17
@@ -8087,18 +9511,27 @@ msgstr ""
 
 #: src/traits/from-into.md:29
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get `Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that _only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
+msgstr ""
+
+#: src/traits/from-into.md:30
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
 msgstr ""
 
 #: src/traits/read-write.md:1
-msgid "# `Read` and `Write`"
+msgid "`Read` and `Write`"
 msgstr ""
 
 #: src/traits/read-write.md:3
-msgid "Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
+msgid ""
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
 msgstr ""
 
 #: src/traits/read-write.md:5
@@ -8123,7 +9556,9 @@ msgid ""
 msgstr ""
 
 #: src/traits/read-write.md:23
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
 msgstr ""
 
 #: src/traits/read-write.md:25
@@ -8147,11 +9582,13 @@ msgid ""
 msgstr ""
 
 #: src/traits/drop.md:1
-msgid "# The `Drop` Trait"
+msgid "The `Drop` Trait"
 msgstr ""
 
 #: src/traits/drop.md:3
-msgid "Values which implement [`Drop`][1] can specify code to run when they go out of scope:"
+msgid ""
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
 
 #: src/traits/drop.md:5
@@ -8189,20 +9626,27 @@ msgid "Discussion points:"
 msgstr ""
 
 #: src/traits/drop.md:36
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr ""
+
+#: src/traits/drop.md:37
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
+msgstr ""
+
+#: src/traits/drop.md:40
+msgid "Try replacing `drop(a)` with `a.drop()`."
 msgstr ""
 
 #: src/traits/default.md:1
-msgid "# The `Default` Trait"
+msgid "The `Default` Trait"
 msgstr ""
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait produces a default value for a type."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
 msgstr ""
 
 #: src/traits/default.md:5
@@ -8243,20 +9687,43 @@ msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via `#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e.g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and provides convenience methods that use it."
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr ""
+
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr ""
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr ""
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
+"provides convenience methods that use it."
 msgstr ""
 
 #: src/traits/operators.md:1
-msgid "# `Add`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
 msgstr ""
 
 #: src/traits/operators.md:3
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
 
 #: src/traits/operators.md:5
@@ -8283,28 +9750,44 @@ msgstr ""
 
 #: src/traits/operators.md:28
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter of the method?\n"
-"    * Short answer: Function type parameters are controlled by the caller, but\n"
-"        associated types (like `Output`) are controlled by the implementor of a\n"
-"        trait.\n"
-"* You could implement `Add` for two different types, e.g.\n"
-"  `impl Add<(i32, i32)> for Point` would add a tuple to a `Point`."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
+msgstr ""
+
+#: src/traits/operators.md:29
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+
+#: src/traits/operators.md:33
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr ""
+
+#: src/traits/operators.md:34
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementor of a "
+"trait."
+msgstr ""
+
+#: src/traits/operators.md:37
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
 msgstr ""
 
 #: src/traits/closures.md:1
-msgid "# Closures"
+msgid "Closures"
 msgstr ""
 
 #: src/traits/closures.md:3
 msgid ""
-"Closures or lambda expressions have types which cannot be named. However, they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"Closures or lambda expressions have types which cannot be named. However, "
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 
@@ -8337,39 +9820,40 @@ msgstr ""
 
 #: src/traits/closures.md:34
 msgid ""
-"An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or perhaps captures\n"
-"nothing at all. It can be called multiple times concurrently."
+"An `Fn` (e.g. `add_3`) neither consumes nor mutates captured values, or "
+"perhaps captures nothing at all. It can be called multiple times "
+"concurrently."
 msgstr ""
 
 #: src/traits/closures.md:37
 msgid ""
-"An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it multiple times,\n"
-"but not concurrently."
+"An `FnMut` (e.g. `accumulate`) might mutate captured values. You can call it "
+"multiple times, but not concurrently."
 msgstr ""
 
 #: src/traits/closures.md:40
 msgid ""
-"If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It might consume\n"
-"captured values."
+"If you have an `FnOnce` (e.g. `multiply_sum`), you may only call it once. It "
+"might consume captured values."
 msgstr ""
 
 #: src/traits/closures.md:43
 msgid ""
-"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever an `FnMut` or `FnOnce`\n"
-"is called for."
+"`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 
 #: src/traits/closures.md:47
 msgid ""
-"The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. `multiply_sum`),\n"
-"depending on what the closure captures."
+"The compiler also infers `Copy` (e.g. for `add_3`) and `Clone` (e.g. "
+"`multiply_sum`), depending on what the closure captures."
 msgstr ""
 
 #: src/traits/closures.md:50
 msgid ""
-"By default, closures will capture by reference if they can. The `move` keyword makes them capture\n"
-"by value."
+"By default, closures will capture by reference if they can. The `move` "
+"keyword makes them capture by value."
 msgstr ""
 
 #: src/traits/closures.md:52
@@ -8387,20 +9871,16 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/morning.md:1
-msgid "# Day 3: Morning Exercises"
+msgid "Day 3: Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-3/morning.md:3
 msgid "We will design a classical GUI library traits and trait objects."
 msgstr ""
 
-#: src/exercises/day-3/simple-gui.md:1
-msgid "# A Simple GUI Library"
-msgstr ""
-
 #: src/exercises/day-3/simple-gui.md:3
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 
@@ -8409,11 +9889,17 @@ msgid "We will have a number of widgets in our library:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:8
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:9
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
+msgstr ""
+
+#: src/exercises/day-3/simple-gui.md:11
+msgid "`Label`: has a `label`."
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:13
@@ -8422,7 +9908,7 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:15
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 
@@ -8531,7 +10017,8 @@ msgid ""
 "\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\",\n"
 "        Box::new(|| println!(\"You clicked the button!\")),\n"
@@ -8560,10 +10047,10 @@ msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:142
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:147
@@ -8579,7 +10066,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:156
-msgid "Using such alignment tricks, you can for example produce output like this:"
+msgid ""
+"Using such alignment tricks, you can for example produce output like this:"
 msgstr ""
 
 #: src/exercises/day-3/simple-gui.md:158
@@ -8596,22 +10084,16 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-msgid "# Error Handling"
-msgstr ""
-
 #: src/error-handling.md:3
 msgid "Error handling in Rust is done using explicit control flow:"
 msgstr ""
 
 #: src/error-handling.md:5
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
+msgid "Functions that can have errors list this in their return type,"
 msgstr ""
 
-#: src/error-handling/panics.md:1
-msgid "# Panics"
+#: src/error-handling.md:6
+msgid "There are no exceptions."
 msgstr ""
 
 #: src/error-handling/panics.md:3
@@ -8629,18 +10111,26 @@ msgid ""
 msgstr ""
 
 #: src/error-handling/panics.md:12
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr ""
+
+#: src/error-handling/panics.md:13
+msgid "Panics are symptoms of bugs in the program."
+msgstr ""
+
+#: src/error-handling/panics.md:14
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:1
-msgid "# Catching the Stack Unwinding"
+msgid "Catching the Stack Unwinding"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:3
-msgid "By default, a panic will cause the stack to unwind. The unwinding can be caught:"
+msgid ""
+"By default, a panic will cause the stack to unwind. The unwinding can be "
+"caught:"
 msgstr ""
 
 #: src/error-handling/panic-unwind.md:5
@@ -8664,19 +10154,22 @@ msgstr ""
 
 #: src/error-handling/panic-unwind.md:21
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
+msgstr ""
+
+#: src/error-handling/panic-unwind.md:23
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
 msgstr ""
 
 #: src/error-handling/result.md:1
-msgid "# Structured Error Handling with `Result`"
+msgid "Structured Error Handling with `Result`"
 msgstr ""
 
 #: src/error-handling/result.md:3
 msgid ""
-"We have already seen the `Result` enum. This is used pervasively when errors are\n"
-"expected as part of normal operation:"
+"We have already seen the `Result` enum. This is used pervasively when errors "
+"are expected as part of normal operation:"
 msgstr ""
 
 #: src/error-handling/result.md:6
@@ -8703,22 +10196,27 @@ msgstr ""
 
 #: src/error-handling/result.md:27
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
+msgstr ""
+
+#: src/error-handling/result.md:30
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
 msgstr ""
 
 #: src/error-handling/try-operator.md:1
-msgid "# Propagating Errors with `?`"
+msgid "Propagating Errors with `?`"
 msgstr ""
 
 #: src/error-handling/try-operator.md:3
 msgid ""
-"The try-operator `?` is used to return errors to the caller. It lets you turn\n"
-"the common"
+"The try-operator `?` is used to return errors to the caller. It lets you "
+"turn the common"
 msgstr ""
 
 #: src/error-handling/try-operator.md:6
@@ -8776,18 +10274,20 @@ msgstr ""
 
 #: src/error-handling/try-operator.md:50
 #: src/error-handling/converting-error-types-example.md:52
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, empty file, file with username."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
-msgid "# Converting Error Types"
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
 msgstr ""
 
 #: src/error-handling/converting-error-types.md:3
-msgid "The effective expansion of `?` is a little more complicated than previously indicated:"
+msgid ""
+"The effective expansion of `?` is a little more complicated than previously "
+"indicated:"
 msgstr ""
 
 #: src/error-handling/converting-error-types.md:5
@@ -8813,7 +10313,7 @@ msgstr ""
 
 #: src/error-handling/converting-error-types.md:18
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
 
@@ -8837,7 +10337,8 @@ msgid ""
 "    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
 "        match self {\n"
 "            Self::IoError(e) => write!(f, \"IO error: {e}\"),\n"
-"            Self::EmptyUsername(filename) => write!(f, \"Found no username in {filename}\"),\n"
+"            Self::EmptyUsername(filename) => write!(f, \"Found no username "
+"in {filename}\"),\n"
 "        }\n"
 "    }\n"
 "}\n"
@@ -8867,20 +10368,17 @@ msgstr ""
 
 #: src/error-handling/converting-error-types-example.md:55
 msgid ""
-"It is good practice for all error types to implement `std::error::Error`, which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't easily do so, because\n"
+"It is good practice for all error types to implement `std::error::Error`, "
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
-msgstr ""
-
-#: src/error-handling/deriving-error-enums.md:1
-msgid "# Deriving Error Enums"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:3
 msgid ""
-"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create an\n"
-"error enum like we did on the previous page:"
+"The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
+"an error enum like we did on the previous page:"
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:6
@@ -8919,23 +10417,20 @@ msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:39
 msgid ""
-"`thiserror`'s derive macro automatically implements `std::error::Error`, and optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the `#[from]` attribute is added).\n"
-"It also works for structs."
+"`thiserror`'s derive macro automatically implements `std::error::Error`, and "
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 
 #: src/error-handling/deriving-error-enums.md:43
 msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr ""
 
-#: src/error-handling/dynamic-errors.md:1
-msgid "# Dynamic Error Types"
-msgstr ""
-
 #: src/error-handling/dynamic-errors.md:3
 msgid ""
-"Sometimes we want to allow any type of error to be returned without writing our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"Sometimes we want to allow any type of error to be returned without writing "
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 
 #: src/error-handling/dynamic-errors.md:6
@@ -8971,21 +10466,18 @@ msgstr ""
 
 #: src/error-handling/dynamic-errors.md:36
 msgid ""
-"This saves on code, but gives up the ability to cleanly handle different error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` in the public API of a\n"
-"library, but it can be a good option in a program where you just want to display the error message\n"
+"This saves on code, but gives up the ability to cleanly handle different "
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
-msgstr ""
-
-#: src/error-handling/error-contexts.md:1
-msgid "# Adding Context to Errors"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:3
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 
 #: src/error-handling/error-contexts.md:7
@@ -9018,17 +10510,26 @@ msgid ""
 msgstr ""
 
 #: src/error-handling/error-contexts.md:35
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in applications.\n"
-"* Actual error type inside of it can be extracted for examination if necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
 
-#: src/testing.md:1
-msgid "# Testing"
+#: src/error-handling/error-contexts.md:36
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:38
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+
+#: src/error-handling/error-contexts.md:39
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
 msgstr ""
 
 #: src/testing.md:3
@@ -9036,14 +10537,11 @@ msgid "Rust and Cargo come with a simple unit test framework:"
 msgstr ""
 
 #: src/testing.md:5
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
+msgid "Unit tests are supported throughout your code."
 msgstr ""
 
-#: src/testing/unit-tests.md:1
-msgid "# Unit Tests"
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
 msgstr ""
 
 #: src/testing/unit-tests.md:3
@@ -9081,14 +10579,10 @@ msgstr ""
 msgid "Use `cargo test` to find and run the unit tests."
 msgstr ""
 
-#: src/testing/test-modules.md:1
-msgid "# Test Modules"
-msgstr ""
-
 #: src/testing/test-modules.md:3
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 
 #: src/testing/test-modules.md:6
@@ -9115,13 +10609,11 @@ msgid ""
 msgstr ""
 
 #: src/testing/test-modules.md:26
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgid "This lets you unit test private helpers."
 msgstr ""
 
-#: src/testing/doc-tests.md:1
-msgid "# Documentation Tests"
+#: src/testing/test-modules.md:27
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
 msgstr ""
 
 #: src/testing/doc-tests.md:3
@@ -9145,14 +10637,17 @@ msgid ""
 msgstr ""
 
 #: src/testing/doc-tests.md:18
-msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
 msgstr ""
 
-#: src/testing/integration-tests.md:1
-msgid "# Integration Tests"
+#: src/testing/doc-tests.md:19
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr ""
+
+#: src/testing/doc-tests.md:20
+msgid ""
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
 
 #: src/testing/integration-tests.md:3
@@ -9180,7 +10675,7 @@ msgid "These tests only have access to the public API of your crate."
 msgstr ""
 
 #: src/testing/useful-crates.md:1
-msgid "## Useful crates for writing tests"
+msgid "Useful crates for writing tests"
 msgstr ""
 
 #: src/testing/useful-crates.md:3
@@ -9193,13 +10688,18 @@ msgstr ""
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised tests."
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
 msgstr ""
 
-#: src/unsafe.md:1
-msgid "# Unsafe Rust"
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr ""
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
 msgstr ""
 
 #: src/unsafe.md:3
@@ -9207,21 +10707,25 @@ msgid "The Rust language has two parts:"
 msgstr ""
 
 #: src/unsafe.md:5
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr ""
+
+#: src/unsafe.md:6
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are violated."
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"violated."
 msgstr ""
 
 #: src/unsafe.md:8
 msgid ""
-"We will be seeing mostly safe Rust in this course, but it's important to know\n"
-"what Unsafe Rust is."
+"We will be seeing mostly safe Rust in this course, but it's important to "
+"know what Unsafe Rust is."
 msgstr ""
 
 #: src/unsafe.md:11
 msgid ""
-"Unsafe code is usually small and isolated, and its correctness should be carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"Unsafe code is usually small and isolated, and its correctness should be "
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 
 #: src/unsafe.md:14
@@ -9229,30 +10733,38 @@ msgid "Unsafe Rust gives you access to five new capabilities:"
 msgstr ""
 
 #: src/unsafe.md:16
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
+msgid "Dereference raw pointers."
+msgstr ""
+
+#: src/unsafe.md:17
+msgid "Access or modify mutable static variables."
+msgstr ""
+
+#: src/unsafe.md:18
+msgid "Access `union` fields."
+msgstr ""
+
+#: src/unsafe.md:19
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr ""
+
+#: src/unsafe.md:20
+msgid "Implement `unsafe` traits."
 msgstr ""
 
 #: src/unsafe.md:22
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please see\n"
-"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"We will briefly cover unsafe capabilities next. For full details, please see "
+"[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 
 #: src/unsafe.md:28
 msgid ""
-"Unsafe Rust does not mean the code is incorrect. It means that developers have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety rules."
-msgstr ""
-
-#: src/unsafe/raw-pointers.md:1
-msgid "# Dereferencing Raw Pointers"
+"Unsafe Rust does not mean the code is incorrect. It means that developers "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
+"rules."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:3
@@ -9269,7 +10781,8 @@ msgid ""
 "    let r2 = r1 as *const i32;\n"
 "\n"
 "    // Safe because r1 and r2 were obtained from references and so are\n"
-"    // guaranteed to be non-null and properly aligned, the objects underlying\n"
+"    // guaranteed to be non-null and properly aligned, the objects "
+"underlying\n"
 "    // the references from which they were obtained are live throughout the\n"
 "    // whole unsafe block, and they are not accessed either through the\n"
 "    // references or concurrently through any other pointers.\n"
@@ -9284,33 +10797,43 @@ msgstr ""
 
 #: src/unsafe/raw-pointers.md:27
 msgid ""
-"It is good practice (and required by the Android Rust style guide) to write a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety requirements of the unsafe\n"
-"operations it is doing."
+"It is good practice (and required by the Android Rust style guide) to write "
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:31
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:34
+msgid "The pointer must be non-null."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:35
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:36
+msgid "The object must not have been deallocated."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:37
+msgid "There must not be concurrent accesses to the same location."
+msgstr ""
+
+#: src/unsafe/raw-pointers.md:38
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
 msgstr ""
 
 #: src/unsafe/raw-pointers.md:41
 msgid "In most cases the pointer must also be properly aligned."
-msgstr ""
-
-#: src/unsafe/mutable-static-variables.md:1
-msgid "# Mutable Static Variables"
 msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:3
@@ -9330,7 +10853,7 @@ msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:13
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 
@@ -9353,12 +10876,9 @@ msgstr ""
 
 #: src/unsafe/mutable-static-variables.md:32
 msgid ""
-"Using a mutable static is generally a bad idea, but there are some cases where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working with some C APIs."
-msgstr ""
-
-#: src/unsafe/unions.md:1
-msgid "# Unions"
+"Using a mutable static is generally a bad idea, but there are some cases "
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 
 #: src/unsafe/unions.md:3
@@ -9384,25 +10904,22 @@ msgstr ""
 
 #: src/unsafe/unions.md:21
 msgid ""
-"Unions are very rarely needed in Rust as you can usually use an enum. They are occasionally needed\n"
-"for interacting with C library APIs."
+"Unions are very rarely needed in Rust as you can usually use an enum. They "
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 
 #: src/unsafe/unions.md:24
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably want\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
-msgstr ""
-
-#: src/unsafe/calling-unsafe-functions.md:1
-msgid "# Calling Unsafe Functions"
+"If you just want to reinterpret bytes as a different type, you probably want "
+"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:3
 msgid ""
-"A function or method can be marked `unsafe` if it has extra preconditions you\n"
-"must uphold to avoid undefined behaviour:"
+"A function or method can be marked `unsafe` if it has extra preconditions "
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 
 #: src/unsafe/calling-unsafe-functions.md:6
@@ -9411,7 +10928,8 @@ msgid ""
 "fn main() {\n"
 "    let emojis = \"🗻∈🌏\";\n"
 "\n"
-"    // Safe because the indices are in the correct order, within the bounds of\n"
+"    // Safe because the indices are in the correct order, within the bounds "
+"of\n"
 "    // the string slice, and lie on UTF-8 sequence boundaries.\n"
 "    unsafe {\n"
 "        println!(\"emoji: {}\", emojis.get_unchecked(0..4));\n"
@@ -9419,11 +10937,13 @@ msgid ""
 "        println!(\"emoji: {}\", emojis.get_unchecked(7..11));\n"
 "    }\n"
 "\n"
-"    println!(\"char count: {}\", count_chars(unsafe { emojis.get_unchecked(0..7) }));\n"
+"    println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..7) }));\n"
 "\n"
 "    // Not upholding the UTF-8 encoding requirement breaks memory safety!\n"
 "    // println!(\"emoji: {}\", unsafe { emojis.get_unchecked(0..3) });\n"
-"    // println!(\"char count: {}\", count_chars(unsafe { emojis.get_unchecked(0..3) }));\n"
+"    // println!(\"char count: {}\", count_chars(unsafe { emojis."
+"get_unchecked(0..3) }));\n"
 "}\n"
 "\n"
 "fn count_chars(s: &str) -> usize {\n"
@@ -9432,14 +10952,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-msgid "# Writing Unsafe Functions"
-msgstr ""
-
 #: src/unsafe/writing-unsafe-functions.md:3
 msgid ""
-"You can mark your own functions as `unsafe` if they require particular conditions to avoid undefined\n"
-"behaviour."
+"You can mark your own functions as `unsafe` if they require particular "
+"conditions to avoid undefined behaviour."
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:6
@@ -9471,22 +10987,25 @@ msgid ""
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:33
-msgid "We wouldn't actually use pointers for this because it can be done safely with references."
+msgid ""
+"We wouldn't actually use pointers for this because it can be done safely "
+"with references."
 msgstr ""
 
 #: src/unsafe/writing-unsafe-functions.md:35
 msgid ""
-"Note that unsafe code is allowed within an unsafe function without an `unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see what happens."
+"Note that unsafe code is allowed within an unsafe function without an "
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 
 #: src/unsafe/extern-functions.md:1
-msgid "# Calling External Code"
+msgid "Calling External Code"
 msgstr ""
 
 #: src/unsafe/extern-functions.md:3
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
 
@@ -9508,31 +11027,27 @@ msgstr ""
 
 #: src/unsafe/extern-functions.md:21
 msgid ""
-"This is usually only a problem for extern functions which do things with pointers which might\n"
-"violate Rust's memory model, but in general any C function might have undefined behaviour under any\n"
-"arbitrary circumstances."
+"This is usually only a problem for extern functions which do things with "
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/external-blocks.html)."
-msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-msgid "# Implementing Unsafe Traits"
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:3
 msgid ""
-"Like with functions, you can mark a trait as `unsafe` if the implementation must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"Like with functions, you can mark a trait as `unsafe` if the implementation "
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:6
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:9
@@ -9547,7 +11062,8 @@ msgid ""
 "pub unsafe trait AsBytes {\n"
 "    fn as_bytes(&self) -> &[u8] {\n"
 "        unsafe {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, size_of_val(self))\n"
+"            slice::from_raw_parts(self as *const Self as *const u8, "
+"size_of_val(self))\n"
 "        }\n"
 "    }\n"
 "}\n"
@@ -9559,12 +11075,14 @@ msgstr ""
 
 #: src/unsafe/unsafe-traits.md:30
 msgid ""
-"There should be a `# Safety` section on the Rustdoc for the trait explaining the requirements for\n"
-"the trait to be safely implemented."
+"There should be a `# Safety` section on the Rustdoc for the trait explaining "
+"the requirements for the trait to be safely implemented."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:33
-msgid "The actual safety section for `AsBytes` is rather longer and more complicated."
+msgid ""
+"The actual safety section for `AsBytes` is rather longer and more "
+"complicated."
 msgstr ""
 
 #: src/unsafe/unsafe-traits.md:35
@@ -9572,7 +11090,7 @@ msgid "The built-in `Send` and `Sync` traits are unsafe."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:1
-msgid "# Day 3: Afternoon Exercises"
+msgid "Day 3: Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:3
@@ -9581,26 +11099,26 @@ msgstr ""
 
 #: src/exercises/day-3/afternoon.md:5
 msgid ""
-"For this exercise, we suggest using a local dev environment instead\n"
-"of the Playground. This will allow you to run your binary on your own machine."
+"For this exercise, we suggest using a local dev environment instead of the "
+"Playground. This will allow you to run your binary on your own machine."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:8
-msgid "To get started, follow the [running locally] instructions."
+msgid ""
+"To get started, follow the [running locally](../../cargo/running-locally.md) "
+"instructions."
 msgstr ""
 
 #: src/exercises/day-3/afternoon.md:14
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr ""
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-msgid "# Safe FFI Wrapper"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 
@@ -9609,25 +11127,72 @@ msgid "You will want to consult the manual pages:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module. There you find a number of\n"
-"string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Encoding"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Use"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"| Types                      | Encoding       | Use                            |\n"
-"|----------------------------|----------------|--------------------------------|\n"
-"| [`str`] and [`String`]     | UTF-8          | Text processing in Rust        |\n"
-"| [`CStr`] and [`CString`]   | NUL-terminated | Communicating with C functions |\n"
-"| [`OsStr`] and [`OsString`] | OS-specific    | Communicating with the OS      |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "UTF-8"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "Text processing in Rust"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "NUL-terminated"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "Communicating with C functions"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "OS-specific"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "Communicating with the OS"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
@@ -9636,24 +11201,47 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:24
 msgid ""
-"- `&str` to `CString`: you need to allocate space for a trailing `\\0` character,\n"
-"- `CString` to `*const i8`: you need a pointer to call C functions,\n"
-"- `*const i8` to `&CStr`: you need something which can find the trailing `\\0` character,\n"
-"- `&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some unknow data\",\n"
-"- `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html)\n"
-"  to create it,\n"
-"- `&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to return it and call\n"
-"  `readdir` again."
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
-msgid "The [Nomicon] also has a very useful chapter about FFI."
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 
@@ -9672,10 +11260,12 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
-"    // Layout according to the Linux man page for readdir(3), where ino_t and\n"
+"    // Layout according to the Linux man page for readdir(3), where ino_t "
+"and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
 "    #[cfg(not(target_os = \"macos\"))]\n"
@@ -9706,11 +11296,14 @@ msgid ""
 "        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
 "        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
 "\n"
-"        // See https://github.com/rust-lang/libc/issues/414 and the section on\n"
+"        // See https://github.com/rust-lang/libc/issues/414 and the section "
+"on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
 "        //\n"
-"        // \"Platforms that existed before these updates were available\" refers\n"
-"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and PowerPC.\n"
+"        // \"Platforms that existed before these updates were available\" "
+"refers\n"
+"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
+"PowerPC.\n"
 "        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
 "        #[link_name = \"readdir$INODE64\"]\n"
 "        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
@@ -9760,32 +11353,28 @@ msgid ""
 msgstr ""
 
 #: src/android.md:1
-msgid "# Welcome to Rust in Android"
+msgid "Welcome to Rust in Android"
 msgstr ""
 
 #: src/android.md:3
 msgid ""
-"Rust is supported for native platform development on Android. This means that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"Rust is supported for native platform development on Android. This means "
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 
 #: src/android.md:7
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try to\n"
-"> find a little corner of your code base where we can move some lines of code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something that\n"
-"> parses some raw bytes would be ideal."
-msgstr ""
-
-#: src/android/setup.md:1
-msgid "# Setup"
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
 
 #: src/android/setup.md:3
 msgid ""
-"We will be using an Android Virtual Device to test our code. Make sure you have\n"
-"access to one or create a new one with:"
+"We will be using an Android Virtual Device to test our code. Make sure you "
+"have access to one or create a new one with:"
 msgstr ""
 
 #: src/android/setup.md:6
@@ -9799,12 +11388,8 @@ msgstr ""
 
 #: src/android/setup.md:12
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
-msgstr ""
-
-#: src/android/build-rules.md:1
-msgid "# Build Rules"
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
 
 #: src/android/build-rules.md:3
@@ -9812,17 +11397,83 @@ msgid "The Android build system (Soong) supports Rust via a number of modules:"
 msgstr ""
 
 #: src/android/build-rules.md:5
+msgid "Module Type"
+msgstr ""
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr ""
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr ""
+
+#: src/android/build-rules.md:9
 msgid ""
-"| Module Type       | Description                                                                                        |\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust binary.                                                                            |\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and `dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging `libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library containing Rust bindings to C libraries.              |"
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
 msgstr ""
 
 #: src/android/build-rules.md:16
@@ -9830,13 +11481,13 @@ msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr ""
 
 #: src/android/build-rules/binary.md:1
-msgid "# Rust Binaries"
+msgid "Rust Binaries"
 msgstr ""
 
 #: src/android/build-rules/binary.md:3
 msgid ""
-"Let us start with a simple application. At the root of an AOSP checkout, create\n"
-"the following files:"
+"Let us start with a simple application. At the root of an AOSP checkout, "
+"create the following files:"
 msgstr ""
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
@@ -9885,7 +11536,7 @@ msgid ""
 msgstr ""
 
 #: src/android/build-rules/library.md:1
-msgid "# Rust Libraries"
+msgid "Rust Libraries"
 msgstr ""
 
 #: src/android/build-rules/library.md:3
@@ -9897,10 +11548,14 @@ msgid "Here we declare a dependency on two libraries:"
 msgstr ""
 
 #: src/android/build-rules/library.md:7
+msgid "`libgreeting`, which we define below,"
+msgstr ""
+
+#: src/android/build-rules/library.md:8
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
 
 #: src/android/build-rules/library.md:15
@@ -9964,31 +11619,30 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m hello_rust_with_dep\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/tmp\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_with_dep /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/hello_rust_with_dep\n"
 "Hello Bob, it is very\n"
 "nice to meet you!\n"
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-msgid "# AIDL"
-msgstr ""
-
 #: src/android/aidl.md:3
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
 
 #: src/android/aidl.md:6
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr ""
+
+#: src/android/aidl.md:7
+msgid "You can create new AIDL servers in Rust."
 msgstr ""
 
 #: src/android/aidl/interface.md:1
-msgid "# AIDL Interfaces"
+msgid "AIDL Interfaces"
 msgstr ""
 
 #: src/android/aidl/interface.md:3
@@ -9996,7 +11650,8 @@ msgid "You declare the API of your service using an AIDL interface:"
 msgstr ""
 
 #: src/android/aidl/interface.md:5
-msgid "*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+msgid ""
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:7
@@ -10013,7 +11668,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/interface.md:17
-msgid "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/interface.md:19
@@ -10034,12 +11689,12 @@ msgstr ""
 
 #: src/android/aidl/interface.md:32
 msgid ""
-"Add `vendor_available: true` if your AIDL file is used by a binary in the vendor\n"
-"partition."
+"Add `vendor_available: true` if your AIDL file is used by a binary in the "
+"vendor partition."
 msgstr ""
 
 #: src/android/aidl/implementation.md:1
-msgid "# Service Implementation"
+msgid "Service Implementation"
 msgstr ""
 
 #: src/android/aidl/implementation.md:3
@@ -10047,14 +11702,15 @@ msgid "We can now implement the AIDL service:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:5
-msgid "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Implementation of the `IBirthdayService` AIDL interface.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "/// The `IBirthdayService` implementation.\n"
@@ -10063,9 +11719,11 @@ msgid ""
 "impl binder::Interface for BirthdayService {}\n"
 "\n"
 "impl IBirthdayService for BirthdayService {\n"
-"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::Result<String> {\n"
+"    fn wishHappyBirthday(&self, name: &str, years: i32) -> binder::"
+"Result<String> {\n"
 "        Ok(format!(\n"
-"            \"Happy Birthday {name}, congratulations with the {years} years!\"\n"
+"            \"Happy Birthday {name}, congratulations with the {years} years!"
+"\"\n"
 "        ))\n"
 "    }\n"
 "}\n"
@@ -10074,7 +11732,7 @@ msgstr ""
 
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
-msgid "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
 msgstr ""
 
 #: src/android/aidl/implementation.md:28
@@ -10093,7 +11751,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/server.md:1
-msgid "# AIDL Server"
+msgid "AIDL Server"
 msgstr ""
 
 #: src/android/aidl/server.md:3
@@ -10101,7 +11759,7 @@ msgid "Finally, we can create a server which exposes the service:"
 msgstr ""
 
 #: src/android/aidl/server.md:5
-msgid "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
 msgstr ""
 
 #: src/android/aidl/server.md:7
@@ -10109,7 +11767,8 @@ msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
 "use birthdayservice::BirthdayService;\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::BnBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::BnBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
@@ -10121,7 +11780,8 @@ msgid ""
 "        birthday_service,\n"
 "        binder::BinderFeatures::default(),\n"
 "    );\n"
-"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder.as_binder())\n"
+"    binder::add_service(SERVICE_IDENTIFIER, birthday_service_binder."
+"as_binder())\n"
 "        .expect(\"Failed to register service\");\n"
 "    binder::ProcessState::join_thread_pool()\n"
 "}\n"
@@ -10145,10 +11805,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/deploy.md:1
-msgid "# Deploy"
-msgstr ""
-
 #: src/android/aidl/deploy.md:3
 msgid "We can now build, push, and start the service:"
 msgstr ""
@@ -10157,7 +11813,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m birthday_server\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/tmp\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_server /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/birthday_server\n"
 "```"
 msgstr ""
@@ -10195,7 +11852,7 @@ msgid ""
 msgstr ""
 
 #: src/android/aidl/client.md:1
-msgid "# AIDL Client"
+msgid "AIDL Client"
 msgstr ""
 
 #: src/android/aidl/client.md:3
@@ -10203,20 +11860,22 @@ msgid "Finally, we can create a Rust client for our new service."
 msgstr ""
 
 #: src/android/aidl/client.md:5
-msgid "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
 msgstr ""
 
 #: src/android/aidl/client.md:7
 msgid ""
 "```rust,ignore\n"
 "//! Birthday service.\n"
-"use com_example_birthdayservice::aidl::com::example::birthdayservice::IBirthdayService::IBirthdayService;\n"
+"use com_example_birthdayservice::aidl::com::example::birthdayservice::"
+"IBirthdayService::IBirthdayService;\n"
 "use com_example_birthdayservice::binder;\n"
 "\n"
 "const SERVICE_IDENTIFIER: &str = \"birthdayservice\";\n"
 "\n"
 "/// Connect to the BirthdayService.\n"
-"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::StatusCode> {\n"
+"pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
+"StatusCode> {\n"
 "    binder::get_interface(SERVICE_IDENTIFIER)\n"
 "}\n"
 "\n"
@@ -10231,7 +11890,8 @@ msgid ""
 "        .unwrap_or(42);\n"
 "\n"
 "    binder::ProcessState::start_thread_pool();\n"
-"    let service = connect().expect(\"Failed to connect to BirthdayService\");\n"
+"    let service = connect().expect(\"Failed to connect to "
+"BirthdayService\");\n"
 "    let msg = service.wishHappyBirthday(&name, years)?;\n"
 "    println!(\"{msg}\");\n"
 "    Ok(())\n"
@@ -10267,20 +11927,17 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m birthday_client\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/tmp\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/birthday_client /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/birthday_client Charlie 60\n"
 "Happy Birthday Charlie, congratulations with the 60 years!\n"
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-msgid "# Changing API"
-msgstr ""
-
 #: src/android/aidl/changing.md:3
 msgid ""
-"Let us extend the API with more functionality: we want to let clients specify a\n"
-"list of lines for the birthday card:"
+"Let us extend the API with more functionality: we want to let clients "
+"specify a list of lines for the birthday card:"
 msgstr ""
 
 #: src/android/aidl/changing.md:6
@@ -10296,14 +11953,10 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-msgid "# Logging"
-msgstr ""
-
 #: src/android/logging.md:3
 msgid ""
-"You should use the `log` crate to automatically log to `logcat` (on-device) or\n"
-"`stdout` (on-host):"
+"You should use the `log` crate to automatically log to `logcat` (on-device) "
+"or `stdout` (on-host):"
 msgstr ""
 
 #: src/android/logging.md:6
@@ -10361,7 +12014,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m hello_rust_logs\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/tmp\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/hello_rust_logs /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/hello_rust_logs\n"
 "```"
 msgstr ""
@@ -10375,40 +12029,40 @@ msgid ""
 "```shell\n"
 "$ adb logcat -s rust\n"
 "09-08 08:38:32.454  2420  2420 D rust: hello_rust_logs: Starting program.\n"
-"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going fine.\n"
-"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went wrong!\n"
+"09-08 08:38:32.454  2420  2420 I rust: hello_rust_logs: Things are going "
+"fine.\n"
+"09-08 08:38:32.454  2420  2420 E rust: hello_rust_logs: Something went "
+"wrong!\n"
 "```"
-msgstr ""
-
-#: src/android/interoperability.md:1
-msgid "# Interoperability"
 msgstr ""
 
 #: src/android/interoperability.md:3
 msgid ""
-"Rust has excellent support for interoperability with other languages. This means\n"
-"that you can:"
+"Rust has excellent support for interoperability with other languages. This "
+"means that you can:"
 msgstr ""
 
 #: src/android/interoperability.md:6
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
+msgid "Call Rust functions from other languages."
+msgstr ""
+
+#: src/android/interoperability.md:7
+msgid "Call functions written in other languages from Rust."
 msgstr ""
 
 #: src/android/interoperability.md:9
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:1
-msgid "# Interoperability with C"
+msgid "Interoperability with C"
 msgstr ""
 
 #: src/android/interoperability/with-c.md:3
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 
@@ -10433,14 +12087,14 @@ msgstr ""
 
 #: src/android/interoperability/with-c.md:20
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:23
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
 
 #: src/android/interoperability/with-c.md:26
@@ -10448,13 +12102,13 @@ msgid "We will look at better options next."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:1
-msgid "# Using Bindgen"
+msgid "Using Bindgen"
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:3
 msgid ""
-"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) tool\n"
-"can auto-generate bindings from a C header file."
+"The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:6
@@ -10519,7 +12173,7 @@ msgstr ""
 
 #: src/android/interoperability/with-c/bindgen.md:44
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 
@@ -10594,7 +12248,8 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m print_birthday_card\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/tmp\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/print_birthday_card /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/print_birthday_card\n"
 "```"
 msgstr ""
@@ -10626,7 +12281,7 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
-msgid "# Calling Rust"
+msgid "Calling Rust"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:3
@@ -10731,48 +12386,44 @@ msgstr ""
 msgid ""
 "```shell\n"
 "$ m analyze_numbers\n"
-"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/tmp\"\n"
+"$ adb push \"$ANDROID_PRODUCT_OUT/system/bin/analyze_numbers /data/local/"
+"tmp\"\n"
 "$ adb shell /data/local/tmp/analyze_numbers\n"
 "```"
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:83
 msgid ""
-"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify whatever name you want."
-msgstr ""
-
-#: src/android/interoperability/cpp.md:1
-msgid "# With C++"
+"`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:3
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
 
 #: src/android/interoperability/cpp.md:6
 msgid "The overall approach looks like this:"
 msgstr ""
 
-#: src/android/interoperability/cpp.md:8
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr ""
-
 #: src/android/interoperability/cpp.md:10
-msgid "See the [CXX tutorial][2] for an full example of using this."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
 
 #: src/android/interoperability/java.md:1
-msgid "# Interoperability with Java"
+msgid "Interoperability with Java"
 msgstr ""
 
 #: src/android/interoperability/java.md:3
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 
 #: src/android/interoperability/java.md:7
@@ -10875,73 +12526,79 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
-#: src/exercises/concurrency/morning.md:1
-#: src/exercises/concurrency/afternoon.md:1
-msgid "# Exercises"
-msgstr ""
-
 #: src/exercises/android/morning.md:3
 msgid ""
-"This is a group exercise: We will look at one of the projects you work with and\n"
-"try to integrate some Rust into it. Some suggestions:"
+"This is a group exercise: We will look at one of the projects you work with "
+"and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 
 #: src/exercises/android/morning.md:6
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr ""
+
+#: src/exercises/android/morning.md:8
+msgid "Move a function from your project to Rust and call it."
 msgstr ""
 
 #: src/exercises/android/morning.md:12
 msgid ""
-"No solution is provided here since this is open-ended: it relies on someone in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"No solution is provided here since this is open-ended: it relies on someone "
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 
 #: src/bare-metal.md:1
-msgid "# Welcome to Bare Metal Rust"
+msgid "Welcome to Bare Metal Rust"
 msgstr ""
 
 #: src/bare-metal.md:3
 msgid ""
-"This is a standalone one-day course about bare-metal Rust, aimed at people who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"This is a standalone one-day course about bare-metal Rust, aimed at people "
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/bare-metal.md:7
 msgid ""
-"Today we will talk about 'bare-metal' Rust: running Rust code without an OS underneath us. This will\n"
-"be divided into several parts:"
+"Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
+"underneath us. This will be divided into several parts:"
 msgstr ""
 
 #: src/bare-metal.md:10
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr ""
+
+#: src/bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr ""
+
+#: src/bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr ""
+
+#: src/bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
 #: src/bare-metal.md:15
 msgid ""
-"For the microcontroller part of the course we will use the [BBC micro:bit](https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected accelerometer and compass, and\n"
+"For the microcontroller part of the course we will use the [BBC micro:bit]"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 
 #: src/bare-metal.md:20
-msgid "To get started, install some tools we'll need later. On gLinux or Debian:"
+msgid ""
+"To get started, install some tools we'll need later. On gLinux or Debian:"
 msgstr ""
 
 #: src/bare-metal.md:22
 msgid ""
 "```bash\n"
-"sudo apt install gcc-aarch64-linux-gnu gdb-multiarch libudev-dev picocom pkg-config qemu-system-arm\n"
+"sudo apt install gcc-aarch64-linux-gnu gdb-multiarch libudev-dev picocom pkg-"
+"config qemu-system-arm\n"
 "rustup update\n"
 "rustup target add aarch64-unknown-none thumbv7em-none-eabihf\n"
 "rustup component add llvm-tools-preview\n"
@@ -10950,13 +12607,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal.md:30
-msgid "And give users in the `plugdev` group access to the micro:bit programmer:"
+msgid ""
+"And give users in the `plugdev` group access to the micro:bit programmer:"
 msgstr ""
 
 #: src/bare-metal.md:32
 msgid ""
 "```bash\n"
-"echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0d28\", MODE=\"0664\", GROUP=\"plugdev\"' |\\\n"
+"echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"0d28\", MODE=\"0664\", "
+"GROUP=\"plugdev\"' |\\\n"
 "  sudo tee /etc/udev/rules.d/50-microbit.rules\n"
 "sudo udevadm control --reload-rules\n"
 "```"
@@ -10980,27 +12639,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/no_std.md:1
-msgid "# `no_std`"
-msgstr ""
-
-#: src/bare-metal/no_std.md:3
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -11008,72 +12654,100 @@ msgstr ""
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:19
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-
 #: src/bare-metal/no_std.md:24
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
+msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
-msgid ""
-"</td>\n"
-"<td>"
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr ""
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:38
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:45
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:56
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:62
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr ""
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
 #: src/bare-metal/minimal.md:1
-msgid "# A minimal `no_std` program"
+msgid "A minimal `no_std` program"
 msgstr ""
 
 #: src/bare-metal/minimal.md:3
@@ -11092,25 +12766,34 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-msgid "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -11132,7 +12815,8 @@ msgid ""
 "static mut HEAP: [u8; 65536] = [0; 65536];\n"
 "\n"
 "pub fn entry() {\n"
-"    // Safe because `HEAP` is only used here and `entry` is only called once.\n"
+"    // Safe because `HEAP` is only used here and `entry` is only called "
+"once.\n"
 "    unsafe {\n"
 "        // Give the allocator some memory to allocate.\n"
 "        HEAP_ALLOCATOR\n"
@@ -11149,23 +12833,38 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i.e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the `panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-msgid "# Microcontrollers"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
-msgid "The `cortex_m_rt` crate provides (among other things) a reset handler for Cortex M microcontrollers."
+msgid ""
+"The `cortex_m_rt` crate provides (among other things) a reset handler for "
+"Cortex M microcontrollers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:5
@@ -11188,24 +12887,25 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:21
-msgid "Next we'll look at how to access peripherals, with increasing levels of abstraction."
+msgid ""
+"Next we'll look at how to access peripherals, with increasing levels of "
+"abstraction."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:1
-msgid "# Raw MMIO"
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
-"Most microcontrollers access peripherals via memory-mapped IO. Let's try turning on an LED on our\n"
-"micro:bit:"
+"Most microcontrollers access peripherals via memory-mapped IO. Let's try "
+"turning on an LED on our micro:bit:"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:6
@@ -11239,23 +12939,29 @@ msgid ""
 "#[entry]\n"
 "fn main() -> ! {\n"
 "    // Configure GPIO 0 pins 21 and 28 as push-pull outputs.\n"
-"    let pin_cnf_21 = (GPIO_P0 + PIN_CNF + 21 * size_of::<u32>()) as *mut u32;\n"
-"    let pin_cnf_28 = (GPIO_P0 + PIN_CNF + 28 * size_of::<u32>()) as *mut u32;\n"
-"    // Safe because the pointers are to valid peripheral control registers, and\n"
+"    let pin_cnf_21 = (GPIO_P0 + PIN_CNF + 21 * size_of::<u32>()) as *mut "
+"u32;\n"
+"    let pin_cnf_28 = (GPIO_P0 + PIN_CNF + 28 * size_of::<u32>()) as *mut "
+"u32;\n"
+"    // Safe because the pointers are to valid peripheral control registers, "
+"and\n"
 "    // no aliases exist.\n"
 "    unsafe {\n"
 "        pin_cnf_21.write_volatile(\n"
-"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | SENSE_DISABLED,\n"
+"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
+"SENSE_DISABLED,\n"
 "        );\n"
 "        pin_cnf_28.write_volatile(\n"
-"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | SENSE_DISABLED,\n"
+"            DIR_OUTPUT | INPUT_DISCONNECT | PULL_DISABLED | DRIVE_S0S1 | "
+"SENSE_DISABLED,\n"
 "        );\n"
 "    }\n"
 "\n"
 "    // Set pin 28 low and pin 21 high to turn the LED on.\n"
 "    let gpio0_outset = (GPIO_P0 + OUTSET) as *mut u32;\n"
 "    let gpio0_outclr = (GPIO_P0 + OUTCLR) as *mut u32;\n"
-"    // Safe because the pointers are to valid peripheral control registers, and\n"
+"    // Safe because the pointers are to valid peripheral control registers, "
+"and\n"
 "    // no aliases exist.\n"
 "    unsafe {\n"
 "        gpio0_outclr.write_volatile(1 << 28);\n"
@@ -11268,7 +12974,9 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
-msgid "* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 to the first row."
+msgid ""
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:66
@@ -11286,14 +12994,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
-msgid "# Peripheral Access Crates"
+msgid "Peripheral Access Crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
-"[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/CMSIS/SVD/html/index.html)\n"
-"files."
+"[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -11341,15 +13049,31 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:61
@@ -11360,14 +13084,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
-msgid "# HAL crates"
+msgid "HAL crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
-"[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -11405,9 +13130,13 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:45
@@ -11418,11 +13147,13 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
-msgid "# Board support crates"
+msgid "Board support crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:3
-msgid "Board support crates provide a further level of wrapping for a specific board for convenience."
+msgid ""
+"Board support crates provide a further level of wrapping for a specific "
+"board for convenience."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:5
@@ -11451,11 +13182,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:28
 msgid ""
-" * In this case the board support crate is just providing more useful names, and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:36
@@ -11466,7 +13204,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
-msgid "# The type state pattern"
+msgid "The type state pattern"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:3
@@ -11485,14 +13223,17 @@ msgid ""
 "        // ...\n"
 "    }\n"
 "    let mut pin_output: P0_01<Output<OpenDrain>> = pin_input\n"
-"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, Level::Low);\n"
+"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
+"Level::Low);\n"
 "    pin_output.set_high().unwrap();\n"
 "    // pin_input.is_high(); // Error, moved.\n"
 "\n"
 "    let _pin2: P0_02<Output<OpenDrain>> = gpio0\n"
 "        .p0_02\n"
-"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, Level::Low);\n"
-"    let _pin3: P0_03<Output<PushPull>> = gpio0.p0_03.into_push_pull_output(Level::Low);\n"
+"        .into_open_drain_output(OpenDrainConfig::Disconnect0Standard1, "
+"Level::Low);\n"
+"    let _pin3: P0_03<Output<PushPull>> = gpio0.p0_03."
+"into_push_pull_output(Level::Low);\n"
 "\n"
 "    loop {}\n"
 "}\n"
@@ -11501,94 +13242,177 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "# `embedded-hal`"
+msgid "`embedded-hal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
-"The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a number of traits\n"
-"covering common microcontroller peripherals."
+"The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
+msgid "GPIO"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 msgid ""
-" * There are implementations for many microcontrollers, as well as other platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it isn't stable yet."
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
+"isn't stable yet."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
-"[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, like OpenOCD but better\n"
-"integrated."
+"[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
+"like OpenOCD but better integrated."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid " server"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
 msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's configured by an\n"
-"`Embed.toml` file in your project directory."
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:1
-msgid "# Debugging"
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/debugging.md:3
@@ -11624,7 +13448,8 @@ msgstr ""
 #: src/bare-metal/microcontrollers/debugging.md:21
 msgid ""
 "```sh\n"
-"gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support --eval-command=\"target remote :1337\"\n"
+"gdb-multiarch target/thumbv7em-none-eabihf/debug/board_support --eval-"
+"command=\"target remote :1337\"\n"
 "```"
 msgstr ""
 
@@ -11646,48 +13471,100 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
-msgid "# Other projects"
+msgid "Other projects"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "[RTIC](https://rtic.rs/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing applications."
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"applications."
 msgstr ""
 
 #: src/exercises/bare-metal/morning.md:3
-msgid "We will read the direction from an I2C compass, and log the readings to a serial port."
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:1
-msgid "# Compass"
+msgid ""
+"We will read the direction from an I2C compass, and log the readings to a "
+"serial port."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
-"We will read the direction from an I2C compass, and log the readings to a serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"We will read the direction from an I2C compass, and log the readings to a "
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:6
@@ -11696,37 +13573,50 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:11
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:12
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:13
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:17
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:19
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23
 msgid ""
-"Download the [exercise template](../../comprehensive-rust-exercises.zip) and look in the `compass`\n"
-"directory for the following files."
+"Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
+"look in the `compass` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 msgid "`src/main.rs`:"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
-#: src/exercises/concurrency/dining-philosophers.md:17
-#: src/exercises/concurrency/link-checker.md:55
-#: src/exercises/concurrency/dining-philosophers-async.md:11
-msgid "<!-- File src/main.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:30
@@ -11770,14 +13660,6 @@ msgstr ""
 msgid "`Cargo.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:66 src/exercises/bare-metal/rtc.md:387
-#: src/exercises/concurrency/dining-philosophers.md:63
-#: src/exercises/concurrency/link-checker.md:35
-#: src/exercises/concurrency/dining-philosophers-async.md:60
-#: src/exercises/concurrency/chat-app.md:17
-msgid "<!-- File Cargo.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
 "```toml\n"
@@ -11802,10 +13684,6 @@ msgstr ""
 msgid "`Embed.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:87
-msgid "<!-- File Embed.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
 "```toml\n"
@@ -11822,10 +13700,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
 msgid "`.cargo/config.toml` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
-msgid "<!-- File .cargo/config.toml -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:104
@@ -11851,7 +13725,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:118
-msgid "Or on Mac OS something like (the device name may be slightly different):"
+msgid ""
+"Or on Mac OS something like (the device name may be slightly different):"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:120
@@ -11866,31 +13741,34 @@ msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
 #: src/bare-metal/aps.md:1
-msgid "# Application processors"
+msgid "Application processors"
 msgstr ""
 
 #: src/bare-metal/aps.md:3
 msgid ""
-"So far we've talked about microcontrollers, such as the Arm Cortex-M series. Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
 msgstr ""
 
-#: src/bare-metal/aps/entry-point.md:1
-msgid "# Getting Ready to Rust"
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:3
-msgid "Before we can start running Rust code, we need to do some initialisation."
+msgid ""
+"Before we can start running Rust code, we need to do some initialisation."
 msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:5
@@ -11900,7 +13778,8 @@ msgid ""
 ".global entry\n"
 "entry:\n"
 "    /*\n"
-"     * Load and apply the memory management configuration, ready to enable MMU and\n"
+"     * Load and apply the memory management configuration, ready to enable "
+"MMU and\n"
 "     * caches.\n"
 "     */\n"
 "    adrp x30, idmap\n"
@@ -11919,7 +13798,8 @@ msgid ""
 "    mov_i x30, .Lsctlrval\n"
 "\n"
 "    /*\n"
-"     * Ensure everything before this point has completed, then invalidate any\n"
+"     * Ensure everything before this point has completed, then invalidate "
+"any\n"
 "     * potentially stale local TLB entries before they start being used.\n"
 "     */\n"
 "    isb\n"
@@ -11929,7 +13809,8 @@ msgid ""
 "    isb\n"
 "\n"
 "    /*\n"
-"     * Configure sctlr_el1 to enable MMU and cache and don't proceed until this\n"
+"     * Configure sctlr_el1 to enable MMU and cache and don't proceed until "
+"this\n"
 "     * has completed.\n"
 "     */\n"
 "    msr sctlr_el1, x30\n"
@@ -11968,39 +13849,87 @@ msgstr ""
 
 #: src/bare-metal/aps/entry-point.md:77
 msgid ""
-"* This is the same as it would be for C: initialising the processor state, zeroing the BSS, and\n"
-"  setting up the stack pointer.\n"
-"  * The BSS (block starting symbol, for historical reasons) is the part of the object file which\n"
-"    containing statically allocated variables which are initialised to zero. They are omitted from\n"
-"    the image, to avoid wasting space on zeroes. The compiler assumes that the loader will take care\n"
-"    of zeroing them.\n"
-"* The BSS may already be zeroed, depending on how memory is initialised and the image is loaded, but\n"
-"  we zero it to be sure.\n"
-"* We need to enable the MMU and cache before reading or writing any memory. If we don't:\n"
-"  * Unaligned accesses will fault. We build the Rust code for the `aarch64-unknown-none` target\n"
-"    which sets `+strict-align` to prevent the compiler generating unaligned accesses, so it should\n"
-"    be fine in this case, but this is not necessarily the case in general.\n"
-"  * If it were running in a VM, this can lead to cache coherency issues. The problem is that the VM\n"
-"    is accessing memory directly with the cache disabled, while the host has cachable aliases to the\n"
-"    same memory. Even if the host doesn't explicitly access the memory, speculative accesses can\n"
-"    lead to cache fills, and then changes from one or the other will get lost when the cache is\n"
-"    cleaned or the VM enables the cache. (Cache is keyed by physical address, not VA or IPA.)\n"
-"* For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which identity maps the first 1\n"
-"  GiB of address space for devices, the next 1 GiB for DRAM, and another 1 GiB higher up for more\n"
-"  devices. This matches the memory layout that QEMU uses.\n"
-"* We also set up the exception vector (`vbar_el1`), which we'll see more about later.\n"
-"* All examples this afternoon assume we will be running at exception level 1 (EL1). If you need to\n"
-"  run at a different exception level you'll need to modify `entry.S` accordingly."
+"This is the same as it would be for C: initialising the processor state, "
+"zeroing the BSS, and setting up the stack pointer."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:79
+msgid ""
+"The BSS (block starting symbol, for historical reasons) is the part of the "
+"object file which containing statically allocated variables which are "
+"initialised to zero. They are omitted from the image, to avoid wasting space "
+"on zeroes. The compiler assumes that the loader will take care of zeroing "
+"them."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:83
+msgid ""
+"The BSS may already be zeroed, depending on how memory is initialised and "
+"the image is loaded, but we zero it to be sure."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:85
+msgid ""
+"We need to enable the MMU and cache before reading or writing any memory. If "
+"we don't:"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:86
+msgid ""
+"Unaligned accesses will fault. We build the Rust code for the `aarch64-"
+"unknown-none` target which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses, so it should be fine in this case, but this "
+"is not necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:89
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cachable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost when the cache "
+"is cleaned or the VM enables the cache. (Cache is keyed by physical address, "
+"not VA or IPA.)"
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:94
+msgid ""
+"For simplicity, we just use a hardcoded pagetable (see `idmap.S`) which "
+"identity maps the first 1 GiB of address space for devices, the next 1 GiB "
+"for DRAM, and another 1 GiB higher up for more devices. This matches the "
+"memory layout that QEMU uses."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:97
+msgid ""
+"We also set up the exception vector (`vbar_el1`), which we'll see more about "
+"later."
+msgstr ""
+
+#: src/bare-metal/aps/entry-point.md:98
+msgid ""
+"All examples this afternoon assume we will be running at exception level 1 "
+"(EL1). If you need to run at a different exception level you'll need to "
+"modify `entry.S` accordingly."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
-msgid "# Inline assembly"
+msgid "Inline assembly"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
-"Sometimes we need to use assembly to do things that aren't possible with Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware to power off the system:"
+"Sometimes we need to use assembly to do things that aren't possible with "
+"Rust code. For example, to make an "
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid " to tell the firmware to power off the system:"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:6
@@ -12040,55 +13969,100 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
-msgid "(If you actually want to do this, use the [`smccc`][1] crate which has wrappers for all these functions.)"
+msgid ""
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than `in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/examples`."
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:51
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:56
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
-msgid "# Volatile memory access for MMIO"
+msgid "Volatile memory access for MMIO"
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:9
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:1
-msgid "# Let's write a UART driver"
+msgid "Let's write a UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
-msgid "The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for that."
+msgid ""
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -12105,13 +14079,16 @@ msgid ""
 "}\n"
 "\n"
 "impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at the\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
 "    ///\n"
-"    /// The given base address must point to the 8 MMIO control registers of a\n"
-"    /// PL011 device, which must be mapped into the address space of the process\n"
+"    /// The given base address must point to the 8 MMIO control registers of "
+"a\n"
+"    /// PL011 device, which must be mapped into the address space of the "
+"process\n"
 "    /// as device memory and not have any other aliases.\n"
 "    pub unsafe fn new(base_address: *mut u8) -> Self {\n"
 "        Self { base_address }\n"
@@ -12136,7 +14113,8 @@ msgid ""
 "    fn read_flag_register(&self) -> u8 {\n"
 "        // Safe because we know that the base address points to the control\n"
 "        // registers of a PL011 device which is appropriately mapped.\n"
-"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET).read_volatile() }\n"
+"        unsafe { self.base_address.add(FLAG_REGISTER_OFFSET)."
+"read_volatile() }\n"
 "    }\n"
 "}\n"
 "```"
@@ -12144,28 +14122,36 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i.e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but `write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls `write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:66
-msgid "</detais>"
+#: src/bare-metal/aps/uart.md:60
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:63
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:1
-msgid "# More traits"
+msgid "More traits"
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:3
-msgid "We derived the `Debug` trait. It would be useful to implement a few more traits too."
+msgid ""
+"We derived the `Debug` trait. It would be useful to implement a few more "
+"traits too."
 msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:5
@@ -12190,51 +14176,194 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/examples`."
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:25
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
-msgid "# A better UART driver"
+msgid "A better UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
+msgid "Offset"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:26
-msgid "- There are also some ID registers which have been omitted for brevity."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-msgid "# Bitflags"
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
-msgid "The [`bitflags`](https://crates.io/crates/bitflags) crate is useful for working with bitflags."
+msgid ""
+"The [`bitflags`](https://crates.io/crates/bitflags) crate is useful for "
+"working with bitflags."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:5
@@ -12272,16 +14401,17 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:1
-msgid "# Multiple registers"
+msgid "Multiple registers"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:3
-msgid "We can use a struct to represent the memory layout of the UART's registers."
+msgid ""
+"We can use a struct to represent the memory layout of the UART's registers."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:5
@@ -12323,14 +14453,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-msgid "# Driver"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -12347,13 +14474,16 @@ msgid ""
 "}\n"
 "\n"
 "impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at the\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
 "    ///\n"
-"    /// The given base address must point to the 8 MMIO control registers of a\n"
-"    /// PL011 device, which must be mapped into the address space of the process\n"
+"    /// The given base address must point to the 8 MMIO control registers of "
+"a\n"
+"    /// PL011 device, which must be mapped into the address space of the "
+"process\n"
 "    /// as device memory and not have any other aliases.\n"
 "    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
 "        Self {\n"
@@ -12377,12 +14507,14 @@ msgid ""
 "        while self.read_flag_register().contains(Flags::BUSY) {}\n"
 "    }\n"
 "\n"
-"    /// Reads and returns a pending byte, or `None` if nothing has been received.\n"
+"    /// Reads and returns a pending byte, or `None` if nothing has been "
+"received.\n"
 "    pub fn read_byte(&self) -> Option<u8> {\n"
 "        if self.read_flag_register().contains(Flags::RXFE) {\n"
 "            None\n"
 "        } else {\n"
-"            let data = unsafe { addr_of!((*self.registers).dr).read_volatile() };\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
 "            // TODO: Check for error conditions in bits 8-11.\n"
 "            Some(data as u8)\n"
 "        }\n"
@@ -12399,19 +14531,19 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
-msgid "# Using it"
+msgid "Using it"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
-"Let's write a small program using our driver to write to the serial console, and echo incoming\n"
-"bytes."
+"Let's write a small program using our driver to write to the serial console, "
+"and echo incoming bytes."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:6
@@ -12435,7 +14567,8 @@ msgid ""
 "\n"
 "#[no_mangle]\n"
 "extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
 "    // and nothing else accesses that address range.\n"
 "    let mut uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
 "\n"
@@ -12462,15 +14595,21 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
 msgid ""
-"* As in the [inline assembly](../inline-assembly.md) example, this `main` function is called from our\n"
-"  entry point code in `entry.S`. See the speaker notes there for details.\n"
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:53
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -12508,7 +14647,8 @@ msgid ""
 "}\n"
 "\n"
 "/// Initialises UART logger.\n"
-"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), SetLoggerError> {\n"
+"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
+"SetLoggerError> {\n"
 "    LOGGER.uart.lock().replace(uart);\n"
 "\n"
 "    log::set_logger(&LOGGER)?;\n"
@@ -12519,7 +14659,9 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
-msgid "* The unwrap in `log` is safe because we initialise `LOGGER` before calling `set_logger`."
+msgid ""
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"`set_logger`."
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:3
@@ -12547,7 +14689,8 @@ msgid ""
 "\n"
 "#[no_mangle]\n"
 "extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
 "    // and nothing else accesses that address range.\n"
 "    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
 "    logger::init(uart, LevelFilter::Trace).unwrap();\n"
@@ -12569,22 +14712,22 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
-msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/examples`."
+msgid "Note that our panic handler can now log details of panics."
 msgstr ""
 
-#: src/bare-metal/aps/exceptions.md:1
-#, fuzzy
-msgid "# Exceptions"
+#: src/bare-metal/aps/logging/using.md:47
+msgid ""
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"examples`."
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:3
 msgid ""
-"AArch64 defines an exception vector table with 16 entries, for 4 types of exceptions (synchronous,\n"
-"IRQ, FIQ, SError) from 4 states (current EL with SP0, current EL with SPx, lower EL using AArch64,\n"
-"lower EL using AArch32). We implement this in assembly to save volatile registers to the stack\n"
-"before calling into Rust code:"
+"AArch64 defines an exception vector table with 16 entries, for 4 types of "
+"exceptions (synchronous, IRQ, FIQ, SError) from 4 states (current EL with "
+"SP0, current EL with SPx, lower EL using AArch64, lower EL using AArch32). "
+"We implement this in assembly to save volatile registers to the stack before "
+"calling into Rust code:"
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:8
@@ -12645,65 +14788,113 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/exceptions.md:64
+msgid "EL is exception level; all our examples this afternoon run in EL1."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:65
 msgid ""
-"* EL is exception level; all our examples this afternoon run in EL1.\n"
-"* For simplicity we aren't distinguishing between SP0 and SPx for the current EL exceptions, or\n"
-"  between AArch32 and AArch64 for the lower EL exceptions.\n"
-"* For this example we just log the exception and power down, as we don't expect any of them to\n"
-"  actually happen.\n"
-"* We can think of exception handlers and our main execution context more or less like different\n"
-"  threads. [`Send` and `Sync`][1] will control what we can share between them, just like with threads.\n"
-"  For example, if we want to share some value between exception handlers and the rest of the\n"
-"  program, and it's `Send` but not `Sync`, then we'll need to wrap it in something like a `Mutex`\n"
-"  and put it in a static."
+"For simplicity we aren't distinguishing between SP0 and SPx for the current "
+"EL exceptions, or between AArch32 and AArch64 for the lower EL exceptions."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:67
+msgid ""
+"For this example we just log the exception and power down, as we don't "
+"expect any of them to actually happen."
+msgstr ""
+
+#: src/bare-metal/aps/exceptions.md:69
+msgid ""
+"We can think of exception handlers and our main execution context more or "
+"less like different threads. [`Send` and `Sync`](../../concurrency/send-sync."
+"md) will control what we can share between them, just like with threads. For "
+"example, if we want to share some value between exception handlers and the "
+"rest of the program, and it's `Send` but not `Sync`, then we'll need to wrap "
+"it in something like a `Mutex` and put it in a static."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:7
 msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, exception handling,\n"
-"     page tables\n"
-"   * Some dodginess around cache maintenance and initialisation in Rust, not necessarily a good\n"
-"     example to copy for production code.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid ""
+"Some dodginess around cache maintenance and initialisation in Rust, not "
+"necessarily a good example to copy for production code."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:12
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:13
+msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:17
 msgid ""
-"* The RaspberryPi OS tutorial runs Rust code before the MMU and caches are enabled. This will read\n"
-"  and write memory (e.g. the stack). However:\n"
-"  * Without the MMU and cache, unaligned accesses will fault. It builds with `aarch64-unknown-none`\n"
-"    which sets `+strict-align` to prevent the compiler generating unaligned accesses so it should be\n"
-"    alright, but this is not necessarily the case in general.\n"
-"  * If it were running in a VM, this can lead to cache coherency issues. The problem is that the VM\n"
-"    is accessing memory directly with the cache disabled, while the host has cachable aliases to the\n"
-"    same memory. Even if the host doesn't explicitly access the memory, speculative accesses can\n"
-"    lead to cache fills, and then changes from one or the other will get lost. Again this is alright\n"
-"    in this particular case (running directly on the hardware with no hypervisor), but isn't a good\n"
-"    pattern in general."
+"The RaspberryPi OS tutorial runs Rust code before the MMU and caches are "
+"enabled. This will read and write memory (e.g. the stack). However:"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
-msgid "# Useful crates"
+#: src/bare-metal/aps/other-projects.md:19
+msgid ""
+"Without the MMU and cache, unaligned accesses will fault. It builds with "
+"`aarch64-unknown-none` which sets `+strict-align` to prevent the compiler "
+"generating unaligned accesses so it should be alright, but this is not "
+"necessarily the case in general."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:22
+msgid ""
+"If it were running in a VM, this can lead to cache coherency issues. The "
+"problem is that the VM is accessing memory directly with the cache disabled, "
+"while the host has cachable aliases to the same memory. Even if the host "
+"doesn't explicitly access the memory, speculative accesses can lead to cache "
+"fills, and then changes from one or the other will get lost. Again this is "
+"alright in this particular case (running directly on the hardware with no "
+"hypervisor), but isn't a good pattern in general."
 msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
-msgid "We'll go over a few crates which solve some common problems in bare-metal programming."
+msgid ""
+"We'll go over a few crates which solve some common problems in bare-metal "
+"programming."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "# `zerocopy`"
+msgid "`zerocopy`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
@@ -12745,29 +14936,45 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:40
 msgid ""
-"This is not suitable for MMIO (as it doesn't use volatile reads and writes), but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some external interface."
+"This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because `RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "# `aarch64-paging`"
+msgid "`aarch64-paging`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
@@ -12795,22 +15002,37 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
-"* For now it only supports EL1, but support for other exception levels should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -12833,22 +15055,27 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+msgid "PCI BARs always have alignment equal to their size."
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "# `tinyvec`"
+msgid "`tinyvec`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
-"Sometimes you want something which can be resized like a `Vec`, but without heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which could be statically\n"
-"allocated or on the stack, which keeps track of how many elements are used and panics if you try to\n"
-"use more than are allocated."
+"Sometimes you want something which can be resized like a `Vec`, but without "
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
+"allocated or on the stack, which keeps track of how many elements are used "
+"and panics if you try to use more than are allocated."
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
@@ -12869,23 +15096,30 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:23
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:1
-msgid "# `spin`"
+msgid "`spin`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
-"`std::sync::Mutex` and the other synchronisation primitives from `std::sync` are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, such as for sharing\n"
-"state between different CPUs?"
+"`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:7
-msgid "The [`spin`][1] crate provides spinlock-based equivalents of many of these primitives."
+msgid ""
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:9
@@ -12904,24 +15138,33 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/android.md:1
-msgid "# Android"
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/android.md:3
 msgid ""
-"To build a bare-metal Rust binary in AOSP, you need to use a `rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"To build a bare-metal Rust binary in AOSP, you need to use a "
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
 #: src/bare-metal/android.md:7
@@ -12966,14 +15209,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-msgid "# vmbase"
-msgstr ""
-
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -12994,9 +15235,14 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:21
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md:3
@@ -13004,32 +15250,51 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:1
-msgid "# RTC driver"
+#: src/exercises/bare-metal/solutions-afternoon.md:3
+msgid "RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. For this exercise, you\n"
-"should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:6
 msgid ""
-"1. Use it to print the current time to the serial console. You can use the [`chrono`][2] crate for\n"
-"   date/time formatting.\n"
-"2. Use the match register and raw interrupt status to busy-wait until a given time, e.g. 3 seconds\n"
-"   in the future. (Call [`core::hint::spin_loop`][3] inside the loop.)\n"
-"3. _Extension if you have time:_ Enable and handle the interrupt generated by the RTC match. You can\n"
-"   use the driver provided in the [`arm-gic`][4] crate to configure the Arm Generic Interrupt Controller.\n"
-"   - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.\n"
-"   - Once the interrupt is enabled, you can put the core to sleep via `arm_gic::wfi()`, which will cause the core to sleep until it receives an interrupt.\n"
-"   "
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:8
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:10
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:12
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:13
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
 msgid ""
-"Download the [exercise template](../../comprehensive-rust-exercises.zip) and look in the `rtc`\n"
-"directory for the following files."
+"Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
+"look in the `rtc` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:23
@@ -13058,17 +15323,20 @@ msgid ""
 "\n"
 "#[no_mangle]\n"
 "extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
 "    // and nothing else accesses that address range.\n"
 "    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
 "    logger::init(uart, LevelFilter::Trace).unwrap();\n"
 "\n"
 "    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
 "\n"
-"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
+"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
+"base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) };\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
 "    gic.setup();\n"
 "\n"
 "    // TODO: Create instance of RTC driver and print current time.\n"
@@ -13088,11 +15356,9 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:75
-msgid "`src/exceptions.rs` (you should only need to change this for the 3rd part of the exercise):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:77
-msgid "<!-- File src/exceptions.rs -->"
+msgid ""
+"`src/exceptions.rs` (you should only need to change this for the 3rd part of "
+"the exercise):"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:79
@@ -13126,7 +15392,8 @@ msgid ""
 "#[no_mangle]\n"
 "extern \"C\" fn irq_current(_elr: u64, _spsr: u64) {\n"
 "    trace!(\"irq_current\");\n"
-"    let intid = GicV3::get_and_acknowledge_interrupt().expect(\"No pending interrupt\");\n"
+"    let intid = GicV3::get_and_acknowledge_interrupt().expect(\"No pending "
+"interrupt\");\n"
 "    info!(\"IRQ {intid:?}\");\n"
 "}\n"
 "\n"
@@ -13170,10 +15437,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:149
 msgid "`src/logger.rs` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:151
-msgid "<!-- File src/logger.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:153
@@ -13226,7 +15489,8 @@ msgid ""
 "}\n"
 "\n"
 "/// Initialises UART logger.\n"
-"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), SetLoggerError> {\n"
+"pub fn init(uart: Uart, max_level: LevelFilter) -> Result<(), "
+"SetLoggerError> {\n"
 "    LOGGER.uart.lock().replace(uart);\n"
 "\n"
 "    log::set_logger(&LOGGER)?;\n"
@@ -13238,10 +15502,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "`src/pl011.rs` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:212
-msgid "<!-- File src/pl011.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:214
@@ -13354,13 +15614,16 @@ msgid ""
 "}\n"
 "\n"
 "impl Uart {\n"
-"    /// Constructs a new instance of the UART driver for a PL011 device at the\n"
+"    /// Constructs a new instance of the UART driver for a PL011 device at "
+"the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
 "    ///\n"
-"    /// The given base address must point to the MMIO control registers of a\n"
-"    /// PL011 device, which must be mapped into the address space of the process\n"
+"    /// The given base address must point to the MMIO control registers of "
+"a\n"
+"    /// PL011 device, which must be mapped into the address space of the "
+"process\n"
 "    /// as device memory and not have any other aliases.\n"
 "    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
 "        Self {\n"
@@ -13384,12 +15647,14 @@ msgid ""
 "        while self.read_flag_register().contains(Flags::BUSY) {}\n"
 "    }\n"
 "\n"
-"    /// Reads and returns a pending byte, or `None` if nothing has been received.\n"
+"    /// Reads and returns a pending byte, or `None` if nothing has been "
+"received.\n"
 "    pub fn read_byte(&self) -> Option<u8> {\n"
 "        if self.read_flag_register().contains(Flags::RXFE) {\n"
 "            None\n"
 "        } else {\n"
-"            let data = unsafe { addr_of!((*self.registers).dr).read_volatile() };\n"
+"            let data = unsafe { addr_of!((*self.registers).dr)."
+"read_volatile() };\n"
 "            // TODO: Check for error conditions in bits 8-11.\n"
 "            Some(data as u8)\n"
 "        }\n"
@@ -13446,10 +15711,6 @@ msgstr ""
 msgid "`build.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:412
-msgid "<!-- File build.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:414
 msgid ""
 "```rust,compile_fail\n"
@@ -13487,10 +15748,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
 msgid "`entry.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:448
-msgid "<!-- File entry.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:450
@@ -13532,24 +15789,29 @@ msgid ""
 ".set .L_TCR_TG0_4KB, 0x0 << 14\n"
 "/* 4 KiB granule size for TTBR1_EL1. */\n"
 ".set .L_TCR_TG1_4KB, 0x2 << 30\n"
-"/* Disable translation table walk for TTBR1_EL1, generating a translation fault instead. */\n"
+"/* Disable translation table walk for TTBR1_EL1, generating a translation "
+"fault instead. */\n"
 ".set .L_TCR_EPD1, 0x1 << 23\n"
 "/* Translation table walks for TTBR0_EL1 are inner sharable. */\n"
 ".set .L_TCR_SH_INNER, 0x3 << 12\n"
 "/*\n"
-" * Translation table walks for TTBR0_EL1 are outer write-back read-allocate write-allocate\n"
+" * Translation table walks for TTBR0_EL1 are outer write-back read-allocate "
+"write-allocate\n"
 " * cacheable.\n"
 " */\n"
 ".set .L_TCR_RGN_OWB, 0x1 << 10\n"
 "/*\n"
-" * Translation table walks for TTBR0_EL1 are inner write-back read-allocate write-allocate\n"
+" * Translation table walks for TTBR0_EL1 are inner write-back read-allocate "
+"write-allocate\n"
 " * cacheable.\n"
 " */\n"
 ".set .L_TCR_RGN_IWB, 0x1 << 8\n"
 "/* Size offset for TTBR0_EL1 is 2**39 bytes (512 GiB). */\n"
 ".set .L_TCR_T0SZ_512, 64 - 39\n"
-".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | .L_TCR_RGN_OWB\n"
-".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | .L_TCR_T0SZ_512\n"
+".set .Ltcrval, .L_TCR_TG0_4KB | .L_TCR_TG1_4KB | .L_TCR_EPD1 | ."
+"L_TCR_RGN_OWB\n"
+".set .Ltcrval, .Ltcrval | .L_TCR_RGN_IWB | .L_TCR_SH_INNER | ."
+"L_TCR_T0SZ_512\n"
 "\n"
 "/* Stage 1 instruction access cacheability is unaffected. */\n"
 ".set .L_SCTLR_ELx_I, 0x1 << 12\n"
@@ -13565,20 +15827,27 @@ msgid ""
 ".set .L_SCTLR_EL1_SED, 0x1 << 8\n"
 "/* Various IT instructions are disabled at EL0 in aarch32 mode. */\n"
 ".set .L_SCTLR_EL1_ITD, 0x1 << 7\n"
-".set .L_SCTLR_EL1_RES1, (0x1 << 11) | (0x1 << 20) | (0x1 << 22) | (0x1 << 28) | (0x1 << 29)\n"
-".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | .L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
-".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | .L_SCTLR_EL1_RES1\n"
+".set .L_SCTLR_EL1_RES1, (0x1 << 11) | (0x1 << 20) | (0x1 << 22) | (0x1 << "
+"28) | (0x1 << 29)\n"
+".set .Lsctlrval, .L_SCTLR_ELx_M | .L_SCTLR_ELx_C | .L_SCTLR_ELx_SA | ."
+"L_SCTLR_EL1_ITD | .L_SCTLR_EL1_SED\n"
+".set .Lsctlrval, .Lsctlrval | .L_SCTLR_ELx_I | .L_SCTLR_EL1_SPAN | ."
+"L_SCTLR_EL1_RES1\n"
 "\n"
 "/**\n"
-" * This is a generic entry point for an image. It carries out the operations required to prepare the\n"
-" * loaded image to be run. Specifically, it zeroes the bss section using registers x25 and above,\n"
-" * prepares the stack, enables floating point, and sets up the exception vector. It preserves x0-x3\n"
+" * This is a generic entry point for an image. It carries out the operations "
+"required to prepare the\n"
+" * loaded image to be run. Specifically, it zeroes the bss section using "
+"registers x25 and above,\n"
+" * prepares the stack, enables floating point, and sets up the exception "
+"vector. It preserves x0-x3\n"
 " * for the Rust entry point, as these may contain boot parameters.\n"
 " */\n"
 ".section .init.entry, \"ax\"\n"
 ".global entry\n"
 "entry:\n"
-"\t/* Load and apply the memory management configuration, ready to enable MMU and caches. */\n"
+"\t/* Load and apply the memory management configuration, ready to enable MMU "
+"and caches. */\n"
 "\tadrp x30, idmap\n"
 "\tmsr ttbr0_el1, x30\n"
 "\n"
@@ -13595,7 +15864,8 @@ msgid ""
 "\tmov_i x30, .Lsctlrval\n"
 "\n"
 "\t/*\n"
-"\t * Ensure everything before this point has completed, then invalidate any potentially stale\n"
+"\t * Ensure everything before this point has completed, then invalidate any "
+"potentially stale\n"
 "\t * local TLB entries before they start being used.\n"
 "\t */\n"
 "\tisb\n"
@@ -13605,7 +15875,8 @@ msgid ""
 "\tisb\n"
 "\n"
 "\t/*\n"
-"\t * Configure sctlr_el1 to enable MMU and cache and don't proceed until this has completed.\n"
+"\t * Configure sctlr_el1 to enable MMU and cache and don't proceed until "
+"this has completed.\n"
 "\t */\n"
 "\tmsr sctlr_el1, x30\n"
 "\tisb\n"
@@ -13645,10 +15916,6 @@ msgstr ""
 msgid "`exceptions.S` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:597
-msgid "<!-- File exceptions.S -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:599
 msgid ""
 "```armasm\n"
@@ -13670,11 +15937,14 @@ msgid ""
 "\n"
 "/**\n"
 " * Saves the volatile registers onto the stack. This currently takes 14\n"
-" * instructions, so it can be used in exception handlers with 18 instructions\n"
+" * instructions, so it can be used in exception handlers with 18 "
+"instructions\n"
 " * left.\n"
 " *\n"
-" * On return, x0 and x1 are initialised to elr_el2 and spsr_el2 respectively,\n"
-" * which can be used as the first and second arguments of a subsequent call.\n"
+" * On return, x0 and x1 are initialised to elr_el2 and spsr_el2 "
+"respectively,\n"
+" * which can be used as the first and second arguments of a subsequent "
+"call.\n"
 " */\n"
 ".macro save_volatile_to_stack\n"
 "\t/* Reserve stack space and save registers x0-x18, x29 & x30. */\n"
@@ -13701,7 +15971,8 @@ msgid ""
 "\n"
 "/**\n"
 " * Restores the volatile registers from the stack. This currently takes 14\n"
-" * instructions, so it can be used in exception handlers while still leaving 18\n"
+" * instructions, so it can be used in exception handlers while still leaving "
+"18\n"
 " * instructions left; if paired with save_volatile_to_stack, there are 4\n"
 " * instructions to spare.\n"
 " */\n"
@@ -13728,12 +15999,15 @@ msgid ""
 ".endm\n"
 "\n"
 "/**\n"
-" * This is a generic handler for exceptions taken at the current EL while using\n"
-" * SP0. It behaves similarly to the SPx case by first switching to SPx, doing\n"
+" * This is a generic handler for exceptions taken at the current EL while "
+"using\n"
+" * SP0. It behaves similarly to the SPx case by first switching to SPx, "
+"doing\n"
 " * the work, then switching back to SP0 before returning.\n"
 " *\n"
 " * Switching to SPx and calling the Rust handler takes 16 instructions. To\n"
-" * restore and return we need an additional 16 instructions, so we can implement\n"
+" * restore and return we need an additional 16 instructions, so we can "
+"implement\n"
 " * the whole handler within the allotted 32 instructions.\n"
 " */\n"
 ".macro current_exception_sp0 handler:req\n"
@@ -13746,15 +16020,18 @@ msgid ""
 ".endm\n"
 "\n"
 "/**\n"
-" * This is a generic handler for exceptions taken at the current EL while using\n"
-" * SPx. It saves volatile registers, calls the Rust handler, restores volatile\n"
+" * This is a generic handler for exceptions taken at the current EL while "
+"using\n"
+" * SPx. It saves volatile registers, calls the Rust handler, restores "
+"volatile\n"
 " * registers, then returns.\n"
 " *\n"
 " * This also works for exceptions taken from EL0, if we don't care about\n"
 " * non-volatile registers.\n"
 " *\n"
 " * Saving state and jumping to the Rust handler takes 15 instructions, and\n"
-" * restoring and returning also takes 15 instructions, so we can fit the whole\n"
+" * restoring and returning also takes 15 instructions, so we can fit the "
+"whole\n"
 " * handler in 30 instructions, under the limit of 32.\n"
 " */\n"
 ".macro current_exception_spx handler:req\n"
@@ -13837,10 +16114,6 @@ msgstr ""
 msgid "`idmap.S` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:782
-msgid "<!-- File idmap.S -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
 "```armasm\n"
@@ -13871,7 +16144,8 @@ msgid ""
 ".set .L_TT_XN, 0x3 << 53\n"
 "\n"
 ".set .L_TT_MT_DEV, 0x0 << 2\t\t\t// MAIR #0 (DEV_nGnRE)\n"
-".set .L_TT_MT_MEM, (0x1 << 2) | (0x3 << 8)\t// MAIR #1 (MEM_WBWA), inner shareable\n"
+".set .L_TT_MT_MEM, (0x1 << 2) | (0x3 << 8)\t// MAIR #1 (MEM_WBWA), inner "
+"shareable\n"
 "\n"
 ".set .L_BLOCK_DEV, .L_TT_TYPE_BLOCK | .L_TT_MT_DEV | .L_TT_AF | .L_TT_XN\n"
 ".set .L_BLOCK_MEM, .L_TT_TYPE_BLOCK | .L_TT_MT_MEM | .L_TT_AF | .L_TT_NG\n"
@@ -13891,10 +16165,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:829
 msgid "`image.ld` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:831
-msgid "<!-- File image.ld -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:833
@@ -13917,7 +16187,8 @@ msgid ""
 " */\n"
 "\n"
 "/*\n"
-" * Code will start running at this symbol which is placed at the start of the\n"
+" * Code will start running at this symbol which is placed at the start of "
+"the\n"
 " * image.\n"
 " */\n"
 "ENTRY(entry)\n"
@@ -14011,10 +16282,6 @@ msgstr ""
 msgid "`Makefile` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:942
-msgid "<!-- File Makefile -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:944
 msgid ""
 "```makefile\n"
@@ -14051,7 +16318,8 @@ msgid ""
 "\t$(OBJCOPY) -O binary target/aarch64-unknown-none/debug/rtc $@\n"
 "\n"
 "qemu: rtc.bin\n"
-"\tqemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio -display none -kernel $< -s\n"
+"\tqemu-system-aarch64 -machine virt,gic-version=3 -cpu max -serial mon:stdio "
+"-display none -kernel $< -s\n"
 "\n"
 "clean:\n"
 "\tcargo clean\n"
@@ -14073,24 +16341,20 @@ msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
 #: src/concurrency.md:1
-msgid "# Welcome to Concurrency in Rust"
+msgid "Welcome to Concurrency in Rust"
 msgstr ""
 
 #: src/concurrency.md:3
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 
 #: src/concurrency.md:6
 msgid ""
-"The Rust type system plays an important role in making many concurrency bugs\n"
-"compile time bugs. This is often referred to as _fearless concurrency_ since you\n"
-"can rely on the compiler to ensure correctness at runtime."
-msgstr ""
-
-#: src/concurrency/threads.md:1
-msgid "# Threads"
+"The Rust type system plays an important role in making many concurrency bugs "
+"compile time bugs. This is often referred to as _fearless concurrency_ since "
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 
 #: src/concurrency/threads.md:3
@@ -14120,28 +16384,38 @@ msgid ""
 msgstr ""
 
 #: src/concurrency/threads.md:24
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
+msgstr ""
+
+#: src/concurrency/threads.md:25
+msgid "Thread panics are independent of each other."
+msgstr ""
+
+#: src/concurrency/threads.md:26
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
 msgstr ""
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md:1
-msgid "# Scoped Threads"
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:3
@@ -14164,7 +16438,9 @@ msgid ""
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
-msgid "However, you can use a [scoped thread][1] for this:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
 msgstr ""
 
 #: src/concurrency/scoped-threads.md:19
@@ -14186,19 +16462,20 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:37
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, all the threads are guaranteed to be joined, so they can return borrowed data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
 
-#: src/concurrency/channels.md:1
-msgid "# Channels"
+#: src/concurrency/scoped-threads.md:38
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
 msgstr ""
 
 #: src/concurrency/channels.md:3
 msgid ""
-"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two parts\n"
-"are connected via the channel, but you only see the end-points."
+"Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
 
 #: src/concurrency/channels.md:6
@@ -14225,14 +16502,15 @@ msgstr ""
 
 #: src/concurrency/channels.md:27
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
 
-#: src/concurrency/channels/unbounded.md:1
-msgid "# Unbounded Channels"
+#: src/concurrency/channels.md:29
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
 msgstr ""
 
 #: src/concurrency/channels/unbounded.md:3
@@ -14266,12 +16544,9 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/concurrency/channels/bounded.md:1
-msgid "# Bounded Channels"
-msgstr ""
-
 #: src/concurrency/channels/bounded.md:3
-msgid "With bounded (synchronous) channels, `send` can block the current thread:"
+msgid ""
+"With bounded (synchronous) channels, `send` can block the current thread:"
 msgstr ""
 
 #: src/concurrency/channels/bounded.md:5
@@ -14303,71 +16578,94 @@ msgstr ""
 
 #: src/concurrency/channels/bounded.md:31
 msgid ""
-"* Calling `send` will block the current thread until there is space in the channel for the new message. The thread can be blocked indefinitely if there is nobody who reads from the channel.\n"
-"* A call to `send` will abort with an error (that is why it returns `Result`) if the channel is closed. A channel is closed when the receiver is dropped.\n"
-"* A bounded channel with a size of zero is called a \"rendezvous channel\". Every send will block the current thread until another thread calls `read`.\n"
-"    "
+"Calling `send` will block the current thread until there is space in the "
+"channel for the new message. The thread can be blocked indefinitely if there "
+"is nobody who reads from the channel."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:32
+msgid ""
+"A call to `send` will abort with an error (that is why it returns `Result`) "
+"if the channel is closed. A channel is closed when the receiver is dropped."
+msgstr ""
+
+#: src/concurrency/channels/bounded.md:33
+msgid ""
+"A bounded channel with a size of zero is called a \"rendezvous channel\". "
+"Every send will block the current thread until another thread calls `read`."
 msgstr ""
 
 #: src/concurrency/send-sync.md:1
-msgid "# `Send` and `Sync`"
+msgid "`Send` and `Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync.md:3
-msgid "How does Rust know to forbid shared access across thread? The answer is in two traits:"
+msgid ""
+"How does Rust know to forbid shared access across thread? The answer is in "
+"two traits:"
 msgstr ""
 
 #: src/concurrency/send-sync.md:5
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
+msgstr ""
+
+#: src/concurrency/send-sync.md:7
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
 msgstr ""
 
 #: src/concurrency/send-sync.md:10
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
 
 #: src/concurrency/send-sync.md:20
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
+msgstr ""
+
+#: src/concurrency/send-sync.md:21
+msgid "They can be used in the generic constraints as normal traits."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:1
-msgid "# `Send`"
+msgid "`Send`"
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:3
-msgid "> A type `T` is [`Send`][1] if it is safe to move a `T` value to another thread."
+msgid ""
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:5
 msgid ""
-"The effect of moving ownership to another thread is that _destructors_ will run\n"
-"in that thread. So the question is when you can allocate a value in one thread\n"
-"and deallocate it in another."
+"The effect of moving ownership to another thread is that _destructors_ will "
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
-"As an example, a connection to the SQLite library must only be accessed from a\n"
-"single thread."
+"As an example, a connection to the SQLite library must only be accessed from "
+"a single thread."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:1
-msgid "# `Sync`"
+msgid "`Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:3
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:6
@@ -14375,23 +16673,27 @@ msgid "More precisely, the definition is:"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:8
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:14
-msgid "This statement is essentially a shorthand way of saying that if a type is thread-safe for shared use, it is also thread-safe to pass references of it across threads."
+msgid ""
+"This statement is essentially a shorthand way of saying that if a type is "
+"thread-safe for shared use, it is also thread-safe to pass references of it "
+"across threads."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:16
-msgid "This is because if a type is Sync it means that it can be shared across multiple threads without the risk of data races or other synchronization issues, so it is safe to move it to another thread. A reference to the type is also safe to move to another thread, because the data it references can be accessed from any thread safely."
-msgstr ""
-
-#: src/concurrency/send-sync/examples.md:1
-msgid "# Examples"
+msgid ""
+"This is because if a type is Sync it means that it can be shared across "
+"multiple threads without the risk of data races or other synchronization "
+"issues, so it is safe to move it to another thread. A reference to the type "
+"is also safe to move to another thread, because the data it references can "
+"be accessed from any thread safely."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:3
-msgid "## `Send + Sync`"
+msgid "`Send + Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:5
@@ -14399,55 +16701,78 @@ msgid "Most types you come across are `Send + Sync`:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:17
-msgid "## `Send + !Sync`"
+msgid "`Send + !Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:19
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:22
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:23
+msgid "`mpsc::Receiver<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:24
+msgid "`Cell<T>`"
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:25
+msgid "`RefCell<T>`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:27
-msgid "## `!Send + Sync`"
+msgid "`!Send + Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:29
-msgid "These types are thread-safe, but they cannot be moved to another thread:"
+msgid ""
+"These types are thread-safe, but they cannot be moved to another thread:"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:31
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:34
-msgid "## `!Send + !Sync`"
+msgid "`!Send + !Sync`"
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:36
@@ -14456,35 +16781,43 @@ msgstr ""
 
 #: src/concurrency/send-sync/examples.md:38
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
 
-#: src/concurrency/shared_state.md:1
-msgid "# Shared State"
+#: src/concurrency/send-sync/examples.md:40
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
 msgstr ""
 
 #: src/concurrency/shared_state.md:3
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 
 #: src/concurrency/shared_state.md:6
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
+msgstr ""
+
+#: src/concurrency/shared_state.md:8
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:1
-msgid "# `Arc`"
+msgid "`Arc`"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:3
-msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
 msgstr ""
 
 #: src/concurrency/shared_state/arc.md:5
@@ -14512,24 +16845,41 @@ msgstr ""
 
 #: src/concurrency/shared_state/arc.md:29
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:31
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:33
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:35
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+
+#: src/concurrency/shared_state/arc.md:36
+msgid "`std::sync::Weak` can help."
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:1
-msgid "# `Mutex`"
+msgid "`Mutex`"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:3
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:6
@@ -14553,23 +16903,50 @@ msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:22
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
 
 #: src/concurrency/shared_state/mutex.md:31
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The `MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes \"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling `lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:32
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:33
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:35
+msgid ""
+"`Mutex<T>` implements both `Send` and `Sync` iff (if and only if) `T` "
+"implements `Send`."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:36
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:37
+msgid "Why does `lock()` return a `Result`? "
+msgstr ""
+
+#: src/concurrency/shared_state/mutex.md:38
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
 msgstr ""
 
 #: src/concurrency/shared_state/example.md:3
@@ -14632,10 +17009,26 @@ msgstr ""
 
 #: src/concurrency/shared_state/example.md:51
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as possible."
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:52
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:53
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+
+#: src/concurrency/shared_state/example.md:54
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"possible."
 msgstr ""
 
 #: src/exercises/concurrency/morning.md:3
@@ -14643,15 +17036,13 @@ msgid "Let us practice our new concurrency skills with"
 msgstr ""
 
 #: src/exercises/concurrency/morning.md:5
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
+msgid "Dining philosophers: a classic problem in concurrency."
 msgstr ""
 
-#: src/exercises/concurrency/dining-philosophers.md:1
-msgid "# Dining Philosophers"
+#: src/exercises/concurrency/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:3
@@ -14660,20 +17051,21 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:5
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has their\n"
-"> own place at the table. There is a fork between each plate. The dish served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will only\n"
-"> be available when their two nearest neighbors are thinking, not eating. After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:13
 msgid ""
-"You will need a local [Cargo installation](../../cargo/running-locally.md) for\n"
-"this exercise. Copy the code below to a file called `src/main.rs`, fill out the\n"
-"blanks, and test that `cargo run` does not deadlock:"
+"You will need a local [Cargo installation](../../cargo/running-locally.md) "
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:19
@@ -14735,22 +17127,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:1
-msgid "# Multi-threaded Link Checker"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:3
 msgid ""
-"Let us use our new knowledge to create a multi-threaded link checker. It should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until all\n"
-"pages have been validated."
+"Let us use our new knowledge to create a multi-threaded link checker. It "
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:8
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:11
@@ -14764,12 +17152,14 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:17
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:20
-msgid "You will also need a way to find links. We can use [`scraper`][2] for that:"
+msgid ""
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:22
@@ -14781,8 +17171,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:26
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:29
@@ -14793,7 +17183,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:33
-msgid "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
+msgid ""
+"The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:37
@@ -14806,7 +17197,8 @@ msgid ""
 "publish = false\n"
 "\n"
 "[dependencies]\n"
-"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-tls\"] }\n"
+"reqwest = { version = \"0.11.12\", features = [\"blocking\", \"rustls-"
+"tls\"] }\n"
 "scraper = \"0.13.0\"\n"
 "thiserror = \"1.0.37\"\n"
 "```"
@@ -14814,8 +17206,8 @@ msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:50
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 
 #: src/exercises/concurrency/link-checker.md:53
@@ -14848,7 +17240,8 @@ msgid ""
 "            match base_url.join(href) {\n"
 "                Ok(url) => valid_urls.push(url),\n"
 "                Err(err) => {\n"
-"                    println!(\"On {base_url}: could not parse {href:?}: {err} (ignored)\",);\n"
+"                    println!(\"On {base_url}: could not parse {href:?}: "
+"{err} (ignored)\",);\n"
 "                }\n"
 "            }\n"
 "        }\n"
@@ -14879,68 +17272,72 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:106
-#: src/exercises/concurrency/chat-app.md:140
-msgid "## Tasks"
-msgstr ""
-
 #: src/exercises/concurrency/link-checker.md:108
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
+msgstr ""
+
+#: src/exercises/concurrency/link-checker.md:110
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
 msgstr ""
 
 #: src/async.md:1
-msgid "# Async Rust"
+msgid "Async Rust"
 msgstr ""
 
 #: src/async.md:3
 msgid ""
-"\"Async\" is a concurrency model where multiple tasks are executed concurrently by\n"
-"executing each task until it would block, then switching to another task that is\n"
-"ready to make progress. The model allows running a larger number of tasks on a\n"
-"limited number of threads. This is because the per-task overhead is typically\n"
-"very low and operating systems provide primitives for efficiently identifying\n"
-"I/O that is able to proceed."
+"\"Async\" is a concurrency model where multiple tasks are executed "
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 
 #: src/async.md:10
 msgid ""
-"Rust's asynchronous operation is based on \"futures\", which represent work that\n"
-"may be completed in the future. Futures are \"polled\" until they signal that\n"
-"they are complete."
+"Rust's asynchronous operation is based on \"futures\", which represent work "
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
 
 #: src/async.md:14
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 
 #: src/async.md:17
-msgid "## Comparisons"
+msgid "Comparisons"
 msgstr ""
 
 #: src/async.md:19
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type is\n"
-"   callback-based, and not polled. Async Python programs require a \"loop\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
+msgstr ""
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
 msgstr ""
 
 #: src/async/async-await.md:1
-msgid "# `async`/`await`"
+msgid "`async`/`await`"
 msgstr ""
 
 #: src/async/async-await.md:3
-msgid "At a high level, async Rust code looks very much like \"normal\" sequential code:"
+msgid ""
+"At a high level, async Rust code looks very much like \"normal\" sequential "
+"code:"
 msgstr ""
 
 #: src/async/async-await.md:5
@@ -14966,38 +17363,54 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
 
-#: src/async/futures.md:1
-msgid "# Futures"
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr ""
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr ""
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr ""
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr ""
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
 msgstr ""
 
 #: src/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
 #: src/async/futures.md:8
@@ -15008,7 +17421,8 @@ msgid ""
 "\n"
 "pub trait Future {\n"
 "    type Output;\n"
-"    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;\n"
+"    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::"
+"Output>;\n"
 "}\n"
 "\n"
 "pub enum Poll<T> {\n"
@@ -15020,75 +17434,87 @@ msgstr ""
 
 #: src/async/futures.md:23
 msgid ""
-"An async function returns an `impl Future`. It's also possible (but uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"An async function returns an `impl Future`. It's also possible (but "
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
 
 #: src/async/futures.md:27
 msgid ""
-"The `.await` keyword, applied to a Future, causes the current async function to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"The `.await` keyword, applied to a Future, causes the current async function "
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers into\n"
-"    that future remain valid. This is required to allow references to remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/runtimes.md:1
-msgid "# Runtimes"
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
 msgstr ""
 
 #: src/async/runtimes.md:3
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
 #: src/async/runtimes.md:7
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
+msgstr ""
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
 msgstr ""
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 
 #: src/async/runtimes.md:20
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
 
-#: src/async/runtimes/tokio.md:1
-msgid "# Tokio"
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:4
@@ -15096,10 +17522,15 @@ msgid "Tokio provides: "
 msgstr ""
 
 #: src/async/runtimes/tokio.md:6
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:10
@@ -15127,12 +17558,15 @@ msgid ""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:39
@@ -15141,17 +17575,17 @@ msgstr ""
 
 #: src/async/runtimes/tokio.md:41
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
 
-#: src/async/tasks.md:1
-msgid "# Tasks"
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
 msgstr ""
 
 #: src/async/tasks.md:3
@@ -15160,10 +17594,11 @@ msgstr ""
 
 #: src/async/tasks.md:5
 msgid ""
-"A task has a single top-level future which the executor polls to make progress.\n"
-"That future may have one or more nested futures that its `poll` method polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"A task has a single top-level future which the executor polls to make "
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
 
 #: src/async/tasks.md:10
@@ -15191,7 +17626,8 @@ msgid ""
 "            let mut buf = vec![0; 1024];\n"
 "            let reply = match socket.read(&mut buf).await {\n"
 "                Ok(n) => {\n"
-"                    let name = std::str::from_utf8(&buf[..n]).unwrap().trim();\n"
+"                    let name = std::str::from_utf8(&buf[..n]).unwrap()."
+"trim();\n"
 "                    format!(\"Thanks for dialing in, {name}!\\n\")\n"
 "                }\n"
 "                Err(e) => {\n"
@@ -15210,27 +17646,32 @@ msgid ""
 msgstr ""
 
 #: src/async/tasks.md:52 src/async/control-flow/join.md:36
-msgid "Copy this example into your prepared `src/main.rs` and run it from there."
+msgid ""
+"Copy this example into your prepared `src/main.rs` and run it from there."
 msgstr ""
 
 #: src/async/tasks.md:54
 msgid ""
-"* Ask students to visualize what the state of the example server would be with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling using `?`."
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/async/channels.md:1
-msgid "# Async Channels"
+#: src/async/tasks.md:57
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+
+#: src/async/tasks.md:61
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
+"using `?`."
 msgstr ""
 
 #: src/async/channels.md:3
-msgid "Several crates have support for asynchronous channels. For instance `tokio`:"
+msgid ""
+"Several crates have support for asynchronous channels. For instance `tokio`:"
 msgstr ""
 
 #: src/async/channels.md:5
@@ -15259,52 +17700,63 @@ msgid ""
 "    }\n"
 "\n"
 "    std::mem::drop(sender);\n"
-"    ping_handler_task.await.expect(\"Something went wrong in ping handler task.\");\n"
+"    ping_handler_task.await.expect(\"Something went wrong in ping handler "
+"task.\");\n"
 "}\n"
 "```"
 msgstr ""
 
 #: src/async/channels.md:35
+msgid "Change the channel size to `3` and see how it affects the execution."
+msgstr ""
+
+#: src/async/channels.md:37
 msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
 msgstr ""
 
 #: src/async/control-flow.md:1
-msgid "# Futures Control Flow"
+msgid "Futures Control Flow"
 msgstr ""
 
 #: src/async/control-flow.md:3
 msgid ""
-"Futures can be combined together to produce concurrent compute flow graphs. We\n"
-"have already seen tasks, that function as independent threads of execution."
+"Futures can be combined together to produce concurrent compute flow graphs. "
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
 
 #: src/async/control-flow.md:6
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
 msgstr ""
 
-#: src/async/control-flow/join.md:1
-msgid "# Join"
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
 msgstr ""
 
 #: src/async/control-flow/join.md:3
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
@@ -15340,37 +17792,40 @@ msgstr ""
 
 #: src/async/control-flow/join.md:38
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but demonstrates `join!`."
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/select.md:1
-msgid "# Select"
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
+"demonstrates `join!`."
 msgstr ""
 
 #: src/async/control-flow/select.md:3
 msgid ""
-"A select operation waits until any of a set of futures is ready, and responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"A select operation waits until any of a set of futures is ready, and "
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
 msgid ""
-"Similar to a match statement, the body of `select!` has a number of arms, each\n"
-"of the form `pattern = future => statement`. When the `future` is ready, the\n"
-"`statement` is executed with the variables in `pattern` bound to the `future`'s\n"
-"result."
+"Similar to a match statement, the body of `select!` has a number of arms, "
+"each of the form `pattern = future => statement`. When the `future` is "
+"ready, the `statement` is executed with the variables in `pattern` bound to "
+"the `future`'s result."
 msgstr ""
 
 #: src/async/control-flow/select.md:13
@@ -15425,49 +17880,74 @@ msgstr ""
 
 #: src/async/control-flow/select.md:62
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` drops unmatched branches, which cancels their futures.\n"
-"  It is easiest to use when every execution of `select!` creates new futures.\n"
-"\n"
-"    * An alternative is to pass `&mut future` instead of the future itself, but\n"
-"      this can lead to issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
+msgstr ""
+
+#: src/async/control-flow/select.md:67
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+
+#: src/async/control-flow/select.md:70
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:73
+msgid ""
+"Note that `select!` drops unmatched branches, which cancels their futures. "
+"It is easiest to use when every execution of `select!` creates new futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:76
+msgid ""
+"An alternative is to pass `&mut future` instead of the future itself, but "
+"this can lead to issues, further discussed in the pinning slide."
 msgstr ""
 
 #: src/async/pitfalls.md:1
-msgid "# Pitfalls of async/await"
+msgid "Pitfalls of async/await"
 msgstr ""
 
 #: src/async/pitfalls.md:3
-msgid "Async / await provides convenient and efficient abstraction for concurrent asynchronous programming. However, the async/await model in Rust also comes with its share of pitfalls and footguns. We illustrate some of them in this chapter:"
+msgid ""
+"Async / await provides convenient and efficient abstraction for concurrent "
+"asynchronous programming. However, the async/await model in Rust also comes "
+"with its share of pitfalls and footguns. We illustrate some of them in this "
+"chapter:"
 msgstr ""
 
 #: src/async/pitfalls.md:5
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfalls/async-traits.md)\n"
-"- [Cancellation](pitfalls/cancellation.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfalls/async-traits.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:8
+msgid "[Cancellation](pitfalls/cancellation.md)"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:1
-msgid "# Blocking the executor"
+msgid "Blocking the executor"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:3
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:7
@@ -15495,45 +17975,57 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an actual\n"
-"  thread and transforms its handle into a future without blocking the executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:1
-msgid "# Pin"
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
-"When you await a future, all local variables (that would ordinarily be stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. If your\n"
-"future has pointers to data on the stack, those pointers might get invalidated.\n"
-"This is unsafe."
+"When you await a future, all local variables (that would ordinarily be "
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:8
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to don't\n"
-"change. That is why we need to `pin` futures. Using the same future repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"Therefore, you must guarantee that the addresses your future points to don't "
+"change. That is why we need to `pin` futures. Using the same future "
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:12
@@ -15595,61 +18087,92 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the `loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that will send to a `oneshot` channel every 100ms."
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:1
-msgid "# Async Traits"
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:3
-msgid "Async methods in traits are not yet supported in the stable channel ([An experimental feature exists in nightly and should be stabilized in the mid term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html))"
+msgid ""
+"Async methods in traits are not yet supported in the stable channel ([An "
+"experimental feature exists in nightly and should be stabilized in the mid "
+"term.](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-"
+"nightly.html))"
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:5
-msgid "The crate [async_trait](https://docs.rs/async-trait/latest/async_trait/) provides a workaround through a macro:"
+msgid ""
+"The crate [async_trait](https://docs.rs/async-trait/latest/async_trait/) "
+"provides a workaround through a macro:"
 msgstr ""
 
 #: src/async/pitfalls/async-traits.md:7
@@ -15675,7 +18198,8 @@ msgid ""
 "    }\n"
 "}\n"
 "\n"
-"async fn run_all_sleepers_multiple_times(sleepers: Vec<Box<dyn Sleeper>>, n_times: usize) {\n"
+"async fn run_all_sleepers_multiple_times(sleepers: Vec<Box<dyn Sleeper>>, "
+"n_times: usize) {\n"
 "    for _ in 0..n_times {\n"
 "        println!(\"running all sleepers..\");\n"
 "        for sleeper in &sleepers {\n"
@@ -15697,36 +18221,33 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:49
-msgid "<details>  "
-msgstr ""
-
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
 msgstr ""
 
-#: src/async/pitfalls/cancellation.md:1
-#, fuzzy
-msgid "# Cancellation"
-msgstr "# Переводы"
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
+msgstr ""
 
 #: src/async/pitfalls/cancellation.md:3
 msgid ""
-"Dropping a future implies it can never be polled again. This is called *cancellation*\n"
-"and it can occur at any `await` point. Care is needed to ensure the system works\n"
-"correctly even when futures are cancelled. For example, it shouldn't deadlock or\n"
-"lose data."
+"Dropping a future implies it can never be polled again. This is called "
+"_cancellation_ and it can occur at any `await` point. Care is needed to "
+"ensure the system works correctly even when futures are cancelled. For "
+"example, it shouldn't deadlock or lose data."
 msgstr ""
 
 #: src/async/pitfalls/cancellation.md:8
@@ -15758,12 +18279,14 @@ msgid ""
 "            return Ok(None)\n"
 "        }\n"
 "        let s = String::from_utf8(bytes)\n"
-"            .map_err(|_| io::Error::new(ErrorKind::InvalidData, \"not UTF-8\"))?;\n"
+"            .map_err(|_| io::Error::new(ErrorKind::InvalidData, \"not "
+"UTF-8\"))?;\n"
 "        Ok(Some(s))\n"
 "    }\n"
 "}\n"
 "\n"
-"async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::Result<()> {\n"
+"async fn slow_copy(source: String, mut dest: DuplexStream) -> std::io::"
+"Result<()> {\n"
 "    for b in source.bytes() {\n"
 "        dest.write_u8(b).await?;\n"
 "        tokio::time::sleep(Duration::from_millis(10)).await\n"
@@ -15774,7 +18297,8 @@ msgid ""
 "#[tokio::main]\n"
 "async fn main() -> std::io::Result<()> {\n"
 "    let (client, server) = tokio::io::duplex(5);\n"
-"    let handle = tokio::spawn(slow_copy(\"hi\\nthere\\n\".to_owned(), client));\n"
+"    let handle = tokio::spawn(slow_copy(\"hi\\nthere\\n\".to_owned(), "
+"client));\n"
 "\n"
 "    let mut lines = LinesReader::new(server);\n"
 "    let mut interval = tokio::time::interval(Duration::from_millis(60));\n"
@@ -15796,78 +18320,110 @@ msgstr ""
 
 #: src/async/pitfalls/cancellation.md:72
 msgid ""
-"* The compiler doesn't help with cancellation-safety. You need to read API\n"
-"  documentation and consider what state your `async fn` holds.\n"
+"The compiler doesn't help with cancellation-safety. You need to read API "
+"documentation and consider what state your `async fn` holds."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:75
+msgid ""
+"Unlike `panic` and `?`, cancellation is part of normal control flow (vs "
+"error-handling)."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:78
+msgid "The example loses parts of the string."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:80
+msgid ""
+"Whenever the `tick()` branch finishes first, `next()` and its `buf` are "
+"dropped."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:82
+msgid ""
+"`LinesReader` can be made cancellation-safe by makeing `buf` part of the "
+"struct:"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:83
+msgid ""
+"```rust,compile_fail\n"
+"struct LinesReader {\n"
+"    stream: DuplexStream,\n"
+"    bytes: Vec<u8>,\n"
+"    buf: [u8; 1],\n"
+"}\n"
 "\n"
-"* Unlike `panic` and `?`, cancellation is part of normal control flow\n"
-"  (vs error-handling).\n"
-"\n"
-"* The example loses parts of the string.\n"
-"\n"
-"    * Whenever the `tick()` branch finishes first, `next()` and its `buf` are dropped.\n"
-"\n"
-"    * `LinesReader` can be made cancellation-safe by makeing `buf` part of the struct:\n"
-"        ```rust,compile_fail\n"
-"        struct LinesReader {\n"
-"            stream: DuplexStream,\n"
-"            bytes: Vec<u8>,\n"
-"            buf: [u8; 1],\n"
-"        }\n"
-"\n"
-"        impl LinesReader {\n"
-"            fn new(stream: DuplexStream) -> Self {\n"
-"                Self { stream, bytes: Vec::new(), buf: [0] }\n"
-"            }\n"
-"            async fn next(&mut self) -> io::Result<Option<String>> {\n"
-"                // prefix buf and bytes with self.\n"
-"                // ...\n"
-"                let raw = std::mem::take(&mut self.bytes);\n"
-"                let s = String::from_utf8(raw)\n"
-"                // ...\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"* [`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick)\n"
-"  is cancellation-safe because it keeps track of whether a tick has been 'delivered'.\n"
-"\n"
-"* [`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read)\n"
-"  is cancellation-safe because it either returns or doesn't read data.\n"
-"\n"
-"* [`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncBufReadExt.html#method.read_line)\n"
-"  is similar to the example and *isn't* cancellation-safe. See its documentation\n"
-"  for details and alternatives."
+"impl LinesReader {\n"
+"    fn new(stream: DuplexStream) -> Self {\n"
+"        Self { stream, bytes: Vec::new(), buf: [0] }\n"
+"    }\n"
+"    async fn next(&mut self) -> io::Result<Option<String>> {\n"
+"        // prefix buf and bytes with self.\n"
+"        // ...\n"
+"        let raw = std::mem::take(&mut self.bytes);\n"
+"        let s = String::from_utf8(raw)\n"
+"        // ...\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:104
+msgid ""
+"[`Interval::tick`](https://docs.rs/tokio/latest/tokio/time/struct.Interval."
+"html#method.tick) is cancellation-safe because it keeps track of whether a "
+"tick has been 'delivered'."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:107
+msgid ""
+"[`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncReadExt.html#method.read) is cancellation-safe because it either "
+"returns or doesn't read data."
+msgstr ""
+
+#: src/async/pitfalls/cancellation.md:110
+msgid ""
+"[`AsyncBufReadExt::read_line`](https://docs.rs/tokio/latest/tokio/io/trait."
+"AsyncBufReadExt.html#method.read_line) is similar to the example and _isn't_ "
+"cancellation-safe. See its documentation for details and alternatives."
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:3
-msgid "To practice your Async Rust skills, we have again two exercises for you:"
+msgid ""
+"To practice your Async Rust skills, we have again two exercises for you:"
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
-"* Dining philosophers: we already saw this problem in the morning. This time\n"
-"  you are going to implement it with Async Rust.\n"
-"\n"
-"* A Broadcast Chat Application: this is a larger project that allows you\n"
-"  experiment with more advanced Async Rust features."
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr ""
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
-msgid "# Dining Philosophers - Async"
+#: src/exercises/concurrency/solutions-afternoon.md:3
+msgid "Dining Philosophers - Async"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the\n"
+"See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 msgid ""
-"As before, you will need a local\n"
-"[Cargo installation](../../cargo/running-locally.md) for this exercise. Copy\n"
-"the code below to a file called `src/main.rs`, fill out the blanks, and test\n"
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
@@ -15890,7 +18446,8 @@ msgid ""
 "impl Philosopher {\n"
 "    async fn think(&self) {\n"
 "        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name)).await\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
 "            .unwrap();\n"
 "    }\n"
 "\n"
@@ -15919,7 +18476,7 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
 msgid ""
-"Since this time you are using Async Rust, you'll need a `tokio` dependency.\n"
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
@@ -15932,38 +18489,36 @@ msgid ""
 "edition = \"2021\"\n"
 "\n"
 "[dependencies]\n"
-"tokio = {version = \"1.26.0\", features = [\"sync\", \"time\", \"macros\", \"rt-multi-thread\"]}\n"
+"tokio = {version = \"1.26.0\", features = [\"sync\", \"time\", \"macros\", "
+"\"rt-multi-thread\"]}\n"
 "```"
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:72
 msgid ""
-"Also note that this time you have to use the `Mutex` and the `mpsc` module\n"
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "* Can you make your implementation single-threaded? "
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:1
-msgid "# Broadcast Chat Application"
+msgid "Can you make your implementation single-threaded? "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
 msgid ""
-"In this exercise, we want to use our new knowledge to implement a broadcast\n"
-"chat application. We have a chat server that the clients connect to and publish\n"
-"their messages. The client reads user messages from the standard input, and\n"
-"sends them to the server. The chat server broadcasts each message that it\n"
-"receives to all the clients."
+"In this exercise, we want to use our new knowledge to implement a broadcast "
+"chat application. We have a chat server that the clients connect to and "
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel][1] on the server, and\n"
-"[`tokio_websockets`][2] for the communication between the client and the\n"
-"server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:13
@@ -15991,55 +18546,69 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:32
-msgid "## The required APIs"
+msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
-"You are going to need the following functions from `tokio` and\n"
-"[`tokio_websockets`][2]. Spend a few minutes to familiarize yourself with the\n"
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
 "API. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
-"- [WebsocketStream::next()][3]: for asynchronously reading messages from a\n"
-"  Websocket Stream.\n"
-"- [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously\n"
-"  sending messages on a Websocket Stream.\n"
-"- [Lines::next_line()][5]: for asynchronously reading user messages\n"
-"  from the standard input.\n"
-"- [Sender::subscribe()][6]: for subscribing to a broadcast channel."
+"[WebsocketStream::next()](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/proto/struct.WebsocketStream.html#method.next): for "
+"asynchronously reading messages from a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:41
+msgid ""
+"[Lines::next_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
-msgid "## Two binaries"
+msgid "Two binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one\n"
-"`src/main.rs` file. In this project, we need two binaries. One for the client,\n"
-"and one for the server. You could potentially make them two separate Cargo\n"
-"projects, but we are going to put them in a single Cargo project with two\n"
-"binaries. For this to work, the client and the server code should go under\n"
-"`src/bin` (see the [documentation][7]). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and\n"
-"`src/bin/client.rs`, respectively. Your task is to complete these files as\n"
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:59
 #: src/exercises/concurrency/solutions-afternoon.md:117
 msgid "`src/bin/server.rs`:"
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:61
-msgid "<!-- File src/bin/server.rs -->"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:63
@@ -16089,10 +18658,6 @@ msgstr ""
 msgid "`src/bin/client.rs`:"
 msgstr ""
 
-#: src/exercises/concurrency/chat-app.md:104
-msgid "<!-- File src/bin/client.rs -->"
-msgstr ""
-
 #: src/exercises/concurrency/chat-app.md:106
 msgid ""
 "```rust,compile_fail\n"
@@ -16103,7 +18668,8 @@ msgid ""
 "\n"
 "#[tokio::main]\n"
 "async fn main() -> Result<(), tokio_websockets::Error> {\n"
-"    let mut ws_stream = ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
+"    let mut ws_stream = ClientBuilder::from_uri(Uri::"
+"from_static(\"ws://127.0.0.1:2000\"))\n"
 "        .connect()\n"
 "        .await?;\n"
 "\n"
@@ -16118,7 +18684,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:127
-msgid "## Running the binaries"
+msgid "Running the binaries"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:128
@@ -16144,51 +18710,60 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:142
-msgid ""
-"* Implement the `handle_connection` function in `src/bin/server.rs`.\n"
-"  * Hint: Use `tokio::select!` for concurrently performing two tasks in a\n"
-"    continuous loop. One task receives messages from the client and broadcasts\n"
-"    them. The other sends messages received by the server to the client.\n"
-"* Complete the main function in `src/bin/client.rs`.\n"
-"  * Hint: As before, use `tokio::select!` in a continuous loop for concurrently\n"
-"    performing two tasks: (1) reading user messages from standard input and\n"
-"    sending them to the server, and (2) receiving messages from the server, and\n"
-"    displaying them for the user.\n"
-"* Optional: Once you are done, change the code to broadcast messages to all\n"
-"  clients, but the sender of the message."
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/thanks.md:1
-msgid "# Thanks!"
+#: src/exercises/concurrency/chat-app.md:143
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:147
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:151
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
 msgstr ""
 
 #: src/thanks.md:3
 msgid ""
-"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and that it\n"
-"was useful."
+"_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
+"that it was useful."
 msgstr ""
 
 #: src/thanks.md:6
 msgid ""
-"We've had a lot of fun putting the course together. The course is not perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would love\n"
-"to hear from you."
+"We've had a lot of fun putting the course together. The course is not "
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 
 #: src/other-resources.md:1
-msgid "# Other Rust Resources"
+msgid "Other Rust Resources"
 msgstr ""
 
 #: src/other-resources.md:3
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 
 #: src/other-resources.md:6
-msgid "## Official Documentation"
+msgid "Official Documentation"
 msgstr ""
 
 #: src/other-resources.md:8
@@ -16197,17 +18772,29 @@ msgstr ""
 
 #: src/other-resources.md:10
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the Rust\n"
-"  syntax via a series of examples which showcase different constructs. Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
+msgstr ""
+
+#: src/other-resources.md:13
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+
+#: src/other-resources.md:17
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+
+#: src/other-resources.md:19
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
 msgstr ""
 
 #: src/other-resources.md:22
@@ -16216,18 +18803,27 @@ msgstr ""
 
 #: src/other-resources.md:24
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/):\n"
-"  covers the new asynchronous programming model which was introduced after the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
+msgstr ""
+
+#: src/other-resources.md:27
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+
+#: src/other-resources.md:30
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
 msgstr ""
 
 #: src/other-resources.md:33
-msgid "## Unofficial Learning Material"
+msgid "Unofficial Learning Material"
 msgstr ""
 
 #: src/other-resources.md:35
@@ -16236,95 +18832,106 @@ msgstr ""
 
 #: src/other-resources.md:37
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): a\n"
-"  series of small presentations covering both basic and advanced part of the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
+msgstr ""
+
+#: src/other-resources.md:39
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+
+#: src/other-resources.md:42
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+
+#: src/other-resources.md:45
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+
+#: src/other-resources.md:47
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+
+#: src/other-resources.md:52
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
 msgstr ""
 
 #: src/other-resources.md:63
 msgid ""
-"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) for\n"
-"even more Rust books."
-msgstr ""
-
-#: src/credits.md:1
-msgid "# Credits"
+"Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
+"for even more Rust books."
 msgstr ""
 
 #: src/credits.md:3
 msgid ""
-"The material here builds on top of the many great sources of Rust documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of useful\n"
-"resources."
+"The material here builds on top of the many great sources of Rust "
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
 
 #: src/credits.md:7
 msgid ""
-"The material of Comprehensive Rust is licensed under the terms of the Apache 2.0\n"
-"license, please see\n"
-"[`LICENSE`](https://github.com/google/comprehensive-rust/blob/main/LICENSE) for\n"
-"details."
+"The material of Comprehensive Rust is licensed under the terms of the Apache "
+"2.0 license, please see [`LICENSE`](https://github.com/google/comprehensive-"
+"rust/blob/main/LICENSE) for details."
 msgstr ""
 
 #: src/credits.md:12
-msgid "## Rust by Example"
+msgid "Rust by Example"
 msgstr ""
 
 #: src/credits.md:14
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
 
 #: src/credits.md:19
-msgid "## Rust on Exercism"
+msgid "Rust on Exercism"
 msgstr ""
 
 #: src/credits.md:21
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
 
 #: src/credits.md:26
-msgid "## CXX"
+msgid "CXX"
 msgstr ""
 
 #: src/credits.md:28
 msgid ""
-"The [Interoperability with C++](android/interoperability/cpp.md) section uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` directory\n"
-"for details, including the license terms."
-msgstr ""
-
-#: src/exercises/solutions.md:1
-msgid "# Solutions"
+"The [Interoperability with C++](android/interoperability/cpp.md) section "
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 
 #: src/exercises/solutions.md:3
@@ -16333,24 +18940,20 @@ msgstr ""
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
 
 #: src/exercises/solutions.md:10
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:1
-msgid "# Day 1 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-morning.md:3
-msgid "## Arrays and `for` Loops"
+msgid "Day 1 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:5
@@ -16433,19 +19036,29 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
-msgid "### Bonus question"
+msgid "Bonus question"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:80
-msgid "It requires more advanced concepts. It might seem that we could use a slice-of-slices (`&[&[i32]]`) as the input type to transpose and thus make our function handle any size of matrix. However, this quickly breaks down: the return type cannot be `&[&[i32]]` since it needs to own the data you return."
+msgid ""
+"It requires more advanced concepts. It might seem that we could use a slice-"
+"of-slices (`&[&[i32]]`) as the input type to transpose and thus make our "
+"function handle any size of matrix. However, this quickly breaks down: the "
+"return type cannot be `&[&[i32]]` since it needs to own the data you return."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:82
-msgid "You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to `&[&[i32]]` so now you cannot easily use `pretty_print` either."
+msgid ""
+"You can attempt to use something like `Vec<Vec<i32>>`, but this doesn't work "
+"out-of-the-box either: it's hard to convert from `Vec<Vec<i32>>` to "
+"`&[&[i32]]` so now you cannot easily use `pretty_print` either."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:84
-msgid "Once we get to traits and generics, we'll be able to use the [`std::convert::AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+msgid ""
+"Once we get to traits and generics, we'll be able to use the [`std::convert::"
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:86
@@ -16479,15 +19092,13 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:113
-msgid "In addition, the type itself would not enforce that the child slices are of the same length, so such variable could contain an invalid matrix."
+msgid ""
+"In addition, the type itself would not enforce that the child slices are of "
+"the same length, so such variable could contain an invalid matrix."
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
-msgid "# Day 1 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-msgid "## Designing a Library"
+msgid "Day 1 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:5
@@ -16575,7 +19186,8 @@ msgid ""
 "\n"
 "    // ANCHOR: Library_print_books\n"
 "    //fn print_books(self) {\n"
-"    //    todo!(\"Iterate over `self.books` and each book's title and year\")\n"
+"    //    todo!(\"Iterate over `self.books` and each book's title and "
+"year\")\n"
 "    //}\n"
 "    // ANCHOR_END: Library_print_books\n"
 "    fn print_books(&self) {\n"
@@ -16613,12 +19225,15 @@ msgid ""
 "fn main() {\n"
 "    let library = Library::new();\n"
 "\n"
-"    //println!(\"The library is empty: library.is_empty() -> {}\", library.is_empty());\n"
+"    //println!(\"The library is empty: library.is_empty() -> {}\", library."
+"is_empty());\n"
 "    //\n"
 "    //library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    //library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    //\n"
-"    //println!(\"The library is no longer empty: library.is_empty() -> {}\", library.is_empty());\n"
+"    //println!(\"The library is no longer empty: library.is_empty() -> {}\", "
+"library.is_empty());\n"
 "    //\n"
 "    //\n"
 "    //library.print_books();\n"
@@ -16640,7 +19255,8 @@ msgid ""
 "    assert!(library.is_empty());\n"
 "\n"
 "    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    assert_eq!(library.len(), 2);\n"
 "    assert!(!library.is_empty());\n"
 "}\n"
@@ -16658,7 +19274,8 @@ msgid ""
 "fn test_library_print_books() {\n"
 "    let mut library = Library::new();\n"
 "    library.add_book(Book::new(\"Lord of the Rings\", 1954));\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    // We could try and capture stdout, but let us just call the\n"
 "    // method to start with.\n"
 "    library.print_books();\n"
@@ -16675,7 +19292,8 @@ msgid ""
 "        Some(\"Lord of the Rings\")\n"
 "    );\n"
 "\n"
-"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", 1865));\n"
+"    library.add_book(Book::new(\"Alice's Adventures in Wonderland\", "
+"1865));\n"
 "    assert_eq!(\n"
 "        library.oldest_book().map(|b| b.title.as_str()),\n"
 "        Some(\"Alice's Adventures in Wonderland\")\n"
@@ -16685,11 +19303,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
-msgid "# Day 2 Morning Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-morning.md:3
-msgid "## Points and Polygons"
+msgid "Day 2 Morning Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:5
@@ -16929,11 +19543,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
-msgid "# Day 2 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-msgid "## Luhn Algorithm"
+msgid "Day 2 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:5
@@ -16962,7 +19572,8 @@ msgid ""
 "    // ANCHOR_END: luhn\n"
 "    let mut digits_seen = 0;\n"
 "    let mut sum = 0;\n"
-"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ').enumerate() {\n"
+"    for (i, ch) in cc_number.chars().rev().filter(|&ch| ch != ' ')."
+"enumerate() {\n"
 "        match ch.to_digit(10) {\n"
 "            Some(d) => {\n"
 "                sum += if i % 2 == 1 {\n"
@@ -17033,10 +19644,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:97
-msgid "## Strings and Iterators"
-msgstr ""
-
 #: src/exercises/day-2/solutions-afternoon.md:99
 msgid "([back to exercise](strings-iterators.md))"
 msgstr ""
@@ -17074,11 +19681,16 @@ msgid ""
 "    }\n"
 "    true\n"
 "\n"
-"    // Alternatively, Iterator::zip() lets us iterate simultaneously over prefix\n"
-"    // and request segments. The zip() iterator is finished as soon as one of\n"
-"    // the source iterators is finished, but we need to iterate over all request\n"
-"    // segments. A neat trick that makes zip() work is to use map() and chain()\n"
-"    // to produce an iterator that returns Some(str) for each pattern segments,\n"
+"    // Alternatively, Iterator::zip() lets us iterate simultaneously over "
+"prefix\n"
+"    // and request segments. The zip() iterator is finished as soon as one "
+"of\n"
+"    // the source iterators is finished, but we need to iterate over all "
+"request\n"
+"    // segments. A neat trick that makes zip() work is to use map() and "
+"chain()\n"
+"    // to produce an iterator that returns Some(str) for each pattern "
+"segments,\n"
 "    // and then returns None indefinitely.\n"
 "}\n"
 "\n"
@@ -17086,12 +19698,15 @@ msgid ""
 "#[test]\n"
 "fn test_matches_without_wildcard() {\n"
 "    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc-123\"));\n"
-"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/books\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/"
+"abc-123\"));\n"
+"    assert!(prefix_matches(\"/v1/publishers\", \"/v1/publishers/abc/"
+"books\"));\n"
 "\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1\"));\n"
 "    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/publishersBooks\"));\n"
-"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers\", \"/v1/parent/"
+"publishers\"));\n"
 "}\n"
 "\n"
 "#[test]\n"
@@ -17109,7 +19724,8 @@ msgid ""
 "        \"/v1/publishers/foo/books/book1\"\n"
 "    ));\n"
 "\n"
-"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/publishers\"));\n"
+"    assert!(!prefix_matches(\"/v1/publishers/*/books\", \"/v1/"
+"publishers\"));\n"
 "    assert!(!prefix_matches(\n"
 "        \"/v1/publishers/*/books\",\n"
 "        \"/v1/publishers/foo/booksByAuthor\"\n"
@@ -17122,11 +19738,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
-msgid "# Day 3 Morning Exercise"
-msgstr ""
-
-#: src/exercises/day-3/solutions-morning.md:3
-msgid "## A Simple GUI Library"
+msgid "Day 3 Morning Exercise"
 msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:5
@@ -17293,7 +19905,8 @@ msgid ""
 "// ANCHOR: main\n"
 "fn main() {\n"
 "    let mut window = Window::new(\"Rust GUI Demo 1.23\");\n"
-"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo.\")));\n"
+"    window.add_widget(Box::new(Label::new(\"This is a small text GUI demo."
+"\")));\n"
 "    window.add_widget(Box::new(Button::new(\n"
 "        \"Click me!\",\n"
 "        Box::new(|| println!(\"You clicked the button!\")),\n"
@@ -17305,11 +19918,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
-msgid "# Day 3 Afternoon Exercises"
-msgstr ""
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-msgid "## Safe FFI Wrapper"
+msgid "Day 3 Afternoon Exercises"
 msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:5
@@ -17343,10 +19952,12 @@ msgid ""
 "    #[repr(C)]\n"
 "    pub struct DIR {\n"
 "        _data: [u8; 0],\n"
-"        _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,\n"
+"        _marker: core::marker::PhantomData<(*mut u8, core::marker::"
+"PhantomPinned)>,\n"
 "    }\n"
 "\n"
-"    // Layout according to the Linux man page for readdir(3), where ino_t and\n"
+"    // Layout according to the Linux man page for readdir(3), where ino_t "
+"and\n"
 "    // off_t are resolved according to the definitions in\n"
 "    // /usr/include/x86_64-linux-gnu/{sys/types.h, bits/typesizes.h}.\n"
 "    #[cfg(not(target_os = \"macos\"))]\n"
@@ -17377,11 +19988,14 @@ msgid ""
 "        #[cfg(not(all(target_os = \"macos\", target_arch = \"x86_64\")))]\n"
 "        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
 "\n"
-"        // See https://github.com/rust-lang/libc/issues/414 and the section on\n"
+"        // See https://github.com/rust-lang/libc/issues/414 and the section "
+"on\n"
 "        // _DARWIN_FEATURE_64_BIT_INODE in the macOS man page for stat(2).\n"
 "        //\n"
-"        // \"Platforms that existed before these updates were available\" refers\n"
-"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and PowerPC.\n"
+"        // \"Platforms that existed before these updates were available\" "
+"refers\n"
+"        // to macOS (as opposed to iOS / wearOS / etc.) on Intel and "
+"PowerPC.\n"
 "        #[cfg(all(target_os = \"macos\", target_arch = \"x86_64\"))]\n"
 "        #[link_name = \"readdir$INODE64\"]\n"
 "        pub fn readdir(s: *mut DIR) -> *const dirent;\n"
@@ -17406,7 +20020,8 @@ msgid ""
 "        // Call opendir and return a Ok value if that worked,\n"
 "        // otherwise return Err with a message.\n"
 "        // ANCHOR_END: DirectoryIterator\n"
-"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: {err}\"))?;\n"
+"        let path = CString::new(path).map_err(|err| format!(\"Invalid path: "
+"{err}\"))?;\n"
 "        // SAFETY: path.as_ptr() cannot be NULL.\n"
 "        let dir = unsafe { ffi::opendir(path.as_ptr()) };\n"
 "        if dir.is_null() {\n"
@@ -17485,7 +20100,8 @@ msgid ""
 "    #[test]\n"
 "    fn test_nonempty_directory() -> Result<(), Box<dyn Error>> {\n"
 "        let tmp = tempfile::TempDir::new()?;\n"
-"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo Diaries\\n\")?;\n"
+"        std::fs::write(tmp.path().join(\"foo.txt\"), \"The Foo "
+"Diaries\\n\")?;\n"
 "        std::fs::write(tmp.path().join(\"bar.png\"), \"<PNG>\\n\")?;\n"
 "        std::fs::write(tmp.path().join(\"crab.rs\"), \"//! Crab\\n\")?;\n"
 "        let iter = DirectoryIterator::new(\n"
@@ -17493,7 +20109,8 @@ msgid ""
 "        )?;\n"
 "        let mut entries = iter.collect::<Vec<_>>();\n"
 "        entries.sort();\n"
-"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", \"foo.txt\"]);\n"
+"        assert_eq!(entries, &[\".\", \"..\", \"bar.png\", \"crab.rs\", \"foo."
+"txt\"]);\n"
 "        Ok(())\n"
 "    }\n"
 "}\n"
@@ -17501,11 +20118,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-msgid "## Compass"
+msgid "Bare Metal Rust Morning Exercise"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:5
@@ -17567,7 +20180,8 @@ msgid ""
 "    // Set up the I2C controller and Inertial Measurement Unit.\n"
 "    // ANCHOR_END: main\n"
 "    writeln!(serial, \"Setting up IMU...\").unwrap();\n"
-"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::K100);\n"
+"    let i2c = Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::"
+"K100);\n"
 "    let mut imu = Lsm303agr::new_with_i2c(i2c);\n"
 "    imu.init().unwrap();\n"
 "    imu.set_mag_odr(MagOutputDataRate::Hz50).unwrap();\n"
@@ -17607,8 +20221,10 @@ msgid ""
 "        let mut image = [[0; 5]; 5];\n"
 "        let (x, y) = match mode {\n"
 "            Mode::Compass => (\n"
-"                scale(-compass_reading.x, -COMPASS_SCALE, COMPASS_SCALE, 0, 4) as usize,\n"
-"                scale(compass_reading.y, -COMPASS_SCALE, COMPASS_SCALE, 0, 4) as usize,\n"
+"                scale(-compass_reading.x, -COMPASS_SCALE, COMPASS_SCALE, 0, "
+"4) as usize,\n"
+"                scale(compass_reading.y, -COMPASS_SCALE, COMPASS_SCALE, 0, "
+"4) as usize,\n"
 "            ),\n"
 "            Mode::Accelerometer => (\n"
 "                scale(\n"
@@ -17630,7 +20246,8 @@ msgid ""
 "        image[y][x] = 255;\n"
 "        display.show(&mut timer, image, 100);\n"
 "\n"
-"        // If button A is pressed, switch to the next mode and briefly blink all LEDs on.\n"
+"        // If button A is pressed, switch to the next mode and briefly blink "
+"all LEDs on.\n"
 "        if board.buttons.button_a.is_low().unwrap() {\n"
 "            if !button_pressed {\n"
 "                mode = mode.next();\n"
@@ -17658,7 +20275,8 @@ msgid ""
 "    }\n"
 "}\n"
 "\n"
-"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -> i32 {\n"
+"fn scale(value: i32, min_in: i32, max_in: i32, min_out: i32, max_out: i32) -"
+"> i32 {\n"
 "    let range_in = max_in - min_in;\n"
 "    let range_out = max_out - min_out;\n"
 "    cap(\n"
@@ -17672,14 +20290,6 @@ msgid ""
 "    max(min_value, min(value, max_value))\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "# Bare Metal Rust Afternoon"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-msgid "## RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -17746,21 +20356,25 @@ msgid ""
 "// ANCHOR: main\n"
 "#[no_mangle]\n"
 "extern \"C\" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {\n"
-"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 device,\n"
+"    // Safe because `PL011_BASE_ADDRESS` is the base address of a PL011 "
+"device,\n"
 "    // and nothing else accesses that address range.\n"
 "    let uart = unsafe { Uart::new(PL011_BASE_ADDRESS) };\n"
 "    logger::init(uart, LevelFilter::Trace).unwrap();\n"
 "\n"
 "    info!(\"main({:#x}, {:#x}, {:#x}, {:#x})\", x0, x1, x2, x3);\n"
 "\n"
-"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the base\n"
+"    // Safe because `GICD_BASE_ADDRESS` and `GICR_BASE_ADDRESS` are the "
+"base\n"
 "    // addresses of a GICv3 distributor and redistributor respectively, and\n"
 "    // nothing else accesses those address ranges.\n"
-"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS) };\n"
+"    let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, "
+"GICR_BASE_ADDRESS) };\n"
 "    gic.setup();\n"
 "    // ANCHOR_END: main\n"
 "\n"
-"    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 device,\n"
+"    // Safe because `PL031_BASE_ADDRESS` is the base address of a PL031 "
+"device,\n"
 "    // and nothing else accesses that address range.\n"
 "    let mut rtc = unsafe { Rtc::new(PL031_BASE_ADDRESS) };\n"
 "    let timestamp = rtc.read();\n"
@@ -17888,13 +20502,16 @@ msgid ""
 "}\n"
 "\n"
 "impl Rtc {\n"
-"    /// Constructs a new instance of the RTC driver for a PL031 device at the\n"
+"    /// Constructs a new instance of the RTC driver for a PL031 device at "
+"the\n"
 "    /// given base address.\n"
 "    ///\n"
 "    /// # Safety\n"
 "    ///\n"
-"    /// The given base address must point to the MMIO control registers of a\n"
-"    /// PL031 device, which must be mapped into the address space of the process\n"
+"    /// The given base address must point to the MMIO control registers of "
+"a\n"
+"    /// PL031 device, which must be mapped into the address space of the "
+"process\n"
 "    /// as device memory and not have any other aliases.\n"
 "    pub unsafe fn new(base_address: *mut u32) -> Self {\n"
 "        Self {\n"
@@ -17909,7 +20526,8 @@ msgid ""
 "        unsafe { addr_of!((*self.registers).dr).read_volatile() }\n"
 "    }\n"
 "\n"
-"    /// Writes a match value. When the RTC value matches this then an interrupt\n"
+"    /// Writes a match value. When the RTC value matches this then an "
+"interrupt\n"
 "    /// will be generated (if it is enabled).\n"
 "    pub fn set_match(&mut self, value: u32) {\n"
 "        // Safe because we know that self.registers points to the control\n"
@@ -17917,12 +20535,14 @@ msgid ""
 "        unsafe { addr_of_mut!((*self.registers).mr).write_volatile(value) }\n"
 "    }\n"
 "\n"
-"    /// Returns whether the match register matches the RTC value, whether or not\n"
+"    /// Returns whether the match register matches the RTC value, whether or "
+"not\n"
 "    /// the interrupt is enabled.\n"
 "    pub fn matched(&self) -> bool {\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).ris).read_volatile() };\n"
+"        let ris = unsafe { addr_of!((*self.registers).ris)."
+"read_volatile() };\n"
 "        (ris & 0x01) != 0\n"
 "    }\n"
 "\n"
@@ -17933,19 +20553,22 @@ msgid ""
 "    pub fn interrupt_pending(&self) -> bool {\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        let ris = unsafe { addr_of!((*self.registers).mis).read_volatile() };\n"
+"        let ris = unsafe { addr_of!((*self.registers).mis)."
+"read_volatile() };\n"
 "        (ris & 0x01) != 0\n"
 "    }\n"
 "\n"
 "    /// Sets or clears the interrupt mask.\n"
 "    ///\n"
-"    /// When the mask is true the interrupt is enabled; when it is false the\n"
+"    /// When the mask is true the interrupt is enabled; when it is false "
+"the\n"
 "    /// interrupt is disabled.\n"
 "    pub fn enable_interrupt(&mut self, mask: bool) {\n"
 "        let imsc = if mask { 0x01 } else { 0x00 };\n"
 "        // Safe because we know that self.registers points to the control\n"
 "        // registers of a PL031 device which is appropriately mapped.\n"
-"        unsafe { addr_of_mut!((*self.registers).imsc).write_volatile(imsc) }\n"
+"        unsafe { addr_of_mut!((*self.registers).imsc)."
+"write_volatile(imsc) }\n"
 "    }\n"
 "\n"
 "    /// Clears a pending interrupt, if any.\n"
@@ -17963,11 +20586,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
-msgid "# Concurrency Morning Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-morning.md:3
-msgid "## Dining Philosophers"
+msgid "Concurrency Morning Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:5
@@ -18075,11 +20694,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
-msgid "# Concurrency Afternoon Exercise"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:3
-msgid "## Dining Philosophers - Async"
+msgid "Concurrency Afternoon Exercise"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:5
@@ -18123,7 +20738,8 @@ msgid ""
 "impl Philosopher {\n"
 "    async fn think(&self) {\n"
 "        self.thoughts\n"
-"            .send(format!(\"Eureka! {} has a new idea!\", &self.name)).await\n"
+"            .send(format!(\"Eureka! {} has a new idea!\", &self.name))."
+"await\n"
 "            .unwrap();\n"
 "    }\n"
 "    // ANCHOR_END: Philosopher-think\n"
@@ -18133,7 +20749,8 @@ msgid ""
 "        // Pick up forks...\n"
 "        // ANCHOR_END: Philosopher-eat\n"
 "        let _first_lock = self.left_fork.lock().await;\n"
-"        // Add a delay before picking the second fork to allow the execution\n"
+"        // Add a delay before picking the second fork to allow the "
+"execution\n"
 "        // to transfer to another task\n"
 "        time::sleep(time::Duration::from_millis(1)).await;\n"
 "        let _second_lock = self.right_fork.lock().await;\n"
@@ -18156,7 +20773,8 @@ msgid ""
 "    // ANCHOR_END: Philosopher-eat-end\n"
 "    // Create forks\n"
 "    let mut forks = vec![];\n"
-"    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::new(Fork))));\n"
+"    (0..PHILOSOPHERS.len()).for_each(|_| forks.push(Arc::new(Mutex::"
+"new(Fork))));\n"
 "\n"
 "    // Create philosophers\n"
 "    let (philosophers, mut rx) = {\n"
@@ -18167,8 +20785,10 @@ msgid ""
 "            let right_fork = forks[(i + 1) % PHILOSOPHERS.len()].clone();\n"
 "            philosophers.push(Philosopher {\n"
 "                name: name.to_string(),\n"
-"                left_fork: if i % 2 == 0 { left_fork.clone() } else { right_fork.clone() },\n"
-"                right_fork: if i % 2 == 0 { right_fork } else { left_fork },\n"
+"                left_fork: if i % 2 == 0 { left_fork.clone() } else "
+"{ right_fork.clone() },\n"
+"                right_fork: if i % 2 == 0 { right_fork } else "
+"{ left_fork },\n"
 "                thoughts: tx.clone(),\n"
 "            });\n"
 "        }\n"
@@ -18193,10 +20813,6 @@ msgid ""
 "    }\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:113
-msgid "## Broadcast Chat Application"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:115
@@ -18242,7 +20858,8 @@ msgid ""
 "        .await?;\n"
 "    let mut bcast_rx = bcast_tx.subscribe();\n"
 "\n"
-"    // A continuous loop for concurrently performing two tasks: (1) receiving\n"
+"    // A continuous loop for concurrently performing two tasks: (1) "
+"receiving\n"
 "    // messages from `ws_stream` and broadcasting them, and (2) receiving\n"
 "    // messages on `bcast_rx` and sending them to the client.\n"
 "    loop {\n"
@@ -18314,7 +20931,8 @@ msgid ""
 "\n"
 "#[tokio::main]\n"
 "async fn main() -> Result<(), tokio_websockets::Error> {\n"
-"    let mut ws_stream = ClientBuilder::from_uri(Uri::from_static(\"ws://127.0.0.1:2000\"))\n"
+"    let mut ws_stream = ClientBuilder::from_uri(Uri::"
+"from_static(\"ws://127.0.0.1:2000\"))\n"
 "        .connect()\n"
 "        .await?;\n"
 "\n"
@@ -18327,7 +20945,8 @@ msgid ""
 "        tokio::select! {\n"
 "            incoming = ws_stream.next() => {\n"
 "                match incoming {\n"
-"                    Some(Ok(msg)) => println!(\"From server: {}\", msg.as_text()?),\n"
+"                    Some(Ok(msg)) => println!(\"From server: {}\", msg."
+"as_text()?),\n"
 "                    Some(Err(err)) => return Err(err.into()),\n"
 "                    None => return Ok(()),\n"
 "                }\n"
@@ -18335,7 +20954,8 @@ msgid ""
 "            res = stdin.next_line() => {\n"
 "                match res {\n"
 "                    Ok(None) => return Ok(()),\n"
-"                    Ok(Some(line)) => ws_stream.send(Message::text(line.to_string())).await?,\n"
+"                    Ok(Some(line)) => ws_stream.send(Message::text(line."
+"to_string())).await?,\n"
 "                    Err(err) => return Err(err.into()),\n"
 "                }\n"
 "            }\n"


### PR DESCRIPTION
Before, po/ru.po had these statistics:

    217 translated messages, 35 fuzzy translations, 1529 untranslated messages.

Afterwards, the statistics for po/ru.po is:

    374 translated messages, 47 fuzzy translations, 2046 untranslated messages.

The number of translated messages changed from 12% to 15%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.