### PR TITLE
el: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/el.po
+++ b/po/el.po
@@ -5,21 +5,21 @@ msgstr ""
 "PO-Revision-Date: 2023-02-07 01:09+0000\n"
 "Last-Translator: root <andrikopoulos@google.com>\n"
 "Language-Team: Greek <team@lists.gnome.gr>\n"
-"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Καλώς ήρθατε στην Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Διεξαγωγή του μαθήματος"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Δομή Μαθήματος"
 
@@ -27,15 +27,15 @@ msgstr "Δομή Μαθήματος"
 msgid "Ημέρα 4η"
 msgstr ""
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Συντομεύσεις πληκτρολογίου"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Μεταφράσεις"
 
-#: src/SUMMARY.md:9
+#: src/SUMMARY.md:9 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Χρήση Cargo"
 
@@ -60,55 +60,55 @@ msgstr "1η μέρα: Πρωί"
 msgid "Welcome"
 msgstr "Καλως Ήρθατε"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Τι είναι η Rust;"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Γειά σου Κόσμε!"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "Μικρό Παράδειγμα"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "Γιατί Rust;"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "Εγγυήσεις Χρόνου Μεταγλώττισης"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "Εγγυήσεις χρόνου εκτέλεσης"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "Σύγχρονα Χαρακτηριστικά"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "Βασική Σύνταξη"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "Βαθμωτοί Τύποι"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "Σύνθετοι τύποι"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "Αναφορές"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "Κρεμασμένες αναφορές"
 
-#: src/SUMMARY.md:32
+#: src/SUMMARY.md:32 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "Φέτες"
 
@@ -116,15 +116,17 @@ msgstr "Φέτες"
 msgid "String vs str"
 msgstr "String vs str"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "Συναρτήσεις"
 
-#: src/SUMMARY.md:35
+#: src/SUMMARY.md:35 src/basic-syntax/rustdoc.md:1
+#, fuzzy
 msgid "Rustdoc"
-msgstr ""
+msgstr "Γιατί Rust;"
 
-#: src/SUMMARY.md:36 src/SUMMARY.md:83
+#: src/SUMMARY.md:36 src/SUMMARY.md:83 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "Μέθοδοι"
 
@@ -134,11 +136,13 @@ msgstr "Υπερφόρτωση"
 
 #: src/SUMMARY.md:38 src/SUMMARY.md:67 src/SUMMARY.md:91 src/SUMMARY.md:120
 #: src/SUMMARY.md:149 src/SUMMARY.md:177 src/SUMMARY.md:200 src/SUMMARY.md:227
-#: src/SUMMARY.md:253 src/SUMMARY.md:279
+#: src/SUMMARY.md:253 src/SUMMARY.md:279 src/exercises/day-4/morning.md:1
+#: src/exercises/day-4/android.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
 msgid "Exercises"
 msgstr "Ασκήσεις"
 
-#: src/SUMMARY.md:39
+#: src/SUMMARY.md:39 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "Έμμεσες μετατροπές"
 
@@ -150,11 +154,11 @@ msgstr "Πίνακες και βρόχοι for"
 msgid "Day 1: Afternoon"
 msgstr "1η μέρα: Απόγευμα"
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "Μεταβλητές"
 
-#: src/SUMMARY.md:45
+#: src/SUMMARY.md:45 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "Συμπερασμός Τύπων"
 
@@ -162,11 +166,11 @@ msgstr "Συμπερασμός Τύπων"
 msgid "static & const"
 msgstr "static & const"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "Εμβέλια και σκίαση"
 
-#: src/SUMMARY.md:48
+#: src/SUMMARY.md:48 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "Διαχείριση μνήμης"
 
@@ -174,15 +178,15 @@ msgstr "Διαχείριση μνήμης"
 msgid "Stack vs Heap"
 msgstr "Στοίβα και Σωρός"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "Μνήμη στοίβας"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "Χειροκίνητη διαχείριση μνήμης"
 
-#: src/SUMMARY.md:52
+#: src/SUMMARY.md:52 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "Διαχείριση μνήμης βάσει εμβέλιας"
 
@@ -194,59 +198,60 @@ msgstr "Συλλογή σκουπιδιών"
 msgid "Rust Memory Management"
 msgstr "Διαχείριση μνήμης στη Rust"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "Σύγκριση"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership.md:1
 msgid "Ownership"
 msgstr "Ιδιοκτησία"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "Σημασιολογία μετακίνησης"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Μετακινημένες συμβολοσειρές στη Rust"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "Διπλές απελευθερώσεις μνήμης στη σύγχρονη C++"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "Μετακινήσεις σε κλήσεις συναρτήσεων"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "Αντιγραφή και κλωνοποίηση"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "Δανεισμός"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "Κοινόχρηστα και μοναδικά δάνεια"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "Διάρκειες"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "Διάρκειες σε κλήσεις συναρτήσεων"
 
-#: src/SUMMARY.md:66
+#: src/SUMMARY.md:66 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "Διάρκειες ζωής σε δομές δεδομένων"
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr "Σχεδιασμός Βιβλιοθηκών"
 
-#: src/SUMMARY.md:69
+#: src/SUMMARY.md:69 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "Iterators και ιδιοκτησία"
 
@@ -254,63 +259,64 @@ msgstr "Iterators και ιδιοκτησία"
 msgid "Day 2: Morning"
 msgstr "2η μέρα: Πρωί"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs.md:1
 msgid "Structs"
 msgstr "Δομές"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "Δομές Τούπλας"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "Συντομευμένο συντακτικό πεδίων"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums.md:1
 msgid "Enums"
 msgstr "Απαριθμήσεις"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "Περιεχόμενο Παραλλαγών"
 
-#: src/SUMMARY.md:82
+#: src/SUMMARY.md:82 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "Μέγεθος Απαριθμήσεων"
 
-#: src/SUMMARY.md:84
+#: src/SUMMARY.md:84 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "Δέκτης Μεθόδων"
 
 #: src/SUMMARY.md:85 src/SUMMARY.md:160 src/SUMMARY.md:195
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "Παράδειγμα"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "Αντιστοίχιση προτύπων"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "Αποδόμηση Απαριθμήσεων"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "Αποδόμηση Δομών"
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "Αποδόμηση Πινάκων"
 
-#: src/SUMMARY.md:90
+#: src/SUMMARY.md:90 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "Φύλακες Αντιστοιχίσεων"
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "Στατιστικά Υγείας"
 
-#: src/SUMMARY.md:93
+#: src/SUMMARY.md:93 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "Σημεία και Πολύγωνα"
 
@@ -318,11 +324,11 @@ msgstr "Σημεία και Πολύγωνα"
 msgid "Day 2: Afternoon"
 msgstr "2η μέρα: Απόγευμα"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "Ροή ελέγχου"
 
-#: src/SUMMARY.md:98
+#: src/SUMMARY.md:98 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "Μπλοκ"
 
@@ -358,7 +364,7 @@ msgstr "Εκφράσεις match"
 msgid "break & continue"
 msgstr "break & continue"
 
-#: src/SUMMARY.md:107
+#: src/SUMMARY.md:107 src/std.md:1
 msgid "Standard Library"
 msgstr "Στάνταρ Βιβλιοθήκη"
 
@@ -366,7 +372,7 @@ msgstr "Στάνταρ Βιβλιοθήκη"
 msgid "Option and Result"
 msgstr "Option και Result"
 
-#: src/SUMMARY.md:109
+#: src/SUMMARY.md:109 src/std/string.md:1
 msgid "String"
 msgstr "Συμβολοσειρές"
 
@@ -386,7 +392,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "Αναδρομικοί τύποι δεδομένων"
 
-#: src/SUMMARY.md:114
+#: src/SUMMARY.md:114 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "Εξειδικευμένη Βελτιστοποίηση"
 
@@ -394,27 +400,29 @@ msgstr "Εξειδικευμένη Βελτιστοποίηση"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules.md:1
 msgid "Modules"
 msgstr "Δομικές Μονάδες"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "Ορατότητα"
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/paths.md:1
 msgid "Paths"
 msgstr "Μονοπάτια"
 
-#: src/SUMMARY.md:119
+#: src/SUMMARY.md:119 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "Ιεραρχία συστήματος αρχείων"
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Αλγόριθμος Luhn"
 
-#: src/SUMMARY.md:122
+#: src/SUMMARY.md:122 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:98
 msgid "Strings and Iterators"
 msgstr "Συμβολοσειρές και Επαναλήπτες"
 
@@ -422,19 +430,19 @@ msgstr "Συμβολοσειρές και Επαναλήπτες"
 msgid "Day 3: Morning"
 msgstr "3η μέρα: Πρωί"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/traits.md:1
 msgid "Traits"
 msgstr "Χαρακτηριστικά"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "Εξάγωντας χαρακτηριστικά"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "Προ-υλοποιημένες μέθοδοι"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "Σημαντικά Χαρακτηριστικά"
 
@@ -442,7 +450,7 @@ msgstr "Σημαντικά Χαρακτηριστικά"
 msgid "Iterator"
 msgstr "Iterator"
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -466,19 +474,19 @@ msgstr "Drop"
 msgid "Default"
 msgstr ""
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/generics.md:1
 msgid "Generics"
 msgstr "Γενικευσεις"
 
-#: src/SUMMARY.md:142
+#: src/SUMMARY.md:142 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "Γενικοί τύποι δεδομένων"
 
-#: src/SUMMARY.md:143
+#: src/SUMMARY.md:143 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "Γενικές Μέθοδοι"
 
-#: src/SUMMARY.md:144
+#: src/SUMMARY.md:144 src/generics/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "Περιορισμοί χαρακτηριστικών"
 
@@ -486,19 +494,20 @@ msgstr "Περιορισμοί χαρακτηριστικών"
 msgid "impl Trait"
 msgstr "impl Trait"
 
-#: src/SUMMARY.md:146
+#: src/SUMMARY.md:146 src/generics/closures.md:1
 msgid "Closures"
 msgstr "Κλεισίματα"
 
-#: src/SUMMARY.md:147
+#: src/SUMMARY.md:147 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "Μονομορφοποίηση"
 
-#: src/SUMMARY.md:148
+#: src/SUMMARY.md:148 src/generics/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "Αντικείμενα Χαρακτηριστικών"
 
-#: src/SUMMARY.md:150
+#: src/SUMMARY.md:150 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "Μια απλή βιβλιοθήκη GUI"
 
@@ -506,11 +515,11 @@ msgstr "Μια απλή βιβλιοθήκη GUI"
 msgid "Day 3: Afternoon"
 msgstr "3η μέρα: Απόγευμα"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "Χειρισμός σφαλμάτων"
 
-#: src/SUMMARY.md:155
+#: src/SUMMARY.md:155 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Πανικοί"
 
@@ -526,63 +535,64 @@ msgstr "Δομημένη διαχείριση σφαλμάτων"
 msgid "Propagating Errors with ?"
 msgstr "Διάδοση σφαλμάτων με ?"
 
-#: src/SUMMARY.md:159
+#: src/SUMMARY.md:159 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "Μετατροπή τύπων σφαλμάτων"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "Εξαγωγή απαριθμήσεων σφαλμάτων"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "Δυναμικοί τύποι σφαλμάτων"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "Προσθήκη περιεχομένου στα σφάλματα"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing.md:1
 msgid "Testing"
 msgstr "Τεστ"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "Τεστ μονάδων"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "Δομικές μονάδες τεστ"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "Τεστ τεκμηρίωσης"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "Τεστ ενσωμάτωσης"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Μη ασφαλής Rust"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "Αποαναφορά δεικτών"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "Μεταβλητές στατικές μεταβλητές"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "Σωματεία"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "Κλήση μη ασφαλών συναρτήσεων"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "Υλοποίηση μη ασφαλών συναρτήσεων"
 
@@ -590,11 +600,12 @@ msgstr "Υλοποίηση μη ασφαλών συναρτήσεων"
 msgid "Extern Functions"
 msgstr "Εξωτερικές Συναρτήσεις"
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "Υλοποίηση μη ασφαλών χαρακτηριστικών"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "Ασφαλές περιτύλιγμα FFI"
 
@@ -606,27 +617,27 @@ msgstr "4η μέρα: Πρωί"
 msgid "Concurrency"
 msgstr "Συγχρονισμός"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "Νήματα"
 
-#: src/SUMMARY.md:188
+#: src/SUMMARY.md:188 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "Νήματα με εμβέλεια"
 
-#: src/SUMMARY.md:189
+#: src/SUMMARY.md:189 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "Κανάλια"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Κανάλια χωρίς Όρια"
 
-#: src/SUMMARY.md:191
+#: src/SUMMARY.md:191 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Κανάλια με Όρια"
 
-#: src/SUMMARY.md:192
+#: src/SUMMARY.md:192 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "Κοινόχρηστα Δεδομένα"
 
@@ -650,15 +661,16 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:199
+#: src/SUMMARY.md:199 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "Παραδείγματα"
 
-#: src/SUMMARY.md:201
+#: src/SUMMARY.md:201 src/exercises/day-4/dining-philosophers.md:1
+#: src/exercises/day-4/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "Δείπνο με φιλόσοφους"
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/exercises/day-4/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "Έλεγχος συνδέσμων πολλαπλών νημάτων"
 
@@ -666,15 +678,16 @@ msgstr "Έλεγχος συνδέσμων πολλαπλών νημάτων"
 msgid "Day 4: Afternoon (Android)"
 msgstr "4η μέρα: Απόγευμα (Android)"
 
-#: src/SUMMARY.md:204 src/SUMMARY.md:277
+#: src/SUMMARY.md:204 src/SUMMARY.md:277 src/running-the-course/day-4.md:15
+#: src/android.md:1 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:209
+#: src/SUMMARY.md:209 src/android/setup.md:1
 msgid "Setup"
 msgstr "Προετοιμασία"
 
-#: src/SUMMARY.md:210
+#: src/SUMMARY.md:210 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "Κανόνες Κατασκευής"
 
@@ -686,7 +699,7 @@ msgstr "Εκτελέσιμα"
 msgid "Library"
 msgstr "Βιβλιοθήκες"
 
-#: src/SUMMARY.md:213
+#: src/SUMMARY.md:213 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -702,7 +715,7 @@ msgstr "Υλοποίηση"
 msgid "Server"
 msgstr "Εξυπηρετητής"
 
-#: src/SUMMARY.md:217
+#: src/SUMMARY.md:217 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "Deploy"
 
@@ -710,15 +723,16 @@ msgstr "Deploy"
 msgid "Client"
 msgstr "Πελάτης"
 
-#: src/SUMMARY.md:219
+#: src/SUMMARY.md:219 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "Αλλαγή API"
 
-#: src/SUMMARY.md:220 src/SUMMARY.md:268
+#: src/SUMMARY.md:220 src/SUMMARY.md:268 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "Καταγραφή"
 
-#: src/SUMMARY.md:221
+#: src/SUMMARY.md:221 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "Διαλειτουργικότητα"
 
@@ -734,7 +748,7 @@ msgstr "Καλώντας C με Bindgen"
 msgid "Calling Rust from C"
 msgstr "Καλώντας Rust από C"
 
-#: src/SUMMARY.md:225
+#: src/SUMMARY.md:225 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "Με C++"
 
@@ -746,7 +760,7 @@ msgstr "Με Java"
 msgid "Final Words"
 msgstr "Κλείσιμο"
 
-#: src/SUMMARY.md:231
+#: src/SUMMARY.md:231 src/thanks.md:1
 msgid "Thanks!"
 msgstr "Ευχαριστήρια"
 
@@ -754,9 +768,10 @@ msgstr "Ευχαριστήρια"
 msgid "Other Resources"
 msgstr "Επιπλέον Υλικό"
 
-#: src/SUMMARY.md:233
+#: src/SUMMARY.md:233 src/credits.md:1
+#, fuzzy
 msgid "Credits"
-msgstr ""
+msgstr "Πιστώσεις"
 
 #: src/SUMMARY.md:237
 msgid "Bare Metal Rust: Morning"
@@ -768,17 +783,17 @@ msgstr ""
 
 #: src/SUMMARY.md:241
 msgid "A Minimal Example"
-msgstr "# Μικρό Παράδειγμα"
+msgstr "Μικρό Παράδειγμα"
 
 #: src/SUMMARY.md:242
 msgid "alloc"
 msgstr ""
 
-#: src/SUMMARY.md:243
+#: src/SUMMARY.md:243 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "Μικροεπεξεργαστές"
 
-#: src/SUMMARY.md:244
+#: src/SUMMARY.md:244 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr ""
 
@@ -806,7 +821,7 @@ msgstr ""
 msgid "probe-rs, cargo-embed"
 msgstr ""
 
-#: src/SUMMARY.md:251
+#: src/SUMMARY.md:251 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "Αποσφαλμάτωση"
 
@@ -814,7 +829,8 @@ msgstr "Αποσφαλμάτωση"
 msgid "Other Projects"
 msgstr "Επιπλέον Projects"
 
-#: src/SUMMARY.md:254
+#: src/SUMMARY.md:254 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "Πυξίδα"
 
@@ -823,12 +839,10 @@ msgid "Bare Metal Rust: Afternoon"
 msgstr "Rust χωρίς λειτουργικό σύστημα: Απόγευμα"
 
 #: src/SUMMARY.md:258
-#, fuzzy
 msgid "Application Processors"
 msgstr ""
 
 #: src/SUMMARY.md:259
-#, fuzzy
 msgid "Inline Assembly"
 msgstr ""
 
@@ -848,7 +862,7 @@ msgstr "Επιπλέον Χαρακτηριστικά"
 msgid "A Better UART Driver"
 msgstr "Ένας καλύτερος οδηγός UART"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr ""
 
@@ -856,7 +870,7 @@ msgstr ""
 msgid "Multiple Registers"
 msgstr "Πολλαπλοί καταχωρητές"
 
-#: src/SUMMARY.md:266
+#: src/SUMMARY.md:266 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "Οδηγός"
 
@@ -889,7 +903,7 @@ msgstr ""
 msgid "spin"
 msgstr ""
 
-#: src/SUMMARY.md:278
+#: src/SUMMARY.md:278 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr ""
 
@@ -897,7 +911,7 @@ msgstr ""
 msgid "RTC Driver"
 msgstr "Οδηγός RTC"
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "Λύσεις"
 
@@ -933,13 +947,9 @@ msgstr "4η ημέρα Πρωί"
 msgid "Bare Metal Rust Morning"
 msgstr "Rust χωρίς λειτουργικό σύστημα: Πρωί"
 
-#: src/SUMMARY.md:297
+#: src/SUMMARY.md:297 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "Rust χωρίς λειτουργικό σύστημα Απόγευμα"
-
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Καλώς ήρθατε στην Comprehensive Rust 🦀"
 
 #: src/welcome.md:3
 msgid ""
@@ -956,8 +966,8 @@ msgstr "Ροή εργασίας κατασκευής"
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml) [![GitHub "
+"contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 msgstr ""
@@ -970,10 +980,9 @@ msgstr "Συνεργάτες GitHub"
 msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
 #: src/welcome.md:5
@@ -990,39 +999,37 @@ msgstr ""
 #: src/welcome.md:7
 msgid ""
 "This is a four day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 "Αυτό είναι ένα τετραήμερο μάθημα Rust που αναπτύχθηκε από την ομάδα Android. "
-"Το μάθημα καλύπτει\n"
-"το πλήρες φάσμα της Rust, από τη βασική σύνταξη έως τα προηγμένα θέματα όπως "
-"οι γενικευμένοι τύποι\n"
-"και διαχείριση σφαλμάτων. Περιλαμβάνει επίσης περιεχόμενο ειδικά για Android "
-"την τελευταία ημέρα."
+"Το μάθημα καλύπτει το πλήρες φάσμα της Rust, από τη βασική σύνταξη έως τα "
+"προηγμένα θέματα όπως οι γενικευμένοι τύποι και διαχείριση σφαλμάτων. "
+"Περιλαμβάνει επίσης περιεχόμενο ειδικά για Android την τελευταία ημέρα."
 
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
 "Ο στόχος του μαθήματος είναι να σας διδάξει τη γλώσσα Rust. Υποθέτουμε ότι "
-"δεν ξέρετε τίποτα\n"
-"σχετικά με τη Rust και ελπίζουμε να:"
+"δεν ξέρετε τίποτα σχετικά με τη Rust και ελπίζουμε να:"
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
 msgstr ""
-"* Σας δώσουμε μια ολοκληρωμένη κατανόηση της σύνταξης και της γλώσσας Rust.\n"
-"* Σας καταστήσουμε ικανούς να τροποποιείτε υπάρχοντα προγράμματα και να "
-"γράφετε νέα προγράμματα με τη Rust.\n"
-"* Σας δείξουμε τους συνήθεις ιδιωματισμούς της Rust."
+"Σας δώσουμε μια ολοκληρωμένη κατανόηση της σύνταξης και της γλώσσας Rust."
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr ""
+"Σας καταστήσουμε ικανούς να τροποποιείτε υπάρχοντα προγράμματα και να "
+"γράφετε νέα προγράμματα με τη Rust."
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
+msgstr "Σας δείξουμε τους συνήθεις ιδιωματισμούς της Rust."
 
 #: src/welcome.md:18
 msgid "On Day 4, we will cover Android-specific things such as:"
@@ -1031,295 +1038,108 @@ msgstr ""
 "όπως:"
 
 #: src/welcome.md:20
-msgid ""
-"* Building Android components in Rust.\n"
-"* AIDL servers and clients.\n"
-"* Interoperability with C, C++, and Java."
-msgstr ""
-"* Δημιουργία Android components με Rust.\n"
-"* Εξυπηρετητές και πελάτες AIDL.\n"
-"* Διαλειτουργικότητα με C, C++ και Java."
+msgid "Building Android components in Rust."
+msgstr "Δημιουργία Android components με Rust."
+
+#: src/welcome.md:21
+msgid "AIDL servers and clients."
+msgstr "Εξυπηρετητές και πελάτες AIDL."
+
+#: src/welcome.md:22
+msgid "Interoperability with C, C++, and Java."
+msgstr "Διαλειτουργικότητα με C, C++ και Java."
 
 #: src/welcome.md:24
 msgid ""
 "It is important to note that this course does not cover Android "
-"**application** \n"
-"development in Rust, and that the Android-specific parts are specifically "
-"about\n"
-"writing code for Android itself, the operating system. "
+"**application**  development in Rust, and that the Android-specific parts "
+"are specifically about writing code for Android itself, the operating "
+"system. "
 msgstr ""
 "Είναι σημαντικό να σημειωθεί ότι αυτό το μάθημα δεν καλύπτει την "
-"ανάπτυξη**εφαρμογών** Android\n"
-"σε Rust. Το κομμάτι του μαθήματος που αφορά τοAndroid\n"
-"έχει να κάνει με ανάπτυξη κώδικα για το ίδιο το Android, ως λειτουργικό "
-"σύστημα."
+"ανάπτυξη**εφαρμογών** Android σε Rust. Το κομμάτι του μαθήματος που αφορά "
+"τοAndroid έχει να κάνει με ανάπτυξη κώδικα για το ίδιο το Android, ως "
+"λειτουργικό σύστημα."
 
 #: src/welcome.md:28
-msgid "## Non-Goals"
-msgstr "## Μη-Στόχοι"
+msgid "Non-Goals"
+msgstr "Μη-Στόχοι"
 
 #: src/welcome.md:30
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 "Η Rust είναι μια μεγάλη γλώσσα και δεν θα μπορούμε να την καλύψουμε όλη σε "
-"λίγες μέρες.\n"
-"Μερικοί μη-στόχοι αυτού του μαθήματος είναι:"
+"λίγες μέρες. Μερικοί μη-στόχοι αυτού του μαθήματος είναι:"
 
 #: src/welcome.md:33
 msgid ""
-"* Learn how to use async Rust --- we'll only mention async Rust when\n"
-"  covering traditional concurrency primitives. Please see [Asynchronous\n"
-"  Programming in Rust](https://rust-lang.github.io/async-book/) instead for\n"
-"  details on this topic.\n"
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to use async Rust --- we'll only mention async Rust when covering "
+"traditional concurrency primitives. Please see [Asynchronous Programming in "
+"Rust](https://rust-lang.github.io/async-book/) instead for details on this "
+"topic."
 msgstr ""
-"* Χρήση async Rust --- θα αναφέρουμε στην async Rust μόνο όταν\n"
-"  καλύψουμε τα παραδοσιακά δομικά στοιχεία συγχρονισμού. Δείτε και "
-"[Ασύγχρονος\n"
-"  Προγραμματισμός σε Rust](https://rust-lang.github.io/async-book/) για\n"
-"  λεπτομέρειες για αυτό το θέμα.\n"
-"* Ανάπτυξη μακροεντολών, ανατρέξτε στο [Κεφάλαιο 19.5 στο Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) και [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) αντ' αυτού."
+"Χρήση async Rust --- θα αναφέρουμε στην async Rust μόνο όταν καλύψουμε τα "
+"παραδοσιακά δομικά στοιχεία συγχρονισμού. Δείτε και [Ασύγχρονος "
+"Προγραμματισμός σε Rust](https://rust-lang.github.io/async-book/) για "
+"λεπτομέρειες για αυτό το θέμα."
+
+#: src/welcome.md:37
+msgid ""
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+msgstr ""
+"Ανάπτυξη μακροεντολών, ανατρέξτε στο [Κεφάλαιο 19.5 στο Rust Book](https://"
+"doc.rust-lang.org/book/ch19-06-macros.html) και [Rust by Example](https://"
+"doc.rust-lang.org/rust-by-example/macros.html) αντ' αυτού."
 
 #: src/welcome.md:41
-msgid "## Assumptions"
-msgstr "## Υποθέσεις"
+msgid "Assumptions"
+msgstr "Υποθέσεις"
 
 #: src/welcome.md:43
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
 "Το μάθημα προϋποθέτει ότι γνωρίζετε ήδη πώς να προγραμματίζετε. Η Rust είναι "
-"γλώσσα με στατικό\n"
-"σύτημα τύπων και μερικές φορές θα κάνουμε συγκρίσεις με C και C++ για "
-"καλύτερη\n"
-"κατανόηση της προσέγγισης της Rust."
+"γλώσσα με στατικό σύτημα τύπων και μερικές φορές θα κάνουμε συγκρίσεις με C "
+"και C++ για καλύτερη κατανόηση της προσέγγισης της Rust."
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 "Εάν γνωρίζετε πώς να προγραμματίζετε σε μια γλώσσα με δυναμικό σύστημα τύπων "
-"όπως Python ή\n"
-"JavaScript, τότε θα μπορέσετε να ακολουθήσετε άνεση."
-
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/compound-types.md:28
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/functions-interlude.md:25 src/exercises/day-1/morning.md:9
-#: src/exercises/day-1/for-loops.md:90 src/basic-syntax/variables.md:15
-#: src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:102
-#: src/structs/tuple-structs.md:35 src/structs/field-shorthand.md:25
-#: src/enums.md:31 src/enums/variant-payloads.md:33 src/enums/sizes.md:27
-#: src/methods.md:28 src/methods/receiver.md:23 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:29
-#: src/control-flow/if-let-expressions.md:19
-#: src/control-flow/while-let-expressions.md:25
-#: src/control-flow/for-expressions.md:22
-#: src/control-flow/loop-expressions.md:23
-#: src/control-flow/match-expressions.md:25 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:38 src/exercises/day-2/afternoon.md:5
-#: src/traits.md:41 src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/operators.md:24 src/traits/drop.md:32
-#: src/traits/default.md:38 src/generics/methods.md:23
-#: src/generics/trait-bounds.md:33 src/generics/impl-trait.md:21
-#: src/generics/closures.md:23 src/generics/trait-objects.md:88
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:48
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:24 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:5 src/welcome-day-4.md:6
-#: src/concurrency/threads.md:28 src/concurrency/scoped-threads.md:35
-#: src/concurrency/channels.md:25 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21 src/concurrency/send-sync.md:18
-#: src/concurrency/send-sync/sync.md:12 src/exercises/day-4/morning.md:10
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/day-4/android.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:36 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart/traits.md:22 src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:47 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:43
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5
-msgid "<details>"
-msgstr ""
+"όπως Python ή JavaScript, τότε θα μπορέσετε να ακολουθήσετε άνεση."
 
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 "Αυτό είναι ένα παράδειγμα _σημειώσεων ομιλητή_. Θα τις χρησιμοποιήσουμε για "
-"να προσθέτουμε επιπλέον\n"
-"πληροφορίες στις διαφάνειες. Αυτές θα μπορούσαν να είναι βασικά σημεία που "
-"θα πρέπει να καλύψει ο εκπαιδευτής \n"
-"καθώς και απαντήσεις σε συχνές ερωτήσεις που προκύπτουν στην τάξη."
-
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
-#: src/why-rust/modern.md:66 src/basic-syntax/compound-types.md:62
-#: src/basic-syntax/references.md:28 src/basic-syntax/slices.md:36
-#: src/basic-syntax/string-slices.md:44 src/basic-syntax/functions.md:54
-#: src/basic-syntax/rustdoc.md:33 src/exercises/day-1/morning.md:28
-#: src/exercises/day-1/for-loops.md:95 src/basic-syntax/variables.md:20
-#: src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:106
-#: src/structs.md:41 src/structs/tuple-structs.md:43
-#: src/structs/field-shorthand.md:72 src/enums.md:41
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:29 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:25
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:46
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:26
-#: src/control-flow/while-let-expressions.md:30
-#: src/control-flow/for-expressions.md:29
-#: src/control-flow/loop-expressions.md:27
-#: src/control-flow/match-expressions.md:32 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:40 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:67 src/exercises/day-2/afternoon.md:11
-#: src/traits.md:47 src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/operators.md:38 src/traits/drop.md:42
-#: src/traits/default.md:47 src/generics/methods.md:31
-#: src/generics/trait-bounds.md:50 src/generics/impl-trait.md:44
-#: src/generics/closures.md:38 src/generics/trait-objects.md:102
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:55
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:42 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:11 src/welcome-day-4.md:11
-#: src/concurrency/threads.md:45 src/concurrency/scoped-threads.md:40
-#: src/concurrency/channels.md:32 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56 src/concurrency/send-sync.md:23
-#: src/concurrency/send-sync/sync.md:18 src/exercises/day-4/morning.md:16
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/day-4/android.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:47
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/inline-assembly.md:51 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:51 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:48
-#: src/bare-metal/useful-crates/zerocopy.md:51
-#: src/bare-metal/useful-crates/aarch64-paging.md:32
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:28
-#: src/bare-metal/useful-crates/tinyvec.md:25
-#: src/bare-metal/useful-crates/spin.md:29 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11
-msgid "</details>"
-msgstr ""
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# Διεξαγωγή του μαθήματος"
+"να προσθέτουμε επιπλέον πληροφορίες στις διαφάνειες. Αυτές θα μπορούσαν να "
+"είναι βασικά σημεία που θα πρέπει να καλύψει ο εκπαιδευτής  καθώς και "
+"απαντήσεις σε συχνές ερωτήσεις που προκύπτουν στην τάξη."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
 #: src/running-the-course/day-4.md:3
-msgid "> This page is for the course instructor."
-msgstr "> Αυτή η σελίδα είναι για τον εκπαιδευτή του μαθήματος."
+msgid "This page is for the course instructor."
+msgstr "Αυτή η σελίδα είναι για τον εκπαιδευτή του μαθήματος."
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
+"course internally at Google."
 msgstr ""
 "Ακολουθούν ορισμένες βασικές πληροφορίες σχετικά με τον τρόπο λειτουργίας "
-"του μαθήματος\n"
-"εσωτερικά στην Google."
+"του μαθήματος εσωτερικά στην Google."
 
 #: src/running-the-course.md:8
 msgid "Before you run the course, you will want to:"
@@ -1327,325 +1147,319 @@ msgstr "Για να διεξάξετε το μάθημα, πρέπει:"
 
 #: src/running-the-course.md:10
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   to help highlight the key points (please help us by contributing more "
-"speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes "
-"in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). "
-"This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Select your topic for the afternoon of the fourth day. This may be based "
-"on\n"
-"   the audience you expect, or on your own expertise.\n"
-"\n"
-"1. Decide on the dates. Since the course is large, we recommend that you\n"
-"   schedule the four days over two weeks. Course participants have said "
-"that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-20 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself "
-"and for the\n"
-"   students: you will all need to be able to sit and work with your "
-"laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, "
-"so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups. Make "
-"sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library.\n"
-"\n"
-"1. Prepare anything you need to have available for the afternoon of day 4."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-" 1. Εξοικειωθείτε με το υλικό του μαθήματος. Έχουμε συμπεριλάβει σημειώσεις "
+"Εξοικειωθείτε με το υλικό του μαθήματος. Έχουμε συμπεριλάβει σημειώσεις "
 "ομιλητών για να τονίσουμε τα βασικά σημεία (παρακαλούμε βοηθήστε μας "
 "συνεισφέροντας περισσότερες σημειώσεις ομιλητή!). Κατά την παρουσίαση, θα "
 "πρέπει να βεβαιωθείτε ότι ανοίγετε τις σημειώσεις του ομιλητή σε ένα "
-"αναδυόμενο παράθυρο (κάντε κλικ στο σύνδεσμο με ένα μικρό βέλος δίπλα "
-"στο \"Speaker Notes\"). Με αυτόν τον τρόπο έχετε μια καθαρή οθόνη για να "
-"παρουσιάσετε στην τάξη.\n"
-"\n"
-" 1. Επιλέξτε το θέμα σας για το απόγευμα της τέταρτης ημέρας. Αυτό "
-"μπορεί να βασίζεται στο κοινό που περιμένετε ή στη δική σας εμπειρία.\n"
-"\n"
-" 1. Αποφασίστε για τις ημερομηνίες. Επειδή το μάθημα είναι μεγάλο, σας "
+"αναδυόμενο παράθυρο (κάντε κλικ στο σύνδεσμο με ένα μικρό βέλος δίπλα στο "
+"\"Speaker Notes\"). Με αυτόν τον τρόπο έχετε μια καθαρή οθόνη για να "
+"παρουσιάσετε στην τάξη."
+
+#: src/running-the-course.md:16
+msgid ""
+"Select your topic for the afternoon of the fourth day. This may be based on "
+"the audience you expect, or on your own expertise."
+msgstr ""
+"Επιλέξτε το θέμα σας για το απόγευμα της τέταρτης ημέρας. Αυτό μπορεί να "
+"βασίζεται στο κοινό που περιμένετε ή στη δική σας εμπειρία."
+
+#: src/running-the-course.md:19
+msgid ""
+"Decide on the dates. Since the course is large, we recommend that you "
+"schedule the four days over two weeks. Course participants have said that "
+"they find it helpful to have a gap in the course since it helps them process "
+"all the information we give them."
+msgstr ""
+"Αποφασίστε για τις ημερομηνίες. Επειδή το μάθημα είναι μεγάλο, σας "
 "συνιστούμε να προγραμματίσετε τις τέσσερις ημέρες σε δύο εβδομάδες. Οι "
-"προηγούμενοι συμμετέχοντες στο μάθημα θεωρούν χρήσιμο να υπάρχει ένα κενό στο "
-"μάθημα, καθώς τους βοηθά να επεξεργάζονται όλες τις πληροφορίες που τους "
-"δίνουμε.\n"
-"\n"
-" 1. Βρείτε ένα δωμάτιο αρκετά μεγάλο για όλους τους "
-"συμμετέχοντες. Προτείνουμε μέγεθος τάξης 15-20 ατόμων. Είναι αρκετά μικρό "
-"ώστε οι άνθρωποι να αισθάνονται άνετα να κάνουν ερωτήσεις - είναι επίσης "
-"αρκετά μικρό ώστε ένας εκπαιδευτής να έχει χρόνο να απαντήσει. "
-"Βεβαιωθείτε ότι το δωμάτιο έχει θρανία για εσάς και τους μαθητές: "
-"όλοι θα πρέπει να μπορείτε να καθίσετε και να εργάζεστε με τους φορητούς "
-"υπολογιστές σας. Συγκεκριμένα, θα γράψετε πολύ κώδικα ζωντανά ως "
-"εκπαιδευτής, επομένως ένα αναλόγιο δεν θα σας βοηθήσει πολύ.\n"
-"\n"
-" 1. Την ημέρα του μαθήματος, εμφανιστείτε στην αίθουσα νωρίς για "
-"να ρυθμίσετε τα πράγματα. Συνιστούμε την απευθείας παρουσίαση "
-"χρησιμοποιώντας την υπηρεσία mdbook που εκτελείται στον φορητό υπολογιστή "
-"σας (δείτε τις οδηγίες εγκατάστασης). Αυτό εξασφαλίζει βέλτιστη απόδοση "
-"χωρίς καθυστέρηση καθώς αλλάζετε σελίδες. Η χρήση του φορητού υπολογιστή "
-"σας θα σας επιτρέψει επίσης να διορθώσετε τυπογραφικά λάθη καθώς τα "
-"εντοπίζετε εσείς ή οι συμμετέχοντες στο μάθημα.\n"
-"\n"
-" 1. Αφήστε τους μαθητές να λύσουν τις ασκήσεις μόνοι τους ή σε μικρές "
-"ομάδες. Βεβαιωθείτε ότι τους ρωτάτε εάν έχουν κολλήσει ή εάν "
-"υπάρχει κάτι με το οποίο μπορείτε να βοηθήσετε. Όταν δείτε ότι πολλά άτομα "
-"έχουν το ίδιο πρόβλημα, αναφέρετέ το στην τάξη και προσφέρετε μια λύση, π.χ., "
-"δείχνοντας στους μαθητές πού να βρουν τις σχετικές πληροφορίες στην τυπική "
-"βιβλιοθήκη.\n"
-"\n"
-" 1. Ετοιμάστε οτιδήποτε χρειάζεστε για το απόγευμα της 4ης ημέρας."
+"προηγούμενοι συμμετέχοντες στο μάθημα θεωρούν χρήσιμο να υπάρχει ένα κενό "
+"στο μάθημα, καθώς τους βοηθά να επεξεργάζονται όλες τις πληροφορίες που τους "
+"δίνουμε."
+
+#: src/running-the-course.md:24
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-20 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"Βρείτε ένα δωμάτιο αρκετά μεγάλο για όλους τους συμμετέχοντες. Προτείνουμε "
+"μέγεθος τάξης 15-20 ατόμων. Είναι αρκετά μικρό ώστε οι άνθρωποι να "
+"αισθάνονται άνετα να κάνουν ερωτήσεις - είναι επίσης αρκετά μικρό ώστε ένας "
+"εκπαιδευτής να έχει χρόνο να απαντήσει. Βεβαιωθείτε ότι το δωμάτιο έχει "
+"θρανία για εσάς και τους μαθητές: όλοι θα πρέπει να μπορείτε να καθίσετε και "
+"να εργάζεστε με τους φορητούς υπολογιστές σας. Συγκεκριμένα, θα γράψετε πολύ "
+"κώδικα ζωντανά ως εκπαιδευτής, επομένως ένα αναλόγιο δεν θα σας βοηθήσει "
+"πολύ."
+
+#: src/running-the-course.md:32
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"Την ημέρα του μαθήματος, εμφανιστείτε στην αίθουσα νωρίς για να ρυθμίσετε τα "
+"πράγματα. Συνιστούμε την απευθείας παρουσίαση χρησιμοποιώντας την υπηρεσία "
+"mdbook που εκτελείται στον φορητό υπολογιστή σας (δείτε τις οδηγίες "
+"εγκατάστασης). Αυτό εξασφαλίζει βέλτιστη απόδοση χωρίς καθυστέρηση καθώς "
+"αλλάζετε σελίδες. Η χρήση του φορητού υπολογιστή σας θα σας επιτρέψει επίσης "
+"να διορθώσετε τυπογραφικά λάθη καθώς τα εντοπίζετε εσείς ή οι συμμετέχοντες "
+"στο μάθημα."
+
+#: src/running-the-course.md:38
+msgid ""
+"Let people solve the exercises by themselves or in small groups. Make sure "
+"to ask people if they're stuck or if there is anything you can help with. "
+"When you see that several people have the same problem, call it out to the "
+"class and offer a solution, e.g., by showing people where to find the "
+"relevant information in the standard library."
+msgstr ""
+"Αφήστε τους μαθητές να λύσουν τις ασκήσεις μόνοι τους ή σε μικρές ομάδες. "
+"Βεβαιωθείτε ότι τους ρωτάτε εάν έχουν κολλήσει ή εάν υπάρχει κάτι με το "
+"οποίο μπορείτε να βοηθήσετε. Όταν δείτε ότι πολλά άτομα έχουν το ίδιο "
+"πρόβλημα, αναφέρετέ το στην τάξη και προσφέρετε μια λύση, π.χ., δείχνοντας "
+"στους μαθητές πού να βρουν τις σχετικές πληροφορίες στην τυπική βιβλιοθήκη."
+
+#: src/running-the-course.md:44
+msgid "Prepare anything you need to have available for the afternoon of day 4."
+msgstr "Ετοιμάστε οτιδήποτε χρειάζεστε για το απόγευμα της 4ης ημέρας."
 
 #: src/running-the-course.md:46
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
+"for you as it has been for us!"
 msgstr ""
 "Αυτό ήταν! Καλή επιτυχία στη διεξαγωγή του μαθήματος! Ελπίζουμε ότι θα είναι "
 "τόσο διασκεδαστικό για εσάς όπως ήταν και για εμάς!"
 
 #: src/running-the-course.md:49
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"Παρακαλούμε [παρέχετε σχόλια][1] μετά το μάθημα, ώστε να συνεχίσουμε να "
-"βελτιώνουμε το υλικό. Θα θέλαμε να ακούσουμε τι πήγε καλά για εσάς και τι "
-"μπορεί να γίνει\n"
+"Παρακαλούμε [παρέχετε σχόλια](https://github.com/google/comprehensive-rust/"
+"discussions/86) μετά το μάθημα, ώστε να συνεχίσουμε να βελτιώνουμε το υλικό. "
+"Θα θέλαμε να ακούσουμε τι πήγε καλά για εσάς και τι μπορεί να γίνει "
 "καλύτερα. Οι μαθητές σας είναι επίσης πολύ ευπρόσδεκτοι να [μας στείλουν "
-"σχόλια][2]!"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# Δομή μαθήματος"
+"σχόλια](https://github.com/google/comprehensive-rust/discussions/100)!"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "Το μάθημα έχει γρήγορο ρυθμό και καλύπτει:"
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust.\n"
-"* Day 4: Concurrency in Rust and seeing Rust in action."
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
+msgstr "Ημέρα 1: Βασική Rust, ιδιοκτησία και ο έλεγχος δανείων."
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
 msgstr ""
-"* Ημέρα 1: Βασική Rust, ιδιοκτησία και ο έλεγχος δανείων.\n"
-"* Ημέρα 2: Σύνθετοι τύποι δεδομένων, ταίριασμα προτύπων, τυπική βιβλιοθήκη.\n"
-"* Ημέρα 3: Χαρακτηριστικά και γενικοί τύποι, χειρισμός σφαλμάτων, τεστ, μη "
-"ασφαλής Rust.\n"
-"* Ημέρα 4: Συγχρονισμός στη Rust. Rust στην πράξη."
+"Ημέρα 2: Σύνθετοι τύποι δεδομένων, ταίριασμα προτύπων, τυπική βιβλιοθήκη."
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr ""
+"Ημέρα 3: Χαρακτηριστικά και γενικοί τύποι, χειρισμός σφαλμάτων, τεστ, μη "
+"ασφαλής Rust."
+
+#: src/running-the-course/course-structure.md:10
+msgid "Day 4: Concurrency in Rust and seeing Rust in action."
+msgstr "Ημέρα 4: Συγχρονισμός στη Rust. Rust στην πράξη."
 
 #: src/running-the-course/course-structure.md:12
-msgid "## Format"
-msgstr "## Μορφή"
+msgid "Format"
+msgstr "Μορφή"
 
 #: src/running-the-course/course-structure.md:14
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
 "Το μάθημα σχεδιάστηκε να είναι διαδραστικό και συνιστούμε να αφήσετε τις "
 "ερωτήσεις να οδηγήσουν την κουβέντα γύρω από τη Rust!"
 
 #: src/running-the-course/day-4.md:1
-msgid "# Day 4"
+msgid "Day 4"
 msgstr "Ημέρα 4η"
 
 #: src/running-the-course/day-4.md:5
 msgid ""
-"The afternoon of the fourth day should cover a topic of your choice. "
-"Include\n"
+"The afternoon of the fourth day should cover a topic of your choice. Include "
 "the topic in the announcement of the course, so that participants know what "
-"to\n"
-"expect."
+"to expect."
 msgstr ""
-"Το απόγευμα της τέταρτης ημέρας μπορεί να καλύψει ένα θέμα της"
-"αρεσκείας σας.\n"
-"Σημειώστε το θέμα που επιλέξατε στην ανακοίνωση του μαθήματος ώστε οι"
-"συμμετέχοντες να ξέρουν τι να περιμένουν."
+"Το απόγευμα της τέταρτης ημέρας μπορεί να καλύψει ένα θέμα τηςαρεσκείας σας. "
+"Σημειώστε το θέμα που επιλέξατε στην ανακοίνωση του μαθήματος ώστε "
+"οισυμμετέχοντες να ξέρουν τι να περιμένουν."
 
 #: src/running-the-course/day-4.md:9
 msgid ""
 "This phase of the course is a chance for participants to see Rust in action "
-"on a\n"
-"codebase they might be familiar with. You can choose from the topics "
-"already\n"
-"defined here, or plan your own."
+"on a codebase they might be familiar with. You can choose from the topics "
+"already defined here, or plan your own."
 msgstr ""
-"Αυτή η φάση του μαθήματος είναι μια ευκαιρία για τους συμμετέχοντες "
-"να δουν τη Rust στην πράξη, σε ένα πρότζεκτ με το οποίο μπορεί να είναι ήδη "
-"εξοικειωμένοι. Μπορείτε να διαλέξετε θέματα που έχουμε ήδη προετοιμάσει, "
-"ή κάτι δικό σας."
-
+"Αυτή η φάση του μαθήματος είναι μια ευκαιρία για τους συμμετέχοντες να δουν "
+"τη Rust στην πράξη, σε ένα πρότζεκτ με το οποίο μπορεί να είναι ήδη "
+"εξοικειωμένοι. Μπορείτε να διαλέξετε θέματα που έχουμε ήδη προετοιμάσει, ή "
+"κάτι δικό σας."
 
 #: src/running-the-course/day-4.md:13
 msgid "Some topics need additional preparation:"
 msgstr "Κάποια θέματα απαιτούν επιπλέον προετοιμασία."
 
-#: src/running-the-course/day-4.md:15
-msgid "## Android"
-msgstr "## Android"
-
 #: src/running-the-course/day-4.md:17
 msgid ""
-"If you chose Android for Day 4 afternoon, you will need an [AOSP checkout]"
-"[1].\n"
-"Make a checkout of the [course repository][2] on the same machine and move "
-"the\n"
-"`src/android/` directory into the root of your AOSP checkout. This will "
-"ensure\n"
-"that the Android build system sees the `Android.bp` files in `src/android/`."
+"If you chose Android for Day 4 afternoon, you will need an \\[AOSP "
+"checkout\\]\\[1\\]. Make a checkout of the \\[course repository\\]\\[2\\] on "
+"the same machine and move the `src/android/` directory into the root of your "
+"AOSP checkout. This will ensure that the Android build system sees the "
+"`Android.bp` files in `src/android/`."
 msgstr ""
-"Εάν δεν επιλέξετε τo κομμάτι του Android την 4η Ημέρα, θα χρειαστείτε "
-"ένα [AOSP\n"
-"   checkout][1]. Δημιουργήστε ένα checkout από το [αποθετήριο του μαθήματος]"
-"[2] στον ίδιο\n"
-"   υπολογιστή και μετακινήστε τον κατάλογο `src/android/` στη ρίζα του AOSP "
-"checkout σας.\n"
-"   Αυτό θα διασφαλίσει ότι το build system του Android βλέπει τα\n"
-"   Αρχεία `Android.bp` κάτω από τον φάκελο `src/android/`."
+"Εάν δεν επιλέξετε τo κομμάτι του Android την 4η Ημέρα, θα χρειαστείτε ένα "
+"\\[AOSP checkout\\]\\[1\\]. Δημιουργήστε ένα checkout από το \\[αποθετήριο "
+"του μαθήματος\\]\\[2\\] στον ίδιο υπολογιστή και μετακινήστε τον κατάλογο "
+"`src/android/` στη ρίζα του AOSP checkout σας. Αυτό θα διασφαλίσει ότι το "
+"build system του Android βλέπει τα Αρχεία `Android.bp` κάτω από τον φάκελο "
+"`src/android/`."
 
 #: src/running-the-course/day-4.md:22
 msgid ""
-"Ensure that `adb sync` works with your emulator or real device and pre-"
-"build\n"
+"Ensure that `adb sync` works with your emulator or real device and pre-build "
 "all Android examples using `src/android/build_all.sh`. Read the script to "
-"see\n"
-"the commands it runs and make sure they work when you run them by hand."
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
-"   Βεβαιωθείτε ότι το \"adb sync\" λειτουργεί με τον εξομοιωτή ή την συσκευή "
+"Βεβαιωθείτε ότι το \"adb sync\" λειτουργεί με τον εξομοιωτή ή την συσκευή "
 "σας και χτίστε όλα τα παραδείγματα του Android χρησιμοποιώντας το `src/"
-"android/build_all.sh`. Διαβάστε το script για να δείτε\n"
-"   τις εντολές που εκτελεί και βεβαιωθείτε ότι λειτουργούν όταν τις "
-"εκτελείτε με το χέρι."
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# Συντομεύσεις πληκτρολογίου"
+"android/build_all.sh`. Διαβάστε το script για να δείτε τις εντολές που "
+"εκτελεί και βεβαιωθείτε ότι λειτουργούν όταν τις εκτελείτε με το χέρι."
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Υπάρχουν πολλές χρήσιμες συντομεύσεις πληκτρολογίου στο mdBook:"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Βέλος-Αριστερά</kbd>: Μεταβείτε στην προηγούμενη σελίδα.\n"
-"* <kbd>Βέλος-Δεξιά</kbd>: Μεταβείτε στην επόμενη σελίδα.\n"
-"* <kbd>Ctrl + Enter</kbd>: Εκτελέστε το δείγμα κώδικα υπό εστίαση.\n"
-"* <kbd>s</kbd>: Ενεργοποιήστε τη γραμμή αναζήτησης."
+msgid "Arrow-Left"
+msgstr "Βέλος-Αριστερά"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# Μεταφράσεις"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr ": Μεταβείτε στην προηγούμενη σελίδα."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Βέλος-Δεξιά"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr ": Μεταβείτε στην επόμενη σελίδα."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Ctrl + Enter"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr ": Εκτελέστε το δείγμα κώδικα υπό εστίαση."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr ": Ενεργοποιήστε τη γραμμή αναζήτησης."
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
-msgstr "Το μάθημα έχουμε μεταφραστεί σε άλλες γλώσσες από ένα σύνολο "
-"εκπληκτικών εθελοντών:"
+msgstr ""
+"Το μάθημα έχουμε μεταφραστεί σε άλλες γλώσσες από ένα σύνολο εκπληκτικών "
+"εθελοντών:"
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
+msgstr ""
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
 msgstr ""
 
 #: src/running-the-course/translations.md:9
-msgid "Use the language picker in the top-right corner to switch between languages."
+msgid ""
+"Use the language picker in the top-right corner to switch between languages."
 msgstr ""
-"Χρησιμοποιήστε την επιλογή γλώσσας στην πάνω-δεξιά γωνία για να "
-"αλλάξετε γλώσσα."
+"Χρησιμοποιήστε την επιλογή γλώσσας στην πάνω-δεξιά γωνία για να αλλάξετε "
+"γλώσσα."
 
 #: src/running-the-course/translations.md:11
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
-"Εάν θέλετε να βοηθήσετε στη μεταγλώττιση δείτε τις οδηγίες μας για το πώς"
-"να ξεκινήσετε. Οι μεταφράσεις οργανώνονται στον [issue tracker]."
-
-#: src/cargo.md:1
-#, fuzzy
-msgid "# Using Cargo"
-msgstr "# Χρήση φορτίου"
+"Εάν θέλετε να βοηθήσετε στη μεταγλώττιση δείτε τις οδηγίες μας για το πώςνα "
+"ξεκινήσετε. Οι μεταφράσεις οργανώνονται στον [issue tracker](https://github."
+"com/google/comprehensive-rust/issues/282)."
 
 #: src/cargo.md:3
 #, fuzzy
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
 "Όταν αρχίσετε να διαβάζετε για το Rust, σύντομα θα συναντήσετε το [Cargo]"
-"(https://doc.rust-lang.org/cargo/), το τυπικό εργαλείο\n"
-"χρησιμοποιείται στο οικοσύστημα Rust για τη δημιουργία και εκτέλεση "
-"εφαρμογών Rust. Εδώ θέλουμε\n"
+"(https://doc.rust-lang.org/cargo/), το τυπικό εργαλείο χρησιμοποιείται στο "
+"οικοσύστημα Rust για τη δημιουργία και εκτέλεση εφαρμογών Rust. Εδώ θέλουμε "
 "δώστε μια σύντομη επισκόπηση του τι είναι το Cargo και πώς ταιριάζει στο "
-"ευρύτερο οικοσύστημα\n"
-"και πώς ταιριάζει σε αυτή την εκπαίδευση."
+"ευρύτερο οικοσύστημα και πώς ταιριάζει σε αυτή την εκπαίδευση."
 
 #: src/cargo.md:8
 #, fuzzy
-msgid "## Installation"
-msgstr "## Εγκατάσταση"
+msgid "Installation"
+msgstr "Εγκατάσταση"
 
 #: src/cargo.md:10
 #, fuzzy
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (Συνιστάται)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (Συνιστάται)"
 
 #: src/cargo.md:12
 #, fuzzy
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
 "Μπορείτε να ακολουθήσετε τις οδηγίες για την εγκατάσταση του μεταγλωττιστή "
 "φορτίου και σκουριάς, μεταξύ άλλων τυπικών εργαλείων οικοσυστήματος με το "
-"εργαλείο [rustup][3], το οποίο διατηρείται από το Rust Foundation."
+"εργαλείο [rustup](https://rust-analyzer.github.io/), το οποίο διατηρείται "
+"από το Rust Foundation."
 
 #: src/cargo.md:14
 #, fuzzy
@@ -1661,19 +1475,19 @@ msgstr ""
 
 #: src/cargo.md:16
 #, fuzzy
-msgid "### Package Managers"
-msgstr "### Διαχειριστές πακέτων"
+msgid "Package Managers"
+msgstr "Διαχειριστές πακέτων"
 
 #: src/cargo.md:18
 #, fuzzy
-msgid "#### Debian"
-msgstr "#### Debian"
+msgid "Debian"
+msgstr "Debian"
 
 #: src/cargo.md:20
 #, fuzzy
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
 "Στο Debian/Ubuntu, μπορείτε να εγκαταστήσετε το Cargo και την πηγή Rust με"
 
@@ -1687,33 +1501,35 @@ msgstr ""
 #: src/cargo.md:26
 #, fuzzy
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"Αυτό θα επιτρέψει στον [rust-analyzer][1] να μεταβεί στους ορισμούς. "
-"Προτείνουμε τη χρήση\n"
-"[VS Code][2] για να επεξεργαστείτε τον κώδικα (αλλά κάθε πρόγραμμα "
-"επεξεργασίας συμβατό με LSP λειτουργεί)."
+"Αυτό θα επιτρέψει στον \\[rust-analyzer\\]\\[1\\] να μεταβεί στους ορισμούς. "
+"Προτείνουμε τη χρήση [VS Code](https://code.visualstudio.com/) για να "
+"επεξεργαστείτε τον κώδικα (αλλά κάθε πρόγραμμα επεξεργασίας συμβατό με LSP "
+"λειτουργεί)."
 
 #: src/cargo.md:29
 #, fuzzy
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
 "Σε μερικούς ανθρώπους αρέσει επίσης να χρησιμοποιούν την οικογένεια IDE "
-"[JetBrains][4], που κάνουν τη δική τους ανάλυση αλλά έχουν τις δικές τους "
-"ανταλλαγές. Εάν τα προτιμάτε, μπορείτε να εγκαταστήσετε το [Rust Plugin][5]. "
-"Λάβετε υπόψη ότι από τον Ιανουάριο του 2023 ο εντοπισμός σφαλμάτων "
-"λειτουργεί μόνο στην έκδοση CLion της σουίτας JetBrains IDEA."
+"[JetBrains](https://www.jetbrains.com/clion/), που κάνουν τη δική τους "
+"ανάλυση αλλά έχουν τις δικές τους ανταλλαγές. Εάν τα προτιμάτε, μπορείτε να "
+"εγκαταστήσετε το [Rust Plugin](https://www.jetbrains.com/rust/). Λάβετε "
+"υπόψη ότι από τον Ιανουάριο του 2023 ο εντοπισμός σφαλμάτων λειτουργεί μόνο "
+"στην έκδοση CLion της σουίτας JetBrains IDEA."
 
 #: src/cargo/rust-ecosystem.md:1
 #, fuzzy
-msgid "# The Rust Ecosystem"
-msgstr "# Το οικοσύστημα της σκουριάς"
+msgid "The Rust Ecosystem"
+msgstr "Το οικοσύστημα της σκουριάς"
 
 #: src/cargo/rust-ecosystem.md:3
 #, fuzzy
@@ -1726,33 +1542,33 @@ msgstr ""
 #: src/cargo/rust-ecosystem.md:5
 #, fuzzy
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* «rustup»: το πρόγραμμα εγκατάστασης και ενημέρωσης της αλυσίδας εργαλείων "
-"Rust. Αυτό το εργαλείο χρησιμοποιείται για να\n"
-"  εγκαταστήστε και ενημερώστε τα «rustc» και «cargo» όταν κυκλοφορήσουν νέες "
-"εκδόσεις του Rust.\n"
-"  Επιπλέον, το \"rustup\" μπορεί επίσης να κατεβάσει τεκμηρίωση για το "
-"πρότυπο\n"
-"  βιβλιοθήκη. Μπορείτε να εγκαταστήσετε πολλές εκδόσεις του Rust ταυτόχρονα "
-"και το \"rustup\".\n"
-"  θα σας επιτρέψει να κάνετε εναλλαγή μεταξύ τους ανάλογα με τις ανάγκες."
+"«rustup»: το πρόγραμμα εγκατάστασης και ενημέρωσης της αλυσίδας εργαλείων "
+"Rust. Αυτό το εργαλείο χρησιμοποιείται για να εγκαταστήστε και ενημερώστε τα "
+"«rustc» και «cargo» όταν κυκλοφορήσουν νέες εκδόσεις του Rust. Επιπλέον, το "
+"\"rustup\" μπορεί επίσης να κατεβάσει τεκμηρίωση για το πρότυπο βιβλιοθήκη. "
+"Μπορείτε να εγκαταστήσετε πολλές εκδόσεις του Rust ταυτόχρονα και το "
+"\"rustup\". θα σας επιτρέψει να κάνετε εναλλαγή μεταξύ τους ανάλογα με τις "
+"ανάγκες."
+
+#: src/cargo/rust-ecosystem.md:8
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1767,77 +1583,122 @@ msgstr "Βασικά σημεία:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
 msgstr ""
 
 #: src/cargo/code-samples.md:1
 #, fuzzy
-msgid "# Code Samples in This Training"
-msgstr "# Δείγματα κώδικα σε αυτήν την εκπαίδευση"
+msgid "Code Samples in This Training"
+msgstr "Δείγματα κώδικα σε αυτήν την εκπαίδευση"
 
 #: src/cargo/code-samples.md:3
 #, fuzzy
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
 "Για αυτήν την εκπαίδευση, θα εξερευνήσουμε κυρίως τη γλώσσα Rust μέσω "
-"παραδειγμάτων\n"
-"που μπορεί να εκτελεστεί μέσω του προγράμματος περιήγησής σας. Αυτό κάνει τη "
-"ρύθμιση πολύ πιο εύκολη και\n"
-"εξασφαλίζει μια συνεπή εμπειρία για όλους."
+"παραδειγμάτων που μπορεί να εκτελεστεί μέσω του προγράμματος περιήγησής σας. "
+"Αυτό κάνει τη ρύθμιση πολύ πιο εύκολη και εξασφαλίζει μια συνεπή εμπειρία "
+"για όλους."
 
 #: src/cargo/code-samples.md:7
 #, fuzzy
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
 "Η εγκατάσταση Cargo εξακολουθεί να ενθαρρύνεται: θα σας διευκολύνει να το "
-"κάνετε\n"
-"γυμνάσια. Την τελευταία μέρα, θα κάνουμε μια μεγαλύτερη άσκηση που σας "
-"δείχνει πώς να το κάνετε\n"
-"εργαστείτε με εξαρτήσεις και για αυτό χρειάζεστε Cargo."
+"κάνετε γυμνάσια. Την τελευταία μέρα, θα κάνουμε μια μεγαλύτερη άσκηση που "
+"σας δείχνει πώς να το κάνετε εργαστείτε με εξαρτήσεις και για αυτό "
+"χρειάζεστε Cargo."
 
 #: src/cargo/code-samples.md:11
 #, fuzzy
@@ -1855,64 +1716,62 @@ msgstr ""
 
 #: src/cargo/code-samples.md:19
 #, fuzzy
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
+msgid "You can use "
+msgstr "Μπορείτε να χρησιμοποιήσετε το "
+
+#: src/cargo/code-samples.md:19
+#, fuzzy
+msgid " to execute the code when focus is in the text box."
 msgstr ""
-"Μπορείτε να χρησιμοποιήσετε το <kbd>Ctrl + Enter</kbd> για να εκτελέσετε τον "
-"κώδικα όταν η εστίαση βρίσκεται στο\n"
-"πλαίσιο κειμένου."
+" για να εκτελέσετε τον κώδικα όταν η εστίαση βρίσκεται στο πλαίσιο κειμένου."
 
 #: src/cargo/code-samples.md:24
 #, fuzzy
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
 "Τα περισσότερα δείγματα κώδικα είναι επεξεργάσιμα όπως φαίνεται παραπάνω. "
-"Μερικά δείγματα κώδικα\n"
-"δεν είναι επεξεργάσιμα για διάφορους λόγους:"
+"Μερικά δείγματα κώδικα δεν είναι επεξεργάσιμα για διάφορους λόγους:"
 
 #: src/cargo/code-samples.md:27
 #, fuzzy
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* Οι ενσωματωμένες παιδικές χαρές χάνουν την κατάστασή τους τη στιγμή που "
-"πλοηγείστε\n"
-"  μακριά από τη σελίδα! Αυτός είναι ο λόγος που πρέπει οι μαθητές\n"
-"  λύστε τις ασκήσεις χρησιμοποιώντας τοπική εγκατάσταση Rust ή μέσω του\n"
-"  Παιδική χαρά."
+"Οι ενσωματωμένες παιδικές χαρές χάνουν την κατάστασή τους τη στιγμή που "
+"πλοηγείστε μακριά από τη σελίδα! Αυτός είναι ο λόγος που πρέπει οι μαθητές "
+"λύστε τις ασκήσεις χρησιμοποιώντας τοπική εγκατάσταση Rust ή μέσω του "
+"Παιδική χαρά."
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
 
 #: src/cargo/running-locally.md:1
 #, fuzzy
-msgid "# Running Code Locally with Cargo"
-msgstr "# Κωδικός λειτουργίας τοπικά με φορτίο"
+msgid "Running Code Locally with Cargo"
+msgstr "Κωδικός λειτουργίας τοπικά με φορτίο"
 
 #: src/cargo/running-locally.md:3
 #, fuzzy
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
 "Εάν θέλετε να πειραματιστείτε με τον κώδικα στο δικό σας σύστημα, τότε θα "
-"χρειαστείτε\n"
-"για να εγκαταστήσετε πρώτα το Rust. Κάντε αυτό ακολουθώντας τις [οδηγίες στο "
-"Rust\n"
-"Βιβλίο][1]. Αυτό θα σας δώσει ένα λειτουργικό «rustc» και «cargo». Την εποχή "
-"του\n"
-"γράφοντας, η τελευταία σταθερή έκδοση Rust έχει αυτούς τους αριθμούς έκδοσης:"
+"χρειαστείτε για να εγκαταστήσετε πρώτα το Rust. Κάντε αυτό ακολουθώντας τις "
+"[οδηγίες στο Rust Βιβλίο](https://doc.rust-lang.org/book/ch01-01-"
+"installation.html). Αυτό θα σας δώσει ένα λειτουργικό «rustc» και «cargo». "
+"Την εποχή του γράφοντας, η τελευταία σταθερή έκδοση Rust έχει αυτούς τους "
+"αριθμούς έκδοσης:"
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -1928,107 +1787,130 @@ msgstr ""
 #, fuzzy
 msgid ""
 "With this is in place, then follow these steps to build a Rust binary from "
-"one\n"
-"of the examples in this training:"
+"one of the examples in this training:"
 msgstr ""
 "Εφόσον υπάρχει αυτό, ακολουθήστε αυτά τα βήματα για να δημιουργήσετε ένα "
-"δυαδικό αρχείο Rust από ένα\n"
-"από τα παραδείγματα αυτής της εκπαίδευσης:"
+"δυαδικό αρχείο Rust από ένα από τα παραδείγματα αυτής της εκπαίδευσης:"
 
 #: src/cargo/running-locally.md:18
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
+msgstr ""
+
+#: src/cargo/running-locally.md:20
 msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in `target/"
-"debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr ""
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr ""
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr ""
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
 msgstr ""
 
 #: src/cargo/running-locally.md:70
 #, fuzzy
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
 "Προσπαθήστε να ενθαρρύνετε τους συμμετέχοντες στην τάξη να εγκαταστήσουν το "
-"Cargo και χρησιμοποιήστε το α\n"
-"τοπικός συντάκτης. Θα τους κάνει τη ζωή πιο εύκολη αφού θα έχουν α\n"
-"κανονικό περιβάλλον ανάπτυξης."
+"Cargo και χρησιμοποιήστε το α τοπικός συντάκτης. Θα τους κάνει τη ζωή πιο "
+"εύκολη αφού θα έχουν α κανονικό περιβάλλον ανάπτυξης."
 
 #: src/welcome-day-1.md:1
 #, fuzzy
-msgid "# Welcome to Day 1"
-msgstr "# Καλώς ήρθατε στην Ημέρα 1"
+msgid "Welcome to Day 1"
+msgstr "Καλώς ήρθατε στην Ημέρα 1"
 
 #: src/welcome-day-1.md:3
 #, fuzzy
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr ""
-"Αυτή είναι η πρώτη μέρα του Comprehensive Rust. Θα καλύψουμε πολύ έδαφος\n"
+"Αυτή είναι η πρώτη μέρα του Comprehensive Rust. Θα καλύψουμε πολύ έδαφος "
 "σήμερα:"
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
+msgstr ""
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
 msgstr ""
 
 #: src/welcome-day-1.md:16
@@ -2039,131 +1921,160 @@ msgstr "Υπενθυμίστε στους μαθητές ότι:"
 #: src/welcome-day-1.md:18
 #, fuzzy
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i."
-"e.,\n"
-"    keep the related to how Rust does things vs some other language. It can "
-"be\n"
-"    hard to find the right balance, but err on the side of allowing "
-"discussions\n"
-"    since they engage people much more than one-way communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
 msgstr ""
-"* Θα πρέπει να κάνουν ερωτήσεις όταν τις πάρουν, μην τις αποθηκεύσετε μέχρι "
-"το τέλος.\n"
-"* Η τάξη προορίζεται να είναι διαδραστική και οι συζητήσεις ενθαρρύνονται "
-"πολύ!\n"
-"  * Ως εκπαιδευτής, θα πρέπει να προσπαθήσετε να διατηρήσετε τις συζητήσεις "
-"σχετικές, π.χ.\n"
-"    κρατήστε τη σχετική με το πώς κάνει τα πράγματα ο Rust σε σχέση με "
-"κάποια άλλη γλώσσα. Μπορεί να είναι\n"
-"    δύσκολο να βρεις τη σωστή ισορροπία, αλλά σφάλλησε να επιτρέψεις "
-"συζητήσεις\n"
-"    αφού εμπλέκουν τους ανθρώπους πολύ περισσότερο από τη μονόδρομη "
-"επικοινωνία.\n"
-"* Οι ερωτήσεις πιθανότατα θα σημαίνουν ότι είμαστε για τα πράγματα πριν από "
-"τις διαφάνειες.\n"
-"  * Αυτό είναι απολύτως εντάξει! Η επανάληψη είναι ένα σημαντικό μέρος της "
-"κλίσης. Θυμάμαι\n"
-"    ότι οι διαφάνειες είναι απλώς μια υποστήριξη και είστε ελεύθεροι να τις "
-"παραλείψετε όπως εσείς\n"
-"    αρέσει."
+"Θα πρέπει να κάνουν ερωτήσεις όταν τις πάρουν, μην τις αποθηκεύσετε μέχρι το "
+"τέλος."
+
+#: src/welcome-day-1.md:19
+#, fuzzy
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr ""
+"Η τάξη προορίζεται να είναι διαδραστική και οι συζητήσεις ενθαρρύνονται πολύ!"
+
+#: src/welcome-day-1.md:20
+#, fuzzy
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the related to how Rust does things vs some other language. It can be "
+"hard to find the right balance, but err on the side of allowing discussions "
+"since they engage people much more than one-way communication."
+msgstr ""
+"Ως εκπαιδευτής, θα πρέπει να προσπαθήσετε να διατηρήσετε τις συζητήσεις "
+"σχετικές, π.χ. κρατήστε τη σχετική με το πώς κάνει τα πράγματα ο Rust σε "
+"σχέση με κάποια άλλη γλώσσα. Μπορεί να είναι δύσκολο να βρεις τη σωστή "
+"ισορροπία, αλλά σφάλλησε να επιτρέψεις συζητήσεις αφού εμπλέκουν τους "
+"ανθρώπους πολύ περισσότερο από τη μονόδρομη επικοινωνία."
+
+#: src/welcome-day-1.md:24
+#, fuzzy
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+"Οι ερωτήσεις πιθανότατα θα σημαίνουν ότι είμαστε για τα πράγματα πριν από "
+"τις διαφάνειες."
+
+#: src/welcome-day-1.md:25
+#, fuzzy
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"Αυτό είναι απολύτως εντάξει! Η επανάληψη είναι ένα σημαντικό μέρος της "
+"κλίσης. Θυμάμαι ότι οι διαφάνειες είναι απλώς μια υποστήριξη και είστε "
+"ελεύθεροι να τις παραλείψετε όπως εσείς αρέσει."
 
 #: src/welcome-day-1.md:29
 #, fuzzy
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
 "Η ιδέα για την πρώτη μέρα είναι να δείξουμε _αρκετά_ Rust για να μπορέσει να "
-"μιλήσει\n"
-"για το περίφημο δάνειο πούλι. Ο τρόπος με τον οποίο η Rust χειρίζεται τη "
-"μνήμη είναι ένα σημαντικό χαρακτηριστικό\n"
-"και αυτό θα πρέπει να το δείξουμε αμέσως στους μαθητές."
+"μιλήσει για το περίφημο δάνειο πούλι. Ο τρόπος με τον οποίο η Rust "
+"χειρίζεται τη μνήμη είναι ένα σημαντικό χαρακτηριστικό και αυτό θα πρέπει να "
+"το δείξουμε αμέσως στους μαθητές."
 
 #: src/welcome-day-1.md:33
 #, fuzzy
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
-"Εάν το διδάσκετε σε μια τάξη, αυτό είναι ένα καλό μέρος για να το δείτε\n"
+"Εάν το διδάσκετε σε μια τάξη, αυτό είναι ένα καλό μέρος για να το δείτε "
 "πρόγραμμα. Προτείνουμε να χωρίσετε την ημέρα σε δύο μέρη (ακολουθώντας τις "
 "διαφάνειες):"
 
 #: src/welcome-day-1.md:36
 #, fuzzy
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* Πρωί: 9:00 έως 12:00,\n"
-"* Απόγευμα: 13:00 έως 16:00."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "Πρωί: 9:00 έως 12:00,"
+
+#: src/welcome-day-1.md:37
+#, fuzzy
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "Απόγευμα: 13:00 έως 16:00."
 
 #: src/welcome-day-1.md:39
 #, fuzzy
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
+"breaks, we recommend a break every hour!"
 msgstr ""
 "Μπορείτε φυσικά να το προσαρμόσετε όπως απαιτείται. Φροντίστε να "
-"συμπεριλάβετε διαλείμματα,\n"
-"προτείνουμε ένα διάλειμμα κάθε ώρα!"
-
-#: src/welcome-day-1/what-is-rust.md:1
-#, fuzzy
-msgid "# What is Rust?"
-msgstr "# Τι είναι το Rust;"
+"συμπεριλάβετε διαλείμματα, προτείνουμε ένα διάλειμμα κάθε ώρα!"
 
 #: src/welcome-day-1/what-is-rust.md:3
 #, fuzzy
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
 "Η Rust είναι μια νέα γλώσσα προγραμματισμού που κυκλοφόρησε το 1.0 το 2015:"
 
 #: src/welcome-day-1/what-is-rust.md:5
 #, fuzzy
-msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+msgid "Rust is a statically compiled language in a similar role as C++"
 msgstr ""
-"* Η Rust είναι μια στατικά μεταγλωττισμένη γλώσσα με παρόμοιο ρόλο με τη C+"
-"+\n"
-"  * Το \"rustc\" χρησιμοποιεί το LLVM ως backend του.\n"
-"* Το Rust υποστηρίζει πολλές [πλατφόρμες και\n"
-"  αρχιτεκτονικές](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Το Rust χρησιμοποιείται για ένα ευρύ φάσμα συσκευών:\n"
-"  * υλικολογισμικό και φορτωτές εκκίνησης,\n"
-"  * έξυπνες οθόνες,\n"
-"  * κινητά τηλέφωνα,\n"
-"  * επιτραπέζιοι υπολογιστές,\n"
-"  * διακομιστές."
+"Η Rust είναι μια στατικά μεταγλωττισμένη γλώσσα με παρόμοιο ρόλο με τη C++"
+
+#: src/welcome-day-1/what-is-rust.md:6
+#, fuzzy
+msgid "`rustc` uses LLVM as its backend."
+msgstr "Το \"rustc\" χρησιμοποιεί το LLVM ως backend του."
+
+#: src/welcome-day-1/what-is-rust.md:7
+#, fuzzy
+msgid ""
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+msgstr ""
+"Το Rust υποστηρίζει πολλές [πλατφόρμες και αρχιτεκτονικές](https://doc.rust-"
+"lang.org/nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+#, fuzzy
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+#, fuzzy
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, ..."
+
+#: src/welcome-day-1/what-is-rust.md:11
+#, fuzzy
+msgid "Rust is used for a wide range of devices:"
+msgstr "Το Rust χρησιμοποιείται για ένα ευρύ φάσμα συσκευών:"
+
+#: src/welcome-day-1/what-is-rust.md:12
+#, fuzzy
+msgid "firmware and boot loaders,"
+msgstr "υλικολογισμικό και φορτωτές εκκίνησης,"
+
+#: src/welcome-day-1/what-is-rust.md:13
+#, fuzzy
+msgid "smart displays,"
+msgstr "έξυπνες οθόνες,"
+
+#: src/welcome-day-1/what-is-rust.md:14
+#, fuzzy
+msgid "mobile phones,"
+msgstr "κινητά τηλέφωνα,"
+
+#: src/welcome-day-1/what-is-rust.md:15
+#, fuzzy
+msgid "desktops,"
+msgstr "επιτραπέζιοι υπολογιστές,"
+
+#: src/welcome-day-1/what-is-rust.md:16
+#, fuzzy
+msgid "servers."
+msgstr "διακομιστές."
 
 #: src/welcome-day-1/what-is-rust.md:21
 #, fuzzy
@@ -2172,31 +2083,37 @@ msgstr "Η σκουριά ταιριάζει στην ίδια περιοχή μ
 
 #: src/welcome-day-1/what-is-rust.md:23
 #, fuzzy
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* Υψηλή ευελιξία.\n"
-"* Υψηλό επίπεδο ελέγχου.\n"
-"* Μπορεί να μειωθεί σε πολύ περιορισμένες συσκευές όπως κινητά τηλέφωνα.\n"
-"* Δεν έχει χρόνο εκτέλεσης ή συλλογή σκουπιδιών.\n"
-"* Εστιάζει στην αξιοπιστία και την ασφάλεια χωρίς να θυσιάζει την απόδοση."
+msgid "High flexibility."
+msgstr "Υψηλή ευελιξία."
 
-#: src/hello-world.md:1
+#: src/welcome-day-1/what-is-rust.md:24
 #, fuzzy
-msgid "# Hello World!"
-msgstr "# Γειά σου Κόσμε!"
+msgid "High level of control."
+msgstr "Υψηλό επίπεδο ελέγχου."
+
+#: src/welcome-day-1/what-is-rust.md:25
+#, fuzzy
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr "Μπορεί να μειωθεί σε πολύ περιορισμένες συσκευές όπως κινητά τηλέφωνα."
+
+#: src/welcome-day-1/what-is-rust.md:26
+#, fuzzy
+msgid "Has no runtime or garbage collection."
+msgstr "Δεν έχει χρόνο εκτέλεσης ή συλλογή σκουπιδιών."
+
+#: src/welcome-day-1/what-is-rust.md:27
+#, fuzzy
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"Εστιάζει στην αξιοπιστία και την ασφάλεια χωρίς να θυσιάζει την απόδοση."
 
 #: src/hello-world.md:3
 #, fuzzy
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
-"Ας μεταβούμε στο απλούστερο δυνατό πρόγραμμα Rust, ένα κλασικό Hello World\n"
+"Ας μεταβούμε στο απλούστερο δυνατό πρόγραμμα Rust, ένα κλασικό Hello World "
 "πρόγραμμα:"
 
 #: src/hello-world.md:6
@@ -2215,58 +2132,66 @@ msgstr "Τι βλέπεις:"
 
 #: src/hello-world.md:14
 #, fuzzy
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "Οι συναρτήσεις εισάγονται με το «fn»."
+
+#: src/hello-world.md:15
+#, fuzzy
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "Τα μπλοκ οριοθετούνται με σγουρά τιράντες όπως στο C και το C++."
+
+#: src/hello-world.md:16
+#, fuzzy
+msgid "The `main` function is the entry point of the program."
+msgstr "Η λειτουργία «κύρια» είναι το σημείο εισόδου του προγράμματος."
+
+#: src/hello-world.md:17
+#, fuzzy
+msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr ""
-"* Οι συναρτήσεις εισάγονται με το «fn».\n"
-"* Τα μπλοκ οριοθετούνται με σγουρά τιράντες όπως στο C και το C++.\n"
-"* Η λειτουργία «κύρια» είναι το σημείο εισόδου του προγράμματος.\n"
-"* Το Rust έχει υγιεινές μακροεντολές, το «println!» είναι ένα παράδειγμα "
-"αυτού.\n"
-"* Οι συμβολοσειρές Rust έχουν κωδικοποίηση UTF-8 και μπορούν να περιέχουν "
+"Το Rust έχει υγιεινές μακροεντολές, το «println!» είναι ένα παράδειγμα αυτού."
+
+#: src/hello-world.md:18
+#, fuzzy
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr ""
+"Οι συμβολοσειρές Rust έχουν κωδικοποίηση UTF-8 και μπορούν να περιέχουν "
 "οποιονδήποτε χαρακτήρα Unicode."
 
 #: src/hello-world.md:22
 #, fuzzy
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 "Αυτή η διαφάνεια προσπαθεί να κάνει τους μαθητές άνετα με τον κώδικα Rust. "
-"Θα δουν\n"
-"ένας τόνος από αυτό τις επόμενες τέσσερις ημέρες, οπότε ξεκινάμε μικρά με "
-"κάτι οικείο."
+"Θα δουν ένας τόνος από αυτό τις επόμενες τέσσερις ημέρες, οπότε ξεκινάμε "
+"μικρά με κάτι οικείο."
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude."
-"md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygenic](https://veykril.github.io/tlborm/decl-macros/minutiae/"
-"hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
 
-#: src/hello-world/small-example.md:1
-#, fuzzy
-msgid "# Small Example"
-msgstr "# Μικρό Παράδειγμα"
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr ""
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygenic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene.html)."
+msgstr ""
 
 #: src/hello-world/small-example.md:3
 #, fuzzy
@@ -2296,43 +2221,42 @@ msgstr ""
 #, fuzzy
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
-"Ο κώδικας υλοποιεί την εικασία Collatz: πιστεύεται ότι ο βρόχος θα\n"
-"πάντα τελειώνει, αλλά αυτό δεν έχει ακόμη αποδειχθεί. Επεξεργαστείτε τον "
-"κώδικα και παίξτε με διαφορετικά\n"
-"εισροές."
+"Ο κώδικας υλοποιεί την εικασία Collatz: πιστεύεται ότι ο βρόχος θα πάντα "
+"τελειώνει, αλλά αυτό δεν έχει ακόμη αποδειχθεί. Επεξεργαστείτε τον κώδικα "
+"και παίξτε με διαφορετικά εισροές."
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::"
-"fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library."
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
 
-#: src/why-rust.md:1
-#, fuzzy
-msgid "# Why Rust?"
-msgstr "# Γιατί Rust;"
+#: src/hello-world/small-example.md:32
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr ""
+
+#: src/hello-world/small-example.md:34
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+
+#: src/hello-world/small-example.md:37
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+
+#: src/hello-world/small-example.md:40
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
 
 #: src/why-rust.md:3
 #, fuzzy
@@ -2341,58 +2265,49 @@ msgstr "Μερικά μοναδικά σημεία πώλησης του Rust:"
 
 #: src/why-rust.md:5
 #, fuzzy
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* Συγκεντρώστε την ασφάλεια της μνήμης χρόνου.\n"
-"* Έλλειψη απροσδιόριστης συμπεριφοράς χρόνου εκτέλεσης.\n"
-"* Χαρακτηριστικά σύγχρονης γλώσσας."
+msgid "Compile time memory safety."
+msgstr "Συγκεντρώστε την ασφάλεια της μνήμης χρόνου."
+
+#: src/why-rust.md:6
+#, fuzzy
+msgid "Lack of undefined runtime behavior."
+msgstr "Έλλειψη απροσδιόριστης συμπεριφοράς χρόνου εκτέλεσης."
+
+#: src/why-rust.md:7
+#, fuzzy
+msgid "Modern language features."
+msgstr "Χαρακτηριστικά σύγχρονης γλώσσας."
 
 #: src/why-rust.md:11
 #, fuzzy
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
-"Φροντίστε να ρωτήσετε την τάξη με ποιες γλώσσες έχουν εμπειρία. Σε "
-"συνάρτηση\n"
+"Φροντίστε να ρωτήσετε την τάξη με ποιες γλώσσες έχουν εμπειρία. Σε συνάρτηση "
 "στην απάντηση μπορείτε να επισημάνετε διαφορετικά χαρακτηριστικά του Rust:"
 
 #: src/why-rust.md:14
 #, fuzzy
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* Εμπειρία με Java, Go, Python, JavaScript...: Έχετε την ίδια ασφάλεια "
-"μνήμης\n"
-"  όπως σε αυτές τις γλώσσες, συν ένα παρόμοιο γλωσσικό συναίσθημα υψηλού "
-"επιπέδου. Επιπλέον\n"
-"  έχετε γρήγορη και προβλέψιμη απόδοση όπως C και C++ (χωρίς "
-"σκουπιδοσυλλέκτη)\n"
-"  καθώς και πρόσβαση σε υλικό χαμηλού επιπέδου (σε περίπτωση που το "
-"χρειάζεστε)"
+"Εμπειρία με Java, Go, Python, JavaScript...: Έχετε την ίδια ασφάλεια μνήμης "
+"όπως σε αυτές τις γλώσσες, συν ένα παρόμοιο γλωσσικό συναίσθημα υψηλού "
+"επιπέδου. Επιπλέον έχετε γρήγορη και προβλέψιμη απόδοση όπως C και C++ "
+"(χωρίς σκουπιδοσυλλέκτη) καθώς και πρόσβαση σε υλικό χαμηλού επιπέδου (σε "
+"περίπτωση που το χρειάζεστε)"
 
-#: src/why-rust/compile-time.md:1
-#, fuzzy
-msgid "# Compile Time Guarantees"
-msgstr "# Συγκεντρώστε Εγγυήσεις χρόνου"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
 
 #: src/why-rust/compile-time.md:3
 #, fuzzy
@@ -2401,75 +2316,101 @@ msgstr "Διαχείριση στατικής μνήμης κατά το χρό�
 
 #: src/why-rust/compile-time.md:5
 #, fuzzy
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* Δεν υπάρχουν μη αρχικοποιημένες μεταβλητές.\n"
-"* Δεν υπάρχουν διαρροές μνήμης (_κυρίως_, βλέπε σημειώσεις).\n"
-"* Χωρίς διπλό δωρεάν.\n"
-"* Καμία χρήση-μετά-δωρεάν.\n"
-"* Δεν υπάρχουν δείκτες «NULL».\n"
-"* Όχι ξεχασμένα κλειδωμένα mutexes.\n"
-"* Δεν υπάρχουν αγώνες δεδομένων μεταξύ των νημάτων.\n"
-"* Χωρίς ακύρωση επαναληπτικού."
+msgid "No uninitialized variables."
+msgstr "Δεν υπάρχουν μη αρχικοποιημένες μεταβλητές."
+
+#: src/why-rust/compile-time.md:6
+#, fuzzy
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "Δεν υπάρχουν διαρροές μνήμης (_κυρίως_, βλέπε σημειώσεις)."
+
+#: src/why-rust/compile-time.md:7
+#, fuzzy
+msgid "No double-frees."
+msgstr "Χωρίς διπλό δωρεάν."
+
+#: src/why-rust/compile-time.md:8
+#, fuzzy
+msgid "No use-after-free."
+msgstr "Καμία χρήση-μετά-δωρεάν."
+
+#: src/why-rust/compile-time.md:9
+#, fuzzy
+msgid "No `NULL` pointers."
+msgstr "Δεν υπάρχουν δείκτες «NULL»."
+
+#: src/why-rust/compile-time.md:10
+#, fuzzy
+msgid "No forgotten locked mutexes."
+msgstr "Όχι ξεχασμένα κλειδωμένα mutexes."
+
+#: src/why-rust/compile-time.md:11
+#, fuzzy
+msgid "No data races between threads."
+msgstr "Δεν υπάρχουν αγώνες δεδομένων μεταξύ των νημάτων."
+
+#: src/why-rust/compile-time.md:12
+#, fuzzy
+msgid "No iterator invalidation."
+msgstr "Χωρίς ακύρωση επαναληπτικού."
 
 #: src/why-rust/compile-time.md:16
 #, fuzzy
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr ""
 "Είναι δυνατό να προκληθούν διαρροές μνήμης στο (ασφαλές) Rust. Μερικά "
-"παραδείγματα\n"
-"είναι:"
+"παραδείγματα είναι:"
 
 #: src/why-rust/compile-time.md:19
 #, fuzzy
 msgid ""
-"* You can for use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can for use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* Μπορείτε να χρησιμοποιήσετε το [`Box::leak`] για να διαρρεύσετε έναν "
-"δείκτη. Μια χρήση αυτού θα μπορούσε\n"
-"  να λάβετε στατικές μεταβλητές με αρχικοποίηση χρόνου εκτέλεσης και "
-"στατικές μεταβλητές μεγέθους χρόνου εκτέλεσης\n"
-"* Μπορείτε να χρησιμοποιήσετε το [`std::mem::forget`] για να κάνετε τον "
-"μεταγλωττιστή να \"ξεχάσει\"\n"
-"  μια τιμή (που σημαίνει ότι ο καταστροφέας δεν εκτελείται ποτέ).\n"
-"* Μπορείτε επίσης να δημιουργήσετε κατά λάθος έναν [κύκλο αναφοράς] με "
-"\"Rc\" ή\n"
-"  «Τόξο».\n"
-"* Στην πραγματικότητα, ορισμένοι θα εξετάσουν το ενδεχόμενο να συμπληρώσουν "
-"άπειρα μια συλλογή ως ανάμνηση\n"
-"  διαρροή και η Rust δεν προστατεύει από αυτά."
+"Μπορείτε να χρησιμοποιήσετε το [`Box::leak`](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html#method.leak) για να διαρρεύσετε έναν δείκτη. Μια χρήση "
+"αυτού θα μπορούσε να λάβετε στατικές μεταβλητές με αρχικοποίηση χρόνου "
+"εκτέλεσης και στατικές μεταβλητές μεγέθους χρόνου εκτέλεσης"
+
+#: src/why-rust/compile-time.md:21
+#, fuzzy
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"Μπορείτε να χρησιμοποιήσετε το [`std::mem::forget`](https://doc.rust-lang."
+"org/std/mem/fn.forget.html) για να κάνετε τον μεταγλωττιστή να \"ξεχάσει\" "
+"μια τιμή (που σημαίνει ότι ο καταστροφέας δεν εκτελείται ποτέ)."
+
+#: src/why-rust/compile-time.md:23
+#, fuzzy
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"Μπορείτε επίσης να δημιουργήσετε κατά λάθος έναν \\[κύκλο αναφοράς\\] με "
+"\"Rc\" ή «Τόξο»."
+
+#: src/why-rust/compile-time.md:25
+#, fuzzy
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"Στην πραγματικότητα, ορισμένοι θα εξετάσουν το ενδεχόμενο να συμπληρώσουν "
+"άπειρα μια συλλογή ως ανάμνηση διαρροή και η Rust δεν προστατεύει από αυτά."
 
 #: src/why-rust/compile-time.md:28
 #, fuzzy
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
 "Για τους σκοπούς αυτού του μαθήματος, θα πρέπει να γίνει κατανοητό το \"No "
-"memory leaks\".\n"
-"ως \"Σχεδόν καμία *τυχαία* διαρροή μνήμης\"."
-
-#: src/why-rust/runtime.md:1
-#, fuzzy
-msgid "# Runtime Guarantees"
-msgstr "# Εγγυήσεις χρόνου εκτέλεσης"
+"memory leaks\". ως \"Σχεδόν καμία _τυχαία_ διαρροή μνήμης\"."
 
 #: src/why-rust/runtime.md:3
 #, fuzzy
@@ -2478,39 +2419,35 @@ msgstr "Χωρίς απροσδιόριστη συμπεριφορά κατά τ
 
 #: src/why-rust/runtime.md:5
 #, fuzzy
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
-msgstr ""
-"* Η πρόσβαση σε πίνακα έχει επιλεγεί τα όρια.\n"
-"* Ορίζεται υπερχείλιση ακέραιου αριθμού."
+msgid "Array access is bounds checked."
+msgstr "Η πρόσβαση σε πίνακα έχει επιλεγεί τα όρια."
+
+#: src/why-rust/runtime.md:6
+#, fuzzy
+msgid "Integer overflow is defined."
+msgstr "Ορίζεται υπερχείλιση ακέραιου αριθμού."
 
 #: src/why-rust/runtime.md:12
 #, fuzzy
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* Η υπερχείλιση ακέραιου αριθμού ορίζεται μέσω μιας επισήμανσης χρόνου "
-"μεταγλώττισης. Οι επιλογές είναι\n"
-"  είτε ένας πανικός (ένα ελεγχόμενο crash του προγράμματος) είτε να "
-"αναδιπλωθεί\n"
-"  σημασιολογία. Από προεπιλογή, λαμβάνετε πανικό στη λειτουργία εντοπισμού "
-"σφαλμάτων (\"κατασκευή φορτίου\")\n"
-"  και περιτύλιξη σε λειτουργία απελευθέρωσης («κατασκευή φορτίου --"
-"απελευθέρωση»)."
+"Η υπερχείλιση ακέραιου αριθμού ορίζεται μέσω μιας επισήμανσης χρόνου "
+"μεταγλώττισης. Οι επιλογές είναι είτε ένας πανικός (ένα ελεγχόμενο crash του "
+"προγράμματος) είτε να αναδιπλωθεί σημασιολογία. Από προεπιλογή, λαμβάνετε "
+"πανικό στη λειτουργία εντοπισμού σφαλμάτων (\"κατασκευή φορτίου\") και "
+"περιτύλιξη σε λειτουργία απελευθέρωσης («κατασκευή φορτίου --απελευθέρωση»)."
 
-#: src/why-rust/modern.md:1
-#, fuzzy
-msgid "# Modern Features"
-msgstr "# Σύγχρονα χαρακτηριστικά"
+#: src/why-rust/runtime.md:17
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
 
 #: src/why-rust/modern.md:3
 #, fuzzy
@@ -2521,95 +2458,123 @@ msgstr ""
 
 #: src/why-rust/modern.md:5
 #, fuzzy
-msgid "## Language Features"
-msgstr "## Χαρακτηριστικά γλώσσας"
+msgid "Language Features"
+msgstr "Χαρακτηριστικά γλώσσας"
 
 #: src/why-rust/modern.md:7
 #, fuzzy
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* Αριθμοί και αντιστοίχιση μοτίβων.\n"
-"* Γενόσημα.\n"
-"* Όχι γενικά FFI.\n"
-"* Αφαιρέσεις μηδενικού κόστους."
+msgid "Enums and pattern matching."
+msgstr "Αριθμοί και αντιστοίχιση μοτίβων."
+
+#: src/why-rust/modern.md:8
+#, fuzzy
+msgid "Generics."
+msgstr "Γενόσημα."
+
+#: src/why-rust/modern.md:9
+#, fuzzy
+msgid "No overhead FFI."
+msgstr "Όχι γενικά FFI."
+
+#: src/why-rust/modern.md:10
+#, fuzzy
+msgid "Zero-cost abstractions."
+msgstr "Αφαιρέσεις μηδενικού κόστους."
 
 #: src/why-rust/modern.md:12
 #, fuzzy
-msgid "## Tooling"
-msgstr "## Εργαλεία"
+msgid "Tooling"
+msgstr "Εργαλεία"
 
 #: src/why-rust/modern.md:14
 #, fuzzy
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* Μεγάλα λάθη μεταγλωττιστή.\n"
-"* Ενσωματωμένος διαχειριστής εξαρτήσεων.\n"
-"* Ενσωματωμένη υποστήριξη για δοκιμές.\n"
-"* Εξαιρετική υποστήριξη πρωτοκόλλου διακομιστή γλώσσας."
+msgid "Great compiler errors."
+msgstr "Μεγάλα λάθη μεταγλωττιστή."
+
+#: src/why-rust/modern.md:15
+#, fuzzy
+msgid "Built-in dependency manager."
+msgstr "Ενσωματωμένος διαχειριστής εξαρτήσεων."
+
+#: src/why-rust/modern.md:16
+#, fuzzy
+msgid "Built-in support for testing."
+msgstr "Ενσωματωμένη υποστήριξη για δοκιμές."
+
+#: src/why-rust/modern.md:17
+#, fuzzy
+msgid "Excellent Language Server Protocol support."
+msgstr "Εξαιρετική υποστήριξη πρωτοκόλλου διακομιστή γλώσσας."
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
 
-#: src/basic-syntax.md:1
-#, fuzzy
-msgid "# Basic Syntax"
-msgstr "# Βασική Σύνταξη"
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr ""
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr ""
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
+
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
 
 #: src/basic-syntax.md:3
 #, fuzzy
@@ -2618,60 +2583,130 @@ msgstr "Μεγάλο μέρος της σύνταξης Rust θα σας είν�
 
 #: src/basic-syntax.md:5
 #, fuzzy
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/"
-"* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
-msgstr ""
-"* Τα μπλοκ και τα πεδία οριοθετούνται με σγουρά τιράντες.\n"
-"* Τα σχόλια γραμμής ξεκινούν με `//`, τα σχόλια αποκλεισμού οριοθετούνται "
-"από `/* ...\n"
-"  */`.\n"
-"* Λέξεις-κλειδιά όπως «αν» και «ενώ» λειτουργούν το ίδιο.\n"
-"* Η ανάθεση μεταβλητής γίνεται με `=`, η σύγκριση γίνεται με `==`."
+msgid "Blocks and scopes are delimited by curly braces."
+msgstr "Τα μπλοκ και τα πεδία οριοθετούνται με σγουρά τιράντες."
 
-#: src/basic-syntax/scalar-types.md:1
-#, fuzzy
-msgid "# Scalar Types"
-msgstr "# Scalar Types"
-
-#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax.md:6
 #, fuzzy
 msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | "
-"`\"foo\"`, `r#\"\\\\\"#`            |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Byte strings           | `&[u8]`                                    | "
-"`b\"abc\"`, `br#\" \" \"#`         |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"| | Τύποι | Κυριολεκτικά |\n"
-"|------------------------------------------------- "
-"-------------------------------------------------- --|\n"
-"| Υπογεγραμμένοι ακέραιοι αριθμοί | `i8`, `i16`, `i32`, `i64`, `i128`, "
-"`isize` | `-10`, `0`, `1_000`, `123i64` |\n"
-"| Ανυπόγραφοι ακέραιοι αριθμοί | «u8», «u16», «u32», «u64», «u128», «χρήση» "
-"| `0`, `123`, `10u16` |\n"
-"| Αριθμοί κινητής υποδιαστολής | `f32`, `f64` | `3,14`, `-10,0e20`, `2f32` "
-"|\n"
-"| Χορδές | `&str` | `\"foo\"`, `r#\"\\\\\"#` |\n"
-"| Βαθμωτές τιμές Unicode | `χαρ` | `'a', `'α'`, `'∞'` |\n"
-"| Συμβολοσειρές byte | `&[u8]` | `b\"abc\"`, `br#\" \" \"#\" |\n"
-"| Booleans | «μπουλ» | \"αληθές\", \"ψευδές\" |"
+"Τα σχόλια γραμμής ξεκινούν με `//`, τα σχόλια αποκλεισμού οριοθετούνται από "
+"`/* ... */`."
+
+#: src/basic-syntax.md:8
+#, fuzzy
+msgid "Keywords like `if` and `while` work the same."
+msgstr "Λέξεις-κλειδιά όπως «αν» και «ενώ» λειτουργούν το ίδιο."
+
+#: src/basic-syntax.md:9
+#, fuzzy
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr "Η ανάθεση μεταβλητής γίνεται με `=`, η σύγκριση γίνεται με `==`."
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#, fuzzy
+msgid "Types"
+msgstr ""
+"\\| | Τύποι | Κυριολεκτικά | "
+"\\|------------------------------------------------- "
+"-------------------------------------------------- --| \\| Υπογεγραμμένοι "
+"ακέραιοι αριθμοί | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | `-10`, `0`, "
+"`1_000`, `123i64` | \\| Ανυπόγραφοι ακέραιοι αριθμοί | «u8», «u16», «u32», "
+"«u64», «u128», «χρήση» | `0`, `123`, `10u16` | \\| Αριθμοί κινητής "
+"υποδιαστολής | `f32`, `f64` | `3,14`, `-10,0e20`, `2f32` | \\| Χορδές | "
+"`&str` | `\"foo\"`, `r#\"\\\\\"#` | \\| Βαθμωτές τιμές Unicode | `χαρ` | "
+"`'a', `'α'`, `'∞'`| | Συμβολοσειρές byte |`&\\[u8\\]`|`b\"abc\"`, `br#\" \" "
+"\"#\" | \\| Booleans | «μπουλ» | \"αληθές\", \"ψευδές\" |"
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+msgid "Literals"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "Signed integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:5
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "Unsigned integers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:6
+msgid "`0`, `123`, `10u16`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "Floating point numbers"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`f32`, `f64`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:7
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "Strings"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`&str`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:8
+msgid "`\"foo\"`, `r#\"\\\\\"#`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "Unicode scalar values"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`char`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:9
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "Byte strings"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`&[u8]`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`b\"abc\"`, `br#\" \" \"#`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "Booleans"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`bool`"
+msgstr ""
+
+#: src/basic-syntax/scalar-types.md:11
+msgid "`true`, `false`"
+msgstr ""
 
 #: src/basic-syntax/scalar-types.md:13
 #, fuzzy
@@ -2680,31 +2715,46 @@ msgstr "Οι τύποι έχουν πλάτη ως εξής:"
 
 #: src/basic-syntax/scalar-types.md:15
 #, fuzzy
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
-msgstr ""
-"* Τα \"iN\", \"uN\" και \"fN\" έχουν πλάτος _N_ bit,\n"
-"* Το \"isize\" και το \"usize\" είναι το πλάτος ενός δείκτη,\n"
-"* Το \"char\" έχει πλάτος 32 bit,\n"
-"* Το «bool» έχει πλάτος 8 bit."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "Τα \"iN\", \"uN\" και \"fN\" έχουν πλάτος _N_ bit,"
 
-#: src/basic-syntax/compound-types.md:1
+#: src/basic-syntax/scalar-types.md:16
 #, fuzzy
-msgid "# Compound Types"
-msgstr "# Σύνθετοι τύποι"
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "Το \"isize\" και το \"usize\" είναι το πλάτος ενός δείκτη,"
 
-#: src/basic-syntax/compound-types.md:3
-msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+#: src/basic-syntax/scalar-types.md:17
+#, fuzzy
+msgid "`char` is 32 bit wide,"
+msgstr "Το \"char\" έχει πλάτος 32 bit,"
+
+#: src/basic-syntax/scalar-types.md:18
+#, fuzzy
+msgid "`bool` is 8 bit wide."
+msgstr "Το «bool» έχει πλάτος 8 bit."
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:8
@@ -2746,24 +2796,28 @@ msgstr "Πίνακες:"
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
-"compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
 msgstr ""
 
 #: src/basic-syntax/compound-types.md:47
@@ -2773,39 +2827,40 @@ msgstr "Πλειάδες:"
 
 #: src/basic-syntax/compound-types.md:49
 #, fuzzy
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
+msgid "Like arrays, tuples have a fixed length."
 msgstr ""
-"* Η άδεια πλειάδα `()` είναι επίσης γνωστή ως \"τύπος μονάδας\". Είναι και "
-"τύπος, και\n"
-"  η μόνη έγκυρη τιμή αυτού του τύπου - δηλαδή και ο τύπος και η τιμή του\n"
-"  εκφράζονται ως «()». Χρησιμοποιείται για να υποδείξει, για παράδειγμα, ότι "
-"μια συνάρτηση ή\n"
-"  Η έκφραση δεν έχει τιμή επιστροφής, όπως θα δούμε σε μια μελλοντική "
-"διαφάνεια.\n"
-"    * Μπορείτε να το σκεφτείτε ως «κενό» που μπορεί να σας είναι οικείο από "
-"άλλους\n"
-"      γλώσσες προγραμματισμού."
+"Η άδεια πλειάδα `()` είναι επίσης γνωστή ως \"τύπος μονάδας\". Είναι και "
+"τύπος, και η μόνη έγκυρη τιμή αυτού του τύπου - δηλαδή και ο τύπος και η "
+"τιμή του εκφράζονται ως «()». Χρησιμοποιείται για να υποδείξει, για "
+"παράδειγμα, ότι μια συνάρτηση ή Η έκφραση δεν έχει τιμή επιστροφής, όπως θα "
+"δούμε σε μια μελλοντική διαφάνεια."
 
-#: src/basic-syntax/references.md:1
+#: src/basic-syntax/compound-types.md:51
 #, fuzzy
-msgid "# References"
-msgstr "# Βιβλιογραφικές αναφορές"
+msgid "Tuples group together values of different types into a compound type."
+msgstr ""
+"Μπορείτε να το σκεφτείτε ως «κενό» που μπορεί να σας είναι οικείο από άλλους "
+"γλώσσες προγραμματισμού."
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr ""
 
 #: src/basic-syntax/references.md:3
 #, fuzzy
@@ -2832,51 +2887,42 @@ msgstr "Μερικές σημειώσεις:"
 #: src/basic-syntax/references.md:16
 #, fuzzy
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* Πρέπει να μην αναφέρουμε το «ref_x» κατά την ανάθεση σε αυτό, παρόμοια με "
-"τους δείκτες C και C++.\n"
-"* Το Rust θα επαναφέρει αυτόματα σε ορισμένες περιπτώσεις, ιδιαίτερα κατά "
-"την επίκληση\n"
-"  μεθόδους (δοκιμάστε το `ref_x.count_ones()`).\n"
-"* Οι αναφορές που δηλώνονται ως «mut» μπορούν να δεσμευτούν σε διαφορετικές "
-"τιμές κατά τη διάρκεια της ζωής τους."
+"Πρέπει να μην αναφέρουμε το «ref_x» κατά την ανάθεση σε αυτό, παρόμοια με "
+"τους δείκτες C και C++."
 
-#: src/basic-syntax/references.md:21
+#: src/basic-syntax/references.md:17
 #, fuzzy
 msgid ""
-"<details>\n"
-"Key points:"
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
 msgstr ""
-"<λεπτομέρειες>\n"
-"Βασικά σημεία:"
+"Το Rust θα επαναφέρει αυτόματα σε ορισμένες περιπτώσεις, ιδιαίτερα κατά την "
+"επίκληση μεθόδους (δοκιμάστε το `ref_x.count_ones()`)."
+
+#: src/basic-syntax/references.md:19
+#, fuzzy
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"Οι αναφορές που δηλώνονται ως «mut» μπορούν να δεσμευτούν σε διαφορετικές "
+"τιμές κατά τη διάρκεια της ζωής τους."
 
 #: src/basic-syntax/references.md:24
 #, fuzzy
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"* Φροντίστε να σημειώσετε τη διαφορά μεταξύ του \"let mut ref_x: &i32\" και "
-"του \"let ref_x:\n"
-"  &mut i32`. Η πρώτη αντιπροσωπεύει μια μεταβλητή αναφορά στην οποία μπορεί "
-"να συνδεθεί\n"
-"  διαφορετικές τιμές, ενώ η δεύτερη αντιπροσωπεύει μια αναφορά σε μια "
-"μεταβλητή τιμή."
-
-#: src/basic-syntax/references-dangling.md:1
-#, fuzzy
-msgid "# Dangling References"
-msgstr "# Κρεμασμένες αναφορές"
+"Φροντίστε να σημειώσετε τη διαφορά μεταξύ του \"let mut ref_x: &i32\" και "
+"του \"let ref_x: &mut i32\\`. Η πρώτη αντιπροσωπεύει μια μεταβλητή αναφορά "
+"στην οποία μπορεί να συνδεθεί διαφορετικές τιμές, ενώ η δεύτερη "
+"αντιπροσωπεύει μια αναφορά σε μια μεταβλητή τιμή."
 
 #: src/basic-syntax/references-dangling.md:3
 #, fuzzy
@@ -2899,22 +2945,22 @@ msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
 #, fuzzy
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
-msgstr ""
-"* Μια αναφορά λέγεται ότι \"δανείζεται\" την τιμή στην οποία αναφέρεται.\n"
-"* Το Rust παρακολουθεί τη διάρκεια ζωής όλων των αναφορών για να διασφαλίσει "
-"ότι ζουν πολύ\n"
-"  αρκετά.\n"
-"* Θα μιλήσουμε περισσότερο για δανεισμό όταν φτάσουμε στην ιδιοκτησία."
+msgid "A reference is said to \"borrow\" the value it refers to."
+msgstr "Μια αναφορά λέγεται ότι \"δανείζεται\" την τιμή στην οποία αναφέρεται."
 
-#: src/basic-syntax/slices.md:1
+#: src/basic-syntax/references-dangling.md:17
 #, fuzzy
-msgid "# Slices"
-msgstr "# Φέτες"
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"Το Rust παρακολουθεί τη διάρκεια ζωής όλων των αναφορών για να διασφαλίσει "
+"ότι ζουν πολύ αρκετά."
+
+#: src/basic-syntax/references-dangling.md:19
+#, fuzzy
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr "Θα μιλήσουμε περισσότερο για δανεισμό όταν φτάσουμε στην ιδιοκτησία."
 
 #: src/basic-syntax/slices.md:3
 #, fuzzy
@@ -2936,62 +2982,78 @@ msgstr ""
 
 #: src/basic-syntax/slices.md:15
 #, fuzzy
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
-msgstr ""
-"* Οι φέτες δανείζονται δεδομένα από τον τύπο σε φέτες.\n"
-"* Ερώτηση: Τι θα συμβεί αν τροποποιήσετε το «a[3]»;"
+msgid "Slices borrow data from the sliced type."
+msgstr "Οι φέτες δανείζονται δεδομένα από τον τύπο σε φέτες."
+
+#: src/basic-syntax/slices.md:16
+#, fuzzy
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "Ερώτηση: Τι θα συμβεί αν τροποποιήσετε το «a\\[3\\]»;"
 
 #: src/basic-syntax/slices.md:20
 #, fuzzy
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
-"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use "
-"`&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
-"(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
 msgstr ""
-"* Το `s` είναι μια αναφορά σε ένα κομμάτι του `i32`. Παρατηρήστε ότι ο τύπος "
+"Το `s` είναι μια αναφορά σε ένα κομμάτι του `i32`. Παρατηρήστε ότι ο τύπος "
 "`s` (`&[i32]`) δεν αναφέρει πλέον το μήκος του πίνακα. Αυτό μας επιτρέπει να "
-"κάνουμε υπολογισμούς σε φέτες διαφορετικών μεγεθών.\n"
-" \n"
-"* Οι φέτες δανείζονται πάντα από άλλο αντικείμενο. Σε αυτό το παράδειγμα, το "
+"κάνουμε υπολογισμούς σε φέτες διαφορετικών μεγεθών."
+
+#: src/basic-syntax/slices.md:22
+#, fuzzy
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"Οι φέτες δανείζονται πάντα από άλλο αντικείμενο. Σε αυτό το παράδειγμα, το "
 "«a» πρέπει να παραμείνει «ζωντανό» (στο πεδίο εφαρμογής) για τουλάχιστον όσο "
-"το κομμάτι μας.\n"
-"    \n"
-"* Η ερώτηση σχετικά με την τροποποίηση του «a[3]» μπορεί να προκαλέσει μια "
+"το κομμάτι μας."
+
+#: src/basic-syntax/slices.md:24
+#, fuzzy
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"Η ερώτηση σχετικά με την τροποποίηση του «a\\[3\\]» μπορεί να προκαλέσει μια "
 "ενδιαφέρουσα συζήτηση, αλλά η απάντηση είναι ότι για λόγους ασφαλείας της "
-"μνήμης\n"
-"  δεν μπορείτε να το κάνετε μέσω του \"a\" αφού δημιουργήσετε ένα slice, "
-"αλλά μπορείτε να διαβάσετε τα δεδομένα από το \"a\" και το \"s\" με "
-"ασφάλεια.\n"
-"  Περισσότερες λεπτομέρειες θα επεξηγηθούν στην ενότητα ελέγχου δανεισμού."
+"μνήμης δεν μπορείτε να το κάνετε μέσω του \"a\" αφού δημιουργήσετε ένα "
+"slice, αλλά μπορείτε να διαβάσετε τα δεδομένα από το \"a\" και το \"s\" με "
+"ασφάλεια. Περισσότερες λεπτομέρειες θα επεξηγηθούν στην ενότητα ελέγχου "
+"δανεισμού."
+
+#: src/basic-syntax/slices.md:26
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+
+#: src/basic-syntax/slices.md:28
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
 
 #: src/basic-syntax/string-slices.md:1
 #, fuzzy
-msgid "# `String` vs `str`"
-msgstr "# `String` vs `str`"
+msgid "`String` vs `str`"
+msgstr "`String` vs `str`"
 
 #: src/basic-syntax/string-slices.md:3
 #, fuzzy
@@ -3023,64 +3085,66 @@ msgstr "Ορολογία σκουριάς:"
 
 #: src/basic-syntax/string-slices.md:22
 #, fuzzy
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
-msgstr ""
-"* «&str» μια αμετάβλητη αναφορά σε ένα κομμάτι συμβολοσειράς.\n"
-"* \"String\" ένα μεταβλητό buffer συμβολοσειρών."
+msgid "`&str` an immutable reference to a string slice."
+msgstr "«&str» μια αμετάβλητη αναφορά σε ένα κομμάτι συμβολοσειράς."
+
+#: src/basic-syntax/string-slices.md:23
+#, fuzzy
+msgid "`String` a mutable string buffer."
+msgstr "\"String\" ένα μεταβλητό buffer συμβολοσειρών."
 
 #: src/basic-syntax/string-slices.md:27
 #, fuzzy
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::"
-"string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* Η μακροεντολή «format!()» είναι ένας βολικός τρόπος για να δημιουργήσετε "
-"μια ιδιόκτητη συμβολοσειρά από δυναμικές τιμές. Το\n"
-"  δέχεται την ίδια προδιαγραφή μορφής με το \"println!()\".\n"
-"    \n"
-"* Μπορείτε να δανειστείτε κομμάτια «&str» από το «String» μέσω του «&» και "
-"προαιρετικά επιλογής εύρους.\n"
-"    \n"
-"* Για προγραμματιστές C++: σκεφτείτε το «&str» ως «const char*» από τη C++, "
-"αλλά αυτό που δείχνει πάντα\n"
-"  σε μια έγκυρη συμβολοσειρά στη μνήμη. Το Rust «String» είναι ένα κατά "
-"προσέγγιση ισοδύναμο του «std::string» από τη C++\n"
-"  (κύρια διαφορά: μπορεί να περιέχει μόνο byte με κωδικοποίηση UTF-8 και δεν "
-"θα χρησιμοποιήσει ποτέ βελτιστοποίηση μικρής συμβολοσειράς).\n"
-"    \n"
-"</details>"
+"Η μακροεντολή «format!()» είναι ένας βολικός τρόπος για να δημιουργήσετε μια "
+"ιδιόκτητη συμβολοσειρά από δυναμικές τιμές. Το δέχεται την ίδια προδιαγραφή "
+"μορφής με το \"println!()\"."
 
-#: src/basic-syntax/functions.md:1
+#: src/basic-syntax/string-slices.md:30
 #, fuzzy
-msgid "# Functions"
-msgstr "# Λειτουργίες"
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+"Μπορείτε να δανειστείτε κομμάτια «&str» από το «String» μέσω του «&» και "
+"προαιρετικά επιλογής εύρους."
+
+#: src/basic-syntax/string-slices.md:32
+#, fuzzy
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"Για προγραμματιστές C++: σκεφτείτε το «&str» ως «const char\\*» από τη C++, "
+"αλλά αυτό που δείχνει πάντα σε μια έγκυρη συμβολοσειρά στη μνήμη. Το Rust "
+"«String» είναι ένα κατά προσέγγιση ισοδύναμο του «std::string» από τη C++ "
+"(κύρια διαφορά: μπορεί να περιέχει μόνο byte με κωδικοποίηση UTF-8 και δεν "
+"θα χρησιμοποιήσει ποτέ βελτιστοποίηση μικρής συμβολοσειράς)."
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
 
 #: src/basic-syntax/functions.md:3
 #, fuzzy
@@ -3125,47 +3189,61 @@ msgid ""
 "```"
 msgstr ""
 "fn fizzbuzz(n: u32) -> () { // Χωρίς επιστροφή τιμής σημαίνει επιστροφή του "
-"τύπου μονάδας `()`\n"
-"    αντιστοίχιση (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
-"        (αληθινό, αληθινό) => println!(\"fizzbuzz\"),\n"
-"        (αληθές, λάθος) => println!(\"fizz\"),\n"
-"        (ψευδές, αληθές) => println!(\"buzz\"),\n"
-"        (ψεύτικο, ψευδές) => println!(\"{n}\"),\n"
-"    }\n"
-"}"
+"τύπου μονάδας `()` αντιστοίχιση (is_divisible_by(n, 3), is_divisible_by(n, "
+"5)) { (αληθινό, αληθινό) => println!(\"fizzbuzz\"), (αληθές, λάθος) => "
+"println!(\"fizz\"), (ψευδές, αληθές) => println!(\"buzz\"), (ψεύτικο, "
+"ψευδές) => println!(\"{n}\"), } }"
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
-"which causes it to include the upper bound.\n"
-"* The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
-"expanded below to show what is happening.\n"
-"\n"
-"  (Type annotations added for clarity, but they can be elided.)\n"
-"\n"
-"  ```rust,ignore\n"
-"  let by_3: bool = is_divisible_by(n, 3);\n"
-"  let by_5: bool = is_divisible_by(n, 5);\n"
-"  let by_35: (bool, bool) = (by_3, by_5);\n"
-"  match by_35 {\n"
-"    // ...\n"
-"  ```\n"
-"\n"
-"  "
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
 msgstr ""
 
-#: src/basic-syntax/rustdoc.md:1
-#, fuzzy
-msgid "# Rustdoc"
-msgstr "# Γιατί Rust;"
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `fizzbuzz_to()` contains `=n`, "
+"which causes it to include the upper bound."
+msgstr ""
+
+#: src/basic-syntax/functions.md:40
+msgid ""
+"The `match` expression in `fizzbuzz()` is doing a lot of work. It is "
+"expanded below to show what is happening."
+msgstr ""
+
+#: src/basic-syntax/functions.md:42
+msgid "(Type annotations added for clarity, but they can be elided.)"
+msgstr ""
+
+#: src/basic-syntax/functions.md:44
+msgid ""
+"```rust,ignore\n"
+"let by_3: bool = is_divisible_by(n, 3);\n"
+"let by_5: bool = is_divisible_by(n, 5);\n"
+"let by_35: (bool, bool) = (by_3, by_5);\n"
+"match by_35 {\n"
+"  // ...\n"
+"```"
+msgstr ""
 
 #: src/basic-syntax/rustdoc.md:3
 msgid ""
@@ -3191,43 +3269,40 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-#, fuzzy
-msgid "# Methods"
-msgstr "# Μέθοδοι"
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr ""
 
 #: src/basic-syntax/methods.md:3
 #, fuzzy
 msgid ""
 "Rust has methods, they are simply functions that are associated with a "
-"particular type. The\n"
-"first argument of a method is an instance of the type it is associated with:"
+"particular type. The first argument of a method is an instance of the type "
+"it is associated with:"
 msgstr ""
 "Το Rust έχει μεθόδους, είναι απλώς λειτουργίες που σχετίζονται με έναν "
-"συγκεκριμένο τύπο. ο\n"
-"Το πρώτο όρισμα μιας μεθόδου είναι ένα παράδειγμα του τύπου με το οποίο "
-"σχετίζεται:"
+"συγκεκριμένο τύπο. ο Το πρώτο όρισμα μιας μεθόδου είναι ένα παράδειγμα του "
+"τύπου με το οποίο σχετίζεται:"
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3259,16 +3334,16 @@ msgstr ""
 #: src/basic-syntax/methods.md:30
 #, fuzzy
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
-"* Θα εξετάσουμε πολύ περισσότερο τις μεθόδους στη σημερινή άσκηση και στην "
+"Θα εξετάσουμε πολύ περισσότερο τις μεθόδους στη σημερινή άσκηση και στην "
 "αυριανή τάξη."
 
 #: src/basic-syntax/functions-interlude.md:1
 #, fuzzy
-msgid "# Function Overloading"
-msgstr "# Λειτουργία Υπερφόρτωση"
+msgid "Function Overloading"
+msgstr "Λειτουργία Υπερφόρτωση"
 
 #: src/basic-syntax/functions-interlude.md:3
 #, fuzzy
@@ -3277,20 +3352,33 @@ msgstr "Η υπερφόρτωση δεν υποστηρίζεται:"
 
 #: src/basic-syntax/functions-interlude.md:5
 #, fuzzy
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
-msgstr ""
-"* Κάθε συνάρτηση έχει μια ενιαία υλοποίηση:\n"
-"  * Λαμβάνει πάντα έναν σταθερό αριθμό παραμέτρων.\n"
-"  * Λαμβάνει πάντα ένα ενιαίο σύνολο τύπων παραμέτρων.\n"
-"* Οι προεπιλεγμένες τιμές δεν υποστηρίζονται:\n"
-"  * Όλοι οι ιστότοποι κλήσεων έχουν τον ίδιο αριθμό ορισμάτων.\n"
-"  * Οι μακροεντολές χρησιμοποιούνται μερικές φορές ως εναλλακτική λύση."
+msgid "Each function has a single implementation:"
+msgstr "Κάθε συνάρτηση έχει μια ενιαία υλοποίηση:"
+
+#: src/basic-syntax/functions-interlude.md:6
+#, fuzzy
+msgid "Always takes a fixed number of parameters."
+msgstr "Λαμβάνει πάντα έναν σταθερό αριθμό παραμέτρων."
+
+#: src/basic-syntax/functions-interlude.md:7
+#, fuzzy
+msgid "Always takes a single set of parameter types."
+msgstr "Λαμβάνει πάντα ένα ενιαίο σύνολο τύπων παραμέτρων."
+
+#: src/basic-syntax/functions-interlude.md:8
+#, fuzzy
+msgid "Default values are not supported:"
+msgstr "Οι προεπιλεγμένες τιμές δεν υποστηρίζονται:"
+
+#: src/basic-syntax/functions-interlude.md:9
+#, fuzzy
+msgid "All call sites have the same number of arguments."
+msgstr "Όλοι οι ιστότοποι κλήσεων έχουν τον ίδιο αριθμό ορισμάτων."
+
+#: src/basic-syntax/functions-interlude.md:10
+#, fuzzy
+msgid "Macros are sometimes used as an alternative."
+msgstr "Οι μακροεντολές χρησιμοποιούνται μερικές φορές ως εναλλακτική λύση."
 
 #: src/basic-syntax/functions-interlude.md:12
 #, fuzzy
@@ -3314,25 +3402,20 @@ msgstr ""
 #: src/basic-syntax/functions-interlude.md:27
 #, fuzzy
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
-"* Όταν χρησιμοποιείτε γενικά, το 'Into<T>' της τυπικής βιβλιοθήκης μπορεί να "
-"παρέχει ένα είδος περιορισμένου\n"
-"  πολυμορφισμός σε τύπους επιχειρημάτων. Θα δούμε περισσότερες λεπτομέρειες "
-"σε επόμενη ενότητα."
-
-#: src/basic-syntax/functions-interlude.md:30
-#, fuzzy
-msgid "</defails>"
-msgstr "</defails>"
+"Όταν χρησιμοποιείτε γενικά, το 'Into\n"
+"\n"
+"' της τυπικής βιβλιοθήκης μπορεί να παρέχει ένα είδος περιορισμένου "
+"πολυμορφισμός σε τύπους επιχειρημάτων. Θα δούμε περισσότερες λεπτομέρειες σε "
+"επόμενη ενότητα."
 
 #: src/exercises/day-1/morning.md:1
 #, fuzzy
-msgid "# Day 1: Morning Exercises"
-msgstr "# Ημέρα 1: Πρωινές ασκήσεις"
+msgid "Day 1: Morning Exercises"
+msgstr "Ημέρα 1: Πρωινές ασκήσεις"
 
 #: src/exercises/day-1/morning.md:3
 #, fuzzy
@@ -3341,11 +3424,12 @@ msgstr "Σε αυτές τις ασκήσεις, θα εξερευνήσουμε
 
 #: src/exercises/day-1/morning.md:5
 #, fuzzy
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
-msgstr "* Σιωπηρές μετατροπές μεταξύ τύπων."
+msgid "Implicit conversions between types."
+msgstr "Σιωπηρές μετατροπές μεταξύ τύπων."
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
+msgstr ""
 
 #: src/exercises/day-1/morning.md:11
 #, fuzzy
@@ -3356,29 +3440,28 @@ msgstr ""
 #: src/exercises/day-1/morning.md:13
 #, fuzzy
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* Χρησιμοποιήστε μια τοπική εγκατάσταση Rust, εάν είναι δυνατόν. Με αυτόν "
-"τον τρόπο μπορείτε να αποκτήσετε\n"
-"  αυτόματη συμπλήρωση στον επεξεργαστή σας. Δείτε τη σελίδα σχετικά με το "
-"[Using Cargo] για λεπτομέρειες\n"
-"  κατά την εγκατάσταση του Rust."
+"Χρησιμοποιήστε μια τοπική εγκατάσταση Rust, εάν είναι δυνατόν. Με αυτόν τον "
+"τρόπο μπορείτε να αποκτήσετε αυτόματη συμπλήρωση στον επεξεργαστή σας. Δείτε "
+"τη σελίδα σχετικά με το [Using Cargo](../../cargo.md) για λεπτομέρειες κατά "
+"την εγκατάσταση του Rust."
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
+msgstr ""
 
 #: src/exercises/day-1/morning.md:19
 #, fuzzy
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
 "Τα αποσπάσματα κώδικα δεν είναι επεξεργάσιμα επίτηδες: τα ενσωματωμένα "
-"αποσπάσματα κώδικα χάνονται\n"
-"την κατάστασή τους εάν απομακρυνθείτε από τη σελίδα."
+"αποσπάσματα κώδικα χάνονται την κατάστασή τους εάν απομακρυνθείτε από τη "
+"σελίδα."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
@@ -3387,25 +3470,20 @@ msgstr ""
 #: src/exercises/bare-metal/afternoon.md:7
 #, fuzzy
 msgid ""
-"After looking at the exercises, you can look at the [solutions] provided."
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
 msgstr ""
-"Αφού δείτε τις ασκήσεις, μπορείτε να δείτε τις [λύσεις] που παρέχονται."
-
-#: src/exercises/day-1/implicit-conversions.md:1
-#, fuzzy
-msgid "# Implicit Conversions"
-msgstr "# Άμεσες μετατροπές"
+"Αφού δείτε τις ασκήσεις, μπορείτε να δείτε τις \\[λύσεις\\] που παρέχονται."
 
 #: src/exercises/day-1/implicit-conversions.md:3
 #, fuzzy
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
 "Το Rust δεν θα εφαρμόσει αυτόματα _implicit conversions_ μεταξύ των τύπων "
-"([σε αντίθεση με\n"
-"C++][3]). Μπορείτε να το δείτε σε ένα πρόγραμμα όπως αυτό:"
+"([σε αντίθεση με C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). Μπορείτε να το δείτε σε ένα πρόγραμμα όπως αυτό:"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
@@ -3426,78 +3504,81 @@ msgstr ""
 #: src/exercises/day-1/implicit-conversions.md:19
 #, fuzzy
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Όλοι οι τύποι ακέραιου αριθμού Rust εφαρμόζουν τα [`From<T>`][1] και "
-"[`Into<T>`][2]\n"
-"χαρακτηριστικά για να μας αφήσουν να μετατρέψουμε μεταξύ τους. Το "
-"χαρακτηριστικό \"From<T>\" έχει ένα μόνο \"from()\".\n"
-"μέθοδο και παρομοίως, το χαρακτηριστικό «Into<T>» έχει μία μόνο μέθοδο "
-"«into()».\n"
-"Η εφαρμογή αυτών των χαρακτηριστικών είναι ο τρόπος με τον οποίο ένας τύπος "
-"εκφράζει ότι μπορεί να μετατραπεί σε\n"
-"άλλου τύπου."
+"Όλοι οι τύποι ακέραιου αριθμού Rust εφαρμόζουν τα [`From<T>`](https://doc."
+"rust-lang.org/std/convert/trait.From.html) και [`Into<T>`](https://doc.rust-"
+"lang.org/std/convert/trait.Into.html) χαρακτηριστικά για να μας αφήσουν να "
+"μετατρέψουμε μεταξύ τους. Το χαρακτηριστικό \"From\n"
+"\n"
+"\" έχει ένα μόνο \"from()\". μέθοδο και παρομοίως, το χαρακτηριστικό «Into\n"
+"\n"
+"» έχει μία μόνο μέθοδο «into()». Η εφαρμογή αυτών των χαρακτηριστικών είναι "
+"ο τρόπος με τον οποίο ένας τύπος εκφράζει ότι μπορεί να μετατραπεί σε άλλου "
+"τύπου."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 #, fuzzy
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
-"Η τυπική βιβλιοθήκη έχει μια υλοποίηση του «From<i8> για i16», που σημαίνει\n"
-"ότι μπορούμε να μετατρέψουμε μια μεταβλητή «x» τύπου «i8» σε «i16» καλώντας\n"
-"`i16::from(x)`. Ή, απλούστερα, με `x.into()`, επειδή `From<i8> για i16`\n"
-"υλοποίηση δημιουργεί αυτόματα μια υλοποίηση του «Into<i16> για i8»."
+"Η τυπική βιβλιοθήκη έχει μια υλοποίηση του «From\n"
+"\n"
+" για i16», που σημαίνει ότι μπορούμε να μετατρέψουμε μια μεταβλητή «x» τύπου "
+"«i8» σε «i16» καλώντας `i16::from(x)`. Ή, απλούστερα, με `x.into()`, επειδή "
+"`From<i8> για i16` υλοποίηση δημιουργεί αυτόματα μια υλοποίηση του «Into\n"
+"\n"
+" για i8»."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 #, fuzzy
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
 "Το ίδιο ισχύει και για τις δικές σας υλοποιήσεις «Από» για τους δικούς σας "
-"τύπους, έτσι είναι\n"
-"αρκεί για να εφαρμοστεί μόνο το \"From\" για να ληφθεί αυτόματα μια "
-"αντίστοιχη υλοποίηση \"Into\"."
+"τύπους, έτσι είναι αρκεί για να εφαρμοστεί μόνο το \"From\" για να ληφθεί "
+"αυτόματα μια αντίστοιχη υλοποίηση \"Into\"."
 
 #: src/exercises/day-1/implicit-conversions.md:33
 #, fuzzy
-msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+msgid "Execute the above program and look at the compiler error."
 msgstr ""
-"3. Αλλάξτε τους τύπους \"x\" και \"y\" σε άλλα πράγματα (όπως \"f32\", "
-"\"bool\",\n"
-"   `i128`) για να δείτε ποιους τύπους μπορείτε να μετατρέψετε σε ποιους "
-"άλλους τύπους. Δοκιμάστε\n"
-"   μετατροπή μικρών τύπων σε μεγάλους τύπους και το αντίστροφο. Ελεγξε το\n"
-"   [τυπική τεκμηρίωση βιβλιοθήκης][1] για να δείτε εάν το \"From<T>\" έχει "
-"εφαρμοστεί για\n"
-"   τα ζευγάρια που ελέγχετε."
+"Αλλάξτε τους τύπους \"x\" και \"y\" σε άλλα πράγματα (όπως \"f32\", "
+"\"bool\", `i128`) για να δείτε ποιους τύπους μπορείτε να μετατρέψετε σε "
+"ποιους άλλους τύπους. Δοκιμάστε μετατροπή μικρών τύπων σε μεγάλους τύπους "
+"και το αντίστροφο. Ελεγξε το [τυπική τεκμηρίωση βιβλιοθήκης](https://doc."
+"rust-lang.org/std/convert/trait.From.html) για να δείτε εάν το \"From"
+
+#: src/exercises/day-1/implicit-conversions.md:35
+#, fuzzy
+msgid "Update the code above to use `into()` to do the conversion."
+msgstr "\" έχει εφαρμοστεί για τα ζευγάρια που ελέγχετε."
+
+#: src/exercises/day-1/implicit-conversions.md:37
+msgid ""
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
+msgstr ""
 
 #: src/exercises/day-1/for-loops.md:1
+#: src/exercises/day-1/solutions-morning.md:3
 #, fuzzy
-msgid "# Arrays and `for` Loops"
-msgstr "# Πίνακες και βρόχοι «για»."
+msgid "Arrays and `for` Loops"
+msgstr "Πίνακες και βρόχοι «για»."
 
 #: src/exercises/day-1/for-loops.md:3
 #, fuzzy
@@ -3533,12 +3614,11 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:18
 #, fuzzy
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr ""
 "Το Rust σάς επιτρέπει να επαναλαμβάνετε πράγματα όπως πίνακες και εύρη "
-"χρησιμοποιώντας το \"για\".\n"
-"λέξη-κλειδί:"
+"χρησιμοποιώντας το \"για\". λέξη-κλειδί:"
 
 #: src/exercises/day-1/for-loops.md:21
 msgid ""
@@ -3564,14 +3644,12 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
 "Χρησιμοποιήστε τα παραπάνω για να γράψετε μια συνάρτηση «pretty_print» που "
-"εκτυπώνει όμορφα έναν πίνακα και\n"
-"μια συνάρτηση \"transpose\" που θα μεταφέρει έναν πίνακα (μετατρέπει τις "
-"γραμμές σε στήλες):"
+"εκτυπώνει όμορφα έναν πίνακα και μια συνάρτηση \"transpose\" που θα "
+"μεταφέρει έναν πίνακα (μετατρέπει τις γραμμές σε στήλες):"
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3591,12 +3669,11 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:49
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
 "Αντιγράψτε τον παρακάτω κώδικα στο <https://play.rust-lang.org/> και "
-"εφαρμόστε το\n"
-"λειτουργίες:"
+"εφαρμόστε το λειτουργίες:"
 
 #: src/exercises/day-1/for-loops.md:52
 msgid ""
@@ -3631,55 +3708,46 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:80
 #, fuzzy
-msgid "## Bonus Question"
-msgstr "## Ερώτηση μπόνους"
+msgid "Bonus Question"
+msgstr "Ερώτηση μπόνους"
 
 #: src/exercises/day-1/for-loops.md:82
 #, fuzzy
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"Θα μπορούσατε να χρησιμοποιήσετε φέτες \"&[i32]\" αντί για σκληρούς "
-"κωδικοποιημένους πίνακες 3 × 3 για\n"
-"όρισμα και τύποι επιστροφής; Κάτι σαν \"&[&[i32]]\" για ένα δισδιάστατο\n"
-"φέτα φέτες. Γιατί ή γιατί όχι?"
+"Θα μπορούσατε να χρησιμοποιήσετε φέτες \"&\\[i32\\]\" αντί για σκληρούς "
+"κωδικοποιημένους πίνακες 3 × 3 για όρισμα και τύποι επιστροφής; Κάτι σαν "
+"\"&\\[&\\[i32\\]\\]\" για ένα δισδιάστατο φέτα φέτες. Γιατί ή γιατί όχι?"
 
 #: src/exercises/day-1/for-loops.md:87
 #, fuzzy
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
-"Δείτε το [`ndarray` crate](https://docs.rs/ndarray/) για ποιότητα παραγωγής\n"
+"Δείτε το [`ndarray` crate](https://docs.rs/ndarray/) για ποιότητα παραγωγής "
 "εκτέλεση."
 
 #: src/exercises/day-1/for-loops.md:92
 #, fuzzy
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"Η λύση και η απάντηση στην ενότητα μπόνους είναι διαθέσιμες στο\n"
-"Ενότητα [Λύση](solutions-morning.md#arrays-and-for-loops)."
-
-#: src/basic-syntax/variables.md:1
-#, fuzzy
-msgid "# Variables"
-msgstr "# Μεταβλητές"
+"Η λύση και η απάντηση στην ενότητα μπόνους είναι διαθέσιμες στο Ενότητα "
+"[Λύση](solutions-morning.md#arrays-and-for-loops)."
 
 #: src/basic-syntax/variables.md:3
 #, fuzzy
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
+"by default:"
 msgstr ""
 "Το Rust παρέχει ασφάλεια τύπου μέσω στατικής πληκτρολόγησης. Οι δεσμεύσεις "
-"μεταβλητών είναι αμετάβλητες κατά\n"
-"Προκαθορισμένο:"
+"μεταβλητών είναι αμετάβλητες κατά Προκαθορισμένο:"
 
 #: src/basic-syntax/variables.md:6
 msgid ""
@@ -3696,21 +3764,21 @@ msgstr ""
 #: src/basic-syntax/variables.md:17
 #, fuzzy
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
+msgstr ""
+"Λόγω συμπερασμάτων τύπου, το «i32» είναι προαιρετικό. Σταδιακά θα δείχνουμε "
+"τους τύπους όλο και λιγότερο όσο προχωρά ο τύπος."
+
+#: src/basic-syntax/variables.md:18
+#, fuzzy
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
 "function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
-"* Λόγω συμπερασμάτων τύπου, το «i32» είναι προαιρετικό. Σταδιακά θα "
-"δείχνουμε τους τύπους όλο και λιγότερο όσο προχωρά ο τύπος.\n"
-"* Σημειώστε ότι επειδή το \"println!\" είναι μακροεντολή, το \"x\" δεν "
+"Σημειώστε ότι επειδή το \"println!\" είναι μακροεντολή, το \"x\" δεν "
 "μετακινείται, ακόμη και χρησιμοποιώντας τη συνάρτηση όπως η σύνταξη του "
 "\"println!(\"x: {}\", x)\""
-
-#: src/basic-syntax/type-inference.md:1
-#, fuzzy
-msgid "# Type Inference"
-msgstr "# Τύπος Συμπερασματικά"
 
 #: src/basic-syntax/type-inference.md:3
 #, fuzzy
@@ -3751,20 +3819,20 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 "Αυτή η διαφάνεια δείχνει πώς ο μεταγλωττιστής Rust συμπεραίνει τύπους με "
 "βάση περιορισμούς που δίνονται από δηλώσεις και χρήσεις μεταβλητών.\n"
-"    \n"
+"\n"
 "Είναι πολύ σημαντικό να τονίσουμε ότι οι μεταβλητές που δηλώνονται όπως αυτή "
-"δεν είναι κάποιου είδους δυναμικού \"οποιουδήποτε τύπου\" που μπορεί\n"
+"δεν είναι κάποιου είδους δυναμικού \"οποιουδήποτε τύπου\" που μπορεί "
 "κρατήστε τυχόν δεδομένα. Ο κωδικός μηχανής που δημιουργείται από μια τέτοια "
-"δήλωση είναι πανομοιότυπος με τη ρητή δήλωση ενός τύπου.\n"
-"Ο μεταγλωττιστής κάνει τη δουλειά για εμάς και μας βοηθά να γράψουμε έναν "
-"πιο συνοπτικό κώδικα."
+"δήλωση είναι πανομοιότυπος με τη ρητή δήλωση ενός τύπου. Ο μεταγλωττιστής "
+"κάνει τη δουλειά για εμάς και μας βοηθά να γράψουμε έναν πιο συνοπτικό "
+"κώδικα."
 
 #: src/basic-syntax/type-inference.md:32
 #, fuzzy
@@ -3775,7 +3843,7 @@ msgid ""
 msgstr ""
 "Ο ακόλουθος κώδικας λέει στον μεταγλωττιστή να αντιγράψει σε ένα "
 "συγκεκριμένο γενικό κοντέινερ χωρίς ποτέ ο κώδικας να προσδιορίζει ρητά τον "
-"τύπο που περιέχεται, χρησιμοποιώντας το «_» ως σύμβολο κράτησης θέσης:"
+"τύπο που περιέχεται, χρησιμοποιώντας το «\\_» ως σύμβολο κράτησης θέσης:"
 
 #: src/basic-syntax/type-inference.md:34
 msgid ""
@@ -3800,13 +3868,13 @@ msgid ""
 "rust-lang.org/std/iter/trait.FromIterator.html) implements."
 msgstr ""
 "Το [`collect`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator."
-"html#method.collect) βασίζεται στο `FromIterator`, το οποίο [`HashSet`]"
+"html#method.collect) βασίζεται στο `FromIterator`, το οποίο \\[`HashSet`\\]"
 "(https:/ /doc.rust-lang.org/std/iter/trait.FromIterator.html) υλοποιεί."
 
 #: src/basic-syntax/static-and-const.md:1
 #, fuzzy
-msgid "# Static and Constant Variables"
-msgstr "# Στατικές και σταθερές μεταβλητές"
+msgid "Static and Constant Variables"
+msgstr "Στατικές και σταθερές μεταβλητές"
 
 #: src/basic-syntax/static-and-const.md:3
 #, fuzzy
@@ -3817,8 +3885,8 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:5
 #, fuzzy
-msgid "## `const`"
-msgstr "## «const»."
+msgid "`const`"
+msgstr "«const»."
 
 #: src/basic-syntax/static-and-const.md:7
 #, fuzzy
@@ -3849,13 +3917,17 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:27
 #, fuzzy
-msgid "According the the [Rust RFC Book][1] these are inlined upon use."
-msgstr "Σύμφωνα με το [Rust RFC Book][1], αυτά ενσωματώνονται κατά τη χρήση."
+msgid ""
+"According the the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-"
+"const-vs-static.html) these are inlined upon use."
+msgstr ""
+"Σύμφωνα με το [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-"
+"static.html), αυτά ενσωματώνονται κατά τη χρήση."
 
 #: src/basic-syntax/static-and-const.md:29
 #, fuzzy
-msgid "## `static`"
-msgstr "## «στατικό»."
+msgid "`static`"
+msgstr "«στατικό»."
 
 #: src/basic-syntax/static-and-const.md:31
 #, fuzzy
@@ -3876,15 +3948,16 @@ msgstr ""
 #: src/basic-syntax/static-and-const.md:41
 #, fuzzy
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
-"Όπως σημειώνεται στο [Rust RFC Book][1], αυτά δεν είναι ενσωματωμένα κατά τη "
-"χρήση και έχουν μια πραγματική συσχετισμένη θέση μνήμης. Αυτό είναι χρήσιμο "
-"για μη ασφαλή και ενσωματωμένο κώδικα και η μεταβλητή ζει σε όλη την "
-"εκτέλεση του προγράμματος."
+"Όπως σημειώνεται στο [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-"
+"const-vs-static.html), αυτά δεν είναι ενσωματωμένα κατά τη χρήση και έχουν "
+"μια πραγματική συσχετισμένη θέση μνήμης. Αυτό είναι χρήσιμο για μη ασφαλή "
+"και ενσωματωμένο κώδικα και η μεταβλητή ζει σε όλη την εκτέλεση του "
+"προγράμματος."
 
 #: src/basic-syntax/static-and-const.md:44
 #, fuzzy
@@ -3892,40 +3965,42 @@ msgid ""
 "We will look at mutating static data in the [chapter on Unsafe Rust](../"
 "unsafe.md)."
 msgstr ""
-"Θα εξετάσουμε τη μετάλλαξη στατικών δεδομένων στο [κεφάλαιο για την Μη "
-"ασφαλή σκουριά] (../unsafe.md)."
+"Θα εξετάσουμε τη μετάλλαξη στατικών δεδομένων στο \\[κεφάλαιο για την Μη "
+"ασφαλή σκουριά\\] (../unsafe.md)."
 
 #: src/basic-syntax/static-and-const.md:48
 #, fuzzy
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
-"* Αναφέρετε ότι το «const» συμπεριφέρεται σημασιολογικά παρόμοια με το "
-"«constexpr» της C++.\n"
-"* Το «static», από την άλλη πλευρά, μοιάζει πολύ περισσότερο με μια «const» "
-"ή μεταβλητή καθολική μεταβλητή στη C++.\n"
-"* Δεν είναι πολύ συνηθισμένο να χρειάζεται κάποιος μια σταθερά αξιολόγησης "
-"χρόνου εκτέλεσης, αλλά είναι χρήσιμο και ασφαλέστερο από τη χρήση στατικού."
+"Αναφέρετε ότι το «const» συμπεριφέρεται σημασιολογικά παρόμοια με το "
+"«constexpr» της C++."
 
-#: src/basic-syntax/scopes-shadowing.md:1
+#: src/basic-syntax/static-and-const.md:49
 #, fuzzy
-msgid "# Scopes and Shadowing"
-msgstr "# Πεδίο εφαρμογής και σκίαση"
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+"Το «static», από την άλλη πλευρά, μοιάζει πολύ περισσότερο με μια «const» ή "
+"μεταβλητή καθολική μεταβλητή στη C++."
+
+#: src/basic-syntax/static-and-const.md:50
+#, fuzzy
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+"Δεν είναι πολύ συνηθισμένο να χρειάζεται κάποιος μια σταθερά αξιολόγησης "
+"χρόνου εκτέλεσης, αλλά είναι χρήσιμο και ασφαλέστερο από τη χρήση στατικού."
 
 #: src/basic-syntax/scopes-shadowing.md:3
 #, fuzzy
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
+"the same scope:"
 msgstr ""
 "Μπορείτε να σκιάζετε μεταβλητές, τόσο αυτές από εξωτερικά πεδία όσο και "
-"μεταβλητές από το\n"
-"ίδιο εύρος:"
+"μεταβλητές από το ίδιο εύρος:"
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
@@ -3950,24 +4025,37 @@ msgstr ""
 #: src/basic-syntax/scopes-shadowing.md:25
 #, fuzzy
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"Ορισμός: Η σκίαση είναι διαφορετική από τη μετάλλαξη, γιατί μετά τη σκίαση "
+"υπάρχουν και οι δύο θέσεις μνήμης της μεταβλητής ταυτόχρονα. Και τα δύο "
+"είναι διαθέσιμα με το ίδιο όνομα, ανάλογα με το πού το χρησιμοποιείτε στον "
+"κωδικό."
+
+#: src/basic-syntax/scopes-shadowing.md:26
+#, fuzzy
+msgid "A shadowing variable can have a different type. "
+msgstr "Μια μεταβλητή σκίασης μπορεί να έχει διαφορετικό τύπο."
+
+#: src/basic-syntax/scopes-shadowing.md:27
+#, fuzzy
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+"Η σκίαση φαίνεται ασαφής στην αρχή, αλλά είναι βολική για να κρατάτε τις "
+"τιμές μετά το «.unwrap()»."
+
+#: src/basic-syntax/scopes-shadowing.md:28
+#, fuzzy
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
-"* Ορισμός: Η σκίαση είναι διαφορετική από τη μετάλλαξη, γιατί μετά τη σκίαση "
-"υπάρχουν και οι δύο θέσεις μνήμης της μεταβλητής ταυτόχρονα. Και τα δύο "
-"είναι διαθέσιμα με το ίδιο όνομα, ανάλογα με το πού το χρησιμοποιείτε στον "
-"κωδικό.\n"
-"* Μια μεταβλητή σκίασης μπορεί να έχει διαφορετικό τύπο.\n"
-"* Η σκίαση φαίνεται ασαφής στην αρχή, αλλά είναι βολική για να κρατάτε τις "
-"τιμές μετά το «.unwrap()».\n"
-"* Ο ακόλουθος κώδικας δείχνει γιατί ο μεταγλωττιστής δεν μπορεί απλώς να "
+"Ο ακόλουθος κώδικας δείχνει γιατί ο μεταγλωττιστής δεν μπορεί απλώς να "
 "επαναχρησιμοποιήσει θέσεις μνήμης όταν σκιάζει μια αμετάβλητη μεταβλητή σε "
 "ένα εύρος, ακόμα κι αν ο τύπος δεν αλλάξει."
 
@@ -3983,11 +4071,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-#, fuzzy
-msgid "# Memory Management"
-msgstr "# Διαχείριση μνήμης"
-
 #: src/memory-management.md:3
 #, fuzzy
 msgid "Traditionally, languages have fallen into two broad categories:"
@@ -3995,13 +4078,17 @@ msgstr "Παραδοσιακά, οι γλώσσες χωρίζονται σε δ
 
 #: src/memory-management.md:5
 #, fuzzy
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr ""
+"Πλήρης έλεγχος μέσω χειροκίνητης διαχείρισης μνήμης: C, C++, Pascal, ..."
+
+#: src/memory-management.md:6
+#, fuzzy
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
-"* Πλήρης έλεγχος μέσω χειροκίνητης διαχείρισης μνήμης: C, C++, Pascal, ...\n"
-"* Πλήρης ασφάλεια μέσω αυτόματης διαχείρισης μνήμης κατά την εκτέλεση: Java, "
+"Πλήρης ασφάλεια μέσω αυτόματης διαχείρισης μνήμης κατά την εκτέλεση: Java, "
 "Python, Go, Haskell, ..."
 
 #: src/memory-management.md:8
@@ -4012,12 +4099,11 @@ msgstr "Η Rust προσφέρει ένα νέο μείγμα:"
 #: src/memory-management.md:10
 #, fuzzy
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
-"> Πλήρης έλεγχος *και* ασφάλεια μέσω επιβολής χρόνου μεταγλώττισης της "
-"σωστής μνήμης\n"
-"> διαχείριση."
+"Πλήρης έλεγχος _και_ ασφάλεια μέσω επιβολής χρόνου μεταγλώττισης της σωστής "
+"μνήμης διαχείριση."
 
 #: src/memory-management.md:13
 #, fuzzy
@@ -4031,44 +4117,58 @@ msgstr "Αρχικά, ας ανανεώσουμε τον τρόπο λειτου
 
 #: src/memory-management/stack-vs-heap.md:1
 #, fuzzy
-msgid "# The Stack vs The Heap"
-msgstr "# The Stack vs The Heap"
+msgid "The Stack vs The Heap"
+msgstr "The Stack vs The Heap"
 
 #: src/memory-management/stack-vs-heap.md:3
 #, fuzzy
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* Στοίβα: Συνεχής περιοχή μνήμης για τοπικές μεταβλητές.\n"
-"  * Οι τιμές έχουν σταθερά μεγέθη γνωστά κατά το χρόνο μεταγλώττισης.\n"
-"  * Εξαιρετικά γρήγορο: απλώς μετακινήστε έναν δείκτη στοίβας.\n"
-"  * Εύκολο στη διαχείριση: ακολουθεί κλήσεις λειτουργιών.\n"
-"  * Μεγάλη τοποθεσία μνήμης."
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "Στοίβα: Συνεχής περιοχή μνήμης για τοπικές μεταβλητές."
 
-#: src/memory-management/stack.md:1
+#: src/memory-management/stack-vs-heap.md:4
 #, fuzzy
-msgid "# Stack Memory"
-msgstr "# Στοίβα Μνήμη"
+msgid "Values have fixed sizes known at compile time."
+msgstr "Οι τιμές έχουν σταθερά μεγέθη γνωστά κατά το χρόνο μεταγλώττισης."
+
+#: src/memory-management/stack-vs-heap.md:5
+#, fuzzy
+msgid "Extremely fast: just move a stack pointer."
+msgstr "Εξαιρετικά γρήγορο: απλώς μετακινήστε έναν δείκτη στοίβας."
+
+#: src/memory-management/stack-vs-heap.md:6
+#, fuzzy
+msgid "Easy to manage: follows function calls."
+msgstr "Εύκολο στη διαχείριση: ακολουθεί κλήσεις λειτουργιών."
+
+#: src/memory-management/stack-vs-heap.md:7
+#, fuzzy
+msgid "Great memory locality."
+msgstr "Μεγάλη τοποθεσία μνήμης."
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr ""
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr ""
 
 #: src/memory-management/stack.md:3
 #, fuzzy
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 "Η δημιουργία ενός \"String\" τοποθετεί δεδομένα σταθερού μεγέθους στη στοίβα "
-"και δυναμικά μεγέθη\n"
-"δεδομένα για το σωρό:"
+"και δυναμικά μεγέθη δεδομένα για το σωρό:"
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -4098,39 +4198,43 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/manual.md:1
-#, fuzzy
-msgid "# Manual Memory Management"
-msgstr "# Χειροκίνητη διαχείριση μνήμης"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/memory-management/manual.md:3
 #, fuzzy
@@ -4148,8 +4252,8 @@ msgstr ""
 
 #: src/memory-management/manual.md:7
 #, fuzzy
-msgid "## C Example"
-msgstr "## Γ Παράδειγμα"
+msgid "C Example"
+msgstr "Γ Παράδειγμα"
 
 #: src/memory-management/manual.md:9
 #, fuzzy
@@ -4174,17 +4278,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
 "Η μνήμη διαρρέει εάν η συνάρτηση επιστρέψει νωρίς μεταξύ \"malloc\" και "
-"\"free\": το\n"
-"Ο δείκτης χάνεται και δεν μπορούμε να εκχωρήσουμε τη μνήμη."
-
-#: src/memory-management/scope-based.md:1
-#, fuzzy
-msgid "# Scope-Based Memory Management"
-msgstr "# Διαχείριση μνήμης βάσει εύρους"
+"\"free\": το Ο δείκτης χάνεται και δεν μπορούμε να εκχωρήσουμε τη μνήμη."
 
 #: src/memory-management/scope-based.md:3
 #, fuzzy
@@ -4197,31 +4294,27 @@ msgstr ""
 #: src/memory-management/scope-based.md:5
 #, fuzzy
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
 "Τυλίγοντας έναν δείκτη σε ένα αντικείμενο, μπορείτε να ελευθερώσετε μνήμη "
-"όταν το αντικείμενο βρίσκεται\n"
-"καταστράφηκε από. Ο μεταγλωττιστής εγγυάται ότι αυτό συμβαίνει, ακόμα κι αν "
-"υπάρχει εξαίρεση\n"
-"ανυψώθηκε."
+"όταν το αντικείμενο βρίσκεται καταστράφηκε από. Ο μεταγλωττιστής εγγυάται "
+"ότι αυτό συμβαίνει, ακόμα κι αν υπάρχει εξαίρεση ανυψώθηκε."
 
 #: src/memory-management/scope-based.md:9
 #, fuzzy
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr ""
-"Αυτό συχνά ονομάζεται _απόκτηση πόρων είναι αρχικοποίηση_ (RAII) και δίνει\n"
+"Αυτό συχνά ονομάζεται _απόκτηση πόρων είναι αρχικοποίηση_ (RAII) και δίνει "
 "έξυπνοι δείκτες."
 
 #: src/memory-management/scope-based.md:12
 #, fuzzy
-msgid "## C++ Example"
-msgstr "## Παράδειγμα C++"
+msgid "C++ Example"
+msgstr "Παράδειγμα C++"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -4235,16 +4328,22 @@ msgstr ""
 #: src/memory-management/scope-based.md:20
 #, fuzzy
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
 msgstr ""
-"* Το αντικείμενο `std::unique_ptr` εκχωρείται στη στοίβα και δείχνει σε\n"
-"  μνήμη που εκχωρείται στο σωρό.\n"
-"* Στο τέλος του «say_hello», θα εκτελεστεί ο καταστροφέας «std::"
-"unique_ptr».\n"
-"* Ο καταστροφέας ελευθερώνει το αντικείμενο «Person» στο οποίο δείχνει."
+"Το αντικείμενο `std::unique_ptr` εκχωρείται στη στοίβα και δείχνει σε μνήμη "
+"που εκχωρείται στο σωρό."
+
+#: src/memory-management/scope-based.md:22
+#, fuzzy
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr ""
+"Στο τέλος του «say_hello», θα εκτελεστεί ο καταστροφέας «std::unique_ptr»."
+
+#: src/memory-management/scope-based.md:23
+#, fuzzy
+msgid "The destructor frees the `Person` object it points to."
+msgstr "Ο καταστροφέας ελευθερώνει το αντικείμενο «Person» στο οποίο δείχνει."
 
 #: src/memory-management/scope-based.md:25
 #, fuzzy
@@ -4264,35 +4363,36 @@ msgstr ""
 
 #: src/memory-management/garbage-collection.md:1
 #, fuzzy
-msgid "# Automatic Memory Management"
-msgstr "# Αυτόματη διαχείριση μνήμης"
+msgid "Automatic Memory Management"
+msgstr "Αυτόματη διαχείριση μνήμης"
 
 #: src/memory-management/garbage-collection.md:3
 #, fuzzy
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
+"memory management:"
 msgstr ""
 "Μια εναλλακτική λύση στη χειροκίνητη διαχείριση μνήμης και τη διαχείριση "
-"μνήμης βάσει εύρους είναι η αυτόματη μνήμη\n"
-"διαχείριση:"
+"μνήμης βάσει εύρους είναι η αυτόματη μνήμη διαχείριση:"
 
 #: src/memory-management/garbage-collection.md:6
 #, fuzzy
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr "Ο προγραμματιστής ποτέ δεν εκχωρεί ή εκχωρεί μνήμη ρητά."
+
+#: src/memory-management/garbage-collection.md:7
+#, fuzzy
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
 msgstr ""
-"* Ο προγραμματιστής ποτέ δεν εκχωρεί ή εκχωρεί μνήμη ρητά.\n"
-"* Ένας συλλέκτης σκουπιδιών βρίσκει αχρησιμοποίητη μνήμη και την εκχωρεί "
-"στον προγραμματιστή."
+"Ένας συλλέκτης σκουπιδιών βρίσκει αχρησιμοποίητη μνήμη και την εκχωρεί στον "
+"προγραμματιστή."
 
 #: src/memory-management/garbage-collection.md:9
 #, fuzzy
-msgid "## Java Example"
-msgstr "## Παράδειγμα Java"
+msgid "Java Example"
+msgstr "Παράδειγμα Java"
 
 #: src/memory-management/garbage-collection.md:11
 #, fuzzy
@@ -4311,8 +4411,8 @@ msgstr ""
 
 #: src/memory-management/rust.md:1
 #, fuzzy
-msgid "# Memory Management in Rust"
-msgstr "# Διαχείριση μνήμης σε Rust"
+msgid "Memory Management in Rust"
+msgstr "Διαχείριση μνήμης σε Rust"
 
 #: src/memory-management/rust.md:3
 #, fuzzy
@@ -4321,22 +4421,34 @@ msgstr "Η διαχείριση μνήμης στο Rust είναι ένας σ�
 
 #: src/memory-management/rust.md:5
 #, fuzzy
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "Ασφαλές και σωστό όπως η Java, αλλά χωρίς σκουπιδοσυλλέκτη."
+
+#: src/memory-management/rust.md:6
+#, fuzzy
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+"Ανάλογα με το ποια αφαίρεση (ή συνδυασμό αφαιρέσεων) επιλέγετε, μπορεί να "
+"είναι ένας μοναδικός δείκτης, να μετράται η αναφορά ή να μετράται ατομικά η "
+"αναφορά."
+
+#: src/memory-management/rust.md:7
+#, fuzzy
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+"Βασίζεται στο πεδίο εφαρμογής όπως η C++, αλλά ο μεταγλωττιστής επιβάλλει "
+"την πλήρη συμμόρφωση."
+
+#: src/memory-management/rust.md:8
+#, fuzzy
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
-"* Ασφαλές και σωστό όπως η Java, αλλά χωρίς σκουπιδοσυλλέκτη.\n"
-"* Ανάλογα με το ποια αφαίρεση (ή συνδυασμό αφαιρέσεων) επιλέγετε, μπορεί να "
-"είναι ένας μοναδικός δείκτης, να μετράται η αναφορά ή να μετράται ατομικά η "
-"αναφορά.\n"
-"* Βασίζεται στο πεδίο εφαρμογής όπως η C++, αλλά ο μεταγλωττιστής επιβάλλει "
-"την πλήρη συμμόρφωση.\n"
-"* Ένας χρήστης του Rust μπορεί να επιλέξει τη σωστή αφαίρεση για την "
+"Ένας χρήστης του Rust μπορεί να επιλέξει τη σωστή αφαίρεση για την "
 "κατάσταση, μερικοί μάλιστα δεν έχουν κόστος κατά τη διάρκεια εκτέλεσης όπως "
 "το C."
 
@@ -4348,23 +4460,27 @@ msgstr "Αυτό το επιτυγχάνει διαμορφώνοντας ρητ
 #: src/memory-management/rust.md:14
 #, fuzzy
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* Εάν ρωτήσετε πώς σε αυτό το σημείο, μπορείτε να αναφέρετε ότι στο Rust "
-"αυτό συνήθως αντιμετωπίζεται από τύπους περιτυλίγματος RAII όπως [Box], "
-"[Vec], [Rc] ή [Arc]. Αυτά ενσωματώνουν την ιδιοκτησία και την εκχώρηση "
-"μνήμης με διάφορα μέσα και αποτρέπουν τα πιθανά σφάλματα στο C."
+"Εάν ρωτήσετε πώς σε αυτό το σημείο, μπορείτε να αναφέρετε ότι στο Rust αυτό "
+"συνήθως αντιμετωπίζεται από τύπους περιτυλίγματος RAII όπως [Box](https://"
+"doc.rust-lang.org/std/boxed/struct.Box.html), [Vec](https://doc.rust-lang."
+"org/std/vec/struct.Vec.html), [Rc](https://doc.rust-lang.org/std/rc/struct."
+"Rc.html) ή [Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html). Αυτά "
+"ενσωματώνουν την ιδιοκτησία και την εκχώρηση μνήμης με διάφορα μέσα και "
+"αποτρέπουν τα πιθανά σφάλματα στο C."
 
-#: src/memory-management/comparison.md:1
-#, fuzzy
-msgid "# Comparison"
-msgstr "# Σύγκριση"
+#: src/memory-management/rust.md:16
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
+msgstr ""
 
 #: src/memory-management/comparison.md:3
 #, fuzzy
@@ -4373,89 +4489,120 @@ msgstr "Ακολουθεί μια πρόχειρη σύγκριση των τε�
 
 #: src/memory-management/comparison.md:5
 #, fuzzy
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## Πλεονεκτήματα Διαφορετικών Τεχνικών Διαχείρισης Μνήμης"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "Πλεονεκτήματα Διαφορετικών Τεχνικών Διαχείρισης Μνήμης"
 
-#: src/memory-management/comparison.md:7
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* Εγχειρίδιο όπως C:\n"
-"  * Χωρίς επιβάρυνση χρόνου εκτέλεσης.\n"
-"* Αυτόματο όπως Java:\n"
-"  * Εντελώς αυτόματο.\n"
-"  * Ασφαλές και σωστό.\n"
-"* Βασισμένο σε πεδίο εφαρμογής όπως η C++:\n"
-"  * Μερικώς αυτόματο.\n"
-"  * Χωρίς επιβάρυνση χρόνου εκτέλεσης.\n"
-"* Βασισμένο σε εύρος με επιβολή μεταγλωττιστή όπως το Rust:\n"
-"  * Επιβάλλεται από τον μεταγλωττιστή.\n"
-"  * Χωρίς επιβάρυνση χρόνου εκτέλεσης.\n"
-"  * Ασφαλές και σωστό."
+msgid "Manual like C:"
+msgstr "Εγχειρίδιο όπως C:"
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+#, fuzzy
+msgid "No runtime overhead."
+msgstr "Χωρίς επιβάρυνση χρόνου εκτέλεσης."
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+#, fuzzy
+msgid "Automatic like Java:"
+msgstr "Αυτόματο όπως Java:"
+
+#: src/memory-management/comparison.md:10
+#, fuzzy
+msgid "Fully automatic."
+msgstr "Εντελώς αυτόματο."
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+#, fuzzy
+msgid "Safe and correct."
+msgstr "Ασφαλές και σωστό."
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+#, fuzzy
+msgid "Scope-based like C++:"
+msgstr "Βασισμένο σε πεδίο εφαρμογής όπως η C++:"
+
+#: src/memory-management/comparison.md:13
+#, fuzzy
+msgid "Partially automatic."
+msgstr "Μερικώς αυτόματο."
+
+#: src/memory-management/comparison.md:15
+#, fuzzy
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "Βασισμένο σε εύρος με επιβολή μεταγλωττιστή όπως το Rust:"
+
+#: src/memory-management/comparison.md:16
+#, fuzzy
+msgid "Enforced by compiler."
+msgstr "Επιβάλλεται από τον μεταγλωττιστή."
 
 #: src/memory-management/comparison.md:20
 #, fuzzy
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## Μειονεκτήματα των διαφορετικών τεχνικών διαχείρισης μνήμης"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "Μειονεκτήματα των διαφορετικών τεχνικών διαχείρισης μνήμης"
 
-#: src/memory-management/comparison.md:22
+#: src/memory-management/comparison.md:23
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* Εγχειρίδιο όπως C:\n"
-"  * Χρήση-μετά-δωρεάν.\n"
-"  * Διπλό δωρεάν.\n"
-"  * Διαρροές μνήμης.\n"
-"* Αυτόματο όπως Java:\n"
-"  * Παύσεις αποκομιδής σκουπιδιών.\n"
-"  * Καθυστερήσεις καταστροφέων.\n"
-"* Βασισμένο σε πεδίο εφαρμογής όπως η C++:\n"
-"  * Σύνθετο, συμμετοχή από προγραμματιστή.\n"
-"  * Δυνατότητα χρήσης-μετά-δωρεάν.\n"
-"* Επιβάλλεται από μεταγλωττιστή και βασίζεται σε εύρος όπως το Rust:\n"
-"  * Κάποια εκ των προτέρων πολυπλοκότητα.\n"
-"  * Μπορεί να απορρίψει έγκυρα προγράμματα."
+msgid "Use-after-free."
+msgstr "Χρήση-μετά-δωρεάν."
 
-#: src/ownership.md:1
+#: src/memory-management/comparison.md:24
 #, fuzzy
-msgid "# Ownership"
-msgstr "# Ιδιοκτησία"
+msgid "Double-frees."
+msgstr "Διπλό δωρεάν."
+
+#: src/memory-management/comparison.md:25
+#, fuzzy
+msgid "Memory leaks."
+msgstr "Διαρροές μνήμης."
+
+#: src/memory-management/comparison.md:27
+#, fuzzy
+msgid "Garbage collection pauses."
+msgstr "Παύσεις αποκομιδής σκουπιδιών."
+
+#: src/memory-management/comparison.md:28
+#, fuzzy
+msgid "Destructor delays."
+msgstr "Καθυστερήσεις καταστροφέων."
+
+#: src/memory-management/comparison.md:30
+#, fuzzy
+msgid "Complex, opt-in by programmer."
+msgstr "Σύνθετο, συμμετοχή από προγραμματιστή."
+
+#: src/memory-management/comparison.md:31
+#, fuzzy
+msgid "Potential for use-after-free."
+msgstr "Δυνατότητα χρήσης-μετά-δωρεάν."
+
+#: src/memory-management/comparison.md:32
+#, fuzzy
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "Επιβάλλεται από μεταγλωττιστή και βασίζεται σε εύρος όπως το Rust:"
+
+#: src/memory-management/comparison.md:33
+#, fuzzy
+msgid "Some upfront complexity."
+msgstr "Κάποια εκ των προτέρων πολυπλοκότητα."
+
+#: src/memory-management/comparison.md:34
+#, fuzzy
+msgid "Can reject valid programs."
+msgstr "Μπορεί να απορρίψει έγκυρα προγράμματα."
 
 #: src/ownership.md:3
 #, fuzzy
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
+"to use a variable outside its scope:"
 msgstr ""
 "Όλες οι δεσμεύσεις μεταβλητών έχουν _scope_ όπου είναι έγκυρες και είναι "
-"σφάλμα\n"
-"χρησιμοποιήστε μια μεταβλητή εκτός του πεδίου εφαρμογής της:"
+"σφάλμα χρησιμοποιήστε μια μεταβλητή εκτός του πεδίου εφαρμογής της:"
 
 #: src/ownership.md:6
 msgid ""
@@ -4475,19 +4622,19 @@ msgstr ""
 #: src/ownership.md:18
 #, fuzzy
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr ""
-"* Στο τέλος του εύρους, η μεταβλητή _αποτέθηκε_ και τα δεδομένα "
-"ελευθερώνονται.\n"
-"* Ένας καταστροφέας μπορεί να τρέξει εδώ για να ελευθερώσει πόρους.\n"
-"* Λέμε ότι η μεταβλητή _κατέχει_ την τιμή."
+"Στο τέλος του εύρους, η μεταβλητή _αποτέθηκε_ και τα δεδομένα ελευθερώνονται."
 
-#: src/ownership/move-semantics.md:1
+#: src/ownership.md:19
 #, fuzzy
-msgid "# Move Semantics"
-msgstr "# Move Semantics"
+msgid "A destructor can run here to free up resources."
+msgstr "Ένας καταστροφέας μπορεί να τρέξει εδώ για να ελευθερώσει πόρους."
+
+#: src/ownership.md:20
+#, fuzzy
+msgid "We say that the variable _owns_ the value."
+msgstr "Λέμε ότι η μεταβλητή _κατέχει_ την τιμή."
 
 #: src/ownership/move-semantics.md:3
 #, fuzzy
@@ -4508,38 +4655,47 @@ msgstr ""
 
 #: src/ownership/move-semantics.md:14
 #, fuzzy
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "Η εκχώρηση του `s1` στο `s2` μεταβιβάζει την ιδιοκτησία."
+
+#: src/ownership/move-semantics.md:15
+#, fuzzy
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
 msgstr ""
-"* Η εκχώρηση του `s1` στο `s2` μεταβιβάζει την ιδιοκτησία.\n"
-"* Τα δεδομένα _μετακινήθηκαν_ από το `s1` και το `s1` δεν είναι πλέον "
-"προσβάσιμο.\n"
-"* Όταν το `s1` βγαίνει εκτός πεδίου εφαρμογής, δεν συμβαίνει τίποτα: δεν "
-"έχει ιδιοκτησία.\n"
-"* Όταν το `s2` βγαίνει εκτός εύρους, τα δεδομένα συμβολοσειράς "
-"ελευθερώνονται.\n"
-"* Υπάρχει πάντα _exactly_ μία δέσμευση μεταβλητής που κατέχει μια τιμή."
+"Τα δεδομένα _μετακινήθηκαν_ από το `s1` και το `s1` δεν είναι πλέον "
+"προσβάσιμο."
+
+#: src/ownership/move-semantics.md:16
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr ""
+"Όταν το `s1` βγαίνει εκτός πεδίου εφαρμογής, δεν συμβαίνει τίποτα: δεν έχει "
+"ιδιοκτησία."
+
+#: src/ownership/move-semantics.md:17
+#, fuzzy
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr ""
+"Όταν το `s2` βγαίνει εκτός εύρους, τα δεδομένα συμβολοσειράς ελευθερώνονται."
+
+#: src/ownership/move-semantics.md:18
+#, fuzzy
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr "Υπάρχει πάντα _exactly_ μία δέσμευση μεταβλητής που κατέχει μια τιμή."
 
 #: src/ownership/move-semantics.md:22
 #, fuzzy
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* Αναφέρετε ότι αυτό είναι το αντίθετο από τις προεπιλογές της C++, η οποία "
+"Αναφέρετε ότι αυτό είναι το αντίθετο από τις προεπιλογές της C++, η οποία "
 "αντιγράφει με βάση την τιμή, εκτός και αν χρησιμοποιήσετε το `std::move` "
 "(και ορίζεται ο κατασκευαστής κίνησης!)."
 
-#: src/ownership/moved-strings-rust.md:1
-#, fuzzy
-msgid "# Moved Strings in Rust"
-msgstr "# Μετακινήθηκαν χορδές σε σκουριά"
+#: src/ownership/move-semantics.md:24
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr ""
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4553,12 +4709,14 @@ msgstr ""
 
 #: src/ownership/moved-strings-rust.md:10
 #, fuzzy
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "Τα δεδομένα σωρού από το `s1` επαναχρησιμοποιούνται για το `s2`."
+
+#: src/ownership/moved-strings-rust.md:11
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
 msgstr ""
-"* Τα δεδομένα σωρού από το `s1` επαναχρησιμοποιούνται για το `s2`.\n"
-"* Όταν το `s1` βγαίνει εκτός πεδίου εφαρμογής, δεν συμβαίνει τίποτα (έχει "
+"Όταν το `s1` βγαίνει εκτός πεδίου εφαρμογής, δεν συμβαίνει τίποτα (έχει "
 "μετακινηθεί από)."
 
 #: src/ownership/moved-strings-rust.md:13
@@ -4613,11 +4771,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:1
-#, fuzzy
-msgid "# Double Frees in Modern C++"
-msgstr "# Double Frees στη σύγχρονη C++"
-
 #: src/ownership/double-free-modern-cpp.md:3
 #, fuzzy
 msgid "Modern C++ solves this differently:"
@@ -4634,13 +4787,16 @@ msgstr ""
 #: src/ownership/double-free-modern-cpp.md:10
 #, fuzzy
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
-"* Τα δεδομένα σωρού από το `s1` είναι διπλά και το `s2` αποκτά το δικό του "
-"ανεξάρτητο αντίγραφο.\n"
-"* Όταν τα «s1» και «s2» βγαίνουν εκτός πεδίου εφαρμογής, το καθένα "
+"Τα δεδομένα σωρού από το `s1` είναι διπλά και το `s2` αποκτά το δικό του "
+"ανεξάρτητο αντίγραφο."
+
+#: src/ownership/double-free-modern-cpp.md:11
+#, fuzzy
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"Όταν τα «s1» και «s2» βγαίνουν εκτός πεδίου εφαρμογής, το καθένα "
 "απελευθερώνει τη δική του μνήμη."
 
 #: src/ownership/double-free-modern-cpp.md:13
@@ -4694,19 +4850,13 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:1
-#, fuzzy
-msgid "# Moves in Function Calls"
-msgstr "# Κινήσεις σε κλήσεις συναρτήσεων"
-
 #: src/ownership/moves-function-calls.md:3
 #, fuzzy
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
-"Όταν μεταβιβάζετε μια τιμή σε μια συνάρτηση, η τιμή εκχωρείται στη "
-"συνάρτηση\n"
+"Όταν μεταβιβάζετε μια τιμή σε μια συνάρτηση, η τιμή εκχωρείται στη συνάρτηση "
 "παράμετρος. Αυτό μεταβιβάζει την ιδιοκτησία:"
 
 #: src/ownership/moves-function-calls.md:6
@@ -4727,36 +4877,50 @@ msgstr ""
 #: src/ownership/moves-function-calls.md:20
 #, fuzzy
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* Με την πρώτη κλήση στο \"say_hello\", ο \"main\" παραιτείται από την "
+"Με την πρώτη κλήση στο \"say_hello\", ο \"main\" παραιτείται από την "
 "ιδιοκτησία του \"name\". Στη συνέχεια, το \"όνομα\" δεν μπορεί να "
-"χρησιμοποιηθεί πλέον στο \"κύριο\".\n"
-"* Η μνήμη σωρού που έχει εκχωρηθεί για το \"όνομα\" θα ελευθερωθεί στο τέλος "
-"της συνάρτησης \"say_hello\".\n"
-"* Το \"main\" μπορεί να διατηρήσει την ιδιοκτησία εάν μεταβιβάσει το "
-"\"name\" ως αναφορά (\"&name\") και εάν το \"say_hello\" αποδεχτεί μια "
-"αναφορά ως παράμετρο.\n"
-"* Εναλλακτικά, το \"main\" μπορεί να περάσει έναν κλώνο του \"name\" στην "
-"πρώτη κλήση (\"name.clone()\").\n"
-"* Το Rust καθιστά δυσκολότερο από την C++ την ακούσια δημιουργία αντιγράφων "
+"χρησιμοποιηθεί πλέον στο \"κύριο\"."
+
+#: src/ownership/moves-function-calls.md:21
+#, fuzzy
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+"Η μνήμη σωρού που έχει εκχωρηθεί για το \"όνομα\" θα ελευθερωθεί στο τέλος "
+"της συνάρτησης \"say_hello\"."
+
+#: src/ownership/moves-function-calls.md:22
+#, fuzzy
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"Το \"main\" μπορεί να διατηρήσει την ιδιοκτησία εάν μεταβιβάσει το \"name\" "
+"ως αναφορά (\"&name\") και εάν το \"say_hello\" αποδεχτεί μια αναφορά ως "
+"παράμετρο."
+
+#: src/ownership/moves-function-calls.md:23
+#, fuzzy
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+"Εναλλακτικά, το \"main\" μπορεί να περάσει έναν κλώνο του \"name\" στην "
+"πρώτη κλήση (\"name.clone()\")."
+
+#: src/ownership/moves-function-calls.md:24
+#, fuzzy
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"Το Rust καθιστά δυσκολότερο από την C++ την ακούσια δημιουργία αντιγράφων "
 "καθιστώντας τη σημασιολογία κίνησης ως προεπιλογή και αναγκάζοντας τους "
 "προγραμματιστές να κάνουν τους κλώνους ξεκάθαρους."
-
-#: src/ownership/copy-clone.md:1
-#, fuzzy
-msgid "# Copying and Cloning"
-msgstr "# Αντιγραφή και κλωνοποίηση"
 
 #: src/ownership/copy-clone.md:3
 #, fuzzy
@@ -4807,13 +4971,16 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:30
 #, fuzzy
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
+msgid "After the assignment, both `p1` and `p2` own their own data."
 msgstr ""
-"* Μετά την ανάθεση, τόσο το «p1» και το «p2» έχουν τα δικά τους δεδομένα.\n"
-"* Μπορούμε επίσης να χρησιμοποιήσουμε το «p1.clone()» για να αντιγράψουμε "
-"ρητά τα δεδομένα."
+"Μετά την ανάθεση, τόσο το «p1» και το «p2» έχουν τα δικά τους δεδομένα."
+
+#: src/ownership/copy-clone.md:31
+#, fuzzy
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr ""
+"Μπορούμε επίσης να χρησιμοποιήσουμε το «p1.clone()» για να αντιγράψουμε ρητά "
+"τα δεδομένα."
 
 #: src/ownership/copy-clone.md:35
 #, fuzzy
@@ -4823,23 +4990,34 @@ msgstr "Η αντιγραφή και η κλωνοποίηση δεν είναι
 #: src/ownership/copy-clone.md:37
 #, fuzzy
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C+"
-"+).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
 msgstr ""
-"* Η αντιγραφή αναφέρεται σε αντίγραφα bitwise περιοχών μνήμης και δεν "
-"λειτουργεί σε αυθαίρετα αντικείμενα.\n"
-"* Η αντιγραφή δεν επιτρέπει προσαρμοσμένη λογική (σε αντίθεση με τους "
-"κατασκευαστές αντιγραφής στη C++).\n"
-"* Η κλωνοποίηση είναι μια πιο γενική λειτουργία και επιτρέπει επίσης "
-"προσαρμοσμένη συμπεριφορά με την εφαρμογή του χαρακτηριστικού "
-"«Κλωνοποίηση».\n"
-"* Η αντιγραφή δεν λειτουργεί σε τύπους που εφαρμόζουν το χαρακτηριστικό "
-"«Drop»."
+"Η αντιγραφή αναφέρεται σε αντίγραφα bitwise περιοχών μνήμης και δεν "
+"λειτουργεί σε αυθαίρετα αντικείμενα."
+
+#: src/ownership/copy-clone.md:38
+#, fuzzy
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+"Η αντιγραφή δεν επιτρέπει προσαρμοσμένη λογική (σε αντίθεση με τους "
+"κατασκευαστές αντιγραφής στη C++)."
+
+#: src/ownership/copy-clone.md:39
+#, fuzzy
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+"Η κλωνοποίηση είναι μια πιο γενική λειτουργία και επιτρέπει επίσης "
+"προσαρμοσμένη συμπεριφορά με την εφαρμογή του χαρακτηριστικού «Κλωνοποίηση»."
+
+#: src/ownership/copy-clone.md:40
+#, fuzzy
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr ""
+"Η αντιγραφή δεν λειτουργεί σε τύπους που εφαρμόζουν το χαρακτηριστικό «Drop»."
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
 #, fuzzy
@@ -4849,48 +5027,46 @@ msgstr "Στο παραπάνω παράδειγμα, δοκιμάστε τα ε
 #: src/ownership/copy-clone.md:44
 #, fuzzy
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* Προσθέστε ένα πεδίο «String» στο «struct Point». Δεν θα μεταγλωττιστεί "
-"επειδή το \"String\" δεν είναι τύπος \"Αντιγραφή\".\n"
-"* Καταργήστε το \"Copy\" από το χαρακτηριστικό \"derive\". Το σφάλμα "
-"μεταγλωττιστή βρίσκεται τώρα στο «println!» για το «p1».\n"
-"* Δείξτε ότι λειτουργεί εάν αντ' αυτού κλωνοποιήσετε το \"p1\"."
+"Προσθέστε ένα πεδίο «String» στο «struct Point». Δεν θα μεταγλωττιστεί "
+"επειδή το \"String\" δεν είναι τύπος \"Αντιγραφή\"."
+
+#: src/ownership/copy-clone.md:45
+#, fuzzy
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"Καταργήστε το \"Copy\" από το χαρακτηριστικό \"derive\". Το σφάλμα "
+"μεταγλωττιστή βρίσκεται τώρα στο «println!» για το «p1»."
+
+#: src/ownership/copy-clone.md:46
+#, fuzzy
+msgid "Show that it works if you clone `p1` instead."
+msgstr "Δείξτε ότι λειτουργεί εάν αντ' αυτού κλωνοποιήσετε το \"p1\"."
 
 #: src/ownership/copy-clone.md:48
 #, fuzzy
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated."
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 "Εάν οι μαθητές ρωτήσουν για το «derive», αρκεί να πούμε ότι αυτός είναι ένας "
-"τρόπος δημιουργίας κώδικα στο Rust\n"
-"την ώρα της μεταγλώττισης. Σε αυτήν την περίπτωση δημιουργούνται οι "
-"προεπιλεγμένες υλοποιήσεις των χαρακτηριστικών «Αντιγραφή» και "
-"«Κλωνοποίηση».\n"
-"    \n"
-"</details>"
-
-#: src/ownership/borrowing.md:1
-#, fuzzy
-msgid "# Borrowing"
-msgstr "#Δανεισμός"
+"τρόπος δημιουργίας κώδικα στο Rust την ώρα της μεταγλώττισης. Σε αυτήν την "
+"περίπτωση δημιουργούνται οι προεπιλεγμένες υλοποιήσεις των χαρακτηριστικών "
+"«Αντιγραφή» και «Κλωνοποίηση»."
 
 #: src/ownership/borrowing.md:3
 #, fuzzy
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
 "Αντί να μεταβιβάζετε την ιδιοκτησία κατά την κλήση μιας συνάρτησης, μπορείτε "
-"να αφήσετε α\n"
-"συνάρτηση _borrow_ την τιμή:"
+"να αφήσετε α συνάρτηση _borrow_ την τιμή:"
 
 #: src/ownership/borrowing.md:6
 msgid ""
@@ -4913,13 +5089,14 @@ msgstr ""
 
 #: src/ownership/borrowing.md:22
 #, fuzzy
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
+msgid "The `add` function _borrows_ two points and returns a new point."
 msgstr ""
-"* Η συνάρτηση «προσθήκη» _δανείζεται_ δύο σημεία και επιστρέφει ένα νέο "
-"σημείο.\n"
-"* Ο καλών διατηρεί την κυριότητα των εισόδων."
+"Η συνάρτηση «προσθήκη» _δανείζεται_ δύο σημεία και επιστρέφει ένα νέο σημείο."
+
+#: src/ownership/borrowing.md:23
+#, fuzzy
+msgid "The caller retains ownership of the inputs."
+msgstr "Ο καλών διατηρεί την κυριότητα των εισόδων."
 
 #: src/ownership/borrowing.md:27
 msgid "Notes on stack returns:"
@@ -4927,41 +5104,46 @@ msgstr ""
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can "
+"Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while they stay the same when changing to the "
-"\"RELEASE\" setting:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification "
-"because constructors can have side effects. In Rust, this is not an issue at "
-"all. If RVO did not happen, Rust will always performs a simple and efficient "
-"`memcpy` copy."
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/ownership/shared-unique-borrows.md:1
-#, fuzzy
-msgid "# Shared and Unique Borrows"
-msgstr "# Κοινόχρηστα και μοναδικά δάνεια"
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr ""
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always performs a simple and efficient "
+"`memcpy` copy."
+msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:3
 #, fuzzy
@@ -4972,12 +5154,13 @@ msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:5
 #, fuzzy
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* Μπορείτε να έχετε μία ή περισσότερες τιμές \"&T\" ανά πάσα στιγμή, _ή_\n"
-"* Μπορείτε να έχετε ακριβώς μία τιμή «&mut T»."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "Μπορείτε να έχετε μία ή περισσότερες τιμές \"&T\" ανά πάσα στιγμή, _ή_"
+
+#: src/ownership/shared-unique-borrows.md:6
+#, fuzzy
+msgid "You can have exactly one `&mut T` value."
+msgstr "Μπορείτε να έχετε ακριβώς μία τιμή «&mut T»."
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
@@ -5000,27 +5183,32 @@ msgstr ""
 #: src/ownership/shared-unique-borrows.md:25
 #, fuzzy
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+"Ο παραπάνω κώδικας δεν μεταγλωττίζεται επειδή το «a» δανείζεται ταυτόχρονα "
+"ως mutable (μέσω «c») και ως αμετάβλητο (μέσω «b»)."
+
+#: src/ownership/shared-unique-borrows.md:26
+#, fuzzy
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"Μετακινήστε τη δήλωση «println!» για το «b» πριν από το εύρος που εισάγει το "
+"«c» για να κάνετε μεταγλώττιση του κώδικα."
+
+#: src/ownership/shared-unique-borrows.md:27
+#, fuzzy
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"* Ο παραπάνω κώδικας δεν μεταγλωττίζεται επειδή το «a» δανείζεται ταυτόχρονα "
-"ως mutable (μέσω «c») και ως αμετάβλητο (μέσω «b»).\n"
-"* Μετακινήστε τη δήλωση «println!» για το «b» πριν από το εύρος που εισάγει "
-"το «c» για να κάνετε μεταγλώττιση του κώδικα.\n"
-"* Μετά από αυτήν την αλλαγή, ο μεταγλωττιστής συνειδητοποιεί ότι το \"b\" "
+"Μετά από αυτήν την αλλαγή, ο μεταγλωττιστής συνειδητοποιεί ότι το \"b\" "
 "χρησιμοποιείται μόνο πριν από το νέο μεταβλητό δάνειο του \"a\" έως το "
 "\"c\". Αυτό είναι ένα χαρακτηριστικό του ελεγκτή δανεισμού που ονομάζεται "
 "\"μη λεξιλογικές ζωές\"."
-
-#: src/ownership/lifetimes.md:1
-#, fuzzy
-msgid "# Lifetimes"
-msgstr "# Διάρκεια ζωής"
 
 #: src/ownership/lifetimes.md:3
 #, fuzzy
@@ -5028,23 +5216,33 @@ msgid "A borrowed value has a _lifetime_:"
 msgstr "Μια δανεισμένη αξία έχει _διάρκεια ζωής_:"
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution."
+msgid "The lifetime can be elided: `add(p1: &Point, p2: &Point) -> Point`."
 msgstr ""
 
-#: src/ownership/lifetimes-function-calls.md:1
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr ""
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
 #, fuzzy
-msgid "# Lifetimes in Function Calls"
-msgstr "# Διάρκεια ζωής σε κλήσεις συναρτήσεων"
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+"Διαβάστε το '&'a Point' ως \"ένα δανεικό \"Point\" που ισχύει τουλάχιστον "
+"για το διάρκεια ζωής «α»»."
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:3
 #, fuzzy
@@ -5076,78 +5274,100 @@ msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:21
 #, fuzzy
-msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "Το `'a` είναι μια γενική παράμετρος, συνάγεται από τον μεταγλωττιστή."
+
+#: src/ownership/lifetimes-function-calls.md:22
+#, fuzzy
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
 msgstr ""
-"* Το `'a` είναι μια γενική παράμετρος, συνάγεται από τον μεταγλωττιστή.\n"
-"* Οι διάρκειες ζωής ξεκινούν με \"\"\" και το \"a\" είναι ένα τυπικό "
-"προεπιλεγμένο όνομα.\n"
-"* Διαβάστε το '&'a Point' ως \"ένα δανεικό \"Point\" που ισχύει τουλάχιστον "
-"για το\n"
-"  διάρκεια ζωής «α»».\n"
-"  * Το τμήμα _τουλάχιστον_ είναι σημαντικό όταν οι παράμετροι βρίσκονται σε "
+"Οι διάρκειες ζωής ξεκινούν με \"\"\" και το \"a\" είναι ένα τυπικό "
+"προεπιλεγμένο όνομα."
+
+#: src/ownership/lifetimes-function-calls.md:25
+#, fuzzy
+msgid ""
+"The _at least_ part is important when parameters are in different scopes."
+msgstr ""
+"Το τμήμα _τουλάχιστον_ είναι σημαντικό όταν οι παράμετροι βρίσκονται σε "
 "διαφορετικά πεδία."
 
 #: src/ownership/lifetimes-function-calls.md:31
 #, fuzzy
 msgid ""
-"* Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"Move the declaration of `p2` and `p3` into a a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
-"* Επαναφέρετε τον χώρο εργασίας και αλλάξτε την υπογραφή της συνάρτησης σε "
-"`fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. Αυτό δεν "
-"θα μεταγλωττιστεί επειδή η σχέση μεταξύ των χρόνων ζωής \"a\" και \"b\" "
-"είναι ασαφής.\n"
-"* Ένας άλλος τρόπος να το εξηγήσετε:\n"
-"  * Δύο αναφορές σε δύο τιμές δανείζονται από μια συνάρτηση και η συνάρτηση "
-"επιστρέφει\n"
-"    άλλη αναφορά.\n"
-"  * Πρέπει να προέρχεται από μία από αυτές τις δύο εισόδους (ή από μια "
-"καθολική μεταβλητή).\n"
-"  * Ποιο είναι απ 'όλα? Ο μεταγλωττιστής πρέπει να γνωρίζει, επομένως στον "
-"ιστότοπο κλήσης δεν χρησιμοποιείται η επιστρεφόμενη αναφορά\n"
-"    για περισσότερο από μια μεταβλητή από την οποία προήλθε η αναφορά."
+"Επαναφέρετε τον χώρο εργασίας και αλλάξτε την υπογραφή της συνάρτησης σε `fn "
+"left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. Αυτό δεν θα "
+"μεταγλωττιστεί επειδή η σχέση μεταξύ των χρόνων ζωής \"a\" και \"b\" είναι "
+"ασαφής."
 
-#: src/ownership/lifetimes-data-structures.md:1
+#: src/ownership/lifetimes-function-calls.md:32
 #, fuzzy
-msgid "# Lifetimes in Data Structures"
-msgstr "# Διάρκεια ζωής σε δομές δεδομένων"
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr "Ένας άλλος τρόπος να το εξηγήσετε:"
+
+#: src/ownership/lifetimes-function-calls.md:50
+#, fuzzy
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+"Δύο αναφορές σε δύο τιμές δανείζονται από μια συνάρτηση και η συνάρτηση "
+"επιστρέφει άλλη αναφορά."
+
+#: src/ownership/lifetimes-function-calls.md:52
+#, fuzzy
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+"Πρέπει να προέρχεται από μία από αυτές τις δύο εισόδους (ή από μια καθολική "
+"μεταβλητή)."
+
+#: src/ownership/lifetimes-function-calls.md:53
+#, fuzzy
+msgid "Another way to explain it:"
+msgstr ""
+"Ποιο είναι απ 'όλα? Ο μεταγλωττιστής πρέπει να γνωρίζει, επομένως στον "
+"ιστότοπο κλήσης δεν χρησιμοποιείται η επιστρεφόμενη αναφορά για περισσότερο "
+"από μια μεταβλητή από την οποία προήλθε η αναφορά."
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
 #, fuzzy
@@ -5182,42 +5402,60 @@ msgstr ""
 #: src/ownership/lifetimes-data-structures.md:25
 #, fuzzy
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data "
+"In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This "
-"can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one "
-"lifetime annotation. This can be necessary if there is a need to describe "
-"lifetime relationships between the references themselves, in addition to the "
-"lifetime of the struct itself. Those are very advanced use cases."
+"`Highlight` that uses that data."
 msgstr ""
-"* Στο παραπάνω παράδειγμα, ο σχολιασμός στο \"Highlight\" επιβάλλει ότι τα "
+"Στο παραπάνω παράδειγμα, ο σχολιασμός στο \"Highlight\" επιβάλλει ότι τα "
 "δεδομένα που βρίσκονται κάτω από το περιεχόμενο \"&str\" ζουν τουλάχιστον "
 "για όσο χρονικό διάστημα οποιοδήποτε στιγμιότυπο του \"Highlight\" που "
-"χρησιμοποιεί αυτά τα δεδομένα.\n"
-"* Εάν το «κείμενο» καταναλωθεί πριν από το τέλος της διάρκειας ζωής του "
-"«αλεπού» (ή του «σκύλου»), ο ελεγκτής δανείου κάνει ένα σφάλμα.\n"
-"* Οι τύποι με δανεικά δεδομένα αναγκάζουν τους χρήστες να παραμείνουν στα "
+"χρησιμοποιεί αυτά τα δεδομένα."
+
+#: src/ownership/lifetimes-data-structures.md:26
+#, fuzzy
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"Εάν το «κείμενο» καταναλωθεί πριν από το τέλος της διάρκειας ζωής του "
+"«αλεπού» (ή του «σκύλου»), ο ελεγκτής δανείου κάνει ένα σφάλμα."
+
+#: src/ownership/lifetimes-data-structures.md:27
+#, fuzzy
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"Οι τύποι με δανεικά δεδομένα αναγκάζουν τους χρήστες να παραμείνουν στα "
 "αρχικά δεδομένα. Αυτό μπορεί να είναι χρήσιμο για τη δημιουργία ελαφριών "
-"προβολών, αλλά γενικά τις καθιστά κάπως πιο δύσκολες στη χρήση.\n"
-"* Όταν είναι δυνατόν, κάντε τις δομές δεδομένων να κατέχουν απευθείας τα "
-"δεδομένα τους.\n"
-"* Ορισμένες δομές με πολλαπλές αναφορές στο εσωτερικό μπορεί να έχουν "
+"προβολών, αλλά γενικά τις καθιστά κάπως πιο δύσκολες στη χρήση."
+
+#: src/ownership/lifetimes-data-structures.md:28
+#, fuzzy
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+"Όταν είναι δυνατόν, κάντε τις δομές δεδομένων να κατέχουν απευθείας τα "
+"δεδομένα τους."
+
+#: src/ownership/lifetimes-data-structures.md:29
+#, fuzzy
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"Ορισμένες δομές με πολλαπλές αναφορές στο εσωτερικό μπορεί να έχουν "
 "περισσότερους από έναν σχολιασμούς διάρκειας ζωής. Αυτό μπορεί να είναι "
 "απαραίτητο εάν υπάρχει ανάγκη να περιγραφούν σχέσεις διάρκειας ζωής μεταξύ "
 "των ίδιων των αναφορών, επιπλέον της διάρκειας ζωής της ίδιας της δομής. "
-"Είναι πολύ προηγμένες περιπτώσεις χρήσης.\n"
-"</details>"
+"Είναι πολύ προηγμένες περιπτώσεις χρήσης."
 
 #: src/exercises/day-1/afternoon.md:1
 #, fuzzy
-msgid "# Day 1: Afternoon Exercises"
-msgstr "# Ημέρα 1: Απογευματινές Ασκήσεις"
+msgid "Day 1: Afternoon Exercises"
+msgstr "Ημέρα 1: Απογευματινές Ασκήσεις"
 
 #: src/exercises/day-1/afternoon.md:3
 #, fuzzy
@@ -5226,27 +5464,21 @@ msgstr "Θα δούμε δύο πράγματα:"
 
 #: src/exercises/day-1/afternoon.md:5
 #, fuzzy
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
-msgstr "* Iterators και ιδιοκτησία (σκληρό)."
+msgid "A small book library,"
+msgstr "Iterators και ιδιοκτησία (σκληρό)."
 
-#: src/exercises/day-1/book-library.md:1
-#, fuzzy
-msgid "# Designing a Library"
-msgstr "# Σχεδιάζοντας μια Βιβλιοθήκη"
+#: src/exercises/day-1/afternoon.md:7
+msgid "Iterators and ownership (hard)."
+msgstr ""
 
 #: src/exercises/day-1/book-library.md:3
 #, fuzzy
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
 "Θα μάθουμε πολλά περισσότερα για τις δομές και τον τύπο `Vec<T>` αύριο. Προς "
-"το παρόν,\n"
-"απλά πρέπει να γνωρίζετε μέρος του API του:"
+"το παρόν, απλά πρέπει να γνωρίζετε μέρος του API του:"
 
 #: src/exercises/day-1/book-library.md:6
 msgid ""
@@ -5265,13 +5497,12 @@ msgstr ""
 #: src/exercises/day-1/book-library.md:17
 #, fuzzy
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 "Χρησιμοποιήστε αυτό για να δημιουργήσετε μια εφαρμογή βιβλιοθήκης. "
-"Αντιγράψτε τον παρακάτω κωδικό στο\n"
-"<https://play.rust-lang.org/> και ενημερώστε τους τύπους για να γίνει "
-"μεταγλώττιση:"
+"Αντιγράψτε τον παρακάτω κωδικό στο <https://play.rust-lang.org/> και "
+"ενημερώστε τους τύπους για να γίνει μεταγλώττιση:"
 
 #: src/exercises/day-1/book-library.md:20
 msgid ""
@@ -5364,48 +5595,38 @@ msgstr ""
 #, fuzzy
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr ""
-"<λεπτομέρειες>\n"
-"    \n"
+"\\<λεπτομέρειες>\n"
+"\n"
 "[Λύση](solutions-afternoon.md#designing-a-library)"
-
-#: src/exercises/day-1/iterators-and-ownership.md:1
-#, fuzzy
-msgid "# Iterators and Ownership"
-msgstr "# Επαναληπτικοί και ιδιοκτησία"
 
 #: src/exercises/day-1/iterators-and-ownership.md:3
 #, fuzzy
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 "Το μοντέλο ιδιοκτησίας του Rust επηρεάζει πολλά API. Ένα παράδειγμα αυτού "
-"είναι το\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) και\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
-"χαρακτηριστικά."
+"είναι το [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator."
+"html) και [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait."
+"IntoIterator.html) χαρακτηριστικά."
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
 #, fuzzy
-msgid "## `Iterator`"
-msgstr "## «Iterator»."
+msgid "`Iterator`"
+msgstr "«Iterator»."
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 #, fuzzy
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
 "Τα γνωρίσματα είναι σαν διεπαφές: περιγράφουν τη συμπεριφορά (μέθοδοι) για "
-"έναν τύπο. ο\n"
-"Το χαρακτηριστικό «Iterator» λέει απλώς ότι μπορείτε να καλέσετε «επόμενο» "
-"μέχρι να λάβετε πίσω το «Κανένα»:"
+"έναν τύπο. ο Το χαρακτηριστικό «Iterator» λέει απλώς ότι μπορείτε να "
+"καλέσετε «επόμενο» μέχρι να λάβετε πίσω το «Κανένα»:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
 msgid ""
@@ -5464,20 +5685,19 @@ msgstr "Γιατί χρησιμοποιείται αυτός ο τύπος;"
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
 #, fuzzy
-msgid "## `IntoIterator`"
-msgstr "## «IntoIterator»."
+msgid "`IntoIterator`"
+msgstr "«IntoIterator»."
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 #, fuzzy
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
 "Το χαρακτηριστικό \"Iterator\" σάς λέει πώς να _επανάληψη_ αφού "
-"δημιουργήσετε ένα\n"
-"επαναλήπτης. Το σχετικό χαρακτηριστικό «IntoIterator» σάς λέει πώς να "
-"δημιουργήσετε τον επαναλήπτη:"
+"δημιουργήσετε ένα επαναλήπτης. Το σχετικό χαρακτηριστικό «IntoIterator» σάς "
+"λέει πώς να δημιουργήσετε τον επαναλήπτη:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:53
 msgid ""
@@ -5494,30 +5714,32 @@ msgstr ""
 #: src/exercises/day-1/iterators-and-ownership.md:62
 #, fuzzy
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
-"Η σύνταξη εδώ σημαίνει ότι κάθε υλοποίηση του «IntoIterator» πρέπει\n"
-"Δηλώστε δύο τύπους:"
+"Η σύνταξη εδώ σημαίνει ότι κάθε υλοποίηση του «IntoIterator» πρέπει Δηλώστε "
+"δύο τύπους:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
 #, fuzzy
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr "\"Στοιχείο\": ο τύπος που επαναλαμβάνουμε, όπως \"i8\","
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+#, fuzzy
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
-"* \"Στοιχείο\": ο τύπος που επαναλαμβάνουμε, όπως \"i8\",\n"
-"* «IntoIter»: ο τύπος «Iterator» που επιστρέφεται με τη μέθοδο «into_iter»."
+"«IntoIter»: ο τύπος «Iterator» που επιστρέφεται με τη μέθοδο «into_iter»."
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 #, fuzzy
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 "Σημειώστε ότι το \"IntoIter\" και το \"Item\" είναι συνδεδεμένα: ο "
-"επαναλήπτης πρέπει να έχει το ίδιο\n"
-"Τύπος «Στοιχείο», που σημαίνει ότι επιστρέφει «Επιλογή<Στοιχείο>»."
+"επαναλήπτης πρέπει να έχει το ίδιο Τύπος «Στοιχείο», που σημαίνει ότι "
+"επιστρέφει «Επιλογή\\<Στοιχείο>»."
 
 #: src/exercises/day-1/iterators-and-ownership.md:71
 #, fuzzy
@@ -5540,22 +5762,19 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
 #, fuzzy
-msgid "## `for` Loops"
-msgstr "## Βρόχοι «για»."
+msgid "`for` Loops"
+msgstr "Βρόχοι «για»."
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 #, fuzzy
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 "Τώρα που γνωρίζουμε και τα δύο \"Iterator\" και \"IntoIterator\", μπορούμε "
-"να δημιουργήσουμε βρόχους \"for\".\n"
-"Καλούν «into_iter()» σε μια έκφραση και επαναλαμβάνεται πάνω από το "
-"αποτέλεσμα\n"
-"επαναλήπτης:"
+"να δημιουργήσουμε βρόχους \"for\". Καλούν «into_iter()» σε μια έκφραση και "
+"επαναλαμβάνεται πάνω από το αποτέλεσμα επαναλήπτης:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
@@ -5583,30 +5802,23 @@ msgstr "Ποιος είναι ο τύπος της λέξης σε κάθε βρ
 #: src/exercises/day-1/iterators-and-ownership.md:105
 #, fuzzy
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 "Πειραματιστείτε με τον παραπάνω κώδικα και, στη συνέχεια, συμβουλευτείτε την "
-"τεκμηρίωση για [`impl\n"
-"IntoIterator για\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"και [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"για να ελέγξετε τις απαντήσεις σας."
+"τεκμηρίωση για [`impl IntoIterator για &Vec<T>`](https://doc.rust-lang.org/"
+"std/vec/struct.Vec.html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) "
+"και [`impl IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) για να ελέγξετε τις "
+"απαντήσεις σας."
 
 #: src/welcome-day-2.md:1
 #, fuzzy
-msgid "# Welcome to Day 2"
-msgstr "# Καλώς ήρθατε στην Ημέρα 2"
+msgid "Welcome to Day 2"
+msgstr "Καλώς ήρθατε στην Ημέρα 2"
 
 #: src/welcome-day-2.md:3
 #, fuzzy
@@ -5614,26 +5826,28 @@ msgid "Now that we have seen a fair amount of Rust, we will continue with:"
 msgstr "Τώρα που είδαμε αρκετή ποσότητα Rust, θα συνεχίσουμε με:"
 
 #: src/welcome-day-2.md:5
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
+msgid "Structs, enums, methods."
 msgstr ""
 
-#: src/structs.md:1
-#, fuzzy
-msgid "# Structs"
-msgstr "# Κατασκευές"
+#: src/welcome-day-2.md:7
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr ""
+
+#: src/welcome-day-2.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr ""
 
 #: src/structs.md:3
 #, fuzzy
@@ -5667,38 +5881,49 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/structs.md:29
-#, fuzzy
-msgid ""
-"<details>\n"
-"Key Points: "
-msgstr ""
-"<λεπτομέρειες>\n"
-"Βασικά σημεία:"
-
 #: src/structs.md:32
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:33
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:35
 msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:36
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
-
-#: src/structs/tuple-structs.md:1
-#, fuzzy
-msgid "# Tuple Structs"
-msgstr "# Πουπλές Κατασκευές"
 
 #: src/structs/tuple-structs.md:3
 #, fuzzy
@@ -5751,42 +5976,52 @@ msgstr ""
 #: src/structs/tuple-structs.md:37
 #, fuzzy
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). "
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
 "Οι νέοι τύποι είναι ένας πολύ καλός τρόπος για να κωδικοποιήσετε πρόσθετες "
-"πληροφορίες σχετικά με την τιμή σε έναν πρωτόγονο τύπο, για παράδειγμα:\n"
-"  * Ο αριθμός μετριέται σε ορισμένες μονάδες: «Newtons» στο παραπάνω "
-"παράδειγμα.\n"
-"  * Η τιμή πέρασε κάποια επικύρωση όταν δημιουργήθηκε, επομένως δεν "
-"χρειάζεται πλέον να την επικυρώνετε ξανά σε κάθε χρήση: "
-"«PhoneNumber(String)» ή «OddNumber(u32)».\n"
-"    \n"
-"</details>"
+"πληροφορίες σχετικά με την τιμή σε έναν πρωτόγονο τύπο, για παράδειγμα:"
 
-#: src/structs/field-shorthand.md:1
+#: src/structs/tuple-structs.md:38
 #, fuzzy
-msgid "# Field Shorthand Syntax"
-msgstr "# Σύντομη σύνταξη πεδίου"
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+"Ο αριθμός μετριέται σε ορισμένες μονάδες: «Newtons» στο παραπάνω παράδειγμα."
+
+#: src/structs/tuple-structs.md:39
+#, fuzzy
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+"Η τιμή πέρασε κάποια επικύρωση όταν δημιουργήθηκε, επομένως δεν χρειάζεται "
+"πλέον να την επικυρώνετε ξανά σε κάθε χρήση: «PhoneNumber(String)» ή "
+"«OddNumber(u32)»."
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics). "
+msgstr ""
 
 #: src/structs/field-shorthand.md:3
 #, fuzzy
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
 "Εάν έχετε ήδη μεταβλητές με τα σωστά ονόματα, τότε μπορείτε να δημιουργήσετε "
-"τις\n"
-"δόμηση χρησιμοποιώντας συντομογραφία:"
+"τις δόμηση χρησιμοποιώντας συντομογραφία:"
 
 #: src/structs/field-shorthand.md:6
 msgid ""
@@ -5812,67 +6047,82 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use "
-"the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-#, fuzzy
-msgid "# Enums"
-msgstr "# Αριθμοί"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
 
 #: src/enums.md:3
 #, fuzzy
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
-"Η λέξη-κλειδί «enum» επιτρέπει τη δημιουργία ενός τύπου που έχει λίγους\n"
+"Η λέξη-κλειδί «enum» επιτρέπει τη δημιουργία ενός τύπου που έχει λίγους "
 "διαφορετικές παραλλαγές:"
 
 #: src/enums.md:6
@@ -5912,48 +6162,63 @@ msgstr "Βασικά σημεία:"
 
 #: src/enums.md:35
 #, fuzzy
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr ""
+"Οι απαριθμήσεις σάς επιτρέπουν να συλλέγετε ένα σύνολο τιμών κάτω από έναν "
+"τύπο"
+
+#: src/enums.md:36
+#, fuzzy
 msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+"Αυτή η σελίδα προσφέρει έναν τύπο \"CoinFlip\" με δύο παραλλαγές \"Heads\" "
+"και \"Tail\". Μπορείτε να σημειώσετε τον χώρο ονομάτων όταν χρησιμοποιείτε "
+"παραλλαγές."
+
+#: src/enums.md:37
+#, fuzzy
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr ""
+"Αυτή μπορεί να είναι μια καλή στιγμή για να συγκρίνετε Structs και Enums:"
+
+#: src/enums.md:38
+#, fuzzy
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"Και στα δύο, μπορείτε να έχετε μια απλή έκδοση χωρίς πεδία (μονάδα δομής) ή "
+"μια με διαφορετικούς τύπους πεδίων (ωφέλιμα φορτία παραλλαγής)."
+
+#: src/enums.md:39
+#, fuzzy
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr ""
+"Και στις δύο, οι συσχετισμένες συναρτήσεις ορίζονται μέσα σε ένα μπλοκ "
+"«impl»."
+
+#: src/enums.md:40
+#, fuzzy
+msgid ""
+"You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
 msgstr ""
-"* Οι απαριθμήσεις σάς επιτρέπουν να συλλέγετε ένα σύνολο τιμών κάτω από έναν "
-"τύπο\n"
-"* Αυτή η σελίδα προσφέρει έναν τύπο \"CoinFlip\" με δύο παραλλαγές \"Heads\" "
-"και \"Tail\". Μπορείτε να σημειώσετε τον χώρο ονομάτων όταν χρησιμοποιείτε "
-"παραλλαγές.\n"
-"* Αυτή μπορεί να είναι μια καλή στιγμή για να συγκρίνετε Structs και Enums:\n"
-"  * Και στα δύο, μπορείτε να έχετε μια απλή έκδοση χωρίς πεδία (μονάδα "
-"δομής) ή μια με διαφορετικούς τύπους πεδίων (ωφέλιμα φορτία παραλλαγής).\n"
-"  * Και στις δύο, οι συσχετισμένες συναρτήσεις ορίζονται μέσα σε ένα μπλοκ "
-"«impl».\n"
-"  * Θα μπορούσατε ακόμη και να εφαρμόσετε τις διαφορετικές παραλλαγές ενός "
-"enum με ξεχωριστές δομές, αλλά τότε δεν θα ήταν του ίδιου τύπου όπως θα ήταν "
-"αν είχαν οριστεί όλες σε ένα enum.\n"
-"</details>"
-
-#: src/enums/variant-payloads.md:1
-#, fuzzy
-msgid "# Variant Payloads"
-msgstr "# Παραλλαγή ωφέλιμων φορτίων"
+"Θα μπορούσατε ακόμη και να εφαρμόσετε τις διαφορετικές παραλλαγές ενός enum "
+"με ξεχωριστές δομές, αλλά τότε δεν θα ήταν του ίδιου τύπου όπως θα ήταν αν "
+"είχαν οριστεί όλες σε ένα enum."
 
 #: src/enums/variant-payloads.md:3
 #, fuzzy
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 "Μπορείτε να ορίσετε πλουσιότερους αριθμούς όπου οι παραλλαγές μεταφέρουν "
-"δεδομένα. Στη συνέχεια, μπορείτε να χρησιμοποιήσετε το\n"
-"Δήλωση «ταιριάσματος» για εξαγωγή των δεδομένων από κάθε παραλλαγή:"
+"δεδομένα. Στη συνέχεια, μπορείτε να χρησιμοποιήσετε το Δήλωση «ταιριάσματος» "
+"για εξαγωγή των δεδομένων από κάθε παραλλαγή:"
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -5988,40 +6253,65 @@ msgstr ""
 #: src/enums/variant-payloads.md:35
 #, fuzzy
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There "
-"is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example.  \n"
-"  "
+"after the `=>`."
 msgstr ""
-"* Στο παραπάνω παράδειγμα, η πρόσβαση στο \"char\" στο \"KeyPress\" ή στο "
+"Στο παραπάνω παράδειγμα, η πρόσβαση στο \"char\" στο \"KeyPress\" ή στο "
 "\"x\" και \"y\" στο \"Click\" λειτουργεί μόνο μέσα σε μια δήλωση "
-"\"ταιριάζουν\".\n"
-"* Το \"match\" επιθεωρεί ένα κρυφό πεδίο διάκρισης στο \"enum\".\n"
-"* Το \"WebEvent::Click { ... }\" δεν είναι ακριβώς το ίδιο με το \"WebEvent::"
+"\"ταιριάζουν\"."
+
+#: src/enums/variant-payloads.md:36
+#, fuzzy
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr "Το \"match\" επιθεωρεί ένα κρυφό πεδίο διάκρισης στο \"enum\"."
+
+#: src/enums/variant-payloads.md:37
+#, fuzzy
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+"Το \"WebEvent::Click { ... }\" δεν είναι ακριβώς το ίδιο με το \"WebEvent::"
 "Click(Click)\" με ένα ανώτερο επίπεδο \"struct Click { ... }\". Η "
 "ενσωματωμένη έκδοση δεν μπορεί να εφαρμόσει χαρακτηριστικά, για παράδειγμα."
 
-#: src/enums/sizes.md:1
-#, fuzzy
-msgid "# Enum Sizes"
-msgstr "# Αριθμητικά μεγέθη"
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr ""
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
 
 #: src/enums/sizes.md:3
 #, fuzzy
@@ -6058,166 +6348,197 @@ msgstr ""
 #: src/enums/sizes.md:25
 #, fuzzy
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 msgstr ""
-"* Δείτε το [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"Δείτε το [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 
 #: src/enums/sizes.md:31
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+
+#: src/enums/sizes.md:33
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr ""
+
+#: src/enums/sizes.md:35
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with "
-"C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:50
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+
+#: src/enums/sizes.md:54
+msgid "Try out other types such as"
+msgstr ""
+
+#: src/enums/sizes.md:56
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr ""
+
+#: src/enums/sizes.md:57
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+
+#: src/enums/sizes.md:58
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+
+#: src/enums/sizes.md:59
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+
+#: src/enums/sizes.md:61
+msgid ""
+"Niche optimization: Rust will merge use unused bit patterns for the enum "
+"discriminant."
+msgstr ""
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits "
-"2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche "
-"optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit "
-"machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge use unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* "
-"look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees "
-"regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
 "\n"
-"     More complex example if you want to discuss what happens when we chain "
-"more than 256 `Option`s together.\n"
+"use std::mem::transmute;\n"
 "\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
 "signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
 "Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods.md:3
 #, fuzzy
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
 "Το Rust σάς επιτρέπει να συσχετίζετε λειτουργίες με τους νέους τύπους σας. "
-"Το κάνετε αυτό με ένα\n"
-"μπλοκ \"impl\":"
+"Το κάνετε αυτό με ένα μπλοκ \"impl\":"
 
 #: src/methods.md:6
 msgid ""
@@ -6246,143 +6567,171 @@ msgstr ""
 
 #: src/methods.md:31
 #, fuzzy
+msgid "It can be helpful to introduce methods by comparing them to functions."
+msgstr "Βασικά σημεία:"
+
+#: src/methods.md:32
+#, fuzzy
 msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
 msgstr ""
-"Βασικά σημεία:\n"
-"* Μπορεί να είναι χρήσιμη η εισαγωγή μεθόδων συγκρίνοντάς τες με "
-"συναρτήσεις.\n"
-"  * Οι μέθοδοι καλούνται σε μια παρουσία ενός τύπου (όπως μια δομή ή ένα "
-"enum), η πρώτη παράμετρος αντιπροσωπεύει την παρουσία ως \"self\".\n"
-"  * Οι προγραμματιστές μπορούν να επιλέξουν να χρησιμοποιήσουν μεθόδους για "
-"να επωφεληθούν από τη σύνταξη του δέκτη μεθόδων και να τους βοηθήσουν να "
+"Μπορεί να είναι χρήσιμη η εισαγωγή μεθόδων συγκρίνοντάς τες με συναρτήσεις."
+
+#: src/methods.md:33
+#, fuzzy
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+"Οι μέθοδοι καλούνται σε μια παρουσία ενός τύπου (όπως μια δομή ή ένα enum), "
+"η πρώτη παράμετρος αντιπροσωπεύει την παρουσία ως \"self\"."
+
+#: src/methods.md:34
+#, fuzzy
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr ""
+"Οι προγραμματιστές μπορούν να επιλέξουν να χρησιμοποιήσουν μεθόδους για να "
+"επωφεληθούν από τη σύνταξη του δέκτη μεθόδων και να τους βοηθήσουν να "
 "διατηρηθούν πιο οργανωμένοι. Χρησιμοποιώντας μεθόδους μπορούμε να "
-"διατηρήσουμε όλο τον κώδικα υλοποίησης σε ένα προβλέψιμο μέρος.\n"
-"* Επισημάνετε τη χρήση της λέξης-κλειδιού «self», ενός δέκτη μεθόδου.\n"
-"  * Δείξτε ότι είναι ένας συντομευμένος όρος για το \"self:&Self\" και ίσως "
-"δείξετε πώς θα μπορούσε επίσης να χρησιμοποιηθεί το όνομα της δομής.\n"
-"  * Εξηγήστε ότι το Self είναι ένα ψευδώνυμο τύπου για τον τύπο στον οποίο "
-"βρίσκεται το μπλοκ «impl» και μπορεί να χρησιμοποιηθεί αλλού στο μπλοκ.\n"
-"  * Σημειώστε πώς χρησιμοποιείται ο εαυτός όπως και άλλες δομές και ο "
+"διατηρήσουμε όλο τον κώδικα υλοποίησης σε ένα προβλέψιμο μέρος."
+
+#: src/methods.md:35
+#, fuzzy
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr "Επισημάνετε τη χρήση της λέξης-κλειδιού «self», ενός δέκτη μεθόδου."
+
+#: src/methods.md:36
+#, fuzzy
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+"Δείξτε ότι είναι ένας συντομευμένος όρος για το \"self:&Self\" και ίσως "
+"δείξετε πώς θα μπορούσε επίσης να χρησιμοποιηθεί το όνομα της δομής."
+
+#: src/methods.md:37
+#, fuzzy
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+"Εξηγήστε ότι το Self είναι ένα ψευδώνυμο τύπου για τον τύπο στον οποίο "
+"βρίσκεται το μπλοκ «impl» και μπορεί να χρησιμοποιηθεί αλλού στο μπλοκ."
+
+#: src/methods.md:38
+#, fuzzy
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+"Σημειώστε πώς χρησιμοποιείται ο εαυτός όπως και άλλες δομές και ο "
 "συμβολισμός κουκκίδων μπορεί να χρησιμοποιηθεί για αναφορά σε μεμονωμένα "
-"πεδία.\n"
-"  * Αυτή μπορεί να είναι μια καλή στιγμή για να δείξετε πώς το \"&self\" "
+"πεδία."
+
+#: src/methods.md:39
+#, fuzzy
+msgid "We describe the distinction between method receivers next."
+msgstr ""
+"Αυτή μπορεί να είναι μια καλή στιγμή για να δείξετε πώς το \"&self\" "
 "διαφέρει από το \"self\" τροποποιώντας τον κώδικα και προσπαθώντας να "
 "εκτελέσετε το say_hello δύο φορές.\n"
-"* Στη συνέχεια περιγράφουμε τη διάκριση μεταξύ των δεκτών μεθόδων.\n"
-"   \n"
-"</details>"
-
-#: src/methods/receiver.md:1
-#, fuzzy
-msgid "# Method Receiver"
-msgstr "# Μέθοδος Δέκτης"
+"\n"
+"Στη συνέχεια περιγράφουμε τη διάκριση μεταξύ των δεκτών μεθόδων."
 
 #: src/methods/receiver.md:3
 #, fuzzy
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
 "Το \"&self\" παραπάνω υποδεικνύει ότι η μέθοδος δανείζεται το αντικείμενο "
-"αμετάβλητα. Εκεί\n"
-"είναι άλλοι πιθανοί δέκτες για μια μέθοδο:"
+"αμετάβλητα. Εκεί είναι άλλοι πιθανοί δέκτες για μια μέθοδο:"
 
 #: src/methods/receiver.md:6
 #, fuzzy
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted.\n"
-"* `mut self`: same as above, but while the method owns the object, it can\n"
-"  mutate it too. Complete ownership does not automatically mean mutability.\n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
 msgstr ""
-"* «&self»: δανείζεται το αντικείμενο από τον καλούντα χρησιμοποιώντας ένα "
-"κοινόχρηστο και αμετάβλητο\n"
-"  αναφορά. Το αντικείμενο μπορεί να χρησιμοποιηθεί ξανά μετά.\n"
-"* \"&mut self\": δανείζεται το αντικείμενο από τον καλούντα χρησιμοποιώντας "
-"ένα μοναδικό και ευμετάβλητο\n"
-"  αναφορά. Το αντικείμενο μπορεί να χρησιμοποιηθεί ξανά μετά.\n"
-"* «self»: αναλαμβάνει την κυριότητα του αντικειμένου και το απομακρύνει από "
-"τον καλούντα. ο\n"
-"  μέθοδος γίνεται ο ιδιοκτήτης του αντικειμένου. Το αντικείμενο θα "
-"απορριφθεί (κατανεμηθεί)\n"
-"  όταν η μέθοδος επιστρέφει, εκτός εάν η ιδιοκτησία της είναι ρητά\n"
-"  μεταδόθηκε.\n"
-"* `mut self`: όπως παραπάνω, αλλά ενώ η μέθοδος κατέχει το αντικείμενο, "
-"μπορεί\n"
-"  μεταλλάξτε το και εσείς. Η πλήρης ιδιοκτησία δεν σημαίνει αυτόματα "
-"μεταβλητότητα.\n"
-"* Χωρίς δέκτη: αυτό γίνεται μια στατική μέθοδος στη δομή. Συνήθως "
-"χρησιμοποιείται σε\n"
-"  δημιουργήστε κατασκευαστές που ονομάζονται «νέοι» κατά σύμβαση."
+"«&self»: δανείζεται το αντικείμενο από τον καλούντα χρησιμοποιώντας ένα "
+"κοινόχρηστο και αμετάβλητο αναφορά. Το αντικείμενο μπορεί να χρησιμοποιηθεί "
+"ξανά μετά."
+
+#: src/methods/receiver.md:8
+#, fuzzy
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+"\"&mut self\": δανείζεται το αντικείμενο από τον καλούντα χρησιμοποιώντας "
+"ένα μοναδικό και ευμετάβλητο αναφορά. Το αντικείμενο μπορεί να "
+"χρησιμοποιηθεί ξανά μετά."
+
+#: src/methods/receiver.md:10
+#, fuzzy
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted."
+msgstr ""
+"«self»: αναλαμβάνει την κυριότητα του αντικειμένου και το απομακρύνει από "
+"τον καλούντα. ο μέθοδος γίνεται ο ιδιοκτήτης του αντικειμένου. Το "
+"αντικείμενο θα απορριφθεί (κατανεμηθεί) όταν η μέθοδος επιστρέφει, εκτός εάν "
+"η ιδιοκτησία της είναι ρητά μεταδόθηκε."
+
+#: src/methods/receiver.md:14
+#, fuzzy
+msgid ""
+"`mut self`: same as above, but while the method owns the object, it can "
+"mutate it too. Complete ownership does not automatically mean mutability."
+msgstr ""
+"`mut self`: όπως παραπάνω, αλλά ενώ η μέθοδος κατέχει το αντικείμενο, μπορεί "
+"μεταλλάξτε το και εσείς. Η πλήρης ιδιοκτησία δεν σημαίνει αυτόματα "
+"μεταβλητότητα."
+
+#: src/methods/receiver.md:16
+#, fuzzy
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
+msgstr ""
+"Χωρίς δέκτη: αυτό γίνεται μια στατική μέθοδος στη δομή. Συνήθως "
+"χρησιμοποιείται σε δημιουργήστε κατασκευαστές που ονομάζονται «νέοι» κατά "
+"σύμβαση."
 
 #: src/methods/receiver.md:19
 #, fuzzy
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
-"Πέρα από παραλλαγές στον «εαυτό», υπάρχουν επίσης\n"
-"[ειδικοί τύποι περιτυλίγματος](https://doc.rust-lang.org/reference/special-"
-"types-and-traits.html)\n"
-"επιτρέπεται να είναι τύποι δεκτών, όπως \"Box<Self>\"."
+"Πέρα από παραλλαγές στον «εαυτό», υπάρχουν επίσης [ειδικοί τύποι "
+"περιτυλίγματος](https://doc.rust-lang.org/reference/special-types-and-traits."
+"html) επιτρέπεται να είναι τύποι δεκτών, όπως \"Box\n"
+"\n"
+"\"."
 
 #: src/methods/receiver.md:25
 #, fuzzy
 msgid ""
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it."
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
-"<λεπτομέρειες>\n"
-"  \n"
+"\\<λεπτομέρειες>\n"
+"\n"
 "Εξετάστε το ενδεχόμενο να δώσετε έμφαση στο \"κοινόχρηστο και αμετάβλητο\" "
-"και στο \"μοναδικό και μεταβλητό\". Αυτοί οι περιορισμοί έρχονται πάντα\n"
-"μαζί στο Rust λόγω των κανόνων του ελεγκτή δανείου, και το \"self\" δεν "
-"αποτελεί εξαίρεση. Δεν θα είναι δυνατόν\n"
-"Αναφέρετε μια δομή από πολλές τοποθεσίες και καλέστε μια μέθοδο μεταλλάξεως "
-"(`&mut self`) σε αυτήν.\n"
-"  \n"
-"</details>"
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-#, fuzzy
-msgid "# Example"
-msgstr "# Παράδειγμα"
+"και στο \"μοναδικό και μεταβλητό\". Αυτοί οι περιορισμοί έρχονται πάντα μαζί "
+"στο Rust λόγω των κανόνων του ελεγκτή δανείου, και το \"self\" δεν αποτελεί "
+"εξαίρεση. Δεν θα είναι δυνατόν Αναφέρετε μια δομή από πολλές τοποθεσίες και "
+"καλέστε μια μέθοδο μεταλλάξεως (`&mut self`) σε αυτήν."
 
 #: src/methods/example.md:3
 msgid ""
@@ -6432,52 +6781,62 @@ msgstr ""
 
 #: src/methods/example.md:47
 #, fuzzy
+msgid "All four methods here use a different method receiver."
+msgstr "\\<λεπτομέρειες>"
+
+#: src/methods/example.md:48
+#, fuzzy
 msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr "Βασικά σημεία:"
+
+#: src/methods/example.md:49
+#, fuzzy
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr "Και οι τέσσερις μέθοδοι εδώ χρησιμοποιούν διαφορετικό δέκτη μεθόδου."
+
+#: src/methods/example.md:50
+#, fuzzy
+msgid ""
+"Note that although the method receivers are different, the non-static "
 "functions are called the same way in the main body. Rust enables automatic "
 "referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
+msgstr ""
+"Μπορείτε να επισημάνετε πώς αλλάζει αυτό που μπορεί να κάνει η συνάρτηση με "
+"τις τιμές των μεταβλητών και εάν/πώς μπορεί να χρησιμοποιηθεί ξανά στο "
+"\"main\"."
+
+#: src/methods/example.md:51
+#, fuzzy
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
 "over. We describe vectors in more detail in the afternoon. "
 msgstr ""
-"<λεπτομέρειες>\n"
-"    \n"
-"Βασικά σημεία:\n"
-"* Και οι τέσσερις μέθοδοι εδώ χρησιμοποιούν διαφορετικό δέκτη μεθόδου.\n"
-"  * Μπορείτε να επισημάνετε πώς αλλάζει αυτό που μπορεί να κάνει η συνάρτηση "
-"με τις τιμές των μεταβλητών και εάν/πώς μπορεί να χρησιμοποιηθεί ξανά στο "
-"\"main\".\n"
-"  * Μπορείτε να επιδείξετε το σφάλμα που εμφανίζεται όταν προσπαθείτε να "
+"Μπορείτε να επιδείξετε το σφάλμα που εμφανίζεται όταν προσπαθείτε να "
 "καλέσετε το \"finish\" δύο φορές.\n"
-"* Σημειώστε ότι παρόλο που οι δέκτες της μεθόδου είναι διαφορετικοί, οι μη "
+"\n"
+"Σημειώστε ότι παρόλο που οι δέκτες της μεθόδου είναι διαφορετικοί, οι μη "
 "στατικές συναρτήσεις ονομάζονται με τον ίδιο τρόπο στο κύριο σώμα. Το Rust "
 "επιτρέπει την αυτόματη αναφορά και αποαναφορά κατά την κλήση μεθόδων. Το "
-"Rust προσθέτει αυτόματα τα \"&\", \"*\", \"muts\", έτσι ώστε αυτό το "
+"Rust προσθέτει αυτόματα τα \"&\", \"\\*\", \"muts\", έτσι ώστε αυτό το "
 "αντικείμενο να ταιριάζει με την υπογραφή της μεθόδου.\n"
-"* Μπορείτε να επισημάνετε ότι το \"print_laps\" χρησιμοποιεί ένα διάνυσμα "
-"που επαναλαμβάνεται. Περιγράφουμε διανύσματα με περισσότερες λεπτομέρειες το "
+"\n"
+"Μπορείτε να επισημάνετε ότι το \"print_laps\" χρησιμοποιεί ένα διάνυσμα που "
+"επαναλαμβάνεται. Περιγράφουμε διανύσματα με περισσότερες λεπτομέρειες το "
 "απόγευμα."
-
-#: src/pattern-matching.md:1
-#, fuzzy
-msgid "# Pattern Matching"
-msgstr "# Αντιστοίχιση προτύπων"
 
 #: src/pattern-matching.md:3
 #, fuzzy
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 "Η λέξη-κλειδί \"αντιστοιχία\" σάς επιτρέπει να αντιστοιχίσετε μια τιμή με "
-"ένα ή περισσότερα _patterns_. ο\n"
-"Οι συγκρίσεις γίνονται από πάνω προς τα κάτω και ο πρώτος αγώνας κερδίζει."
+"ένα ή περισσότερα _patterns_. ο Οι συγκρίσεις γίνονται από πάνω προς τα κάτω "
+"και ο πρώτος αγώνας κερδίζει."
 
 #: src/pattern-matching.md:6
 #, fuzzy
@@ -6510,54 +6869,70 @@ msgstr ""
 #: src/pattern-matching.md:26
 #, fuzzy
 msgid ""
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
+msgstr "\\<λεπτομέρειες>"
+
+#: src/pattern-matching.md:27
+#, fuzzy
+msgid "`|` as an `or`"
+msgstr "Βασικά σημεία:"
+
+#: src/pattern-matching.md:28
+#, fuzzy
+msgid "`..` can expand as much as it needs to be"
 msgstr ""
-"<λεπτομέρειες>\n"
-"    \n"
-"Βασικά σημεία:\n"
-"* Θα μπορούσατε να επισημάνετε πώς χρησιμοποιούνται ορισμένοι συγκεκριμένοι "
-"χαρακτήρες όταν βρίσκονται σε ένα δίπλωμα ευρεσιτεχνίας\n"
-"  * «|» ως «ή».\n"
-"  * Το «..» μπορεί να επεκταθεί όσο χρειάζεται\n"
-"  * Το \"1..=5\" αντιπροσωπεύει ένα εύρος που περιλαμβάνει\n"
-"  * Το `_` είναι μπαλαντέρ\n"
-"* Μπορεί να είναι χρήσιμο να δείξετε πώς λειτουργεί το δεσμευτικό, για "
+"Θα μπορούσατε να επισημάνετε πώς χρησιμοποιούνται ορισμένοι συγκεκριμένοι "
+"χαρακτήρες όταν βρίσκονται σε ένα δίπλωμα ευρεσιτεχνίας"
+
+#: src/pattern-matching.md:29
+#, fuzzy
+msgid "`1..=5` represents an inclusive range"
+msgstr "«|» ως «ή»."
+
+#: src/pattern-matching.md:30
+#, fuzzy
+msgid "`_` is a wild card"
+msgstr "Το «..» μπορεί να επεκταθεί όσο χρειάζεται"
+
+#: src/pattern-matching.md:31
+#, fuzzy
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr "Το \"1..=5\" αντιπροσωπεύει ένα εύρος που περιλαμβάνει"
+
+#: src/pattern-matching.md:32
+#, fuzzy
+msgid "You can demonstrate matching on a reference."
+msgstr "Το `_` είναι μπαλαντέρ"
+
+#: src/pattern-matching.md:33
+#, fuzzy
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
+msgstr ""
+"Μπορεί να είναι χρήσιμο να δείξετε πώς λειτουργεί το δεσμευτικό, για "
 "παράδειγμα αντικαθιστώντας έναν χαρακτήρα μπαλαντέρ με μια μεταβλητή ή "
 "αφαιρώντας τα εισαγωγικά γύρω από το `q`.\n"
-"* Μπορείτε να επιδείξετε την αντιστοίχιση σε μια αναφορά.\n"
-"* Αυτή μπορεί να είναι μια καλή στιγμή για να αναδείξετε την έννοια των "
+"\n"
+"Μπορείτε να επιδείξετε την αντιστοίχιση σε μια αναφορά.\n"
+"\n"
+"Αυτή μπορεί να είναι μια καλή στιγμή για να αναδείξετε την έννοια των "
 "αδιαμφισβήτητων προτύπων, καθώς ο όρος μπορεί να εμφανίζεται σε μηνύματα "
-"λάθους.\n"
-"   \n"
-"</details>"
-
-#: src/pattern-matching/destructuring-enums.md:1
-#, fuzzy
-msgid "# Destructuring Enums"
-msgstr "# Καταστροφή Αριθμών"
+"λάθους."
 
 #: src/pattern-matching/destructuring-enums.md:3
 #, fuzzy
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 "Τα μοτίβα μπορούν επίσης να χρησιμοποιηθούν για τη σύνδεση μεταβλητών σε "
-"μέρη των τιμών σας. Ετσι\n"
-"επιθεωρείτε τη δομή των τύπων σας. Ας ξεκινήσουμε με έναν απλό τύπο «enum»:"
+"μέρη των τιμών σας. Ετσι επιθεωρείτε τη δομή των τύπων σας. Ας ξεκινήσουμε "
+"με έναν απλό τύπο «enum»:"
 
 #: src/pattern-matching/destructuring-enums.md:6
 msgid ""
@@ -6588,39 +6963,36 @@ msgstr ""
 #: src/pattern-matching/destructuring-enums.md:29
 #, fuzzy
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
 "Εδώ χρησιμοποιήσαμε τους βραχίονες για να _καταστρέψουμε_ την τιμή "
-"\"Αποτέλεσμα\". Κατά την πρώτη\n"
-"βραχίονα, το \"μισό\" είναι δεσμευμένο στην τιμή μέσα στην παραλλαγή \"Ok\". "
-"Στο δεύτερο χέρι,\n"
-"Το \"msg\" συνδέεται με το μήνυμα σφάλματος."
+"\"Αποτέλεσμα\". Κατά την πρώτη βραχίονα, το \"μισό\" είναι δεσμευμένο στην "
+"τιμή μέσα στην παραλλαγή \"Ok\". Στο δεύτερο χέρι, Το \"msg\" συνδέεται με "
+"το μήνυμα σφάλματος."
 
 #: src/pattern-matching/destructuring-enums.md:36
 #, fuzzy
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
+msgstr "Βασικά σημεία:"
+
+#: src/pattern-matching/destructuring-enums.md:37
+#, fuzzy
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
 msgstr ""
-"Βασικά σημεία:\n"
-"* Η έκφραση `if`/`else` επιστρέφει έναν αριθμό που αργότερα αποσυσκευάζεται "
-"με ένα \"match\".\n"
-"* Μπορείτε να δοκιμάσετε να προσθέσετε μια τρίτη παραλλαγή στον ορισμό enum "
+"Η έκφραση `if`/`else` επιστρέφει έναν αριθμό που αργότερα αποσυσκευάζεται με "
+"ένα \"match\".\n"
+"\n"
+"Μπορείτε να δοκιμάσετε να προσθέσετε μια τρίτη παραλλαγή στον ορισμό enum "
 "και να εμφανίσετε τα σφάλματα κατά την εκτέλεση του κώδικα. Επισημάνετε τα "
 "σημεία όπου ο κώδικας σας είναι πλέον ανεξάντλητος και πώς ο μεταγλωττιστής "
 "προσπαθεί να σας δώσει συμβουλές."
-
-#: src/pattern-matching/destructuring-structs.md:1
-#, fuzzy
-msgid "# Destructuring Structs"
-msgstr "# Κατασκευές καταστροφής"
 
 #: src/pattern-matching/destructuring-structs.md:3
 #, fuzzy
@@ -6649,15 +7021,12 @@ msgid ""
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-#, fuzzy
-msgid "# Destructuring Arrays"
-msgstr "# Αποδιάρθρωση συστοιχιών"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
 #, fuzzy
@@ -6685,50 +7054,57 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were "
-"ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of "
-"elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:1
-#, fuzzy
-msgid "# Match Guards"
-msgstr "# Match Guards"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 #, fuzzy
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 "Κατά την αντιστοίχιση, μπορείτε να προσθέσετε ένα _guard_ σε ένα μοτίβο. "
-"Αυτό είναι ένα αυθαίρετο Boolean\n"
-"έκφραση που θα εκτελεστεί εάν το μοτίβο ταιριάζει:"
+"Αυτό είναι ένα αυθαίρετο Boolean έκφραση που θα εκτελεστεί εάν το μοτίβο "
+"ταιριάζει:"
 
 #: src/pattern-matching/match-guards.md:6
 msgid ""
@@ -6750,36 +7126,48 @@ msgstr ""
 #: src/pattern-matching/match-guards.md:23
 #, fuzzy
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr "Βασικά σημεία:"
+
+#: src/pattern-matching/match-guards.md:24
+#, fuzzy
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`."
+"result in other arms of the original `match` expression being considered."
 msgstr ""
-"Βασικά σημεία:\n"
-"* Οι προστατευτικοί αγώνες ως ξεχωριστό συντακτικό χαρακτηριστικό είναι "
-"σημαντικοί και απαραίτητοι.\n"
-"* Δεν είναι ίδια με την ξεχωριστή έκφραση «αν» μέσα στο βραχίονα του αγώνα. "
+"Οι προστατευτικοί αγώνες ως ξεχωριστό συντακτικό χαρακτηριστικό είναι "
+"σημαντικοί και απαραίτητοι."
+
+#: src/pattern-matching/match-guards.md:26
+#, fuzzy
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+"Δεν είναι ίδια με την ξεχωριστή έκφραση «αν» μέσα στο βραχίονα του αγώνα. "
 "Μια έκφραση `if` μέσα στο μπλοκ διακλάδωσης (μετά από `=>`) εμφανίζεται μετά "
 "την επιλογή του βραχίονα αντιστοίχισης. Η αποτυχία της συνθήκης \"αν\" μέσα "
-"σε αυτό το μπλοκ δεν θα οδηγήσει σε άλλους βραχίονες\n"
-"της αρχικής έκφρασης «ταιριάσματος» που εξετάζεται.\n"
-"* Μπορείτε να χρησιμοποιήσετε τις μεταβλητές που ορίζονται στο μοτίβο στην "
+"σε αυτό το μπλοκ δεν θα οδηγήσει σε άλλους βραχίονες της αρχικής έκφρασης "
+"«ταιριάσματος» που εξετάζεται."
+
+#: src/pattern-matching/match-guards.md:27
+#, fuzzy
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr ""
+"Μπορείτε να χρησιμοποιήσετε τις μεταβλητές που ορίζονται στο μοτίβο στην "
 "έκφραση if σας.\n"
-"* Η συνθήκη που ορίζεται στο προστατευτικό ισχύει για κάθε έκφραση σε μοτίβο "
-"με ένα `|`.\n"
-"</details>"
+"\n"
+"Η συνθήκη που ορίζεται στο προστατευτικό ισχύει για κάθε έκφραση σε μοτίβο "
+"με ένα `|`."
 
 #: src/exercises/day-2/morning.md:1
 #, fuzzy
-msgid "# Day 2: Morning Exercises"
-msgstr "# Ημέρα 2: Πρωινές ασκήσεις"
+msgid "Day 2: Morning Exercises"
+msgstr "Ημέρα 2: Πρωινές ασκήσεις"
 
 #: src/exercises/day-2/morning.md:3
 #, fuzzy
@@ -6788,52 +7176,43 @@ msgstr "Θα εξετάσουμε την εφαρμογή μεθόδων σε δ
 
 #: src/exercises/day-2/morning.md:5
 #, fuzzy
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
-msgstr "* Πολλαπλές δομές και αριθμοί για μια βιβλιοθήκη σχεδίων."
+msgid "Simple struct which tracks health statistics."
+msgstr "Πολλαπλές δομές και αριθμοί για μια βιβλιοθήκη σχεδίων."
 
-#: src/exercises/day-2/health-statistics.md:1
-#, fuzzy
-msgid "# Health Statistics"
-msgstr "# Στατιστικά Υγείας"
+#: src/exercises/day-2/morning.md:7
+msgid "Multiple structs and enums for a drawing library."
+msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
 #, fuzzy
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
 "Εργάζεστε για την εφαρμογή ενός συστήματος παρακολούθησης της υγείας. Ως "
-"μέρος αυτού, εσείς\n"
-"πρέπει να παρακολουθεί τα στατιστικά στοιχεία υγείας των χρηστών."
+"μέρος αυτού, εσείς πρέπει να παρακολουθεί τα στατιστικά στοιχεία υγείας των "
+"χρηστών."
 
 #: src/exercises/day-2/health-statistics.md:6
 #, fuzzy
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
 "Θα ξεκινήσετε με ορισμένες αποκομμένες συναρτήσεις σε ένα μπλοκ \"impl\" "
-"καθώς και σε ένα \"User\".\n"
-"ορισμός κατασκευής. Ο στόχος σας είναι να εφαρμόσετε τις αποκομμένες "
-"μεθόδους στο\n"
-"Η δομή \"User\" ορίζεται στο μπλοκ \"impl\"."
+"καθώς και σε ένα \"User\". ορισμός κατασκευής. Ο στόχος σας είναι να "
+"εφαρμόσετε τις αποκομμένες μεθόδους στο Η δομή \"User\" ορίζεται στο μπλοκ "
+"\"impl\"."
 
 #: src/exercises/day-2/health-statistics.md:10
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 "Αντιγράψτε τον παρακάτω κώδικα στο <https://play.rust-lang.org/> και "
-"συμπληρώστε τον κωδικό που λείπει\n"
-"μέθοδοι:"
+"συμπληρώστε τον κωδικό που λείπει μέθοδοι:"
 
 #: src/exercises/day-2/health-statistics.md:13
 msgid ""
@@ -6896,23 +7275,19 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
 #, fuzzy
-msgid "# Polygon Struct"
-msgstr "# Πολυγωνική κατασκευή"
+msgid "Polygon Struct"
+msgstr "Πολυγωνική κατασκευή"
 
 #: src/exercises/day-2/points-polygons.md:3
 #, fuzzy
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 "Θα δημιουργήσουμε μια δομή «Πολύγωνο» που περιέχει μερικά σημεία. Αντιγράψτε "
-"τον παρακάτω κωδικό\n"
-"στο <https://play.rust-lang.org/> και συμπληρώστε τις μεθόδους που λείπουν "
-"για να το κάνετε\n"
-"οι δοκιμές περνούν:"
+"τον παρακάτω κωδικό στο <https://play.rust-lang.org/> και συμπληρώστε τις "
+"μεθόδους που λείπουν για να το κάνετε οι δοκιμές περνούν:"
 
 #: src/exercises/day-2/points-polygons.md:7
 msgid ""
@@ -7029,13 +7404,11 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 "Δεδομένου ότι οι υπογραφές της μεθόδου λείπουν από τις δηλώσεις προβλημάτων, "
-"το βασικό μέρος\n"
-"της άσκησης είναι να τα προσδιορίσετε σωστά."
+"το βασικό μέρος της άσκησης είναι να τα προσδιορίσετε σωστά."
 
 #: src/exercises/day-2/points-polygons.md:120
 msgid "Other interesting parts of the exercise:"
@@ -7044,55 +7417,43 @@ msgstr ""
 #: src/exercises/day-2/points-polygons.md:122
 #, fuzzy
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
-msgstr ""
-"Άλλα ενδιαφέροντα μέρη της άσκησης:\n"
-"    \n"
-"* Εξάγετε ένα χαρακτηριστικό «Αντιγραφή» για ορισμένες δομές, καθώς στις "
-"δοκιμές οι μέθοδοι μερικές φορές δεν δανείζονται τα επιχειρήματά τους.\n"
-"* Ανακαλύψτε ότι το χαρακτηριστικό «Προσθήκη» πρέπει να εφαρμοστεί για δύο "
-"αντικείμενα που μπορούν να προστεθούν μέσω του «+»."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
+msgstr "Άλλα ενδιαφέροντα μέρη της άσκησης:"
 
-#: src/control-flow.md:1
+#: src/exercises/day-2/points-polygons.md:123
 #, fuzzy
-msgid "# Control Flow"
-msgstr "# Έλεγχος ροής"
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
+"Εξάγετε ένα χαρακτηριστικό «Αντιγραφή» για ορισμένες δομές, καθώς στις "
+"δοκιμές οι μέθοδοι μερικές φορές δεν δανείζονται τα επιχειρήματά τους.\n"
+"\n"
+"Ανακαλύψτε ότι το χαρακτηριστικό «Προσθήκη» πρέπει να εφαρμοστεί για δύο "
+"αντικείμενα που μπορούν να προστεθούν μέσω του «+»."
 
 #: src/control-flow.md:3
 #, fuzzy
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
-"Όπως είδαμε, το «αν» είναι μια έκφραση στο Rust. Χρησιμοποιείται υπό όρους\n"
+"Όπως είδαμε, το «αν» είναι μια έκφραση στο Rust. Χρησιμοποιείται υπό όρους "
 "αξιολογήστε ένα από τα δύο μπλοκ, αλλά τα μπλοκ μπορεί να έχουν μια τιμή που "
-"στη συνέχεια γίνεται\n"
-"την τιμή της έκφρασης «αν». Άλλες εκφράσεις ροής ελέγχου λειτουργούν "
-"παρόμοια\n"
-"στο Rust."
-
-#: src/control-flow/blocks.md:1
-#, fuzzy
-msgid "# Blocks"
-msgstr "# Μπλοκ"
+"στη συνέχεια γίνεται την τιμή της έκφρασης «αν». Άλλες εκφράσεις ροής "
+"ελέγχου λειτουργούν παρόμοια στο Rust."
 
 #: src/control-flow/blocks.md:3
 #, fuzzy
 msgid ""
 "A block in Rust has a value and a type: the value is the last expression of "
-"the\n"
-"block:"
+"the block:"
 msgstr ""
 "Ένα μπλοκ στο Rust έχει μια τιμή και έναν τύπο: η τιμή είναι η τελευταία "
-"έκφραση του\n"
-"ΟΙΚΟΔΟΜΙΚΟ ΤΕΤΡΑΓΩΝΟ:"
+"έκφραση του ΟΙΚΟΔΟΜΙΚΟ ΤΕΤΡΑΓΩΝΟ:"
 
 #: src/control-flow/blocks.md:6
 msgid ""
@@ -7119,12 +7480,11 @@ msgstr ""
 #: src/control-flow/blocks.md:25
 #, fuzzy
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
 "Ο ίδιος κανόνας χρησιμοποιείται για τις συναρτήσεις: η τιμή του σώματος "
-"συνάρτησης είναι το\n"
-"επιστρεφόμενη τιμή:"
+"συνάρτησης είναι το επιστρεφόμενη τιμή:"
 
 #: src/control-flow/blocks.md:28
 msgid ""
@@ -7148,26 +7508,27 @@ msgstr ""
 #: src/control-flow/blocks.md:43
 #, fuzzy
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
+msgstr "Βασικά σημεία:"
+
+#: src/control-flow/blocks.md:44
+#, fuzzy
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
 msgstr ""
-"Βασικά σημεία:\n"
-"* Ο σκοπός αυτής της διαφάνειας είναι να δείξει ότι τα μπλοκ έχουν τύπο και "
+"Ο σκοπός αυτής της διαφάνειας είναι να δείξει ότι τα μπλοκ έχουν τύπο και "
 "τιμή στο Rust.\n"
-"* Μπορείτε να δείξετε πώς αλλάζει η τιμή του μπλοκ αλλάζοντας την τελευταία "
+"\n"
+"Μπορείτε να δείξετε πώς αλλάζει η τιμή του μπλοκ αλλάζοντας την τελευταία "
 "γραμμή στο μπλοκ. Για παράδειγμα, προσθέτοντας/αφαιρώντας ένα ερωτηματικό ή "
-"χρησιμοποιώντας ένα «return».\n"
-"   \n"
-"</details>"
+"χρησιμοποιώντας ένα «return»."
 
 #: src/control-flow/if-expressions.md:1
 #, fuzzy
-msgid "# `if` expressions"
-msgstr "# εκφράσεις \"αν\"."
+msgid "`if` expressions"
+msgstr "εκφράσεις \"αν\"."
 
 #: src/control-flow/if-expressions.md:3
 #, fuzzy
@@ -7221,8 +7582,8 @@ msgstr ""
 
 #: src/control-flow/if-let-expressions.md:1
 #, fuzzy
-msgid "# `if let` expressions"
-msgstr "# εκφράσεις \"αν ας\"."
+msgid "`if let` expressions"
+msgstr "εκφράσεις \"αν ας\"."
 
 #: src/control-flow/if-let-expressions.md:3
 #, fuzzy
@@ -7251,39 +7612,50 @@ msgstr ""
 #, fuzzy
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
 "Δείτε το [pattern matching](../pattern-matching.md) για περισσότερες "
-"λεπτομέρειες σχετικά με τα μοτίβα στο\n"
-"Σκουριά."
+"λεπτομέρειες σχετικά με τα μοτίβα στο Σκουριά."
 
 #: src/control-flow/if-let-expressions.md:21
 #, fuzzy
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is "
-"interesting. In contrast, `match` requires all branches to be covered.\n"
-"    * For the similar use case consider demonstrating a newly stabilized "
-"[`let else`](https://github.com/rust-lang/rust/pull/93628) feature.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching."
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
 msgstr ""
-"* Το «αν ας» μπορεί να είναι πιο συνοπτικό από το «ταίριασμα», π.χ., όταν "
-"μόνο μία περίπτωση είναι ενδιαφέρουσα. Αντίθετα, το \"match\" απαιτεί να "
-"καλύπτονται όλοι οι κλάδοι.\n"
-"    * Για παρόμοια περίπτωση χρήσης, εξετάστε το ενδεχόμενο να επιδείξετε "
-"μια νέα σταθεροποιημένη λειτουργία [`let else`](https://github.com/rust-lang/"
-"rust/pull/93628).\n"
-"* Μια κοινή χρήση είναι ο χειρισμός των τιμών \"Μερικών\" όταν εργάζεστε με "
-"το \"Option\".\n"
-"* Σε αντίθεση με το \"match\", το \"if let\" δεν υποστηρίζει προστατευτικές "
+"Το «αν ας» μπορεί να είναι πιο συνοπτικό από το «ταίριασμα», π.χ., όταν μόνο "
+"μία περίπτωση είναι ενδιαφέρουσα. Αντίθετα, το \"match\" απαιτεί να "
+"καλύπτονται όλοι οι κλάδοι."
+
+#: src/control-flow/if-let-expressions.md:22
+#, fuzzy
+msgid ""
+"For the similar use case consider demonstrating a newly stabilized [`let "
+"else`](https://github.com/rust-lang/rust/pull/93628) feature."
+msgstr ""
+"Για παρόμοια περίπτωση χρήσης, εξετάστε το ενδεχόμενο να επιδείξετε μια νέα "
+"σταθεροποιημένη λειτουργία [`let else`](https://github.com/rust-lang/rust/"
+"pull/93628)."
+
+#: src/control-flow/if-let-expressions.md:23
+#, fuzzy
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+"Μια κοινή χρήση είναι ο χειρισμός των τιμών \"Μερικών\" όταν εργάζεστε με το "
+"\"Option\"."
+
+#: src/control-flow/if-let-expressions.md:24
+#, fuzzy
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr ""
+"Σε αντίθεση με το \"match\", το \"if let\" δεν υποστηρίζει προστατευτικές "
 "ρήτρες για την αντιστοίχιση μοτίβων."
 
 #: src/control-flow/while-expressions.md:1
 #, fuzzy
-msgid "# `while` expressions"
-msgstr "# εκφράσεις «ενώ»."
+msgid "`while` expressions"
+msgstr "εκφράσεις «ενώ»."
 
 #: src/control-flow/while-expressions.md:3
 #, fuzzy
@@ -7309,19 +7681,17 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
 #, fuzzy
-msgid "# `while let` expressions"
-msgstr "# εκφράσεις «ενώ ας»."
+msgid "`while let` expressions"
+msgstr "εκφράσεις «ενώ ας»."
 
 #: src/control-flow/while-let-expressions.md:3
 #, fuzzy
 msgid ""
 "Like with `if`, there is a `while let` variant which repeatedly tests a "
-"value\n"
-"against a pattern:"
+"value against a pattern:"
 msgstr ""
 "Όπως και με το \"if\", υπάρχει μια παραλλαγή \"while let\" που ελέγχει "
-"επανειλημμένα μια τιμή\n"
-"σε σχέση με ένα μοτίβο:"
+"επανειλημμένα μια τιμή σε σχέση με ένα μοτίβο:"
 
 #: src/control-flow/while-let-expressions.md:6
 msgid ""
@@ -7341,52 +7711,50 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 "Εδώ ο επαναλήπτης που επιστρέφεται από το `v.iter()` θα επιστρέψει ένα "
-"`Option<i32>` σε κάθε\n"
-"κλήση στο `επόμενο()`. Επιστρέφει \"Some(x)\" μέχρι να ολοκληρωθεί, μετά από "
-"αυτό θα γίνει\n"
-"επιστροφή «Κανένα». Το \"while let\" μας επιτρέπει να συνεχίσουμε να "
-"επαναλαμβάνουμε όλα τα στοιχεία."
+"`Option<i32>` σε κάθε κλήση στο `επόμενο()`. Επιστρέφει \"Some(x)\" μέχρι να "
+"ολοκληρωθεί, μετά από αυτό θα γίνει επιστροφή «Κανένα». Το \"while let\" μας "
+"επιτρέπει να συνεχίσουμε να επαναλαμβάνουμε όλα τα στοιχεία."
 
 #: src/control-flow/while-let-expressions.md:27
 #, fuzzy
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
-"statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
 msgstr ""
-"* Επισημάνετε ότι ο βρόχος \"while let\" θα συνεχίσει να λειτουργεί όσο η "
-"τιμή ταιριάζει με το μοτίβο.\n"
-"* Θα μπορούσατε να ξαναγράψετε τον βρόχο «while let» ως άπειρο βρόχο με μια "
+"Επισημάνετε ότι ο βρόχος \"while let\" θα συνεχίσει να λειτουργεί όσο η τιμή "
+"ταιριάζει με το μοτίβο."
+
+#: src/control-flow/while-let-expressions.md:28
+#, fuzzy
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
+msgstr ""
+"Θα μπορούσατε να ξαναγράψετε τον βρόχο «while let» ως άπειρο βρόχο με μια "
 "πρόταση if που διακόπτεται όταν δεν υπάρχει τιμή για ξετύλιγμα για το «iter."
-"next()». Το \"while let\" παρέχει συντακτική ζάχαρη για το παραπάνω "
-"σενάριο.\n"
-"    \n"
-"</details>"
+"next()». Το \"while let\" παρέχει συντακτική ζάχαρη για το παραπάνω σενάριο."
 
 #: src/control-flow/for-expressions.md:1
 #, fuzzy
-msgid "# `for` expressions"
-msgstr "# εκφράσεις «για»."
+msgid "`for` expressions"
+msgstr "εκφράσεις «για»."
 
 #: src/control-flow/for-expressions.md:3
 #, fuzzy
 msgid ""
 "The `for` expression is closely related to the `while let` expression. It "
-"will\n"
-"automatically call `into_iter()` on the expression and then iterate over it:"
+"will automatically call `into_iter()` on the expression and then iterate "
+"over it:"
 msgstr ""
-"Η έκφραση \"for\" σχετίζεται στενά με την έκφραση \"while let\". Θα\n"
-"καλεί αυτόματα το «into_iter()» στην έκφραση και, στη συνέχεια, "
-"επαναλαμβάνει πάνω από αυτήν:"
+"Η έκφραση \"for\" σχετίζεται στενά με την έκφραση \"while let\". Θα καλεί "
+"αυτόματα το «into_iter()» στην έκφραση και, στη συνέχεια, επαναλαμβάνει πάνω "
+"από αυτήν:"
 
 #: src/control-flow/for-expressions.md:6
 msgid ""
@@ -7413,40 +7781,47 @@ msgstr ""
 
 #: src/control-flow/for-expressions.md:24
 #, fuzzy
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr "\\<λεπτομέρειες>"
+
+#: src/control-flow/for-expressions.md:25
+#, fuzzy
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr ""
+"Η επανάληψη ευρετηρίου δεν είναι ειδική σύνταξη στο Rust για αυτήν την "
+"περίπτωση."
+
+#: src/control-flow/for-expressions.md:26
+#, fuzzy
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+"Το \"(0..10)\" είναι μια περιοχή που υλοποιεί ένα χαρακτηριστικό "
+"\"Iterator\"."
+
+#: src/control-flow/for-expressions.md:27
+#, fuzzy
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
-"<λεπτομέρειες>\n"
-"    \n"
-"* Η επανάληψη ευρετηρίου δεν είναι ειδική σύνταξη στο Rust για αυτήν την "
-"περίπτωση.\n"
-"* Το \"(0..10)\" είναι μια περιοχή που υλοποιεί ένα χαρακτηριστικό "
-"\"Iterator\".\n"
-"* Το \"step_by\" είναι μια μέθοδος που επιστρέφει έναν άλλο \"Iterator\" που "
-"παραλείπει κάθε άλλο στοιχείο.\n"
-"    \n"
-"</details>"
+"Το \"step_by\" είναι μια μέθοδος που επιστρέφει έναν άλλο \"Iterator\" που "
+"παραλείπει κάθε άλλο στοιχείο."
 
 #: src/control-flow/loop-expressions.md:1
 #, fuzzy
-msgid "# `loop` expressions"
-msgstr "# εκφράσεις «βρόχου»."
+msgid "`loop` expressions"
+msgstr "εκφράσεις «βρόχου»."
 
 #: src/control-flow/loop-expressions.md:3
 #, fuzzy
 msgid ""
 "Finally, there is a `loop` keyword which creates an endless loop. Here you "
-"must\n"
-"either `break` or `return` to stop the loop:"
+"must either `break` or `return` to stop the loop:"
 msgstr ""
 "Τέλος, υπάρχει μια λέξη-κλειδί «βρόχος» που δημιουργεί έναν ατελείωτο βρόχο. "
-"Εδώ πρέπει\n"
-"είτε \"break\" είτε \"return\" για να σταματήσει ο βρόχος:"
+"Εδώ πρέπει είτε \"break\" είτε \"return\" για να σταματήσει ο βρόχος:"
 
 #: src/control-flow/loop-expressions.md:6
 msgid ""
@@ -7469,24 +7844,23 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:25
-msgid "* Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:1
 #, fuzzy
-msgid "# `match` expressions"
-msgstr "# «ταιριάζουν» εκφράσεις"
+msgid "`match` expressions"
+msgstr "«ταιριάζουν» εκφράσεις"
 
 #: src/control-flow/match-expressions.md:3
 #, fuzzy
 msgid ""
 "The `match` keyword is used to match a value against one or more patterns. "
-"In\n"
-"that sense, it works like a series of `if let` expressions:"
+"In that sense, it works like a series of `if let` expressions:"
 msgstr ""
 "Η λέξη-κλειδί \"αντιστοιχία\" χρησιμοποιείται για την αντιστοίχιση μιας "
-"τιμής με ένα ή περισσότερα μοτίβα. Σε\n"
-"Με αυτή την έννοια, λειτουργεί σαν μια σειρά από εκφράσεις «αν ας»:"
+"τιμής με ένα ή περισσότερα μοτίβα. Σε Με αυτή την έννοια, λειτουργεί σαν μια "
+"σειρά από εκφράσεις «αν ας»:"
 
 #: src/control-flow/match-expressions.md:6
 msgid ""
@@ -7507,45 +7881,54 @@ msgstr ""
 #: src/control-flow/match-expressions.md:19
 #, fuzzy
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 "Όπως το \"αν ας\", κάθε βραχίονας αγώνα πρέπει να έχει τον ίδιο τύπο. Ο "
-"τύπος είναι ο τελευταίος\n"
-"έκφραση του μπλοκ, εάν υπάρχει. Στο παραπάνω παράδειγμα, ο τύπος είναι `()`."
+"τύπος είναι ο τελευταίος έκφραση του μπλοκ, εάν υπάρχει. Στο παραπάνω "
+"παράδειγμα, ο τύπος είναι `()`."
 
 #: src/control-flow/match-expressions.md:27
+msgid "Save the match expression to a variable and print it out."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:28
+msgid "Remove `.as_deref()` and explain the error."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:29
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:30
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
 msgstr ""
 
 #: src/control-flow/break-continue.md:1
 #, fuzzy
-msgid "# `break` and `continue`"
-msgstr "# «διάλειμμα» και «συνέχεια»."
+msgid "`break` and `continue`"
+msgstr "«διάλειμμα» και «συνέχεια»."
 
 #: src/control-flow/break-continue.md:3
 #, fuzzy
 msgid ""
 "If you want to exit a loop early, use `break`, if you want to immediately "
-"start\n"
-"the next iteration use `continue`. Both `continue` and `break` can "
-"optionally\n"
-"take a label argument which is used to break out of nested loops:"
+"start the next iteration use `continue`. Both `continue` and `break` can "
+"optionally take a label argument which is used to break out of nested loops:"
 msgstr ""
 "Εάν θέλετε να βγείτε νωρίς από έναν βρόχο, χρησιμοποιήστε το «διάλειμμα», "
-"εάν θέλετε να ξεκινήσετε αμέσως\n"
-"την επόμενη επανάληψη χρησιμοποιήστε «continue». Τόσο το \"continue\" και το "
-"\"break\" μπορούν προαιρετικά\n"
-"πάρτε ένα όρισμα ετικέτας που χρησιμοποιείται για να ξεφύγει από ένθετους "
-"βρόχους:"
+"εάν θέλετε να ξεκινήσετε αμέσως την επόμενη επανάληψη χρησιμοποιήστε "
+"«continue». Τόσο το \"continue\" και το \"break\" μπορούν προαιρετικά πάρτε "
+"ένα όρισμα ετικέτας που χρησιμοποιείται για να ξεφύγει από ένθετους βρόχους:"
 
 #: src/control-flow/break-continue.md:7
 msgid ""
@@ -7576,25 +7959,17 @@ msgstr ""
 "Σε αυτή την περίπτωση σπάμε τον εξωτερικό βρόχο μετά από 3 επαναλήψεις του "
 "εσωτερικού βρόχου."
 
-#: src/std.md:1
-#, fuzzy
-msgid "# Standard Library"
-msgstr "# Τυπική βιβλιοθήκη"
-
 #: src/std.md:3
 #, fuzzy
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 "Το Rust συνοδεύεται από μια τυπική βιβλιοθήκη που βοηθά στη δημιουργία ενός "
-"συνόλου κοινών τύπων\n"
-"χρησιμοποιείται από τη βιβλιοθήκη και τα προγράμματα της Rust. Με αυτόν τον "
-"τρόπο, δύο βιβλιοθήκες μπορούν να συνεργαστούν\n"
-"ομαλά γιατί και οι δύο χρησιμοποιούν τον ίδιο τύπο «String»."
+"συνόλου κοινών τύπων χρησιμοποιείται από τη βιβλιοθήκη και τα προγράμματα "
+"της Rust. Με αυτόν τον τρόπο, δύο βιβλιοθήκες μπορούν να συνεργαστούν ομαλά "
+"γιατί και οι δύο χρησιμοποιούν τον ίδιο τύπο «String»."
 
 #: src/std.md:7
 #, fuzzy
@@ -7603,51 +7978,75 @@ msgstr "Οι συνήθεις τύποι λεξιλογίου περιλαμβά
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
+msgstr ""
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr ""
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr ""
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr ""
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
 "data."
 msgstr ""
 
 #: src/std.md:25
 #, fuzzy
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
+msgstr "\\<λεπτομέρειες>"
+
+#: src/std.md:26
+#, fuzzy
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
 msgstr ""
-"<λεπτομέρειες>\n"
-"  \n"
-"  * Στην πραγματικότητα, το Rust περιέχει πολλά επίπεδα της τυπικής "
-"βιβλιοθήκης: «core», «alloc» και «std».\n"
-"  * Ο «πυρήνας» περιλαμβάνει τους πιο βασικούς τύπους και λειτουργίες που "
-"δεν εξαρτώνται από το «libc», τον εκχωρητή ή\n"
-"    ακόμη και η παρουσία ενός λειτουργικού συστήματος.\n"
-"  * Το \"alloc\" περιλαμβάνει τύπους που απαιτούν καθολικό εκχωρητή σωρού, "
-"όπως \"Vec\", \"Box\" και \"Arc\".\n"
-"  * Οι εφαρμογές Embedded Rust χρησιμοποιούν συχνά μόνο «core» και μερικές "
-"φορές «alloc»."
+"Στην πραγματικότητα, το Rust περιέχει πολλά επίπεδα της τυπικής βιβλιοθήκης: "
+"«core», «alloc» και «std»."
+
+#: src/std.md:28
+#, fuzzy
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+"Ο «πυρήνας» περιλαμβάνει τους πιο βασικούς τύπους και λειτουργίες που δεν "
+"εξαρτώνται από το «libc», τον εκχωρητή ή ακόμη και η παρουσία ενός "
+"λειτουργικού συστήματος."
+
+#: src/std.md:29
+#, fuzzy
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"Το \"alloc\" περιλαμβάνει τύπους που απαιτούν καθολικό εκχωρητή σωρού, όπως "
+"\"Vec\", \"Box\" και \"Arc\".\n"
+"\n"
+"Οι εφαρμογές Embedded Rust χρησιμοποιούν συχνά μόνο «core» και μερικές φορές "
+"«alloc»."
 
 #: src/std/option-result.md:1
 #, fuzzy
-msgid "# `Option` and `Result`"
-msgstr "# «Επιλογή» και «Αποτέλεσμα»."
+msgid "`Option` and `Result`"
+msgstr "«Επιλογή» και «Αποτέλεσμα»."
 
 #: src/std/option-result.md:3
 #, fuzzy
@@ -7670,39 +8069,54 @@ msgstr ""
 
 #: src/std/option-result.md:18
 #, fuzzy
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
-"* Η επιλογή «Επιλογή» και «Αποτέλεσμα» χρησιμοποιούνται ευρέως όχι μόνο στην "
-"τυπική βιβλιοθήκη.\n"
-"* Το \"Option<&T>\" έχει μηδενικό χώρο σε σύγκριση με το \"&T\".\n"
-"* Το \"Αποτέλεσμα\" είναι ο τυπικός τύπος για την υλοποίηση του χειρισμού "
-"σφαλμάτων, όπως θα δούμε την Ημέρα 3.\n"
-"* Η \"δυαδική_αναζήτηση\" επιστρέφει \"Αποτέλεσμα<χρήση, χρήση>\".\n"
-"  * Εάν βρεθεί, το «Αποτέλεσμα::Οκ» διατηρεί το ευρετήριο όπου βρίσκεται το "
-"στοιχείο.\n"
-"  * Διαφορετικά, το \"Αποτέλεσμα::Σφάλμα\" περιέχει το ευρετήριο όπου θα "
-"πρέπει να εισαχθεί ένα τέτοιο στοιχείο."
+"Η επιλογή «Επιλογή» και «Αποτέλεσμα» χρησιμοποιούνται ευρέως όχι μόνο στην "
+"τυπική βιβλιοθήκη."
 
-#: src/std/string.md:1
+#: src/std/option-result.md:19
 #, fuzzy
-msgid "# String"
-msgstr "# Χορδή"
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "Το \"Option\\<&T>\" έχει μηδενικό χώρο σε σύγκριση με το \"&T\"."
+
+#: src/std/option-result.md:20
+#, fuzzy
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+"Το \"Αποτέλεσμα\" είναι ο τυπικός τύπος για την υλοποίηση του χειρισμού "
+"σφαλμάτων, όπως θα δούμε την Ημέρα 3."
+
+#: src/std/option-result.md:21
+#, fuzzy
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "Η \"δυαδική_αναζήτηση\" επιστρέφει \"Αποτέλεσμα\\<χρήση, χρήση>\"."
+
+#: src/std/option-result.md:22
+#, fuzzy
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr ""
+"Εάν βρεθεί, το «Αποτέλεσμα::Οκ» διατηρεί το ευρετήριο όπου βρίσκεται το "
+"στοιχείο."
+
+#: src/std/option-result.md:23
+#, fuzzy
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr ""
+"Διαφορετικά, το \"Αποτέλεσμα::Σφάλμα\" περιέχει το ευρετήριο όπου θα πρέπει "
+"να εισαχθεί ένα τέτοιο στοιχείο."
 
 #: src/std/string.md:3
 #, fuzzy
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
-"Το [`String`][1] είναι το τυπικό buffer συμβολοσειρών UTF-8 που εκχωρείται "
-"σε σωρό:"
+"Το [`String`](https://doc.rust-lang.org/std/string/struct.String.html) είναι "
+"το τυπικό buffer συμβολοσειρών UTF-8 που εκχωρείται σε σωρό:"
 
 #: src/std/string.md:5
 msgid ""
@@ -7727,50 +8141,83 @@ msgstr ""
 #: src/std/string.md:22
 #, fuzzy
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"Το `String` υλοποιεί [`Deref<Target = str>`][2], που σημαίνει ότι μπορείτε "
-"να καλέσετε όλα\n"
-"Μέθοδοι `str` σε μια συμβολοσειρά."
+"Το `String` υλοποιεί [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), που σημαίνει ότι μπορείτε να "
+"καλέσετε όλα Μέθοδοι `str` σε μια συμβολοσειρά."
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to index a `String` by using `s3[i]` and `s3."
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid ""
+"Compare the different ways to index a `String` by using `s3[i]` and `s3."
 "chars().nth(i).unwrap()` where `i` is in-bound, out-of-bounds, and \"on\" "
 "the flag Unicode character."
 msgstr ""
 
 #: src/std/vec.md:1
 #, fuzzy
-msgid "# `Vec`"
-msgstr "# «Vec»."
+msgid "`Vec`"
+msgstr "«Vec»."
 
 #: src/std/vec.md:3
 #, fuzzy
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
 msgstr ""
-"Το [`Vec`][1] είναι το τυπικό buffer με δυνατότητα αλλαγής μεγέθους που "
-"εκχωρείται σε σωρό:"
+"Το [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) είναι το "
+"τυπικό buffer με δυνατότητα αλλαγής μεγέθους που εκχωρείται σε σωρό:"
 
 #: src/std/vec.md:5
 msgid ""
@@ -7802,40 +8249,51 @@ msgstr ""
 #: src/std/vec.md:29
 #, fuzzy
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
-"Το `Vec` υλοποιεί το [`Deref<Target = [T]>`][2], που σημαίνει ότι μπορείτε "
-"να καλέσετε το slice\n"
-"μεθόδους σε ένα «Vec»."
+"Το `Vec` υλοποιεί το [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/"
+"vec/struct.Vec.html#deref-methods-%5BT%5D), που σημαίνει ότι μπορείτε να "
+"καλέσετε το slice μεθόδους σε ένα «Vec»."
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
 #, fuzzy
-msgid "# `HashMap`"
-msgstr "# `HashMap`"
+msgid "`HashMap`"
+msgstr "`HashMap`"
 
 #: src/std/hashmap.md:3
 #, fuzzy
@@ -7882,50 +8340,82 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
 #, fuzzy
-msgid "# `Box`"
-msgstr "# «Κουτί»."
+msgid "`Box`"
+msgstr "«Κουτί»."
 
 #: src/std/box.md:3
 #, fuzzy
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "Το [`Πλαίσιο`][1] είναι ένας ιδιόκτητος δείκτης σε δεδομένα στο σωρό:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"Το [`Πλαίσιο`](https://doc.rust-lang.org/std/boxed/struct.Box.html) είναι "
+"ένας ιδιόκτητος δείκτης σε δεδομένα στο σωρό:"
 
 #: src/std/box.md:5
 msgid ""
@@ -7957,31 +8447,50 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
-"Το \"Box<T>\" υλοποιεί το \"Deref<Target = T>\", που σημαίνει ότι μπορείτε "
-"[μεθόδους κλήσης\n"
-"από το \"T\" απευθείας σε ένα \"Box<T>\"][2]."
+"Το \"Box\n"
+"\n"
+"\" υλοποιεί το \"Deref\\<Target = T>\", που σημαίνει ότι μπορείτε [μεθόδους "
+"κλήσης από το \"T\" απευθείας σε ένα \"Box\n"
+"\n"
+"\"](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-"
+"coercion)."
 
 #: src/std/box.md:34
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
+msgstr ""
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr ""
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
 msgstr ""
 
 #: src/std/box-recursive.md:1
 #, fuzzy
-msgid "# Box with Recursive Data Structures"
-msgstr "# Πλαίσιο με αναδρομικές δομές δεδομένων"
+msgid "Box with Recursive Data Structures"
+msgstr "Πλαίσιο με αναδρομικές δομές δεδομένων"
 
 #: src/std/box-recursive.md:3
 #, fuzzy
@@ -8032,36 +8541,33 @@ msgstr ""
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly "
-"into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it "
-"would look infinite.\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
 
-#: src/std/box-niche.md:1
-#, fuzzy
-msgid "# Niche Optimization"
-msgstr "# Niche Optimization"
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
 
 #: src/std/box-niche.md:16
 #, fuzzy
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 "Ένα «Πλαίσιο» δεν μπορεί να είναι κενό, επομένως ο δείκτης είναι πάντα "
-"έγκυρος και μη «μηδενικός». Αυτό\n"
-"επιτρέπει στον μεταγλωττιστή να βελτιστοποιήσει τη διάταξη της μνήμης:"
+"έγκυρος και μη «μηδενικός». Αυτό επιτρέπει στον μεταγλωττιστή να "
+"βελτιστοποιήσει τη διάταξη της μνήμης:"
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -8087,19 +8593,19 @@ msgstr ""
 
 #: src/std/rc.md:1
 #, fuzzy
-msgid "# `Rc`"
-msgstr "# «Rc»."
+msgid "`Rc`"
+msgstr "«Rc»."
 
 #: src/std/rc.md:3
 #, fuzzy
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"Το [`Rc`][1] είναι ένας κοινόχρηστος δείκτης με μέτρηση αναφοράς. "
-"Χρησιμοποιήστε το όταν πρέπει να ανατρέξετε\n"
-"στα ίδια δεδομένα από πολλά μέρη:"
+"Το [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) είναι ένας "
+"κοινόχρηστος δείκτης με μέτρηση αναφοράς. Χρησιμοποιήστε το όταν πρέπει να "
+"ανατρέξετε στα ίδια δεδομένα από πολλά μέρη:"
 
 #: src/std/rc.md:6
 msgid ""
@@ -8119,45 +8625,74 @@ msgstr ""
 #: src/std/rc.md:18
 #, fuzzy
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
 msgstr ""
 "Εάν πρέπει να μεταλλάξετε τα δεδομένα μέσα σε ένα \"Rc\", θα πρέπει να "
-"τυλίξετε τα δεδομένα μέσα\n"
-"έναν τύπο όπως [`Cell` ή `RefCell`][2]. Ανατρέξτε στο [`Arc`][3] εάν "
-"βρίσκεστε σε ένα multi-threaded\n"
-"συμφραζόμενα."
+"τυλίξετε τα δεδομένα μέσα έναν τύπο όπως [`Cell` ή `RefCell`](../concurrency/"
+"shared_state/arc.md). Ανατρέξτε στο [`Arc`](https://doc.rust-lang.org/std/"
+"sync/struct.Mutex.html) εάν βρίσκεστε σε ένα multi-threaded συμφραζόμενα."
+
+#: src/std/rc.md:20
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
 
 #: src/std/rc.md:31
 #, fuzzy
 msgid ""
-"* `Rc`'s Count ensures that its contained value is valid for as long as "
-"there are references.\n"
-"* Like C++'s `std::shared_ptr`.\n"
-"* `clone` is cheap: it creates a pointer to the same allocation and "
-"increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-"
-"write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable "
-"borrows that are enforced at compile time. `RefCell` enables (im)mutable "
-"borrows that are enforced at run time and will panic if it fails at "
-"runtime.\n"
-"* You can `downgrade()` a `Rc` into a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"`Rc`'s Count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr "Όπως το `std::shared_ptr` της C++."
+
+#: src/std/rc.md:32
+#, fuzzy
+msgid "Like C++'s `std::shared_ptr`."
 msgstr ""
-"* Όπως το `std::shared_ptr` της C++.\n"
-"* Το \"clone\" είναι φθηνό: δημιουργεί έναν δείκτη στην ίδια κατανομή και "
-"αυξάνει το πλήθος αναφοράς.\n"
-"* Το `make_mut` στην πραγματικότητα κλωνοποιεί την εσωτερική τιμή εάν είναι "
+"Το \"clone\" είναι φθηνό: δημιουργεί έναν δείκτη στην ίδια κατανομή και "
+"αυξάνει το πλήθος αναφοράς."
+
+#: src/std/rc.md:33
+#, fuzzy
+msgid ""
+"`clone` is cheap: it creates a pointer to the same allocation and increases "
+"the reference count. Does not make a deep clone and can generally be ignored "
+"when looking for performance issues in code."
+msgstr ""
+"Το `make_mut` στην πραγματικότητα κλωνοποιεί την εσωτερική τιμή εάν είναι "
 "απαραίτητο (\"clone-on-write\") και επιστρέφει μια μεταβλητή αναφορά."
+
+#: src/std/rc.md:34
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+
+#: src/std/rc.md:35
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr ""
+
+#: src/std/rc.md:36
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+
+#: src/std/rc.md:37
+msgid ""
+"You can `downgrade()` a `Rc` into a _weakly reference-counted_ object to "
+"create cycles that will be dropped properly (likely in combination with "
+"`RefCell`)."
+msgstr ""
 
 #: src/std/rc.md:41
 msgid ""
@@ -8189,11 +8724,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/modules.md:1
-#, fuzzy
-msgid "# Modules"
-msgstr "# Ενότητες"
 
 #: src/modules.md:3
 #, fuzzy
@@ -8231,17 +8761,19 @@ msgstr ""
 
 #: src/modules.md:28
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/visibility.md:1
-#, fuzzy
-msgid "# Visibility"
-msgstr "# Ορατότητα"
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr ""
 
 #: src/modules/visibility.md:3
 #, fuzzy
@@ -8250,16 +8782,21 @@ msgstr "Οι ενότητες αποτελούν όριο απορρήτου:"
 
 #: src/modules/visibility.md:5
 #, fuzzy
-msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+msgid "Module items are private by default (hides implementation details)."
 msgstr ""
-"* Τα στοιχεία της μονάδας είναι ιδιωτικά από προεπιλογή (αποκρύπτει τις "
-"λεπτομέρειες υλοποίησης).\n"
-"* Τα στοιχεία γονέα και αδελφών είναι πάντα ορατά."
+"Τα στοιχεία της μονάδας είναι ιδιωτικά από προεπιλογή (αποκρύπτει τις "
+"λεπτομέρειες υλοποίησης)."
+
+#: src/modules/visibility.md:6
+#, fuzzy
+msgid "Parent and sibling items are always visible."
+msgstr "Τα στοιχεία γονέα και αδελφών είναι πάντα ορατά."
+
+#: src/modules/visibility.md:7
+msgid ""
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
+msgstr ""
 
 #: src/modules/visibility.md:10
 msgid ""
@@ -8292,7 +8829,7 @@ msgid ""
 msgstr ""
 
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
+msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
 #: src/modules/visibility.md:41
@@ -8303,18 +8840,23 @@ msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
-"its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/paths.md:1
-#, fuzzy
-msgid "# Paths"
-msgstr "# Μονοπάτια"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
+msgstr ""
 
 #: src/modules/paths.md:3
 #, fuzzy
@@ -8323,24 +8865,31 @@ msgstr "Οι διαδρομές επιλύονται ως εξής:"
 
 #: src/modules/paths.md:5
 #, fuzzy
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
-msgstr ""
-"2. Ως απόλυτη διαδρομή:\n"
-"   * Το \"crate::foo\" αναφέρεται στο \"foo\" στη ρίζα του τρέχοντος "
-"κιβωτίου,\n"
-"   * Το «bar::foo» αναφέρεται στο «foo» στο κιβώτιο «bar»."
+msgid "As a relative path:"
+msgstr "Ως απόλυτη διαδρομή:"
 
-#: src/modules/filesystem.md:1
+#: src/modules/paths.md:6
 #, fuzzy
-msgid "# Filesystem Hierarchy"
-msgstr "# Ιεραρχία συστήματος αρχείων"
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
+msgstr ""
+"Το \"crate::foo\" αναφέρεται στο \"foo\" στη ρίζα του τρέχοντος κιβωτίου,"
+
+#: src/modules/paths.md:7
+#, fuzzy
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr "Το «bar::foo» αναφέρεται στο «foo» στο κιβώτιο «bar»."
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr ""
 
 #: src/modules/filesystem.md:3
 #, fuzzy
@@ -8361,12 +8910,13 @@ msgstr "Το περιεχόμενο της ενότητας «garden» βρίσ�
 
 #: src/modules/filesystem.md:11
 #, fuzzy
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden.rs` (μοντέρνο στυλ Rust 2018)\n"
-"* `src/garden/mod.rs` (παλαιότερο στυλ Rust 2015)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr "`src/garden.rs` (μοντέρνο στυλ Rust 2018)"
+
+#: src/modules/filesystem.md:12
+#, fuzzy
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/mod.rs` (παλαιότερο στυλ Rust 2015)"
 
 #: src/modules/filesystem.md:14
 #, fuzzy
@@ -8376,12 +8926,13 @@ msgstr ""
 
 #: src/modules/filesystem.md:16
 #, fuzzy
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden/vegetables.rs` (μοντέρνο στυλ Rust 2018)\n"
-"* `src/garden/vegetables/mod.rs` (παλαιότερο στυλ Rust 2015)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr "`src/garden/vegetables.rs` (μοντέρνο στυλ Rust 2018)"
+
+#: src/modules/filesystem.md:17
+#, fuzzy
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/vegetables/mod.rs` (παλαιότερο στυλ Rust 2015)"
 
 #: src/modules/filesystem.md:19
 #, fuzzy
@@ -8390,18 +8941,19 @@ msgstr "Η ρίζα «κλουβί» βρίσκεται σε:"
 
 #: src/modules/filesystem.md:21
 #, fuzzy
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
-msgstr ""
-"* `src/lib.rs` (για κλουβί βιβλιοθήκης)\n"
-"* `src/main.rs` (για δυαδικό κιβώτιο)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr "`src/lib.rs` (για κλουβί βιβλιοθήκης)"
+
+#: src/modules/filesystem.md:22
+#, fuzzy
+msgid "`src/main.rs` (for a binary crate)"
+msgstr "`src/main.rs` (για δυαδικό κιβώτιο)"
 
 #: src/modules/filesystem.md:24
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
-"comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 
 #: src/modules/filesystem.md:27
@@ -8421,42 +8973,55 @@ msgstr ""
 
 #: src/modules/filesystem.md:40
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:43
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:45
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:53
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:56
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:59
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:64
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
 #, fuzzy
-msgid "# Day 2: Afternoon Exercises"
-msgstr "# Ημέρα 2: Απογευματινές Ασκήσεις"
+msgid "Day 2: Afternoon Exercises"
+msgstr "Ημέρα 2: Απογευματινές Ασκήσεις"
 
 #: src/exercises/day-2/afternoon.md:3
 #, fuzzy
@@ -8465,52 +9030,50 @@ msgstr ""
 "Οι ασκήσεις για σήμερα το απόγευμα θα επικεντρωθούν σε έγχορδα και "
 "επαναλήπτες."
 
-#: src/exercises/day-2/luhn.md:1
-#, fuzzy
-msgid "# Luhn Algorithm"
-msgstr "# Αλγόριθμος Luhn"
-
 #: src/exercises/day-2/luhn.md:3
 #, fuzzy
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 "Ο [αλγόριθμος Luhn](https://en.wikipedia.org/wiki/Luhn_algorithm) "
-"χρησιμοποιείται για\n"
-"επικύρωση αριθμών πιστωτικών καρτών. Ο αλγόριθμος παίρνει μια συμβολοσειρά "
-"ως είσοδο και κάνει το\n"
-"παρακάτω για να επικυρώσετε τον αριθμό της πιστωτικής κάρτας:"
+"χρησιμοποιείται για επικύρωση αριθμών πιστωτικών καρτών. Ο αλγόριθμος "
+"παίρνει μια συμβολοσειρά ως είσοδο και κάνει το παρακάτω για να επικυρώσετε "
+"τον αριθμό της πιστωτικής κάρτας:"
 
 #: src/exercises/day-2/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:19
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 "Αντιγράψτε τον παρακάτω κώδικα στο <https://play.rust-lang.org/> και "
-"εφαρμόστε το\n"
-"λειτουργία:"
+"εφαρμόστε το λειτουργία:"
 
 #: src/exercises/day-2/luhn.md:23
 msgid ""
@@ -8564,39 +9127,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-#, fuzzy
-msgid "# Strings and Iterators"
-msgstr "# Χορδές και επαναλήπτες"
-
 #: src/exercises/day-2/strings-iterators.md:3
 #, fuzzy
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 "Σε αυτήν την άσκηση, υλοποιείτε ένα στοιχείο δρομολόγησης ενός διακομιστή "
-"web. ο\n"
-"Ο διακομιστής έχει ρυθμιστεί με έναν αριθμό προθεμάτων _διαδρομών_ με τα "
-"οποία αντιστοιχίζονται\n"
-"_αίτημα μονοπατιών_. Τα προθέματα διαδρομής μπορούν να περιέχουν έναν "
-"χαρακτήρα μπαλαντέρ που\n"
-"αντιστοιχεί σε ένα πλήρες τμήμα. Δείτε τις δοκιμές μονάδας παρακάτω."
+"web. ο Ο διακομιστής έχει ρυθμιστεί με έναν αριθμό προθεμάτων _διαδρομών_ με "
+"τα οποία αντιστοιχίζονται _αίτημα μονοπατιών_. Τα προθέματα διαδρομής "
+"μπορούν να περιέχουν έναν χαρακτήρα μπαλαντέρ που αντιστοιχεί σε ένα πλήρες "
+"τμήμα. Δείτε τις δοκιμές μονάδας παρακάτω."
 
 #: src/exercises/day-2/strings-iterators.md:8
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 "Αντιγράψτε τον παρακάτω κώδικα στο <https://play.rust-lang.org/> και κάντε "
-"τις δοκιμές\n"
-"πέρασμα. Προσπαθήστε να αποφύγετε να εκχωρήσετε ένα «Vec» για τα ενδιάμεσα "
-"αποτελέσματά σας:"
+"τις δοκιμές πέρασμα. Προσπαθήστε να αποφύγετε να εκχωρήσετε ένα «Vec» για τα "
+"ενδιάμεσα αποτελέσματά σας:"
 
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
@@ -8649,8 +9202,8 @@ msgstr ""
 
 #: src/welcome-day-3.md:1
 #, fuzzy
-msgid "# Welcome to Day 3"
-msgstr "# Καλώς ήρθατε στην Ημέρα 3"
+msgid "Welcome to Day 3"
+msgstr "Καλώς ήρθατε στην Ημέρα 3"
 
 #: src/welcome-day-3.md:3
 #, fuzzy
@@ -8659,25 +9212,29 @@ msgstr "Σήμερα, θα καλύψουμε μερικά πιο προχωρη
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
 
-#: src/traits.md:1
-#, fuzzy
-msgid "# Traits"
-msgstr "# Χαρακτηριστικά"
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
 
 #: src/traits.md:3
 #, fuzzy
@@ -8729,17 +9286,10 @@ msgstr ""
 
 #: src/traits.md:43
 msgid ""
-"* Later sections will get into more detail on generic functions like "
-"`greet`.\n"
-"  For now, students only need to know that `greet` will operate on a "
-"reference\n"
-"  to anything that implements `Pet`."
+"Later sections will get into more detail on generic functions like `greet`. "
+"For now, students only need to know that `greet` will operate on a reference "
+"to anything that implements `Pet`."
 msgstr ""
-
-#: src/traits/deriving-traits.md:1
-#, fuzzy
-msgid "# Deriving Traits"
-msgstr "# Απόκτηση γνωρισμάτων"
 
 #: src/traits/deriving-traits.md:3
 #, fuzzy
@@ -8766,11 +9316,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/default-methods.md:1
-#, fuzzy
-msgid "# Default Methods"
-msgstr "# Προεπιλεγμένες μέθοδοι"
 
 #: src/traits/default-methods.md:3
 #, fuzzy
@@ -8807,11 +9352,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/traits/important-traits.md:1
-#, fuzzy
-msgid "# Important Traits"
-msgstr "# Σημαντικά Χαρακτηριστικά"
-
 #: src/traits/important-traits.md:3
 #, fuzzy
 msgid ""
@@ -8824,27 +9364,57 @@ msgstr ""
 #: src/traits/important-traits.md:5
 #, fuzzy
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
+msgstr "«Iterator» και «IntoIterator» που χρησιμοποιούνται σε βρόχους «for»,"
+
+#: src/traits/important-traits.md:6
+#, fuzzy
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr "Τα \"From\" και \"Into\" χρησιμοποιούνται για τη μετατροπή τιμών,"
+
+#: src/traits/important-traits.md:7
+#, fuzzy
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr "«Read» και «Write» που χρησιμοποιούνται για IO,"
+
+#: src/traits/important-traits.md:8
+#, fuzzy
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr "«Προσθήκη», «Mul», ... χρησιμοποιείται για υπερφόρτωση χειριστή και"
+
+#: src/traits/important-traits.md:9
+#, fuzzy
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr "«Drop» που χρησιμοποιείται για τον ορισμό των καταστροφέων."
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
 msgstr ""
-"* «Iterator» και «IntoIterator» που χρησιμοποιούνται σε βρόχους «for»,\n"
-"* Τα \"From\" και \"Into\" χρησιμοποιούνται για τη μετατροπή τιμών,\n"
-"* «Read» και «Write» που χρησιμοποιούνται για IO,\n"
-"* «Προσθήκη», «Mul», ... χρησιμοποιείται για υπερφόρτωση χειριστή και\n"
-"* «Drop» που χρησιμοποιείται για τον ορισμό των καταστροφέων."
 
 #: src/traits/iterator.md:1
 #, fuzzy
-msgid "# Iterators"
-msgstr "# Επαναληπτικοί"
+msgid "Iterators"
+msgstr "Επαναληπτικοί"
 
 #: src/traits/iterator.md:3
 #, fuzzy
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
 "Μπορείτε να εφαρμόσετε το χαρακτηριστικό «Iterator» στους δικούς σας τύπους:"
 
@@ -8878,31 +9448,27 @@ msgstr ""
 
 #: src/traits/iterator.md:32
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
 
-#: src/traits/from-iterator.md:1
-#, fuzzy
-msgid "# FromIterator"
-msgstr "# FromIterator"
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
 
 #: src/traits/from-iterator.md:3
 #, fuzzy
 msgid ""
-"[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
 "Το \"FromIterator\" σάς επιτρέπει να δημιουργήσετε μια συλλογή από ένα "
 "\"Iterator\"."
@@ -8923,37 +9489,35 @@ msgstr ""
 #: src/traits/from-iterator.md:17
 #, fuzzy
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"Το «Iterator» υλοποιεί\n"
-"`fn collect<B>(self) -> B\n"
-"που\n"
-"    Β: FromIterator<Self::Item>,\n"
-"    Self: Μέγεθος`"
+"Το «Iterator» υλοποιεί `fn collect<B>(self) -> B που Β: FromIterator<Self::"
+"Item>, Self: Μέγεθος`"
 
 #: src/traits/from-iterator.md:23
 #, fuzzy
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
 "Υπάρχουν επίσης υλοποιήσεις που σας επιτρέπουν να κάνετε καταπληκτικά "
-"πράγματα όπως η μετατροπή ενός\n"
-"\"Iterator<Item = Αποτέλεσμα<V, E>>\" σε ένα \"Result<Vec<V>, E>\"."
+"πράγματα όπως η μετατροπή ενός \"Iterator\\<Item = Αποτέλεσμα\\<V, E>>\" σε "
+"ένα \"Result\\<Vec\n"
+"\n"
+", E>\"."
 
 #: src/traits/from-into.md:1
 #, fuzzy
-msgid "# `From` and `Into`"
-msgstr "# «Από» και «Μέσα»."
+msgid "`From` and `Into`"
+msgstr "«Από» και «Μέσα»."
 
 #: src/traits/from-into.md:3
 #, fuzzy
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
 "Οι τύποι εφαρμόζουν τα «Από» και «Μέσα» για να διευκολύνουν τις μετατροπές "
 "τύπων:"
@@ -8974,7 +9538,9 @@ msgstr ""
 #: src/traits/from-into.md:15
 #, fuzzy
 msgid ""
-"[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr "Το \"Into\" υλοποιείται αυτόματα όταν υλοποιείται το \"From\":"
 
 #: src/traits/from-into.md:17
@@ -8993,35 +9559,37 @@ msgstr ""
 #: src/traits/from-into.md:29
 #, fuzzy
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
+msgstr "\\<λεπτομέρειες>"
+
+#: src/traits/from-into.md:30
+#, fuzzy
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
 msgstr ""
-"<λεπτομέρειες>\n"
-"  \n"
-"* Αυτός είναι ο λόγος για τον οποίο είναι σύνηθες να εφαρμόζετε μόνο το "
+"Αυτός είναι ο λόγος για τον οποίο είναι σύνηθες να εφαρμόζετε μόνο το "
 "\"From\", καθώς ο τύπος σας θα λάβει επίσης την εφαρμογή \"Into\".\n"
-"* Όταν δηλώνετε έναν τύπο εισόδου ορίσματος συνάρτησης όπως \"οτιδήποτε "
-"μπορεί να μετατραπεί σε \"Συμβολοσειρά\", ο κανόνας είναι αντίθετος, θα "
-"πρέπει να χρησιμοποιήσετε το \"Into\".\n"
-"  Η συνάρτησή σας θα δέχεται τύπους που υλοποιούν το \"From\" και εκείνους "
-"που _only_ υλοποιούν το \"Into\".\n"
-"    \n"
-"</details>"
+"\n"
+"Όταν δηλώνετε έναν τύπο εισόδου ορίσματος συνάρτησης όπως \"οτιδήποτε μπορεί "
+"να μετατραπεί σε \"Συμβολοσειρά\", ο κανόνας είναι αντίθετος, θα πρέπει να "
+"χρησιμοποιήσετε το \"Into\". Η συνάρτησή σας θα δέχεται τύπους που υλοποιούν "
+"το \"From\" και εκείνους που _only_ υλοποιούν το \"Into\"."
 
 #: src/traits/read-write.md:1
 #, fuzzy
-msgid "# `Read` and `Write`"
-msgstr "# «Διαβάστε» και «Γράψτε»."
+msgid "`Read` and `Write`"
+msgstr "«Διαβάστε» και «Γράψτε»."
 
 #: src/traits/read-write.md:3
 #, fuzzy
 msgid ""
-"Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
 msgstr ""
 "Χρησιμοποιώντας το \"Read\" και το \"BufRead\", μπορείτε να αφαιρέσετε τις "
 "πηγές \"u8\":"
@@ -9049,7 +9617,9 @@ msgstr ""
 
 #: src/traits/read-write.md:23
 #, fuzzy
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
 msgstr ""
 "Παρομοίως, το «Write» σάς επιτρέπει να κάνετε αφηρήσεις πάνω από τα νεροχύτα "
 "«u8»:"
@@ -9076,12 +9646,14 @@ msgstr ""
 
 #: src/traits/operators.md:1
 #, fuzzy
-msgid "# `Add`, `Mul`, ..."
-msgstr "# \"Προσθήκη\", \"Mul\", ..."
+msgid "`Add`, `Mul`, ..."
+msgstr "\"Προσθήκη\", \"Mul\", ..."
 
 #: src/traits/operators.md:3
 #, fuzzy
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
 "Η υπερφόρτωση χειριστή υλοποιείται μέσω χαρακτηριστικών στο `std::ops`:"
 
@@ -9115,47 +9687,50 @@ msgstr "Σημεία συζήτησης:"
 #: src/traits/operators.md:28
 #, fuzzy
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter?\n"
-"    * Short answer: Type parameters are controlled by the caller, but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
 msgstr ""
-"* Θα μπορούσατε να εφαρμόσετε το \"Add\" για το \"&Point\". Σε ποιες "
-"περιπτώσεις είναι χρήσιμο;\n"
-"    * Απάντηση: Το «Προσθήκη: Προσθήκη» καταναλώνει τον «εαυτό». Αν "
-"πληκτρολογήστε `T` για το οποίο είστε\n"
-"        Η υπερφόρτωση του χειριστή δεν είναι «Αντιγραφή», θα πρέπει να "
-"εξετάσετε την υπερφόρτωση\n"
-"        ο χειριστής για το «&T» επίσης. Αυτό αποφεύγει την περιττή "
-"κλωνοποίηση στο\n"
-"        τοποθεσία κλήσης.\n"
-"* Γιατί το \"Έξοδος\" είναι συσχετισμένος τύπος; Θα μπορούσε να γίνει "
-"παράμετρος τύπου;\n"
-"    * Σύντομη απάντηση: Οι παράμετροι τύπου ελέγχονται από τον καλούντα, "
-"αλλά\n"
-"        οι συσχετισμένοι τύποι (όπως \"Έξοδος\") ελέγχονται από τον "
-"υλοποιητή του a\n"
-"        χαρακτηριστικό."
+"Θα μπορούσατε να εφαρμόσετε το \"Add\" για το \"&Point\". Σε ποιες "
+"περιπτώσεις είναι χρήσιμο;"
+
+#: src/traits/operators.md:29
+#, fuzzy
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"Απάντηση: Το «Προσθήκη: Προσθήκη» καταναλώνει τον «εαυτό». Αν πληκτρολογήστε "
+"`T` για το οποίο είστε Η υπερφόρτωση του χειριστή δεν είναι «Αντιγραφή», θα "
+"πρέπει να εξετάσετε την υπερφόρτωση ο χειριστής για το «&T» επίσης. Αυτό "
+"αποφεύγει την περιττή κλωνοποίηση στο τοποθεσία κλήσης."
+
+#: src/traits/operators.md:33
+#, fuzzy
+msgid "Why is `Output` an associated type? Could it be made a type parameter?"
+msgstr ""
+"Γιατί το \"Έξοδος\" είναι συσχετισμένος τύπος; Θα μπορούσε να γίνει "
+"παράμετρος τύπου;"
+
+#: src/traits/operators.md:34
+#, fuzzy
+msgid ""
+"Short answer: Type parameters are controlled by the caller, but associated "
+"types (like `Output`) are controlled by the implementor of a trait."
+msgstr ""
+"Σύντομη απάντηση: Οι παράμετροι τύπου ελέγχονται από τον καλούντα, αλλά οι "
+"συσχετισμένοι τύποι (όπως \"Έξοδος\") ελέγχονται από τον υλοποιητή του a "
+"χαρακτηριστικό."
 
 #: src/traits/drop.md:1
 #, fuzzy
-msgid "# The `Drop` Trait"
-msgstr "# Το χαρακτηριστικό «Drop»."
+msgid "The `Drop` Trait"
+msgstr "Το χαρακτηριστικό «Drop»."
 
 #: src/traits/drop.md:3
 #, fuzzy
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
 "Οι τιμές που εφαρμόζουν το \"Drop\" μπορούν να καθορίσουν τον κώδικα που θα "
 "εκτελείται όταν εξέρχονται από το πεδίο εφαρμογής:"
@@ -9192,29 +9767,33 @@ msgstr ""
 
 #: src/traits/drop.md:36
 #, fuzzy
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "Γιατί το «Drop::drop» δεν σημαίνει «self»;"
+
+#: src/traits/drop.md:37
+#, fuzzy
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
-"* Γιατί το «Drop::drop» δεν σημαίνει «self»;\n"
-"    * Σύντομη απάντηση: Εάν συνέβαινε, το `std::mem::drop` θα καλούνταν στο "
-"τέλος του\n"
-"        το μπλοκ, με αποτέλεσμα μια άλλη κλήση στο «Drop::drop» και μια "
-"στοίβα\n"
-"        ξεχείλισμα!\n"
-"* Δοκιμάστε να αντικαταστήσετε το «drop(a)» με το «a.drop()»."
+"Σύντομη απάντηση: Εάν συνέβαινε, το `std::mem::drop` θα καλούνταν στο τέλος "
+"του το μπλοκ, με αποτέλεσμα μια άλλη κλήση στο «Drop::drop» και μια στοίβα "
+"ξεχείλισμα!"
+
+#: src/traits/drop.md:40
+#, fuzzy
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "Δοκιμάστε να αντικαταστήσετε το «drop(a)» με το «a.drop()»."
 
 #: src/traits/default.md:1
 #, fuzzy
-msgid "# The `Default` Trait"
-msgstr "# Το χαρακτηριστικό «Drop»."
+msgid "The `Default` Trait"
+msgstr "Το χαρακτηριστικό «Drop»."
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait provides a default implementation of a trait."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"provides a default implementation of a trait."
 msgstr ""
 
 #: src/traits/default.md:5
@@ -9255,37 +9834,43 @@ msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e."
-"g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
-"provides convenience methods that use it."
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
 msgstr ""
 
-#: src/generics.md:1
-#, fuzzy
-msgid "# Generics"
-msgstr "# Γενόσημα"
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr ""
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr ""
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
+"provides convenience methods that use it."
+msgstr ""
 
 #: src/generics.md:3
 #, fuzzy
 msgid ""
 "Rust support generics, which lets you abstract an algorithm (such as "
-"sorting)\n"
-"over the types used in the algorithm."
+"sorting) over the types used in the algorithm."
 msgstr ""
 "Γενικά υποστήριξη σκουριάς, που σας επιτρέπει να αφαιρέσετε έναν αλγόριθμο "
-"(όπως ταξινόμηση)\n"
-"πάνω από τους τύπους που χρησιμοποιούνται στον αλγόριθμο."
-
-#: src/generics/data-types.md:1
-msgid "# Generic Data Types"
-msgstr "# Γενικοί τύποι δεδομένων"
+"(όπως ταξινόμηση) πάνω από τους τύπους που χρησιμοποιούνται στον αλγόριθμο."
 
 #: src/generics/data-types.md:3
 #, fuzzy
@@ -9310,11 +9895,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/generics/methods.md:1
-#, fuzzy
-msgid "# Generic Methods"
-msgstr "# Γενικές Μέθοδοι"
 
 #: src/generics/methods.md:3
 #, fuzzy
@@ -9345,40 +9925,53 @@ msgstr ""
 #: src/generics/methods.md:25
 #, fuzzy
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
-"* *Ε:* Γιατί το `T` καθορίζεται δύο φορές στο `impl<T> Point<T> {}`; Δεν "
-"είναι περιττό;\n"
-"    * Αυτό συμβαίνει επειδή είναι μια γενική ενότητα υλοποίησης για γενικό "
-"τύπο. Είναι ανεξάρτητα γενικά.\n"
-"    * Σημαίνει ότι αυτές οι μέθοδοι ορίζονται για οποιοδήποτε «T».\n"
-"    * Είναι δυνατό να γράψετε `impl Point<u32> { .. }`.\n"
-"      * Το \"Point\" εξακολουθεί να είναι γενικό και μπορείτε να "
-"χρησιμοποιήσετε το \"Point<f64>\", αλλά οι μέθοδοι σε αυτό το μπλοκ θα είναι "
-"διαθέσιμες μόνο για το \"Point<u32>\"."
+"_Ε:_ Γιατί το `T` καθορίζεται δύο φορές στο `impl<T> Point<T> {}`; Δεν είναι "
+"περιττό;"
 
-#: src/generics/trait-bounds.md:1
+#: src/generics/methods.md:26
 #, fuzzy
-msgid "# Trait Bounds"
-msgstr "# Όρια χαρακτηριστικών"
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"Αυτό συμβαίνει επειδή είναι μια γενική ενότητα υλοποίησης για γενικό τύπο. "
+"Είναι ανεξάρτητα γενικά."
+
+#: src/generics/methods.md:27
+#, fuzzy
+msgid "It means these methods are defined for any `T`."
+msgstr "Σημαίνει ότι αυτές οι μέθοδοι ορίζονται για οποιοδήποτε «T»."
+
+#: src/generics/methods.md:28
+#, fuzzy
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "Είναι δυνατό να γράψετε `impl Point<u32> { .. }`."
+
+#: src/generics/methods.md:29
+#, fuzzy
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"Το \"Point\" εξακολουθεί να είναι γενικό και μπορείτε να χρησιμοποιήσετε το "
+"\"Point\n"
+"\n"
+"\", αλλά οι μέθοδοι σε αυτό το μπλοκ θα είναι διαθέσιμες μόνο για το "
+"\"Point\n"
+"\n"
+"\"."
 
 #: src/generics/trait-bounds.md:3
 #, fuzzy
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 "Όταν εργάζεστε με γενόσημα, συχνά θέλετε να περιορίσετε τους τύπους. "
-"Μπορείτε να το κάνετε αυτό\n"
-"με \"T: Trait\" ή \"immpl Trait\":"
+"Μπορείτε να το κάνετε αυτό με \"T: Trait\" ή \"immpl Trait\":"
 
 #: src/generics/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
@@ -9430,34 +10023,38 @@ msgstr ""
 
 #: src/generics/trait-bounds.md:46
 #, fuzzy
+msgid "It declutters the function signature if you have many parameters."
+msgstr "Καταργεί την υπογραφή της συνάρτησης εάν έχετε πολλές παραμέτρους."
+
+#: src/generics/trait-bounds.md:47
+#, fuzzy
+msgid "It has additional features making it more powerful."
+msgstr "Διαθέτει πρόσθετα χαρακτηριστικά που το κάνουν πιο ισχυρό."
+
+#: src/generics/trait-bounds.md:48
+#, fuzzy
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":"
-"\" can be arbitrary, like `Option<T>`.\n"
-"    "
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
-"* Καταργεί την υπογραφή της συνάρτησης εάν έχετε πολλές παραμέτρους.\n"
-"* Διαθέτει πρόσθετα χαρακτηριστικά που το κάνουν πιο ισχυρό.\n"
-"    * Εάν κάποιος ρωτήσει, το επιπλέον χαρακτηριστικό είναι ότι ο τύπος στα "
-"αριστερά του \":\" μπορεί να είναι αυθαίρετος, όπως \"Επιλογή<T>\".\n"
-"    \n"
-"</details>"
+"Εάν κάποιος ρωτήσει, το επιπλέον χαρακτηριστικό είναι ότι ο τύπος στα "
+"αριστερά του \":\" μπορεί να είναι αυθαίρετος, όπως \"Επιλογή\n"
+"\n"
+"\"."
 
 #: src/generics/impl-trait.md:1
 #, fuzzy
-msgid "# `impl Trait`"
-msgstr "# `impl Trait`"
+msgid "`impl Trait`"
+msgstr "`impl Trait`"
 
 #: src/generics/impl-trait.md:3
 #, fuzzy
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 "Παρόμοια με τα όρια χαρακτηριστικών, μια σύνταξη «impl Trait» μπορεί να "
-"χρησιμοποιηθεί στη συνάρτηση\n"
-"ορίσματα και τιμές επιστροφής:"
+"χρησιμοποιηθεί στη συνάρτηση ορίσματα και τιμές επιστροφής:"
 
 #: src/generics/impl-trait.md:6
 msgid ""
@@ -9477,11 +10074,12 @@ msgstr ""
 
 #: src/generics/impl-trait.md:19
 #, fuzzy
-msgid "* `impl Trait` allows you to work with types which you cannot name."
+msgid "`impl Trait` allows you to work with types which you cannot name."
 msgstr ""
-"* Το \"impl Trait\" δεν μπορεί να χρησιμοποιηθεί με τη σύνταξη \"::<>\" "
+"Το \"impl Trait\" δεν μπορεί να χρησιμοποιηθεί με τη σύνταξη \"::\\<\\>\" "
 "turbo fish.\n"
-"* Το \"impl Trait\" σάς επιτρέπει να εργάζεστε με τύπους που δεν μπορείτε να "
+"\n"
+"Το \"impl Trait\" σάς επιτρέπει να εργάζεστε με τύπους που δεν μπορείτε να "
 "ονομάσετε."
 
 #: src/generics/impl-trait.md:23
@@ -9494,81 +10092,67 @@ msgstr ""
 #: src/generics/impl-trait.md:25
 #, fuzzy
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` "
-"picks\n"
-"  the concrete type it returns, without writing it out in the source. A "
-"function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let "
-"x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
 msgstr ""
-"* Για μια παράμετρο, το \"impl Trait\" είναι σαν μια ανώνυμη γενική "
-"παράμετρος με δεσμευμένο χαρακτηριστικό.\n"
-"* Για έναν τύπο επιστροφής, σημαίνει ότι ο τύπος επιστροφής είναι κάποιος "
-"συγκεκριμένος τύπος που υλοποιεί το χαρακτηριστικό,\n"
-"  χωρίς να ονομάσουμε τον τύπο. Αυτό μπορεί να είναι χρήσιμο όταν δεν θέλετε "
-"να εκθέσετε τον τύπο σκυροδέματος στο α\n"
-"  δημόσιο API."
+"Για μια παράμετρο, το \"impl Trait\" είναι σαν μια ανώνυμη γενική παράμετρος "
+"με δεσμευμένο χαρακτηριστικό."
+
+#: src/generics/impl-trait.md:27
+#, fuzzy
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+"Για έναν τύπο επιστροφής, σημαίνει ότι ο τύπος επιστροφής είναι κάποιος "
+"συγκεκριμένος τύπος που υλοποιεί το χαρακτηριστικό, χωρίς να ονομάσουμε τον "
+"τύπο. Αυτό μπορεί να είναι χρήσιμο όταν δεν θέλετε να εκθέσετε τον τύπο "
+"σκυροδέματος στο α δημόσιο API."
+
+#: src/generics/impl-trait.md:31
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
+msgstr ""
 
 #: src/generics/impl-trait.md:37
 #, fuzzy
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters."
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 "Αυτό το παράδειγμα είναι υπέροχο, επειδή χρησιμοποιεί το \"immpl Display\" "
-"δύο φορές. Βοηθά να το εξηγήσω\n"
-"τίποτα εδώ δεν επιβάλλει ότι είναι _ο ίδιος_ τύπος \"impl Display\". Αν "
-"χρησιμοποιούσαμε ένα μονό\n"
-"«T: Εμφάνιση», θα επιβάλει τον περιορισμό ότι η είσοδος «T» και η επιστροφή "
-"του τύπου «T» είναι του ίδιου τύπου.\n"
-"Δεν θα λειτουργούσε για τη συγκεκριμένη λειτουργία, καθώς ο τύπος που "
-"περιμένουμε ως είσοδο είναι πιθανό να μην είναι\n"
-"τι «μορφή!» επιστρέφει. Αν θέλαμε να κάνουμε το ίδιο μέσω της σύνταξης `: "
-"Display`, θα χρειαζόμασταν δύο\n"
-"ανεξάρτητες γενικές παραμέτρους.\n"
-"    \n"
-"</details>"
-
-#: src/generics/closures.md:1
-#, fuzzy
-msgid "# Closures"
-msgstr "# Κλείσιμο"
+"δύο φορές. Βοηθά να το εξηγήσω τίποτα εδώ δεν επιβάλλει ότι είναι _ο ίδιος_ "
+"τύπος \"impl Display\". Αν χρησιμοποιούσαμε ένα μονό «T: Εμφάνιση», θα "
+"επιβάλει τον περιορισμό ότι η είσοδος «T» και η επιστροφή του τύπου «T» "
+"είναι του ίδιου τύπου. Δεν θα λειτουργούσε για τη συγκεκριμένη λειτουργία, "
+"καθώς ο τύπος που περιμένουμε ως είσοδο είναι πιθανό να μην είναι τι "
+"«μορφή!» επιστρέφει. Αν θέλαμε να κάνουμε το ίδιο μέσω της σύνταξης `: "
+"Display`, θα χρειαζόμασταν δύο ανεξάρτητες γενικές παραμέτρους."
 
 #: src/generics/closures.md:3
 #, fuzzy
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 "Τα κλεισίματα ή οι εκφράσεις λάμδα έχουν τύπους που δεν μπορούν να "
-"ονομαστούν. Ωστόσο, αυτοί\n"
-"εφαρμογή ειδικού [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) και\n"
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) "
-"χαρακτηριστικά:"
+"ονομαστούν. Ωστόσο, αυτοί εφαρμογή ειδικού [`Fn`](https://doc.rust-lang.org/"
+"std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait."
+"FnMut.html) και [`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce."
+"html) χαρακτηριστικά:"
 
 #: src/generics/closures.md:8
 msgid ""
@@ -9610,37 +10194,28 @@ msgstr ""
 #, fuzzy
 msgid ""
 "An `Fn` neither consumes nor mutates captured values, or perhaps captures "
-"nothing at all, so it can\n"
-"be called multiple times concurrently."
+"nothing at all, so it can be called multiple times concurrently."
 msgstr ""
 "Ένα \"Fn\" ούτε καταναλώνει ούτε μεταλλάσσει τις καταγεγραμμένες τιμές ή "
-"ίσως δεν καταγράφει τίποτα απολύτως, επομένως μπορεί\n"
-"καλείται πολλές φορές ταυτόχρονα."
+"ίσως δεν καταγράφει τίποτα απολύτως, επομένως μπορεί καλείται πολλές φορές "
+"ταυτόχρονα."
 
 #: src/generics/closures.md:32
 #, fuzzy
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 "Το \"FnMut\" είναι ένας υποτύπος του \"FnOnce\". Το \"Fn\" είναι ένας "
-"υποτύπος των \"FnMut\" και \"FnOnce\". Δηλ. μπορείτε να χρησιμοποιήσετε ένα\n"
+"υποτύπος των \"FnMut\" και \"FnOnce\". Δηλ. μπορείτε να χρησιμοποιήσετε ένα "
 "«FnMut» όπου ζητείται ένα «FnOnce» και μπορείτε να χρησιμοποιήσετε ένα «Fn» "
-"όπου ένα «FnMut» ή «FnOnce»\n"
-"καλείται."
+"όπου ένα «FnMut» ή «FnOnce» καλείται."
 
 #: src/generics/closures.md:36
 #, fuzzy
 msgid "`move` closures only implement `FnOnce`."
 msgstr "Τα κλεισίματα «μετακίνησης» εφαρμόζουν μόνο το «FnOnce»."
-
-#: src/generics/monomorphization.md:1
-#, fuzzy
-msgid "# Monomorphization"
-msgstr "# Μονομορφοποίηση"
 
 #: src/generics/monomorphization.md:3
 #, fuzzy
@@ -9688,17 +10263,11 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 "Αυτή είναι μια αφαίρεση μηδενικού κόστους: παίρνετε ακριβώς το ίδιο "
-"αποτέλεσμα όπως αν είχατε\n"
-"κωδικοποίησαν τις δομές δεδομένων χωρίς την αφαίρεση."
-
-#: src/generics/trait-objects.md:1
-#, fuzzy
-msgid "# Trait Objects"
-msgstr "# Αντικείμενα χαρακτηριστικών"
+"αποτέλεσμα όπως αν είχατε κωδικοποίησαν τις δομές δεδομένων χωρίς την "
+"αφαίρεση."
 
 #: src/generics/trait-objects.md:3
 #, fuzzy
@@ -9821,12 +10390,11 @@ msgstr ""
 #: src/generics/trait-objects.md:69
 #, fuzzy
 msgid ""
-"Similarly, you need a trait object if you want to return different types\n"
+"Similarly, you need a trait object if you want to return different types "
 "implementing a trait:"
 msgstr ""
 "Ομοίως, χρειάζεστε ένα αντικείμενο χαρακτηριστικών εάν θέλετε να επιστρέψετε "
-"διαφορετικές τιμές\n"
-"υλοποίηση ενός χαρακτηριστικού:"
+"διαφορετικές τιμές υλοποίηση ενός χαρακτηριστικού:"
 
 #: src/generics/trait-objects.md:72
 msgid ""
@@ -9850,41 +10418,59 @@ msgstr ""
 #: src/generics/trait-objects.md:90
 #, fuzzy
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Display>` in the example above.\n"
-"* `dyn Display` is a way to tell the compiler about a dynamically sized type "
-"that implements `Display`.\n"
-"* In the example, `displayables` holds *fat pointers* to objects that "
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Display>` in the example above."
+msgstr ""
+"Τα χαρακτηριστικά μπορεί να προσδιορίζουν προ-εφαρμοσμένες (προεπιλεγμένες) "
+"μεθόδους και μεθόδους που απαιτείται από τους χρήστες να εφαρμόσουν οι "
+"ίδιοι. Οι μέθοδοι με προεπιλεγμένες υλοποιήσεις μπορούν να βασίζονται στις "
+"απαιτούμενες μεθόδους."
+
+#: src/generics/trait-objects.md:91
+#, fuzzy
+msgid ""
+"`dyn Display` is a way to tell the compiler about a dynamically sized type "
+"that implements `Display`."
+msgstr ""
+"Οι τύποι που εφαρμόζουν ένα δεδομένο χαρακτηριστικό μπορεί να είναι "
+"διαφορετικών μεγεθών. Αυτό καθιστά αδύνατο να υπάρχουν πράγματα όπως το \"Vec"
+
+#: src/generics/trait-objects.md:92
+#, fuzzy
+msgid ""
+"In the example, `displayables` holds _fat pointers_ to objects that "
 "implement `Display`. The fat pointer consists of two components, a pointer "
 "to the actual object and a pointer to the virtual method table for the "
-"`Display` implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"\t\t use std::fmt::Display;\n"
-"         println!(\"{}\", std::mem::size_of::<u32>());\n"
-"         println!(\"{}\", std::mem::size_of::<&u32>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Display>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Display>>());\n"
-"     ```"
+"`Display` implementation of that particular object."
+msgstr "\" στο παραπάνω παράδειγμα."
+
+#: src/generics/trait-objects.md:93
+#, fuzzy
+msgid "Compare these outputs in the above example:"
 msgstr ""
-"* Τα χαρακτηριστικά μπορεί να προσδιορίζουν προ-εφαρμοσμένες "
-"(προεπιλεγμένες) μεθόδους και μεθόδους που απαιτείται από τους χρήστες να "
-"εφαρμόσουν οι ίδιοι. Οι μέθοδοι με προεπιλεγμένες υλοποιήσεις μπορούν να "
-"βασίζονται στις απαιτούμενες μεθόδους.\n"
-"* Οι τύποι που εφαρμόζουν ένα δεδομένο χαρακτηριστικό μπορεί να είναι "
-"διαφορετικών μεγεθών. Αυτό καθιστά αδύνατο να υπάρχουν πράγματα όπως το "
-"\"Vec<Greet>\" στο παραπάνω παράδειγμα.\n"
-"* Το \"dyn Greet\" είναι ένας τρόπος να πείτε στον μεταγλωττιστή έναν τύπο "
-"δυναμικού μεγέθους που υλοποιεί το \"Greet\".\n"
-"* Στο παράδειγμα, τα «κατοικίδια» κρατούν δείκτες λίπους σε αντικείμενα που "
+"Το \"dyn Greet\" είναι ένας τρόπος να πείτε στον μεταγλωττιστή έναν τύπο "
+"δυναμικού μεγέθους που υλοποιεί το \"Greet\"."
+
+#: src/generics/trait-objects.md:94
+#, fuzzy
+msgid ""
+"```rust,ignore\n"
+"    use std::fmt::Display;\n"
+"    println!(\"{}\", std::mem::size_of::<u32>());\n"
+"    println!(\"{}\", std::mem::size_of::<&u32>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Display>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Display>>());\n"
+"```"
+msgstr ""
+"Στο παράδειγμα, τα «κατοικίδια» κρατούν δείκτες λίπους σε αντικείμενα που "
 "υλοποιούν το «Χαιρετισμός». Ο δείκτης λίπους αποτελείται από δύο στοιχεία, "
 "έναν δείκτη προς το πραγματικό αντικείμενο και έναν δείκτη στον πίνακα "
 "εικονικής μεθόδου για την υλοποίηση «Greet» του συγκεκριμένου αντικειμένου."
 
 #: src/exercises/day-3/morning.md:1
 #, fuzzy
-msgid "# Day 3: Morning Exercises"
-msgstr "# Ημέρα 3: Πρωινές ασκήσεις"
+msgid "Day 3: Morning Exercises"
+msgstr "Ημέρα 3: Πρωινές ασκήσεις"
 
 #: src/exercises/day-3/morning.md:3
 #, fuzzy
@@ -9893,20 +10479,14 @@ msgstr ""
 "Θα σχεδιάσουμε μια κλασική βιβλιοθήκη GUI χαρακτηριστικά και αντικείμενα "
 "χαρακτηριστικών."
 
-#: src/exercises/day-3/simple-gui.md:1
-#, fuzzy
-msgid "# A Simple GUI Library"
-msgstr "# Μια απλή βιβλιοθήκη GUI"
-
 #: src/exercises/day-3/simple-gui.md:3
 #, fuzzy
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 "Ας σχεδιάσουμε μια κλασική βιβλιοθήκη GUI χρησιμοποιώντας τις νέες μας "
-"γνώσεις για τα χαρακτηριστικά και\n"
-"γνωρίσματα αντικειμένων."
+"γνώσεις για τα χαρακτηριστικά και γνωρίσματα αντικειμένων."
 
 #: src/exercises/day-3/simple-gui.md:6
 #, fuzzy
@@ -9915,17 +10495,22 @@ msgstr "Θα έχουμε έναν αριθμό γραφικών στοιχεί�
 
 #: src/exercises/day-3/simple-gui.md:8
 #, fuzzy
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr "«Παράθυρο»: έχει «τίτλο» και περιέχει άλλα γραφικά στοιχεία."
+
+#: src/exercises/day-3/simple-gui.md:9
+#, fuzzy
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
 msgstr ""
-"* «Παράθυρο»: έχει «τίτλο» και περιέχει άλλα γραφικά στοιχεία.\n"
-"* «Κουμπί»: έχει μια «ετικέτα» και μια λειτουργία επανάκλησης που καλείται "
-"όταν το\n"
-"  πατιέται το κουμπί.\n"
-"* \"Ετικέτα\": έχει \"ετικέτα\"."
+"«Κουμπί»: έχει μια «ετικέτα» και μια λειτουργία επανάκλησης που καλείται "
+"όταν το πατιέται το κουμπί."
+
+#: src/exercises/day-3/simple-gui.md:11
+#, fuzzy
+msgid "`Label`: has a `label`."
+msgstr "\"Ετικέτα\": έχει \"ετικέτα\"."
 
 #: src/exercises/day-3/simple-gui.md:13
 #, fuzzy
@@ -9937,12 +10522,12 @@ msgstr ""
 #: src/exercises/day-3/simple-gui.md:15
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 "Αντιγράψτε τον παρακάτω κώδικα στο <https://play.rust-lang.org/>, "
-"συμπληρώστε τον κωδικό που λείπει\n"
-"Μέθοδοι \"draw_into\", ώστε να εφαρμόσετε το χαρακτηριστικό \"Widget\":"
+"συμπληρώστε τον κωδικό που λείπει Μέθοδοι \"draw_into\", ώστε να εφαρμόσετε "
+"το χαρακτηριστικό \"Widget\":"
 
 #: src/exercises/day-3/simple-gui.md:18
 msgid ""
@@ -10075,19 +10660,16 @@ msgstr ""
 #: src/exercises/day-3/simple-gui.md:135
 #, fuzzy
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
-"Εάν θέλετε να σχεδιάσετε στοιχισμένο κείμενο, μπορείτε να χρησιμοποιήσετε "
-"το\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
+"Εάν θέλετε να σχεδιάσετε στοιχισμένο κείμενο, μπορείτε να χρησιμοποιήσετε το "
+"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment) "
 "τελεστές μορφοποίησης. Ειδικότερα, παρατηρήστε πώς μπορείτε να γεμίσετε "
-"διαφορετικά\n"
-"χαρακτήρες (εδώ ένα `'/'`) και πώς μπορείτε να ελέγξετε τη στοίχιση:"
+"διαφορετικά χαρακτήρες (εδώ ένα `'/'`) και πώς μπορείτε να ελέγξετε τη "
+"στοίχιση:"
 
 #: src/exercises/day-3/simple-gui.md:140
 msgid ""
@@ -10123,11 +10705,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-#, fuzzy
-msgid "# Error Handling"
-msgstr "# Χειρισμός σφαλμάτων"
-
 #: src/error-handling.md:3
 #, fuzzy
 msgid "Error handling in Rust is done using explicit control flow:"
@@ -10136,18 +10713,15 @@ msgstr ""
 
 #: src/error-handling.md:5
 #, fuzzy
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
+msgid "Functions that can have errors list this in their return type,"
 msgstr ""
-"* Οι συναρτήσεις που μπορεί να έχουν σφάλματα το αναφέρουν στον τύπο "
-"επιστροφής τους,\n"
-"* Δεν υπάρχουν εξαιρέσεις."
+"Οι συναρτήσεις που μπορεί να έχουν σφάλματα το αναφέρουν στον τύπο "
+"επιστροφής τους,"
 
-#: src/error-handling/panics.md:1
+#: src/error-handling.md:6
 #, fuzzy
-msgid "# Panics"
-msgstr "# Πανικός"
+msgid "There are no exceptions."
+msgstr "Δεν υπάρχουν εξαιρέσεις."
 
 #: src/error-handling/panics.md:3
 #, fuzzy
@@ -10168,20 +10742,26 @@ msgstr ""
 
 #: src/error-handling/panics.md:12
 #, fuzzy
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "Οι πανικοί αφορούν μη αναστρέψιμα και απροσδόκητα σφάλματα."
+
+#: src/error-handling/panics.md:13
+#, fuzzy
+msgid "Panics are symptoms of bugs in the program."
+msgstr "Οι πανικοί είναι συμπτώματα σφαλμάτων στο πρόγραμμα."
+
+#: src/error-handling/panics.md:14
+#, fuzzy
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
-"* Οι πανικοί αφορούν μη αναστρέψιμα και απροσδόκητα σφάλματα.\n"
-"  * Οι πανικοί είναι συμπτώματα σφαλμάτων στο πρόγραμμα.\n"
-"* Χρησιμοποιήστε API που δεν προκαλούν πανικό (όπως \"Vec::get\") εάν το "
+"Χρησιμοποιήστε API που δεν προκαλούν πανικό (όπως \"Vec::get\") εάν το "
 "σφάλμα δεν είναι αποδεκτό."
 
 #: src/error-handling/panic-unwind.md:1
 #, fuzzy
-msgid "# Catching the Stack Unwinding"
-msgstr "# Αλίευση της στοίβας Ξετύλιγμα"
+msgid "Catching the Stack Unwinding"
+msgstr "Αλίευση της στοίβας Ξετύλιγμα"
 
 #: src/error-handling/panic-unwind.md:3
 #, fuzzy
@@ -10212,31 +10792,32 @@ msgstr ""
 #: src/error-handling/panic-unwind.md:19
 #, fuzzy
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* Αυτό μπορεί να είναι χρήσιμο σε διακομιστές που θα πρέπει να συνεχίσουν να "
-"εκτελούνται ακόμα και αν είναι μόνοι\n"
-"  κολλάει το αίτημα.\n"
-"* Αυτό δεν λειτουργεί εάν το \"panic = \"abort\" έχει οριστεί στο \"Cargo."
+"Αυτό μπορεί να είναι χρήσιμο σε διακομιστές που θα πρέπει να συνεχίσουν να "
+"εκτελούνται ακόμα και αν είναι μόνοι κολλάει το αίτημα."
+
+#: src/error-handling/panic-unwind.md:21
+#, fuzzy
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+"Αυτό δεν λειτουργεί εάν το \"panic = \"abort\" έχει οριστεί στο \"Cargo."
 "toml\"."
 
 #: src/error-handling/result.md:1
 #, fuzzy
-msgid "# Structured Error Handling with `Result`"
-msgstr "# Χειρισμός δομημένου σφάλματος με «Αποτέλεσμα»."
+msgid "Structured Error Handling with `Result`"
+msgstr "Χειρισμός δομημένου σφάλματος με «Αποτέλεσμα»."
 
 #: src/error-handling/result.md:3
 #, fuzzy
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
 "Έχουμε ήδη δει τον αριθμό «Αποτέλεσμα». Αυτό χρησιμοποιείται ευρέως όταν "
-"υπάρχουν σφάλματα\n"
-"αναμένεται ως μέρος της κανονικής λειτουργίας:"
+"υπάρχουν σφάλματα αναμένεται ως μέρος της κανονικής λειτουργίας:"
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10263,46 +10844,41 @@ msgstr ""
 #: src/error-handling/result.md:27
 #, fuzzy
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
 msgstr ""
-"  * Όπως και με την \"Επιλογή\", η επιτυχημένη τιμή βρίσκεται μέσα στο "
-"\"Αποτέλεσμα\", αναγκάζοντας τον προγραμματιστή να το κάνει\n"
-"    το εξάγετε ρητά. Αυτό ενθαρρύνει τον έλεγχο σφαλμάτων. Στην περίπτωση "
-"που δεν πρέπει να συμβεί ποτέ λάθος,\n"
-"    Το \"unwrap()\" ή το \"expect()\" μπορεί να κληθεί, και αυτό είναι "
-"επίσης ένα σήμα της πρόθεσης του προγραμματιστή.\n"
-"  * Η τεκμηρίωση «Αποτελέσματος» συνιστάται για ανάγνωση. Όχι κατά τη "
-"διάρκεια του μαθήματος, αλλά αξίζει να αναφερθεί.\n"
-"    Περιέχει πολλές πρακτικές μεθόδους και λειτουργίες που βοηθούν τον "
-"προγραμματισμό λειτουργικού στυλ.\n"
-"    \n"
-"</details>"
+"Όπως και με την \"Επιλογή\", η επιτυχημένη τιμή βρίσκεται μέσα στο "
+"\"Αποτέλεσμα\", αναγκάζοντας τον προγραμματιστή να το κάνει το εξάγετε ρητά. "
+"Αυτό ενθαρρύνει τον έλεγχο σφαλμάτων. Στην περίπτωση που δεν πρέπει να "
+"συμβεί ποτέ λάθος, Το \"unwrap()\" ή το \"expect()\" μπορεί να κληθεί, και "
+"αυτό είναι επίσης ένα σήμα της πρόθεσης του προγραμματιστή."
+
+#: src/error-handling/result.md:30
+#, fuzzy
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr ""
+"Η τεκμηρίωση «Αποτελέσματος» συνιστάται για ανάγνωση. Όχι κατά τη διάρκεια "
+"του μαθήματος, αλλά αξίζει να αναφερθεί. Περιέχει πολλές πρακτικές μεθόδους "
+"και λειτουργίες που βοηθούν τον προγραμματισμό λειτουργικού στυλ."
 
 #: src/error-handling/try-operator.md:1
 #, fuzzy
-msgid "# Propagating Errors with `?`"
-msgstr "# Σφάλματα διάδοσης με το \"?\"."
+msgid "Propagating Errors with `?`"
+msgstr "Σφάλματα διάδοσης με το \"?\"."
 
 #: src/error-handling/try-operator.md:3
 #, fuzzy
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
+"turn the common"
 msgstr ""
 "Ο τελεστής δοκιμής `?` χρησιμοποιείται για την επιστροφή σφαλμάτων στον "
-"καλούντα. Σας αφήνει να στρίψετε\n"
-"το κοινό"
+"καλούντα. Σας αφήνει να στρίψετε το κοινό"
 
 #: src/error-handling/try-operator.md:6
 msgid ""
@@ -10366,21 +10942,20 @@ msgstr ""
 #: src/error-handling/try-operator.md:52
 #: src/error-handling/converting-error-types-example.md:52
 #, fuzzy
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
-"* Η μεταβλητή \"username\" μπορεί να είναι είτε \"Ok(string)\" είτε "
-"\"Err(error)\".\n"
-"* Χρησιμοποιήστε την κλήση `fs::write` για να δοκιμάσετε τα διαφορετικά "
-"σενάρια: κανένα αρχείο, κενό αρχείο, αρχείο με όνομα χρήστη."
+"Η μεταβλητή \"username\" μπορεί να είναι είτε \"Ok(string)\" είτε "
+"\"Err(error)\"."
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
+#: src/error-handling/try-operator.md:53
+#: src/error-handling/converting-error-types-example.md:53
 #, fuzzy
-msgid "# Converting Error Types"
-msgstr "# Μετατροπή τύπων σφαλμάτων"
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
+"Χρησιμοποιήστε την κλήση `fs::write` για να δοκιμάσετε τα διαφορετικά "
+"σενάρια: κανένα αρχείο, κενό αρχείο, αρχείο με όνομα χρήστη."
 
 #: src/error-handling/converting-error-types.md:3
 #, fuzzy
@@ -10416,13 +10991,11 @@ msgstr ""
 #: src/error-handling/converting-error-types.md:18
 #, fuzzy
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
 "Η κλήση \"From::from\" εδώ σημαίνει ότι προσπαθούμε να μετατρέψουμε τον τύπο "
-"σφάλματος στο\n"
-"τύπος που επιστρέφεται από τη συνάρτηση:"
+"σφάλματος στο τύπος που επιστρέφεται από τη συνάρτηση:"
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -10477,36 +11050,26 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
 msgstr ""
 "Είναι καλή πρακτική για όλους τους τύπους σφαλμάτων να εφαρμόζουν το \"std::"
-"error::Error\", το οποίο απαιτεί \"Debug\" και\n"
-"'Εμφάνιση'. Είναι γενικά χρήσιμο γι 'αυτούς να εφαρμόσουν το \"Clone\" και "
-"το \"Eq\" όπου είναι δυνατόν\n"
-"ευκολότερη ζωή για τα τεστ και τους καταναλωτές της βιβλιοθήκης σας. Σε αυτή "
-"την περίπτωση δεν μπορούμε εύκολα να το κάνουμε, γιατί\n"
-"Το `io::Error` δεν τα υλοποιεί."
-
-#: src/error-handling/deriving-error-enums.md:1
-#, fuzzy
-msgid "# Deriving Error Enums"
-msgstr "# Παραγωγή Αριθμών σφαλμάτων"
+"error::Error\", το οποίο απαιτεί \"Debug\" και 'Εμφάνιση'. Είναι γενικά "
+"χρήσιμο γι 'αυτούς να εφαρμόσουν το \"Clone\" και το \"Eq\" όπου είναι "
+"δυνατόν ευκολότερη ζωή για τα τεστ και τους καταναλωτές της βιβλιοθήκης σας. "
+"Σε αυτή την περίπτωση δεν μπορούμε εύκολα να το κάνουμε, γιατί Το `io::"
+"Error` δεν τα υλοποιεί."
 
 #: src/error-handling/deriving-error-enums.md:3
 #, fuzzy
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
 "Το κιβώτιο [thiserror](https://docs.rs/thiserror/) είναι ένας δημοφιλής "
-"τρόπος δημιουργίας\n"
-"enum σφαλμάτων όπως κάναμε στην προηγούμενη σελίδα:"
+"τρόπος δημιουργίας enum σφαλμάτων όπως κάναμε στην προηγούμενη σελίδα:"
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -10546,16 +11109,13 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 "Η μακροεντολή εξαγωγής \"thiserror\" εφαρμόζει αυτόματα το \"std::error::"
-"Error\" και προαιρετικά το \"Display\"\n"
-"(εάν παρέχονται τα χαρακτηριστικά \"#[σφάλμα(...)]\") και \"Από\" (αν "
-"προστεθεί το χαρακτηριστικό \"#[από]\".\n"
-"Λειτουργεί επίσης για δομές."
+"Error\" και προαιρετικά το \"Display\" (εάν παρέχονται τα χαρακτηριστικά "
+"\"#\\[σφάλμα(...)\\]\") και \"Από\" (αν προστεθεί το χαρακτηριστικό "
+"\"#\\[από\\]\". Λειτουργεί επίσης για δομές."
 
 #: src/error-handling/deriving-error-enums.md:43
 #, fuzzy
@@ -10563,21 +11123,16 @@ msgid "It doesn't affect your public API, which makes it good for libraries."
 msgstr ""
 "Δεν επηρεάζει το δημόσιο API σας, κάτι που το κάνει καλό για βιβλιοθήκες."
 
-#: src/error-handling/dynamic-errors.md:1
-#, fuzzy
-msgid "# Dynamic Error Types"
-msgstr "# Δυναμικοί τύποι σφαλμάτων"
-
 #: src/error-handling/dynamic-errors.md:3
 #, fuzzy
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 "Μερικές φορές θέλουμε να επιτρέψουμε την επιστροφή οποιουδήποτε τύπου "
-"σφάλματος χωρίς να γράψουμε το δικό μας κάλυμμα enum\n"
-"όλες τις διαφορετικές δυνατότητες. Το `std::error::Error` το καθιστά εύκολο."
+"σφάλματος χωρίς να γράψουμε το δικό μας κάλυμμα enum όλες τις διαφορετικές "
+"δυνατότητες. Το `std::error::Error` το καθιστά εύκολο."
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -10614,37 +11169,29 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
 "Αυτό εξοικονομεί κώδικα, αλλά παραιτείται από τη δυνατότητα καθαρής "
-"διαχείρισης διαφορετικών περιπτώσεων σφαλμάτων με διαφορετικό τρόπο\n"
-"το πρόγραμμα. Ως εκ τούτου, γενικά δεν είναι καλή ιδέα να χρησιμοποιήσετε το "
-"\"Box<dyn Error>\" στο δημόσιο API ενός\n"
-"βιβλιοθήκη, αλλά μπορεί να είναι μια καλή επιλογή σε ένα πρόγραμμα όπου "
-"θέλετε απλώς να εμφανίσετε το μήνυμα σφάλματος\n"
-"κάπου."
-
-#: src/error-handling/error-contexts.md:1
-#, fuzzy
-msgid "# Adding Context to Errors"
-msgstr "# Προσθήκη περιβάλλοντος στα σφάλματα"
+"διαχείρισης διαφορετικών περιπτώσεων σφαλμάτων με διαφορετικό τρόπο το "
+"πρόγραμμα. Ως εκ τούτου, γενικά δεν είναι καλή ιδέα να χρησιμοποιήσετε το "
+"\"Box\n"
+"\n"
+"\" στο δημόσιο API ενός βιβλιοθήκη, αλλά μπορεί να είναι μια καλή επιλογή σε "
+"ένα πρόγραμμα όπου θέλετε απλώς να εμφανίσετε το μήνυμα σφάλματος κάπου."
 
 #: src/error-handling/error-contexts.md:3
 #, fuzzy
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 "Το ευρέως χρησιμοποιούμενο κιβώτιο [anyhow](https://docs.rs/anyhow/) μπορεί "
-"να σας βοηθήσει να προσθέσετε\n"
-"πληροφορίες για τα λάθη σας και σας επιτρέπει να έχετε λιγότερα\n"
-"προσαρμοσμένοι τύποι σφαλμάτων:"
+"να σας βοηθήσει να προσθέσετε πληροφορίες για τα λάθη σας και σας επιτρέπει "
+"να έχετε λιγότερα προσαρμοσμένοι τύποι σφαλμάτων:"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -10677,34 +11224,42 @@ msgstr ""
 
 #: src/error-handling/error-contexts.md:35
 #, fuzzy
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
 msgstr ""
-"* Το `ούτως ή άλλως::Αποτέλεσμα<V>` είναι ένα ψευδώνυμο τύπου για το "
-"\"Αποτέλεσμα<V, ούτως ή άλλως::Σφάλμα>\".\n"
-"* Το \"anyhow::Error\" είναι ουσιαστικά ένα περιτύλιγμα γύρω από το "
-"\"Box<dyn Error>\". Ως τέτοιο και πάλι γενικά δεν είναι\n"
-"  μια καλή επιλογή για το δημόσιο API μιας βιβλιοθήκης, αλλά χρησιμοποιείται "
-"ευρέως σε εφαρμογές.\n"
-"* Ο πραγματικός τύπος σφάλματος στο εσωτερικό του μπορεί να εξαχθεί για "
-"εξέταση εάν είναι απαραίτητο.\n"
-"* Η λειτουργικότητα που παρέχεται από το \"anyhow::Result<T>\" μπορεί να "
-"είναι οικεία στους προγραμματιστές της Go, καθώς παρέχει\n"
-"  παρόμοια μοτίβα χρήσης και εργονομία με το «(T, error)» από το Go."
+"Το `ούτως ή άλλως::Αποτέλεσμα<V>` είναι ένα ψευδώνυμο τύπου για το "
+"\"Αποτέλεσμα\\<V, ούτως ή άλλως::Σφάλμα>\"."
 
-#: src/testing.md:1
+#: src/error-handling/error-contexts.md:36
 #, fuzzy
-msgid "# Testing"
-msgstr "# Δοκιμές"
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+"Το \"anyhow::Error\" είναι ουσιαστικά ένα περιτύλιγμα γύρω από το \"Box"
+
+#: src/error-handling/error-contexts.md:38
+#, fuzzy
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+"\". Ως τέτοιο και πάλι γενικά δεν είναι μια καλή επιλογή για το δημόσιο API "
+"μιας βιβλιοθήκης, αλλά χρησιμοποιείται ευρέως σε εφαρμογές."
+
+#: src/error-handling/error-contexts.md:39
+#, fuzzy
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"Ο πραγματικός τύπος σφάλματος στο εσωτερικό του μπορεί να εξαχθεί για "
+"εξέταση εάν είναι απαραίτητο.\n"
+"\n"
+"Η λειτουργικότητα που παρέχεται από το \"anyhow::Result\n"
+"\n"
+"\" μπορεί να είναι οικεία στους προγραμματιστές της Go, καθώς παρέχει "
+"παρόμοια μοτίβα χρήσης και εργονομία με το «(T, error)» από το Go."
 
 #: src/testing.md:3
 #, fuzzy
@@ -10713,21 +11268,17 @@ msgstr "Το Rust and Cargo συνοδεύεται από ένα απλό πλα
 
 #: src/testing.md:5
 #, fuzzy
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
-msgstr "* Οι δοκιμές ενσωμάτωσης υποστηρίζονται μέσω του καταλόγου «tests/»."
+msgid "Unit tests are supported throughout your code."
+msgstr "Οι δοκιμές ενσωμάτωσης υποστηρίζονται μέσω του καταλόγου «tests/»."
 
-#: src/testing/unit-tests.md:1
-#, fuzzy
-msgid "# Unit Tests"
-msgstr "# Δοκιμές μονάδων"
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr ""
 
 #: src/testing/unit-tests.md:3
 #, fuzzy
 msgid "Mark unit tests with `#[test]`:"
-msgstr "Επισημάνετε τις δοκιμές μονάδας με «#[test]»:"
+msgstr "Επισημάνετε τις δοκιμές μονάδας με «#\\[test\\]»:"
 
 #: src/testing/unit-tests.md:5
 msgid ""
@@ -10763,20 +11314,14 @@ msgstr ""
 "Χρησιμοποιήστε τη «δοκιμή φορτίου» για να βρείτε και να εκτελέσετε τις "
 "δοκιμές μονάδας."
 
-#: src/testing/test-modules.md:1
-#, fuzzy
-msgid "# Test Modules"
-msgstr "# Δοκιμαστικές Ενότητες"
-
 #: src/testing/test-modules.md:3
 #, fuzzy
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
 "Οι δοκιμές μονάδας τοποθετούνται συχνά σε μια ένθετη ενότητα (εκτελέστε "
-"δοκιμές στο\n"
-"[Παιδική χαρά](https://play.rust-lang.org/)):"
+"δοκιμές στο [Παιδική χαρά](https://play.rust-lang.org/)):"
 
 #: src/testing/test-modules.md:6
 msgid ""
@@ -10803,18 +11348,15 @@ msgstr ""
 
 #: src/testing/test-modules.md:26
 #, fuzzy
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
-msgstr ""
-"* Αυτό σας επιτρέπει να δοκιμάσετε ιδιωτικούς βοηθούς μονάδας.\n"
-"* Το χαρακτηριστικό «#[cfg(test)]» είναι ενεργό μόνο όταν εκτελείτε «δοκιμή "
-"φορτίου»."
+msgid "This lets you unit test private helpers."
+msgstr "Αυτό σας επιτρέπει να δοκιμάσετε ιδιωτικούς βοηθούς μονάδας."
 
-#: src/testing/doc-tests.md:1
+#: src/testing/test-modules.md:27
 #, fuzzy
-msgid "# Documentation Tests"
-msgstr "# Δοκιμές τεκμηρίωσης"
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr ""
+"Το χαρακτηριστικό «#\\[cfg(test)\\]» είναι ενεργό μόνο όταν εκτελείτε "
+"«δοκιμή φορτίου»."
 
 #: src/testing/doc-tests.md:3
 #, fuzzy
@@ -10839,23 +11381,25 @@ msgstr ""
 
 #: src/testing/doc-tests.md:18
 #, fuzzy
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr ""
+"Τα μπλοκ κώδικα στα σχόλια `///` εμφανίζονται αυτόματα ως κώδικας Rust."
+
+#: src/testing/doc-tests.md:19
+#, fuzzy
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr ""
+"Ο κώδικας θα μεταγλωττιστεί και θα εκτελεστεί ως μέρος της «δοκιμής φορτίου»."
+
+#: src/testing/doc-tests.md:20
+#, fuzzy
 msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"* Τα μπλοκ κώδικα στα σχόλια `///` εμφανίζονται αυτόματα ως κώδικας Rust.\n"
-"* Ο κώδικας θα μεταγλωττιστεί και θα εκτελεστεί ως μέρος της «δοκιμής "
-"φορτίου».\n"
-"* Δοκιμάστε τον παραπάνω κώδικα στο [Rust Playground](https://play.rust-lang."
+"Δοκιμάστε τον παραπάνω κώδικα στο [Rust Playground](https://play.rust-lang."
 "org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
-
-#: src/testing/integration-tests.md:1
-#, fuzzy
-msgid "# Integration Tests"
-msgstr "# Δοκιμές ολοκλήρωσης"
 
 #: src/testing/integration-tests.md:3
 #, fuzzy
@@ -10886,11 +11430,6 @@ msgstr ""
 msgid "These tests only have access to the public API of your crate."
 msgstr "Αυτές οι δοκιμές έχουν πρόσβαση μόνο στο δημόσιο API του κλουβιού σας."
 
-#: src/unsafe.md:1
-#, fuzzy
-msgid "# Unsafe Rust"
-msgstr "# Μη ασφαλής Σκουριά"
-
 #: src/unsafe.md:3
 #, fuzzy
 msgid "The Rust language has two parts:"
@@ -10898,37 +11437,37 @@ msgstr "Η γλώσσα Rust έχει δύο μέρη:"
 
 #: src/unsafe.md:5
 #, fuzzy
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr ""
+"**Safe Rust:** ασφαλής μνήμη, δεν είναι δυνατή η απροσδιόριστη συμπεριφορά."
+
+#: src/unsafe.md:6
+#, fuzzy
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
-"* **Safe Rust:** ασφαλής μνήμη, δεν είναι δυνατή η απροσδιόριστη "
-"συμπεριφορά.\n"
-"* **Μη ασφαλής σκουριά:** μπορεί να προκαλέσει απροσδιόριστη συμπεριφορά εάν "
+"**Μη ασφαλής σκουριά:** μπορεί να προκαλέσει απροσδιόριστη συμπεριφορά εάν "
 "παραβιάζονται προϋποθέσεις."
 
 #: src/unsafe.md:8
 #, fuzzy
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr ""
 "Θα δούμε κυρίως ασφαλή Rust σε αυτό το μάθημα, αλλά είναι σημαντικό να το "
-"γνωρίζουμε\n"
-"τι είναι το Unsafe Rust."
+"γνωρίζουμε τι είναι το Unsafe Rust."
 
 #: src/unsafe.md:11
 #, fuzzy
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 "Ο μη ασφαλής κώδικας είναι συνήθως μικρός και απομονωμένος και η ορθότητά "
-"του θα πρέπει να γίνεται προσεκτικά\n"
-"τεκμηριωμένη. Συνήθως είναι τυλιγμένο σε ένα ασφαλές στρώμα αφαίρεσης."
+"του θα πρέπει να γίνεται προσεκτικά τεκμηριωμένη. Συνήθως είναι τυλιγμένο σε "
+"ένα ασφαλές στρώμα αφαίρεσης."
 
 #: src/unsafe.md:14
 #, fuzzy
@@ -10937,55 +11476,56 @@ msgstr "Το Unsafe Rust σάς δίνει πρόσβαση σε πέντε νέ
 
 #: src/unsafe.md:16
 #, fuzzy
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
+msgid "Dereference raw pointers."
+msgstr "Αναφορά ακατέργαστων δεικτών."
+
+#: src/unsafe.md:17
+#, fuzzy
+msgid "Access or modify mutable static variables."
+msgstr "Πρόσβαση ή τροποποίηση μεταβλητών στατικών μεταβλητών."
+
+#: src/unsafe.md:18
+#, fuzzy
+msgid "Access `union` fields."
+msgstr "Πρόσβαση στα πεδία «ένωση»."
+
+#: src/unsafe.md:19
+#, fuzzy
+msgid "Call `unsafe` functions, including `extern` functions."
 msgstr ""
-"* Αναφορά ακατέργαστων δεικτών.\n"
-"* Πρόσβαση ή τροποποίηση μεταβλητών στατικών μεταβλητών.\n"
-"* Πρόσβαση στα πεδία «ένωση».\n"
-"* Καλέστε «μη ασφαλείς» συναρτήσεις, συμπεριλαμβανομένων των «εξωτερικών» "
-"συναρτήσεων.\n"
-"* Εφαρμόστε «μη ασφαλή» χαρακτηριστικά."
+"Καλέστε «μη ασφαλείς» συναρτήσεις, συμπεριλαμβανομένων των «εξωτερικών» "
+"συναρτήσεων."
+
+#: src/unsafe.md:20
+#, fuzzy
+msgid "Implement `unsafe` traits."
+msgstr "Εφαρμόστε «μη ασφαλή» χαρακτηριστικά."
 
 #: src/unsafe.md:22
 #, fuzzy
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
+"We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 "Θα καλύψουμε εν συντομία τις μη ασφαλείς δυνατότητες στη συνέχεια. Για "
-"πλήρεις λεπτομέρειες, δείτε\n"
-"[Κεφάλαιο 19.1 στο βιβλίο της σκουριάς](https://doc.rust-lang.org/book/"
-"ch19-01-unsafe-rust.html)\n"
-"και το [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"πλήρεις λεπτομέρειες, δείτε [Κεφάλαιο 19.1 στο βιβλίο της σκουριάς](https://"
+"doc.rust-lang.org/book/ch19-01-unsafe-rust.html) και το [Rustonomicon]"
+"(https://doc.rust-lang.org/nomicon/)."
 
 #: src/unsafe.md:28
 #, fuzzy
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
 "Το Unsafe Rust δεν σημαίνει ότι ο κωδικός είναι εσφαλμένος. Σημαίνει ότι οι "
-"προγραμματιστές έχουν\n"
-"απενεργοποίησε τις δυνατότητες ασφαλείας του μεταγλωττιστή και πρέπει να "
-"γράψει τον σωστό κώδικα από\n"
-"τους εαυτούς τους. Σημαίνει ότι ο μεταγλωττιστής δεν επιβάλλει πλέον τους "
-"κανόνες ασφαλείας της μνήμης του Rust."
-
-#: src/unsafe/raw-pointers.md:1
-#, fuzzy
-msgid "# Dereferencing Raw Pointers"
-msgstr "# Αποαναφορά ακατέργαστων δεικτών"
+"προγραμματιστές έχουν απενεργοποίησε τις δυνατότητες ασφαλείας του "
+"μεταγλωττιστή και πρέπει να γράψει τον σωστό κώδικα από τους εαυτούς τους. "
+"Σημαίνει ότι ο μεταγλωττιστής δεν επιβάλλει πλέον τους κανόνες ασφαλείας της "
+"μνήμης του Rust."
 
 #: src/unsafe/raw-pointers.md:3
 #, fuzzy
@@ -11023,47 +11563,57 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 "Είναι καλή πρακτική (και απαιτείται από τον οδηγό στυλ Android Rust) να "
-"γράψετε ένα σχόλιο για το καθένα\n"
-"Μπλοκ \"μη ασφαλής\" που εξηγεί πώς ο κωδικός μέσα σε αυτό ικανοποιεί τις "
-"απαιτήσεις ασφαλείας του μη ασφαλούς\n"
+"γράψετε ένα σχόλιο για το καθένα Μπλοκ \"μη ασφαλής\" που εξηγεί πώς ο "
+"κωδικός μέσα σε αυτό ικανοποιεί τις απαιτήσεις ασφαλείας του μη ασφαλούς "
 "λειτουργίες που κάνει."
 
 #: src/unsafe/raw-pointers.md:30
 #, fuzzy
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
 "Στην περίπτωση των αποαναφορών δείκτη, αυτό σημαίνει ότι οι δείκτες πρέπει "
-"να είναι\n"
-"[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), π.χ.:"
+"να είναι [_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), π."
+"χ.:"
 
 #: src/unsafe/raw-pointers.md:33
 #, fuzzy
+msgid "The pointer must be non-null."
+msgstr "Ο δείκτης δεν πρέπει να είναι μηδενικός."
+
+#: src/unsafe/raw-pointers.md:34
+#, fuzzy
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
 msgstr ""
-" * Ο δείκτης δεν πρέπει να είναι μηδενικός.\n"
-" * Ο δείκτης πρέπει να είναι _dereferenceable_ (εντός των ορίων ενός "
-"μεμονωμένου αντικειμένου).\n"
-" * Το αντικείμενο δεν πρέπει να έχει εκχωρηθεί.\n"
-" * Δεν πρέπει να υπάρχουν ταυτόχρονες προσβάσεις στην ίδια τοποθεσία.\n"
-" * Εάν ο δείκτης λήφθηκε με τη μετάδοση μιας αναφοράς, το υποκείμενο "
-"αντικείμενο πρέπει να είναι ζωντανό και όχι\n"
-"   μπορεί να χρησιμοποιηθεί αναφορά για πρόσβαση στη μνήμη."
+"Ο δείκτης πρέπει να είναι _dereferenceable_ (εντός των ορίων ενός "
+"μεμονωμένου αντικειμένου)."
+
+#: src/unsafe/raw-pointers.md:35
+#, fuzzy
+msgid "The object must not have been deallocated."
+msgstr "Το αντικείμενο δεν πρέπει να έχει εκχωρηθεί."
+
+#: src/unsafe/raw-pointers.md:36
+#, fuzzy
+msgid "There must not be concurrent accesses to the same location."
+msgstr "Δεν πρέπει να υπάρχουν ταυτόχρονες προσβάσεις στην ίδια τοποθεσία."
+
+#: src/unsafe/raw-pointers.md:37
+#, fuzzy
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr ""
+"Εάν ο δείκτης λήφθηκε με τη μετάδοση μιας αναφοράς, το υποκείμενο "
+"αντικείμενο πρέπει να είναι ζωντανό και όχι μπορεί να χρησιμοποιηθεί αναφορά "
+"για πρόσβαση στη μνήμη."
 
 #: src/unsafe/raw-pointers.md:40
 #, fuzzy
@@ -11071,11 +11621,6 @@ msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 "Στις περισσότερες περιπτώσεις ο δείκτης πρέπει επίσης να είναι σωστά "
 "ευθυγραμμισμένος."
-
-#: src/unsafe/mutable-static-variables.md:1
-#, fuzzy
-msgid "# Mutable Static Variables"
-msgstr "# Μεταβλητές στατικές μεταβλητές"
 
 #: src/unsafe/mutable-static-variables.md:3
 #, fuzzy
@@ -11096,12 +11641,11 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:13
 #, fuzzy
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 "Ωστόσο, δεδομένου ότι μπορεί να προκύψουν αγώνες δεδομένων, δεν είναι "
-"ασφαλές να διαβάζετε και να γράφετε μεταβλητά\n"
-"στατικές μεταβλητές:"
+"ασφαλές να διαβάζετε και να γράφετε μεταβλητά στατικές μεταβλητές:"
 
 #: src/unsafe/mutable-static-variables.md:16
 msgid ""
@@ -11124,19 +11668,13 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 "Η χρήση ενός μεταβλητού στατικού είναι γενικά κακή ιδέα, αλλά υπάρχουν "
-"ορισμένες περιπτώσεις όπου μπορεί να έχει νόημα\n"
-"σε κώδικα «no_std» χαμηλού επιπέδου, όπως η εφαρμογή ενός κατανεμητή σωρού ή "
-"η εργασία με ορισμένα C API."
-
-#: src/unsafe/unions.md:1
-#, fuzzy
-msgid "# Unions"
-msgstr "# Σωματεία"
+"ορισμένες περιπτώσεις όπου μπορεί να έχει νόημα σε κώδικα «no_std» χαμηλού "
+"επιπέδου, όπως η εφαρμογή ενός κατανεμητή σωρού ή η εργασία με ορισμένα C "
+"API."
 
 #: src/unsafe/unions.md:3
 #, fuzzy
@@ -11166,43 +11704,34 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 "Οι ενώσεις χρειάζονται πολύ σπάνια στο Rust καθώς συνήθως μπορείτε να "
-"χρησιμοποιήσετε ένα enum. Περιστασιακά χρειάζονται\n"
-"για αλληλεπίδραση με API βιβλιοθήκης C."
+"χρησιμοποιήσετε ένα enum. Περιστασιακά χρειάζονται για αλληλεπίδραση με API "
+"βιβλιοθήκης C."
 
 #: src/unsafe/unions.md:24
 #, fuzzy
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
+"If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 "Εάν θέλετε απλώς να ερμηνεύσετε ξανά τα byte ως διαφορετικού τύπου, μάλλον "
-"θέλετε\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) ή χρηματοκιβώτιο\n"
-"περιτύλιγμα όπως το κιβώτιο [`zerocopy`](https://crates.io/crates/zerocopy)."
-
-#: src/unsafe/calling-unsafe-functions.md:1
-#, fuzzy
-msgid "# Calling Unsafe Functions"
-msgstr "# Κλήση μη ασφαλών λειτουργιών"
+"θέλετε [`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
+"transmute.html) ή χρηματοκιβώτιο περιτύλιγμα όπως το κιβώτιο [`zerocopy`]"
+"(https://crates.io/crates/zerocopy)."
 
 #: src/unsafe/calling-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 "Μια συνάρτηση ή μια μέθοδος μπορεί να επισημανθεί ως «μη ασφαλής» εάν έχει "
-"επιπλέον προϋποθέσεις\n"
-"πρέπει να τηρεί για την αποφυγή απροσδιόριστης συμπεριφοράς:"
+"επιπλέον προϋποθέσεις πρέπει να τηρεί για την αποφυγή απροσδιόριστης "
+"συμπεριφοράς:"
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
@@ -11234,21 +11763,15 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-#, fuzzy
-msgid "# Writing Unsafe Functions"
-msgstr "# Γράψιμο μη ασφαλών λειτουργιών"
-
 #: src/unsafe/writing-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
 "Μπορείτε να επισημάνετε τις δικές σας λειτουργίες ως \"μη ασφαλείς\" εάν "
-"απαιτούν συγκεκριμένες συνθήκες για να αποφευχθούν απροσδιόριστες\n"
-"η ΣΥΜΠΕΡΙΦΟΡΑ."
+"απαιτούν συγκεκριμένες συνθήκες για να αποφευχθούν απροσδιόριστες η "
+"ΣΥΜΠΕΡΙΦΟΡΑ."
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -11291,30 +11814,27 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 "Σημειώστε ότι ο μη ασφαλής κωδικός επιτρέπεται σε μια μη ασφαλή συνάρτηση "
-"χωρίς μπλοκ \"μη ασφαλής\". Μπορούμε\n"
-"απαγορεύστε αυτό με \"#[deny(unsafe_op_in_unsafe_fn)]\". Δοκιμάστε να το "
-"προσθέσετε και δείτε τι θα συμβεί."
+"χωρίς μπλοκ \"μη ασφαλής\". Μπορούμε απαγορεύστε αυτό με "
+"\"#\\[deny(unsafe_op_in_unsafe_fn)\\]\". Δοκιμάστε να το προσθέσετε και "
+"δείτε τι θα συμβεί."
 
 #: src/unsafe/extern-functions.md:1
 #, fuzzy
-msgid "# Calling External Code"
-msgstr "# Κλήση εξωτερικού κωδικού"
+msgid "Calling External Code"
+msgstr "Κλήση εξωτερικού κωδικού"
 
 #: src/unsafe/extern-functions.md:3
 #, fuzzy
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
 "Λειτουργίες από άλλες γλώσσες ενδέχεται να παραβιάζουν τις εγγυήσεις του "
-"Rust. Κλήση\n"
-"είναι επομένως ανασφαλείς:"
+"Rust. Κλήση είναι επομένως ανασφαλείς:"
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
@@ -11336,50 +11856,39 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 "Αυτό είναι συνήθως ένα πρόβλημα μόνο για εξωτερικές συναρτήσεις που κάνουν "
-"πράγματα με δείκτες που μπορεί\n"
-"παραβιάζουν το μοντέλο μνήμης του Rust, αλλά γενικά οποιαδήποτε συνάρτηση C "
-"μπορεί να έχει απροσδιόριστη συμπεριφορά κάτω από οποιαδήποτε\n"
-"αυθαίρετες περιστάσεις."
+"πράγματα με δείκτες που μπορεί παραβιάζουν το μοντέλο μνήμης του Rust, αλλά "
+"γενικά οποιαδήποτε συνάρτηση C μπορεί να έχει απροσδιόριστη συμπεριφορά κάτω "
+"από οποιαδήποτε αυθαίρετες περιστάσεις."
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/"
-"external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-#, fuzzy
-msgid "# Implementing Unsafe Traits"
-msgstr "# Εφαρμογή μη ασφαλών χαρακτηριστικών"
 
 #: src/unsafe/unsafe-traits.md:3
 #, fuzzy
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 "Όπως και με τις συναρτήσεις, μπορείτε να επισημάνετε ένα χαρακτηριστικό ως "
-"\"μη ασφαλές\", εάν η υλοποίηση πρέπει να είναι εγγυημένη\n"
-"συγκεκριμένες συνθήκες για την αποφυγή απροσδιόριστης συμπεριφοράς."
+"\"μη ασφαλές\", εάν η υλοποίηση πρέπει να είναι εγγυημένη συγκεκριμένες "
+"συνθήκες για την αποφυγή απροσδιόριστης συμπεριφοράς."
 
 #: src/unsafe/unsafe-traits.md:6
 #, fuzzy
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 "Για παράδειγμα, το κιβώτιο «zerocopy» έχει ένα μη ασφαλές χαρακτηριστικό που "
-"φαίνεται\n"
-"[κάτι σαν αυτό](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
+"φαίνεται [κάτι σαν αυτό](https://docs.rs/zerocopy/latest/zerocopy/trait."
+"AsBytes.html):"
 
 #: src/unsafe/unsafe-traits.md:9
 #, fuzzy
@@ -11404,28 +11913,20 @@ msgid ""
 "unsafe impl AsBytes for u32 {}\n"
 "```"
 msgstr ""
-"///...\n"
-"/// # Ασφάλεια\n"
-"/// Ο τύπος πρέπει να έχει καθορισμένη αναπαράσταση και χωρίς γέμιση.\n"
-"μη ασφαλές χαρακτηριστικό παμπ AsBytes {\n"
-"    fn as_bytes(&self) -> &[u8] {\n"
-"        μη ασφαλές {\n"
-"            slice::from_raw_parts(self as *const Self as *const u8, "
-"size_of_val(self))\n"
-"        }\n"
-"    }\n"
-"}"
+"///... /// # Ασφάλεια /// Ο τύπος πρέπει να έχει καθορισμένη αναπαράσταση "
+"και χωρίς γέμιση. μη ασφαλές χαρακτηριστικό παμπ AsBytes { fn "
+"as_bytes(&self) -> &\\[u8\\] { μη ασφαλές { slice::from_raw_parts(self as "
+"\\*const Self as \\*const u8, size_of_val(self)) } } }"
 
 #: src/unsafe/unsafe-traits.md:30
 #, fuzzy
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
 "Θα πρέπει να υπάρχει μια ενότητα «# Ασφάλεια» στο Rustdoc για το "
-"χαρακτηριστικό που εξηγεί τις απαιτήσεις για\n"
-"το χαρακτηριστικό που πρέπει να εφαρμοστεί με ασφάλεια."
+"χαρακτηριστικό που εξηγεί τις απαιτήσεις για το χαρακτηριστικό που πρέπει να "
+"εφαρμοστεί με ασφάλεια."
 
 #: src/unsafe/unsafe-traits.md:33
 #, fuzzy
@@ -11445,8 +11946,8 @@ msgstr ""
 
 #: src/exercises/day-3/afternoon.md:1
 #, fuzzy
-msgid "# Day 3: Afternoon Exercises"
-msgstr "# Ημέρα 3: Απογευματινές Ασκήσεις"
+msgid "Day 3: Afternoon Exercises"
+msgstr "Ημέρα 3: Απογευματινές Ασκήσεις"
 
 #: src/exercises/day-3/afternoon.md:3
 #, fuzzy
@@ -11457,27 +11958,22 @@ msgstr ""
 
 #: src/exercises/day-3/afternoon.md:7
 #, fuzzy
-msgid "After looking at the exercise, you can look at the [solution] provided."
-msgstr "Αφού δείτε την άσκηση, μπορείτε να δείτε τη [λύση] που παρέχεται."
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-#, fuzzy
-msgid "# Safe FFI Wrapper"
-msgstr "# Ασφαλές περιτύλιγμα FFI"
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
+msgstr "Αφού δείτε την άσκηση, μπορείτε να δείτε τη \\[λύση\\] που παρέχεται."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 #, fuzzy
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 "Το Rust έχει μεγάλη υποστήριξη για την κλήση συναρτήσεων μέσω μιας "
-"συνάρτησης _foreign\n"
-"διεπαφή_ (FFI). Θα το χρησιμοποιήσουμε για να δημιουργήσουμε ένα ασφαλές "
-"περιτύλιγμα για το `libc`\n"
-"συναρτήσεις που θα χρησιμοποιούσατε από το C για να διαβάσετε τα ονόματα "
-"αρχείων ενός καταλόγου."
+"συνάρτησης _foreign διεπαφή_ (FFI). Θα το χρησιμοποιήσουμε για να "
+"δημιουργήσουμε ένα ασφαλές περιτύλιγμα για το `libc` συναρτήσεις που θα "
+"χρησιμοποιούσατε από το C για να διαβάσετε τα ονόματα αρχείων ενός καταλόγου."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:7
 #, fuzzy
@@ -11486,40 +11982,45 @@ msgstr "Θα θελήσετε να συμβουλευτείτε τις σελί�
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
 #, fuzzy
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
-msgstr ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+#, fuzzy
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+#, fuzzy
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 #, fuzzy
 msgid ""
-"You will also want to browse the [`std::ffi`] module, particular for "
-"[`CStr`]\n"
-"and [`CString`] types which are used to hold NUL-terminated strings coming "
-"from\n"
-"C. The [Nomicon] also has a very useful chapter about FFI."
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module, particular for [`CStr`](https://doc.rust-lang.org/std/ffi/"
+"struct.CStr.html) and [`CString`](https://doc.rust-lang.org/std/ffi/struct."
+"CString.html) types which are used to hold NUL-terminated strings coming "
+"from C. The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a "
+"very useful chapter about FFI."
 msgstr ""
-"Θα θέλετε επίσης να περιηγηθείτε στη λειτουργική μονάδα [`std::ffi`], ειδικά "
-"για το [`CStr`]\n"
-"και τύπους [`CString`] που χρησιμοποιούνται για τη διατήρηση συμβολοσειρών "
-"με τερματισμό NUL που προέρχονται από\n"
-"Γ. Το [Nomicon] έχει επίσης ένα πολύ χρήσιμο κεφάλαιο για το FFI."
+"Θα θέλετε επίσης να περιηγηθείτε στη λειτουργική μονάδα [`std::ffi`](https://"
+"doc.rust-lang.org/std/ffi/), ειδικά για το [`CStr`](https://doc.rust-lang."
+"org/std/ffi/struct.CStr.html) και τύπους [`CString`](https://doc.rust-lang."
+"org/std/ffi/struct.CString.html) που χρησιμοποιούνται για τη διατήρηση "
+"συμβολοσειρών με τερματισμό NUL που προέρχονται από Γ. Το [Nomicon](https://"
+"doc.rust-lang.org/nomicon/ffi.html) έχει επίσης ένα πολύ χρήσιμο κεφάλαιο "
+"για το FFI."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 "Αντιγράψτε τον παρακάτω κώδικα στο <https://play.rust-lang.org/> και "
-"συμπληρώστε τον κωδικό που λείπει\n"
-"λειτουργίες και μέθοδοι:"
+"συμπληρώστε τον κωδικό που λείπει λειτουργίες και μέθοδοι:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:25
 msgid ""
@@ -11598,58 +12099,47 @@ msgstr ""
 
 #: src/welcome-day-4.md:1
 #, fuzzy
-msgid "# Welcome to Day 4"
-msgstr "# Καλώς ήρθατε στην Ημέρα 4"
+msgid "Welcome to Day 4"
+msgstr "Καλώς ήρθατε στην Ημέρα 4"
 
 #: src/welcome-day-4.md:3
 msgid ""
 "This morning, we will focus on Concurrency: threads, channels, shared state, "
-"`Send` and `Sync`.\n"
-"In the afternoon, we will have a chance to see Rust in action."
+"`Send` and `Sync`. In the afternoon, we will have a chance to see Rust in "
+"action."
 msgstr ""
 
 #: src/welcome-day-4.md:8
 msgid ""
 "This is a good time to give an outline of what you will cover in the "
-"afternoon\n"
-"section, as announced in the course offering."
+"afternoon section, as announced in the course offering."
 msgstr ""
 
 #: src/concurrency.md:1
 #, fuzzy
-msgid "# Fearless Concurrency"
-msgstr "# Ατρόμητος Συγχρονισμός"
+msgid "Fearless Concurrency"
+msgstr "Ατρόμητος Συγχρονισμός"
 
 #: src/concurrency.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 "Το Rust έχει πλήρη υποστήριξη για ταυτόχρονη χρήση νημάτων λειτουργικού "
-"συστήματος με mutexes και\n"
-"καναλιών."
+"συστήματος με mutexes και καναλιών."
 
 #: src/concurrency.md:6
 #, fuzzy
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 "Το σύστημα τύπου Rust παίζει σημαντικό ρόλο στη δημιουργία πολλών σφαλμάτων "
-"συγχρονισμού\n"
-"μεταγλώττιση χρονικών σφαλμάτων. Αυτό αναφέρεται συχνά ως _ατρόμητος "
-"συγχρονισμός_ αφού εσείς\n"
-"μπορεί να βασιστεί στον μεταγλωττιστή για να διασφαλίσει την ορθότητα κατά "
-"το χρόνο εκτέλεσης."
-
-#: src/concurrency/threads.md:1
-#, fuzzy
-msgid "# Threads"
-msgstr "# Νήματα"
+"συγχρονισμού μεταγλώττιση χρονικών σφαλμάτων. Αυτό αναφέρεται συχνά ως "
+"_ατρόμητος συγχρονισμός_ αφού εσείς μπορεί να βασιστεί στον μεταγλωττιστή "
+"για να διασφαλίσει την ορθότητα κατά το χρόνο εκτέλεσης."
 
 #: src/concurrency/threads.md:3
 #, fuzzy
@@ -11680,37 +12170,43 @@ msgstr ""
 
 #: src/concurrency/threads.md:24
 #, fuzzy
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
+msgstr "Τα νήματα είναι όλα νήματα δαίμονα, το κύριο νήμα δεν τα περιμένει."
+
+#: src/concurrency/threads.md:25
+#, fuzzy
+msgid "Thread panics are independent of each other."
+msgstr "Οι πανικοί των νημάτων είναι ανεξάρτητοι ο ένας από τον άλλο."
+
+#: src/concurrency/threads.md:26
+#, fuzzy
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
 msgstr ""
-"* Τα νήματα είναι όλα νήματα δαίμονα, το κύριο νήμα δεν τα περιμένει.\n"
-"* Οι πανικοί των νημάτων είναι ανεξάρτητοι ο ένας από τον άλλο.\n"
-"  * Οι πανικοί μπορούν να μεταφέρουν ένα ωφέλιμο φορτίο, το οποίο μπορεί να "
+"Οι πανικοί μπορούν να μεταφέρουν ένα ωφέλιμο φορτίο, το οποίο μπορεί να "
 "αποσυμπιεστεί με το «downcast_ref»."
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md:1
-#, fuzzy
-msgid "# Scoped Threads"
-msgstr "# Νήματα με εμβέλεια"
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
 
 #: src/concurrency/scoped-threads.md:3
 #, fuzzy
@@ -11734,8 +12230,12 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
 #, fuzzy
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "Ωστόσο, μπορείτε να χρησιμοποιήσετε ένα [νήμα εμβέλειας][1] για αυτό:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"Ωστόσο, μπορείτε να χρησιμοποιήσετε ένα [νήμα εμβέλειας](https://doc.rust-"
+"lang.org/std/thread/fn.scope.html) για αυτό:"
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -11757,38 +12257,35 @@ msgstr ""
 #: src/concurrency/scoped-threads.md:37
 #, fuzzy
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    "
-msgstr ""
-"<λεπτομέρειες>\n"
-"    \n"
-"* Ο λόγος για αυτό είναι ότι όταν ολοκληρωθεί η συνάρτηση `thread::scope`, "
-"όλα τα νήματα είναι εγγυημένα ότι θα ενωθούν, ώστε να μπορούν να επιστρέψουν "
-"τα δεδομένα που έχουν δανειστεί.\n"
-"* Ισχύουν οι κανονικοί κανόνες δανεισμού Rust: μπορείτε είτε να δανειστείτε "
-"μεταλλάξιμα με ένα νήμα ή αμετάβλητα με οποιονδήποτε αριθμό νημάτων.\n"
-"    \n"
-"</details>"
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
+msgstr "\\<λεπτομέρειες>"
 
-#: src/concurrency/channels.md:1
+#: src/concurrency/scoped-threads.md:38
 #, fuzzy
-msgid "# Channels"
-msgstr "# Κανάλια"
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"Ο λόγος για αυτό είναι ότι όταν ολοκληρωθεί η συνάρτηση `thread::scope`, όλα "
+"τα νήματα είναι εγγυημένα ότι θα ενωθούν, ώστε να μπορούν να επιστρέψουν τα "
+"δεδομένα που έχουν δανειστεί.\n"
+"\n"
+"Ισχύουν οι κανονικοί κανόνες δανεισμού Rust: μπορείτε είτε να δανειστείτε "
+"μεταλλάξιμα με ένα νήμα ή αμετάβλητα με οποιονδήποτε αριθμό νημάτων."
 
 #: src/concurrency/channels.md:3
 #, fuzzy
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
-"Τα κανάλια Rust έχουν δύο μέρη: ένα \"Αποστολέας<T>\" και ένα \"Δέκτης<T>\". "
-"Τα δύο μέρη\n"
-"συνδέονται μέσω του καναλιού, αλλά βλέπετε μόνο τα τελικά σημεία."
+"Τα κανάλια Rust έχουν δύο μέρη: ένα \"Αποστολέας\n"
+"\n"
+"\" και ένα \"Δέκτης\n"
+"\n"
+"\". Τα δύο μέρη συνδέονται μέσω του καναλιού, αλλά βλέπετε μόνο τα τελικά "
+"σημεία."
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -11815,24 +12312,23 @@ msgstr ""
 #: src/concurrency/channels.md:27
 #, fuzzy
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* Το «mpsc» σημαίνει Multi-Producer, Single-Consumer. Το \"Sender\" και το "
-"\"SyncSender\" υλοποιούν το \"Clone\" (έτσι\n"
-"  μπορείτε να δημιουργήσετε πολλούς παραγωγούς) αλλά ο «Δέκτης» όχι.\n"
-"* Το \"send()\" και το \"recv()\" επιστρέφουν \"Αποτέλεσμα\". Εάν "
-"επιστρέψουν \"Err\", σημαίνει το αντίστοιχο \"Αποστολέας\" ή\n"
-"  Ο \"δέκτης\" πέφτει και το κανάλι είναι κλειστό."
+"Το «mpsc» σημαίνει Multi-Producer, Single-Consumer. Το \"Sender\" και το "
+"\"SyncSender\" υλοποιούν το \"Clone\" (έτσι μπορείτε να δημιουργήσετε "
+"πολλούς παραγωγούς) αλλά ο «Δέκτης» όχι."
 
-#: src/concurrency/channels/unbounded.md:1
+#: src/concurrency/channels.md:29
 #, fuzzy
-msgid "# Unbounded Channels"
-msgstr "# Κανάλια χωρίς περιορισμούς"
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"Το \"send()\" και το \"recv()\" επιστρέφουν \"Αποτέλεσμα\". Εάν επιστρέψουν "
+"\"Err\", σημαίνει το αντίστοιχο \"Αποστολέας\" ή Ο \"δέκτης\" πέφτει και το "
+"κανάλι είναι κλειστό."
 
 #: src/concurrency/channels/unbounded.md:3
 #, fuzzy
@@ -11865,11 +12361,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/concurrency/channels/bounded.md:1
-#, fuzzy
-msgid "# Bounded Channels"
-msgstr "# Οριοθετημένα κανάλια"
 
 #: src/concurrency/channels/bounded.md:3
 #, fuzzy
@@ -11905,47 +12396,48 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/concurrency/shared_state.md:1
-#, fuzzy
-msgid "# Shared State"
-msgstr "# Κοινό κράτος"
-
 #: src/concurrency/shared_state.md:3
 #, fuzzy
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 "Το Rust χρησιμοποιεί το σύστημα τύπων για να επιβάλει το συγχρονισμό των "
-"κοινόχρηστων δεδομένων. Αυτό είναι\n"
-"γίνεται κυρίως μέσω δύο τύπων:"
+"κοινόχρηστων δεδομένων. Αυτό είναι γίνεται κυρίως μέσω δύο τύπων:"
 
 #: src/concurrency/shared_state.md:6
 #, fuzzy
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1], η ατομική αναφορά μετράται ως \"T\": χειρίζεται την κοινή "
-"χρήση μεταξύ νημάτων και\n"
-"  φροντίζει να κατανείμει το \"T\" όταν απορριφθεί η τελευταία αναφορά,\n"
-"* [`Mutex<T>`][2]: εξασφαλίζει αμοιβαία αποκλειστική πρόσβαση στην τιμή "
-"\"T\"."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), η ατομική "
+"αναφορά μετράται ως \"T\": χειρίζεται την κοινή χρήση μεταξύ νημάτων και "
+"φροντίζει να κατανείμει το \"T\" όταν απορριφθεί η τελευταία αναφορά,"
+
+#: src/concurrency/shared_state.md:8
+#, fuzzy
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): "
+"εξασφαλίζει αμοιβαία αποκλειστική πρόσβαση στην τιμή \"T\"."
 
 #: src/concurrency/shared_state/arc.md:1
 #, fuzzy
-msgid "# `Arc`"
-msgstr "# «Τόξο»."
+msgid "`Arc`"
+msgstr "«Τόξο»."
 
 #: src/concurrency/shared_state/arc.md:3
 #, fuzzy
-msgid "[`Arc<T>`][1] allows shared read-only access via its `clone` method:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via its `clone` method:"
 msgstr ""
-"Το [`Arc<T>`][1] επιτρέπει την κοινόχρηστη πρόσβαση μόνο για ανάγνωση μέσω "
-"της μεθόδου \"clone\" του:"
+"Το [`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) επιτρέπει "
+"την κοινόχρηστη πρόσβαση μόνο για ανάγνωση μέσω της μεθόδου \"clone\" του:"
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -11973,46 +12465,61 @@ msgstr ""
 #: src/concurrency/shared_state/arc.md:29
 #, fuzzy
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
 msgstr ""
-"* Το \"Arc\" σημαίνει \"Atomic Reference Counted\", μια ασφαλής έκδοση "
-"νημάτων του \"Rc\" που χρησιμοποιεί ατομική\n"
-"  επιχειρήσεις.\n"
-"* Το \"Arc<T>\" υλοποιεί το \"Clone\" είτε το κάνει το \"T\" είτε όχι. "
-"Εφαρμόζει «Αποστολή» και «Συγχρονισμός» αν «T».\n"
-"  τα εφαρμόζει και τα δύο.\n"
-"* Το \"Arc::clone()\" έχει το κόστος των ατομικών λειτουργιών που "
-"εκτελούνται, αλλά μετά από αυτό η χρήση του\n"
-"  Το \"T\" είναι δωρεάν.\n"
-"* Προσοχή στους κύκλους αναφοράς, το «Arc» δεν χρησιμοποιεί συλλέκτη "
+"Το \"Arc\" σημαίνει \"Atomic Reference Counted\", μια ασφαλής έκδοση νημάτων "
+"του \"Rc\" που χρησιμοποιεί ατομική επιχειρήσεις."
+
+#: src/concurrency/shared_state/arc.md:31
+#, fuzzy
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr "Το \"Arc"
+
+#: src/concurrency/shared_state/arc.md:33
+#, fuzzy
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"\" υλοποιεί το \"Clone\" είτε το κάνει το \"T\" είτε όχι. Εφαρμόζει "
+"«Αποστολή» και «Συγχρονισμός» αν «T». τα εφαρμόζει και τα δύο."
+
+#: src/concurrency/shared_state/arc.md:35
+#, fuzzy
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+"Το \"Arc::clone()\" έχει το κόστος των ατομικών λειτουργιών που εκτελούνται, "
+"αλλά μετά από αυτό η χρήση του Το \"T\" είναι δωρεάν."
+
+#: src/concurrency/shared_state/arc.md:36
+#, fuzzy
+msgid "`std::sync::Weak` can help."
+msgstr ""
+"Προσοχή στους κύκλους αναφοράς, το «Arc» δεν χρησιμοποιεί συλλέκτη "
 "σκουπιδιών για να τους εντοπίσει.\n"
-"    * Το `std::sync::Weak` μπορεί να βοηθήσει."
+"\n"
+"Το `std::sync::Weak` μπορεί να βοηθήσει."
 
 #: src/concurrency/shared_state/mutex.md:1
 #, fuzzy
-msgid "# `Mutex`"
-msgstr "# «Mutex»."
+msgid "`Mutex`"
+msgstr "«Mutex»."
 
 #: src/concurrency/shared_state/mutex.md:3
 #, fuzzy
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
-"[`Mutex<T>`][1] διασφαλίζει την αμοιβαία εξαίρεση _και_ επιτρέπει τη "
-"μεταβλητή πρόσβαση στο \"T\"\n"
-"πίσω από μια διεπαφή μόνο για ανάγνωση:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) "
+"διασφαλίζει την αμοιβαία εξαίρεση _και_ επιτρέπει τη μεταβλητή πρόσβαση στο "
+"\"T\" πίσω από μια διεπαφή μόνο για ανάγνωση:"
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -12036,53 +12543,78 @@ msgstr ""
 #: src/concurrency/shared_state/mutex.md:22
 #, fuzzy
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
-"Παρατηρήστε πώς έχουμε μια κουβέρτα [`impl<T: Send> Sync for Mutex<T>`][2]\n"
-"εκτέλεση."
+"Παρατηρήστε πώς έχουμε μια κουβέρτα [`impl<T: Send> Sync for Mutex<T>`]"
+"(https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-"
+"Mutex%3CT%3E) εκτέλεση."
 
 #: src/concurrency/shared_state/mutex.md:31
 #, fuzzy
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
+msgstr "\\<λεπτομέρειες>"
+
+#: src/concurrency/shared_state/mutex.md:32
+#, fuzzy
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
 msgstr ""
-"<λεπτομέρειες>\n"
-"    \n"
-"* Το \"Mutex\" στο Rust μοιάζει με μια συλλογή με ένα μόνο στοιχείο - τα "
-"προστατευμένα δεδομένα.\n"
-"    * Δεν είναι δυνατό να ξεχάσετε να αποκτήσετε το mutex πριν αποκτήσετε "
-"πρόσβαση στα προστατευμένα δεδομένα.\n"
-"* Μπορείτε να πάρετε ένα «&mut T» από ένα «&Mutex<T>» παίρνοντας την "
-"κλειδαριά. Το «MutexGuard» διασφαλίζει ότι το\n"
-"  Το \"&mut T\" δεν ξεπερνά την κλειδαριά που κρατιέται.\n"
-"* Το \"Mutex<T>\" υλοποιεί και το \"Send\" και το \"Sync\" εάν το \"T\" "
-"υλοποιεί το \"Send\".\n"
-"* Ένα αντίστοιχο κλείδωμα ανάγνωσης-εγγραφής - «RwLock».\n"
-"* Γιατί το «lock()» επιστρέφει ένα «Αποτέλεσμα»;\n"
-"    * Εάν το νήμα που συγκρατούσε το \"Mutex\" πανικοβλήθηκε, το \"Mutex\" "
-"γίνεται \"δηλητηριασμένο\" για να σηματοδοτήσει ότι\n"
-"      τα δεδομένα που προστατεύει ενδέχεται να είναι σε ασυνεπή κατάσταση. "
-"Κλήση «lock()» σε ένα δηλητηριασμένο mutex\n"
-"      αποτυγχάνει με ένα [`PoisonError`]. Μπορείτε να καλέσετε το "
-"«into_inner()» στο σφάλμα για να ανακτήσετε τα δεδομένα\n"
-"      Ανεξάρτητα."
+"Το \"Mutex\" στο Rust μοιάζει με μια συλλογή με ένα μόνο στοιχείο - τα "
+"προστατευμένα δεδομένα."
+
+#: src/concurrency/shared_state/mutex.md:33
+#, fuzzy
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+"Δεν είναι δυνατό να ξεχάσετε να αποκτήσετε το mutex πριν αποκτήσετε πρόσβαση "
+"στα προστατευμένα δεδομένα."
+
+#: src/concurrency/shared_state/mutex.md:35
+#, fuzzy
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr "Μπορείτε να πάρετε ένα «&mut T» από ένα «&Mutex"
+
+#: src/concurrency/shared_state/mutex.md:36
+#, fuzzy
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr ""
+"» παίρνοντας την κλειδαριά. Το «MutexGuard» διασφαλίζει ότι το Το \"&mut T\" "
+"δεν ξεπερνά την κλειδαριά που κρατιέται."
+
+#: src/concurrency/shared_state/mutex.md:37
+#, fuzzy
+msgid "Why does `lock()` return a `Result`? "
+msgstr "Το \"Mutex"
+
+#: src/concurrency/shared_state/mutex.md:38
+#, fuzzy
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"\" υλοποιεί και το \"Send\" και το \"Sync\" εάν το \"T\" υλοποιεί το "
+"\"Send\".\n"
+"\n"
+"Ένα αντίστοιχο κλείδωμα ανάγνωσης-εγγραφής - «RwLock».\n"
+"\n"
+"Γιατί το «lock()» επιστρέφει ένα «Αποτέλεσμα»;\n"
+"\n"
+"Εάν το νήμα που συγκρατούσε το \"Mutex\" πανικοβλήθηκε, το \"Mutex\" γίνεται "
+"\"δηλητηριασμένο\" για να σηματοδοτήσει ότι τα δεδομένα που προστατεύει "
+"ενδέχεται να είναι σε ασυνεπή κατάσταση. Κλήση «lock()» σε ένα "
+"δηλητηριασμένο mutex αποτυγχάνει με ένα [`PoisonError`](https://doc.rust-"
+"lang.org/std/sync/struct.PoisonError.html). Μπορείτε να καλέσετε το "
+"«into_inner()» στο σφάλμα για να ανακτήσετε τα δεδομένα Ανεξάρτητα."
 
 #: src/concurrency/shared_state/example.md:3
 #, fuzzy
@@ -12146,30 +12678,45 @@ msgstr ""
 #: src/concurrency/shared_state/example.md:51
 #, fuzzy
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr ""
+"Το \"v\" είναι τυλιγμένο και σε \"Arc\" και \"Mutex\", επειδή οι ανησυχίες "
+"τους είναι ορθογώνιες."
+
+#: src/concurrency/shared_state/example.md:52
+#, fuzzy
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+"Το τύλιγμα ενός \"Mutex\" σε ένα \"Arc\" είναι ένα συνηθισμένο μοτίβο για "
+"κοινή χρήση μεταβλητής κατάστασης μεταξύ των νημάτων."
+
+#: src/concurrency/shared_state/example.md:53
+#, fuzzy
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+"Το `v: Το Arc<_>` πρέπει να κλωνοποιηθεί ως `v2` για να μπορέσει να "
+"μετακινηθεί σε άλλο νήμα. Η σημείωση \"move\" προστέθηκε στην υπογραφή λάμδα."
+
+#: src/concurrency/shared_state/example.md:54
+#, fuzzy
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
-"* Το \"v\" είναι τυλιγμένο και σε \"Arc\" και \"Mutex\", επειδή οι ανησυχίες "
-"τους είναι ορθογώνιες.\n"
-"  * Το τύλιγμα ενός \"Mutex\" σε ένα \"Arc\" είναι ένα συνηθισμένο μοτίβο "
-"για κοινή χρήση μεταβλητής κατάστασης μεταξύ των νημάτων.\n"
-"* Το `v: Το Arc<_>` πρέπει να κλωνοποιηθεί ως `v2` για να μπορέσει να "
-"μετακινηθεί σε άλλο νήμα. Η σημείωση \"move\" προστέθηκε στην υπογραφή "
-"λάμδα.\n"
-"* Τα μπλοκ εισάγονται για να περιορίσουν όσο το δυνατόν περισσότερο το πεδίο "
+"Τα μπλοκ εισάγονται για να περιορίσουν όσο το δυνατόν περισσότερο το πεδίο "
 "εφαρμογής του \"LockGuard\".\n"
-"* Πρέπει ακόμα να αποκτήσουμε το «Mutex» για να εκτυπώσουμε το «Vec» μας."
+"\n"
+"Πρέπει ακόμα να αποκτήσουμε το «Mutex» για να εκτυπώσουμε το «Vec» μας."
 
 #: src/concurrency/send-sync.md:1
 #, fuzzy
-msgid "# `Send` and `Sync`"
-msgstr "# «Αποστολή» και «Συγχρονισμός»."
+msgid "`Send` and `Sync`"
+msgstr "«Αποστολή» και «Συγχρονισμός»."
 
 #: src/concurrency/send-sync.md:3
 #, fuzzy
@@ -12183,94 +12730,92 @@ msgstr ""
 #: src/concurrency/send-sync.md:5
 #, fuzzy
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [\"Αποστολή\"][1]: ένας τύπος \"T\" είναι \"Αποστολή\" εάν είναι ασφαλές "
-"να μετακινήσετε ένα \"T\" σε ένα νήμα\n"
-"  Όριο.\n"
-"* [\"Συγχρονισμός\"][2]: ένας τύπος \"T\" είναι \"Συγχρονισμός\" εάν είναι "
-"ασφαλές να μετακινήσετε ένα \"&T\" σε ένα νήμα\n"
-"  Όριο."
+"[\"Αποστολή\"](https://doc.rust-lang.org/std/marker/trait.Send.html): ένας "
+"τύπος \"T\" είναι \"Αποστολή\" εάν είναι ασφαλές να μετακινήσετε ένα \"T\" "
+"σε ένα νήμα Όριο."
+
+#: src/concurrency/send-sync.md:7
+#, fuzzy
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[\"Συγχρονισμός\"](https://doc.rust-lang.org/std/marker/trait.Sync.html): "
+"ένας τύπος \"T\" είναι \"Συγχρονισμός\" εάν είναι ασφαλές να μετακινήσετε "
+"ένα \"&T\" σε ένα νήμα Όριο."
 
 #: src/concurrency/send-sync.md:10
 #, fuzzy
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
-"Η \"Αποστολή\" και η \"Συγχρονισμός\" είναι [μη ασφαλή χαρακτηριστικά][3]. Ο "
-"μεταγλωττιστής θα τα παράγει αυτόματα για τους τύπους σας\n"
-"εφόσον περιέχουν μόνο τύπους «Αποστολή» και «Συγχρονισμός». Μπορείτε επίσης "
-"να τα εφαρμόσετε χειροκίνητα όταν το κάνετε\n"
-"να ξέρεις ότι ισχύει."
+"Η \"Αποστολή\" και η \"Συγχρονισμός\" είναι [μη ασφαλή χαρακτηριστικά](../"
+"unsafe/unsafe-traits.md). Ο μεταγλωττιστής θα τα παράγει αυτόματα για τους "
+"τύπους σας εφόσον περιέχουν μόνο τύπους «Αποστολή» και «Συγχρονισμός». "
+"Μπορείτε επίσης να τα εφαρμόσετε χειροκίνητα όταν το κάνετε να ξέρεις ότι "
+"ισχύει."
 
 #: src/concurrency/send-sync.md:20
 #, fuzzy
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-"
-"safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr ""
-"* Κάποιος μπορεί να σκεφτεί αυτά τα χαρακτηριστικά ως δείκτες ότι ο τύπος "
-"έχει ορισμένες ιδιότητες ασφαλείας νήματος.\n"
-"* Μπορούν να χρησιμοποιηθούν στους γενικούς περιορισμούς ως φυσιολογικά "
-"χαρακτηριστικά.\n"
-"  \n"
-"</details>"
+"Κάποιος μπορεί να σκεφτεί αυτά τα χαρακτηριστικά ως δείκτες ότι ο τύπος έχει "
+"ορισμένες ιδιότητες ασφαλείας νήματος."
+
+#: src/concurrency/send-sync.md:21
+#, fuzzy
+msgid "They can be used in the generic constraints as normal traits."
+msgstr ""
+"Μπορούν να χρησιμοποιηθούν στους γενικούς περιορισμούς ως φυσιολογικά "
+"χαρακτηριστικά."
 
 #: src/concurrency/send-sync/send.md:1
 #, fuzzy
-msgid "# `Send`"
-msgstr "# «Αποστολή»."
+msgid "`Send`"
+msgstr "«Αποστολή»."
 
 #: src/concurrency/send-sync/send.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
-"> Ένας τύπος `T` είναι [`Αποστολή`][1] εάν είναι ασφαλές να μετακινήσετε μια "
-"τιμή `T` σε άλλο νήμα."
+"Ένας τύπος `T` είναι [`Αποστολή`](https://doc.rust-lang.org/std/marker/trait."
+"Send.html) εάν είναι ασφαλές να μετακινήσετε μια τιμή `T` σε άλλο νήμα."
 
 #: src/concurrency/send-sync/send.md:5
 #, fuzzy
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 "Το αποτέλεσμα της μετακίνησης ιδιοκτησίας σε άλλο νήμα είναι ότι οι "
-"_destructors_ θα εκτελεστούν\n"
-"σε αυτό το νήμα. Το ερώτημα λοιπόν είναι πότε μπορείτε να εκχωρήσετε μια "
-"τιμή σε ένα νήμα\n"
-"και να το διαθέσει σε άλλο."
+"_destructors_ θα εκτελεστούν σε αυτό το νήμα. Το ερώτημα λοιπόν είναι πότε "
+"μπορείτε να εκχωρήσετε μια τιμή σε ένα νήμα και να το διαθέσει σε άλλο."
 
 #: src/concurrency/send-sync/sync.md:1
 #, fuzzy
-msgid "# `Sync`"
-msgstr "# `Συγχρονισμός`"
+msgid "`Sync`"
+msgstr "`Συγχρονισμός`"
 
 #: src/concurrency/send-sync/sync.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"> Ένας τύπος `T` είναι [`Συγχρονισμός`][1] εάν είναι ασφαλής η πρόσβαση σε "
-"μια τιμή `T` από πολλαπλές\n"
-"> νήματα ταυτόχρονα."
+"Ένας τύπος `T` είναι [`Συγχρονισμός`](https://doc.rust-lang.org/std/marker/"
+"trait.Sync.html) εάν είναι ασφαλής η πρόσβαση σε μια τιμή `T` από πολλαπλές "
+"νήματα ταυτόχρονα."
 
 #: src/concurrency/send-sync/sync.md:6
 #, fuzzy
@@ -12279,9 +12824,9 @@ msgstr "Πιο συγκεκριμένα, ο ορισμός είναι:"
 
 #: src/concurrency/send-sync/sync.md:8
 #, fuzzy
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
 msgstr ""
-"> Το \"T\" είναι \"Συγχρονισμός\" εάν και μόνο εάν το \"&T\" είναι "
+"Το \"T\" είναι \"Συγχρονισμός\" εάν και μόνο εάν το \"&T\" είναι "
 "\"Αποστολή\"."
 
 #: src/concurrency/send-sync/sync.md:14
@@ -12311,15 +12856,10 @@ msgstr ""
 "νήμα, επειδή τα δεδομένα που παραπέμπει είναι προσβάσιμα από οποιοδήποτε "
 "νήμα με ασφάλεια."
 
-#: src/concurrency/send-sync/examples.md:1
-#, fuzzy
-msgid "# Examples"
-msgstr "# Παραδείγματα"
-
 #: src/concurrency/send-sync/examples.md:3
 #, fuzzy
-msgid "## `Send + Sync`"
-msgstr "## «Αποστολή + Συγχρονισμός»."
+msgid "`Send + Sync`"
+msgstr "«Αποστολή + Συγχρονισμός»."
 
 #: src/concurrency/send-sync/examples.md:5
 #, fuzzy
@@ -12327,57 +12867,76 @@ msgid "Most types you come across are `Send + Sync`:"
 msgstr "Οι περισσότεροι τύποι που συναντάτε είναι «Αποστολή + Συγχρονισμός»:"
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 #, fuzzy
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 "Οι γενικοί τύποι είναι συνήθως «Αποστολή + Συγχρονισμός» όταν οι παράμετροι "
-"τύπου είναι\n"
-"«Αποστολή + Συγχρονισμός»."
+"τύπου είναι «Αποστολή + Συγχρονισμός»."
 
 #: src/concurrency/send-sync/examples.md:17
 #, fuzzy
-msgid "## `Send + !Sync`"
-msgstr "## `Αποστολή + !Συγχρονισμός`"
+msgid "`Send + !Sync`"
+msgstr "`Αποστολή + !Συγχρονισμός`"
 
 #: src/concurrency/send-sync/examples.md:19
 #, fuzzy
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 "Αυτοί οι τύποι μπορούν να μετακινηθούν σε άλλα νήματα, αλλά δεν είναι "
-"ασφαλείς για νήματα.\n"
-"Τυπικά λόγω της εσωτερικής μεταβλητότητας:"
+"ασφαλείς για νήματα. Τυπικά λόγω της εσωτερικής μεταβλητότητας:"
 
 #: src/concurrency/send-sync/examples.md:22
 #, fuzzy
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Αποστολέας<T>`\n"
-"* `mpsc::Δέκτης<T>`\n"
-"* `Κελλί<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Αποστολέας<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+#, fuzzy
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Δέκτης<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+#, fuzzy
+msgid "`Cell<T>`"
+msgstr "`Κελλί<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+#, fuzzy
+msgid "`RefCell<T>`"
+msgstr "`RefCell<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
 #, fuzzy
-msgid "## `!Send + Sync`"
-msgstr "## `!Αποστολή + Συγχρονισμός`"
+msgid "`!Send + Sync`"
+msgstr "`!Αποστολή + Συγχρονισμός`"
 
 #: src/concurrency/send-sync/examples.md:29
 #, fuzzy
@@ -12390,18 +12949,16 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:31
 #, fuzzy
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
-"* `MutexGuard<T>`: Χρησιμοποιεί πρωτόγονα επιπέδου λειτουργικού συστήματος "
-"που πρέπει να κατανεμηθούν στο\n"
-"  νήμα που τα δημιούργησε."
+"`MutexGuard<T>`: Χρησιμοποιεί πρωτόγονα επιπέδου λειτουργικού συστήματος που "
+"πρέπει να κατανεμηθούν στο νήμα που τα δημιούργησε."
 
 #: src/concurrency/send-sync/examples.md:34
 #, fuzzy
-msgid "## `!Send + !Sync`"
-msgstr "## `!Αποστολή + !Συγχρονισμός`"
+msgid "`!Send + !Sync`"
+msgstr "`!Αποστολή + !Συγχρονισμός`"
 
 #: src/concurrency/send-sync/examples.md:36
 #, fuzzy
@@ -12413,24 +12970,22 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:38
 #, fuzzy
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
-msgstr ""
-"* `Rc<T>`: κάθε «Rc<T>» έχει μια αναφορά σε ένα «RcBox<T>», το οποίο "
-"περιέχει ένα\n"
-"  μη ατομική μέτρηση αναφοράς.\n"
-"* `*const T`, `*mut T`: Το Rust υποθέτει ότι οι ακατέργαστοι δείκτες μπορεί "
-"να έχουν ειδικούς\n"
-"  ζητήματα ταυτόχρονης ύπαρξης."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
+msgstr "`Rc<T>`: κάθε «Rc"
 
-#: src/exercises/day-4/morning.md:1 src/exercises/day-4/android.md:1
-#: src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
+#: src/concurrency/send-sync/examples.md:40
 #, fuzzy
-msgid "# Exercises"
-msgstr "# Ασκήσεις"
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr ""
+"» έχει μια αναφορά σε ένα «RcBox\n"
+"\n"
+"», το οποίο περιέχει ένα μη ατομική μέτρηση αναφοράς.\n"
+"\n"
+"`*const T`, `*mut T`: Το Rust υποθέτει ότι οι ακατέργαστοι δείκτες μπορεί να "
+"έχουν ειδικούς ζητήματα ταυτόχρονης ύπαρξης."
 
 #: src/exercises/day-4/morning.md:3
 #, fuzzy
@@ -12439,21 +12994,17 @@ msgstr "Ας εξασκήσουμε τις νέες μας δεξιότητες 
 
 #: src/exercises/day-4/morning.md:5
 #, fuzzy
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
+msgid "Dining philosophers: a classic problem in concurrency."
 msgstr ""
-"* Έλεγχος συνδέσμων πολλαπλών νημάτων: ένα μεγαλύτερο έργο στο οποίο θα "
-"χρησιμοποιήσετε το Cargo\n"
-"  κατεβάστε τις εξαρτήσεις και, στη συνέχεια, ελέγξτε τους συνδέσμους "
-"παράλληλα."
+"Έλεγχος συνδέσμων πολλαπλών νημάτων: ένα μεγαλύτερο έργο στο οποίο θα "
+"χρησιμοποιήσετε το Cargo κατεβάστε τις εξαρτήσεις και, στη συνέχεια, ελέγξτε "
+"τους συνδέσμους παράλληλα."
 
-#: src/exercises/day-4/dining-philosophers.md:1
-#, fuzzy
-msgid "# Dining Philosophers"
-msgstr "# Δείπνο Φιλόσοφοι"
+#: src/exercises/day-4/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
+msgstr ""
 
 #: src/exercises/day-4/dining-philosophers.md:3
 #, fuzzy
@@ -12464,48 +13015,34 @@ msgstr ""
 #: src/exercises/day-4/dining-philosophers.md:5
 #, fuzzy
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
-"> Πέντε φιλόσοφοι δειπνούν μαζί στο ίδιο τραπέζι. Κάθε φιλόσοφος έχει το "
-"δικό του\n"
-"> δική σου θέση στο τραπέζι. Ανάμεσα σε κάθε πιάτο υπάρχει ένα πιρούνι. Το "
-"πιάτο που σερβίρεται είναι\n"
-"> ένα είδος σπαγγέτι που τρώγεται με δύο πιρούνια. Κάθε φιλόσοφος μπορεί\n"
-"> μόνο εναλλάξ σκεφτείτε και τρώτε. Επιπλέον, ένας φιλόσοφος μπορεί να φάει "
-"μόνο τους\n"
-"> μακαρόνια όταν έχουν και αριστερό και δεξί πιρούνι. Έτσι θα μόνο δύο "
-"πιρούνια\n"
-"> να είναι διαθέσιμοι όταν οι δύο κοντινότεροι γείτονές τους σκέφτονται και "
-"δεν τρώνε. Μετά\n"
-"> ένας μεμονωμένος φιλόσοφος τελειώνει το φαγητό, θα βάλει κάτω και τα δύο "
-"πιρούνια."
+"Πέντε φιλόσοφοι δειπνούν μαζί στο ίδιο τραπέζι. Κάθε φιλόσοφος έχει το δικό "
+"του δική σου θέση στο τραπέζι. Ανάμεσα σε κάθε πιάτο υπάρχει ένα πιρούνι. Το "
+"πιάτο που σερβίρεται είναι ένα είδος σπαγγέτι που τρώγεται με δύο πιρούνια. "
+"Κάθε φιλόσοφος μπορεί μόνο εναλλάξ σκεφτείτε και τρώτε. Επιπλέον, ένας "
+"φιλόσοφος μπορεί να φάει μόνο τους μακαρόνια όταν έχουν και αριστερό και "
+"δεξί πιρούνι. Έτσι θα μόνο δύο πιρούνια να είναι διαθέσιμοι όταν οι δύο "
+"κοντινότεροι γείτονές τους σκέφτονται και δεν τρώνε. Μετά ένας μεμονωμένος "
+"φιλόσοφος τελειώνει το φαγητό, θα βάλει κάτω και τα δύο πιρούνια."
 
 #: src/exercises/day-4/dining-philosophers.md:13
 #, fuzzy
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to `src/main.rs` file, fill out the "
-"blanks,\n"
-"and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to `src/main.rs` file, fill out the "
+"blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 "Θα χρειαστείτε μια τοπική [Εγκατάσταση φορτίου](../../cargo/running-locally."
-"md) για\n"
-"αυτή η άσκηση. Αντιγράψτε τον παρακάτω κώδικα στο αρχείο `src/main.rs, "
-"συμπληρώστε τα κενά,\n"
-"και ελέγξτε ότι το «cargo run» δεν είναι αδιέξοδο:"
+"md) για αυτή η άσκηση. Αντιγράψτε τον παρακάτω κώδικα στο αρχείο \\`src/main."
+"rs, συμπληρώστε τα κενά, και ελέγξτε ότι το «cargo run» δεν είναι αδιέξοδο:"
 
 #: src/exercises/day-4/dining-philosophers.md:17
 msgid ""
@@ -12552,38 +13089,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-4/link-checker.md:1
-#, fuzzy
-msgid "# Multi-threaded Link Checker"
-msgstr "# Έλεγχος συνδέσμων πολλαπλών νημάτων"
-
 #: src/exercises/day-4/link-checker.md:3
 #, fuzzy
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 "Ας χρησιμοποιήσουμε τις νέες γνώσεις μας για να δημιουργήσουμε έναν έλεγχο "
-"συνδέσμων πολλαπλών νημάτων. Θα έπρεπε\n"
-"ξεκινήστε από μια ιστοσελίδα και ελέγξτε ότι οι σύνδεσμοι στη σελίδα είναι "
-"έγκυροι. Θα έπρεπε\n"
-"ελέγξτε αναδρομικά άλλες σελίδες στον ίδιο τομέα και συνεχίστε να το κάνετε "
-"αυτό μέχρι να τελειώσει\n"
-"οι σελίδες έχουν επικυρωθεί."
+"συνδέσμων πολλαπλών νημάτων. Θα έπρεπε ξεκινήστε από μια ιστοσελίδα και "
+"ελέγξτε ότι οι σύνδεσμοι στη σελίδα είναι έγκυροι. Θα έπρεπε ελέγξτε "
+"αναδρομικά άλλες σελίδες στον ίδιο τομέα και συνεχίστε να το κάνετε αυτό "
+"μέχρι να τελειώσει οι σελίδες έχουν επικυρωθεί."
 
 #: src/exercises/day-4/link-checker.md:8
 #, fuzzy
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as \\[`reqwest`\\]\\[1\\]. "
+"Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
-"Για αυτό, θα χρειαστείτε ένα πρόγραμμα-πελάτη HTTP όπως το [`reqwest`][1]. "
-"Δημιούργησε ένα νέο\n"
-"Έργο φορτίου και το «ζήτησε» ως εξάρτηση με:"
+"Για αυτό, θα χρειαστείτε ένα πρόγραμμα-πελάτη HTTP όπως το "
+"\\[`reqwest`\\]\\[1\\]. Δημιούργησε ένα νέο Έργο φορτίου και το «ζήτησε» ως "
+"εξάρτηση με:"
 
 #: src/exercises/day-4/link-checker.md:11
 msgid ""
@@ -12597,22 +13125,21 @@ msgstr ""
 #: src/exercises/day-4/link-checker.md:17
 #, fuzzy
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
-"> Εάν η «προσθήκη φορτίου» αποτύχει με «σφάλμα: δεν υπάρχει τέτοια "
-"υποεντολή», τότε επεξεργαστείτε το\n"
-"> Αρχείο «Cargo.toml» με το χέρι. Προσθέστε τις εξαρτήσεις που αναφέρονται "
-"παρακάτω."
+"Εάν η «προσθήκη φορτίου» αποτύχει με «σφάλμα: δεν υπάρχει τέτοια υποεντολή», "
+"τότε επεξεργαστείτε το Αρχείο «Cargo.toml» με το χέρι. Προσθέστε τις "
+"εξαρτήσεις που αναφέρονται παρακάτω."
 
 #: src/exercises/day-4/link-checker.md:20
 #, fuzzy
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use \\[`scraper`\\]\\[2\\] "
+"for that:"
 msgstr ""
 "Θα χρειαστείτε επίσης έναν τρόπο να βρείτε συνδέσμους. Μπορούμε να "
-"χρησιμοποιήσουμε το [`scraper`][2] για αυτό:"
+"χρησιμοποιήσουμε το \\[`scraper`\\]\\[2\\] για αυτό:"
 
 #: src/exercises/day-4/link-checker.md:22
 msgid ""
@@ -12624,13 +13151,11 @@ msgstr ""
 #: src/exercises/day-4/link-checker.md:26
 #, fuzzy
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use "
+"\\[`thiserror`\\]\\[3\\] for that:"
 msgstr ""
 "Τέλος, θα χρειαστούμε κάποιο τρόπο χειρισμού των σφαλμάτων. Χρησιμοποιούμε "
-"[`αυτό το σφάλμα`][3] για\n"
-"ότι:"
+"\\[`αυτό το σφάλμα`\\]\\[3\\] για ότι:"
 
 #: src/exercises/day-4/link-checker.md:29
 msgid ""
@@ -12661,12 +13186,11 @@ msgstr ""
 #: src/exercises/day-4/link-checker.md:42
 #, fuzzy
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 "Τώρα μπορείτε να κάνετε λήψη της αρχικής σελίδας. Δοκιμάστε με ένα μικρό "
-"site όπως π.χ\n"
-"`https://www.google.org/`."
+"site όπως π.χ `https://www.google.org/`."
 
 #: src/exercises/day-4/link-checker.md:45
 #, fuzzy
@@ -12734,83 +13258,63 @@ msgstr ""
 
 #: src/exercises/day-4/link-checker.md:96
 #, fuzzy
-msgid "## Tasks"
-msgstr "## Καθήκοντα"
+msgid "Tasks"
+msgstr "Καθήκοντα"
 
 #: src/exercises/day-4/link-checker.md:98
 #, fuzzy
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
 msgstr ""
-"* Χρησιμοποιήστε νήματα για να ελέγξετε τους συνδέσμους παράλληλα: στείλτε "
-"τις διευθύνσεις URL που θα ελεγχθούν στο a\n"
-"  κανάλι και αφήστε μερικά νήματα να ελέγξουν τις διευθύνσεις URL "
-"παράλληλα.\n"
-"* Επεκτείνετε αυτό για να εξαγάγετε αναδρομικά συνδέσμους από όλες τις "
-"σελίδες του\n"
-"  τομέας `www.google.org`. Βάλτε ένα ανώτατο όριο 100 σελίδων περίπου έτσι "
-"ώστε να\n"
-"  μην καταλήξετε να αποκλειστείτε από τον ιστότοπο."
+"Χρησιμοποιήστε νήματα για να ελέγξετε τους συνδέσμους παράλληλα: στείλτε τις "
+"διευθύνσεις URL που θα ελεγχθούν στο a κανάλι και αφήστε μερικά νήματα να "
+"ελέγξουν τις διευθύνσεις URL παράλληλα."
 
-#: src/android.md:1 src/bare-metal/android.md:1
+#: src/exercises/day-4/link-checker.md:100
 #, fuzzy
-msgid "# Android"
-msgstr "# Android"
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
+msgstr ""
+"Επεκτείνετε αυτό για να εξαγάγετε αναδρομικά συνδέσμους από όλες τις σελίδες "
+"του τομέας `www.google.org`. Βάλτε ένα ανώτατο όριο 100 σελίδων περίπου έτσι "
+"ώστε να μην καταλήξετε να αποκλειστείτε από τον ιστότοπο."
 
 #: src/android.md:3
 #, fuzzy
 msgid ""
 "Rust is supported for native platform development on Android. This means "
-"that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 "Το Rust υποστηρίζεται για ανάπτυξη εγγενούς πλατφόρμας στο Android. Αυτό "
-"σημαίνει ότι\n"
-"μπορείτε να γράψετε νέες υπηρεσίες λειτουργικού συστήματος στο Rust, καθώς "
-"και να επεκτείνετε\n"
-"υπάρχουσες υπηρεσίες."
+"σημαίνει ότι μπορείτε να γράψετε νέες υπηρεσίες λειτουργικού συστήματος στο "
+"Rust, καθώς και να επεκτείνετε υπάρχουσες υπηρεσίες."
 
 #: src/android.md:7
 #, fuzzy
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try "
-"to\n"
-"> find a little corner of your code base where we can move some lines of "
-"code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
-"that\n"
-"> parses some raw bytes would be ideal."
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
-"> Θα προσπαθήσουμε να καλέσουμε τον Rust από ένα από τα δικά σας έργα "
-"σήμερα. Προσπάθησε λοιπόν\n"
-"> βρείτε μια μικρή γωνία της βάσης του κώδικα όπου μπορούμε να μετακινήσουμε "
-"ορισμένες γραμμές κώδικα\n"
-"> Σκουριά. Όσο λιγότερες εξαρτήσεις και «εξωτικοί» τύποι τόσο το καλύτερο. "
-"Κάτι που\n"
-"> η ανάλυση ορισμένων ακατέργαστων byte θα ήταν ιδανική."
-
-#: src/android/setup.md:1
-#, fuzzy
-msgid "# Setup"
-msgstr "# Ρύθμιση"
+"Θα προσπαθήσουμε να καλέσουμε τον Rust από ένα από τα δικά σας έργα σήμερα. "
+"Προσπάθησε λοιπόν βρείτε μια μικρή γωνία της βάσης του κώδικα όπου μπορούμε "
+"να μετακινήσουμε ορισμένες γραμμές κώδικα Σκουριά. Όσο λιγότερες εξαρτήσεις "
+"και «εξωτικοί» τύποι τόσο το καλύτερο. Κάτι που η ανάλυση ορισμένων "
+"ακατέργαστων byte θα ήταν ιδανική."
 
 #: src/android/setup.md:3
 #, fuzzy
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
-"have\n"
-"access to one or create a new one with:"
+"have access to one or create a new one with:"
 msgstr ""
 "Θα χρησιμοποιήσουμε μια εικονική συσκευή Android για να δοκιμάσουμε τον "
-"κώδικά μας. Βεβαιωθείτε ότι έχετε\n"
-"πρόσβαση σε ένα ή δημιουργήστε ένα νέο με:"
+"κώδικά μας. Βεβαιωθείτε ότι έχετε πρόσβαση σε ένα ή δημιουργήστε ένα νέο με:"
 
 #: src/android/setup.md:6
 msgid ""
@@ -12824,16 +13328,11 @@ msgstr ""
 #: src/android/setup.md:12
 #, fuzzy
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-"Ανατρέξτε στο [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) για λεπτομέρειες."
-
-#: src/android/build-rules.md:1
-#, fuzzy
-msgid "# Build Rules"
-msgstr "# Δημιουργία κανόνων"
+"Ανατρέξτε στο [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) για λεπτομέρειες."
 
 #: src/android/build-rules.md:3
 #, fuzzy
@@ -12844,47 +13343,99 @@ msgstr ""
 
 #: src/android/build-rules.md:5
 #, fuzzy
-msgid ""
-"| Module Type       | "
-"Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust "
-"binary.                                                                            "
-"|\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
-"`dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
-"provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
-"analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard "
-"Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging "
-"`libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that "
-"provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library "
-"containing Rust bindings to C libraries.              |"
+msgid "Module Type"
 msgstr ""
-"| Τύπος ενότητας | Περιγραφή |\n"
-"|------------------------------------------------- "
-"-------------------------------------------------- ---------------------|\n"
-"| `rust_binary` | Παράγει ένα Rust δυαδικό. |\n"
-"| `rust_library` | Παράγει μια βιβλιοθήκη Rust και παρέχει παραλλαγές «rlib» "
-"και «dylib». |\n"
-"| `rust_ffi` | Παράγει μια βιβλιοθήκη Rust C που μπορεί να χρησιμοποιηθεί "
-"από μονάδες «cc» και παρέχει τόσο στατικές όσο και κοινόχρηστες παραλλαγές. "
-"|\n"
-"| `rust_proc_macro` | Παράγει μια «proc-macro» βιβλιοθήκη Rust. Αυτά είναι "
-"ανάλογα με τα πρόσθετα μεταγλωττιστή. |\n"
-"| «δοκιμή_σκουριάς» | Παράγει ένα δυαδικό σύστημα δοκιμής Rust που "
-"χρησιμοποιεί την τυπική ζώνη δοκιμής Rust. |\n"
-"| `rust_fuzz` | Παράγει ένα Rust fuzz δυαδικό μόχλευσης «libfuzzer». |\n"
-"| `rust_protobuf` | Δημιουργεί πηγή και παράγει μια βιβλιοθήκη Rust που "
-"παρέχει μια διεπαφή για ένα συγκεκριμένο protobuf. |\n"
-"| `rust_bindgen` | Δημιουργεί πηγή και παράγει μια βιβλιοθήκη Rust που "
-"περιέχει δεσμεύσεις Rust σε βιβλιοθήκες C. |"
+"\\| Τύπος ενότητας | Περιγραφή | "
+"\\|------------------------------------------------- "
+"-------------------------------------------------- ---------------------| "
+"\\| `rust_binary` | Παράγει ένα Rust δυαδικό. | \\| `rust_library` | Παράγει "
+"μια βιβλιοθήκη Rust και παρέχει παραλλαγές «rlib» και «dylib». | \\| "
+"`rust_ffi` | Παράγει μια βιβλιοθήκη Rust C που μπορεί να χρησιμοποιηθεί από "
+"μονάδες «cc» και παρέχει τόσο στατικές όσο και κοινόχρηστες παραλλαγές. | "
+"\\| `rust_proc_macro` | Παράγει μια «proc-macro» βιβλιοθήκη Rust. Αυτά είναι "
+"ανάλογα με τα πρόσθετα μεταγλωττιστή. | \\| «δοκιμή_σκουριάς» | Παράγει ένα "
+"δυαδικό σύστημα δοκιμής Rust που χρησιμοποιεί την τυπική ζώνη δοκιμής Rust. "
+"| \\| `rust_fuzz` | Παράγει ένα Rust fuzz δυαδικό μόχλευσης «libfuzzer». | "
+"\\| `rust_protobuf` | Δημιουργεί πηγή και παράγει μια βιβλιοθήκη Rust που "
+"παρέχει μια διεπαφή για ένα συγκεκριμένο protobuf. | \\| `rust_bindgen` | "
+"Δημιουργεί πηγή και παράγει μια βιβλιοθήκη Rust που περιέχει δεσμεύσεις Rust "
+"σε βιβλιοθήκες C. |"
+
+#: src/android/build-rules.md:5
+msgid "Description"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "`rust_binary`"
+msgstr ""
+
+#: src/android/build-rules.md:7
+msgid "Produces a Rust binary."
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "`rust_library`"
+msgstr ""
+
+#: src/android/build-rules.md:8
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
+msgstr ""
+
+#: src/android/build-rules.md:9
+msgid "`rust_ffi`"
+msgstr ""
+
+#: src/android/build-rules.md:9
+msgid ""
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid "`rust_proc_macro`"
+msgstr ""
+
+#: src/android/build-rules.md:10
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "`rust_test`"
+msgstr ""
+
+#: src/android/build-rules.md:11
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "`rust_fuzz`"
+msgstr ""
+
+#: src/android/build-rules.md:12
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid "`rust_protobuf`"
+msgstr ""
+
+#: src/android/build-rules.md:13
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid "`rust_bindgen`"
+msgstr ""
+
+#: src/android/build-rules.md:14
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr ""
 
 #: src/android/build-rules.md:16
 #, fuzzy
@@ -12893,19 +13444,17 @@ msgstr "Στη συνέχεια θα δούμε τα «rust_binary» και «ru
 
 #: src/android/build-rules/binary.md:1
 #, fuzzy
-msgid "# Rust Binaries"
-msgstr "# Rust Binaries"
+msgid "Rust Binaries"
+msgstr "Rust Binaries"
 
 #: src/android/build-rules/binary.md:3
 #, fuzzy
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr ""
 "Ας ξεκινήσουμε με μια απλή εφαρμογή. Στη ρίζα ενός ταμείου AOSP, "
-"δημιουργήστε\n"
-"τα ακόλουθα αρχεία:"
+"δημιουργήστε τα ακόλουθα αρχεία:"
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 #, fuzzy
@@ -12958,8 +13507,8 @@ msgstr ""
 
 #: src/android/build-rules/library.md:1
 #, fuzzy
-msgid "# Rust Libraries"
-msgstr "# Βιβλιοθήκες Rust"
+msgid "Rust Libraries"
+msgstr "Βιβλιοθήκες Rust"
 
 #: src/android/build-rules/library.md:3
 #, fuzzy
@@ -12975,14 +13524,18 @@ msgstr "Εδώ δηλώνουμε μια εξάρτηση από δύο βιβλ
 
 #: src/android/build-rules/library.md:7
 #, fuzzy
+msgid "`libgreeting`, which we define below,"
+msgstr "'libgreeting', που ορίζουμε παρακάτω,"
+
+#: src/android/build-rules/library.md:8
+#, fuzzy
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"* 'libgreeting', που ορίζουμε παρακάτω,\n"
-"* «libtextwrap», το οποίο είναι ένα κιβώτιο που έχει ήδη πωληθεί\n"
-"  [`εξωτερικά/σκουριά/κιβώτια/`][κιβώτια]."
+"«libtextwrap», το οποίο είναι ένα κιβώτιο που έχει ήδη πωληθεί \\[`εξωτερικά/"
+"σκουριά/κιβώτια/`\\]\\[κιβώτια\\]."
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -13055,35 +13608,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-#, fuzzy
-msgid "# AIDL"
-msgstr "# AIDL"
-
 #: src/android/aidl.md:3
 #, fuzzy
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
-"Η [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) υποστηρίζεται "
-"στο Rust:"
+"Η [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) υποστηρίζεται στο Rust:"
 
 #: src/android/aidl.md:6
 #, fuzzy
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
-msgstr ""
-"* Ο κώδικας σκουριάς μπορεί να καλέσει υπάρχοντες διακομιστές AIDL,\n"
-"* Μπορείτε να δημιουργήσετε νέους διακομιστές AIDL στο Rust."
+msgid "Rust code can call existing AIDL servers,"
+msgstr "Ο κώδικας σκουριάς μπορεί να καλέσει υπάρχοντες διακομιστές AIDL,"
+
+#: src/android/aidl.md:7
+#, fuzzy
+msgid "You can create new AIDL servers in Rust."
+msgstr "Μπορείτε να δημιουργήσετε νέους διακομιστές AIDL στο Rust."
 
 #: src/android/aidl/interface.md:1
 #, fuzzy
-msgid "# AIDL Interfaces"
-msgstr "# Διεπαφές AIDL"
+msgid "AIDL Interfaces"
+msgstr "Διεπαφές AIDL"
 
 #: src/android/aidl/interface.md:3
 #, fuzzy
@@ -13093,9 +13640,9 @@ msgstr "Δηλώνετε το API της υπηρεσίας σας χρησιμ�
 #: src/android/aidl/interface.md:5
 #, fuzzy
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 
 #: src/android/aidl/interface.md:7
 msgid ""
@@ -13112,8 +13659,8 @@ msgstr ""
 
 #: src/android/aidl/interface.md:17
 #, fuzzy
-msgid "*birthday_service/aidl/Android.bp*:"
-msgstr "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_birthday_service/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md:19
 msgid ""
@@ -13135,17 +13682,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 "Προσθέστε το \"vendor_available: true\" εάν το αρχείο AIDL σας "
-"χρησιμοποιείται από ένα δυαδικό αρχείο στον προμηθευτή\n"
-"χώρισμα."
+"χρησιμοποιείται από ένα δυαδικό αρχείο στον προμηθευτή χώρισμα."
 
 #: src/android/aidl/implementation.md:1
 #, fuzzy
-msgid "# Service Implementation"
-msgstr "# Υλοποίηση υπηρεσίας"
+msgid "Service Implementation"
+msgstr "Υλοποίηση υπηρεσίας"
 
 #: src/android/aidl/implementation.md:3
 #, fuzzy
@@ -13154,8 +13699,8 @@ msgstr "Μπορούμε τώρα να εφαρμόσουμε την υπηρε�
 
 #: src/android/aidl/implementation.md:5
 #, fuzzy
-msgid "*birthday_service/src/lib.rs*:"
-msgstr "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
+msgstr "_birthday_service/src/lib.rs_:"
 
 #: src/android/aidl/implementation.md:7
 msgid ""
@@ -13185,8 +13730,8 @@ msgstr ""
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
 #, fuzzy
-msgid "*birthday_service/Android.bp*:"
-msgstr "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
+msgstr "_birthday_service/Android.bp_:"
 
 #: src/android/aidl/implementation.md:28
 msgid ""
@@ -13205,8 +13750,8 @@ msgstr ""
 
 #: src/android/aidl/server.md:1
 #, fuzzy
-msgid "# AIDL Server"
-msgstr "# Διακομιστής AIDL"
+msgid "AIDL Server"
+msgstr "Διακομιστής AIDL"
 
 #: src/android/aidl/server.md:3
 #, fuzzy
@@ -13216,8 +13761,8 @@ msgstr ""
 
 #: src/android/aidl/server.md:5
 #, fuzzy
-msgid "*birthday_service/src/server.rs*:"
-msgstr "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_birthday_service/src/server.rs_:"
 
 #: src/android/aidl/server.md:7
 msgid ""
@@ -13261,11 +13806,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/android/aidl/deploy.md:1
-#, fuzzy
-msgid "# Deploy"
-msgstr "# Ανάπτυξη"
 
 #: src/android/aidl/deploy.md:3
 #, fuzzy
@@ -13319,8 +13859,8 @@ msgstr ""
 
 #: src/android/aidl/client.md:1
 #, fuzzy
-msgid "# AIDL Client"
-msgstr "# Πελάτης AIDL"
+msgid "AIDL Client"
+msgstr "Πελάτης AIDL"
 
 #: src/android/aidl/client.md:3
 #, fuzzy
@@ -13330,8 +13870,8 @@ msgstr ""
 
 #: src/android/aidl/client.md:5
 #, fuzzy
-msgid "*birthday_service/src/client.rs*:"
-msgstr "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
+msgstr "_birthday_service/src/client.rs_:"
 
 #: src/android/aidl/client.md:7
 msgid ""
@@ -13405,21 +13945,15 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-#, fuzzy
-msgid "# Changing API"
-msgstr "# Αλλαγή API"
-
 #: src/android/aidl/changing.md:3
 #, fuzzy
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr ""
 "Ας επεκτείνουμε το API με περισσότερη λειτουργικότητα: θέλουμε να "
-"επιτρέψουμε στους πελάτες να καθορίσουν α\n"
-"λίστα γραμμών για την κάρτα γενεθλίων:"
+"επιτρέψουμε στους πελάτες να καθορίσουν α λίστα γραμμών για την κάρτα "
+"γενεθλίων:"
 
 #: src/android/aidl/changing.md:6
 msgid ""
@@ -13434,21 +13968,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-#, fuzzy
-msgid "# Logging"
-msgstr "# Καταγραφή"
-
 #: src/android/logging.md:3
 #, fuzzy
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
 "Θα πρέπει να χρησιμοποιήσετε το κιβώτιο «log» για αυτόματη σύνδεση στο "
-"«logcat» (σε συσκευή) ή\n"
-"`stdout` (στον οικοδεσπότη):"
+"«logcat» (σε συσκευή) ή `stdout` (στον οικοδεσπότη):"
 
 #: src/android/logging.md:6
 #, fuzzy
@@ -13530,54 +14057,48 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-#, fuzzy
-msgid "# Interoperability"
-msgstr "# Διαλειτουργικότητα"
-
 #: src/android/interoperability.md:3
 #, fuzzy
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 "Το Rust έχει εξαιρετική υποστήριξη για διαλειτουργικότητα με άλλες γλώσσες. "
-"Αυτό σημαίνει\n"
-"ότι μπορείτε να:"
+"Αυτό σημαίνει ότι μπορείτε να:"
 
 #: src/android/interoperability.md:6
 #, fuzzy
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
-msgstr ""
-"* Καλέστε τις λειτουργίες Rust από άλλες γλώσσες.\n"
-"* Κλήση συναρτήσεων γραμμένων σε άλλες γλώσσες από το Rust."
+msgid "Call Rust functions from other languages."
+msgstr "Καλέστε τις λειτουργίες Rust από άλλες γλώσσες."
+
+#: src/android/interoperability.md:7
+#, fuzzy
+msgid "Call functions written in other languages from Rust."
+msgstr "Κλήση συναρτήσεων γραμμένων σε άλλες γλώσσες από το Rust."
 
 #: src/android/interoperability.md:9
 #, fuzzy
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
-"Όταν καλείτε συναρτήσεις σε μια ξένη γλώσσα, λέμε ότι χρησιμοποιείτε a\n"
-"_ξένη διεπαφή λειτουργίας_, επίσης γνωστή ως FFI."
+"Όταν καλείτε συναρτήσεις σε μια ξένη γλώσσα, λέμε ότι χρησιμοποιείτε a _ξένη "
+"διεπαφή λειτουργίας_, επίσης γνωστή ως FFI."
 
 #: src/android/interoperability/with-c.md:1
 #, fuzzy
-msgid "# Interoperability with C"
-msgstr "# Διαλειτουργικότητα με C"
+msgid "Interoperability with C"
+msgstr "Διαλειτουργικότητα με C"
 
 #: src/android/interoperability/with-c.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 "Το Rust έχει πλήρη υποστήριξη για τη σύνδεση αρχείων αντικειμένων με μια "
-"σύμβαση κλήσης C.\n"
-"Ομοίως, μπορείτε να εξάγετε συναρτήσεις Rust και να τις καλέσετε από το C."
+"σύμβαση κλήσης C. Ομοίως, μπορείτε να εξάγετε συναρτήσεις Rust και να τις "
+"καλέσετε από το C."
 
 #: src/android/interoperability/with-c.md:6
 #, fuzzy
@@ -13602,20 +14123,20 @@ msgstr ""
 #: src/android/interoperability/with-c.md:20
 #, fuzzy
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
-"Το είδαμε ήδη στο [Safe FFI Wrapper\n"
-"άσκηση](../../exercises/day-3/safe-ffi-wrapper.md)."
+"Το είδαμε ήδη στο [Safe FFI Wrapper άσκηση](../../exercises/day-3/safe-ffi-"
+"wrapper.md)."
 
 #: src/android/interoperability/with-c.md:23
 #, fuzzy
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
-"> Αυτό προϋποθέτει πλήρη γνώση της πλατφόρμας-στόχου. Δεν συνιστάται για\n"
-"> παραγωγή."
+"Αυτό προϋποθέτει πλήρη γνώση της πλατφόρμας-στόχου. Δεν συνιστάται για "
+"παραγωγή."
 
 #: src/android/interoperability/with-c.md:26
 #, fuzzy
@@ -13624,19 +14145,17 @@ msgstr "Θα εξετάσουμε καλύτερες επιλογές στη σ�
 
 #: src/android/interoperability/with-c/bindgen.md:1
 #, fuzzy
-msgid "# Using Bindgen"
-msgstr "# Χρήση Bindgen"
+msgid "Using Bindgen"
+msgstr "Χρήση Bindgen"
 
 #: src/android/interoperability/with-c/bindgen.md:3
 #, fuzzy
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 "Το εργαλείο [bindgen](https://rust-lang.github.io/rust-bindgen/introduction."
-"html)\n"
-"μπορεί να δημιουργήσει αυτόματα δεσμεύσεις από ένα αρχείο κεφαλίδας C."
+"html) μπορεί να δημιουργήσει αυτόματα δεσμεύσεις από ένα αρχείο κεφαλίδας C."
 
 #: src/android/interoperability/with-c/bindgen.md:6
 #, fuzzy
@@ -13706,12 +14225,11 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:44
 #, fuzzy
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
 "Δημιουργήστε ένα αρχείο κεφαλίδας περιτυλίγματος για τη βιβλιοθήκη (δεν "
-"απαιτείται αυστηρά σε αυτό\n"
-"παράδειγμα):"
+"απαιτείται αυστηρά σε αυτό παράδειγμα):"
 
 #: src/android/interoperability/with-c/bindgen.md:47
 #, fuzzy
@@ -13825,8 +14343,8 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
 #, fuzzy
-msgid "# Calling Rust"
-msgstr "# Calling Rust"
+msgid "Calling Rust"
+msgstr "Calling Rust"
 
 #: src/android/interoperability/with-c/rust.md:3
 #, fuzzy
@@ -13946,63 +14464,53 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
-"Το \"#[no_mangle]\" απενεργοποιεί τη συνήθη παραποίηση ονόματος του Rust, "
-"επομένως το σύμβολο που θα εξαχθεί θα είναι απλώς το όνομα του\n"
-"η λειτουργία. Μπορείτε επίσης να χρησιμοποιήσετε το `#[export_name = "
+"Το \"#\\[no_mangle\\]\" απενεργοποιεί τη συνήθη παραποίηση ονόματος του "
+"Rust, επομένως το σύμβολο που θα εξαχθεί θα είναι απλώς το όνομα του η "
+"λειτουργία. Μπορείτε επίσης να χρησιμοποιήσετε το `#[export_name = "
 "\"some_name\"]` για να καθορίσετε όποιο όνομα θέλετε."
-
-#: src/android/interoperability/cpp.md:1
-#, fuzzy
-msgid "# With C++"
-msgstr "# Με C++"
 
 #: src/android/interoperability/cpp.md:3
 #, fuzzy
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
-"Το [CXX crate][1] καθιστά δυνατή την ασφαλή διαλειτουργικότητα μεταξύ του "
-"Rust\n"
-"και C++."
+"Το [CXX crate](https://cxx.rs/) καθιστά δυνατή την ασφαλή διαλειτουργικότητα "
+"μεταξύ του Rust και C++."
 
 #: src/android/interoperability/cpp.md:6
 #, fuzzy
 msgid "The overall approach looks like this:"
 msgstr "Η συνολική προσέγγιση μοιάζει με αυτό:"
 
-#: src/android/interoperability/cpp.md:8
-#, fuzzy
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr "<img src=\"cpp/overview.svg\">"
-
 #: src/android/interoperability/cpp.md:10
 #, fuzzy
-msgid "See the [CXX tutorial][2] for an full example of using this."
-msgstr "Δείτε το [CXX tutorial][2] για ένα πλήρες παράδειγμα χρήσης αυτού."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
+msgstr ""
+"Δείτε το [CXX tutorial](https://cxx.rs/tutorial.html) για ένα πλήρες "
+"παράδειγμα χρήσης αυτού."
 
 #: src/android/interoperability/java.md:1
 #, fuzzy
-msgid "# Interoperability with Java"
-msgstr "# Διαλειτουργικότητα με Java"
+msgid "Interoperability with Java"
+msgstr "Διαλειτουργικότητα με Java"
 
 #: src/android/interoperability/java.md:3
 #, fuzzy
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
 "Η Java μπορεί να φορτώσει κοινόχρηστα αντικείμενα μέσω του [Java Native "
-"Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). Το [`jni`\n"
-"crate](https://docs.rs/jni/) σας επιτρέπει να δημιουργήσετε μια συμβατή "
-"βιβλιοθήκη."
+"Interface (JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). Το "
+"[`jni` crate](https://docs.rs/jni/) σας επιτρέπει να δημιουργήσετε μια "
+"συμβατή βιβλιοθήκη."
 
 #: src/android/interoperability/java.md:7
 #, fuzzy
@@ -14116,87 +14624,70 @@ msgstr ""
 #, fuzzy
 msgid ""
 "For the last exercise, we will look at one of the projects you work with. "
-"Let us\n"
-"group up and do this together. Some suggestions:"
+"Let us group up and do this together. Some suggestions:"
 msgstr ""
 "Για την τελευταία άσκηση, θα δούμε ένα από τα έργα με τα οποία εργάζεστε. "
-"Αφήστε μας\n"
-"ομαδοποιήστε και κάντε αυτό μαζί. Μερικές προτάσεις:"
+"Αφήστε μας ομαδοποιήστε και κάντε αυτό μαζί. Μερικές προτάσεις:"
 
 #: src/exercises/day-4/android.md:6
 #, fuzzy
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
-msgstr "* Μετακινήστε μια συνάρτηση από το έργο σας στο Rust και καλέστε την."
+msgid "Call your AIDL service with a client written in Rust."
+msgstr "Μετακινήστε μια συνάρτηση από το έργο σας στο Rust και καλέστε την."
+
+#: src/exercises/day-4/android.md:8
+msgid "Move a function from your project to Rust and call it."
+msgstr ""
 
 #: src/exercises/day-4/android.md:12
 #, fuzzy
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 "Δεν παρέχεται λύση εδώ, δεδομένου ότι αυτό είναι ανοιχτό: βασίζεται σε "
-"κάποιον μέσα\n"
-"η τάξη έχει ένα κομμάτι κώδικα που μπορείτε να μεταφέρετε στο Rust on the "
-"fly."
-
-#: src/thanks.md:1
-#, fuzzy
-msgid "# Thanks!"
-msgstr "# Ευχαριστώ!"
+"κάποιον μέσα η τάξη έχει ένα κομμάτι κώδικα που μπορείτε να μεταφέρετε στο "
+"Rust on the fly."
 
 #: src/thanks.md:3
 #, fuzzy
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
-"that it\n"
-"was useful."
+"that it was useful."
 msgstr ""
 "_Σας ευχαριστούμε που πήρατε το Comprehensive Rust 🦀!_ Ελπίζουμε να σας "
-"άρεσε και να\n"
-"ήταν χρήσιμο."
+"άρεσε και να ήταν χρήσιμο."
 
 #: src/thanks.md:6
 #, fuzzy
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
-"Διασκεδάσαμε πολύ όταν συνδυάσαμε το μάθημα. Το μάθημα δεν είναι τέλειο,\n"
-"οπότε αν εντοπίσατε λάθη ή έχετε ιδέες για βελτιώσεις, παρακαλούμε μπείτε\n"
-"[επικοινωνήστε μαζί μας στο\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Θα "
-"αγαπούσαμε\n"
-"να ακούσω από σένα."
+"Διασκεδάσαμε πολύ όταν συνδυάσαμε το μάθημα. Το μάθημα δεν είναι τέλειο, "
+"οπότε αν εντοπίσατε λάθη ή έχετε ιδέες για βελτιώσεις, παρακαλούμε μπείτε "
+"[επικοινωνήστε μαζί μας στο GitHub](https://github.com/google/comprehensive-"
+"rust/discussions). Θα αγαπούσαμε να ακούσω από σένα."
 
 #: src/other-resources.md:1
 #, fuzzy
-msgid "# Other Rust Resources"
-msgstr "# Άλλοι πόροι σκουριάς"
+msgid "Other Rust Resources"
+msgstr "Άλλοι πόροι σκουριάς"
 
 #: src/other-resources.md:3
 #, fuzzy
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 "Η κοινότητα του Rust έχει δημιουργήσει έναν πλούτο υψηλής ποιότητας και "
-"δωρεάν πόρων\n"
-"Σε σύνδεση."
+"δωρεάν πόρων Σε σύνδεση."
 
 #: src/other-resources.md:6
 #, fuzzy
-msgid "## Official Documentation"
-msgstr "## Επίσημη Τεκμηρίωση"
+msgid "Official Documentation"
+msgstr "Επίσημη Τεκμηρίωση"
 
 #: src/other-resources.md:8
 #, fuzzy
@@ -14206,40 +14697,44 @@ msgstr "Το έργο Rust φιλοξενεί πολλούς πόρους. Αυ�
 #: src/other-resources.md:10
 #, fuzzy
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
 msgstr ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): το\n"
-"  κανονικό δωρεάν βιβλίο για το Rust. Καλύπτει αναλυτικά τη γλώσσα και "
-"περιλαμβάνει α\n"
-"  λίγα έργα για να κατασκευάσουν οι άνθρωποι.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): καλύπτει τη "
-"σκουριά\n"
-"  σύνταξη μέσω μιας σειράς παραδειγμάτων που παρουσιάζουν διαφορετικές "
-"κατασκευές. Ωρες ωρες\n"
-"  περιλαμβάνει μικρές ασκήσεις όπου σας ζητείται να αναπτύξετε τον κώδικα "
-"στο\n"
-"  παραδείγματα.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): πλήρης τεκμηρίωση "
-"του\n"
-"  η τυπική βιβλιοθήκη για το Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): ένα ημιτελές "
-"βιβλίο\n"
-"  που περιγράφει το μοντέλο της γραμματικής και της μνήμης Rust."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): το "
+"κανονικό δωρεάν βιβλίο για το Rust. Καλύπτει αναλυτικά τη γλώσσα και "
+"περιλαμβάνει α λίγα έργα για να κατασκευάσουν οι άνθρωποι."
+
+#: src/other-resources.md:13
+#, fuzzy
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): καλύπτει τη "
+"σκουριά σύνταξη μέσω μιας σειράς παραδειγμάτων που παρουσιάζουν διαφορετικές "
+"κατασκευές. Ωρες ωρες περιλαμβάνει μικρές ασκήσεις όπου σας ζητείται να "
+"αναπτύξετε τον κώδικα στο παραδείγματα."
+
+#: src/other-resources.md:17
+#, fuzzy
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): πλήρης τεκμηρίωση "
+"του η τυπική βιβλιοθήκη για το Rust."
+
+#: src/other-resources.md:19
+#, fuzzy
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
+msgstr ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): ένα ημιτελές "
+"βιβλίο που περιγράφει το μοντέλο της γραμματικής και της μνήμης Rust."
 
 #: src/other-resources.md:22
 #, fuzzy
@@ -14251,37 +14746,40 @@ msgstr ""
 #: src/other-resources.md:24
 #, fuzzy
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
 msgstr ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): καλύπτει το μη "
-"ασφαλές Rust,\n"
-"  συμπεριλαμβανομένης της εργασίας με ακατέργαστους δείκτες και της διεπαφής "
-"με άλλες γλώσσες\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  καλύπτει το νέο μοντέλο ασύγχρονου προγραμματισμού που εισήχθη μετά το\n"
-"  Το Rust Book γράφτηκε.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-"
-"book/):\n"
-"  εισαγωγή στη χρήση του Rust σε ενσωματωμένες συσκευές χωρίς λειτουργικό "
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): καλύπτει το μη "
+"ασφαλές Rust, συμπεριλαμβανομένης της εργασίας με ακατέργαστους δείκτες και "
+"της διεπαφής με άλλες γλώσσες (FFI)."
+
+#: src/other-resources.md:27
+#, fuzzy
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"καλύπτει το νέο μοντέλο ασύγχρονου προγραμματισμού που εισήχθη μετά το Το "
+"Rust Book γράφτηκε."
+
+#: src/other-resources.md:30
+#, fuzzy
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
+msgstr ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"εισαγωγή στη χρήση του Rust σε ενσωματωμένες συσκευές χωρίς λειτουργικό "
 "σύστημα."
 
 #: src/other-resources.md:33
 #, fuzzy
-msgid "## Unofficial Learning Material"
-msgstr "## Ανεπίσημο Εκπαιδευτικό Υλικό"
+msgid "Unofficial Learning Material"
+msgstr "Ανεπίσημο Εκπαιδευτικό Υλικό"
 
 #: src/other-resources.md:35
 #, fuzzy
@@ -14291,210 +14789,200 @@ msgstr "Μια μικρή επιλογή άλλων οδηγών και οδηγ
 #: src/other-resources.md:37
 #, fuzzy
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
 msgstr ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): καλύπτει "
-"το Rust\n"
-"  από την οπτική γωνία των προγραμματιστών χαμηλού επιπέδου C.\n"
-"* [Rust for Embedded C\n"
-"  Προγραμματιστές](https://docs.opentitan.org/doc/ug/rust_for_c/): καλύπτει "
-"το Rust από\n"
-"  η προοπτική των προγραμματιστών που γράφουν υλικολογισμικό σε C.\n"
-"* [Rust για επαγγελματίες](https://overexact.com/rust-for-professionals/):\n"
-"  καλύπτει τη σύνταξη του Rust χρησιμοποιώντας συγκρίσεις δίπλα-δίπλα με "
-"άλλες γλώσσες\n"
-"  όπως C, C++, Java, JavaScript και Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ ασκήσεις για "
-"βοήθεια\n"
-"  μαθαίνεις Rust.\n"
-"* [Σιδήρου Διδασκαλία\n"
-"  Υλικό](https://ferrous-systems.github.io/teaching-material/index.html): α\n"
-"  σειρά μικρών παρουσιάσεων που καλύπτουν τόσο βασικό όσο και προχωρημένο "
-"μέρος του\n"
-"  Γλώσσα σκουριάς. Άλλα θέματα όπως το WebAssembly και το async/wait είναι "
-"επίσης\n"
-"  σκεπαστός.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"και\n"
-"  [Κάντε τα πρώτα σας βήματα με\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"δύο\n"
-"  Οδηγοί Rust που απευθύνονται σε νέους προγραμματιστές. Το πρώτο είναι ένα "
-"σύνολο 35 βίντεο και το\n"
-"  Το δεύτερο είναι ένα σύνολο 11 ενοτήτων που καλύπτει τη σύνταξη του Rust "
-"και τις βασικές δομές."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): καλύπτει το "
+"Rust από την οπτική γωνία των προγραμματιστών χαμηλού επιπέδου C."
+
+#: src/other-resources.md:39
+#, fuzzy
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+"[Rust for Embedded C Προγραμματιστές](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): καλύπτει το Rust από η προοπτική των προγραμματιστών που "
+"γράφουν υλικολογισμικό σε C."
+
+#: src/other-resources.md:42
+#, fuzzy
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+"[Rust για επαγγελματίες](https://overexact.com/rust-for-professionals/): "
+"καλύπτει τη σύνταξη του Rust χρησιμοποιώντας συγκρίσεις δίπλα-δίπλα με άλλες "
+"γλώσσες όπως C, C++, Java, JavaScript και Python."
+
+#: src/other-resources.md:45
+#, fuzzy
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ ασκήσεις για "
+"βοήθεια μαθαίνεις Rust."
+
+#: src/other-resources.md:47
+#, fuzzy
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+"[Σιδήρου Διδασκαλία Υλικό](https://ferrous-systems.github.io/teaching-"
+"material/index.html): α σειρά μικρών παρουσιάσεων που καλύπτουν τόσο βασικό "
+"όσο και προχωρημένο μέρος του Γλώσσα σκουριάς. Άλλα θέματα όπως το "
+"WebAssembly και το async/wait είναι επίσης σκεπαστός."
+
+#: src/other-resources.md:52
+#, fuzzy
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) και [Κάντε τα πρώτα σας βήματα με Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): δύο Οδηγοί Rust που "
+"απευθύνονται σε νέους προγραμματιστές. Το πρώτο είναι ένα σύνολο 35 βίντεο "
+"και το Το δεύτερο είναι ένα σύνολο 11 ενοτήτων που καλύπτει τη σύνταξη του "
+"Rust και τις βασικές δομές."
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
+msgstr ""
 
 #: src/other-resources.md:63
 #, fuzzy
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
+"for even more Rust books."
 msgstr ""
-"Δείτε το [Little Book of Rust Books](https://lborb.github.io/book/) για\n"
+"Δείτε το [Little Book of Rust Books](https://lborb.github.io/book/) για "
 "ακόμα περισσότερα βιβλία Rust."
-
-#: src/credits.md:1
-#, fuzzy
-msgid "# Credits"
-msgstr "# Πιστώσεις"
 
 #: src/credits.md:3
 #, fuzzy
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
-"Το υλικό εδώ βασίζεται στις πολλές σπουδαίες πηγές τεκμηρίωσης του Rust.\n"
+"Το υλικό εδώ βασίζεται στις πολλές σπουδαίες πηγές τεκμηρίωσης του Rust. "
 "Δείτε τη σελίδα στο [other resources](other-resources.md) για μια πλήρη "
-"λίστα χρήσιμων\n"
-"πόροι."
+"λίστα χρήσιμων πόροι."
 
 #: src/credits.md:7
 #, fuzzy
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
 msgstr ""
 "Το υλικό του Comprehensive Rust έχει άδεια χρήσης σύμφωνα με τους όρους του "
-"Apache 2.0\n"
-"άδεια, ανατρέξτε στην ενότητα [`ΑΔΕΙΑ`](../LICENSE) για λεπτομέρειες."
+"Apache 2.0 άδεια, ανατρέξτε στην ενότητα [`ΑΔΕΙΑ`](../LICENSE) για "
+"λεπτομέρειες."
 
 #: src/credits.md:10
 #, fuzzy
-msgid "## Rust by Example"
-msgstr "## Σκουριά από Παράδειγμα"
+msgid "Rust by Example"
+msgstr "Σκουριά από Παράδειγμα"
 
 #: src/credits.md:12
 #, fuzzy
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
 "Ορισμένα παραδείγματα και ασκήσεις έχουν αντιγραφεί και προσαρμοστεί από το "
-"[Rust by\n"
-"Παράδειγμα](https://doc.rust-lang.org/rust-by-example/). Παρακαλώ δείτε το\n"
-"Κατάλογος `third_party/rust-by-example/` για λεπτομέρειες, "
-"συμπεριλαμβανομένης της άδειας χρήσης\n"
-"όροι."
+"[Rust by Παράδειγμα](https://doc.rust-lang.org/rust-by-example/). Παρακαλώ "
+"δείτε το Κατάλογος `third_party/rust-by-example/` για λεπτομέρειες, "
+"συμπεριλαμβανομένης της άδειας χρήσης όροι."
 
 #: src/credits.md:17
 #, fuzzy
-msgid "## Rust on Exercism"
-msgstr "## Σκουριά στην άσκηση"
+msgid "Rust on Exercism"
+msgstr "Σκουριά στην άσκηση"
 
 #: src/credits.md:19
 #, fuzzy
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"Ορισμένες ασκήσεις έχουν αντιγραφεί και προσαρμοστεί από το [Rust on\n"
-"Άσκηση](https://exercism.org/tracks/rust). Παρακαλώ δείτε το\n"
-"Κατάλογος `third_party/rust-on-exercism/` για λεπτομέρειες, "
-"συμπεριλαμβανομένης της άδειας\n"
-"όροι."
+"Ορισμένες ασκήσεις έχουν αντιγραφεί και προσαρμοστεί από το [Rust on Άσκηση]"
+"(https://exercism.org/tracks/rust). Παρακαλώ δείτε το Κατάλογος `third_party/"
+"rust-on-exercism/` για λεπτομέρειες, συμπεριλαμβανομένης της άδειας όροι."
 
 #: src/credits.md:24
 #, fuzzy
-msgid "## CXX"
-msgstr "## CXX"
+msgid "CXX"
+msgstr "CXX"
 
 #: src/credits.md:26
 #, fuzzy
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 "Η ενότητα [Διαλειτουργικότητα με C++](android/interoperability/cpp.md) "
-"χρησιμοποιεί ένα\n"
-"εικόνα από [CXX](https://cxx.rs/). Δείτε τον κατάλογο `third_party/cxx/`\n"
-"για λεπτομέρειες, συμπεριλαμβανομένων των όρων άδειας."
+"χρησιμοποιεί ένα εικόνα από [CXX](https://cxx.rs/). Δείτε τον κατάλογο "
+"`third_party/cxx/` για λεπτομέρειες, συμπεριλαμβανομένων των όρων άδειας."
 
 #: src/welcome-bare-metal.md:1
 #, fuzzy
-msgid "# Welcome to Bare Metal Rust"
-msgstr "# Καλώς ήρθατε στην Comprehensive Rust 🦀"
+msgid "Welcome to Bare Metal Rust"
+msgstr "Καλώς ήρθατε στην Comprehensive Rust 🦀"
 
 #: src/welcome-bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/welcome-bare-metal.md:7
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 
 #: src/welcome-bare-metal.md:10
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr ""
+
+#: src/welcome-bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr ""
+
+#: src/welcome-bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr ""
+
+#: src/welcome-bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
 #: src/welcome-bare-metal.md:15
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 
@@ -14548,27 +15036,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/no_std.md:1
-msgid "# `no_std`"
-msgstr ""
-
-#: src/bare-metal/no_std.md:3
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -14576,72 +15051,100 @@ msgstr ""
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:19
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-
 #: src/bare-metal/no_std.md:24
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
+msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
-msgid ""
-"</td>\n"
-"<td>"
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr ""
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:38
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:45
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:56
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:62
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr ""
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
 #: src/bare-metal/minimal.md:1
-msgid "# A minimal `no_std` program"
+msgid "A minimal `no_std` program"
 msgstr ""
 
 #: src/bare-metal/minimal.md:3
@@ -14660,29 +15163,34 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-msgid "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -14721,24 +15229,28 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:38
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-msgid "# Microcontrollers"
+#: src/bare-metal/alloc.md:40
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:42
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:44
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
@@ -14774,21 +15286,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:1
-msgid "# Raw MMIO"
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:6
@@ -14858,8 +15367,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:66
@@ -14877,16 +15386,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
-msgid "# Peripheral Access Crates"
+msgid "Peripheral Access Crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -14934,19 +15441,31 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:61
@@ -14957,16 +15476,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
-msgid "# HAL crates"
+msgid "HAL crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -15004,11 +15522,13 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:45
@@ -15020,8 +15540,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
 #, fuzzy
-msgid "# Board support crates"
-msgstr "# Συντομεύσεις πληκτρολογίου"
+msgid "Board support crates"
+msgstr "Συντομεύσεις πληκτρολογίου"
 
 #: src/bare-metal/microcontrollers/board-support.md:3
 msgid ""
@@ -15055,13 +15575,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:28
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:36
@@ -15072,7 +15597,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
-msgid "# The type state pattern"
+msgid "The type state pattern"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:3
@@ -15110,120 +15635,178 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "# `embedded-hal`"
+msgid "`embedded-hal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
+msgid "GPIO"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "# probe-rs, `cargo-embed`"
+msgid "probe-rs, `cargo-embed`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid " server"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
 msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:1
-#, fuzzy
-msgid "# Debugging"
-msgstr "# Καταγραφή"
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
+msgstr ""
 
 #: src/bare-metal/microcontrollers/debugging.md:3
 msgid "Embed.toml:"
@@ -15282,39 +15865,86 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
-msgid "# Other projects"
+msgid "Other projects"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "[RTIC](https://rtic.rs/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
 
@@ -15324,16 +15954,11 @@ msgid ""
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:1
-#, fuzzy
-msgid "# Compass"
-msgstr "# Σύγκριση"
-
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
-"serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:6
@@ -15342,27 +15967,40 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C "
-"bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:11
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:12
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:13
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:17
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:19
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23 src/exercises/bare-metal/rtc.md:7
@@ -15492,39 +16130,47 @@ msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
 #: src/bare-metal/aps.md:1
-msgid "# Application processors"
+msgid "Application processors"
 msgstr ""
 
 #: src/bare-metal/aps.md:3
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
+msgstr ""
+
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
-msgid "# Inline assembly"
+msgid "Inline assembly"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid " to tell the firmware to power off the system:"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:6
@@ -15565,62 +16211,83 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the [`psci`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`psci`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
-msgid "# Volatile memory access for MMIO"
+msgid "Volatile memory access for MMIO"
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:9
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:1
-msgid "# Let's write a UART driver"
+msgid "Let's write a UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -15680,8 +16347,8 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:1
 #, fuzzy
-msgid "# More traits"
-msgstr "# Χαρακτηριστικά"
+msgid "More traits"
+msgstr "Χαρακτηριστικά"
 
 #: src/bare-metal/aps/uart/traits.md:3
 msgid ""
@@ -15711,51 +16378,188 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with "
-"our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:25
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
-msgid "# A better UART driver"
+msgid "A better UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
+msgid "Offset"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:26
-msgid "- There are also some ID registers which have been omitted for brevity."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-msgid "# Bitflags"
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
@@ -15799,13 +16603,12 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
-"with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:1
-msgid "# Multiple registers"
+msgid "Multiple registers"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:3
@@ -15852,17 +16655,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust "
-"representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-msgid "# Driver"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -15936,22 +16733,20 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
-"fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
 #, fuzzy
-msgid "# Using it"
-msgstr "# Χρήση Bindgen"
+msgid "Using it"
+msgstr "Χρήση Bindgen"
 
 #: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
-"and echo incoming\n"
-"bytes."
+"and echo incoming bytes."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:6
@@ -16002,15 +16797,14 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:49
 msgid ""
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/"
-"examples`."
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -16061,7 +16855,7 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
@@ -16112,29 +16906,57 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:45
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:46
 msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:7
 msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling, page tables\n"
-"   * Not all very well written, so beware.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:9
+msgid "Not all very well written, so beware."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:11
+msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
 #: src/bare-metal/useful-crates.md:1
-msgid "# Useful crates"
+msgid "Useful crates"
 msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
@@ -16144,14 +16966,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "# `zerocopy`"
+msgid "`zerocopy`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
@@ -16194,31 +17016,37 @@ msgstr ""
 #: src/bare-metal/useful-crates/zerocopy.md:40
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives."
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "# `aarch64-paging`"
+msgid "`aarch64-paging`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
@@ -16246,25 +17074,31 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2]."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -16287,22 +17121,20 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
-msgid "* PCI BARs always have alignment equal to their size."
+msgid "PCI BARs always have alignment equal to their size."
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "# `tinyvec`"
+msgid "`tinyvec`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
@@ -16323,28 +17155,26 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:23
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
+"`tinyvec` requires that the element type implement `Default` for "
 "initialisation."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:1
 #, fuzzy
-msgid "# `spin`"
-msgstr "## «στατικό»."
+msgid "`spin`"
+msgstr "«στατικό»."
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:7
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:9
@@ -16363,23 +17193,28 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:24
 msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`."
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
 msgstr ""
 
 #: src/bare-metal/android.md:3
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
 #: src/bare-metal/android.md:7
@@ -16424,16 +17259,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-msgid "# vmbase"
-msgstr ""
-
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -16454,11 +17285,14 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:21
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md:3
@@ -16466,16 +17300,17 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:1
-msgid "# RTC driver"
+#: src/exercises/bare-metal/solutions-afternoon.md:3
+msgid "RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. "
-"For this exercise, you\n"
-"should write a driver for it and use it to print the current time to the "
-"serial console. You can use\n"
-"the [`chrono`][2] crate for date/time formatting."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it and use it to print the current time to the "
+"serial console. You can use the [`chrono`](https://crates.io/crates/chrono) "
+"crate for date/time formatting."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:8
@@ -17498,11 +18333,6 @@ msgstr ""
 msgid "Run the code in QEMU with `make qemu`."
 msgstr ""
 
-#: src/exercises/solutions.md:1
-#, fuzzy
-msgid "# Solutions"
-msgstr "# Λύσεις"
-
 #: src/exercises/solutions.md:3
 #, fuzzy
 msgid "You will find solutions to the exercises on the following pages."
@@ -17511,37 +18341,29 @@ msgstr "Θα βρείτε λύσεις στις ασκήσεις στις επό
 #: src/exercises/solutions.md:5
 #, fuzzy
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
-"Μη διστάσετε να κάνετε ερωτήσεις σχετικά με τις λύσεις [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Ενημέρωσέ "
-"μας\n"
-"εάν έχετε διαφορετική ή καλύτερη λύση από αυτή που παρουσιάζεται εδώ."
+"Μη διστάσετε να κάνετε ερωτήσεις σχετικά με τις λύσεις [on GitHub](https://"
+"github.com/google/comprehensive-rust/discussions). Ενημέρωσέ μας εάν έχετε "
+"διαφορετική ή καλύτερη λύση από αυτή που παρουσιάζεται εδώ."
 
 #: src/exercises/solutions.md:10
 #, fuzzy
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
-"> **Σημείωση:** Αγνοήστε τα \"// ANCHOR: label\" και \"// ANCHOR_END: "
-"label\"\n"
-"> σχόλια που βλέπετε στις λύσεις. Είναι εκεί για να το κάνουν δυνατό\n"
-"> επαναχρησιμοποιήστε μέρη των λύσεων ως ασκήσεις."
+"**Σημείωση:** Αγνοήστε τα \"// ANCHOR: label\" και \"// ANCHOR_END: label\" "
+"σχόλια που βλέπετε στις λύσεις. Είναι εκεί για να το κάνουν δυνατό "
+"επαναχρησιμοποιήστε μέρη των λύσεων ως ασκήσεις."
 
 #: src/exercises/day-1/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 1 Morning Exercises"
-msgstr "# Πρωινές ασκήσεις 1ης ημέρας"
-
-#: src/exercises/day-1/solutions-morning.md:3
-#, fuzzy
-msgid "## Arrays and `for` Loops"
-msgstr "## Πίνακες και βρόχοι «for»."
+msgid "Day 1 Morning Exercises"
+msgstr "Πρωινές ασκήσεις 1ης ημέρας"
 
 #: src/exercises/day-1/solutions-morning.md:5
 #, fuzzy
@@ -17625,8 +18447,8 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
 #, fuzzy
-msgid "### Bonus question"
-msgstr "## Ερώτηση μπόνους"
+msgid "Bonus question"
+msgstr "Ερώτηση μπόνους"
 
 #: src/exercises/day-1/solutions-morning.md:80
 #, fuzzy
@@ -17640,8 +18462,8 @@ msgstr ""
 "χρησιμοποιήσουμε ένα slice-of-slices (`&[&[i32]]`) ως τύπο εισόδου για να "
 "μεταφέρουμε και έτσι να κάνουμε τη συνάρτησή μας να χειρίζεται οποιοδήποτε "
 "μέγεθος πίνακα. Ωστόσο, αυτό αναλύεται γρήγορα: ο τύπος επιστροφής δεν "
-"μπορεί να είναι \"&[&[i32]]\", καθώς πρέπει να είναι κάτοχος των δεδομένων "
-"που επιστρέφετε."
+"μπορεί να είναι \"&\\[&\\[i32\\]\\]\", καθώς πρέπει να είναι κάτοχος των "
+"δεδομένων που επιστρέφετε."
 
 #: src/exercises/day-1/solutions-morning.md:82
 #, fuzzy
@@ -17652,13 +18474,14 @@ msgid ""
 msgstr ""
 "Μπορείτε να επιχειρήσετε να χρησιμοποιήσετε κάτι σαν `Vec<Vec<i32>>`, αλλά "
 "ούτε αυτό λειτουργεί πολύ καλά: είναι δύσκολο να μετατρέψετε από "
-"`Vec<Vec<i32>>` σε `&[&[i32]] Έτσι τώρα δεν μπορείτε να χρησιμοποιήσετε "
-"εύκολα ούτε το \"pretty_print\"."
+"`Vec<Vec<i32>>` σε \\`&\\[&\\[i32\\]\\] Έτσι τώρα δεν μπορείτε να "
+"χρησιμοποιήσετε εύκολα ούτε το \"pretty_print\"."
 
 #: src/exercises/day-1/solutions-morning.md:84
 msgid ""
 "Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:86
@@ -17703,13 +18526,8 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 1 Afternoon Exercises"
-msgstr "# 1η ημέρα Απογευματινές Ασκήσεις"
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Designing a Library"
-msgstr "## Σχεδιασμός Βιβλιοθήκης"
+msgid "Day 1 Afternoon Exercises"
+msgstr "1η ημέρα Απογευματινές Ασκήσεις"
 
 #: src/exercises/day-1/solutions-afternoon.md:5
 #, fuzzy
@@ -17903,13 +18721,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 2 Morning Exercises"
-msgstr "# 2η ημέρα Πρωινές ασκήσεις"
-
-#: src/exercises/day-2/solutions-morning.md:3
-#, fuzzy
-msgid "## Points and Polygons"
-msgstr "## Σημεία και πολύγωνα"
+msgid "Day 2 Morning Exercises"
+msgstr "2η ημέρα Πρωινές ασκήσεις"
 
 #: src/exercises/day-2/solutions-morning.md:5
 #, fuzzy
@@ -18150,13 +18963,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 2 Afternoon Exercises"
-msgstr "# 2η μέρα Απογευματινές Ασκήσεις"
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Luhn Algorithm"
-msgstr "## Αλγόριθμος Luhn"
+msgid "Day 2 Afternoon Exercises"
+msgstr "2η μέρα Απογευματινές Ασκήσεις"
 
 #: src/exercises/day-2/solutions-afternoon.md:5
 #, fuzzy
@@ -18258,11 +19066,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:98
-#, fuzzy
-msgid "## Strings and Iterators"
-msgstr "## Συμβολοσειρές και επαναλήπτες"
-
 #: src/exercises/day-2/solutions-afternoon.md:100
 #, fuzzy
 msgid "([back to exercise](strings-iterators.md))"
@@ -18352,13 +19155,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 3 Morning Exercise"
-msgstr "# 3η ημέρα Πρωινή άσκηση"
-
-#: src/exercises/day-3/solutions-morning.md:3
-#, fuzzy
-msgid "## A Simple GUI Library"
-msgstr "## Μια απλή βιβλιοθήκη GUI"
+msgid "Day 3 Morning Exercise"
+msgstr "3η ημέρα Πρωινή άσκηση"
 
 #: src/exercises/day-3/solutions-morning.md:5
 #, fuzzy
@@ -18534,13 +19332,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 3 Afternoon Exercises"
-msgstr "# 3η ημέρα Απογευματινές Ασκήσεις"
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Safe FFI Wrapper"
-msgstr "## Ασφαλές περιτύλιγμα FFI"
+msgid "Day 3 Afternoon Exercises"
+msgstr "3η ημέρα Απογευματινές Ασκήσεις"
 
 #: src/exercises/day-3/solutions-afternoon.md:5
 #, fuzzy
@@ -18668,13 +19461,8 @@ msgstr ""
 
 #: src/exercises/day-4/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 4 Morning Exercise"
-msgstr "# 4η ημέρα Πρωινή άσκηση"
-
-#: src/exercises/day-4/solutions-morning.md:3
-#, fuzzy
-msgid "## Dining Philosophers"
-msgstr "## Dining Philosophers"
+msgid "Day 4 Morning Exercise"
+msgstr "4η ημέρα Πρωινή άσκηση"
 
 #: src/exercises/day-4/solutions-morning.md:5
 #, fuzzy
@@ -18783,13 +19571,8 @@ msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
 #, fuzzy
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr "# 3η ημέρα Πρωινή άσκηση"
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-#, fuzzy
-msgid "## Compass"
-msgstr "# Σύγκριση"
+msgid "Bare Metal Rust Morning Exercise"
+msgstr "3η ημέρα Πρωινή άσκηση"
 
 #: src/exercises/bare-metal/solutions-morning.md:5
 #, fuzzy
@@ -18967,14 +19750,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "# Bare Metal Rust Afternoon"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-msgid "## RTC driver"
-msgstr ""
-
 #: src/exercises/bare-metal/solutions-afternoon.md:5
 #, fuzzy
 msgid "([back to exercise](rtc.md))"
@@ -19141,2880 +19916,3 @@ msgid ""
 "unsafe impl Send for Rtc {}\n"
 "```"
 msgstr ""
-
-#~ msgid ""
-#~ "1. Make yourself familiar with the course material. We've included "
-#~ "speaker notes\n"
-#~ "   on some of the pages to help highlight the key points (please help us "
-#~ "by\n"
-#~ "   contributing more speaker notes!). You should make sure to open the "
-#~ "speaker\n"
-#~ "   notes in a popup (click the link with a little arrow next to "
-#~ "\"Speaker\n"
-#~ "   Notes\"). This way you have a clean screen to present to the class."
-#~ msgstr ""
-#~ "1. Εξοικειωθείτε με το υλικό του μαθήματος. Έχουμε συμπεριλάβει "
-#~ "σημειώσεις ομιλητή\n"
-#~ "   σε ορισμένες από τις σελίδες για να τονίσουμε τα βασικά σημεία "
-#~ "(παρακαλούμε βοηθήστε μας να\n"
-#~ "   συνεισφέροντας περισσότερες σημειώσεις ομιλητή!). Θα πρέπει να "
-#~ "φροντίσετε να ανοίξετε τις σημειώσεις\n"
-#~ "   σε ένα αναδυόμενο παράθυρο (κάντε κλικ στο σύνδεσμο με ένα μικρό βέλος "
-#~ "δίπλα στο \"Speaker\n"
-#~ "   Notes\"). Με αυτόν τον τρόπο θα έχετε μια καθαρή οθόνη για να "
-#~ "παρουσιάσετε στην τάξη."
-
-#~ msgid ""
-#~ "2. Decide on the dates. Since the course is large, we recommend that you\n"
-#~ "   schedule the four days over two weeks. Course participants have said "
-#~ "that\n"
-#~ "   they find it helpful to have a gap in the course since it helps them "
-#~ "process\n"
-#~ "   all the information we give them."
-#~ msgstr ""
-#~ "2. Αποφασίστε τις ημερομηνίες. Επειδή το μάθημα είναι μεγάλο, σας "
-#~ "συνιστούμε να το απλώσετε\n"
-#~ "   τις τέσσερις ημέρες σε δύο εβδομάδες. Οι συμμετέχοντες στο μάθημα το "
-#~ "θεωρούν γενικά\n"
-#~ "   χρήσιμο να έχουν ένα κενό στο μεταξύ των παραδόσεων, καθώς τους βοηθά "
-#~ "να επεξεργαστούν\n"
-#~ "   όλες τις πληροφορίες που τους δίνουμε."
-
-#~ msgid ""
-#~ "3. Find a room large enough for your in-person participants. We recommend "
-#~ "a\n"
-#~ "   class size of 15-20 people. That's small enough that people are "
-#~ "comfortable\n"
-#~ "   asking questions --- it's also small enough that one instructor will "
-#~ "have\n"
-#~ "   time to answer the questions."
-#~ msgstr ""
-#~ "3. Βρείτε ένα δωμάτιο αρκετά μεγάλο για τους φυσικούς σας συμμετέχοντες. "
-#~ "Συνιστούμε τάξεις μεγέθους 15-20 άτομα. Είναι αρκετά μικρό ώστε οι "
-#~ "συμμετέχοντες να νιώθουν άνετα\n"
-#~ "   κάνοντας ερωτήσεις --- αλλά και ο εκπαιδευτής\n"
-#~ "   να έχει χρόνο να απαντήσει στις ερωτήσεις."
-
-#~ msgid ""
-#~ "4. On the day of your course, show up to the room a little early to set "
-#~ "things\n"
-#~ "   up. We recommend presenting directly using `mdbook serve` running on "
-#~ "your\n"
-#~ "   laptop (see the [installation instructions][5]). This ensures optimal "
-#~ "performance with no lag as you change pages.\n"
-#~ "   Using your laptop will also allow you to fix typos as you or the "
-#~ "course\n"
-#~ "   participants spot them."
-#~ msgstr ""
-#~ "4. Την ημέρα του μαθήματος, πηγαίνετε στην αίθουσα λίγο νωρίς για να "
-#~ "προετοιμαστείτε.\n"
-#~ "   Συνιστούμε την απευθείας παρουσίαση χρησιμοποιώντας την υπηρεσία "
-#~ "\"mdbook serve\" που θα τρέξετε στον δικό σας\n"
-#~ "   λάπτοπ(βλέπε τις [οδηγίες εγκατάστασης][5]. Αυτό εξασφαλίζει βέλτιστη "
-#~ "απόδοση χωρίς καθυστέρηση μεταξύ των σελίδων.\n"
-#~ "   Η χρήση του φορητού υπολογιστή σας θα σας επιτρέψει επίσης να "
-#~ "διορθώσετε τυπογραφικά λάθη όταν εσείς ή οι συμμετέχοντες\n"
-#~ "   τα εντοπίζετε."
-
-#~ msgid ""
-#~ "5. Let people solve the exercises by themselves or in small groups. Make "
-#~ "sure to\n"
-#~ "   ask people if they're stuck or if there is anything you can help with. "
-#~ "When\n"
-#~ "   you see that several people have the same problem, call it out to the "
-#~ "class\n"
-#~ "   and offer a solution, e.g., by showing people where to find the "
-#~ "relevant\n"
-#~ "   information in the standard library."
-#~ msgstr ""
-#~ "5. Αφήστε τους συμμετέχοντες να λύσουν τις ασκήσεις μόνοι τους ή σε "
-#~ "μικρές ομάδες.    Να ρωτάτε περιοδικά τους μαθητές αν έχουν κολλήσει ή αν "
-#~ "υπάρχει κάτι με το οποίο μπορείτε να βοηθήσετε. Οταν\n"
-#~ "   βλέπετε ότι πολλοί άνθρωποι έχουν το ίδιο πρόβλημα, αναφέρετέ το στην "
-#~ "τάξη\n"
-#~ "   βρείτε μια λύση, π.χ., δείχνοντας στους ανθρώπους πώς να ψάξουν για "
-#~ "σχετικές\n"
-#~ "   πληροφορίες στην standard βιβλιοθήκη."
-
-#~ msgid ""
-#~ "> **Exercise for Day 4:** Do you interface with some C/C++ code in your "
-#~ "project\n"
-#~ "> which we could attempt to move to Rust? The fewer dependencies the "
-#~ "better.\n"
-#~ "> Parsing code would be ideal."
-#~ msgstr ""
-#~ "> **Άσκηση για την 4η Ημέρα:** Διασυνδέεστε με κώδικα C/C++ στο πρότζεκτ "
-#~ "σας\n"
-#~ "> που θα μπορούσαμε να προσπαθήσουμε να μεταφέρουμε στο Rust; Όσο "
-#~ "λιγότερες εξαρτήσεις τόσο το καλύτερο.\n"
-#~ "> Η ανάλυση του κώδικα θα ήταν ιδανικό παράδειγμα."
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://rust-analyzer.github.io/\n"
-#~ "[2]: https://code.visualstudio.com/\n"
-#~ "[3]: https://rustup.rs/\n"
-#~ "[4]: https://www.jetbrains.com/clion/\n"
-#~ "[5]: https://www.jetbrains.com/rust/\n"
-#~ "[6]: https://github.com/rust-lang/rustfmt"
-#~ msgstr ""
-#~ "[1]: https://rust-analyzer.github.io/\n"
-#~ "[2]: https://code.visualstudio.com/\n"
-#~ "[3]: https://rustup.rs/\n"
-#~ "[4]: https://www.jetbrains.com/clion/\n"
-#~ "[5]: https://www.jetbrains.com/rust/"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-#~ "other\n"
-#~ "  intermediate formats."
-#~ msgstr ""
-#~ "* `rustc`: ο μεταγλωττιστής Rust που μετατρέπει τα αρχεία `.rs` σε "
-#~ "δυαδικά και άλλα\n"
-#~ "  ενδιάμεσες μορφές[^rustc]."
-
-#, fuzzy
-#~ msgid ""
-#~ "* `cargo`: the Rust dependency manager and build tool. Cargo knows how "
-#~ "to\n"
-#~ "  download dependencies hosted on <https://crates.io> and it will pass "
-#~ "them to\n"
-#~ "  `rustc` when building your project. Cargo also comes with a built-in "
-#~ "test\n"
-#~ "  runner which is used to execute unit tests."
-#~ msgstr ""
-#~ "* «cargo»: ο διαχειριστής εξάρτησης Rust και το εργαλείο κατασκευής. Το "
-#~ "φορτίο ξέρει πώς να\n"
-#~ "  κατεβάστε τις εξαρτήσεις που φιλοξενούνται στο <https://crates.io> και "
-#~ "θα τις μεταβιβάσει\n"
-#~ "  «rustc» κατά την κατασκευή του έργου σας. Το Cargo συνοδεύεται επίσης "
-#~ "από ενσωματωμένη δοκιμή\n"
-#~ "  runner που χρησιμοποιείται για την εκτέλεση δοκιμών μονάδας[^cargo]."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust has a rapid release schedule with a new release coming out\n"
-#~ "  every six weeks. New releases maintain backwards compatibility with\n"
-#~ "  old releases --- plus they enable new functionality."
-#~ msgstr ""
-#~ "* Το Rust έχει ένα γρήγορο πρόγραμμα κυκλοφορίας με μια νέα κυκλοφορία να "
-#~ "κυκλοφορεί\n"
-#~ "  κάθε έξι εβδομάδες. Οι νέες εκδόσεις διατηρούν συμβατότητα προς τα πίσω "
-#~ "με\n"
-#~ "  παλιές εκδόσεις --- συν ότι επιτρέπουν νέες λειτουργίες."
-
-#, fuzzy
-#~ msgid ""
-#~ "* There are three release channels: \"stable\", \"beta\", and \"nightly\"."
-#~ msgstr ""
-#~ "* Υπάρχουν τρία κανάλια κυκλοφορίας: \"σταθερό\", \"beta\" και "
-#~ "\"νυχτερινό\"."
-
-#, fuzzy
-#~ msgid ""
-#~ "* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-#~ "  \"stable\" every six weeks."
-#~ msgstr ""
-#~ "* Νέες δυνατότητες δοκιμάζονται σε \"νυχτερινό\", \"beta\" είναι αυτό που "
-#~ "γίνεται\n"
-#~ "  «σταθερό» κάθε έξι εβδομάδες."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-#~ "  editions were Rust 2015 and Rust 2018."
-#~ msgstr ""
-#~ "* Το Rust έχει επίσης [εκδόσεις]: η τρέχουσα έκδοση είναι Rust 2021. "
-#~ "Προηγούμενο\n"
-#~ "  οι εκδόσεις ήταν Rust 2015 και Rust 2018."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * The editions are allowed to make backwards incompatible changes to\n"
-#~ "    the language."
-#~ msgstr ""
-#~ "  * Οι εκδόσεις επιτρέπεται να κάνουν προς τα πίσω μη συμβατές αλλαγές\n"
-#~ "    η γλώσσα."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * To prevent breaking code, editions are opt-in: you select the\n"
-#~ "    edition for your crate via the `Cargo.toml` file."
-#~ msgstr ""
-#~ "  * Για να αποφευχθεί η παραβίαση του κώδικα, οι εκδόσεις επιλέγονται: "
-#~ "επιλέγετε το\n"
-#~ "    έκδοση για το κλουβί σας μέσω του αρχείου «Cargo.toml»."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-#~ "    written for different editions."
-#~ msgstr ""
-#~ "  * Για να αποφευχθεί η διάσπαση του οικοσυστήματος, οι μεταγλωττιστές "
-#~ "Rust μπορούν να συνδυάσουν κώδικα\n"
-#~ "    γραμμένο για διαφορετικές εκδόσεις."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * Mention that it is quite rare to ever use the compiler directly not "
-#~ "through `cargo` (most users never do)."
-#~ msgstr ""
-#~ "  * Αναφέρετε ότι είναι πολύ σπάνιο να χρησιμοποιήσετε ποτέ τον "
-#~ "μεταγλωττιστή απευθείας όχι μέσω «cargo» (οι περισσότεροι χρήστες δεν το "
-#~ "κάνουν ποτέ)."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * It might be worth alluding that Cargo itself is an extremely powerful "
-#~ "and comprehensive tool.  It is capable of many advanced features "
-#~ "including but not limited to: \n"
-#~ "      * Project/package structure\n"
-#~ "      * [workspaces]\n"
-#~ "      * Dev Dependencies and Runtime Dependency management/caching\n"
-#~ "      * [build scripting]\n"
-#~ "      * [global installation]\n"
-#~ "      * It is also extensible with sub command plugins as well (such as "
-#~ "[cargo clippy]).\n"
-#~ "  * Read more from the [official Cargo Book]"
-#~ msgstr ""
-#~ "  * Ίσως αξίζει να αναφέρουμε ότι το ίδιο το Cargo είναι ένα εξαιρετικά "
-#~ "ισχυρό και ολοκληρωμένο εργαλείο. Είναι ικανό για πολλά προηγμένα "
-#~ "χαρακτηριστικά, όπως ενδεικτικά:\n"
-#~ "      * Δομή έργου/πακέτου\n"
-#~ "      * [χώροι εργασίας]\n"
-#~ "      * Εξαρτήσεις προγραμματιστή και διαχείριση/αποθήκευση εξαρτήσεων "
-#~ "χρόνου εκτέλεσης\n"
-#~ "      * [κατασκευή σεναρίων]\n"
-#~ "      * [καθολική εγκατάσταση]\n"
-#~ "      * Είναι επίσης επεκτάσιμο με πρόσθετα δευτερευουσών εντολών (όπως "
-#~ "[cargo clippy]).\n"
-#~ "  * Διαβάστε περισσότερα από το [επίσημο βιβλίο φορτίου]"
-
-#, fuzzy
-#~ msgid "[editions]: https://doc.rust-lang.org/edition-guide/"
-#~ msgstr "[εκδόσεις]: https://doc.rust-lang.org/edition-guide/"
-
-#, fuzzy
-#~ msgid ""
-#~ "[workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
-#~ msgstr ""
-#~ "[χώροι εργασίας]: https://doc.rust-lang.org/cargo/reference/workspaces."
-#~ "html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[build scripting]: https://doc.rust-lang.org/cargo/reference/build-"
-#~ "scripts.html"
-#~ msgstr ""
-#~ "[build scripting]: https://doc.rust-lang.org/cargo/reference/build-"
-#~ "scripts.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[global installation]: https://doc.rust-lang.org/cargo/commands/cargo-"
-#~ "install.html"
-#~ msgstr ""
-#~ "[παγκόσμια εγκατάσταση]: https://doc.rust-lang.org/cargo/commands/cargo-"
-#~ "install.html"
-
-#, fuzzy
-#~ msgid "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
-#~ msgstr "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
-
-#, fuzzy
-#~ msgid "[official Cargo Book]: https://doc.rust-lang.org/cargo/"
-#~ msgstr "[επίσημο βιβλίο φορτίου]: https://doc.rust-lang.org/cargo/"
-
-#, fuzzy
-#~ msgid ""
-#~ "* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-#~ "  code and open it in the real Playground to demonstrate unit tests."
-#~ msgstr ""
-#~ "* Οι ενσωματωμένες παιδικές χαρές δεν μπορούν να εκτελέσουν δοκιμές "
-#~ "μονάδων. Αντιγραφή-επικόλληση το\n"
-#~ "  κωδικοποιήστε και ανοίξτε το στην πραγματική παιδική χαρά για να "
-#~ "επιδείξετε δοκιμές μονάδων."
-
-#, fuzzy
-#~ msgid ""
-#~ "1. Click the \"Copy to clipboard\" button on the example you want to copy."
-#~ msgstr ""
-#~ "1. Κάντε κλικ στο κουμπί \"Αντιγραφή στο πρόχειρο\" στο παράδειγμα που "
-#~ "θέλετε να αντιγράψετε."
-
-#, fuzzy
-#~ msgid ""
-#~ "2. Use `cargo new exercise` to create a new `exercise/` directory for "
-#~ "your code:"
-#~ msgstr ""
-#~ "2. Χρησιμοποιήστε το «cargo new exercise» για να δημιουργήσετε έναν νέο "
-#~ "κατάλογο «exercise/» για τον κώδικά σας:"
-
-#, fuzzy
-#~ msgid ""
-#~ "3. Navigate into `exercise/` and use `cargo run` to build and run your "
-#~ "binary:"
-#~ msgstr ""
-#~ "3. Πλοηγηθείτε στο «άσκηση/» και χρησιμοποιήστε το «cargo run» για να "
-#~ "δημιουργήσετε και να εκτελέσετε το δυαδικό σας αρχείο:"
-
-#, fuzzy
-#~ msgid ""
-#~ "4. Replace the boiler-plate code in `src/main.rs` with your own code. "
-#~ "For\n"
-#~ "   example, using the example on the previous page, make `src/main.rs` "
-#~ "look like"
-#~ msgstr ""
-#~ "4. Αντικαταστήστε τον κωδικό λέβητα στο «src/main.rs» με τον δικό σας "
-#~ "κωδικό. Για\n"
-#~ "   Για παράδειγμα, χρησιμοποιώντας το παράδειγμα της προηγούμενης "
-#~ "σελίδας, κάντε το \"src/main.rs\" να μοιάζει"
-
-#, fuzzy
-#~ msgid "5. Use `cargo run` to build and run your updated binary:"
-#~ msgstr ""
-#~ "5. Χρησιμοποιήστε το \"cargo run\" για να δημιουργήσετε και να εκτελέσετε "
-#~ "το ενημερωμένο δυαδικό σας αρχείο:"
-
-#, fuzzy
-#~ msgid ""
-#~ "6. Use `cargo check` to quickly check your project for errors, use `cargo "
-#~ "build`\n"
-#~ "   to compile it without running it. You will find the output in `target/"
-#~ "debug/`\n"
-#~ "   for a normal debug build. Use `cargo build --release` to produce an "
-#~ "optimized\n"
-#~ "   release build in `target/release/`."
-#~ msgstr ""
-#~ "6. Χρησιμοποιήστε «έλεγχος φορτίου» για να ελέγξετε γρήγορα το έργο σας "
-#~ "για σφάλματα, χρησιμοποιήστε «κατασκευή φορτίου».\n"
-#~ "   για να το μεταγλωττίσετε χωρίς να το εκτελέσετε. Θα βρείτε την έξοδο "
-#~ "στο «target/debug/».\n"
-#~ "   για μια κανονική κατασκευή εντοπισμού σφαλμάτων. Χρησιμοποιήστε το "
-#~ "\"cargo build --release\" για να δημιουργήσετε ένα βελτιστοποιημένο\n"
-#~ "   έκδοση build σε `target/release/`."
-
-#, fuzzy
-#~ msgid ""
-#~ "7. You can add dependencies for your project by editing `Cargo.toml`. "
-#~ "When you\n"
-#~ "   run `cargo` commands, it will automatically download and compile "
-#~ "missing\n"
-#~ "   dependencies for you."
-#~ msgstr ""
-#~ "7. Μπορείτε να προσθέσετε εξαρτήσεις για το έργο σας επεξεργάζοντας το "
-#~ "«Cargo.toml». Οταν εσύ\n"
-#~ "   εκτελέστε τις εντολές «cargo», θα γίνει αυτόματα λήψη και μεταγλώττιση "
-#~ "λείπει\n"
-#~ "   εξαρτήσεις για εσάς."
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Basic Rust syntax: variables, scalar and compound types, enums, "
-#~ "structs,\n"
-#~ "  references, functions, and methods."
-#~ msgstr ""
-#~ "* Βασική σύνταξη Rust: μεταβλητές, βαθμωτοί και σύνθετοι τύποι, enums, "
-#~ "δομές,\n"
-#~ "  αναφορές, συναρτήσεις και μεθόδους."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Memory management: stack vs heap, manual memory management, scope-based "
-#~ "memory\n"
-#~ "  management, and garbage collection."
-#~ msgstr ""
-#~ "* Διαχείριση μνήμης: στοίβα έναντι σωρού, χειροκίνητη διαχείριση μνήμης, "
-#~ "μνήμη βάσει εμβέλειας\n"
-#~ "  διαχείριση και αποκομιδή σκουπιδιών."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Ownership: move semantics, copying and cloning, borrowing, and "
-#~ "lifetimes."
-#~ msgstr ""
-#~ "* Ιδιοκτησία: μετακίνηση σημασιολογίας, αντιγραφή και κλωνοποίηση, "
-#~ "δανεισμός και διάρκειες ζωής."
-
-#, fuzzy
-#~ msgid "[1]: https://blog.rust-lang.org/2015/05/15/Rust-1.0.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust is very much like other languages in the C/C++/Java tradition. It "
-#~ "is\n"
-#~ "  imperative (not functional) and it doesn't try to reinvent things "
-#~ "unless\n"
-#~ "  absolutely necessary."
-#~ msgstr ""
-#~ "* Η σκουριά μοιάζει πολύ με άλλες γλώσσες στην παράδοση C/C++/Java. "
-#~ "είναι\n"
-#~ "  επιτακτική (όχι λειτουργική) και δεν προσπαθεί να επανεφεύρει πράγματα "
-#~ "εκτός και αν\n"
-#~ "  Απόλυτα αναγκαίο."
-
-#, fuzzy
-#~ msgid "* Rust is modern with full support for things like Unicode."
-#~ msgstr ""
-#~ "* Το Rust είναι μοντέρνο με πλήρη υποστήριξη για πράγματα όπως το Unicode."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust uses macros for situations where you want to have a variable "
-#~ "number of\n"
-#~ "  arguments (no function [overloading](basic-syntax/functions-interlude."
-#~ "md))."
-#~ msgstr ""
-#~ "* Το Rust χρησιμοποιεί μακροεντολές για καταστάσεις όπου θέλετε να έχετε "
-#~ "έναν μεταβλητό αριθμό\n"
-#~ "  ορίσματα (καμία συνάρτηση [υπερφόρτωση](βασική-σύνταξη/συναρτήσεις-"
-#~ "ενδιάμεσο.md))."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Explain that all variables are statically typed. Try removing `i32` to "
-#~ "trigger\n"
-#~ "  type inference. Try with `i8` instead and trigger a runtime integer "
-#~ "overflow."
-#~ msgstr ""
-#~ "* Εξηγήστε ότι όλες οι μεταβλητές πληκτρολογούνται στατικά. Δοκιμάστε να "
-#~ "αφαιρέσετε το \"i32\" για ενεργοποίηση\n"
-#~ "  συμπέρασμα τύπου. Δοκιμάστε με το `i8` και ενεργοποιήστε μια "
-#~ "υπερχείλιση ακέραιου χρόνου εκτέλεσης."
-
-#, fuzzy
-#~ msgid "* Change `let mut x` to `let x`, discuss the compiler error."
-#~ msgstr ""
-#~ "* Αλλάξτε το «let mut x» σε «let x», συζητήστε το σφάλμα του "
-#~ "μεταγλωττιστή."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Show how `print!` gives a compilation error if the arguments don't "
-#~ "match the\n"
-#~ "  format string."
-#~ msgstr ""
-#~ "* Δείξτε πώς το \"print!\" δίνει ένα σφάλμα μεταγλώττισης εάν τα ορίσματα "
-#~ "δεν ταιριάζουν με το\n"
-#~ "  συμβολοσειρά μορφής."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Show how you need to use `{}` as a placeholder if you want to print an\n"
-#~ "  expression which is more complex than just a single variable."
-#~ msgstr ""
-#~ "* Δείξτε πώς πρέπει να χρησιμοποιήσετε το \"{}\" ως σύμβολο κράτησης "
-#~ "θέσης εάν θέλετε να εκτυπώσετε ένα\n"
-#~ "  έκφραση που είναι πιο σύνθετη από μια απλή μεταβλητή."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Show the students the standard library, show them how to search for "
-#~ "`std::fmt`\n"
-#~ "  which has the rules of the formatting mini-language. It's important "
-#~ "that the\n"
-#~ "  students become familiar with searching in the standard library."
-#~ msgstr ""
-#~ "* Δείξτε στους μαθητές την τυπική βιβλιοθήκη, δείξτε τους πώς να "
-#~ "αναζητούν το «std::fmt».\n"
-#~ "  που έχει τους κανόνες της μορφοποίησης της μίνι-γλώσσας. Είναι "
-#~ "σημαντικό ότι το\n"
-#~ "  οι μαθητές εξοικειώνονται με την αναζήτηση στην τυπική βιβλιοθήκη."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Experience with C or C++: Rust eliminates a whole class of _runtime "
-#~ "errors_\n"
-#~ "  via the borrow checker. You get performance like in C and C++, but you "
-#~ "don't\n"
-#~ "  have the memory unsafety issues. In addition, you get a modern language "
-#~ "with\n"
-#~ "  constructs like pattern matching and built-in dependency management."
-#~ msgstr ""
-#~ "* Εμπειρία με C ή C++: Το Rust εξαλείφει μια ολόκληρη κατηγορία _runtime "
-#~ "errors_\n"
-#~ "  μέσω του ελεγκτή δανείου. Έχετε απόδοση όπως στη C και τη C++, αλλά δεν "
-#~ "έχετε\n"
-#~ "  έχετε προβλήματα με την ασφάλεια της μνήμης. Επιπλέον, αποκτάτε μια "
-#~ "σύγχρονη γλώσσα με\n"
-#~ "  κατασκευές όπως η αντιστοίχιση προτύπων και η ενσωματωμένη διαχείριση "
-#~ "εξαρτήσεων."
-
-#, fuzzy
-#~ msgid ""
-#~ "[`Box::leak`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
-#~ "leak\n"
-#~ "[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-#~ "[reference cycle]: https://doc.rust-lang.org/book/ch15-06-reference-"
-#~ "cycles.html"
-#~ msgstr ""
-#~ "[`Box::leak`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
-#~ "leak\n"
-#~ "[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-#~ "[κύκλος αναφοράς]: https://doc.rust-lang.org/book/ch15-06-reference-"
-#~ "cycles.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-#~ "  not be disabled directly with the `unsafe` keyword. However,\n"
-#~ "  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-#~ "  which does not do bounds checking."
-#~ msgstr ""
-#~ "* Ο έλεγχος ορίων δεν μπορεί να απενεργοποιηθεί με μια σημαία "
-#~ "μεταγλωττιστή. Μπορεί επίσης\n"
-#~ "  να μην απενεργοποιηθεί απευθείας με τη λέξη-κλειδί \"μη ασφαλής\". "
-#~ "Ωστόσο,\n"
-#~ "  Το \"unsafe\" σάς επιτρέπει να καλείτε συναρτήσεις όπως \"slice::"
-#~ "get_unchecked\".\n"
-#~ "  που δεν κάνει έλεγχο ορίων."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Zero-cost abstractions, similar to C++, means that you don't have to "
-#~ "'pay'\n"
-#~ "  for higher-level programming constructs with memory or CPU. For "
-#~ "example,\n"
-#~ "  writing a loop using `for` should result in roughly the same low level\n"
-#~ "  instructions as using the `.iter().fold()` construct."
-#~ msgstr ""
-#~ "* Αφαιρέσεις μηδενικού κόστους, παρόμοιες με τη C++, σημαίνει ότι δεν "
-#~ "χρειάζεται να «πληρώσετε»\n"
-#~ "  για κατασκευές προγραμματισμού υψηλότερου επιπέδου με μνήμη ή CPU. Για "
-#~ "παράδειγμα,\n"
-#~ "  Η σύνταξη ενός βρόχου χρησιμοποιώντας «για» θα πρέπει να έχει περίπου "
-#~ "το ίδιο χαμηλό επίπεδο\n"
-#~ "  οδηγίες όπως χρησιμοποιώντας την κατασκευή `.iter().fold()`."
-
-#, fuzzy
-#~ msgid ""
-#~ "* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-#~ "also\n"
-#~ "  known as 'sum types', which allow the type system to express things "
-#~ "like\n"
-#~ "  `Option<T>` and `Result<T, E>`."
-#~ msgstr ""
-#~ "* Αξίζει να αναφέρουμε ότι τα Rust enums είναι επίσης «Αλγεβρικοί τύποι "
-#~ "δεδομένων».\n"
-#~ "  γνωστοί ως «τύποι αθροίσματος», οι οποίοι επιτρέπουν στο σύστημα τύπων "
-#~ "να εκφράσει πράγματα όπως\n"
-#~ "  \"Επιλογή<T>\" και \"Αποτέλεσμα<T, E>\"."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Remind people to read the errors --- many developers have gotten used "
-#~ "to\n"
-#~ "  ignore lengthy compiler output. The Rust compiler is significantly "
-#~ "more\n"
-#~ "  talkative than other compilers. It will often provide you with "
-#~ "_actionable_\n"
-#~ "  feedback, ready to copy-paste into your code."
-#~ msgstr ""
-#~ "* Υπενθυμίστε στους ανθρώπους να διαβάσουν τα σφάλματα --- πολλοί "
-#~ "προγραμματιστές έχουν συνηθίσει\n"
-#~ "  αγνοήστε την έξοδο του μεταγλωττιστή μεγάλης διάρκειας. Ο "
-#~ "μεταγλωττιστής Rust είναι πολύ περισσότερος\n"
-#~ "  ομιλητικός από άλλους μεταγλωττιστές. Συχνά θα σας παρέχει "
-#~ "_actionable_\n"
-#~ "  σχόλια, έτοιμο για αντιγραφή-επικόλληση στον κώδικά σας."
-
-#, fuzzy
-#~ msgid ""
-#~ "* The Rust standard library is small compared to languages like Java, "
-#~ "Python,\n"
-#~ "  and Go. Rust does not come with several things you might consider "
-#~ "standard and\n"
-#~ "  essential:"
-#~ msgstr ""
-#~ "* Η τυπική βιβλιοθήκη Rust είναι μικρή σε σύγκριση με γλώσσες όπως Java, "
-#~ "Python,\n"
-#~ "  και φύγε. Η σκουριά δεν συνοδεύεται από πολλά πράγματα που μπορεί να "
-#~ "θεωρήσετε τυπικά και\n"
-#~ "  ουσιώδης:"
-
-#, fuzzy
-#~ msgid ""
-#~ "  * a random number generator, but see [rand].\n"
-#~ "  * support for SSL or TLS, but see [rusttls].\n"
-#~ "  * support for JSON, but see [serde_json]."
-#~ msgstr ""
-#~ "  * μια γεννήτρια τυχαίων αριθμών, αλλά δείτε [rand].\n"
-#~ "  * υποστήριξη για SSL ή TLS, αλλά ανατρέξτε στο [rusttls].\n"
-#~ "  * υποστήριξη για JSON, αλλά ανατρέξτε στο [serde_json]."
-
-#, fuzzy
-#~ msgid ""
-#~ "  The reasoning behind this is that functionality in the standard library "
-#~ "cannot\n"
-#~ "  go away, so it has to be very stable. For the examples above, the Rust\n"
-#~ "  community is still working on finding the best solution --- and perhaps "
-#~ "there\n"
-#~ "  isn't a single \"best solution\" for some of these things."
-#~ msgstr ""
-#~ "  Το σκεπτικό πίσω από αυτό είναι ότι η λειτουργικότητα στην τυπική "
-#~ "βιβλιοθήκη δεν μπορεί\n"
-#~ "  φύγετε, οπότε πρέπει να είναι πολύ σταθερό. Για τα παραπάνω "
-#~ "παραδείγματα, η Σκουριά\n"
-#~ "  Η κοινότητα εξακολουθεί να εργάζεται για την εύρεση της καλύτερης λύσης "
-#~ "--- και ίσως εκεί\n"
-#~ "  δεν είναι μια ενιαία \"καλύτερη λύση\" για μερικά από αυτά τα πράγματα."
-
-#, fuzzy
-#~ msgid ""
-#~ "  Rust comes with a built-in package manager in the form of Cargo and "
-#~ "this makes\n"
-#~ "  it trivial to download and compile third-party crates. A consequence of "
-#~ "this\n"
-#~ "  is that the standard library can be smaller."
-#~ msgstr ""
-#~ "  Το Rust έρχεται με ενσωματωμένο διαχειριστή πακέτων σε μορφή Cargo και "
-#~ "αυτό κάνει\n"
-#~ "  Είναι ασήμαντο να κατεβάζετε και να μεταγλωττίζετε κιβώτια τρίτων. "
-#~ "Συνέπεια αυτού\n"
-#~ "  είναι ότι η τυπική βιβλιοθήκη μπορεί να είναι μικρότερη."
-
-#, fuzzy
-#~ msgid ""
-#~ "  Discovering good third-party crates can be a problem. Sites like\n"
-#~ "  <https://lib.rs/> help with this by letting you compare health metrics "
-#~ "for\n"
-#~ "  crates to find a good and trusted one.\n"
-#~ "  \n"
-#~ "* [rust-analyzer] is a well supported LSP implementation used in major\n"
-#~ "  IDEs and text editors."
-#~ msgstr ""
-#~ "  Η ανακάλυψη καλών κιβωτίων τρίτων μπορεί να είναι πρόβλημα. Ιστότοποι "
-#~ "όπως\n"
-#~ "  <https://lib.rs/> βοηθήστε σε αυτό, επιτρέποντάς σας να συγκρίνετε "
-#~ "μετρήσεις υγείας για\n"
-#~ "  κιβώτια για να βρείτε ένα καλό και αξιόπιστο.\n"
-#~ "  \n"
-#~ "* Το [rust-analyzer] είναι μια καλά υποστηριζόμενη υλοποίηση LSP που "
-#~ "χρησιμοποιείται σε μεγάλες\n"
-#~ "  IDE και επεξεργαστές κειμένου."
-
-#, fuzzy
-#~ msgid ""
-#~ "[rand]: https://docs.rs/rand/\n"
-#~ "[rusttls]: https://docs.rs/rustls/\n"
-#~ "[serde_json]: https://docs.rs/serde_json/\n"
-#~ "[rust-analyzer]: https://rust-analyzer.github.io/"
-#~ msgstr ""
-#~ "[rand]: https://docs.rs/rand/\n"
-#~ "[rusttls]: https://docs.rs/rustls/\n"
-#~ "[serde_json]: https://docs.rs/serde_json/\n"
-#~ "[rust-analyzer]: https://rust-analyzer.github.io/"
-
-#, fuzzy
-#~ msgid "* We can use literals to assign values to arrays."
-#~ msgstr ""
-#~ "* Μπορούμε να χρησιμοποιήσουμε literals για να εκχωρήσουμε τιμές σε "
-#~ "πίνακες."
-
-#, fuzzy
-#~ msgid ""
-#~ "* In the main function, the print statement asks for the debug "
-#~ "implementation with the `?` format\n"
-#~ "  parameter: `{}` gives the default output, `{:?}` gives the debug "
-#~ "output. We\n"
-#~ "  could also have used `{a}` and `{a:?}` without specifying the value "
-#~ "after the\n"
-#~ "  format string."
-#~ msgstr ""
-#~ "* Στην κύρια συνάρτηση, η δήλωση εκτύπωσης ζητά την υλοποίηση εντοπισμού "
-#~ "σφαλμάτων με τη μορφή «?».\n"
-#~ "  παράμετρος: Το `{}` δίνει την προεπιλεγμένη έξοδο, το `{:?}` δίνει την "
-#~ "έξοδο εντοπισμού σφαλμάτων. Εμείς\n"
-#~ "  θα μπορούσε επίσης να χρησιμοποιήσει τα \"{a}\" και \"{a:?}\" χωρίς να "
-#~ "καθορίσει την τιμή μετά το\n"
-#~ "  συμβολοσειρά μορφής."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which "
-#~ "can be easier to read."
-#~ msgstr ""
-#~ "* Προσθέτοντας `#`, π.χ. `{a:#?}`, προκαλείται μια μορφή \"όμορφης "
-#~ "εκτύπωσης\", η οποία μπορεί να είναι πιο ευανάγνωστη."
-
-#, fuzzy
-#~ msgid "* Like arrays, tuples have a fixed length."
-#~ msgstr "* Όπως και οι πίνακες, οι πλειάδες έχουν σταθερό μήκος."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Tuples group together values of different types into a compound type."
-#~ msgstr ""
-#~ "* Οι πλειάδες ομαδοποιούν τιμές διαφορετικών τύπων σε έναν σύνθετο τύπο."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Fields of a tuple can be accessed by the period and the index of the "
-#~ "value, e.g. `t.0`, `t.1`."
-#~ msgstr ""
-#~ "* Τα πεδία μιας πλειάδας είναι προσβάσιμα από την περίοδο και τον δείκτη "
-#~ "της τιμής, π.χ. «t.0», «t.1»."
-
-#, fuzzy
-#~ msgid ""
-#~ "* We create a slice by borrowing `a` and specifying the starting and "
-#~ "ending indexes in brackets."
-#~ msgstr ""
-#~ "* Δημιουργούμε ένα slice δανειζόμενοι το `a` και προσδιορίζοντας τους "
-#~ "δείκτες έναρξης και λήξης σε αγκύλες."
-
-#, fuzzy
-#~ msgid ""
-#~ "* If the slice starts at index 0, Rust’s range syntax allows us to drop "
-#~ "the starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-#~ "identical.\n"
-#~ "    \n"
-#~ "* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` "
-#~ "are identical."
-#~ msgstr ""
-#~ "* Εάν το slice ξεκινά από το δείκτη 0, η σύνταξη εύρους του Rust μας "
-#~ "επιτρέπει να απορρίψουμε τον αρχικό δείκτη, πράγμα που σημαίνει ότι το "
-#~ "«&a[0..a.len()]» και το «&a[..a.len()]» είναι πανομοιότυπα .\n"
-#~ "    \n"
-#~ "* Το ίδιο ισχύει και για τον τελευταίο δείκτη, επομένως τα «&a[2..a."
-#~ "len()]» και «&a[2..]» είναι πανομοιότυπα."
-
-#, fuzzy
-#~ msgid ""
-#~ "* To easily create a slice of the full array, we can therefore use "
-#~ "`&a[..]`."
-#~ msgstr ""
-#~ "* Για να δημιουργήσουμε εύκολα ένα κομμάτι του πλήρους πίνακα, μπορούμε "
-#~ "επομένως να χρησιμοποιήσουμε το «&a[..]»."
-
-#, fuzzy
-#~ msgid ""
-#~ "* `&str` introduces a string slice, which is an immutable reference to "
-#~ "UTF-8 encoded string data \n"
-#~ "  stored in a block of memory. String literals (`”Hello”`), are stored in "
-#~ "the program’s binary."
-#~ msgstr ""
-#~ "* Το \"&str\" εισάγει ένα slice συμβολοσειράς, το οποίο είναι μια "
-#~ "αμετάβλητη αναφορά σε κωδικοποιημένα δεδομένα συμβολοσειράς UTF-8\n"
-#~ "  αποθηκευμένο σε ένα μπλοκ μνήμης. Οι κυριολεκτικές συμβολοσειρές "
-#~ "(\"Hello\"\"), αποθηκεύονται στο δυαδικό αρχείο του προγράμματος."
-
-#, fuzzy
-#~ msgid "  (Type annotations added for clarity, but they can be elided.)"
-#~ msgstr ""
-#~ "  (Πληκτρολογήστε σχολιασμούς για λόγους σαφήνειας, αλλά μπορούν να "
-#~ "διαγραφούν.)"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Rectangle {\n"
-#~ "    fn area(&self) -> u32 {\n"
-#~ "        self.width * self.height\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impmpl Rectangle {\n"
-#~ "    fn area(&self) -> u32 {\n"
-#~ "        αυτο.πλάτος * εαυτός.ύψος\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid "* Arrays and `for` loops."
-#~ msgstr "* Πίνακες και βρόχοι «για»."
-
-#, fuzzy
-#~ msgid "* Alternatively, use the Rust Playground."
-#~ msgstr "* Εναλλακτικά, χρησιμοποιήστε την παιδική χαρά Rust."
-
-#, fuzzy
-#~ msgid "[solutions]: solutions-morning.md"
-#~ msgstr "[λύσεις]: λύσεις-πρωί.μδ"
-
-#, fuzzy
-#~ msgid "[Using Cargo]: ../../cargo.md"
-#~ msgstr "[Χρήση φορτίου]: ../../cargo.md"
-
-#, fuzzy
-#~ msgid "1. Execute the above program and look at the compiler error."
-#~ msgstr ""
-#~ "1. Εκτελέστε το παραπάνω πρόγραμμα και δείτε το σφάλμα μεταγλωττιστή."
-
-#, fuzzy
-#~ msgid "2. Update the code above to use `into()` to do the conversion."
-#~ msgstr ""
-#~ "2. Ενημερώστε τον παραπάνω κώδικα για να χρησιμοποιήσετε το «into()» για "
-#~ "να κάνετε τη μετατροπή."
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-#~ "[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-#~ "[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
-
-#, fuzzy
-#~ msgid "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
-#~ msgstr "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Heap: Storage of values outside of function calls.\n"
-#~ "  * Values have dynamic sizes determined at runtime.\n"
-#~ "  * Slightly slower than the stack: some book-keeping needed.\n"
-#~ "  * No guarantee of memory locality."
-#~ msgstr ""
-#~ "* Σωρός: Αποθήκευση τιμών εκτός κλήσεων συναρτήσεων.\n"
-#~ "  * Οι τιμές έχουν δυναμικά μεγέθη που καθορίζονται κατά το χρόνο "
-#~ "εκτέλεσης.\n"
-#~ "  * Ελαφρώς πιο αργό από τη στοίβα: χρειάζεται λίγη τήρηση βιβλίων.\n"
-#~ "  * Καμία εγγύηση εντοπισμού μνήμης."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-#~ "length and can grow if mutable via reallocation on the heap."
-#~ msgstr ""
-#~ "* Αναφέρετε ότι ένα \"String\" υποστηρίζεται από ένα \"Vec\", επομένως "
-#~ "έχει χωρητικότητα και μήκος και μπορεί να αναπτυχθεί εάν είναι μεταβλητό "
-#~ "μέσω ανακατανομής στο σωρό."
-
-#, fuzzy
-#~ msgid ""
-#~ "* If students ask about it, you can mention that the underlying memory is "
-#~ "heap allocated using the [System Allocator] and custom allocators can be "
-#~ "implemented using the [Allocator API]"
-#~ msgstr ""
-#~ "* Εάν οι μαθητές το ρωτήσουν, μπορείτε να αναφέρετε ότι η υποκείμενη "
-#~ "μνήμη είναι ένα σωρό που εκχωρείται με χρήση του [System Allocator] και "
-#~ "οι προσαρμοσμένοι εκχωρητές μπορούν να υλοποιηθούν χρησιμοποιώντας το "
-#~ "[Allocator API]"
-
-#, fuzzy
-#~ msgid ""
-#~ "[System Allocator]: https://doc.rust-lang.org/std/alloc/struct.System."
-#~ "html\n"
-#~ "[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
-#~ msgstr ""
-#~ "[Διανομέας συστήματος]: https://doc.rust-lang.org/std/alloc/struct.System."
-#~ "html\n"
-#~ "[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* You may be asked about destructors here, the [Drop] trait is the Rust "
-#~ "equivalent."
-#~ msgstr ""
-#~ "* Μπορεί να ερωτηθείτε για τους καταστροφείς εδώ, το χαρακτηριστικό "
-#~ "[Drop] είναι το ισοδύναμο της Σκουριάς."
-
-#, fuzzy
-#~ msgid ""
-#~ "[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-#~ msgstr ""
-#~ "[Πλαίσιο]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-
-#, fuzzy
-#~ msgid "* In Rust, you clones are explicit (by using `clone`)."
-#~ msgstr ""
-#~ "* Στο Rust, οι κλώνοι σας είναι ξεκάθαροι (χρησιμοποιώντας «κλώνο»)."
-
-#, fuzzy
-#~ msgid ""
-#~ "fn add(p1: &Point, p2: &Point) -> Point {\n"
-#~ "    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn add(p1: &Point, p2: &Point) -> Point {\n"
-#~ "    Σημείο(p1.0 + p2.0, p1.1 + p2.1)\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "Notes on stack returns:\n"
-#~ "* Demonstrate that the return from `add` is cheap because the compiler "
-#~ "can eliminate the copy operation. Change the above code to print stack "
-#~ "addresses and run it on the [Playground]. In the \"DEBUG\" optimization "
-#~ "level, the addresses should change, while the stay the same when changing "
-#~ "to the \"RELEASE\" setting:"
-#~ msgstr ""
-#~ "Σημειώσεις για τις επιστροφές στοίβας:\n"
-#~ "* Αποδείξτε ότι η επιστροφή από το «add» είναι φθηνή επειδή ο "
-#~ "μεταγλωττιστής μπορεί να εξαλείψει τη λειτουργία αντιγραφής. Αλλάξτε τον "
-#~ "παραπάνω κωδικό για να εκτυπώσετε διευθύνσεις στοίβας και εκτελέστε τον "
-#~ "στην [Playground]. Στο επίπεδο βελτιστοποίησης \"DEBUG\", οι διευθύνσεις "
-#~ "θα πρέπει να αλλάξουν, ενώ θα παραμείνουν οι ίδιες κατά την αλλαγή στη "
-#~ "ρύθμιση \"RELEASE\":"
-
-#, fuzzy
-#~ msgid "[Playground]: https://play.rust-lang.org/"
-#~ msgstr "[Παιδική χαρά]: https://play.rust-lang.org/"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-#~ "    if p1.0 < p2.0 { p1 } else { p2 }\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-#~ "    αν p1.0 < p2.0 { p1 } other { p2 }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-#~ "      if p1.0 < p2.0 { p1 } else { p2 }\n"
-#~ "  }"
-#~ msgstr ""
-#~ "  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-#~ "      αν p1.0 < p2.0 { p1 } other { p2 }\n"
-#~ "  }"
-
-#, fuzzy
-#~ msgid "* A small book library,"
-#~ msgstr "* Μια μικρή βιβλιοθήκη,"
-
-#, fuzzy
-#~ msgid "[solutions]: solutions-afternoon.md"
-#~ msgstr "[λύσεις]: λύσεις-απόγευμα.μδ"
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Library {\n"
-#~ "    books: Vec<Book>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Library {\n"
-#~ "    βιβλία: Vec<Book>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Book {\n"
-#~ "    title: String,\n"
-#~ "    year: u16,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Βιβλίο {\n"
-#~ "    τίτλος: String,\n"
-#~ "    έτος: u16,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Book {\n"
-#~ "    // This is a constructor, used below.\n"
-#~ "    fn new(title: &str, year: u16) -> Book {\n"
-#~ "        Book {\n"
-#~ "            title: String::from(title),\n"
-#~ "            year,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impmpl Book {\n"
-#~ "    // Αυτός είναι ένας κατασκευαστής, που χρησιμοποιείται παρακάτω.\n"
-#~ "    fn new(title: &str, year: u16) -> Book {\n"
-#~ "        Βιβλίο {\n"
-#~ "            τίτλος: Συμβολοσειρά::από(τίτλος),\n"
-#~ "            έτος,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// This makes it possible to print Book values with {}.\n"
-#~ "impl std::fmt::Display for Book {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-#~ "        write!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "// Αυτό καθιστά δυνατή την εκτύπωση τιμών βιβλίου με {}.\n"
-#~ "impl std::fmt::Display for Book {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::"
-#~ "Αποτέλεσμα {\n"
-#~ "        write!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Library {\n"
-#~ "    fn new() -> Library {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Library {\n"
-#~ "    fn new() -> Library {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn len(self) -> usize {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn len(self) -> χρήση {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn add_book(self, book: Book) {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn add_book(self, book: Book) {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn print_books(self) {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn print_books(self) {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn oldest_book(self) -> Option<&Book> {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "}"
-#~ msgstr ""
-#~ "    //fn oldest_book(self) -> Option<&Book> {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "* Structs, enums, methods."
-#~ msgstr "* Δομές, αρίθμηση, μέθοδοι."
-
-#, fuzzy
-#~ msgid "* Pattern matching: destructuring enums, structs, and arrays."
-#~ msgstr "* Αντιστοίχιση προτύπων: καταστροφή αριθμών, δομών και πινάκων."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-#~ "and\n"
-#~ "  `continue`."
-#~ msgstr ""
-#~ "* Κατασκευές ροής ελέγχου: \"if\", \"if let\", \"while\", \"while let\", "
-#~ "\"break\" και\n"
-#~ "  «συνέχεια»."
-
-#, fuzzy
-#~ msgid ""
-#~ "* The Standard Library: `String`, `Option` and `Result`, `Vec`, "
-#~ "`HashMap`, `Rc`\n"
-#~ "  and `Arc`."
-#~ msgstr ""
-#~ "* Η τυπική βιβλιοθήκη: \"String\", \"Option\" και \"Result\", \"Vec\", "
-#~ "\"HashMap\", \"Rc\"\n"
-#~ "  και «Arc»."
-
-#, fuzzy
-#~ msgid "* Modules: visibility, paths, and filesystem hierarchy."
-#~ msgstr "* Ενότητες: ορατότητα, μονοπάτια και ιεραρχία συστήματος αρχείων."
-
-#, fuzzy
-#~ msgid ""
-#~ "fn compute_thruster_force() -> PoundOfForce {\n"
-#~ "    todo!(\"Ask a rocket scientist at NASA\")\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn compute_thruster_force() -> PoundOfForce {\n"
-#~ "    todo! (\"Ρωτήστε έναν επιστήμονα πυραύλων στη NASA\")\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn set_thruster_force(force: Newtons) {\n"
-#~ "    // ...\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn set_thruster_force(δύναμη: Newtons) {\n"
-#~ "    //...\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Person {\n"
-#~ "    fn new(name: String, age: u8) -> Person {\n"
-#~ "        Person { name, age }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impmpl Person {\n"
-#~ "    fn new(όνομα: String, ηλικία: u8) -> Άτομο {\n"
-#~ "        Άτομο { όνομα, ηλικία }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "The `new` function could be written using `Self` as a type, as it is "
-#~ "interchangeable with the struct type name"
-#~ msgstr ""
-#~ "Η συνάρτηση \"new\" θα μπορούσε να γραφτεί χρησιμοποιώντας το \"Self\" ως "
-#~ "τύπο, καθώς είναι εναλλάξιμη με το όνομα τύπου δομής"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "enum CoinFlip {\n"
-#~ "    Heads,\n"
-#~ "    Tails,\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[παραγωγή (Εντοπισμός σφαλμάτων)]\n"
-#~ "enum CoinFlip {\n"
-#~ "    κεφάλια,\n"
-#~ "    Ουρές,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "<details>\n"
-#~ "    \n"
-#~ "Key Points:"
-#~ msgstr ""
-#~ "<λεπτομέρειες>\n"
-#~ "    \n"
-#~ "Βασικά σημεία:"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[rustfmt::skip]\n"
-#~ "fn inspect(event: WebEvent) {\n"
-#~ "    match event {\n"
-#~ "        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
-#~ "        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
-#~ "        WebEvent::Click { x, y } => println!(\"clicked at x={x}, "
-#~ "y={y}\"),\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[rustfmt::skip]\n"
-#~ "fn inspect(event: WebEvent) {\n"
-#~ "    αγώνας εκδήλωσης {\n"
-#~ "        WebEvent::PageLoad => println!(\"σελίδα φορτώθηκε\"),\n"
-#~ "        WebEvent::KeyPress(c) => println!(\"πατήθηκε '{c}'\"),\n"
-#~ "        WebEvent::Κάντε κλικ στο { x, y } => println!(\"κλικ στο x={x}, "
-#~ "y={y}\"),\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "enum Foo {\n"
-#~ "    A,\n"
-#~ "    B,\n"
-#~ "}"
-#~ msgstr ""
-#~ "enum Foo {\n"
-#~ "    ΕΝΑ,\n"
-#~ "    ΣΙ,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[repr(u32)]\n"
-#~ "enum Bar {\n"
-#~ "    A,  // 0\n"
-#~ "    B = 10000,\n"
-#~ "    C,  // 10001\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[repr(u32)]\n"
-#~ "enum Bar {\n"
-#~ "    Α, // 0\n"
-#~ "    B = 10000,\n"
-#~ "    C, // 10001\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "<details>\n"
-#~ "    \n"
-#~ "Key Points: \n"
-#~ " * Internally Rust is using a field (discriminant) to keep track of the "
-#~ "enum variant.\n"
-#~ " * `Bar` enum demonstrates that there is a way to control the "
-#~ "discriminant value and type. If `repr` is removed, the discriminant type "
-#~ "takes 2 bytes, becuase 10001 fits 2 bytes.\n"
-#~ " * As a niche optimization an enum discriminant is merged with the "
-#~ "pointer so that `Option<&Foo>` is the same size as `&Foo`.\n"
-#~ " * `Option<bool>` is another example of tight packing.\n"
-#~ " * For [some types](https://doc.rust-lang.org/std/option/"
-#~ "#representation), Rust guarantees that `size_of::<T>()` equals `size_of::"
-#~ "<Option<T>>()`.\n"
-#~ " * Zero-sized types allow for efficient implementation of `HashSet` using "
-#~ "`HashMap` with `()` as the value."
-#~ msgstr ""
-#~ "<λεπτομέρειες>\n"
-#~ "    \n"
-#~ "Βασικά σημεία:\n"
-#~ " * Εσωτερικά το Rust χρησιμοποιεί ένα πεδίο (διακριτικό) για να "
-#~ "παρακολουθεί την παραλλαγή enum.\n"
-#~ " * Το \"Bar\" enum δείχνει ότι υπάρχει τρόπος να ελέγχεται η τιμή και ο "
-#~ "τύπος διάκρισης. Εάν αφαιρεθεί το \"repr\", ο τύπος διάκρισης παίρνει 2 "
-#~ "byte, επειδή το 10001 ταιριάζει σε 2 byte.\n"
-#~ " * Ως βελτιστοποίηση εξειδικευμένης θέσης, ένα διακριτικό enum "
-#~ "συγχωνεύεται με τον δείκτη έτσι ώστε το \"Option<&Foo>\" να έχει το ίδιο "
-#~ "μέγεθος με το \"&Foo\".\n"
-#~ " * Το \"Option<bool>\" είναι ένα άλλο παράδειγμα στενής συσκευασίας.\n"
-#~ " * Για [ορισμένους τύπους](https://doc.rust-lang.org/std/option/"
-#~ "#representation), η Rust εγγυάται ότι το \"size_of::<T>()\" ισούται με "
-#~ "\"size_of::<Επιλογή<T> >()».\n"
-#~ " * Οι τύποι μηδενικού μεγέθους επιτρέπουν την αποτελεσματική εφαρμογή του "
-#~ "\"HashSet\" χρησιμοποιώντας το \"HashMap\" με το \"()\" ως τιμή."
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Race {\n"
-#~ "    fn new(name: &str) -> Race {  // No receiver, a static method\n"
-#~ "        Race { name: String::from(name), laps: Vec::new() }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impmpl Race {\n"
-#~ "    fn new(name: &str) -> Race { // Χωρίς δέκτη, μια στατική μέθοδος\n"
-#~ "        Race { name: String::from(name), laps: Vec::new() }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn divide_in_two(n: i32) -> Result {\n"
-#~ "    if n % 2 == 0 {\n"
-#~ "        Result::Ok(n / 2)\n"
-#~ "    } else {\n"
-#~ "        Result::Err(format!(\"cannot divide {n} into two equal parts\"))\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn divide_in_two(n: i32) -> Αποτέλεσμα {\n"
-#~ "    αν n % 2 == 0 {\n"
-#~ "        Αποτέλεσμα::Ok(n / 2)\n"
-#~ "    } αλλο {\n"
-#~ "        Αποτέλεσμα::Err(μορφή!(\"δεν μπορεί να διαιρεθεί το {} σε δύο ίσα "
-#~ "μέρη\", n))\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "* Simple struct which tracks health statistics."
-#~ msgstr "* Απλή δομή που παρακολουθεί τα στατιστικά στοιχεία υγείας."
-
-#, fuzzy
-#~ msgid ""
-#~ "struct User {\n"
-#~ "    name: String,\n"
-#~ "    age: u32,\n"
-#~ "    weight: f32,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Χρήστης {\n"
-#~ "    όνομα: String,\n"
-#~ "    ηλικία: u32,\n"
-#~ "    βάρος: f32,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl User {\n"
-#~ "    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Χρήστης {\n"
-#~ "    pub fn new(όνομα: String, ηλικία: u32, βάρος: f32) -> Self {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn name(&self) -> &str {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn name(&self) -> &str {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn age(&self) -> u32 {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    παμπ fn age(&self) -> u32 {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn weight(&self) -> f32 {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    παμπ fn βάρος(&self) -> f32 {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn set_age(&mut self, new_age: u32) {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn set_age(&mut self, new_age: u32) {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn set_weight(&mut self, new_weight: f32) {\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    pub fn set_weight(&mut self, new_weight: f32) {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Point {\n"
-#~ "    // add fields\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Point {\n"
-#~ "    // προσθήκη πεδίων\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Point {\n"
-#~ "    // add methods\n"
-#~ "}"
-#~ msgstr ""
-#~ "εμφ. Σημείο {\n"
-#~ "    // προσθήκη μεθόδων\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Polygon {\n"
-#~ "    // add fields\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Πολύγωνο {\n"
-#~ "    // προσθήκη πεδίων\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Polygon {\n"
-#~ "    // add methods\n"
-#~ "}"
-#~ msgstr ""
-#~ "impmpl Polygon {\n"
-#~ "    // προσθήκη μεθόδων\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Circle {\n"
-#~ "    // add fields\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Circle {\n"
-#~ "    // προσθήκη πεδίων\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Circle {\n"
-#~ "    // add methods\n"
-#~ "}"
-#~ msgstr ""
-#~ "impmpl Circle {\n"
-#~ "    // προσθήκη μεθόδων\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub enum Shape {\n"
-#~ "    Polygon(Polygon),\n"
-#~ "    Circle(Circle),\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub enum Shape {\n"
-#~ "    Πολύγωνο (Πολύγωνο),\n"
-#~ "    Κύκλος (Κύκλος),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn round_two_digits(x: f64) -> f64 {\n"
-#~ "        (x * 100.0).round() / 100.0\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    fn round_two_digits(x: f64) -> f64 {\n"
-#~ "        (x * 100.0).round() / 100.0\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`Option` and `Result`](std/option-result.md) types: used for optional "
-#~ "values\n"
-#~ "  and [error handling](error-handling.md)."
-#~ msgstr ""
-#~ "* Τύποι ['Option' και 'Result'](std/option-result.md): χρησιμοποιούνται "
-#~ "για προαιρετικές τιμές\n"
-#~ "  και [error handling](error-handling.md)."
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`String`](std/string.md): the default string type used for owned data."
-#~ msgstr ""
-#~ "* [`String`](std/string.md): ο προεπιλεγμένος τύπος συμβολοσειράς που "
-#~ "χρησιμοποιείται για ιδιόκτητα δεδομένα."
-
-#, fuzzy
-#~ msgid "* [`Vec`](std/vec.md): a standard extensible vector."
-#~ msgstr "* [`Vec`](std/vec.md): ένα τυπικό επεκτάσιμο διάνυσμα."
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`HashMap`](std/hashmap.md): a hash map type with a configurable "
-#~ "hashing\n"
-#~ "  algorithm."
-#~ msgstr ""
-#~ "* [`HashMap`](std/hashmap.md): τύπος χάρτη κατακερματισμού με δυνατότητα "
-#~ "διαμόρφωσης κατακερματισμού\n"
-#~ "  αλγόριθμος."
-
-#, fuzzy
-#~ msgid "* [`Box`](std/box.md): an owned pointer for heap-allocated data."
-#~ msgstr ""
-#~ "* [`Box`](std/box.md): ένας ιδιόκτητος δείκτης για δεδομένα που "
-#~ "εκχωρούνται σε σωρό."
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-"
-#~ "allocated data."
-#~ msgstr ""
-#~ "* [`Rc`](std/rc.md): κοινόχρηστος δείκτης μέτρησης αναφοράς για δεδομένα "
-#~ "που εκχωρούνται σε σωρό."
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/string/struct.String.html#deref-"
-#~ "methods-str"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/string/struct.String.html#deref-"
-#~ "methods-str"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `len` returns the size of the `String` in bytes, not its length in "
-#~ "characters.\n"
-#~ "* `chars` returns an iterator over the actual characters.\n"
-#~ "* `String` implements `Deref<Target = str>` which transparently gives it "
-#~ "access to `str`'s methods."
-#~ msgstr ""
-#~ "* Το «len» επιστρέφει το μέγεθος του «String» σε byte, όχι το μήκος του "
-#~ "σε χαρακτήρες.\n"
-#~ "* Το `chars` επιστρέφει έναν επαναλήπτη πάνω από τους πραγματικούς "
-#~ "χαρακτήρες.\n"
-#~ "* Το `String` υλοποιεί το `Deref<Target = str>` που του δίνει με "
-#~ "διαφάνεια πρόσβαση στις μεθόδους του `str`."
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-"
-#~ "coercion"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-"
-#~ "coercion"
-
-#, fuzzy
-#~ msgid ""
-#~ "* If the `Box` was not used here and we attempted to embed a `List` "
-#~ "directly into the `List`,\n"
-#~ "the compiler would not compute a fixed size of the struct in memory, it "
-#~ "would look infinite."
-#~ msgstr ""
-#~ "<λεπτομέρειες>\n"
-#~ "    \n"
-#~ "Εάν το \"Πλαίσιο\" δεν χρησιμοποιήθηκε εδώ και προσπαθήσαμε να "
-#~ "ενσωματώσουμε μια \"Λίστα\" απευθείας στη \"Λίστα\",\n"
-#~ "ο μεταγλωττιστής δεν θα υπολόγιζε ένα σταθερό μέγεθος της δομής στη "
-#~ "μνήμη, θα φαινόταν άπειρο.\n"
-#~ "    \n"
-#~ "Το \"Box\" λύνει αυτό το πρόβλημα καθώς έχει το ίδιο μέγεθος με έναν "
-#~ "κανονικό δείκτη και απλώς δείχνει τον επόμενο\n"
-#~ "στοιχείο της «Λίστας» στο σωρό.\n"
-#~ "    \n"
-#~ "</details>"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/cell/index.html\n"
-#~ "[3]: ../concurrency/shared_state/arc.md\n"
-#~ "[4]: https://doc.rust-lang.org/std/rc/struct.Weak.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/cell/index.html\n"
-#~ "[3]: ../concurrency/shared_state/arc.md"
-
-#, fuzzy
-#~ msgid ""
-#~ "1. As a relative path:\n"
-#~ "   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-#~ "   * `super::foo` refers to `foo` in the parent module."
-#~ msgstr ""
-#~ "1. Ως σχετική διαδρομή:\n"
-#~ "   * Το \"foo\" ή το \"self::foo\" αναφέρεται στο \"foo\" στην τρέχουσα "
-#~ "ενότητα,\n"
-#~ "   * Το «super::foo» αναφέρεται στο «foo» στη γονική μονάδα."
-
-#, fuzzy
-#~ msgid "* Ignore all spaces. Reject number with less than two digits."
-#~ msgstr "* Αγνοήστε όλα τα κενά. Απόρριψη αριθμού με λιγότερα από δύο ψηφία."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Moving from right to left, double every second digit: for the number "
-#~ "`1234`,\n"
-#~ "  we double `3` and `1`."
-#~ msgstr ""
-#~ "* Μετακίνηση από τα δεξιά προς τα αριστερά, διπλασιάστε κάθε δεύτερο "
-#~ "ψηφίο: για τον αριθμό «1234»,\n"
-#~ "  διπλασιάζουμε «3» και «1»."
-
-#, fuzzy
-#~ msgid ""
-#~ "* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-#~ "which\n"
-#~ "  becomes `5`."
-#~ msgstr ""
-#~ "* Μετά τον διπλασιασμό ενός ψηφίου, αθροίστε τα ψηφία. Έτσι ο "
-#~ "διπλασιασμός του '7' γίνεται '14' που\n"
-#~ "  γίνεται «5»."
-
-#, fuzzy
-#~ msgid "* Sum all the undoubled and doubled digits."
-#~ msgstr "* Άθροισμα όλων των μη διπλασιασμένων και διπλασιασμένων ψηφίων."
-
-#, fuzzy
-#~ msgid "* The credit card number is valid if the sum ends with `0`."
-#~ msgstr ""
-#~ "* Ο αριθμός της πιστωτικής κάρτας είναι έγκυρος εάν το άθροισμα τελειώνει "
-#~ "με «0»."
-
-#, fuzzy
-#~ msgid ""
-#~ "pub fn luhn(cc_number: &str) -> bool {\n"
-#~ "    unimplemented!()\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub fn luhn(cc_number: &str) -> bool {\n"
-#~ "    ανεφάρμοστη!()\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-#~ "    unimplemented!()\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub fn prefix_matches(πρόθεμα: &str, request_path: &str) -> bool {\n"
-#~ "    ανεφάρμοστη!()\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Traits: deriving traits, default methods, and important standard "
-#~ "library\n"
-#~ "  traits."
-#~ msgstr ""
-#~ "* Χαρακτηριστικά: εξαγωγή χαρακτηριστικών, προεπιλεγμένες μέθοδοι και "
-#~ "σημαντική τυπική βιβλιοθήκη\n"
-#~ "  χαρακτηριστικά."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Generics: generic data types, generic methods, monomorphization, and "
-#~ "trait\n"
-#~ "  objects."
-#~ msgstr ""
-#~ "* Γενικά: γενικοί τύποι δεδομένων, γενικές μέθοδοι, μονομορφοποίηση και "
-#~ "χαρακτηριστικό\n"
-#~ "  αντικείμενα."
-
-#, fuzzy
-#~ msgid "* Error handling: panics, `Result`, and the try operator `?`."
-#~ msgstr ""
-#~ "* Διαχείριση σφαλμάτων: πανικός, «Αποτέλεσμα» και ο τελεστής δοκιμής «?»."
-
-#, fuzzy
-#~ msgid "* Testing: unit tests, documentation tests, and integration tests."
-#~ msgstr ""
-#~ "* Δοκιμές: δοκιμές μονάδων, δοκιμές τεκμηρίωσης και δοκιμές ολοκλήρωσης."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Unsafe Rust: raw pointers, static variables, unsafe functions, and "
-#~ "extern\n"
-#~ "  functions."
-#~ msgstr ""
-#~ "* Μη ασφαλής σκουριά: ακατέργαστες δείκτες, στατικές μεταβλητές, μη "
-#~ "ασφαλείς συναρτήσεις και εξωτερικά\n"
-#~ "  λειτουργίες."
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Dog {\n"
-#~ "    name: String,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Dog {\n"
-#~ "    όνομα: String,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Equals for Centimeter {\n"
-#~ "    fn equal(&self, other: &Centimeter) -> bool {\n"
-#~ "        self.0 == other.0\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Ισούται με εκατοστό {\n"
-#~ "    fn ίσον(&self, other: &Centimeter) -> bool {\n"
-#~ "        εαυτός.0 == άλλος.0\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `IntoIterator` is the trait that makes for loops work. It is "
-#~ "implemented by collection types such as\n"
-#~ "  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges "
-#~ "also implement it.\n"
-#~ "* The `Iterator` trait implements many common functional programming "
-#~ "operations over collections \n"
-#~ "  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-#~ "find all the documentation\n"
-#~ "  about them. In Rust these functions should produce the code as "
-#~ "efficient as equivalent imperative\n"
-#~ "  implementations.\n"
-#~ "    \n"
-#~ "</details>"
-#~ msgstr ""
-#~ "* Το \"IntoIterator\" είναι το χαρακτηριστικό που κάνει τους βρόχους να "
-#~ "λειτουργούν. Υλοποιείται από τύπους συλλογής όπως π.χ\n"
-#~ "  `Vec<T>` και αναφορές σε αυτά, όπως \"&Vec<T>\" και \"&[T]\". Το "
-#~ "εφαρμόζουν και οι Ranges.\n"
-#~ "* Το χαρακτηριστικό «Iterator» υλοποιεί πολλές κοινές λειτουργίες "
-#~ "λειτουργικού προγραμματισμού σε συλλογές\n"
-#~ "  (π.χ. \"χάρτης\", \"φίλτρο\", \"μείωση\" κ.λπ.). Αυτό είναι το "
-#~ "χαρακτηριστικό όπου μπορείτε να βρείτε όλη την τεκμηρίωση\n"
-#~ "  Για αυτούς. Στο Rust αυτές οι συναρτήσεις θα πρέπει να παράγουν τον "
-#~ "κώδικα τόσο αποτελεσματικό όσο και ισοδύναμη επιταγή\n"
-#~ "  υλοποιήσεις.\n"
-#~ "    \n"
-#~ "</details>"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/iter/trait.FromIterator.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/iter/trait.Iterator.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/convert/trait.Into.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/io/trait.Read.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/io/trait.BufRead.html\n"
-#~ "[3]: https://doc.rust-lang.org/std/io/trait.Write.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-"
-#~ "Mutex%3CT%3E\n"
-#~ "[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn add(self, other: Self) -> Self {\n"
-#~ "        Self {x: self.x + other.x, y: self.y + other.y}\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn add(self, other: Self) -> Self {\n"
-#~ "        Self {x: self.x + other.x, y: self.y + other.y}\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/ops/index.html"
-#~ msgstr "[`Οποιοδήποτε`]: https://doc.rust-lang.org/std/any/index.html"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Default for Implemented {\n"
-#~ "    fn default() -> Self {\n"
-#~ "        Self(\"John Smith\".into())\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Widget για παράθυρο {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/default/trait.Default.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl<T> Point<T> {\n"
-#~ "    fn x(&self) -> &T {\n"
-#~ "        &self.0  // + 10\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl<T> Σημείο<T> {\n"
-#~ "    fn x(&self) -> &T {\n"
-#~ "        &self.0 // + 10\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // fn set_x(&mut self, x: T)\n"
-#~ "}"
-#~ msgstr ""
-#~ "    // fn set_x(&mut self, x: T)\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn get_x(name: impl Display) -> impl Display {\n"
-#~ "    format!(\"Hello {name}\")\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn get_x(name: impl Display) -> impl Display {\n"
-#~ "    μορφή! (\"Hello {name}\")\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "enum Option_f64 {\n"
-#~ "    Some(f64),\n"
-#~ "    None,\n"
-#~ "}"
-#~ msgstr ""
-#~ "enum Option_f64 {\n"
-#~ "    Μερικοί (f64),\n"
-#~ "    Κανένας,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Label {\n"
-#~ "    label: String,\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Label {\n"
-#~ "    Ετικέτα: String,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Label {\n"
-#~ "    fn new(label: &str) -> Label {\n"
-#~ "        Label {\n"
-#~ "            label: label.to_owned(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Label {\n"
-#~ "    fn new(label: &str) -> Label {\n"
-#~ "        Ετικέτα {\n"
-#~ "            label: label.to_owned(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Button {\n"
-#~ "    label: Label,\n"
-#~ "    callback: Box<dyn FnMut()>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Κουμπί {\n"
-#~ "    ετικέτα: ετικέτα,\n"
-#~ "    επανάκληση: Box<dyn FnMut()>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Button {\n"
-#~ "    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
-#~ "        Button {\n"
-#~ "            label: Label::new(label),\n"
-#~ "            callback,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "Κουμπί εμφύτευσης {\n"
-#~ "    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
-#~ "        Κουμπί {\n"
-#~ "            ετικέτα: Ετικέτα::νέο(ετικέτα),\n"
-#~ "            επανάκληση,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Window {\n"
-#~ "    title: String,\n"
-#~ "    widgets: Vec<Box<dyn Widget>>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Παράθυρο {\n"
-#~ "    τίτλος: String,\n"
-#~ "    widgets: Vec<Box<dyn Widget>>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Window {\n"
-#~ "    fn new(title: &str) -> Window {\n"
-#~ "        Window {\n"
-#~ "            title: title.to_owned(),\n"
-#~ "            widgets: Vec::new(),\n"
-#~ "        }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "παράθυρο εμφ. {\n"
-#~ "    fn new(title: &str) -> Παράθυρο {\n"
-#~ "        Παράθυρο {\n"
-#~ "            title: title.to_owned(),\n"
-#~ "            widgets: Vec::new(),\n"
-#~ "        }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Widget for Label {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Widget για ετικέτα {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Widget for Button {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Widget for Button {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Widget for Window {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Widget για παράθυρο {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid "This is a small text GUI demo."
-#~ msgstr "Αυτό είναι ένα μικρό κείμενο επίδειξης GUI."
-
-#, fuzzy
-#~ msgid ""
-#~ "    match username_file.read_to_string(&mut username) {\n"
-#~ "        Ok(_) => Ok(username),\n"
-#~ "        Err(e) => Err(e),\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    αντιστοίχιση username_file.read_to_string(&mut username) {\n"
-#~ "        Ok(_) => Ok(όνομα χρήστη),\n"
-#~ "        Σφάλμα(ε) => Σφάλμα(ε),\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    IoError(io::Error),\n"
-#~ "    EmptyUsername(String),\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[παραγωγή (Εντοπισμός σφαλμάτων)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    IoError(io::Error),\n"
-#~ "    EmptyUsername(String),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "impl Error for ReadUsernameError {}"
-#~ msgstr "impl Σφάλμα για ReadUsernameError {}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Display for ReadUsernameError {\n"
-#~ "    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-#~ "        match self {\n"
-#~ "            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
-#~ "            Self::EmptyUsername(filename) => write!(f, \"Found no "
-#~ "username in {}\", filename),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Εμφάνιση για ReadUsernameError {\n"
-#~ "    fn fmt(&self, f: &mut Formatter) -> fmt::Αποτέλεσμα {\n"
-#~ "        ταίριασμα εαυτού {\n"
-#~ "            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
-#~ "            Self::EmptyUsername(filename) => write!(f, \"Δεν βρέθηκε "
-#~ "όνομα χρήστη στο {}\", όνομα αρχείου),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl From<io::Error> for ReadUsernameError {\n"
-#~ "    fn from(err: io::Error) -> ReadUsernameError {\n"
-#~ "        ReadUsernameError::IoError(err)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl From<io::Error> για ReadUsernameError {\n"
-#~ "    fn from(err: io::Error) -> ReadUsernameError {\n"
-#~ "        ReadUsernameError::IoError(err)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug, Error)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    #[error(\"Could not read: {0}\")]\n"
-#~ "    IoError(#[from] io::Error),\n"
-#~ "    #[error(\"Found no username in {0}\")]\n"
-#~ "    EmptyUsername(String),\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[παραγωγή (Εντοπισμός σφαλμάτων, Σφάλμα)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    #[σφάλμα (\"Δεν ήταν δυνατή η ανάγνωση: {0}\")]\n"
-#~ "    IoError(#[from] io::Error),\n"
-#~ "    #[error(\"Δεν βρέθηκε όνομα χρήστη στο {0}\")]\n"
-#~ "    EmptyUsername(String),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "* Unit tests are supported throughout your code."
-#~ msgstr "* Οι δοκιμές μονάδας υποστηρίζονται σε όλο τον κώδικά σας."
-
-#, fuzzy
-#~ msgid "[solution]: solutions-afternoon.md"
-#~ msgstr "[λύση]: λύσεις-απόγευμα.μδ"
-
-#, fuzzy
-#~ msgid ""
-#~ "[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
-#~ "[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
-#~ "[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
-#~ "[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
-#~ msgstr ""
-#~ "[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
-#~ "[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
-#~ "[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
-#~ "[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    path: CString,\n"
-#~ "    dir: *mut ffi::DIR,\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[παραγωγή (Εντοπισμός σφαλμάτων)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    διαδρομή: CString,\n"
-#~ "    σκηνοθεσία: *mut ffi::DIR,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl DirectoryIterator {\n"
-#~ "    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-#~ "        // Call opendir and return a Ok value if that worked,\n"
-#~ "        // otherwise return Err with a message.\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl DirectoryIterator {\n"
-#~ "    fn new(διαδρομή: &str) -> Αποτέλεσμα<DirectoryIterator, String> {\n"
-#~ "        // Καλέστε το opendir και επιστρέψτε μια τιμή Ok εάν "
-#~ "λειτούργησε,\n"
-#~ "        // διαφορετικά επιστρέψτε το Err με ένα μήνυμα.\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Drop for DirectoryIterator {\n"
-#~ "    fn drop(&mut self) {\n"
-#~ "        // Call closedir as needed.\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Drop for DirectoryIterator {\n"
-#~ "    fn drop(&mut self) {\n"
-#~ "        // Καλέστε το κλείσιμο όπως απαιτείται.\n"
-#~ "        ανεφάρμοστη!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "Today we will look at two main topics:"
-#~ msgstr "Σήμερα θα εξετάσουμε δύο βασικά θέματα:"
-
-#, fuzzy
-#~ msgid "* Concurrency: threads, channels, shared state, `Send` and `Sync`."
-#~ msgstr ""
-#~ "* Συγχρονισμός: νήματα, κανάλια, κοινή κατάσταση, \"Αποστολή\" και "
-#~ "\"Συγχρονισμός\"."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Android: building binaries and libraries, using AIDL, logging, and\n"
-#~ "  interoperability with C, C++, and Java."
-#~ msgstr ""
-#~ "* Android: δημιουργία δυαδικών αρχείων και βιβλιοθηκών, χρησιμοποιώντας "
-#~ "AIDL, καταγραφή και\n"
-#~ "  διαλειτουργικότητα με C, C++ και Java."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Notice that the thread is stopped before it reaches 10 — the main "
-#~ "thread is\n"
-#~ "  not waiting."
-#~ msgstr ""
-#~ "* Παρατηρήστε ότι το νήμα σταματά πριν φτάσει στο 10 — το κύριο νήμα "
-#~ "είναι\n"
-#~ "  δεν περιμένει."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-#~ "for\n"
-#~ "  the thread to finish."
-#~ msgstr ""
-#~ "* Χρησιμοποιήστε το \"let handle = thread::spawn(...)\" και αργότερα το "
-#~ "\"handle.join()\" για να περιμένετε\n"
-#~ "  το νήμα για να τελειώσει."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Trigger a panic in the thread, notice how this doesn't affect `main`."
-#~ msgstr ""
-#~ "* Προκαλέστε έναν πανικό στο νήμα, παρατηρήστε πώς αυτό δεν επηρεάζει το "
-#~ "\"κύριο\"."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Use the `Result` return value from `handle.join()` to get access to the "
-#~ "panic\n"
-#~ "  payload. This is a good time to talk about [`Any`]."
-#~ msgstr ""
-#~ "* Χρησιμοποιήστε την τιμή επιστροφής \"Αποτέλεσμα\" από το \"handle."
-#~ "join()\" για να αποκτήσετε πρόσβαση στον πανικό\n"
-#~ "  φορτίο επί πληρωμή. Αυτή είναι μια καλή στιγμή για να μιλήσουμε για το "
-#~ "[`Οποιοδήποτε`]."
-
-#, fuzzy
-#~ msgid "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
-#~ msgstr "[`Οποιοδήποτε`]: https://doc.rust-lang.org/std/any/index.html"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-"
-#~ "Mutex%3CT%3E\n"
-#~ "[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-"
-#~ "Mutex%3CT%3E\n"
-#~ "[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError."
-#~ "html  \n"
-#~ "    \n"
-#~ "</details>"
-#~ msgstr ""
-#~ "[\"PoisonError\"]: https://doc.rust-lang.org/std/sync/struct.PoisonError."
-#~ "html\n"
-#~ "    \n"
-#~ "</details>"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
-#~ "[3]: ../unsafe/unsafe-traits.md"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
-#~ "[3]: ../unsafe/unsafe-traits.md"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
-
-#, fuzzy
-#~ msgid "* Dining philosophers: a classic problem in concurrency."
-#~ msgstr "* Φιλόσοφοι τραπεζαρίας: ένα κλασικό πρόβλημα συγχρονισμού."
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Philosopher {\n"
-#~ "    name: String,\n"
-#~ "    // left_fork: ...\n"
-#~ "    // right_fork: ...\n"
-#~ "    // thoughts: ...\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Φιλόσοφος {\n"
-#~ "    όνομα: String,\n"
-#~ "    // left_fork: ...\n"
-#~ "    // right_fork: ...\n"
-#~ "    // σκέψεις: ...\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn main() {\n"
-#~ "    // Create forks"
-#~ msgstr ""
-#~ "fn main() {\n"
-#~ "    // Δημιουργία πιρουνιών"
-
-#, fuzzy
-#~ msgid "    // Create philosophers"
-#~ msgstr "    // Δημιουργία φιλοσόφων"
-
-#, fuzzy
-#~ msgid "    // Make them think and eat"
-#~ msgstr "    // Κάνε τους να σκεφτούν και να φάνε"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Error, Debug)]\n"
-#~ "enum Error {\n"
-#~ "    #[error(\"request error: {0}\")]\n"
-#~ "    ReqwestError(#[from] reqwest::Error),\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[παραγωγή (Σφάλμα, Εντοπισμός σφαλμάτων)]\n"
-#~ "enum Σφάλμα {\n"
-#~ "    #[error(\"σφάλμα αιτήματος: {0}\")]\n"
-#~ "    ReqwestError(#[from] reqwest::Error),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    Ok(valid_urls)\n"
-#~ "}"
-#~ msgstr ""
-#~ "    Ok(valid_urls)\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://docs.rs/reqwest/\n"
-#~ "[2]: https://docs.rs/scraper/\n"
-#~ "[3]: https://docs.rs/thiserror/"
-#~ msgstr ""
-#~ "[1]: https://docs.rs/reqwest/\n"
-#~ "[2]: https://docs.rs/scraper/\n"
-#~ "[3]: https://docs.rs/thiserror/"
-
-#, fuzzy
-#~ msgid ""
-#~ "[crates]: https://cs.android.com/android/platform/superproject/+/master:"
-#~ "external/rust/crates/"
-#~ msgstr ""
-#~ "[κλουβιά]: https://cs.android.com/android/platform/superproject/+/master:"
-#~ "external/rust/crates/"
-
-#, fuzzy
-#~ msgid "impl binder::Interface for BirthdayService {}"
-#~ msgstr "impl binder::Διεπαφή για BirthdayService {}"
-
-#, fuzzy
-#~ msgid ""
-#~ "/// Connect to the BirthdayService.\n"
-#~ "pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
-#~ "StatusCode> {\n"
-#~ "    binder::get_interface(SERVICE_IDENTIFIER)\n"
-#~ "}"
-#~ msgstr ""
-#~ "/// Συνδεθείτε στην υπηρεσία BirthdayService.\n"
-#~ "pub fn connect() -> Αποτέλεσμα<binder::Strong<dyn IBirthdayService>, "
-#~ "binder::StatusCode> {\n"
-#~ "    binder::get_interface(SERVICE_IDENTIFIER)\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://cxx.rs/\n"
-#~ "[2]: https://cxx.rs/tutorial.html"
-#~ msgstr ""
-#~ "[1]: https://cxx.rs/\n"
-#~ "[2]: https://cxx.rs/tutorial.html"
-
-#, fuzzy
-#~ msgid "* Call your AIDL service with a client written in Rust."
-#~ msgstr "* Καλέστε την υπηρεσία AIDL με έναν πελάτη γραμμένο σε Rust."
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/convert/trait.AsRef.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: setup\n"
-#~ "struct Library {\n"
-#~ "    books: Vec<Book>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: ρύθμιση\n"
-#~ "struct Library {\n"
-#~ "    βιβλία: Vec<Book>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// This makes it possible to print Book values with {}.\n"
-#~ "impl std::fmt::Display for Book {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-#~ "        write!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}\n"
-#~ "// ANCHOR_END: setup"
-#~ msgstr ""
-#~ "// Αυτό καθιστά δυνατή την εκτύπωση τιμών βιβλίου με {}.\n"
-#~ "impl std::fmt::Display for Book {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::"
-#~ "Αποτέλεσμα {\n"
-#~ "        write!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}\n"
-#~ "// ANCHOR_END: ρύθμιση"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Library_new\n"
-#~ "impl Library {\n"
-#~ "    fn new() -> Library {\n"
-#~ "        // ANCHOR_END: Library_new\n"
-#~ "        Library { books: Vec::new() }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Library_new\n"
-#~ "impl Library {\n"
-#~ "    fn new() -> Library {\n"
-#~ "        // ANCHOR_END: Library_new\n"
-#~ "        Βιβλιοθήκη { βιβλία: Vec::new() }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_len\n"
-#~ "    //fn len(self) -> usize {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_len\n"
-#~ "    fn len(&self) -> usize {\n"
-#~ "        self.books.len()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    // ΑΓΚΥΡΑ: Library_len\n"
-#~ "    //fn len(self) -> χρήση {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_len\n"
-#~ "    fn len(&self) -> χρήση {\n"
-#~ "        self.books.len()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_is_empty\n"
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_is_empty\n"
-#~ "    fn is_empty(&self) -> bool {\n"
-#~ "        self.books.is_empty()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    // ANCHOR: Library_is_empty\n"
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_is_empty\n"
-#~ "    fn is_empty(&self) -> bool {\n"
-#~ "        self.books.is_empty()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_add_book\n"
-#~ "    //fn add_book(self, book: Book) {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_add_book\n"
-#~ "    fn add_book(&mut self, book: Book) {\n"
-#~ "        self.books.push(book)\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    // ANCHOR: Library_add_book\n"
-#~ "    //fn add_book(self, book: Book) {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_add_book\n"
-#~ "    fn add_book(&mut self, book: Book) {\n"
-#~ "        self.books.push(βιβλίο)\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_oldest_book\n"
-#~ "    //fn oldest_book(self) -> Option<&Book> {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_oldest_book\n"
-#~ "    fn oldest_book(&self) -> Option<&Book> {\n"
-#~ "        self.books.iter().min_by_key(|book| book.year)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    // ANCHOR: Library_oldest_book\n"
-#~ "    //fn oldest_book(self) -> Option<&Book> {\n"
-#~ "    // δεν εφαρμόζεται!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_oldest_book\n"
-#~ "    fn oldest_book(&self) -> Option<&Book> {\n"
-#~ "        self.books.iter().min_by_key(|βιβλίο| βιβλίο.έτος)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-#~ "// ANCHOR: Point\n"
-#~ "pub struct Point {\n"
-#~ "    // ANCHOR_END: Point\n"
-#~ "    x: i32,\n"
-#~ "    y: i32,\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[παραγωγή (Εντοπισμός σφαλμάτων, Αντιγραφή, Κλώνος, PartialEq, Eq)]\n"
-#~ "// Αγκυροβόλι\n"
-#~ "pub struct Point {\n"
-#~ "    // ANCHOR_END: Σημείο\n"
-#~ "    x: i32,\n"
-#~ "    y: i32,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Point-impl\n"
-#~ "impl Point {\n"
-#~ "    // ANCHOR_END: Point-impl\n"
-#~ "    pub fn new(x: i32, y: i32) -> Point {\n"
-#~ "        Point { x, y }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Point-immpl\n"
-#~ "εμφ. Σημείο {\n"
-#~ "    // ANCHOR_END: Point-immpl\n"
-#~ "    pub fn new(x: i32, y: i32) -> Point {\n"
-#~ "        Σημείο { x, y }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn magnitude(self) -> f64 {\n"
-#~ "        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn magnitude(self) -> f64 {\n"
-#~ "        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn dist(self, other: Point) -> f64 {\n"
-#~ "        (self - other).magnitude()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    pub fn dist(self, other: Point) -> f64 {\n"
-#~ "        (self - other).magnitude()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn add(self, other: Self) -> Self::Output {\n"
-#~ "        Self {\n"
-#~ "            x: self.x + other.x,\n"
-#~ "            y: self.y + other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn add(self, other: Self) -> Self::Output {\n"
-#~ "        αυτος {\n"
-#~ "            x: self.x + other.x,\n"
-#~ "            y: self.y + other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn sub(self, other: Self) -> Self::Output {\n"
-#~ "        Self {\n"
-#~ "            x: self.x - other.x,\n"
-#~ "            y: self.y - other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn sub(self, other: Self) -> Self::Output {\n"
-#~ "        αυτος {\n"
-#~ "            x: εαυτός.χ - άλλος.χ,\n"
-#~ "            y: self.y - other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Polygon\n"
-#~ "pub struct Polygon {\n"
-#~ "    // ANCHOR_END: Polygon\n"
-#~ "    points: Vec<Point>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Πολύγωνο\n"
-#~ "pub struct Πολύγωνο {\n"
-#~ "    // ANCHOR_END: Πολύγωνο\n"
-#~ "    σημεία: Vec<Point>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Polygon-impl\n"
-#~ "impl Polygon {\n"
-#~ "    // ANCHOR_END: Polygon-impl\n"
-#~ "    pub fn new() -> Polygon {\n"
-#~ "        Polygon { points: Vec::new() }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Polygon-impl\n"
-#~ "impmpl Polygon {\n"
-#~ "    // ANCHOR_END: Polygon-impl\n"
-#~ "    pub fn new() -> Πολύγωνο {\n"
-#~ "        Πολύγωνο { points: Vec::new() }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn left_most_point(&self) -> Option<Point> {\n"
-#~ "        self.points.iter().min_by_key(|p| p.x).copied()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn left_most_point(&self) -> Option<Point> {\n"
-#~ "        self.points.iter().min_by_key(|p| p.x).copied()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-#~ "        self.points.iter()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-#~ "        self.points.iter()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Circle\n"
-#~ "pub struct Circle {\n"
-#~ "    // ANCHOR_END: Circle\n"
-#~ "    center: Point,\n"
-#~ "    radius: i32,\n"
-#~ "}"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Κύκλος\n"
-#~ "pub struct Circle {\n"
-#~ "    // ANCHOR_END: Κύκλος\n"
-#~ "    κεντρικό σημείο,\n"
-#~ "    ακτίνα: i32,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Circle-impl\n"
-#~ "impl Circle {\n"
-#~ "    // ANCHOR_END: Circle-impl\n"
-#~ "    pub fn new(center: Point, radius: i32) -> Circle {\n"
-#~ "        Circle { center, radius }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Circle-immpl\n"
-#~ "impmpl Circle {\n"
-#~ "    // ANCHOR_END: Circle-impl\n"
-#~ "    pub fn new(κέντρο: Σημείο, ακτίνα: i32) -> Κύκλος {\n"
-#~ "        Κύκλος { κέντρο, ακτίνα }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn circumference(&self) -> f64 {\n"
-#~ "        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn circumference(&self) -> f64 {\n"
-#~ "        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn dist(&self, other: &Self) -> f64 {\n"
-#~ "        self.center.dist(other.center)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    pub fn dist(&self, other: &Self) -> f64 {\n"
-#~ "        self.center.dist(other.center)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Shape\n"
-#~ "pub enum Shape {\n"
-#~ "    Polygon(Polygon),\n"
-#~ "    Circle(Circle),\n"
-#~ "}\n"
-#~ "// ANCHOR_END: Shape"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Σχήμα\n"
-#~ "pub enum Shape {\n"
-#~ "    Πολύγωνο (Πολύγωνο),\n"
-#~ "    Κύκλος (Κύκλος),\n"
-#~ "}\n"
-#~ "// ANCHOR_END: Σχήμα"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl From<Polygon> for Shape {\n"
-#~ "    fn from(poly: Polygon) -> Self {\n"
-#~ "        Shape::Polygon(poly)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl From<Polygon> for Shape {\n"
-#~ "    fn from(poly: Polygon) -> Self {\n"
-#~ "        Σχήμα::Πολύγωνο(πολύγωνο)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl From<Circle> for Shape {\n"
-#~ "    fn from(circle: Circle) -> Self {\n"
-#~ "        Shape::Circle(circle)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl From<Circle> for Shape {\n"
-#~ "    fn from(circle: Circle) -> Self {\n"
-#~ "        Σχήμα::Κύκλος (κύκλος)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Shape {\n"
-#~ "    pub fn perimeter(&self) -> f64 {\n"
-#~ "        match self {\n"
-#~ "            Shape::Polygon(poly) => poly.length(),\n"
-#~ "            Shape::Circle(circle) => circle.circumference(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impmpl Shape {\n"
-#~ "    pub fn perimeter(&self) -> f64 {\n"
-#~ "        ταίριασμα εαυτού {\n"
-#~ "            Shape::Polygon(poly) => poly.length(),\n"
-#~ "            Σχήμα::Κύκλος(κύκλος) => κύκλος.περιφέρεια(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    sum % 10 == 0\n"
-#~ "}"
-#~ msgstr ""
-#~ "    άθροισμα % 10 == 0\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "// ANCHOR_END: setup"
-#~ msgstr "// ANCHOR_END: ρύθμιση"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Window-width\n"
-#~ "impl Widget for Window {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        // ANCHOR_END: Window-width\n"
-#~ "        std::cmp::max(\n"
-#~ "            self.title.chars().count(),\n"
-#~ "            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-#~ "        )\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Παράθυρο-πλάτος\n"
-#~ "impl Widget για παράθυρο {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        // ANCHOR_END: Παράθυρο-πλάτος\n"
-#~ "        std::cmp::max(\n"
-#~ "            self.title.chars().count(),\n"
-#~ "            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-#~ "        )\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Button-width\n"
-#~ "impl Widget for Button {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        // ANCHOR_END: Button-width\n"
-#~ "        self.label.width() + 8 // add a bit of padding\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Κουμπί-πλάτος\n"
-#~ "impl Widget for Button {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        // ANCHOR_END: Κουμπί-πλάτος\n"
-#~ "        self.label.width() + 8 // προσθέστε λίγο padding\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Label-width\n"
-#~ "impl Widget for Label {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        // ANCHOR_END: Label-width\n"
-#~ "        self.label\n"
-#~ "            .lines()\n"
-#~ "            .map(|line| line.chars().count())\n"
-#~ "            .max()\n"
-#~ "            .unwrap_or(0)\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ΑΓΚΥΡΑ: Label-width\n"
-#~ "impl Widget για ετικέτα {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        // ANCHOR_END: Ετικέτα-πλάτος\n"
-#~ "        αυτο.ετικέτα\n"
-#~ "            .lines()\n"
-#~ "            .map(|line| line.chars().count())\n"
-#~ "            .Μέγιστη()\n"
-#~ "            .unwrap_or(0)\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    path: CString,\n"
-#~ "    dir: *mut ffi::DIR,\n"
-#~ "}\n"
-#~ "// ANCHOR_END: ffi"
-#~ msgstr ""
-#~ "#[παραγωγή (Εντοπισμός σφαλμάτων)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    διαδρομή: CString,\n"
-#~ "    σκηνοθεσία: *mut ffi::DIR,\n"
-#~ "}\n"
-#~ "// ANCHOR_END: ffi"
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Philosopher {\n"
-#~ "    name: String,\n"
-#~ "    // ANCHOR_END: Philosopher\n"
-#~ "    left_fork: Arc<Mutex<Fork>>,\n"
-#~ "    right_fork: Arc<Mutex<Fork>>,\n"
-#~ "    thoughts: mpsc::SyncSender<String>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Φιλόσοφος {\n"
-#~ "    όνομα: String,\n"
-#~ "    // ANCHOR_END: Φιλόσοφος\n"
-#~ "    left_fork: Arc<Mutex<Fork>>,\n"
-#~ "    right_fork: Arc<Mutex<Fork>>,\n"
-#~ "    σκέψεις: mpsc::SyncSender<String>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `Box` is like `std::unique_ptr` in C++.\n"
-#~ "* In the above example, you can even leave out the `*` in the `println!` "
-#~ "statement thanks to `Deref`."
-#~ msgstr ""
-#~ "* Το \"Box\" είναι σαν το \"std::unique_ptr\" στη C++.\n"
-#~ "* Στο παραπάνω παράδειγμα, μπορείτε ακόμη και να αφήσετε έξω το «*» στη "
-#~ "δήλωση «println!» χάρη στο «Deref»."


### PR DESCRIPTION
Before, po/el.po had these statistics:

    227 translated messages, 846 fuzzy translations, 708 untranslated messages.

Afterwards, the statistics for po/el.po is:

    236 translated messages, 992 fuzzy translations, 1239 untranslated messages.

The number of translated messages changed from 13% to 10%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.