### PR TITLE
de: normalize with mdbook-i18n-helpers 0.2.2

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -5,34 +5,33 @@ msgstr ""
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.3.2\n"
 
-#: src/SUMMARY.md:3
+#: src/SUMMARY.md:3 src/welcome.md:1
 msgid "Welcome to Comprehensive Rust 🦀"
 msgstr "Willkommen bei Comprehensive Rust 🦀"
 
-#: src/SUMMARY.md:4
+#: src/SUMMARY.md:4 src/running-the-course.md:1
 msgid "Running the Course"
 msgstr "Ablauf des Kurses"
 
-#: src/SUMMARY.md:5
+#: src/SUMMARY.md:5 src/running-the-course/course-structure.md:1
 msgid "Course Structure"
 msgstr "Kursstruktur"
 
-#: src/SUMMARY.md:6
+#: src/SUMMARY.md:6 src/running-the-course/keyboard-shortcuts.md:1
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkürzel"
 
-#: src/SUMMARY.md:7
+#: src/SUMMARY.md:7 src/running-the-course/translations.md:1
 msgid "Translations"
 msgstr "Übersetzungen"
 
-#: src/SUMMARY.md:8
+#: src/SUMMARY.md:8 src/cargo.md:1
 msgid "Using Cargo"
 msgstr "Cargo verwenden"
 
@@ -57,55 +56,55 @@ msgstr "Tag 1: Morgens"
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: src/SUMMARY.md:19
+#: src/SUMMARY.md:19 src/welcome-day-1/what-is-rust.md:1
 msgid "What is Rust?"
 msgstr "Was ist Rust?"
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:20 src/hello-world.md:1
 msgid "Hello World!"
 msgstr "Hallo Welt!"
 
-#: src/SUMMARY.md:21
+#: src/SUMMARY.md:21 src/hello-world/small-example.md:1
 msgid "Small Example"
 msgstr "Ein kleines Beispiel"
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:22 src/why-rust.md:1
 msgid "Why Rust?"
 msgstr "Warum Rust?"
 
-#: src/SUMMARY.md:23
+#: src/SUMMARY.md:23 src/why-rust/compile-time.md:1
 msgid "Compile Time Guarantees"
 msgstr "Kompilierzeitgarantien"
 
-#: src/SUMMARY.md:24
+#: src/SUMMARY.md:24 src/why-rust/runtime.md:1
 msgid "Runtime Guarantees"
 msgstr "Laufzeitgarantien"
 
-#: src/SUMMARY.md:25
+#: src/SUMMARY.md:25 src/why-rust/modern.md:1
 msgid "Modern Features"
 msgstr "Moderne Merkmale"
 
-#: src/SUMMARY.md:26
+#: src/SUMMARY.md:26 src/basic-syntax.md:1
 msgid "Basic Syntax"
 msgstr "Grundlegende Syntax"
 
-#: src/SUMMARY.md:27
+#: src/SUMMARY.md:27 src/basic-syntax/scalar-types.md:1
 msgid "Scalar Types"
 msgstr "Skalare Typen"
 
-#: src/SUMMARY.md:28
+#: src/SUMMARY.md:28 src/basic-syntax/compound-types.md:1
 msgid "Compound Types"
 msgstr "Verbundtypen"
 
-#: src/SUMMARY.md:29
+#: src/SUMMARY.md:29 src/basic-syntax/references.md:1
 msgid "References"
 msgstr "Referenzen"
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:30 src/basic-syntax/references-dangling.md:1
 msgid "Dangling References"
 msgstr "Hängende Referenzen"
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:31 src/basic-syntax/slices.md:1
 msgid "Slices"
 msgstr "Anteilstypen"
 
@@ -113,15 +112,16 @@ msgstr "Anteilstypen"
 msgid "String vs str"
 msgstr "String vs. str"
 
-#: src/SUMMARY.md:33
+#: src/SUMMARY.md:33 src/basic-syntax/functions.md:1
 msgid "Functions"
 msgstr "Funktionen"
 
-#: src/SUMMARY.md:34
+#: src/SUMMARY.md:34 src/basic-syntax/rustdoc.md:1
 msgid "Rustdoc"
-msgstr ""
+msgstr "Rustdoc"
 
-#: src/SUMMARY.md:35 src/SUMMARY.md:82
+#: src/SUMMARY.md:35 src/SUMMARY.md:82 src/basic-syntax/methods.md:1
+#: src/methods.md:1
 msgid "Methods"
 msgstr "Methoden"
 
@@ -132,10 +132,14 @@ msgstr "Überladen"
 #: src/SUMMARY.md:37 src/SUMMARY.md:66 src/SUMMARY.md:90 src/SUMMARY.md:119
 #: src/SUMMARY.md:148 src/SUMMARY.md:177 src/SUMMARY.md:204 src/SUMMARY.md:225
 #: src/SUMMARY.md:251 src/SUMMARY.md:273 src/SUMMARY.md:293
+#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
+#: src/exercises/bare-metal/afternoon.md:1
+#: src/exercises/concurrency/morning.md:1
+#: src/exercises/concurrency/afternoon.md:1
 msgid "Exercises"
 msgstr "Übungen"
 
-#: src/SUMMARY.md:38
+#: src/SUMMARY.md:38 src/exercises/day-1/implicit-conversions.md:1
 msgid "Implicit Conversions"
 msgstr "Implizite Konvertierungen"
 
@@ -147,11 +151,11 @@ msgstr "Arrays und for-Schleifen"
 msgid "Day 1: Afternoon"
 msgstr "Tag 1: Nachmittags"
 
-#: src/SUMMARY.md:43
+#: src/SUMMARY.md:43 src/basic-syntax/variables.md:1
 msgid "Variables"
 msgstr "Variablen"
 
-#: src/SUMMARY.md:44
+#: src/SUMMARY.md:44 src/basic-syntax/type-inference.md:1
 msgid "Type Inference"
 msgstr "Typinferenz"
 
@@ -159,11 +163,11 @@ msgstr "Typinferenz"
 msgid "static & const"
 msgstr "static & const"
 
-#: src/SUMMARY.md:46
+#: src/SUMMARY.md:46 src/basic-syntax/scopes-shadowing.md:1
 msgid "Scopes and Shadowing"
 msgstr "Gültigkeitsbereiche und Verschattungen"
 
-#: src/SUMMARY.md:47
+#: src/SUMMARY.md:47 src/memory-management.md:1
 msgid "Memory Management"
 msgstr "Speicherverwaltung"
 
@@ -171,15 +175,15 @@ msgstr "Speicherverwaltung"
 msgid "Stack vs Heap"
 msgstr "Stapelspeicher vs. Haldenspeicher"
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:49 src/memory-management/stack.md:1
 msgid "Stack Memory"
 msgstr "Stapelspeicher"
 
-#: src/SUMMARY.md:50
+#: src/SUMMARY.md:50 src/memory-management/manual.md:1
 msgid "Manual Memory Management"
 msgstr "Manuelle Speicherverwaltung"
 
-#: src/SUMMARY.md:51
+#: src/SUMMARY.md:51 src/memory-management/scope-based.md:1
 msgid "Scope-Based Memory Management"
 msgstr "Gültigkeitsbereichbasierte Speicherverwaltung"
 
@@ -191,59 +195,60 @@ msgstr "Automatische Speicherbereinigung"
 msgid "Rust Memory Management"
 msgstr "Rust Speicherverwaltung"
 
-#: src/SUMMARY.md:54
+#: src/SUMMARY.md:54 src/memory-management/comparison.md:1
 msgid "Comparison"
 msgstr "Vergleich"
 
-#: src/SUMMARY.md:55
+#: src/SUMMARY.md:55 src/ownership.md:1
 msgid "Ownership"
 msgstr "Eigentümerschaft"
 
-#: src/SUMMARY.md:56
+#: src/SUMMARY.md:56 src/ownership/move-semantics.md:1
 msgid "Move Semantics"
 msgstr "Semantik des Verschiebens"
 
-#: src/SUMMARY.md:57
+#: src/SUMMARY.md:57 src/ownership/moved-strings-rust.md:1
 msgid "Moved Strings in Rust"
 msgstr "Verschieben von String in Rust"
 
-#: src/SUMMARY.md:58
+#: src/SUMMARY.md:58 src/ownership/double-free-modern-cpp.md:1
 msgid "Double Frees in Modern C++"
 msgstr "Doppel-Freigabe-Fehler in modernem C++"
 
-#: src/SUMMARY.md:59
+#: src/SUMMARY.md:59 src/ownership/moves-function-calls.md:1
 msgid "Moves in Function Calls"
 msgstr "Verschieben in Funktionsaufrufen"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:60 src/ownership/copy-clone.md:1
 msgid "Copying and Cloning"
 msgstr "Kopieren und Klonen"
 
-#: src/SUMMARY.md:61
+#: src/SUMMARY.md:61 src/ownership/borrowing.md:1
 msgid "Borrowing"
 msgstr "Ausleihen"
 
-#: src/SUMMARY.md:62
+#: src/SUMMARY.md:62 src/ownership/shared-unique-borrows.md:1
 msgid "Shared and Unique Borrows"
 msgstr "Geteiltes und einmaliges Ausleihen"
 
-#: src/SUMMARY.md:63
+#: src/SUMMARY.md:63 src/ownership/lifetimes.md:1
 msgid "Lifetimes"
 msgstr "Lebensdauern"
 
-#: src/SUMMARY.md:64
+#: src/SUMMARY.md:64 src/ownership/lifetimes-function-calls.md:1
 msgid "Lifetimes in Function Calls"
 msgstr "Lebensdauern in Funktionsaufrufen"
 
-#: src/SUMMARY.md:65
+#: src/SUMMARY.md:65 src/ownership/lifetimes-data-structures.md:1
 msgid "Lifetimes in Data Structures"
 msgstr "Lebensdauern in Datenstrukturen"
 
-#: src/SUMMARY.md:67
+#: src/SUMMARY.md:67 src/exercises/day-1/book-library.md:1
+#: src/exercises/day-1/solutions-afternoon.md:3
 msgid "Designing a Library"
 msgstr "Entwerfen einer Bibliothek"
 
-#: src/SUMMARY.md:68
+#: src/SUMMARY.md:68 src/exercises/day-1/iterators-and-ownership.md:1
 msgid "Iterators and Ownership"
 msgstr "Iteratoren und Eigentümerschaft"
 
@@ -251,63 +256,64 @@ msgstr "Iteratoren und Eigentümerschaft"
 msgid "Day 2: Morning"
 msgstr "Tag 2: Morgens"
 
-#: src/SUMMARY.md:76
+#: src/SUMMARY.md:76 src/structs.md:1
 msgid "Structs"
 msgstr "Strukturen"
 
-#: src/SUMMARY.md:77
+#: src/SUMMARY.md:77 src/structs/tuple-structs.md:1
 msgid "Tuple Structs"
 msgstr "Tupelstrukturen"
 
-#: src/SUMMARY.md:78
+#: src/SUMMARY.md:78 src/structs/field-shorthand.md:1
 msgid "Field Shorthand Syntax"
 msgstr "Feld Abkürzungs Syntax"
 
-#: src/SUMMARY.md:79
+#: src/SUMMARY.md:79 src/enums.md:1
 msgid "Enums"
 msgstr "Aufzählungstypen"
 
-#: src/SUMMARY.md:80
+#: src/SUMMARY.md:80 src/enums/variant-payloads.md:1
 msgid "Variant Payloads"
 msgstr "Varianteninhalte"
 
-#: src/SUMMARY.md:81
+#: src/SUMMARY.md:81 src/enums/sizes.md:1
 msgid "Enum Sizes"
 msgstr "Größen von Aufzählungstypen"
 
-#: src/SUMMARY.md:83
+#: src/SUMMARY.md:83 src/methods/receiver.md:1
 msgid "Method Receiver"
 msgstr "Methodenempfänger"
 
 #: src/SUMMARY.md:84 src/SUMMARY.md:159 src/SUMMARY.md:272
+#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
 msgid "Example"
 msgstr "Beispiel"
 
-#: src/SUMMARY.md:85
+#: src/SUMMARY.md:85 src/pattern-matching.md:1
 msgid "Pattern Matching"
 msgstr "Musterabgleich"
 
-#: src/SUMMARY.md:86
+#: src/SUMMARY.md:86 src/pattern-matching/destructuring-enums.md:1
 msgid "Destructuring Enums"
 msgstr "Aufzählungstypen destrukturieren"
 
-#: src/SUMMARY.md:87
+#: src/SUMMARY.md:87 src/pattern-matching/destructuring-structs.md:1
 msgid "Destructuring Structs"
 msgstr "Strukturen destrukturieren"
 
-#: src/SUMMARY.md:88
+#: src/SUMMARY.md:88 src/pattern-matching/destructuring-arrays.md:1
 msgid "Destructuring Arrays"
 msgstr "Arrays destrukturieren"
 
-#: src/SUMMARY.md:89
+#: src/SUMMARY.md:89 src/pattern-matching/match-guards.md:1
 msgid "Match Guards"
 msgstr "Abgleichsbedingungen"
 
-#: src/SUMMARY.md:91
+#: src/SUMMARY.md:91 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
 msgstr "Gesundheitsstatistiken"
 
-#: src/SUMMARY.md:92
+#: src/SUMMARY.md:92 src/exercises/day-2/solutions-morning.md:3
 msgid "Points and Polygons"
 msgstr "Punkte und Polygone"
 
@@ -315,11 +321,11 @@ msgstr "Punkte und Polygone"
 msgid "Day 2: Afternoon"
 msgstr "Tag 2: Nachmittags"
 
-#: src/SUMMARY.md:96 src/SUMMARY.md:286
+#: src/SUMMARY.md:96 src/SUMMARY.md:286 src/control-flow.md:1
 msgid "Control Flow"
 msgstr "Kontrollfluss"
 
-#: src/SUMMARY.md:97
+#: src/SUMMARY.md:97 src/control-flow/blocks.md:1
 msgid "Blocks"
 msgstr "Blöcke"
 
@@ -355,7 +361,7 @@ msgstr "match-Ausdrücke"
 msgid "break & continue"
 msgstr "break & continue"
 
-#: src/SUMMARY.md:106
+#: src/SUMMARY.md:106 src/std.md:1
 msgid "Standard Library"
 msgstr "Standardbibliothek"
 
@@ -363,7 +369,7 @@ msgstr "Standardbibliothek"
 msgid "Option and Result"
 msgstr "Option und Result"
 
-#: src/SUMMARY.md:108
+#: src/SUMMARY.md:108 src/std/string.md:1
 msgid "String"
 msgstr "String"
 
@@ -383,7 +389,7 @@ msgstr "Box"
 msgid "Recursive Data Types"
 msgstr "Rekursive Datentypen"
 
-#: src/SUMMARY.md:113
+#: src/SUMMARY.md:113 src/std/box-niche.md:1
 msgid "Niche Optimization"
 msgstr "Nischenoptimierung"
 
@@ -391,27 +397,29 @@ msgstr "Nischenoptimierung"
 msgid "Rc"
 msgstr "Rc"
 
-#: src/SUMMARY.md:115
+#: src/SUMMARY.md:115 src/modules.md:1
 msgid "Modules"
 msgstr "Module"
 
-#: src/SUMMARY.md:116
+#: src/SUMMARY.md:116 src/modules/visibility.md:1
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: src/SUMMARY.md:117
+#: src/SUMMARY.md:117 src/modules/paths.md:1
 msgid "Paths"
 msgstr "Pfade"
 
-#: src/SUMMARY.md:118
+#: src/SUMMARY.md:118 src/modules/filesystem.md:1
 msgid "Filesystem Hierarchy"
 msgstr "Dateisystemhierarchie"
 
-#: src/SUMMARY.md:120
+#: src/SUMMARY.md:120 src/exercises/day-2/luhn.md:1
+#: src/exercises/day-2/solutions-afternoon.md:3
 msgid "Luhn Algorithm"
 msgstr "Luhn-Algorithmus"
 
-#: src/SUMMARY.md:121
+#: src/SUMMARY.md:121 src/exercises/day-2/strings-iterators.md:1
+#: src/exercises/day-2/solutions-afternoon.md:97
 msgid "Strings and Iterators"
 msgstr "Strings und Iteratoren"
 
@@ -419,39 +427,39 @@ msgstr "Strings und Iteratoren"
 msgid "Day 3: Morning"
 msgstr "Tag 3: Morgens"
 
-#: src/SUMMARY.md:129
+#: src/SUMMARY.md:129 src/generics.md:1
 msgid "Generics"
 msgstr "Generische Datentypen und Methoden"
 
-#: src/SUMMARY.md:130
+#: src/SUMMARY.md:130 src/generics/data-types.md:1
 msgid "Generic Data Types"
 msgstr "Generische Datentypen"
 
-#: src/SUMMARY.md:131
+#: src/SUMMARY.md:131 src/generics/methods.md:1
 msgid "Generic Methods"
 msgstr "Generische Methoden"
 
-#: src/SUMMARY.md:132
+#: src/SUMMARY.md:132 src/generics/monomorphization.md:1
 msgid "Monomorphization"
 msgstr "Monomorphisierung"
 
-#: src/SUMMARY.md:133
+#: src/SUMMARY.md:133 src/traits.md:1
 msgid "Traits"
 msgstr "Merkmale"
 
-#: src/SUMMARY.md:134
+#: src/SUMMARY.md:134 src/traits/trait-objects.md:1
 msgid "Trait Objects"
 msgstr "Merkmalsobjekte"
 
-#: src/SUMMARY.md:135
+#: src/SUMMARY.md:135 src/traits/deriving-traits.md:1
 msgid "Deriving Traits"
 msgstr "Ableitung von Merkmalen"
 
-#: src/SUMMARY.md:136
+#: src/SUMMARY.md:136 src/traits/default-methods.md:1
 msgid "Default Methods"
 msgstr "Standardmethoden"
 
-#: src/SUMMARY.md:137
+#: src/SUMMARY.md:137 src/traits/trait-bounds.md:1
 msgid "Trait Bounds"
 msgstr "Merkmalsgrenzen"
 
@@ -459,7 +467,7 @@ msgstr "Merkmalsgrenzen"
 msgid "impl Trait"
 msgstr "impl Merkmal"
 
-#: src/SUMMARY.md:139
+#: src/SUMMARY.md:139 src/traits/important-traits.md:1
 msgid "Important Traits"
 msgstr "Wichtige Merkmale"
 
@@ -467,7 +475,7 @@ msgstr "Wichtige Merkmale"
 msgid "Iterator"
 msgstr "Iterator"
 
-#: src/SUMMARY.md:141
+#: src/SUMMARY.md:141 src/traits/from-iterator.md:1
 msgid "FromIterator"
 msgstr "FromIterator"
 
@@ -495,7 +503,8 @@ msgstr "Operatoren: Add, Mul, ..."
 msgid "Closures: Fn, FnMut, FnOnce"
 msgstr ""
 
-#: src/SUMMARY.md:149
+#: src/SUMMARY.md:149 src/exercises/day-3/simple-gui.md:1
+#: src/exercises/day-3/solutions-morning.md:3
 msgid "A Simple GUI Library"
 msgstr "Eine einfache GUI-Bibliothek"
 
@@ -503,11 +512,11 @@ msgstr "Eine einfache GUI-Bibliothek"
 msgid "Day 3: Afternoon"
 msgstr "Tag 3: Nachmittags"
 
-#: src/SUMMARY.md:153
+#: src/SUMMARY.md:153 src/error-handling.md:1
 msgid "Error Handling"
 msgstr "Fehlerbehandlung"
 
-#: src/SUMMARY.md:154
+#: src/SUMMARY.md:154 src/error-handling/panics.md:1
 msgid "Panics"
 msgstr "Laufzeitabbrüche"
 
@@ -523,67 +532,68 @@ msgstr "Strukturierte Fehlerbehandlung"
 msgid "Propagating Errors with ?"
 msgstr "Weitergabe von Fehlern mit ?"
 
-#: src/SUMMARY.md:158
+#: src/SUMMARY.md:158 src/error-handling/converting-error-types.md:1
+#: src/error-handling/converting-error-types-example.md:1
 msgid "Converting Error Types"
 msgstr "Fehlertypen konvertieren"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:160 src/error-handling/deriving-error-enums.md:1
 msgid "Deriving Error Enums"
 msgstr "Ableiten von Fehleraufzählungen"
 
-#: src/SUMMARY.md:161
+#: src/SUMMARY.md:161 src/error-handling/dynamic-errors.md:1
 msgid "Dynamic Error Types"
 msgstr "Dynamische Fehlertypen"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:162 src/error-handling/error-contexts.md:1
 msgid "Adding Context to Errors"
 msgstr "Kontext zu Fehlern hinzufügen"
 
-#: src/SUMMARY.md:163
+#: src/SUMMARY.md:163 src/testing.md:1
 msgid "Testing"
 msgstr "Testen"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:164 src/testing/unit-tests.md:1
 msgid "Unit Tests"
 msgstr "Unit-Tests"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:165 src/testing/test-modules.md:1
 msgid "Test Modules"
 msgstr "Testmodule"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:166 src/testing/doc-tests.md:1
 msgid "Documentation Tests"
 msgstr "Dokumentationstests"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:167 src/testing/integration-tests.md:1
 msgid "Integration Tests"
 msgstr "Integrationstests"
 
-#: src/SUMMARY.md:168
+#: src/SUMMARY.md:168 src/bare-metal/useful-crates.md:1
 msgid "Useful crates"
 msgstr "Nützliche Kisten (Crates)"
 
-#: src/SUMMARY.md:169
+#: src/SUMMARY.md:169 src/unsafe.md:1
 msgid "Unsafe Rust"
 msgstr "Unsicheres Rust"
 
-#: src/SUMMARY.md:170
+#: src/SUMMARY.md:170 src/unsafe/raw-pointers.md:1
 msgid "Dereferencing Raw Pointers"
 msgstr "Roh-zeiger dereferenzieren"
 
-#: src/SUMMARY.md:171
+#: src/SUMMARY.md:171 src/unsafe/mutable-static-variables.md:1
 msgid "Mutable Static Variables"
 msgstr "Veränderbare statische Variablen"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:172 src/unsafe/unions.md:1
 msgid "Unions"
 msgstr "Vereinigungen"
 
-#: src/SUMMARY.md:173
+#: src/SUMMARY.md:173 src/unsafe/calling-unsafe-functions.md:1
 msgid "Calling Unsafe Functions"
 msgstr "Unsichere Funktionen aufrufen"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:174 src/unsafe/writing-unsafe-functions.md:1
 msgid "Writing Unsafe Functions"
 msgstr "Unsichere Funktionen schreiben"
 
@@ -591,23 +601,25 @@ msgstr "Unsichere Funktionen schreiben"
 msgid "Extern Functions"
 msgstr "Externe Funktionen"
 
-#: src/SUMMARY.md:176
+#: src/SUMMARY.md:176 src/unsafe/unsafe-traits.md:1
 msgid "Implementing Unsafe Traits"
 msgstr "Unsichere Merkmale implementieren"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:178 src/exercises/day-3/safe-ffi-wrapper.md:1
+#: src/exercises/day-3/solutions-afternoon.md:3
 msgid "Safe FFI Wrapper"
 msgstr "Sicherer FFI-Wrapper"
 
 #: src/SUMMARY.md:181 src/SUMMARY.md:249
+#: src/running-the-course/course-structure.md:16 src/bare-metal/android.md:1
 msgid "Android"
 msgstr "Android"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:186 src/android/setup.md:1
 msgid "Setup"
 msgstr "Einrichtung"
 
-#: src/SUMMARY.md:187
+#: src/SUMMARY.md:187 src/android/build-rules.md:1
 msgid "Build Rules"
 msgstr "Regeln beim Bauen"
 
@@ -619,7 +631,7 @@ msgstr "Binärdatei"
 msgid "Library"
 msgstr "Bibliothek"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:190 src/android/aidl.md:1
 msgid "AIDL"
 msgstr "AIDL"
 
@@ -635,7 +647,7 @@ msgstr "Implementierung"
 msgid "Server"
 msgstr "Server"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:194 src/android/aidl/deploy.md:1
 msgid "Deploy"
 msgstr "Einsetzen"
 
@@ -643,15 +655,16 @@ msgstr "Einsetzen"
 msgid "Client"
 msgstr "Klient"
 
-#: src/SUMMARY.md:196
+#: src/SUMMARY.md:196 src/android/aidl/changing.md:1
 msgid "Changing API"
 msgstr "API verändern"
 
-#: src/SUMMARY.md:197 src/SUMMARY.md:240
+#: src/SUMMARY.md:197 src/SUMMARY.md:240 src/android/logging.md:1
+#: src/bare-metal/aps/logging.md:1
 msgid "Logging"
 msgstr "Protokollierung"
 
-#: src/SUMMARY.md:198
+#: src/SUMMARY.md:198 src/android/interoperability.md:1
 msgid "Interoperability"
 msgstr "Interoperabilität"
 
@@ -667,7 +680,7 @@ msgstr "Aufruf von C-Funktionen mit Bindgen"
 msgid "Calling Rust from C"
 msgstr "Aufruf von Rust aus C"
 
-#: src/SUMMARY.md:202
+#: src/SUMMARY.md:202 src/android/interoperability/cpp.md:1
 msgid "With C++"
 msgstr "Mit C++"
 
@@ -691,11 +704,11 @@ msgstr "Kleines Beispiel"
 msgid "alloc"
 msgstr ""
 
-#: src/SUMMARY.md:215
+#: src/SUMMARY.md:215 src/bare-metal/microcontrollers.md:1
 msgid "Microcontrollers"
 msgstr "Mikrokontroller"
 
-#: src/SUMMARY.md:216
+#: src/SUMMARY.md:216 src/bare-metal/microcontrollers/mmio.md:1
 msgid "Raw MMIO"
 msgstr "MMIO"
 
@@ -723,7 +736,7 @@ msgstr ""
 msgid "probe-rs, cargo-embed"
 msgstr ""
 
-#: src/SUMMARY.md:223
+#: src/SUMMARY.md:223 src/bare-metal/microcontrollers/debugging.md:1
 msgid "Debugging"
 msgstr "Debugging"
 
@@ -731,7 +744,8 @@ msgstr "Debugging"
 msgid "Other Projects"
 msgstr "Andere Ressourcen"
 
-#: src/SUMMARY.md:226
+#: src/SUMMARY.md:226 src/exercises/bare-metal/compass.md:1
+#: src/exercises/bare-metal/solutions-morning.md:3
 msgid "Compass"
 msgstr "Kompass"
 
@@ -763,7 +777,7 @@ msgstr "Noch mehr Merkmale"
 msgid "A Better UART Driver"
 msgstr "Ein besserer UART Treiber"
 
-#: src/SUMMARY.md:236
+#: src/SUMMARY.md:236 src/bare-metal/aps/better-uart/bitflags.md:1
 msgid "Bitflags"
 msgstr ""
 
@@ -771,7 +785,7 @@ msgstr ""
 msgid "Multiple Registers"
 msgstr "Mehrere Register"
 
-#: src/SUMMARY.md:238
+#: src/SUMMARY.md:238 src/bare-metal/aps/better-uart/driver.md:1
 msgid "Driver"
 msgstr "Treiber"
 
@@ -803,7 +817,7 @@ msgstr ""
 msgid "spin"
 msgstr ""
 
-#: src/SUMMARY.md:250
+#: src/SUMMARY.md:250 src/bare-metal/android/vmbase.md:1
 msgid "vmbase"
 msgstr ""
 
@@ -815,23 +829,23 @@ msgstr "RTC Treiber"
 msgid "Concurrency: Morning"
 msgstr "Nebenläufigkeit: Morgens"
 
-#: src/SUMMARY.md:260
+#: src/SUMMARY.md:260 src/concurrency/threads.md:1
 msgid "Threads"
 msgstr "Ausführungsstrang"
 
-#: src/SUMMARY.md:261
+#: src/SUMMARY.md:261 src/concurrency/scoped-threads.md:1
 msgid "Scoped Threads"
 msgstr "Ausführungsstrang mit Sichtbarkeitsbereich"
 
-#: src/SUMMARY.md:262
+#: src/SUMMARY.md:262 src/concurrency/channels.md:1
 msgid "Channels"
 msgstr "Kanäle"
 
-#: src/SUMMARY.md:263
+#: src/SUMMARY.md:263 src/concurrency/channels/unbounded.md:1
 msgid "Unbounded Channels"
 msgstr "Unbegrenzte Kanäle"
 
-#: src/SUMMARY.md:264
+#: src/SUMMARY.md:264 src/concurrency/channels/bounded.md:1
 msgid "Bounded Channels"
 msgstr "Unbeschränkte Kanäle"
 
@@ -847,11 +861,11 @@ msgstr "Send"
 msgid "Sync"
 msgstr "Sync"
 
-#: src/SUMMARY.md:268
+#: src/SUMMARY.md:268 src/concurrency/send-sync/examples.md:1
 msgid "Examples"
 msgstr "Beispiele"
 
-#: src/SUMMARY.md:269
+#: src/SUMMARY.md:269 src/concurrency/shared_state.md:1
 msgid "Shared State"
 msgstr "Geteilter Zustand"
 
@@ -864,10 +878,12 @@ msgid "Mutex"
 msgstr "Mutex"
 
 #: src/SUMMARY.md:274 src/SUMMARY.md:294
+#: src/exercises/concurrency/dining-philosophers.md:1
+#: src/exercises/concurrency/solutions-morning.md:3
 msgid "Dining Philosophers"
 msgstr "Philosophenproblem"
 
-#: src/SUMMARY.md:275
+#: src/SUMMARY.md:275 src/exercises/concurrency/link-checker.md:1
 msgid "Multi-threaded Link Checker"
 msgstr "Link Überprüfung mit mehreren Ausführungssträngen"
 
@@ -883,33 +899,36 @@ msgstr "Async Grundlagen"
 msgid "async/await"
 msgstr ""
 
-#: src/SUMMARY.md:281
+#: src/SUMMARY.md:281 src/async/futures.md:1
+#, fuzzy
 msgid "Futures"
-msgstr ""
+msgstr "Schließungen"
 
-#: src/SUMMARY.md:282
+#: src/SUMMARY.md:282 src/async/runtimes.md:1
 msgid "Runtimes"
 msgstr "Laufzeiten"
 
-#: src/SUMMARY.md:283
+#: src/SUMMARY.md:283 src/async/runtimes/tokio.md:1
 msgid "Tokio"
 msgstr ""
 
-#: src/SUMMARY.md:284
+#: src/SUMMARY.md:284 src/exercises/concurrency/link-checker.md:106
+#: src/exercises/concurrency/chat-app.md:140 src/async/tasks.md:1
 msgid "Tasks"
 msgstr "Aufgaben"
 
-#: src/SUMMARY.md:285
+#: src/SUMMARY.md:285 src/async/channels.md:1
 msgid "Async Channels"
 msgstr "Async Kanäle"
 
-#: src/SUMMARY.md:287
+#: src/SUMMARY.md:287 src/async/control-flow/join.md:1
 msgid "Join"
 msgstr ""
 
-#: src/SUMMARY.md:288
+#: src/SUMMARY.md:288 src/async/control-flow/select.md:1
+#, fuzzy
 msgid "Select"
-msgstr ""
+msgstr "Aufstellen"
 
 #: src/SUMMARY.md:289
 msgid "Pitfalls"
@@ -919,15 +938,16 @@ msgstr "Tücken"
 msgid "Blocking the Executor"
 msgstr "Blockieren des Ausführers"
 
-#: src/SUMMARY.md:291
+#: src/SUMMARY.md:291 src/async/pitfalls/pin.md:1
 msgid "Pin"
 msgstr ""
 
-#: src/SUMMARY.md:292
+#: src/SUMMARY.md:292 src/async/pitfalls/async-traits.md:1
 msgid "Async Traits"
 msgstr "Async Merkmale"
 
-#: src/SUMMARY.md:295
+#: src/SUMMARY.md:295 src/exercises/concurrency/chat-app.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:113
 msgid "Broadcast Chat Application"
 msgstr ""
 
@@ -935,7 +955,7 @@ msgstr ""
 msgid "Final Words"
 msgstr "Letzte Worte"
 
-#: src/SUMMARY.md:302
+#: src/SUMMARY.md:302 src/thanks.md:1
 msgid "Thanks!"
 msgstr "Danke!"
 
@@ -943,11 +963,11 @@ msgstr "Danke!"
 msgid "Other Resources"
 msgstr "Andere Ressourcen"
 
-#: src/SUMMARY.md:304
+#: src/SUMMARY.md:304 src/credits.md:1
 msgid "Credits"
 msgstr "Würdigungen"
 
-#: src/SUMMARY.md:307
+#: src/SUMMARY.md:307 src/exercises/solutions.md:1
 msgid "Solutions"
 msgstr "Lösungen"
 
@@ -979,7 +999,7 @@ msgstr "Tag 3 Nachmittags"
 msgid "Bare Metal Rust Morning"
 msgstr "Hardwarenahes Rust: Morgens"
 
-#: src/SUMMARY.md:319
+#: src/SUMMARY.md:319 src/exercises/bare-metal/solutions-afternoon.md:1
 msgid "Bare Metal Rust Afternoon"
 msgstr "Hadwarenahes Rust: Nachmittags"
 
@@ -990,10 +1010,6 @@ msgstr "Nebenläufigkeit Morgens"
 #: src/SUMMARY.md:321
 msgid "Concurrency Afternoon"
 msgstr "Nebenläufigkeit Nachmittags"
-
-#: src/welcome.md:1
-msgid "# Welcome to Comprehensive Rust 🦀"
-msgstr "# Willkommen bei Comprehensive Rust 🦀"
 
 #: src/welcome.md:3
 msgid ""
@@ -1010,8 +1026,8 @@ msgstr ""
 msgid ""
 "[![Build workflow](https://img.shields.io/github/actions/workflow/status/"
 "google/comprehensive-rust/build.yml?style=flat-square)](https://github.com/"
-"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain)\n"
-"[![GitHub contributors](https://img.shields.io/github/contributors/google/"
+"google/comprehensive-rust/actions/workflows/build.yml?query=branch%3Amain) [!"
+"[GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
 "comprehensive-rust/graphs/contributors)"
 msgstr ""
@@ -1024,10 +1040,9 @@ msgstr "Github Beiträger"
 msgid ""
 "[![GitHub contributors](https://img.shields.io/github/contributors/google/"
 "comprehensive-rust?style=flat-square)](https://github.com/google/"
-"comprehensive-rust/graphs/contributors)\n"
-"[![GitHub stars](https://img.shields.io/github/stars/google/comprehensive-"
-"rust?style=flat-square)](https://github.com/google/comprehensive-rust/"
-"stargazers)"
+"comprehensive-rust/graphs/contributors) [![GitHub stars](https://img.shields."
+"io/github/stars/google/comprehensive-rust?style=flat-square)](https://github."
+"com/google/comprehensive-rust/stargazers)"
 msgstr ""
 
 #: src/welcome.md:5
@@ -1044,363 +1059,145 @@ msgstr ""
 #: src/welcome.md:7
 msgid ""
 "This is a three day Rust course developed by the Android team. The course "
-"covers\n"
-"the full spectrum of Rust, from basic syntax to advanced topics like "
-"generics\n"
-"and error handling. It also includes Android-specific content on the last "
-"day."
+"covers the full spectrum of Rust, from basic syntax to advanced topics like "
+"generics and error handling. It also includes Android-specific content on "
+"the last day."
 msgstr ""
 "Dies ist ein dreitägiger Rust-Kurs, der vom Android-Team entwickelt wurde. "
-"Der Kurs umfasst\n"
-"das gesamte Spektrum von Rust, von grundlegender Syntax bis hin zu "
-"fortgeschrittenen Themen wie generischen Methoden und Datentypen\n"
+"Der Kurs umfasst das gesamte Spektrum von Rust, von grundlegender Syntax bis "
+"hin zu fortgeschrittenen Themen wie generischen Methoden und Datentypen "
 "sowie Fehlerbehandlung. Am letzten Tag werden auch Android-spezifische "
 "Inhalte behandelt."
 
 #: src/welcome.md:11
 msgid ""
 "The goal of the course is to teach you Rust. We assume you don't know "
-"anything\n"
-"about Rust and hope to:"
+"anything about Rust and hope to:"
 msgstr ""
 "Das Ziel des Kurses ist es, Dir Rust beizubringen. Wie setzen keine "
 "Vorkenntnisse über Rust voraus, und hoffen das Folgende zu erreichen:"
 
 #: src/welcome.md:14
-msgid ""
-"* Give you a comprehensive understanding of the Rust syntax and language.\n"
-"* Enable you to modify existing programs and write new programs in Rust.\n"
-"* Show you common Rust idioms."
+msgid "Give you a comprehensive understanding of the Rust syntax and language."
 msgstr ""
-"* Dir ein umfassendes Verständnis der Rust-Syntax und -Sprache  zu "
-"vermitteln.\n"
-"* Es dir ermöglichen, bestehende Programme zu modifizieren und neue "
-"Programme in Rust zu schreiben.\n"
-"* Dir gängige Rust-Idiome zu zeigen."
+"Dir ein umfassendes Verständnis der Rust-Syntax und -Sprache  zu vermitteln."
+
+#: src/welcome.md:15
+msgid "Enable you to modify existing programs and write new programs in Rust."
+msgstr ""
+"Es dir ermöglichen, bestehende Programme zu modifizieren und neue Programme "
+"in Rust zu schreiben."
+
+#: src/welcome.md:16
+msgid "Show you common Rust idioms."
+msgstr "Dir gängige Rust-Idiome zu zeigen."
 
 #: src/welcome.md:18
 msgid ""
 "The first three days show you the fundamentals of Rust. Following this, "
-"you're\n"
-"invited to dive into one or more specialized topics:"
+"you're invited to dive into one or more specialized topics:"
 msgstr ""
 "In den ersten drei Tagen zeigen wir die Grundlagen von Rust. Danach, laden "
-"wir dich ein\n"
-"sich mit einem oder mehreren Spezialthemen zu befassen:"
+"wir dich ein sich mit einem oder mehreren Spezialthemen zu befassen:"
 
 #: src/welcome.md:21
 msgid ""
-"* [Android](android.md): a half-day course on using Rust for Android "
-"platform\n"
-"  development (AOSP). This includes interoperability with C, C++, and Java.\n"
-"* [Bare-metal](bare-metal.md): a full day class on using Rust for bare-"
-"metal\n"
-"  (embedded) development. Both microcontrollers and application processors "
-"are\n"
-"  covered.\n"
-"* [Concurrency](concurrency.md): a full day class on concurrency in Rust. "
-"We\n"
-"  cover both classical concurrency (preemptively scheduling using threads "
-"and\n"
-"  mutexes) and async/await concurrency (cooperative multitasking using\n"
-"  futures)."
+"[Android](android.md): a half-day course on using Rust for Android platform "
+"development (AOSP). This includes interoperability with C, C++, and Java."
 msgstr ""
-"* [Android](android.md): ein halbtägiger Kurs zur Verwendung von Rust für "
-"die Android-Plattform\n"
-"   Entwicklung (AOSP). Dazu gehört die Interoperabilität mit C, C++ und "
-"Java.\n"
-"* [Bare-Metal](bare-metal.md): ein ganztägiger Kurs über die Verwendung von "
-"Rust für Bare-Metal\n"
-"   (eingebettete) Entwicklung. Sowohl Mikrocontroller als auch "
-"Anwendungsprozessoren\n"
-"   bedeckt.\n"
-"* [Concurrency](concurrency.md): ein ganztägiger Kurs zum Thema Parallelität "
-"in Rust. Wir\n"
-"   decken sowohl die klassische Parallelität ab (präventive Planung mithilfe "
-"von Threads als auch\n"
-"   Mutexe) und Async/Await-Parallelität (kooperatives Multitasking mit\n"
-"   Futures)."
+"[Android](android.md): ein halbtägiger Kurs zur Verwendung von Rust für die "
+"Android-Plattform Entwicklung (AOSP). Dazu gehört die Interoperabilität mit "
+"C, C++ und Java."
+
+#: src/welcome.md:23
+msgid ""
+"[Bare-metal](bare-metal.md): a full day class on using Rust for bare-metal "
+"(embedded) development. Both microcontrollers and application processors are "
+"covered."
+msgstr ""
+"[Bare-Metal](bare-metal.md): ein ganztägiger Kurs über die Verwendung von "
+"Rust für Bare-Metal (eingebettete) Entwicklung. Sowohl Mikrocontroller als "
+"auch Anwendungsprozessoren bedeckt."
+
+#: src/welcome.md:26
+msgid ""
+"[Concurrency](concurrency.md): a full day class on concurrency in Rust. We "
+"cover both classical concurrency (preemptively scheduling using threads and "
+"mutexes) and async/await concurrency (cooperative multitasking using "
+"futures)."
+msgstr ""
+"[Concurrency](concurrency.md): ein ganztägiger Kurs zum Thema Parallelität "
+"in Rust. Wir decken sowohl die klassische Parallelität ab (präventive "
+"Planung mithilfe von Threads als auch Mutexe) und Async/Await-Parallelität "
+"(kooperatives Multitasking mit Futures)."
 
 #: src/welcome.md:32
-msgid "## Non-Goals"
-msgstr "## Nicht-Ziele"
+msgid "Non-Goals"
+msgstr "Nicht-Ziele"
 
 #: src/welcome.md:34
 msgid ""
 "Rust is a large language and we won't be able to cover all of it in a few "
-"days.\n"
-"Some non-goals of this course are:"
+"days. Some non-goals of this course are:"
 msgstr ""
 "Rust ist eine große Sprache und wir werden sie in ein paar Tagen nicht "
-"vollständig abdecken können.\n"
-"Einige Nicht-Ziele dieses Kurses sind:"
+"vollständig abdecken können. Einige Nicht-Ziele dieses Kurses sind:"
 
 #: src/welcome.md:37
 msgid ""
-"* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-"  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-"  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
+"Learn how to develop macros, please see [Chapter 19.5 in the Rust Book]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by Example]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html) instead."
 msgstr ""
-"* Um zu erfahren, wie Du Makros entwickelst, siehe [Kapitel 19.5 im Rust\n"
-"   Buch](https://doc.rust-lang.org/book/ch19-06-macros.html) und [Rust im\n"
-"   Beispiel](https://doc.rust-lang.org/rust-by-example/macros.html)."
+"Um zu erfahren, wie Du Makros entwickelst, siehe [Kapitel 19.5 im Rust Buch]"
+"(https://doc.rust-lang.org/book/ch19-06-macros.html) und [Rust im Beispiel]"
+"(https://doc.rust-lang.org/rust-by-example/macros.html)."
 
 #: src/welcome.md:41
-msgid "## Assumptions"
-msgstr "## Annahmen"
+msgid "Assumptions"
+msgstr "Annahmen"
 
 #: src/welcome.md:43
 msgid ""
 "The course assumes that you already know how to program. Rust is a "
-"statically\n"
-"typed language and we will sometimes make comparisons with C and C++ to "
-"better\n"
-"explain or contrast the Rust approach."
+"statically typed language and we will sometimes make comparisons with C and "
+"C++ to better explain or contrast the Rust approach."
 msgstr ""
 "Der Kurs setzt voraus, dass du bereits Programmierkenntnisse besitzt. Rust "
-"ist eine statisch\n"
-"typisierte Sprache und wir werden manchmal Vergleiche mit C und C++ machen, "
-"um besser den Rust-Ansatz zu erklären oder gegenüberzustellen."
+"ist eine statisch typisierte Sprache und wir werden manchmal Vergleiche mit "
+"C und C++ machen, um besser den Rust-Ansatz zu erklären oder "
+"gegenüberzustellen."
 
 #: src/welcome.md:47
 msgid ""
-"If you know how to program in a dynamically typed language such as Python "
-"or\n"
+"If you know how to program in a dynamically typed language such as Python or "
 "JavaScript, then you will be able to follow along just fine too."
 msgstr ""
 "Aber auch wenn du Vorwissen in einer dynamisch typisierten Sprache wie "
-"Python oder\n"
-"JavaScript hast, wirst du problemlos folgen können."
-
-#: src/welcome.md:50 src/cargo/rust-ecosystem.md:19
-#: src/cargo/code-samples.md:22 src/cargo/running-locally.md:68
-#: src/welcome-day-1.md:14 src/welcome-day-1/what-is-rust.md:19
-#: src/hello-world.md:20 src/hello-world/small-example.md:21 src/why-rust.md:9
-#: src/why-rust/compile-time.md:14 src/why-rust/runtime.md:8
-#: src/why-rust/modern.md:19 src/basic-syntax/scalar-types.md:19
-#: src/basic-syntax/compound-types.md:28 src/basic-syntax/references.md:21
-#: src/basic-syntax/slices.md:18 src/basic-syntax/string-slices.md:25
-#: src/basic-syntax/functions.md:33 src/basic-syntax/rustdoc.md:22
-#: src/basic-syntax/methods.md:32 src/basic-syntax/functions-interlude.md:25
-#: src/exercises/day-1/morning.md:9 src/exercises/day-1/for-loops.md:90
-#: src/basic-syntax/variables.md:15 src/basic-syntax/type-inference.md:24
-#: src/basic-syntax/static-and-const.md:46
-#: src/basic-syntax/scopes-shadowing.md:23 src/memory-management/stack.md:26
-#: src/memory-management/rust.md:12 src/ownership/move-semantics.md:20
-#: src/ownership/moves-function-calls.md:18 src/ownership/copy-clone.md:33
-#: src/ownership/borrowing.md:25 src/ownership/shared-unique-borrows.md:23
-#: src/ownership/lifetimes-function-calls.md:27
-#: src/ownership/lifetimes-data-structures.md:23
-#: src/exercises/day-1/afternoon.md:9 src/exercises/day-1/book-library.md:100
-#: src/structs.md:29 src/structs/tuple-structs.md:35
-#: src/structs/field-shorthand.md:25 src/enums.md:32
-#: src/enums/variant-payloads.md:33 src/enums/sizes.md:27 src/methods.md:28
-#: src/methods/receiver.md:22 src/methods/example.md:44
-#: src/pattern-matching.md:23 src/pattern-matching/destructuring-enums.md:33
-#: src/pattern-matching/destructuring-structs.md:21
-#: src/pattern-matching/destructuring-arrays.md:19
-#: src/pattern-matching/match-guards.md:20 src/exercises/day-2/morning.md:9
-#: src/exercises/day-2/points-polygons.md:115 src/control-flow/blocks.md:40
-#: src/control-flow/if-expressions.md:33
-#: src/control-flow/if-let-expressions.md:21
-#: src/control-flow/while-let-expressions.md:24
-#: src/control-flow/for-expressions.md:23
-#: src/control-flow/loop-expressions.md:25
-#: src/control-flow/match-expressions.md:26 src/std.md:23
-#: src/std/option-result.md:16 src/std/string.md:28 src/std/vec.md:35
-#: src/std/hashmap.md:36 src/std/box.md:32 src/std/box-recursive.md:31
-#: src/std/rc.md:29 src/modules.md:26 src/modules/visibility.md:37
-#: src/modules/filesystem.md:42 src/exercises/day-2/afternoon.md:5
-#: src/generics/data-types.md:19 src/generics/methods.md:23
-#: src/traits/trait-objects.md:70 src/traits/default-methods.md:30
-#: src/traits/trait-bounds.md:33 src/traits/impl-trait.md:21
-#: src/traits/iterator.md:30 src/traits/from-iterator.md:15
-#: src/traits/from-into.md:27 src/traits/drop.md:32 src/traits/default.md:38
-#: src/traits/operators.md:24 src/traits/closures.md:23
-#: src/exercises/day-3/morning.md:5 src/error-handling/result.md:25
-#: src/error-handling/try-operator.md:46
-#: src/error-handling/converting-error-types-example.md:48
-#: src/error-handling/deriving-error-enums.md:37
-#: src/error-handling/dynamic-errors.md:34
-#: src/error-handling/error-contexts.md:33 src/unsafe.md:26
-#: src/unsafe/raw-pointers.md:25 src/unsafe/mutable-static-variables.md:30
-#: src/unsafe/unions.md:19 src/unsafe/writing-unsafe-functions.md:31
-#: src/unsafe/extern-functions.md:19 src/unsafe/unsafe-traits.md:28
-#: src/exercises/day-3/afternoon.md:5
-#: src/android/interoperability/with-c/rust.md:81
-#: src/exercises/android/morning.md:10 src/bare-metal/minimal.md:15
-#: src/bare-metal/alloc.md:37 src/bare-metal/microcontrollers.md:23
-#: src/bare-metal/microcontrollers/mmio.md:62
-#: src/bare-metal/microcontrollers/pacs.md:47
-#: src/bare-metal/microcontrollers/hals.md:37
-#: src/bare-metal/microcontrollers/board-support.md:26
-#: src/bare-metal/microcontrollers/type-state.md:30
-#: src/bare-metal/microcontrollers/embedded-hal.md:17
-#: src/bare-metal/microcontrollers/probe-rs.md:14
-#: src/bare-metal/microcontrollers/debugging.md:25
-#: src/bare-metal/microcontrollers/other-projects.md:16
-#: src/exercises/bare-metal/morning.md:5 src/bare-metal/aps.md:7
-#: src/bare-metal/aps/inline-assembly.md:41 src/bare-metal/aps/mmio.md:7
-#: src/bare-metal/aps/uart.md:53 src/bare-metal/aps/uart/traits.md:22
-#: src/bare-metal/aps/better-uart.md:24
-#: src/bare-metal/aps/better-uart/bitflags.md:35
-#: src/bare-metal/aps/better-uart/registers.md:39
-#: src/bare-metal/aps/better-uart/driver.md:62
-#: src/bare-metal/aps/better-uart/using.md:49 src/bare-metal/aps/logging.md:48
-#: src/bare-metal/aps/logging/using.md:44
-#: src/bare-metal/useful-crates/zerocopy.md:43
-#: src/bare-metal/useful-crates/aarch64-paging.md:26
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:24
-#: src/bare-metal/useful-crates/tinyvec.md:21
-#: src/bare-metal/useful-crates/spin.md:21 src/bare-metal/android/vmbase.md:19
-#: src/exercises/bare-metal/afternoon.md:5 src/concurrency/threads.md:28
-#: src/concurrency/scoped-threads.md:35 src/concurrency/channels.md:25
-#: src/concurrency/send-sync.md:18 src/concurrency/send-sync/send.md:11
-#: src/concurrency/send-sync/sync.md:12 src/concurrency/shared_state/arc.md:27
-#: src/concurrency/shared_state/mutex.md:29
-#: src/concurrency/shared_state/example.md:21
-#: src/exercises/concurrency/morning.md:10 src/async/async-await.md:23
-#: src/async/futures.md:30 src/async/runtimes.md:18
-#: src/async/runtimes/tokio.md:31 src/async/tasks.md:51
-#: src/async/channels.md:33 src/async/control-flow/join.md:34
-#: src/async/control-flow/select.md:59
-#: src/async/pitfalls/blocking-executor.md:27 src/async/pitfalls/pin.md:66
-#: src/exercises/concurrency/afternoon.md:11
-#: src/exercises/concurrency/dining-philosophers-async.md:75
-msgid "<details>"
-msgstr "<details>"
+"Python oder JavaScript hast, wirst du problemlos folgen können."
 
 #: src/welcome.md:52
 msgid ""
-"This is an example of a _speaker note_. We will use these to add additional\n"
+"This is an example of a _speaker note_. We will use these to add additional "
 "information to the slides. This could be key points which the instructor "
-"should\n"
-"cover as well as answers to typical questions which come up in class."
+"should cover as well as answers to typical questions which come up in class."
 msgstr ""
 "Dies ist ein Beispiel für eine _Sprechernotiz_, welche wir verwenden, um "
-"weitere \n"
-"Informationen zu den Folien hinzuzufügen. Sprechernotizen können wichtige "
-"Punkte \n"
-"beinhalten, die vom Kursleiter erwähnt werden sollten, oder auch Antworten "
-"auf \n"
-"Fragen, die typischerweise im Kurs vorkommen."
-
-#: src/welcome.md:56 src/cargo/rust-ecosystem.md:67
-#: src/cargo/code-samples.md:35 src/cargo/running-locally.md:74
-#: src/welcome-day-1.md:42 src/welcome-day-1/what-is-rust.md:29
-#: src/hello-world.md:40 src/hello-world/small-example.md:44 src/why-rust.md:24
-#: src/why-rust/compile-time.md:35 src/why-rust/runtime.md:22
-#: src/why-rust/modern.md:66 src/basic-syntax/scalar-types.md:43
-#: src/basic-syntax/compound-types.md:62 src/basic-syntax/references.md:29
-#: src/basic-syntax/slices.md:36 src/basic-syntax/string-slices.md:44
-#: src/basic-syntax/functions.md:41 src/basic-syntax/rustdoc.md:33
-#: src/basic-syntax/methods.md:45 src/basic-syntax/functions-interlude.md:30
-#: src/exercises/day-1/morning.md:28 src/exercises/day-1/for-loops.md:95
-#: src/basic-syntax/variables.md:20 src/basic-syntax/type-inference.md:48
-#: src/basic-syntax/static-and-const.md:52
-#: src/basic-syntax/scopes-shadowing.md:39 src/memory-management/stack.md:49
-#: src/memory-management/rust.md:18 src/ownership/move-semantics.md:26
-#: src/ownership/moves-function-calls.md:26 src/ownership/copy-clone.md:51
-#: src/ownership/borrowing.md:51 src/ownership/shared-unique-borrows.md:29
-#: src/ownership/lifetimes-function-calls.md:60
-#: src/ownership/lifetimes-data-structures.md:30
-#: src/exercises/day-1/afternoon.md:15 src/exercises/day-1/book-library.md:104
-#: src/structs.md:42 src/structs/tuple-structs.md:43
-#: src/structs/field-shorthand.md:72 src/enums.md:42
-#: src/enums/variant-payloads.md:45 src/enums/sizes.md:155 src/methods.md:41
-#: src/methods/receiver.md:28 src/methods/example.md:53
-#: src/pattern-matching.md:35 src/pattern-matching/destructuring-enums.md:39
-#: src/pattern-matching/destructuring-structs.md:29
-#: src/pattern-matching/destructuring-arrays.md:46
-#: src/pattern-matching/match-guards.md:28 src/exercises/day-2/morning.md:15
-#: src/exercises/day-2/points-polygons.md:125 src/control-flow/blocks.md:46
-#: src/control-flow/if-expressions.md:37
-#: src/control-flow/if-let-expressions.md:41
-#: src/control-flow/while-let-expressions.md:29
-#: src/control-flow/for-expressions.md:30
-#: src/control-flow/loop-expressions.md:32
-#: src/control-flow/match-expressions.md:33 src/std.md:31
-#: src/std/option-result.md:25 src/std/string.md:42 src/std/vec.md:49
-#: src/std/hashmap.md:66 src/std/box.md:39 src/std/box-recursive.md:41
-#: src/std/rc.md:69 src/modules.md:32 src/modules/visibility.md:48
-#: src/modules/filesystem.md:71 src/exercises/day-2/afternoon.md:11
-#: src/generics/data-types.md:25 src/generics/methods.md:31
-#: src/traits/trait-objects.md:83 src/traits/default-methods.md:60
-#: src/traits/trait-bounds.md:50 src/traits/impl-trait.md:44
-#: src/traits/iterator.md:42 src/traits/from-iterator.md:26
-#: src/traits/from-into.md:33 src/traits/drop.md:42 src/traits/default.md:47
-#: src/traits/operators.md:40 src/traits/closures.md:38
-#: src/exercises/day-3/morning.md:11 src/error-handling/result.md:33
-#: src/error-handling/try-operator.md:53
-#: src/error-handling/converting-error-types-example.md:60
-#: src/error-handling/deriving-error-enums.md:45
-#: src/error-handling/dynamic-errors.md:41
-#: src/error-handling/error-contexts.md:42 src/unsafe.md:32
-#: src/unsafe/raw-pointers.md:43 src/unsafe/mutable-static-variables.md:35
-#: src/unsafe/unions.md:28 src/unsafe/writing-unsafe-functions.md:38
-#: src/unsafe/extern-functions.md:28 src/unsafe/unsafe-traits.md:37
-#: src/exercises/day-3/afternoon.md:11
-#: src/android/interoperability/with-c/rust.md:86
-#: src/exercises/android/morning.md:15 src/bare-metal/no_std.md:65
-#: src/bare-metal/minimal.md:26 src/bare-metal/alloc.md:49
-#: src/bare-metal/microcontrollers.md:29
-#: src/bare-metal/microcontrollers/mmio.md:72
-#: src/bare-metal/microcontrollers/pacs.md:65
-#: src/bare-metal/microcontrollers/hals.md:49
-#: src/bare-metal/microcontrollers/board-support.md:40
-#: src/bare-metal/microcontrollers/type-state.md:43
-#: src/bare-metal/microcontrollers/embedded-hal.md:23
-#: src/bare-metal/microcontrollers/probe-rs.md:29
-#: src/bare-metal/microcontrollers/debugging.md:38
-#: src/bare-metal/microcontrollers/other-projects.md:26
-#: src/exercises/bare-metal/morning.md:11 src/bare-metal/aps.md:15
-#: src/bare-metal/aps/inline-assembly.md:58 src/bare-metal/aps/mmio.md:17
-#: src/bare-metal/aps/uart/traits.md:27 src/bare-metal/aps/better-uart.md:28
-#: src/bare-metal/aps/better-uart/bitflags.md:40
-#: src/bare-metal/aps/better-uart/registers.md:46
-#: src/bare-metal/aps/better-uart/driver.md:67
-#: src/bare-metal/aps/better-uart/using.md:55 src/bare-metal/aps/logging.md:52
-#: src/bare-metal/aps/logging/using.md:49
-#: src/bare-metal/useful-crates/zerocopy.md:53
-#: src/bare-metal/useful-crates/aarch64-paging.md:33
-#: src/bare-metal/useful-crates/buddy_system_allocator.md:30
-#: src/bare-metal/useful-crates/tinyvec.md:26
-#: src/bare-metal/useful-crates/spin.md:30 src/bare-metal/android/vmbase.md:25
-#: src/exercises/bare-metal/afternoon.md:11 src/concurrency/threads.md:45
-#: src/concurrency/scoped-threads.md:40 src/concurrency/channels.md:32
-#: src/concurrency/send-sync.md:23 src/concurrency/send-sync/send.md:16
-#: src/concurrency/send-sync/sync.md:18 src/concurrency/shared_state/arc.md:38
-#: src/concurrency/shared_state/mutex.md:45
-#: src/concurrency/shared_state/example.md:56
-#: src/exercises/concurrency/morning.md:16 src/async/async-await.md:48
-#: src/async/futures.md:45 src/async/runtimes.md:29
-#: src/async/runtimes/tokio.md:49 src/async/tasks.md:64
-#: src/async/channels.md:49 src/async/control-flow/join.md:50
-#: src/async/control-flow/select.md:77
-#: src/async/pitfalls/blocking-executor.md:50 src/async/pitfalls/pin.md:112
-#: src/async/pitfalls/async-traits.md:63
-#: src/exercises/concurrency/afternoon.md:17
-#: src/exercises/concurrency/dining-philosophers-async.md:79
-msgid "</details>"
-msgstr "</details>"
-
-#: src/running-the-course.md:1
-msgid "# Running the Course"
-msgstr "# Ablauf des Kurses"
+"weitere  Informationen zu den Folien hinzuzufügen. Sprechernotizen können "
+"wichtige Punkte  beinhalten, die vom Kursleiter erwähnt werden sollten, oder "
+"auch Antworten auf  Fragen, die typischerweise im Kurs vorkommen."
 
 #: src/running-the-course.md:3 src/running-the-course/course-structure.md:3
-msgid "> This page is for the course instructor."
-msgstr "> Diese Seite ist für den Kursleiter."
+msgid "This page is for the course instructor."
+msgstr "Diese Seite ist für den Kursleiter."
 
 #: src/running-the-course.md:5
 msgid ""
 "Here is a bit of background information about how we've been running the "
-"course\n"
-"internally at Google."
+"course internally at Google."
 msgstr ""
 "Hier ein paar Hintergrundinformationen darüber, wie wir den Kurs intern bei "
-"Google \n"
-"durchführen."
+"Google  durchführen."
 
 #: src/running-the-course.md:8
 msgid "Before you run the course, you will want to:"
@@ -1409,245 +1206,224 @@ msgstr "Bevor du den Kurs vorstellst solltest du:"
 #: src/running-the-course.md:10
 #, fuzzy
 msgid ""
-"1. Make yourself familiar with the course material. We've included speaker "
-"notes\n"
-"   to help highlight the key points (please help us by contributing more "
-"speaker\n"
-"   notes!). When presenting, you should make sure to open the speaker notes "
-"in a\n"
-"   popup (click the link with a little arrow next to \"Speaker Notes\"). "
-"This way\n"
-"   you have a clean screen to present to the class.\n"
-"\n"
-"1. Decide on the dates. Since the course takes at least three full days, we "
-"recommend that you\n"
-"   schedule the days over two weeks. Course participants have said that\n"
-"   they find it helpful to have a gap in the course since it helps them "
-"process\n"
-"   all the information we give them.\n"
-"\n"
-"1. Find a room large enough for your in-person participants. We recommend a\n"
-"   class size of 15-25 people. That's small enough that people are "
-"comfortable\n"
-"   asking questions --- it's also small enough that one instructor will "
-"have\n"
-"   time to answer the questions. Make sure the room has _desks_ for yourself "
-"and for the\n"
-"   students: you will all need to be able to sit and work with your "
-"laptops.\n"
-"   In particular, you will be doing a lot of live-coding as an instructor, "
-"so a lectern won't\n"
-"   be very helpful for you.\n"
-"\n"
-"1. On the day of your course, show up to the room a little early to set "
-"things\n"
-"   up. We recommend presenting directly using `mdbook serve` running on "
-"your\n"
-"   laptop (see the [installation instructions][3]). This ensures optimal "
-"performance with no lag as you change pages.\n"
-"   Using your laptop will also allow you to fix typos as you or the course\n"
-"   participants spot them.\n"
-"\n"
-"1. Let people solve the exercises by themselves or in small groups.\n"
-"   We typically spend 30-45 minutes on exercises in the morning and in the "
-"afternoon (including time to review the solutions).\n"
-"   Make sure to\n"
-"   ask people if they're stuck or if there is anything you can help with. "
-"When\n"
-"   you see that several people have the same problem, call it out to the "
-"class\n"
-"   and offer a solution, e.g., by showing people where to find the relevant\n"
-"   information in the standard library."
+"Make yourself familiar with the course material. We've included speaker "
+"notes to help highlight the key points (please help us by contributing more "
+"speaker notes!). When presenting, you should make sure to open the speaker "
+"notes in a popup (click the link with a little arrow next to \"Speaker "
+"Notes\"). This way you have a clean screen to present to the class."
 msgstr ""
-"1. Setze dich mit dem Kursmaterial auseinander. Wir haben Sprechernotizen "
+"Setze dich mit dem Kursmaterial auseinander. Wir haben Sprechernotizen "
 "hinzugefügt, um Schlüsselpunkte hervorzuheben (gerne kannst du uns helfen "
 "weitere Sprechernotizen hinzuzufügen!). Beim Vorstellen kannst du die "
 "Sprechernotizen in einem Seitenfenster öffnen (klick dazu auf den kleinen "
 "Pfeil neben \"Speaker Notes\"). Dadurch hast du eine übersichtliche "
-"Oberfläche wenn du den Kurs vorstellst.\n"
-"1. Am Nachmittag des vierten Tages kannst du ein Thema frei wählen. Du "
-"kannst entweder ein Thema nach Schwierigkeitsgrad wählen, oder aber ein "
-"Thema was zu deiner Zuhörerschaft passt.\n"
-"1. Lege im Vorhinein die Kurszeiten fest. Der Kurs ist umfangreich, daher "
+"Oberfläche wenn du den Kurs vorstellst."
+
+#: src/running-the-course.md:16
+#, fuzzy
+msgid ""
+"Decide on the dates. Since the course takes at least three full days, we "
+"recommend that you schedule the days over two weeks. Course participants "
+"have said that they find it helpful to have a gap in the course since it "
+"helps them process all the information we give them."
+msgstr ""
+"Am Nachmittag des vierten Tages kannst du ein Thema frei wählen. Du kannst "
+"entweder ein Thema nach Schwierigkeitsgrad wählen, oder aber ein Thema was "
+"zu deiner Zuhörerschaft passt."
+
+#: src/running-the-course.md:21
+#, fuzzy
+msgid ""
+"Find a room large enough for your in-person participants. We recommend a "
+"class size of 15-25 people. That's small enough that people are comfortable "
+"asking questions --- it's also small enough that one instructor will have "
+"time to answer the questions. Make sure the room has _desks_ for yourself "
+"and for the students: you will all need to be able to sit and work with your "
+"laptops. In particular, you will be doing a lot of live-coding as an "
+"instructor, so a lectern won't be very helpful for you."
+msgstr ""
+"Lege im Vorhinein die Kurszeiten fest. Der Kurs ist umfangreich, daher "
 "empfehlen wir vier Tage in einem Zeitraum von zwei Wochen. Kursteilnehmer "
 "meinten, dass Pausen zwischen den Tagen sinnvoll seien um die Menge an "
-"Informationen zu verarbeiten.\n"
-"1. Finde einen Raum der groß genug für alle anwesenden Teilnehmer ist. Wir "
+"Informationen zu verarbeiten."
+
+#: src/running-the-course.md:29
+#, fuzzy
+msgid ""
+"On the day of your course, show up to the room a little early to set things "
+"up. We recommend presenting directly using `mdbook serve` running on your "
+"laptop (see the [installation instructions](https://github.com/google/"
+"comprehensive-rust#building)). This ensures optimal performance with no lag "
+"as you change pages. Using your laptop will also allow you to fix typos as "
+"you or the course participants spot them."
+msgstr ""
+"Finde einen Raum der groß genug für alle anwesenden Teilnehmer ist. Wir "
 "empfehlen eine Teilnehmeranzahl von 15 bis 20 Leuten. Das schafft ein gutes "
 "Klima, um Fragen zu stellen, und es ist möglich alle Fragen zeitnah zu "
 "beantworten. Stelle auch sicher, dass der Raum _Tische_ mit Stühlen für die "
 "Teilnehmer und dich hat. Ihr werdet nämlich eure Laptops benötigen. Um genau "
-"zu sein wirst du viel vorprogrammieren.\n"
-"1. Sei schon etwas vor dem ersten Termin da, um alles vorzubereiten. Wir "
+"zu sein wirst du viel vorprogrammieren."
+
+#: src/running-the-course.md:35
+#, fuzzy
+msgid ""
+"Let people solve the exercises by themselves or in small groups. We "
+"typically spend 30-45 minutes on exercises in the morning and in the "
+"afternoon (including time to review the solutions). Make sure to ask people "
+"if they're stuck or if there is anything you can help with. When you see "
+"that several people have the same problem, call it out to the class and "
+"offer a solution, e.g., by showing people where to find the relevant "
+"information in the standard library."
+msgstr ""
+"Sei schon etwas vor dem ersten Termin da, um alles vorzubereiten. Wir "
 "schlagen vor, dass du `mdbook serve` direkt präsentierst (siehe "
-"[Installationsanleitung][3]). Somit entstehen keine Störungen oder "
-"Unklarheiten bei dem Wechseln von Seiten und falls du oder die Teilnehmer "
-"Rechtschreibfehler finden können diese sofort behoben werden.\n"
-"1. Gib den Kursteilnehmern Zeit die Aufgaben selbst oder in kleinen Gruppen "
-"zu lösen. Vergiss nicht ab und an zu fragen ob jemand Hilfe benötigt. Wenn "
+"[Installationsanleitung](https://github.com/google/comprehensive-"
+"rust#building)). Somit entstehen keine Störungen oder Unklarheiten bei dem "
+"Wechseln von Seiten und falls du oder die Teilnehmer Rechtschreibfehler "
+"finden können diese sofort behoben werden.\n"
+"\n"
+"Gib den Kursteilnehmern Zeit die Aufgaben selbst oder in kleinen Gruppen zu "
+"lösen. Vergiss nicht ab und an zu fragen ob jemand Hilfe benötigt. Wenn "
 "mehrere Teilnehmer das gleiche Problem haben, spreche es vor allen "
 "Teilnehmern an und zeige einen möglichen Lösungsweg auf. Z. B. könntest du "
 "zeigen wo man die relevante Information in der Standardbibliothek findet.\n"
-"1. Bereite alles vor was du am Nachmittag des vierten Tages behandeln "
-"möchtest."
+"\n"
+"Bereite alles vor was du am Nachmittag des vierten Tages behandeln möchtest."
 
 #: src/running-the-course.md:43
 msgid ""
 "That is all, good luck running the course! We hope it will be as much fun "
-"for\n"
-"you as it has been for us!"
+"for you as it has been for us!"
 msgstr ""
 "Das ist alles, viel Glück bei der Durchführung des Kurses! Wir hoffen, dass "
-"es dir \n"
-"genauso viel Spaß machen wird wie uns!"
+"es dir  genauso viel Spaß machen wird wie uns!"
 
 #: src/running-the-course.md:46
 msgid ""
-"Please [provide feedback][1] afterwards so that we can keep improving the\n"
-"course. We would love to hear what worked well for you and what can be made\n"
-"better. Your students are also very welcome to [send us feedback][2]!"
+"Please [provide feedback](https://github.com/google/comprehensive-rust/"
+"discussions/86) afterwards so that we can keep improving the course. We "
+"would love to hear what worked well for you and what can be made better. "
+"Your students are also very welcome to [send us feedback](https://github.com/"
+"google/comprehensive-rust/discussions/100)!"
 msgstr ""
-"Bitte [gib anschließend Rückmeldung][1], damit wir den Kurs weiter "
-"verbessern können. \n"
-"Was uns besonders interessieren würde ist was gut funktioniert hat aber auch "
-"was wir verbessern könnten.\n"
-"Deine Teilnehmer sind natürlich auch herzlich eingeladen, [uns Rückmeldung "
-"zu geben][2]!"
-
-#: src/running-the-course/course-structure.md:1
-msgid "# Course Structure"
-msgstr "# Kursstruktur"
+"Bitte [gib anschließend Rückmeldung](https://github.com/google/comprehensive-"
+"rust/discussions/86), damit wir den Kurs weiter verbessern können.  Was uns "
+"besonders interessieren würde ist was gut funktioniert hat aber auch was wir "
+"verbessern könnten. Deine Teilnehmer sind natürlich auch herzlich "
+"eingeladen, [uns Rückmeldung zu geben](https://github.com/google/"
+"comprehensive-rust/discussions/100)!"
 
 #: src/running-the-course/course-structure.md:5
 msgid "The course is fast paced and covers a lot of ground:"
 msgstr "Der Kurs geht in schnellem Tempo voran und deckt viele Themen ab:"
 
 #: src/running-the-course/course-structure.md:7
-msgid ""
-"* Day 1: Basic Rust, ownership and the borrow checker.\n"
-"* Day 2: Compound data types,  pattern matching, the standard library.\n"
-"* Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgid "Day 1: Basic Rust, ownership and the borrow checker."
 msgstr ""
-"* Tag 1: Rust Grundlagen, Eigentümerschaft (ownership) und der "
-"Ausleihenprüfer (borrow checker).\n"
-"* Tag 2: Zusammengesetzte Datentypen, Musterabgleich, die "
-"Standardbibliothek.\n"
-"* Tag 3: Merkmale und Generika, Fehlerbehandlung, Testen, unsicheres Rust."
+"Tag 1: Rust Grundlagen, Eigentümerschaft (ownership) und der Ausleihenprüfer "
+"(borrow checker)."
+
+#: src/running-the-course/course-structure.md:8
+msgid "Day 2: Compound data types,  pattern matching, the standard library."
+msgstr ""
+"Tag 2: Zusammengesetzte Datentypen, Musterabgleich, die Standardbibliothek."
+
+#: src/running-the-course/course-structure.md:9
+msgid "Day 3: Traits and generics, error handling, testing, unsafe Rust."
+msgstr ""
+"Tag 3: Merkmale und Generika, Fehlerbehandlung, Testen, unsicheres Rust."
 
 #: src/running-the-course/course-structure.md:11
-msgid "## Deep Dives"
-msgstr "## Vertiefungen"
+msgid "Deep Dives"
+msgstr "Vertiefungen"
 
 #: src/running-the-course/course-structure.md:13
 msgid ""
-"In addition to the 3-day class on Rust Fundamentals, we cover some more\n"
+"In addition to the 3-day class on Rust Fundamentals, we cover some more "
 "specialized topics:"
 msgstr ""
-"Zusätzlich zu den Rust-Grundlagen behandeln wir noch einiges mehr\n"
+"Zusätzlich zu den Rust-Grundlagen behandeln wir noch einiges mehr "
 "Spezialthemen nach Tag 3:"
-
-#: src/running-the-course/course-structure.md:16
-msgid "### Android"
-msgstr "### Android"
 
 #: src/running-the-course/course-structure.md:18
 msgid ""
 "The [Android Deep Dive](../android.md) is a half-day course on using Rust "
-"for\n"
-"Android platform development. This includes interoperability with C, C++, "
-"and\n"
-"Java."
+"for Android platform development. This includes interoperability with C, C+"
+"+, and Java."
 msgstr ""
 "Der [Android Deep Dive](../android.md) ist ein halbtägiger Kurs zur "
-"Verwendung von Rust für\n"
-"Entwicklung der Android-Plattform. Dazu gehört die Interoperabilität mit C, "
-"C++ und\n"
-"Java."
+"Verwendung von Rust für Entwicklung der Android-Plattform. Dazu gehört die "
+"Interoperabilität mit C, C++ und Java."
 
 #: src/running-the-course/course-structure.md:22
 msgid ""
-"You will need an [AOSP checkout][1]. Make a checkout of the [course\n"
-"repository][2] on the same machine and move the `src/android/` directory "
-"into\n"
-"the root of your AOSP checkout. This will ensure that the Android build "
-"system\n"
-"sees the `Android.bp` files in `src/android/`."
+"You will need an [AOSP checkout](https://source.android.com/docs/setup/"
+"download/downloading). Make a checkout of the [course repository](https://"
+"github.com/google/comprehensive-rust) on the same machine and move the `src/"
+"android/` directory into the root of your AOSP checkout. This will ensure "
+"that the Android build system sees the `Android.bp` files in `src/android/`."
 msgstr ""
-"Du wirst eine lokale Arbeitskopie von [AOSP][1] benötigen. \n"
-"Mache eine Arbeitskopie des [Kurses][2] \n"
-"   auf deinem Laptop und verschiebe das Verzeichnis `src/android/` in \n"
-"   das Stammverzeichnis Deiner AOSP Arbeitskopie. Dadurch wird \n"
-"   sichergestellt, dass das Android-Buildsystem die \n"
-"   `Android.bp`-Dateien in `src/android/` sehen kann."
+"Du wirst eine lokale Arbeitskopie von [AOSP](https://source.android.com/docs/"
+"setup/download/downloading) benötigen.  Mache eine Arbeitskopie des [Kurses]"
+"(https://github.com/google/comprehensive-rust)  auf deinem Laptop und "
+"verschiebe das Verzeichnis `src/android/` in  das Stammverzeichnis Deiner "
+"AOSP Arbeitskopie. Dadurch wird  sichergestellt, dass das Android-"
+"Buildsystem die  `Android.bp`\\-Dateien in `src/android/` sehen kann."
 
 #: src/running-the-course/course-structure.md:27
 msgid ""
 "Ensure that `adb sync` works with your emulator or real device and pre-build "
-"all\n"
-"Android examples using `src/android/build_all.sh`. Read the script to see "
-"the\n"
-"commands it runs and make sure they work when you run them by hand."
+"all Android examples using `src/android/build_all.sh`. Read the script to "
+"see the commands it runs and make sure they work when you run them by hand."
 msgstr ""
 "Stelle sicher, dass `adb sync` auf deinem Emulator oder Rechner "
-"funktioniert.\n"
-"Erstelle bereits vor dem Kurs alle Android-Beispiele mit `src/android/"
-"build_all.sh`. \n"
-"Schaue auch in das Skript rein und probiere aus, ob alle Befehle, die es "
-"ausführt\n"
-"auch von Hand ausgeführt funktionieren."
+"funktioniert. Erstelle bereits vor dem Kurs alle Android-Beispiele mit `src/"
+"android/build_all.sh`.  Schaue auch in das Skript rein und probiere aus, ob "
+"alle Befehle, die es ausführt auch von Hand ausgeführt funktionieren."
 
 #: src/running-the-course/course-structure.md:34
-msgid "### Bare-Metal"
-msgstr "### Bare-Metal"
+msgid "Bare-Metal"
+msgstr "Bare-Metal"
 
 #: src/running-the-course/course-structure.md:36
 msgid ""
 "The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust "
-"for\n"
-"bare-metal (embedded) development. Both microcontrollers and application\n"
+"for bare-metal (embedded) development. Both microcontrollers and application "
 "processors are covered."
 msgstr ""
 "Der [Bare-Metal Deep Dive](../bare-metal.md): ein ganztägiger Kurs über die "
-"Verwendung von Rust für\n"
-"Bare-Metal-Entwicklung (eingebettet). Sowohl Mikrocontroller als auch "
-"Anwendungen\n"
-"Prozessoren sind abgedeckt."
+"Verwendung von Rust für Bare-Metal-Entwicklung (eingebettet). Sowohl "
+"Mikrocontroller als auch Anwendungen Prozessoren sind abgedeckt."
 
 #: src/running-the-course/course-structure.md:40
 msgid ""
-"For the microcontroller part, you will need to buy the [BBC\n"
-"micro:bit](https://microbit.org/) v2 development board ahead of time. "
-"Everybody\n"
-"will need to install a number of packages as described on the [welcome\n"
-"page](../bare-metal.md)."
+"For the microcontroller part, you will need to buy the [BBC micro:bit]"
+"(https://microbit.org/) v2 development board ahead of time. Everybody will "
+"need to install a number of packages as described on the [welcome page](../"
+"bare-metal.md)."
 msgstr ""
-"Für den Mikrocontroller-Teil solltest Du das [BBC\n"
-"micro:bit](https://microbit.org/) v2-Entwicklungsboard im Voraus kaufen. "
-"Alle\n"
-"müssen eine Reihe von Paketen installieren, wie auf der [Willkommens \n"
-"Seite](../bare-metal.md) beschrieben."
+"Für den Mikrocontroller-Teil solltest Du das [BBC micro:bit](https://"
+"microbit.org/) v2-Entwicklungsboard im Voraus kaufen. Alle müssen eine Reihe "
+"von Paketen installieren, wie auf der [Willkommens  Seite](../bare-metal.md) "
+"beschrieben."
 
 #: src/running-the-course/course-structure.md:45
-msgid "### Concurrency"
-msgstr "### Nebenläufigkeit"
+msgid "Concurrency"
+msgstr "Nebenläufigkeit"
 
 #: src/running-the-course/course-structure.md:47
 msgid ""
 "The [Concurrency Deep Dive](../concurrency.md) is a full day class on "
-"classical\n"
-"as well as `async`/`await` concurrency."
+"classical as well as `async`/`await` concurrency."
 msgstr ""
 "Der [Nebensläufgkeitsvertiefung](../concurrency.md) ist ein ganztägiger Kurs "
-"zur klassischen \n"
-"sowie „async“/„await“-Parallelität."
+"zur klassischen  sowie „async“/„await“-Parallelität."
 
 #: src/running-the-course/course-structure.md:50
 msgid ""
 "You will need a fresh crate set up and the dependencies downloaded and ready "
-"to\n"
-"go. You can then copy/paste the examples into `src/main.rs` to experiment "
-"with\n"
-"them:"
+"to go. You can then copy/paste the examples into `src/main.rs` to experiment "
+"with them:"
 msgstr ""
 "Du solltest eine neue Kiste (crate) einrichten und die Abhängigkeiten "
 "(dependencies) herunterladen und einsatzbereit machen. Anschließend kannst "
@@ -1665,56 +1441,78 @@ msgid ""
 msgstr ""
 
 #: src/running-the-course/course-structure.md:61
-msgid "## Format"
-msgstr "## Format"
+msgid "Format"
+msgstr "Format"
 
 #: src/running-the-course/course-structure.md:63
 msgid ""
-"The course is meant to be very interactive and we recommend letting the\n"
+"The course is meant to be very interactive and we recommend letting the "
 "questions drive the exploration of Rust!"
 msgstr ""
-"Der Kurs soll sehr interaktiv ablaufen und wir empfehlen, durch Fragen die \n"
+"Der Kurs soll sehr interaktiv ablaufen und wir empfehlen, durch Fragen die  "
 "Erkundung von Rust voranzutreiben!"
-
-#: src/running-the-course/keyboard-shortcuts.md:1
-msgid "# Keyboard Shortcuts"
-msgstr "# Tastaturkürzel"
 
 #: src/running-the-course/keyboard-shortcuts.md:3
 msgid "There are several useful keyboard shortcuts in mdBook:"
 msgstr "Es gibt mehrere nützliche Tastaturkürzel in mdBook:"
 
 #: src/running-the-course/keyboard-shortcuts.md:5
-msgid ""
-"* <kbd>Arrow-Left</kbd>: Navigate to the previous page.\n"
-"* <kbd>Arrow-Right</kbd>: Navigate to the next page.\n"
-"* <kbd>Ctrl + Enter</kbd>: Execute the code sample that has focus.\n"
-"* <kbd>s</kbd>: Activate the search bar."
-msgstr ""
-"* <kbd>Pfeil-links</kbd>: Zur vorherigen Seite navigieren.\n"
-"* <kbd>Pfeil-rechts</kbd>: Zur nächsten Seite navigieren.\n"
-"* <kbd>Strg + Eingabe</kbd>: Führe das Codebeispiel aus, das aktuell den "
-"Fokus hat.\n"
-"* <kbd>s</kbd>: Suchleiste aktivieren."
+msgid "Arrow-Left"
+msgstr "Pfeil-links"
 
-#: src/running-the-course/translations.md:1
-msgid "# Translations"
-msgstr "# Übersetzungen"
+#: src/running-the-course/keyboard-shortcuts.md:5
+msgid ": Navigate to the previous page."
+msgstr ": Zur vorherigen Seite navigieren."
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid "Arrow-Right"
+msgstr "Pfeil-rechts"
+
+#: src/running-the-course/keyboard-shortcuts.md:6
+msgid ": Navigate to the next page."
+msgstr ": Zur nächsten Seite navigieren."
+
+#: src/running-the-course/keyboard-shortcuts.md:7 src/cargo/code-samples.md:19
+msgid "Ctrl + Enter"
+msgstr "Strg + Eingabe"
+
+#: src/running-the-course/keyboard-shortcuts.md:7
+msgid ": Execute the code sample that has focus."
+msgstr ": Führe das Codebeispiel aus, das aktuell den Fokus hat."
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid "s"
+msgstr "s"
+
+#: src/running-the-course/keyboard-shortcuts.md:8
+msgid ": Activate the search bar."
+msgstr ": Suchleiste aktivieren."
 
 #: src/running-the-course/translations.md:3
 msgid ""
-"The course has been translated into other languages by a set of wonderful\n"
+"The course has been translated into other languages by a set of wonderful "
 "volunteers:"
 msgstr "Der Kurs wurde auch in andere Sprachen übersetzt:"
 
 #: src/running-the-course/translations.md:6
 msgid ""
-"* [Brazilian Portuguese][pt-BR] by [@rastringer] and [@hugojacob].\n"
-"* [Korean][ko] by [@keispace], [@jiyongp] and [@jooyunghan]."
+"[Brazilian Portuguese](https://google.github.io/comprehensive-rust/pt-BR/) "
+"by [@rastringer](https://github.com/rastringer) and [@hugojacob](https://"
+"github.com/hugojacob)."
 msgstr ""
-"* [Brasilianisches Portugiesisch][pt-BR] von [@rastringer] und "
-"[@hugojacob].\n"
-"* [Koreanisch][ko] von [@keispace], [@jiyongp] und [@jooyunghan]."
+"[Brasilianisches Portugiesisch](https://google.github.io/comprehensive-rust/"
+"pt-BR/) von [@rastringer](https://github.com/rastringer) und [@hugojacob]"
+"(https://github.com/hugojacob)."
+
+#: src/running-the-course/translations.md:7
+msgid ""
+"[Korean](https://google.github.io/comprehensive-rust/ko/) by [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) and "
+"[@jooyunghan](https://github.com/jooyunghan)."
+msgstr ""
+"[Koreanisch](https://google.github.io/comprehensive-rust/ko/) von [@keispace]"
+"(https://github.com/keispace), [@jiyongp](https://github.com/jiyongp) und "
+"[@jooyunghan](https://github.com/jooyunghan)."
 
 #: src/running-the-course/translations.md:9
 msgid ""
@@ -1722,71 +1520,77 @@ msgid ""
 msgstr "Benutze die Sprachenauswahl oben rechts, um die Sprache zu wechseln."
 
 #: src/running-the-course/translations.md:11
-msgid "## Incomplete Translations"
-msgstr "# Angefangene Übersetzungen"
+msgid "Incomplete Translations"
+msgstr "Angefangene Übersetzungen"
 
 #: src/running-the-course/translations.md:13
 msgid ""
-"There is a large number of in-progress translations. We link to the most\n"
+"There is a large number of in-progress translations. We link to the most "
 "recently updated translations:"
 msgstr ""
 
 #: src/running-the-course/translations.md:16
 msgid ""
-"* [French][fr] by [@KookaS] and [@vcaen].\n"
-"* [German][de] by [@Throvn] and [@ronaldfw].\n"
-"* [Japanese][ja] by [@CoinEZ-JPN] and [@momotaro1105]."
+"[French](https://google.github.io/comprehensive-rust/fr/) by [@KookaS]"
+"(https://github.com/KookaS) and [@vcaen](https://github.com/vcaen)."
+msgstr ""
+
+#: src/running-the-course/translations.md:17
+msgid ""
+"[German](https://google.github.io/comprehensive-rust/de/) by [@Throvn]"
+"(https://github.com/Throvn) and [@ronaldfw](https://github.com/ronaldfw)."
+msgstr ""
+
+#: src/running-the-course/translations.md:18
+msgid ""
+"[Japanese](https://google.github.io/comprehensive-rust/ja/) by [@CoinEZ-JPN]"
+"(https://github.com/CoinEZ) and [@momotaro1105](https://github.com/"
+"momotaro1105)."
 msgstr ""
 
 #: src/running-the-course/translations.md:20
 msgid ""
-"If you want to help with this effort, please see [our instructions] for how "
-"to\n"
-"get going. Translations are coordinated on the [issue tracker]."
+"If you want to help with this effort, please see [our instructions](https://"
+"github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md) for how to "
+"get going. Translations are coordinated on the [issue tracker](https://"
+"github.com/google/comprehensive-rust/issues/282)."
 msgstr ""
 "Wenn du uns hierbei unterstützen möchtest, lies dir bitte [unsere "
-"Anweisungen][our instructions] durch.\n"
-"Übersetzungen werden mit dem [Issue-Tracker][issue tracker] koordiniert."
-
-#: src/cargo.md:1
-msgid "# Using Cargo"
-msgstr "# Cargo verwenden"
+"Anweisungen](https://github.com/google/comprehensive-rust/blob/main/"
+"TRANSLATIONS.md) durch. Übersetzungen werden mit dem [Issue-Tracker](https://"
+"github.com/google/comprehensive-rust/issues/282) koordiniert."
 
 #: src/cargo.md:3
 msgid ""
 "When you start reading about Rust, you will soon meet [Cargo](https://doc."
-"rust-lang.org/cargo/), the standard tool\n"
-"used in the Rust ecosystem to build and run Rust applications. Here we want "
-"to\n"
-"give a brief overview of what Cargo is and how it fits into the wider "
-"ecosystem\n"
-"and how it fits into this training."
+"rust-lang.org/cargo/), the standard tool used in the Rust ecosystem to build "
+"and run Rust applications. Here we want to give a brief overview of what "
+"Cargo is and how it fits into the wider ecosystem and how it fits into this "
+"training."
 msgstr ""
 "Wenn du anfängst über Rust zu lesen, wirst du sehr bald [Cargo](https://doc."
-"rust-lang.org/cargo/), \n"
-"ein Standardwerkzeug, welches im Rust-Ökosystem verwendet wird, um Rust-"
-"Anwendungen zu erstellen \n"
-"und auszuführen, kennenlernen. Hier wollen wir einen kurzen Überblick geben, "
-"was Cargo ist und wie es\n"
-"in das breitere Ökosystem und in dieses Training passt."
+"rust-lang.org/cargo/),  ein Standardwerkzeug, welches im Rust-Ökosystem "
+"verwendet wird, um Rust-Anwendungen zu erstellen  und auszuführen, "
+"kennenlernen. Hier wollen wir einen kurzen Überblick geben, was Cargo ist "
+"und wie es in das breitere Ökosystem und in dieses Training passt."
 
 #: src/cargo.md:8
-msgid "## Installation"
-msgstr "## Installation"
+msgid "Installation"
+msgstr "Installation"
 
 #: src/cargo.md:10
-msgid "### Rustup (Recommended)"
-msgstr "### Rustup (empfohlen)"
+msgid "Rustup (Recommended)"
+msgstr "Rustup (empfohlen)"
 
 #: src/cargo.md:12
 msgid ""
 "You can follow the instructions to install cargo and rust compiler, among "
-"other standard ecosystem tools with the [rustup][3] tool, which is "
-"maintained by the Rust Foundation."
+"other standard ecosystem tools with the [rustup](https://rust-analyzer."
+"github.io/) tool, which is maintained by the Rust Foundation."
 msgstr ""
 "Du kannst den Anweisungen zur Installation von Cargo und des Rust-Compilers "
-"sowie anderer Standard-Ökosystem-Tools mit dem Tool [rustup][3] folgen, das "
-"von der Rust Foundation verwaltet wird."
+"sowie anderer Standard-Ökosystem-Tools mit dem Tool [rustup](https://rust-"
+"analyzer.github.io/) folgen, das von der Rust Foundation verwaltet wird."
 
 #: src/cargo.md:14
 msgid ""
@@ -1799,17 +1603,17 @@ msgstr ""
 "cross-Kompilierung einrichten kannst."
 
 #: src/cargo.md:16
-msgid "### Package Managers"
-msgstr "### Paketmanager"
+msgid "Package Managers"
+msgstr "Paketmanager"
 
 #: src/cargo.md:18
-msgid "#### Debian"
-msgstr "#### Debian"
+msgid "Debian"
+msgstr "Debian"
 
 #: src/cargo.md:20
 msgid ""
 "On Debian/Ubuntu, you can install Cargo, the Rust source and the [Rust "
-"formatter][6] with"
+"formatter](https://github.com/rust-lang/rustfmt) with"
 msgstr ""
 "Auf Debian/Ubuntu kannst du Cargo und den Rust Quellcode wie folgt "
 "installieren"
@@ -1823,31 +1627,32 @@ msgstr ""
 
 #: src/cargo.md:26
 msgid ""
-"This will allow [rust-analyzer][1] to jump to the definitions. We suggest "
-"using\n"
-"[VS Code][2] to edit the code (but any LSP compatible editor works)."
+"This will allow \\[rust-analyzer\\]\\[1\\] to jump to the definitions. We "
+"suggest using [VS Code](https://code.visualstudio.com/) to edit the code "
+"(but any LSP compatible editor works)."
 msgstr ""
-"Dadurch kann [rust-analyzer][1] zu den Definitionen springen. Wir empfehlen "
-"die Verwendung\n"
-"von [VS Code][2], um Code zu bearbeiten (aber jeder LSP-kompatible Editor "
-"funktioniert auch)."
+"Dadurch kann \\[rust-analyzer\\]\\[1\\] zu den Definitionen springen. Wir "
+"empfehlen die Verwendung von [VS Code](https://code.visualstudio.com/), um "
+"Code zu bearbeiten (aber jeder LSP-kompatible Editor funktioniert auch)."
 
 #: src/cargo.md:29
 msgid ""
-"Some folks also like to use the [JetBrains][4] family of IDEs, which do "
-"their own analysis but have their own tradeoffs. If you prefer them, you can "
-"install the [Rust Plugin][5]. Please take note that as of January 2023 "
-"debugging only works on the CLion version of the JetBrains IDEA suite."
+"Some folks also like to use the [JetBrains](https://www.jetbrains.com/"
+"clion/) family of IDEs, which do their own analysis but have their own "
+"tradeoffs. If you prefer them, you can install the [Rust Plugin](https://www."
+"jetbrains.com/rust/). Please take note that as of January 2023 debugging "
+"only works on the CLion version of the JetBrains IDEA suite."
 msgstr ""
-"Einige Leute verwenden auch gerne die [JetBrains][4]-Familie von IDEs, die "
-"eigene Code-Analysen durchführen, aber auch eigene Einschränkungen haben. "
-"Wenn du diese IDEs bevorzugst, kannst du das [Rust-Plugin] [5] installieren. "
-"Bitte beachte, dass das Debuggen seit Januar 2023 nur auf der CLion-Version "
+"Einige Leute verwenden auch gerne die [JetBrains](https://www.jetbrains.com/"
+"clion/)\\-Familie von IDEs, die eigene Code-Analysen durchführen, aber auch "
+"eigene Einschränkungen haben. Wenn du diese IDEs bevorzugst, kannst du das "
+"\\[Rust-Plugin\\] [5](https://www.jetbrains.com/rust/) installieren. Bitte "
+"beachte, dass das Debuggen seit Januar 2023 nur auf der CLion-Version "
 "funktioniert, welche Teil der JetBrains IDEA-Suite ist."
 
 #: src/cargo/rust-ecosystem.md:1
-msgid "# The Rust Ecosystem"
-msgstr "# Das Rust-Ökosystem"
+msgid "The Rust Ecosystem"
+msgstr "Das Rust-Ökosystem"
 
 #: src/cargo/rust-ecosystem.md:3
 msgid ""
@@ -1857,35 +1662,36 @@ msgstr ""
 "wichtigsten die Folgenden sind:"
 
 #: src/cargo/rust-ecosystem.md:5
+#, fuzzy
 msgid ""
-"* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-"other\n"
-"  intermediate formats.\n"
-"\n"
-"* `cargo`: the Rust dependency manager and build tool. Cargo knows how to\n"
-"  download dependencies hosted on <https://crates.io> and it will pass them "
-"to\n"
-"  `rustc` when building your project. Cargo also comes with a built-in test\n"
-"  runner which is used to execute unit tests.\n"
-"\n"
-"* `rustup`: the Rust toolchain installer and updater. This tool is used to\n"
-"  install and update `rustc` and `cargo` when new versions of Rust is "
-"released.\n"
-"  In addition, `rustup` can also download documentation for the standard\n"
-"  library. You can have multiple versions of Rust installed at once and "
-"`rustup`\n"
-"  will let you switch between them as needed."
+"`rustc`: the Rust compiler which turns `.rs` files into binaries and other "
+"intermediate formats."
 msgstr ""
-"* `rustc`: der Rust-Compiler, der `.rs`-Dateien in Binärdateien und andere "
-"Zwischenformate umwandelt\n"
-"\n"
-"* `cargo`: der Rust-Abhängigkeitsmanager (Dependency manager) und das "
+"`rustc`: der Rust-Compiler, der `.rs`\\-Dateien in Binärdateien und andere "
+"Zwischenformate umwandelt"
+
+#: src/cargo/rust-ecosystem.md:8
+#, fuzzy
+msgid ""
+"`cargo`: the Rust dependency manager and build tool. Cargo knows how to "
+"download dependencies hosted on <https://crates.io> and it will pass them to "
+"`rustc` when building your project. Cargo also comes with a built-in test "
+"runner which is used to execute unit tests."
+msgstr ""
+"`cargo`: der Rust-Abhängigkeitsmanager (Dependency manager) und das "
 "Bauwerkzeug (Build-Tool). Cargo weiß, wie die Abhängigkeiten heruntergeladen "
 "werden müssen, die auf <https://crates.io> gehostet werden, und übergibt sie "
-"an\n"
-"   `rustc` beim Erstellen Ihres Projekts. Cargo verfügt außerdem über einen "
-"integrierten Testausführer, \n"
-"   der zum Ausführen von Unit-Tests verwendet wird."
+"an `rustc` beim Erstellen Ihres Projekts. Cargo verfügt außerdem über einen "
+"integrierten Testausführer,  der zum Ausführen von Unit-Tests verwendet wird."
+
+#: src/cargo/rust-ecosystem.md:13
+msgid ""
+"`rustup`: the Rust toolchain installer and updater. This tool is used to "
+"install and update `rustc` and `cargo` when new versions of Rust is "
+"released. In addition, `rustup` can also download documentation for the "
+"standard library. You can have multiple versions of Rust installed at once "
+"and `rustup` will let you switch between them as needed."
+msgstr ""
 
 #: src/cargo/rust-ecosystem.md:21 src/hello-world.md:25
 #: src/hello-world/small-example.md:27 src/why-rust/runtime.md:10
@@ -1900,109 +1706,138 @@ msgstr "Schlüsselpunkte:"
 
 #: src/cargo/rust-ecosystem.md:23
 msgid ""
-"* Rust has a rapid release schedule with a new release coming out\n"
-"  every six weeks. New releases maintain backwards compatibility with\n"
-"  old releases --- plus they enable new functionality.\n"
-"\n"
-"* There are three release channels: \"stable\", \"beta\", and \"nightly\".\n"
-"\n"
-"* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-"  \"stable\" every six weeks.\n"
-"\n"
-"* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-"  editions were Rust 2015 and Rust 2018.\n"
-"\n"
-"  * The editions are allowed to make backwards incompatible changes to\n"
-"    the language.\n"
-"\n"
-"  * To prevent breaking code, editions are opt-in: you select the\n"
-"    edition for your crate via the `Cargo.toml` file.\n"
-"\n"
-"  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-"    written for different editions.\n"
-"\n"
-"  * Mention that it is quite rare to ever use the compiler directly not "
-"through `cargo` (most users never do).\n"
-"\n"
-"  * It might be worth alluding that Cargo itself is an extremely powerful "
-"and comprehensive tool.  It is capable of many advanced features including "
-"but not limited to: \n"
-"      * Project/package structure\n"
-"      * [workspaces]\n"
-"      * Dev Dependencies and Runtime Dependency management/caching\n"
-"      * [build scripting]\n"
-"      * [global installation]\n"
-"      * It is also extensible with sub command plugins as well (such as "
-"[cargo clippy]).\n"
-"  * Read more from the [official Cargo Book]"
+"Rust has a rapid release schedule with a new release coming out every six "
+"weeks. New releases maintain backwards compatibility with old releases --- "
+"plus they enable new functionality."
 msgstr ""
-"* Rust hat einen schnellen Veröffentlichungsplan. Alle sechs Wochen wird "
-"eine neue Version veröffentlicht. Neue Versionen bleiben rückwärtskompatibel "
-"mit älteren Versionen und fügen neue Funktionen hinzu.\n"
-"\n"
-"* Es gibt drei Veröffentlichungskanäle: „stable“, „beta“ und „nightly“.\n"
-"\n"
-"* Neue Funktionen werden in „nightly“ getestet. „Beta“ wird\n"
-"   alle sechs Wochen „stabil“.\n"
-"\n"
-"* Rust hat auch [Editionen]: Die aktuelle Edition ist Rust 2021. Vorherige\n"
-"   Editionen waren Rust 2015 und Rust 2018.\n"
-"\n"
-"   * Editionen dürfen rückwärtsinkompatible Änderungen vornehmen.\n"
-"\n"
-"   * Um zu verhindern, dass Code nicht kaputt geht, sind Editionen optional: "
-"Du wählst ihre Edition für deine Kiste (crate) in der Datei `Cargo.toml`\n"
-"\n"
-"   * Um eine Aufspaltung des Ökosystems zu vermeiden, können Rust-Compiler "
-"Code der für verschiedene Editionen geschrieben wurde vermischen.\n"
-"\n"
-"   * Erwähne, dass es ziemlich selten vorkommt, dass der Compiler jemals "
-"direkt und nicht über `cargo` verwendet wird (die meisten Benutzer tun dies "
-"nie).\n"
-"\n"
-"   * Es könnte erwähnenswert sein, dass Cargo selbst ein äußerst "
-"leistungsstarkes und umfassendes Tool ist. Es verfügt über viele erweiterte "
-"Funktionen, einschließlich, aber nicht beschränkt auf:\n"
-"       * Projekt-/Paketstruktur\n"
-"       * [Arbeitsbereiche]\n"
-"       * Verwaltung/Caching von Entwicklungsabhängigkeiten und "
-"Laufzeitabhängigkeiten\n"
-"       * [Build-Skripting]\n"
-"       * [globale Installation]\n"
-"       * Es ist auch mit Unterbefehls-Plugins erweiterbar (z. B. [cargo "
-"clippy]).\n"
-"   * Lese mehr aus dem [offiziellen Cargo Buch]"
+"Rust hat einen schnellen Veröffentlichungsplan. Alle sechs Wochen wird eine "
+"neue Version veröffentlicht. Neue Versionen bleiben rückwärtskompatibel mit "
+"älteren Versionen und fügen neue Funktionen hinzu."
+
+#: src/cargo/rust-ecosystem.md:27
+msgid ""
+"There are three release channels: \"stable\", \"beta\", and \"nightly\"."
+msgstr "Es gibt drei Veröffentlichungskanäle: „stable“, „beta“ und „nightly“."
+
+#: src/cargo/rust-ecosystem.md:29
+msgid ""
+"New features are being tested on \"nightly\", \"beta\" is what becomes "
+"\"stable\" every six weeks."
+msgstr ""
+"Neue Funktionen werden in „nightly“ getestet. „Beta“ wird alle sechs Wochen "
+"„stabil“."
+
+#: src/cargo/rust-ecosystem.md:32
+msgid ""
+"Rust also has [editions](https://doc.rust-lang.org/edition-guide/): the "
+"current edition is Rust 2021. Previous editions were Rust 2015 and Rust 2018."
+msgstr ""
+"Rust hat auch \\[Editionen\\]: Die aktuelle Edition ist Rust 2021. Vorherige "
+"Editionen waren Rust 2015 und Rust 2018."
+
+#: src/cargo/rust-ecosystem.md:35
+msgid ""
+"The editions are allowed to make backwards incompatible changes to the "
+"language."
+msgstr "Editionen dürfen rückwärtsinkompatible Änderungen vornehmen."
+
+#: src/cargo/rust-ecosystem.md:38
+msgid ""
+"To prevent breaking code, editions are opt-in: you select the edition for "
+"your crate via the `Cargo.toml` file."
+msgstr ""
+"Um zu verhindern, dass Code nicht kaputt geht, sind Editionen optional: Du "
+"wählst ihre Edition für deine Kiste (crate) in der Datei `Cargo.toml`"
+
+#: src/cargo/rust-ecosystem.md:41
+msgid ""
+"To avoid splitting the ecosystem, Rust compilers can mix code written for "
+"different editions."
+msgstr ""
+"Um eine Aufspaltung des Ökosystems zu vermeiden, können Rust-Compiler Code "
+"der für verschiedene Editionen geschrieben wurde vermischen."
+
+#: src/cargo/rust-ecosystem.md:44
+msgid ""
+"Mention that it is quite rare to ever use the compiler directly not through "
+"`cargo` (most users never do)."
+msgstr ""
+"Erwähne, dass es ziemlich selten vorkommt, dass der Compiler jemals direkt "
+"und nicht über `cargo` verwendet wird (die meisten Benutzer tun dies nie)."
+
+#: src/cargo/rust-ecosystem.md:46
+msgid ""
+"It might be worth alluding that Cargo itself is an extremely powerful and "
+"comprehensive tool.  It is capable of many advanced features including but "
+"not limited to: "
+msgstr ""
+"Es könnte erwähnenswert sein, dass Cargo selbst ein äußerst leistungsstarkes "
+"und umfassendes Tool ist. Es verfügt über viele erweiterte Funktionen, "
+"einschließlich, aber nicht beschränkt auf:"
+
+#: src/cargo/rust-ecosystem.md:47
+msgid "Project/package structure"
+msgstr "Projekt-/Paketstruktur"
+
+#: src/cargo/rust-ecosystem.md:48
+msgid "[workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)"
+msgstr "\\[Arbeitsbereiche\\]"
+
+#: src/cargo/rust-ecosystem.md:49
+msgid "Dev Dependencies and Runtime Dependency management/caching"
+msgstr ""
+"Verwaltung/Caching von Entwicklungsabhängigkeiten und Laufzeitabhängigkeiten"
+
+#: src/cargo/rust-ecosystem.md:50
+msgid ""
+"[build scripting](https://doc.rust-lang.org/cargo/reference/build-scripts."
+"html)"
+msgstr "\\[Build-Skripting\\]"
+
+#: src/cargo/rust-ecosystem.md:51
+msgid ""
+"[global installation](https://doc.rust-lang.org/cargo/commands/cargo-install."
+"html)"
+msgstr "\\[globale Installation\\]"
+
+#: src/cargo/rust-ecosystem.md:52
+msgid ""
+"It is also extensible with sub command plugins as well (such as [cargo "
+"clippy](https://github.com/rust-lang/rust-clippy))."
+msgstr ""
+"Es ist auch mit Unterbefehls-Plugins erweiterbar (z. B. [cargo clippy]"
+"(https://github.com/rust-lang/rust-clippy))."
+
+#: src/cargo/rust-ecosystem.md:53
+msgid ""
+"Read more from the [official Cargo Book](https://doc.rust-lang.org/cargo/)"
+msgstr "Lese mehr aus dem \\[offiziellen Cargo Buch\\]"
 
 #: src/cargo/code-samples.md:1
-msgid "# Code Samples in This Training"
-msgstr "# Codebeispiele in diesem Training"
+msgid "Code Samples in This Training"
+msgstr "Codebeispiele in diesem Training"
 
 #: src/cargo/code-samples.md:3
 msgid ""
-"For this training, we will mostly explore the Rust language through "
-"examples\n"
+"For this training, we will mostly explore the Rust language through examples "
 "which can be executed through your browser. This makes the setup much easier "
-"and\n"
-"ensures a consistent experience for everyone."
+"and ensures a consistent experience for everyone."
 msgstr ""
 "In diesem Training werden wir die Rust-Sprache hauptsächlich anhand von "
-"Beispielen erkunden\n"
-"die über Ihren Browser ausgeführt werden können. Dies erleichtert die "
-"Einrichtung erheblich und\n"
-"sorgt für ein konsistentes Erlebnis."
+"Beispielen erkunden die über Ihren Browser ausgeführt werden können. Dies "
+"erleichtert die Einrichtung erheblich und sorgt für ein konsistentes "
+"Erlebnis."
 
 #: src/cargo/code-samples.md:7
 msgid ""
 "Installing Cargo is still encouraged: it will make it easier for you to do "
-"the\n"
-"exercises. On the last day, we will do a larger exercise which shows you how "
-"to\n"
-"work with dependencies and for that you need Cargo."
+"the exercises. On the last day, we will do a larger exercise which shows you "
+"how to work with dependencies and for that you need Cargo."
 msgstr ""
 "Die Installation von Cargo wird dennoch empfohlen: Es wird Dir die "
-"Bearbeitung der Übungen erleichtern.\n"
-"Am letzten Tag werden wir eine größere Übung machen, die zeigt, wie\n"
-"Du mit Abhängigkeiten (dependencies) arbeitest und dafür benötigst Du Cargo."
+"Bearbeitung der Übungen erleichtern. Am letzten Tag werden wir eine größere "
+"Übung machen, die zeigt, wie Du mit Abhängigkeiten (dependencies) arbeitest "
+"und dafür benötigst Du Cargo."
 
 #: src/cargo/code-samples.md:11
 msgid "The code blocks in this course are fully interactive:"
@@ -2018,62 +1853,58 @@ msgid ""
 msgstr ""
 
 #: src/cargo/code-samples.md:19
-msgid ""
-"You can use <kbd>Ctrl + Enter</kbd> to execute the code when focus is in "
-"the\n"
-"text box."
+msgid "You can use "
+msgstr "Du kannst "
+
+#: src/cargo/code-samples.md:19
+msgid " to execute the code when focus is in the text box."
 msgstr ""
-"Du kannst <kbd>Strg + Eingabe</kbd> verwenden, um den Code auszuführen, wenn "
-"der Fokus auf dem Textfeld ist."
+" verwenden, um den Code auszuführen, wenn der Fokus auf dem Textfeld ist."
 
 #: src/cargo/code-samples.md:24
 msgid ""
-"Most code samples are editable like shown above. A few code samples\n"
-"are not editable for various reasons:"
+"Most code samples are editable like shown above. A few code samples are not "
+"editable for various reasons:"
 msgstr ""
 "Die meisten Codebeispiele können wie oben gezeigt bearbeitet werden. Ein "
-"paar Codebeispiele\n"
-"sind aus verschiedenen Gründen nicht editierbar:"
+"paar Codebeispiele sind aus verschiedenen Gründen nicht editierbar:"
 
 #: src/cargo/code-samples.md:27
 msgid ""
-"* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-"  code and open it in the real Playground to demonstrate unit tests.\n"
-"\n"
-"* The embedded playgrounds lose their state the moment you navigate\n"
-"  away from the page! This is the reason that the students should\n"
-"  solve the exercises using a local Rust installation or via the\n"
-"  Playground."
+"The embedded playgrounds cannot execute unit tests. Copy-paste the code and "
+"open it in the real Playground to demonstrate unit tests."
 msgstr ""
-"* Die eingebetteten Testumgebungen (embedded Playgrounds) können keine Unit-"
-"Tests durchführen. Kopiere die Datei und füge \n"
-"   den Code in der echten Testumgebung ein, um Unit-Tests zu demonstrieren.\n"
-"\n"
-"* Die eingebetteten Testumgebungen verlieren ihren Zustand, sobald Du von "
-"der Seite weg navigierst!\n"
-"   Aus diesem Grund sollten die Schüler die Übungen mit einer lokalen Rust-"
-"Installation oder in der\n"
-"   lokalen Testumgebung lösen."
+"Die eingebetteten Testumgebungen (embedded Playgrounds) können keine Unit-"
+"Tests durchführen. Kopiere die Datei und füge  den Code in der echten "
+"Testumgebung ein, um Unit-Tests zu demonstrieren."
+
+#: src/cargo/code-samples.md:30
+msgid ""
+"The embedded playgrounds lose their state the moment you navigate away from "
+"the page! This is the reason that the students should solve the exercises "
+"using a local Rust installation or via the Playground."
+msgstr ""
+"Die eingebetteten Testumgebungen verlieren ihren Zustand, sobald Du von der "
+"Seite weg navigierst! Aus diesem Grund sollten die Schüler die Übungen mit "
+"einer lokalen Rust-Installation oder in der lokalen Testumgebung lösen."
 
 #: src/cargo/running-locally.md:1
-msgid "# Running Code Locally with Cargo"
-msgstr "# Code lokal mit Cargo ausführen"
+msgid "Running Code Locally with Cargo"
+msgstr "Code lokal mit Cargo ausführen"
 
 #: src/cargo/running-locally.md:3
 msgid ""
 "If you want to experiment with the code on your own system, then you will "
-"need\n"
-"to first install Rust. Do this by following the [instructions in the Rust\n"
-"Book][1]. This should give you a working `rustc` and `cargo`. At the time "
-"of\n"
-"writing, the latest stable Rust release has these version numbers:"
+"need to first install Rust. Do this by following the [instructions in the "
+"Rust Book](https://doc.rust-lang.org/book/ch01-01-installation.html). This "
+"should give you a working `rustc` and `cargo`. At the time of writing, the "
+"latest stable Rust release has these version numbers:"
 msgstr ""
 "Wenn Du mit dem Code auf Deinem eigenen System experimentieren möchten, "
-"solltest Du\n"
-"zuerst Rust installieren. Befolge dazu die [Anweisungen in dem Rust\n"
-"Buch 1]. Dies sollte ein funktionierendes `rustc` und `cargo` hervorbringen. "
-"Zum Verfassungszeitpunkt\n"
-"hat die neueste stabile Rust-Version folgende Versionsnummer:"
+"solltest Du zuerst Rust installieren. Befolge dazu die \\[Anweisungen in dem "
+"Rust Buch 1\\]. Dies sollte ein funktionierendes `rustc` und `cargo` "
+"hervorbringen. Zum Verfassungszeitpunkt hat die neueste stabile Rust-Version "
+"folgende Versionsnummer:"
 
 #: src/cargo/running-locally.md:8
 msgid ""
@@ -2087,131 +1918,150 @@ msgstr ""
 
 #: src/cargo/running-locally.md:15
 msgid ""
-"With this in place, follow these steps to build a Rust binary from one\n"
-"of the examples in this training:"
+"With this in place, follow these steps to build a Rust binary from one of "
+"the examples in this training:"
 msgstr ""
 "Wenn dies vorhanden ist, befolge die folgenden Schritte, um eine Rust-"
 "Binärdatei aus einem Beispiel zu erstellen:"
 
 #: src/cargo/running-locally.md:18
-msgid ""
-"1. Click the \"Copy to clipboard\" button on the example you want to copy.\n"
-"\n"
-"2. Use `cargo new exercise` to create a new `exercise/` directory for your "
-"code:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"\n"
-"3. Navigate into `exercise/` and use `cargo run` to build and run your "
-"binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"\n"
-"4. Replace the boiler-plate code in `src/main.rs` with your own code. For\n"
-"   example, using the example on the previous page, make `src/main.rs` look "
-"like\n"
-"\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"\n"
-"5. Use `cargo run` to build and run your updated binary:\n"
-"\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"\n"
-"6. Use `cargo check` to quickly check your project for errors, use `cargo "
-"build`\n"
-"   to compile it without running it. You will find the output in `target/"
-"debug/`\n"
-"   for a normal debug build. Use `cargo build --release` to produce an "
-"optimized\n"
-"   release build in `target/release/`.\n"
-"\n"
-"7. You can add dependencies for your project by editing `Cargo.toml`. When "
-"you\n"
-"   run `cargo` commands, it will automatically download and compile missing\n"
-"   dependencies for you."
+msgid "Click the \"Copy to clipboard\" button on the example you want to copy."
 msgstr ""
-"1. Klicke bei dem Beispiel, dass Du kopieren möchtest, auf die Schaltfläche "
-"„In die Zwischenablage kopieren“.\n"
-"2. Verwende `cargo new exercise`, um ein neues `exercise/`-Verzeichnis für "
-"Deinen Code zu erstellen:\n"
-"    ```shell\n"
-"    $ cargo new exercise\n"
-"         Created binary (application) `exercise` package\n"
-"    ```\n"
-"3. Navigiere zu `exercise/` und verwende `cargo run, um eine Binärdatei zu "
-"erstellen und auszuführen:\n"
-"    ```shell\n"
-"    $ cd exercise\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
-"         Running `target/debug/exercise`\n"
-"    Hello, world!\n"
-"    ```\n"
-"4. Ersetze den Platzhalter-Code in `src/main.rs` durch eigenen Code. "
-"Verwende beispielsweise das Beispiel auf der vorherigen Seite und lasse `src/"
-"main.rs` so aussehen:\n"
-"    ```rust\n"
-"    fn main() {\n"
-"        println!(\"Edit me!\");\n"
-"    }\n"
-"    ```\n"
-"5. Verwende `cargo run`, um die neue Binärdatei zu erstellen und "
-"auszuführen:\n"
-"    ```shell\n"
-"    $ cargo run\n"
-"       Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
-"        Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
-"         Running `target/debug/exercise`\n"
-"    Edit me!\n"
-"    ```\n"
-"6. Verwende `cargo check`, um Dein Projekt schnell auf Fehler zu überprüfen, "
+"Klicke bei dem Beispiel, dass Du kopieren möchtest, auf die Schaltfläche „In "
+"die Zwischenablage kopieren“."
+
+#: src/cargo/running-locally.md:20
+msgid ""
+"Use `cargo new exercise` to create a new `exercise/` directory for your code:"
+msgstr ""
+"Verwende `cargo new exercise`, um ein neues `exercise/`\\-Verzeichnis für "
+"Deinen Code zu erstellen:"
+
+#: src/cargo/running-locally.md:22
+msgid ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo new exercise\n"
+"     Created binary (application) `exercise` package\n"
+"```"
+
+#: src/cargo/running-locally.md:27
+msgid ""
+"Navigate into `exercise/` and use `cargo run` to build and run your binary:"
+msgstr ""
+"Navigiere zu `exercise/` und verwende \\`cargo run, um eine Binärdatei zu "
+"erstellen und auszuführen:"
+
+#: src/cargo/running-locally.md:29
+msgid ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cd exercise\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.75s\n"
+"     Running `target/debug/exercise`\n"
+"Hello, world!\n"
+"```"
+
+#: src/cargo/running-locally.md:38
+msgid ""
+"Replace the boiler-plate code in `src/main.rs` with your own code. For "
+"example, using the example on the previous page, make `src/main.rs` look like"
+msgstr ""
+"Ersetze den Platzhalter-Code in `src/main.rs` durch eigenen Code. Verwende "
+"beispielsweise das Beispiel auf der vorherigen Seite und lasse `src/main.rs` "
+"so aussehen:"
+
+#: src/cargo/running-locally.md:41
+msgid ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+msgstr ""
+"```rust\n"
+"fn main() {\n"
+"    println!(\"Edit me!\");\n"
+"}\n"
+"```"
+
+#: src/cargo/running-locally.md:47
+msgid "Use `cargo run` to build and run your updated binary:"
+msgstr ""
+"Verwende `cargo run`, um die neue Binärdatei zu erstellen und auszuführen:"
+
+#: src/cargo/running-locally.md:49
+msgid ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+msgstr ""
+"```shell\n"
+"$ cargo run\n"
+"   Compiling exercise v0.1.0 (/home/mgeisler/tmp/exercise)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.24s\n"
+"     Running `target/debug/exercise`\n"
+"Edit me!\n"
+"```"
+
+#: src/cargo/running-locally.md:57
+msgid ""
+"Use `cargo check` to quickly check your project for errors, use `cargo "
+"build` to compile it without running it. You will find the output in `target/"
+"debug/` for a normal debug build. Use `cargo build --release` to produce an "
+"optimized release build in `target/release/`."
+msgstr ""
+"Verwende `cargo check`, um Dein Projekt schnell auf Fehler zu überprüfen, "
 "und verwende `cargo build`, um es zu kompilieren, ohne es auszuführen. Du "
 "findest die Ausgabe in `target/debug/` für einen normalen Debug-Build. "
 "Verwende `cargo build --release`, um einen optimierten Release-Build in "
-"`target/release/` zu erstellen.\n"
-"7. Du kannst Abhängigkeiten (dependencies) zu Deinem Projekt hinzufügen, "
-"indem Du `Cargo.toml` bearbeitest. Wenn Du `cargo`-Befehle ausführst, werden "
+"`target/release/` zu erstellen."
+
+#: src/cargo/running-locally.md:62
+msgid ""
+"You can add dependencies for your project by editing `Cargo.toml`. When you "
+"run `cargo` commands, it will automatically download and compile missing "
+"dependencies for you."
+msgstr ""
+"Du kannst Abhängigkeiten (dependencies) zu Deinem Projekt hinzufügen, indem "
+"Du `Cargo.toml` bearbeitest. Wenn Du `cargo`\\-Befehle ausführst, werden "
 "fehlende Abhängigkeiten automatisch heruntergeladen und für Dich kompiliert."
 
 #: src/cargo/running-locally.md:70
 msgid ""
-"Try to encourage the class participants to install Cargo and use a\n"
-"local editor. It will make their life easier since they will have a\n"
-"normal development environment."
+"Try to encourage the class participants to install Cargo and use a local "
+"editor. It will make their life easier since they will have a normal "
+"development environment."
 msgstr ""
 "Versuche, die Kursteilnehmer zu ermutigen, Cargo zu installieren und einen "
-"lokalen Texteditor zu verwenden\n"
-"Es wird Dein Leben einfacher machen, wenn alle eine lokale "
-"Entwicklungsumgebung haben."
+"lokalen Texteditor zu verwenden Es wird Dein Leben einfacher machen, wenn "
+"alle eine lokale Entwicklungsumgebung haben."
 
 #: src/welcome-day-1.md:1
-msgid "# Welcome to Day 1"
-msgstr "# Willkommen zu Tag 1"
+msgid "Welcome to Day 1"
+msgstr "Willkommen zu Tag 1"
 
 #: src/welcome-day-1.md:3
 msgid ""
-"This is the first day of Comprehensive Rust. We will cover a lot of ground\n"
+"This is the first day of Comprehensive Rust. We will cover a lot of ground "
 "today:"
 msgstr ""
 "Dies ist der erste Tag von Comprehensive Rust. Heute werden wir viel "
@@ -2219,24 +2069,27 @@ msgstr ""
 
 #: src/welcome-day-1.md:6
 msgid ""
-"* Basic Rust syntax: variables, scalar and compound types, enums, structs,\n"
-"  references, functions, and methods.\n"
-"\n"
-"* Memory management: stack vs heap, manual memory management, scope-based "
-"memory\n"
-"  management, and garbage collection.\n"
-"\n"
-"* Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+"Basic Rust syntax: variables, scalar and compound types, enums, structs, "
+"references, functions, and methods."
 msgstr ""
-"* Grundlegende Rust-Syntax: Variablen, Skalar- und zusammengesetzte Typen "
-"(scalar-types, union-types) , Aufzählungen (enums), Strukturen (structs),\n"
-"   Referenzen (references), Funktionen (functions) und Methoden (methods).\n"
-"\n"
-"* Speicherverwaltung: Stack vs. Heap, manuelle Speicherverwaltung, "
+"Grundlegende Rust-Syntax: Variablen, Skalar- und zusammengesetzte Typen "
+"(scalar-types, union-types) , Aufzählungen (enums), Strukturen (structs), "
+"Referenzen (references), Funktionen (functions) und Methoden (methods)."
+
+#: src/welcome-day-1.md:9
+msgid ""
+"Memory management: stack vs heap, manual memory management, scope-based "
+"memory management, and garbage collection."
+msgstr ""
+"Speicherverwaltung: Stack vs. Heap, manuelle Speicherverwaltung, "
 "bereichsbasierte Speicherverwaltung und Speicherbereinigung (garbage "
-"collection).\n"
-"\n"
-"* Eigentum (ownership): Bewegungssemantik (move semantics), Kopieren und "
+"collection)."
+
+#: src/welcome-day-1.md:12
+msgid ""
+"Ownership: move semantics, copying and cloning, borrowing, and lifetimes."
+msgstr ""
+"Eigentum (ownership): Bewegungssemantik (move semantics), Kopieren und "
 "Klonen (copy and cloning), Ausleihen (borrowing) und Lebensdauer (lifetimes)."
 
 #: src/welcome-day-1.md:16
@@ -2245,153 +2098,174 @@ msgstr "Bitte erinnere die Kursteilnehmer daran:"
 
 #: src/welcome-day-1.md:18
 msgid ""
-"* They should ask questions when they get them, don't save them to the end.\n"
-"* The class is meant to be interactive and discussions are very much "
-"encouraged!\n"
-"  * As an instructor, you should try to keep the discussions relevant, i."
-"e.,\n"
-"    keep the discussions related to how Rust does things vs some other "
-"language. \n"
-"    It can be hard to find the right balance, but err on the side of "
-"allowing \n"
-"    discussions since they engage people much more than one-way "
-"communication.\n"
-"* The questions will likely mean that we talk about things ahead of the "
-"slides.\n"
-"  * This is perfectly okay! Repetition is an important part of learning. "
-"Remember\n"
-"    that the slides are just a support and you are free to skip them as you\n"
-"    like."
+"They should ask questions when they get them, don't save them to the end."
 msgstr ""
-"* Sie sollten Fragen stellen, sobald ihnen welche einfallen, und nicht bis "
-"zum Ende warten.\n"
-"* Der Unterricht soll interaktiv sein und Diskussionen sind erwünscht!\n"
-"  * Als Dozent sollten Sie versuchen, die Diskussionen relevant zu halten, "
-"d. h.\n"
-"    Behalten Sie den Bezug dazu bei, wie Rust Dinge im Vergleich zu einer "
-"anderen Sprache tut. Es kann schwer sein,\n"
-"    die richtige Balance zu finden, aber lassen Sie lieber Diskussionen zu,\n"
-"    um Kursteilnehmer einzubeziehen und lange Monologe zu vermeiden.\n"
-"* Bei Fragen wird es wahrscheinlich dazu kommen, dass wir über die Dinge vor "
-"den eigentlichen Folien sprechen.\n"
-"  * Das ist vollkommen in Ordnung! Wiederholung ist ein wichtiger Teil des "
-"Lernens.\n"
-"    Die Folien sind nur eine Unterstützung und Sie können sie nach Belieben "
-"überspringen."
+"Sie sollten Fragen stellen, sobald ihnen welche einfallen, und nicht bis zum "
+"Ende warten."
+
+#: src/welcome-day-1.md:19
+msgid ""
+"The class is meant to be interactive and discussions are very much "
+"encouraged!"
+msgstr "Der Unterricht soll interaktiv sein und Diskussionen sind erwünscht!"
+
+#: src/welcome-day-1.md:20
+msgid ""
+"As an instructor, you should try to keep the discussions relevant, i.e., "
+"keep the discussions related to how Rust does things vs some other "
+"language.  It can be hard to find the right balance, but err on the side of "
+"allowing  discussions since they engage people much more than one-way "
+"communication."
+msgstr ""
+"Als Dozent sollten Sie versuchen, die Diskussionen relevant zu halten, d. h. "
+"Behalten Sie den Bezug dazu bei, wie Rust Dinge im Vergleich zu einer "
+"anderen Sprache tut. Es kann schwer sein, die richtige Balance zu finden, "
+"aber lassen Sie lieber Diskussionen zu, um Kursteilnehmer einzubeziehen und "
+"lange Monologe zu vermeiden."
+
+#: src/welcome-day-1.md:24
+msgid ""
+"The questions will likely mean that we talk about things ahead of the slides."
+msgstr ""
+"Bei Fragen wird es wahrscheinlich dazu kommen, dass wir über die Dinge vor "
+"den eigentlichen Folien sprechen."
+
+#: src/welcome-day-1.md:25
+msgid ""
+"This is perfectly okay! Repetition is an important part of learning. "
+"Remember that the slides are just a support and you are free to skip them as "
+"you like."
+msgstr ""
+"Das ist vollkommen in Ordnung! Wiederholung ist ein wichtiger Teil des "
+"Lernens. Die Folien sind nur eine Unterstützung und Sie können sie nach "
+"Belieben überspringen."
 
 #: src/welcome-day-1.md:29
 msgid ""
 "The idea for the first day is to show _just enough_ of Rust to be able to "
-"speak\n"
-"about the famous borrow checker. The way Rust handles memory is a major "
-"feature\n"
-"and we should show students this right away."
+"speak about the famous borrow checker. The way Rust handles memory is a "
+"major feature and we should show students this right away."
 msgstr ""
 "Die Idee für den ersten Tag ist, Rust _gerade genug_ zu zeigen, um über den "
-"berühmten Ausleihenprüfer (borrow checker) sprechen zu können.\n"
-"Die Art und Weise, wie Rust mit Speicher umgeht, ist ein wichtiges Merkmal\n"
-"und das solltest Du den Kursteilnehmern direkt zeigen."
+"berühmten Ausleihenprüfer (borrow checker) sprechen zu können. Die Art und "
+"Weise, wie Rust mit Speicher umgeht, ist ein wichtiges Merkmal und das "
+"solltest Du den Kursteilnehmern direkt zeigen."
 
 #: src/welcome-day-1.md:33
 msgid ""
-"If you're teaching this in a classroom, this is a good place to go over the\n"
+"If you're teaching this in a classroom, this is a good place to go over the "
 "schedule. We suggest splitting the day into two parts (following the slides):"
 msgstr ""
 "Wenn Du in einem Klassenzimmer unterrichtest, ist dies ein guter Ort, um "
-"über den Zeitplan zu gehen.\n"
-"Wir empfehlen, den Tag in zwei Teile aufzuteilen (nach den Folien):"
+"über den Zeitplan zu gehen. Wir empfehlen, den Tag in zwei Teile aufzuteilen "
+"(nach den Folien):"
 
 #: src/welcome-day-1.md:36
-msgid ""
-"* Morning: 9:00 to 12:00,\n"
-"* Afternoon: 13:00 to 16:00."
-msgstr ""
-"* Morgens: 9:00 bis 12:00 Uhr,\n"
-"* Nachmittag: 13:00 bis 16:00 Uhr."
+msgid "Morning: 9:00 to 12:00,"
+msgstr "Morgens: 9:00 bis 12:00 Uhr,"
+
+#: src/welcome-day-1.md:37
+msgid "Afternoon: 13:00 to 16:00."
+msgstr "Nachmittag: 13:00 bis 16:00 Uhr."
 
 #: src/welcome-day-1.md:39
 msgid ""
 "You can of course adjust this as necessary. Please make sure to include "
-"breaks,\n"
-"we recommend a break every hour!"
+"breaks, we recommend a break every hour!"
 msgstr ""
 "Dies kannst Du natürlich bei Bedarf anpassen. Bitte achte darauf, Pausen "
-"einzuplanen.\n"
-"Wir empfehlen jede Stunde eine Pause!"
-
-#: src/welcome-day-1/what-is-rust.md:1
-msgid "# What is Rust?"
-msgstr "# Was ist Rust?"
+"einzuplanen. Wir empfehlen jede Stunde eine Pause!"
 
 #: src/welcome-day-1/what-is-rust.md:3
 msgid ""
-"Rust is a new programming language which had its [1.0 release in 2015][1]:"
+"Rust is a new programming language which had its [1.0 release in 2015]"
+"(https://blog.rust-lang.org/2015/05/15/Rust-1.0.html):"
 msgstr ""
 "Rust ist eine neue Programmiersprache, die 2015 ihre Version 1.0 hatte:"
 
 #: src/welcome-day-1/what-is-rust.md:5
-msgid ""
-"* Rust is a statically compiled language in a similar role as C++\n"
-"  * `rustc` uses LLVM as its backend.\n"
-"* Rust supports many [platforms and\n"
-"  architectures](https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust is used for a wide range of devices:\n"
-"  * firmware and boot loaders,\n"
-"  * smart displays,\n"
-"  * mobile phones,\n"
-"  * desktops,\n"
-"  * servers."
+msgid "Rust is a statically compiled language in a similar role as C++"
 msgstr ""
-"* Rust ist eine statisch kompilierte Sprache in einer ähnlichen Rolle wie C+"
-"+\n"
-"  * `rustc` verwendet LLVM als Backend.\n"
-"* Rust unterstützt viele [Plattformen und\n"
-"  Architekturen] (https://doc.rust-lang.org/nightly/rustc/platform-support."
-"html):\n"
-"  * x86, ARM, WebAssembly, ...\n"
-"  * Linux, Mac, Windows, ...\n"
-"* Rust wird für eine Vielzahl von Geräten verwendet:\n"
-"  * Firmware und Bootloader,\n"
-"  * intelligente Displays,\n"
-"  * Mobiltelefone,\n"
-"  * Desktops,\n"
-"  * Server."
+"Rust ist eine statisch kompilierte Sprache in einer ähnlichen Rolle wie C++"
+
+#: src/welcome-day-1/what-is-rust.md:6
+msgid "`rustc` uses LLVM as its backend."
+msgstr "`rustc` verwendet LLVM als Backend."
+
+#: src/welcome-day-1/what-is-rust.md:7
+msgid ""
+"Rust supports many [platforms and architectures](https://doc.rust-lang.org/"
+"nightly/rustc/platform-support.html):"
+msgstr ""
+"Rust unterstützt viele \\[Plattformen und Architekturen\\] (https://doc.rust-"
+"lang.org/nightly/rustc/platform-support.html):"
+
+#: src/welcome-day-1/what-is-rust.md:9
+msgid "x86, ARM, WebAssembly, ..."
+msgstr "x86, ARM, WebAssembly, ..."
+
+#: src/welcome-day-1/what-is-rust.md:10
+msgid "Linux, Mac, Windows, ..."
+msgstr "Linux, Mac, Windows, ..."
+
+#: src/welcome-day-1/what-is-rust.md:11
+msgid "Rust is used for a wide range of devices:"
+msgstr "Rust wird für eine Vielzahl von Geräten verwendet:"
+
+#: src/welcome-day-1/what-is-rust.md:12
+msgid "firmware and boot loaders,"
+msgstr "Firmware und Bootloader,"
+
+#: src/welcome-day-1/what-is-rust.md:13
+msgid "smart displays,"
+msgstr "intelligente Displays,"
+
+#: src/welcome-day-1/what-is-rust.md:14
+msgid "mobile phones,"
+msgstr "Mobiltelefone,"
+
+#: src/welcome-day-1/what-is-rust.md:15
+msgid "desktops,"
+msgstr "Desktops,"
+
+#: src/welcome-day-1/what-is-rust.md:16
+msgid "servers."
+msgstr "Server."
 
 #: src/welcome-day-1/what-is-rust.md:21
 msgid "Rust fits in the same area as C++:"
 msgstr "Rust passt in den gleichen Bereich wie C++:"
 
 #: src/welcome-day-1/what-is-rust.md:23
-msgid ""
-"* High flexibility.\n"
-"* High level of control.\n"
-"* Can be scaled down to very constrained devices like mobile phones.\n"
-"* Has no runtime or garbage collection.\n"
-"* Focuses on reliability and safety without sacrificing performance."
-msgstr ""
-"* Hohe Flexibilität.\n"
-"* Hohes Maß an Kontrolle.\n"
-"* Kann auf sehr eingeschränkte Geräte wie Mobiltelefone herunterskaliert "
-"werden.\n"
-"* Hat keine Laufzeit oder Speicherbereinigung (garbage collection).\n"
-"* Konzentriert sich auf Zuverlässigkeit und Sicherheit ohne "
-"Leistungseinbußen."
+msgid "High flexibility."
+msgstr "Hohe Flexibilität."
 
-#: src/hello-world.md:1
-msgid "# Hello World!"
-msgstr "# Hallo Welt!"
+#: src/welcome-day-1/what-is-rust.md:24
+msgid "High level of control."
+msgstr "Hohes Maß an Kontrolle."
+
+#: src/welcome-day-1/what-is-rust.md:25
+msgid "Can be scaled down to very constrained devices like mobile phones."
+msgstr ""
+"Kann auf sehr eingeschränkte Geräte wie Mobiltelefone herunterskaliert "
+"werden."
+
+#: src/welcome-day-1/what-is-rust.md:26
+msgid "Has no runtime or garbage collection."
+msgstr "Hat keine Laufzeit oder Speicherbereinigung (garbage collection)."
+
+#: src/welcome-day-1/what-is-rust.md:27
+msgid "Focuses on reliability and safety without sacrificing performance."
+msgstr ""
+"Konzentriert sich auf Zuverlässigkeit und Sicherheit ohne Leistungseinbußen."
 
 #: src/hello-world.md:3
 msgid ""
-"Let us jump into the simplest possible Rust program, a classic Hello World\n"
+"Let us jump into the simplest possible Rust program, a classic Hello World "
 "program:"
 msgstr ""
 "Lasst uns in das einfachste Rust-Programm einsteigen, ein klassisches Hallo "
-"Welt\n"
-"Programm:"
+"Welt Programm:"
 
 #: src/hello-world.md:6
 msgid ""
@@ -2407,74 +2281,72 @@ msgid "What you see:"
 msgstr "Du siehst:"
 
 #: src/hello-world.md:14
-msgid ""
-"* Functions are introduced with `fn`.\n"
-"* Blocks are delimited by curly braces like in C and C++.\n"
-"* The `main` function is the entry point of the program.\n"
-"* Rust has hygienic macros, `println!` is an example of this.\n"
-"* Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgid "Functions are introduced with `fn`."
+msgstr "Funktionen beginnen mit `fn`."
+
+#: src/hello-world.md:15
+msgid "Blocks are delimited by curly braces like in C and C++."
+msgstr "Blöcke werden wie in C und C++ durch geschweifte Klammern getrennt."
+
+#: src/hello-world.md:16
+msgid "The `main` function is the entry point of the program."
+msgstr "Die `main`\\-Funktion ist der Einstiegspunkt des Programms."
+
+#: src/hello-world.md:17
+msgid "Rust has hygienic macros, `println!` is an example of this."
 msgstr ""
-"* Funktionen beginnen mit `fn`.\n"
-"* Blöcke werden wie in C und C++ durch geschweifte Klammern getrennt.\n"
-"* Die `main`-Funktion ist der Einstiegspunkt des Programms.\n"
-"* Rust hat hygienische (hygienic) Makros, `println!` ist ein Beispiel "
-"dafür.\n"
-"* Rust-Strings sind UTF-8-codiert und können beliebige Unicode-Zeichen "
+"Rust hat hygienische (hygienic) Makros, `println!` ist ein Beispiel dafür."
+
+#: src/hello-world.md:18
+msgid "Rust strings are UTF-8 encoded and can contain any Unicode character."
+msgstr ""
+"Rust-Strings sind UTF-8-codiert und können beliebige Unicode-Zeichen "
 "enthalten."
 
 #: src/hello-world.md:22
 msgid ""
 "This slide tries to make the students comfortable with Rust code. They will "
-"see\n"
-"a ton of it over the next four days so we start small with something "
+"see a ton of it over the next four days so we start small with something "
 "familiar."
 msgstr ""
 "Diese Folie versucht, die Schüler mit Rust-Code vertraut zu machen. Sie "
-"werden viel\n"
-"davon in den nächsten vier Tagen sehen, also fangen wir klein und mit etwas "
-"Vertrautem an."
+"werden viel davon in den nächsten vier Tagen sehen, also fangen wir klein "
+"und mit etwas Vertrautem an."
 
 #: src/hello-world.md:27
 msgid ""
-"* Rust is very much like other languages in the C/C++/Java tradition. It is\n"
-"  imperative (not functional) and it doesn't try to reinvent things unless\n"
-"  absolutely necessary.\n"
-"\n"
-"* Rust is modern with full support for things like Unicode.\n"
-"\n"
-"* Rust uses macros for situations where you want to have a variable number "
-"of\n"
-"  arguments (no function [overloading](basic-syntax/functions-interlude."
-"md)).\n"
-"\n"
-"* Macros being 'hygienic' means they don't accidentally capture identifiers "
-"from\n"
-"  the scope they are used in. Rust macros are actually only\n"
-"  [partially hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/"
-"hygiene.html)."
+"Rust is very much like other languages in the C/C++/Java tradition. It is "
+"imperative (not functional) and it doesn't try to reinvent things unless "
+"absolutely necessary."
 msgstr ""
-"* Rust ist anderen Sprachen in der C/C++/Java-Tradition sehr ähnlich. Es "
-"ist\n"
-"   Imperativ (nicht funktional) und es wird nicht versucht, Dinge neu zu "
-"erfinden, es sei denn es ist\n"
-"   absolut notwendig.\n"
-"\n"
-"* Rust ist modern und unterstützt Dinge wie Unicode vollständig.\n"
-"\n"
-"* Rust verwendet Makros für Situationen, in denen Du eine variable Anzahl "
-"von Argumenten haben möchtest\n"
-"   (keine [Funktionüberladung](basic-syntax/functions-interlude.md)).\n"
-"\n"
-"* Makros sind „hygienisch“, was bedeutet, dass sie nicht versehentlich "
-"Identifikatoren in ihrem Umfang (scope) in dem sie verwendet werden "
-"erfassen\n"
-"   Rust-Makros sind eigentlich nur\n"
-"   [teilweise hygienisch](https://veykril.github.io/tlborm/decl-macros/"
-"minutiae/hygiene.html)."
+"Rust ist anderen Sprachen in der C/C++/Java-Tradition sehr ähnlich. Es ist "
+"Imperativ (nicht funktional) und es wird nicht versucht, Dinge neu zu "
+"erfinden, es sei denn es ist absolut notwendig."
 
-#: src/hello-world/small-example.md:1
-msgid "# Small Example"
-msgstr "# Ein kleines Beispiel"
+#: src/hello-world.md:31
+msgid "Rust is modern with full support for things like Unicode."
+msgstr "Rust ist modern und unterstützt Dinge wie Unicode vollständig."
+
+#: src/hello-world.md:33
+msgid ""
+"Rust uses macros for situations where you want to have a variable number of "
+"arguments (no function [overloading](basic-syntax/functions-interlude.md))."
+msgstr ""
+"Rust verwendet Makros für Situationen, in denen Du eine variable Anzahl von "
+"Argumenten haben möchtest (keine [Funktionüberladung](basic-syntax/functions-"
+"interlude.md))."
+
+#: src/hello-world.md:36
+msgid ""
+"Macros being 'hygienic' means they don't accidentally capture identifiers "
+"from the scope they are used in. Rust macros are actually only [partially "
+"hygienic](https://veykril.github.io/tlborm/decl-macros/minutiae/hygiene."
+"html)."
+msgstr ""
+"Makros sind „hygienisch“, was bedeutet, dass sie nicht versehentlich "
+"Identifikatoren in ihrem Umfang (scope) in dem sie verwendet werden erfassen "
+"Rust-Makros sind eigentlich nur [teilweise hygienisch](https://veykril."
+"github.io/tlborm/decl-macros/minutiae/hygiene.html)."
 
 #: src/hello-world/small-example.md:3
 msgid "Here is a small example program in Rust:"
@@ -2502,10 +2374,8 @@ msgstr ""
 #: src/hello-world/small-example.md:23
 msgid ""
 "The code implements the Collatz conjecture: it is believed that the loop "
-"will\n"
-"always end, but this is not yet proved. Edit the code and play with "
-"different\n"
-"inputs."
+"will always end, but this is not yet proved. Edit the code and play with "
+"different inputs."
 msgstr ""
 "Der Code implementiert die Collatz-Vermutung: Es wird angenommen, dass die "
 "Schleife immer enden wird, allerdings ist das noch nicht bewiesen. Ändere "
@@ -2513,427 +2383,516 @@ msgstr ""
 
 #: src/hello-world/small-example.md:29
 msgid ""
-"* Explain that all variables are statically typed. Try removing `i32` to "
-"trigger\n"
-"  type inference. Try with `i8` instead and trigger a runtime integer "
-"overflow.\n"
-"\n"
-"* Change `let mut x` to `let x`, discuss the compiler error.\n"
-"\n"
-"* Show how `print!` gives a compilation error if the arguments don't match "
-"the\n"
-"  format string.\n"
-"\n"
-"* Show how you need to use `{}` as a placeholder if you want to print an\n"
-"  expression which is more complex than just a single variable.\n"
-"\n"
-"* Show the students the standard library, show them how to search for `std::"
-"fmt`\n"
-"  which has the rules of the formatting mini-language. It's important that "
-"the\n"
-"  students become familiar with searching in the standard library."
+"Explain that all variables are statically typed. Try removing `i32` to "
+"trigger type inference. Try with `i8` instead and trigger a runtime integer "
+"overflow."
 msgstr ""
-"* Erkläre, dass alle Variablen statisch typisiert sind. Versuche, `i32` zu "
+"Erkläre, dass alle Variablen statisch typisiert sind. Versuche, `i32` zu "
 "entfernen um Typinferenz (type inference) auszulösen. Versuche es "
 "stattdessen mit `i8` und löse dadurch einen Ganzzahlüberlauf zur Laufzeit "
-"aus.\n"
-"\n"
-"* Ändere `let mut x` in `let x`, und bespreche den Compilerfehler.\n"
-"\n"
-"* Zeige, wie `print!` einen Kompilierungsfehler ausgibt, wenn die Argumente "
-"nicht mit dem Format-String übereinstimmen.\n"
-"\n"
-"* Zeige, wie Du `{}` als Platzhalter verwenden musst, wenn Du einen Ausdruck "
-"(Expression) drucken möchtest,\n"
-"   der komplexer als nur eine einzelne Variable ist.\n"
-"\n"
-"* Zeige den Kursteilnehmern die Standardbibliothek (standard library) und "
-"zeige ihnen, wie sie nach `std::fmt` suchen\n"
-"   welches die Regeln der Formatierungs-Minisprache enthält. Es ist wichtig, "
-"dass die\n"
-"   Kursteilnehmer mit der Suche in der Standardbibliothek vertraut gemacht "
-"werden."
+"aus."
 
-#: src/why-rust.md:1
-msgid "# Why Rust?"
-msgstr "# Warum Rust?"
+#: src/hello-world/small-example.md:32
+msgid "Change `let mut x` to `let x`, discuss the compiler error."
+msgstr "Ändere `let mut x` in `let x`, und bespreche den Compilerfehler."
+
+#: src/hello-world/small-example.md:34
+msgid ""
+"Show how `print!` gives a compilation error if the arguments don't match the "
+"format string."
+msgstr ""
+"Zeige, wie `print!` einen Kompilierungsfehler ausgibt, wenn die Argumente "
+"nicht mit dem Format-String übereinstimmen."
+
+#: src/hello-world/small-example.md:37
+msgid ""
+"Show how you need to use `{}` as a placeholder if you want to print an "
+"expression which is more complex than just a single variable."
+msgstr ""
+"Zeige, wie Du `{}` als Platzhalter verwenden musst, wenn Du einen Ausdruck "
+"(Expression) drucken möchtest, der komplexer als nur eine einzelne Variable "
+"ist."
+
+#: src/hello-world/small-example.md:40
+msgid ""
+"Show the students the standard library, show them how to search for `std::"
+"fmt` which has the rules of the formatting mini-language. It's important "
+"that the students become familiar with searching in the standard library."
+msgstr ""
+"Zeige den Kursteilnehmern die Standardbibliothek (standard library) und "
+"zeige ihnen, wie sie nach `std::fmt` suchen welches die Regeln der "
+"Formatierungs-Minisprache enthält. Es ist wichtig, dass die Kursteilnehmer "
+"mit der Suche in der Standardbibliothek vertraut gemacht werden."
 
 #: src/why-rust.md:3
 msgid "Some unique selling points of Rust:"
 msgstr "Einige Alleinstellungsmerkmale von Rust:"
 
 #: src/why-rust.md:5
-msgid ""
-"* Compile time memory safety.\n"
-"* Lack of undefined runtime behavior.\n"
-"* Modern language features."
-msgstr ""
-"* Kompilierzeit-Speichersicherheit.\n"
-"* Mangel in undefiniertem Laufzeitverhalten.\n"
-"* Moderne Sprachfunktionen."
+msgid "Compile time memory safety."
+msgstr "Kompilierzeit-Speichersicherheit."
+
+#: src/why-rust.md:6
+msgid "Lack of undefined runtime behavior."
+msgstr "Mangel in undefiniertem Laufzeitverhalten."
+
+#: src/why-rust.md:7
+msgid "Modern language features."
+msgstr "Moderne Sprachfunktionen."
 
 #: src/why-rust.md:11
 msgid ""
 "Make sure to ask the class which languages they have experience with. "
-"Depending\n"
-"on the answer you can highlight different features of Rust:"
+"Depending on the answer you can highlight different features of Rust:"
 msgstr ""
 "Frage den Kurs unbedingt, mit welchen Programmiersprachen sie Erfahrung "
-"haben. Abhängig\n"
-"von der Antwort kannst Du verschiedene Funktionen von Rust hervorheben:"
+"haben. Abhängig von der Antwort kannst Du verschiedene Funktionen von Rust "
+"hervorheben:"
 
 #: src/why-rust.md:14
 msgid ""
-"* Experience with C or C++: Rust eliminates a whole class of _runtime "
-"errors_\n"
-"  via the borrow checker. You get performance like in C and C++, but you "
-"don't\n"
-"  have the memory unsafety issues. In addition, you get a modern language "
-"with\n"
-"  constructs like pattern matching and built-in dependency management.\n"
-"\n"
-"* Experience with Java, Go, Python, JavaScript...: You get the same memory "
-"safety\n"
-"  as in those languages, plus a similar high-level language feeling. In "
-"addition\n"
-"  you get fast and predictable performance like C and C++ (no garbage "
-"collector)\n"
-"  as well as access to low-level hardware (should you need it)"
+"Experience with C or C++: Rust eliminates a whole class of _runtime errors_ "
+"via the borrow checker. You get performance like in C and C++, but you don't "
+"have the memory unsafety issues. In addition, you get a modern language with "
+"constructs like pattern matching and built-in dependency management."
 msgstr ""
-"* Erfahrung mit C oder C++: Rust eliminiert eine ganze Klasse von "
-"_Laufzeitfehlern (runtime Errors)_\n"
-"   über den Ausleihenprüfer (borrow checker). Du erhältst eine ähnliche "
-"Leistung wie in C und C++, aber hast\n"
-"   keine Probleme mit der Speicherunsicherheit. Darüber hinaus erhältst Du "
-"eine moderne Sprache mit\n"
-"   Konstrukten wie Mustervergleich (Pattern matching) und integriertes "
-"Abhängigkeitsmanagement (dependency management).\n"
-"\n"
-"* Erfahrung mit Java, Go, Python, JavaScript...: Du erhältst die gleiche "
-"Speichersicherheit\n"
-"   wie in diesen Sprachen, dazu ein ähnlich hohes Sprachgefühl. Zusätzlich\n"
-"   erhältst Du eine schnelle und vorhersehbare Leistung wie in C und C++ "
-"(keine Speicherbereinigung (garbage collector))\n"
-"   sowie Zugriff auf Low-Level-Hardware (falls benötigt)."
+"Erfahrung mit C oder C++: Rust eliminiert eine ganze Klasse von "
+"_Laufzeitfehlern (runtime Errors)_ über den Ausleihenprüfer (borrow "
+"checker). Du erhältst eine ähnliche Leistung wie in C und C++, aber hast "
+"keine Probleme mit der Speicherunsicherheit. Darüber hinaus erhältst Du eine "
+"moderne Sprache mit Konstrukten wie Mustervergleich (Pattern matching) und "
+"integriertes Abhängigkeitsmanagement (dependency management)."
 
-#: src/why-rust/compile-time.md:1
-msgid "# Compile Time Guarantees"
-msgstr "# Kompilierzeitgarantien"
+#: src/why-rust.md:19
+msgid ""
+"Experience with Java, Go, Python, JavaScript...: You get the same memory "
+"safety as in those languages, plus a similar high-level language feeling. In "
+"addition you get fast and predictable performance like C and C++ (no garbage "
+"collector) as well as access to low-level hardware (should you need it)"
+msgstr ""
+"Erfahrung mit Java, Go, Python, JavaScript...: Du erhältst die gleiche "
+"Speichersicherheit wie in diesen Sprachen, dazu ein ähnlich hohes "
+"Sprachgefühl. Zusätzlich erhältst Du eine schnelle und vorhersehbare "
+"Leistung wie in C und C++ (keine Speicherbereinigung (garbage collector)) "
+"sowie Zugriff auf Low-Level-Hardware (falls benötigt)."
 
 #: src/why-rust/compile-time.md:3
 msgid "Static memory management at compile time:"
 msgstr "Statische Speicherverwaltung zur Kompilierzeit:"
 
 #: src/why-rust/compile-time.md:5
-msgid ""
-"* No uninitialized variables.\n"
-"* No memory leaks (_mostly_, see notes).\n"
-"* No double-frees.\n"
-"* No use-after-free.\n"
-"* No `NULL` pointers.\n"
-"* No forgotten locked mutexes.\n"
-"* No data races between threads.\n"
-"* No iterator invalidation."
-msgstr ""
-"* Keine nicht initialisierten (uninitialized) Variablen.\n"
-"* Keine Speicherlecks (_meistens_, siehe Anmerkungen).\n"
-"* Keine Doppelbefreiungen (double-frees).\n"
-"* Keine Nachnutzung (use-after-free).\n"
-"* Keine `NULL`-Zeiger (null Pointer).\n"
-"* Keine vergessenen gesperrten Mutexe.\n"
-"* Keine Datenrennen (data races) zwischen Ausführungssträngen (threads).\n"
-"* Keine Invalidierung des Iterators."
+msgid "No uninitialized variables."
+msgstr "Keine nicht initialisierten (uninitialized) Variablen."
+
+#: src/why-rust/compile-time.md:6
+msgid "No memory leaks (_mostly_, see notes)."
+msgstr "Keine Speicherlecks (_meistens_, siehe Anmerkungen)."
+
+#: src/why-rust/compile-time.md:7
+msgid "No double-frees."
+msgstr "Keine Doppelbefreiungen (double-frees)."
+
+#: src/why-rust/compile-time.md:8
+msgid "No use-after-free."
+msgstr "Keine Nachnutzung (use-after-free)."
+
+#: src/why-rust/compile-time.md:9
+msgid "No `NULL` pointers."
+msgstr "Keine `NULL`\\-Zeiger (null Pointer)."
+
+#: src/why-rust/compile-time.md:10
+msgid "No forgotten locked mutexes."
+msgstr "Keine vergessenen gesperrten Mutexe."
+
+#: src/why-rust/compile-time.md:11
+msgid "No data races between threads."
+msgstr "Keine Datenrennen (data races) zwischen Ausführungssträngen (threads)."
+
+#: src/why-rust/compile-time.md:12
+msgid "No iterator invalidation."
+msgstr "Keine Invalidierung des Iterators."
 
 #: src/why-rust/compile-time.md:16
 msgid ""
-"It is possible to produce memory leaks in (safe) Rust. Some examples\n"
-"are:"
+"It is possible to produce memory leaks in (safe) Rust. Some examples are:"
 msgstr ""
 "Es ist möglich, Speicherlecks in (sicherem) Rust zu erzeugen. Einige "
 "Beispiele sind:"
 
 #: src/why-rust/compile-time.md:19
 msgid ""
-"* You can use [`Box::leak`] to leak a pointer. A use of this could\n"
-"  be to get runtime-initialized and runtime-sized static variables\n"
-"* You can use [`std::mem::forget`] to make the compiler \"forget\" about\n"
-"  a value (meaning the destructor is never run).\n"
-"* You can also accidentally create a [reference cycle] with `Rc` or\n"
-"  `Arc`.\n"
-"* In fact, some will consider infinitely populating a collection a memory\n"
-"  leak and Rust does not protect from those."
+"You can use [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) to leak a pointer. A use of this could be to get runtime-"
+"initialized and runtime-sized static variables"
 msgstr ""
-"* Du kannst [`Box::leak`] verwenden, um einen Zeiger zu verlieren. Eine "
-"Nutzung dieser könnte\n"
-"  sein, um zur Laufzeit initialisierte statische Variablen in Laufzeitgröße "
-"zu erhalten\n"
-"* Du kannst [`std::mem::forget`] verwenden, um den Compiler einen Wert "
-"\"vergessen\" zu lassen\n"
-"  (was bedeutet, dass der Destruktor niemals ausgeführt wird).\n"
-"* Du kannst auch versehentlich einen [Referenzzyklus] mit `Rc` oder `Arc` "
-"erstellen\n"
-"* In der Tat werden einige in Betracht ziehen, eine Sammlung (Collection) "
-"unendlich  zu befüllen\n"
-"  Rust schützt nicht vor sowelchen Speicherlecks (memory leaks)."
+"Du kannst [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box."
+"html#method.leak) verwenden, um einen Zeiger zu verlieren. Eine Nutzung "
+"dieser könnte sein, um zur Laufzeit initialisierte statische Variablen in "
+"Laufzeitgröße zu erhalten"
+
+#: src/why-rust/compile-time.md:21
+msgid ""
+"You can use [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) to make the compiler \"forget\" about a value (meaning the destructor "
+"is never run)."
+msgstr ""
+"Du kannst [`std::mem::forget`](https://doc.rust-lang.org/std/mem/fn.forget."
+"html) verwenden, um den Compiler einen Wert \"vergessen\" zu lassen (was "
+"bedeutet, dass der Destruktor niemals ausgeführt wird)."
+
+#: src/why-rust/compile-time.md:23
+msgid ""
+"You can also accidentally create a [reference cycle](https://doc.rust-lang."
+"org/book/ch15-06-reference-cycles.html) with `Rc` or `Arc`."
+msgstr ""
+"Du kannst auch versehentlich einen \\[Referenzzyklus\\] mit `Rc` oder `Arc` "
+"erstellen"
+
+#: src/why-rust/compile-time.md:25
+msgid ""
+"In fact, some will consider infinitely populating a collection a memory leak "
+"and Rust does not protect from those."
+msgstr ""
+"In der Tat werden einige in Betracht ziehen, eine Sammlung (Collection) "
+"unendlich  zu befüllen Rust schützt nicht vor sowelchen Speicherlecks "
+"(memory leaks)."
 
 #: src/why-rust/compile-time.md:28
 msgid ""
-"For the purpose of this course, \"No memory leaks\" should be understood\n"
-"as \"Pretty much no *accidental* memory leaks\"."
+"For the purpose of this course, \"No memory leaks\" should be understood as "
+"\"Pretty much no _accidental_ memory leaks\"."
 msgstr ""
-"\"Keine Speicherlecks\" sollten somit verstanden werden\n"
-"als \"so gut wie keine *versehentlichen* Speicherlecks\"."
-
-#: src/why-rust/runtime.md:1
-msgid "# Runtime Guarantees"
-msgstr "# Laufzeitgarantien"
+"\"Keine Speicherlecks\" sollten somit verstanden werden als \"so gut wie "
+"keine _versehentlichen_ Speicherlecks\"."
 
 #: src/why-rust/runtime.md:3
 msgid "No undefined behavior at runtime:"
 msgstr "Kein undefiniertes Verhalten (undefined behavior) zur Laufzeit:"
 
 #: src/why-rust/runtime.md:5
-msgid ""
-"* Array access is bounds checked.\n"
-"* Integer overflow is defined."
-msgstr ""
-"* Der Array-Zugriff wird auf Grenzen geprüft.\n"
-"* Ganzzahlüberlauf ist definiert."
+msgid "Array access is bounds checked."
+msgstr "Der Array-Zugriff wird auf Grenzen geprüft."
+
+#: src/why-rust/runtime.md:6
+msgid "Integer overflow is defined."
+msgstr "Ganzzahlüberlauf ist definiert."
 
 #: src/why-rust/runtime.md:12
 msgid ""
-"* Integer overflow is defined via a compile-time flag. The options are\n"
-"  either a panic (a controlled crash of the program) or wrap-around\n"
-"  semantics. By default, you get panics in debug mode (`cargo build`)\n"
-"  and wrap-around in release mode (`cargo build --release`).\n"
-"\n"
-"* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-"  not be disabled directly with the `unsafe` keyword. However,\n"
-"  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-"  which does not do bounds checking."
+"Integer overflow is defined via a compile-time flag. The options are either "
+"a panic (a controlled crash of the program) or wrap-around semantics. By "
+"default, you get panics in debug mode (`cargo build`) and wrap-around in "
+"release mode (`cargo build --release`)."
 msgstr ""
-"* Ganzzahlüberlauf (integer overflow) wird über ein Flag zur Kompilierzeit "
-"definiert. Die Optionen sind\n"
-"  entweder ein kontrollierter Abbruch des Programms (panic) oder eine Wrap-"
-"Around\n"
-"  Semantik. Standardmäßig erhältst Du einen Abbruch (panic) im Debug-Modus "
-"(`cargo build`)\n"
-"  und ein Wrap-Around im Release-Modus (`cargo build --release`).\n"
-"\n"
-"* Die Grenzüberprüfung (bounds checking) kann nicht mit einem Compiler-Flag "
-"deaktiviert werden. Es kann auch\n"
-"   nicht direkt mit dem Schlüsselwort „unsafe“ deaktiviert werden. Jedoch "
-"kannst Du Funktionen wie\n"
-"   `slice::get_unchecked` mit `unsafe` aufrufen\n"
-"   was keine Grenzenprüfung durchführt."
+"Ganzzahlüberlauf (integer overflow) wird über ein Flag zur Kompilierzeit "
+"definiert. Die Optionen sind entweder ein kontrollierter Abbruch des "
+"Programms (panic) oder eine Wrap-Around Semantik. Standardmäßig erhältst Du "
+"einen Abbruch (panic) im Debug-Modus (`cargo build`) und ein Wrap-Around im "
+"Release-Modus (`cargo build --release`)."
 
-#: src/why-rust/modern.md:1
-msgid "# Modern Features"
-msgstr "# Moderne Funktionen"
+#: src/why-rust/runtime.md:17
+msgid ""
+"Bounds checking cannot be disabled with a compiler flag. It can also not be "
+"disabled directly with the `unsafe` keyword. However, `unsafe` allows you to "
+"call functions such as `slice::get_unchecked` which does not do bounds "
+"checking."
+msgstr ""
+"Die Grenzüberprüfung (bounds checking) kann nicht mit einem Compiler-Flag "
+"deaktiviert werden. Es kann auch nicht direkt mit dem Schlüsselwort „unsafe“ "
+"deaktiviert werden. Jedoch kannst Du Funktionen wie `slice::get_unchecked` "
+"mit `unsafe` aufrufen was keine Grenzenprüfung durchführt."
 
 #: src/why-rust/modern.md:3
 msgid "Rust is built with all the experience gained in the last 40 years."
 msgstr "Rust wurde mit vielen Erfahrungen aus den letzten 40 Jahren gebaut."
 
 #: src/why-rust/modern.md:5
-msgid "## Language Features"
-msgstr "## Sprachmerkmale"
+msgid "Language Features"
+msgstr "Sprachmerkmale"
 
 #: src/why-rust/modern.md:7
-msgid ""
-"* Enums and pattern matching.\n"
-"* Generics.\n"
-"* No overhead FFI.\n"
-"* Zero-cost abstractions."
-msgstr ""
-"* Enums und Musterabgleich (pattern matching).\n"
-"* Generika.\n"
-"* Kein Overhead-FFI.\n"
-"* Nullkosten-Abstraktionen."
+msgid "Enums and pattern matching."
+msgstr "Enums und Musterabgleich (pattern matching)."
+
+#: src/why-rust/modern.md:8
+msgid "Generics."
+msgstr "Generika."
+
+#: src/why-rust/modern.md:9
+msgid "No overhead FFI."
+msgstr "Kein Overhead-FFI."
+
+#: src/why-rust/modern.md:10
+msgid "Zero-cost abstractions."
+msgstr "Nullkosten-Abstraktionen."
 
 #: src/why-rust/modern.md:12
-msgid "## Tooling"
-msgstr "## Werkzeuge (Tools)"
+msgid "Tooling"
+msgstr "Werkzeuge (Tools)"
 
 #: src/why-rust/modern.md:14
-msgid ""
-"* Great compiler errors.\n"
-"* Built-in dependency manager.\n"
-"* Built-in support for testing.\n"
-"* Excellent Language Server Protocol support."
-msgstr ""
-"* Gute Compiler-Fehler.\n"
-"* Eingebauter Paketmanager.\n"
-"* Eingebaute Unterstützung für Tests.\n"
-"* Hervorragende Unterstützung des Language Server Protokolls."
+msgid "Great compiler errors."
+msgstr "Gute Compiler-Fehler."
+
+#: src/why-rust/modern.md:15
+msgid "Built-in dependency manager."
+msgstr "Eingebauter Paketmanager."
+
+#: src/why-rust/modern.md:16
+msgid "Built-in support for testing."
+msgstr "Eingebaute Unterstützung für Tests."
+
+#: src/why-rust/modern.md:17
+msgid "Excellent Language Server Protocol support."
+msgstr "Hervorragende Unterstützung des Language Server Protokolls."
 
 #: src/why-rust/modern.md:23
 msgid ""
-"* Zero-cost abstractions, similar to C++, means that you don't have to "
-"'pay'\n"
-"  for higher-level programming constructs with memory or CPU. For example,\n"
-"  writing a loop using `for` should result in roughly the same low level\n"
-"  instructions as using the `.iter().fold()` construct.\n"
-"\n"
-"* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-"also\n"
-"  known as 'sum types', which allow the type system to express things like\n"
-"  `Option<T>` and `Result<T, E>`.\n"
-"\n"
-"* Remind people to read the errors --- many developers have gotten used to\n"
-"  ignore lengthy compiler output. The Rust compiler is significantly more\n"
-"  talkative than other compilers. It will often provide you with "
-"_actionable_\n"
-"  feedback, ready to copy-paste into your code.\n"
-"\n"
-"* The Rust standard library is small compared to languages like Java, "
-"Python,\n"
-"  and Go. Rust does not come with several things you might consider standard "
-"and\n"
-"  essential:\n"
-"\n"
-"  * a random number generator, but see [rand].\n"
-"  * support for SSL or TLS, but see [rusttls].\n"
-"  * support for JSON, but see [serde_json].\n"
-"\n"
-"  The reasoning behind this is that functionality in the standard library "
-"cannot\n"
-"  go away, so it has to be very stable. For the examples above, the Rust\n"
-"  community is still working on finding the best solution --- and perhaps "
-"there\n"
-"  isn't a single \"best solution\" for some of these things.\n"
-"\n"
-"  Rust comes with a built-in package manager in the form of Cargo and this "
-"makes\n"
-"  it trivial to download and compile third-party crates. A consequence of "
-"this\n"
-"  is that the standard library can be smaller.\n"
-"\n"
-"  Discovering good third-party crates can be a problem. Sites like\n"
-"  <https://lib.rs/> help with this by letting you compare health metrics "
-"for\n"
-"  crates to find a good and trusted one.\n"
-"  \n"
-"* [rust-analyzer] is a well supported LSP implementation used in major\n"
-"  IDEs and text editors."
+"Zero-cost abstractions, similar to C++, means that you don't have to 'pay' "
+"for higher-level programming constructs with memory or CPU. For example, "
+"writing a loop using `for` should result in roughly the same low level "
+"instructions as using the `.iter().fold()` construct."
 msgstr ""
-"* Kostenfreie Abstraktionen, ähnlich wie bei C++, bedeuten, dass Du für "
+"Kostenfreie Abstraktionen, ähnlich wie bei C++, bedeuten, dass Du für "
 "Programmierkonstrukte auf höherer Ebene nicht mit Speicher oder CPU "
 "„bezahlen“ musst. Beispielsweise sollte das Schreiben einer Schleife mit "
 "`for` ungefähr zu denselben Low-Level-Anweisungen führen wie die Verwendung "
-"des Konstrukts `.iter().fold()`.\n"
-"\n"
-"* Es kann erwähnenswert sein, dass Rust-Enums „algebraische Datentypen“ "
-"sind, auch bekannt als „Summentypen“, die es dem Typsystem ermöglichen, "
-"Dinge wie `Option<T>` und `Result<T, E>` auszudrücken.\n"
-"\n"
-"* Erinnere die Teilnehmer daran, die Fehler zu lesen – viele Entwickler "
-"haben sich daran gewöhnt, lange Compiler-Ausgaben zu ignorieren. Der Rust-"
-"Compiler ist deutlich gesprächiger als andere Compiler. Es liefert Ihnen oft "
-"_umsetzbares_ Feedback, das Sie in Ihren Code einfach übernehmen können.\n"
-"\n"
-"* Die Rust-Standardbibliothek ist im Vergleich zu Sprachen wie Java, Python "
+"des Konstrukts `.iter().fold()`."
+
+#: src/why-rust/modern.md:28
+msgid ""
+"It may be worth mentioning that Rust enums are 'Algebraic Data Types', also "
+"known as 'sum types', which allow the type system to express things like "
+"`Option<T>` and `Result<T, E>`."
+msgstr ""
+"Es kann erwähnenswert sein, dass Rust-Enums „algebraische Datentypen“ sind, "
+"auch bekannt als „Summentypen“, die es dem Typsystem ermöglichen, Dinge wie "
+"`Option<T>` und `Result<T, E>` auszudrücken."
+
+#: src/why-rust/modern.md:32
+msgid ""
+"Remind people to read the errors --- many developers have gotten used to "
+"ignore lengthy compiler output. The Rust compiler is significantly more "
+"talkative than other compilers. It will often provide you with _actionable_ "
+"feedback, ready to copy-paste into your code."
+msgstr ""
+"Erinnere die Teilnehmer daran, die Fehler zu lesen – viele Entwickler haben "
+"sich daran gewöhnt, lange Compiler-Ausgaben zu ignorieren. Der Rust-Compiler "
+"ist deutlich gesprächiger als andere Compiler. Es liefert Ihnen oft "
+"_umsetzbares_ Feedback, das Sie in Ihren Code einfach übernehmen können."
+
+#: src/why-rust/modern.md:37
+msgid ""
+"The Rust standard library is small compared to languages like Java, Python, "
+"and Go. Rust does not come with several things you might consider standard "
+"and essential:"
+msgstr ""
+"Die Rust-Standardbibliothek ist im Vergleich zu Sprachen wie Java, Python "
 "und Go klein. Rust bringt einige Dinge nicht mit, die Sie als normal "
-"betrachten könnten:\n"
-"\n"
-"   * ein Zufallszahlengenerator, siehe aber [rand].\n"
-"   * Unterstützung für SSL oder TLS, siehe jedoch [rusttls].\n"
-"   * Unterstützung für JSON, siehe jedoch [serde_json].\n"
-"\n"
+"betrachten könnten:"
+
+#: src/why-rust/modern.md:41
+msgid "a random number generator, but see [rand](https://docs.rs/rand/)."
+msgstr "ein Zufallszahlengenerator, siehe aber [rand](https://docs.rs/rand/)."
+
+#: src/why-rust/modern.md:42
+msgid "support for SSL or TLS, but see [rusttls](https://docs.rs/rustls/)."
+msgstr ""
+"Unterstützung für SSL oder TLS, siehe jedoch [rusttls](https://docs.rs/"
+"rustls/)."
+
+#: src/why-rust/modern.md:43
+msgid "support for JSON, but see [serde_json](https://docs.rs/serde_json/)."
+msgstr ""
+"Unterstützung für JSON, siehe jedoch [serde_json](https://docs.rs/"
+"serde_json/)."
+
+#: src/why-rust/modern.md:45
+msgid ""
+"The reasoning behind this is that functionality in the standard library "
+"cannot go away, so it has to be very stable. For the examples above, the "
+"Rust community is still working on finding the best solution --- and perhaps "
+"there isn't a single \"best solution\" for some of these things."
+msgstr ""
 "Der Grund dafür ist, dass die Funktionalität in der Standardbibliothek nicht "
 "herausgenommen werden dürfen und daher sehr stabil sein muss. Für die obigen "
 "Beispiele arbeitet die Rust-Gemeinschaft immer noch daran, die beste Lösung "
 "zu finden – und vielleicht gibt es für einige dieser Dinge keine einzige "
-"„beste Lösung“.\n"
-"\n"
-"   Rust verfügt über einen integrierten Paketmanager in Form von Cargo, der "
-"das Herunterladen und Kompilieren von Crates von Drittanbietern vereinfacht. "
-"Dies hat zur Folge, dass die Standardbibliothek kleiner sein kann.\n"
-"\n"
-"   Das Auffinden guter Kisten von Drittanbietern kann ein Problem sein. "
-"Websites wie\n"
-"   <https://lib.rs/> hilft Dir dabei, indem es Dir ermöglicht, "
-"Gesundheitsmetriken für Kisten zu vergleichen, um eine gute und "
-"vertrauenswürdige zu finden.\n"
-"  \n"
-"* [rust-analyzer] ist eine gut unterstützte LSP-Implementierung, die in "
-"wichtigen IDEs und Texteditoren verwendet wird."
+"„beste Lösung“."
 
-#: src/basic-syntax.md:1
-msgid "# Basic Syntax"
-msgstr "# Grundlegende Syntax"
+#: src/why-rust/modern.md:50
+msgid ""
+"Rust comes with a built-in package manager in the form of Cargo and this "
+"makes it trivial to download and compile third-party crates. A consequence "
+"of this is that the standard library can be smaller."
+msgstr ""
+"Rust verfügt über einen integrierten Paketmanager in Form von Cargo, der das "
+"Herunterladen und Kompilieren von Crates von Drittanbietern vereinfacht. "
+"Dies hat zur Folge, dass die Standardbibliothek kleiner sein kann."
+
+#: src/why-rust/modern.md:54
+msgid ""
+"Discovering good third-party crates can be a problem. Sites like <https://"
+"lib.rs/> help with this by letting you compare health metrics for crates to "
+"find a good and trusted one."
+msgstr ""
+"Das Auffinden guter Kisten von Drittanbietern kann ein Problem sein. "
+"Websites wie <https://lib.rs/> hilft Dir dabei, indem es Dir ermöglicht, "
+"Gesundheitsmetriken für Kisten zu vergleichen, um eine gute und "
+"vertrauenswürdige zu finden."
+
+#: src/why-rust/modern.md:58
+msgid ""
+"[rust-analyzer](https://rust-analyzer.github.io/) is a well supported LSP "
+"implementation used in major IDEs and text editors."
+msgstr ""
+"[rust-analyzer](https://rust-analyzer.github.io/) ist eine gut unterstützte "
+"LSP-Implementierung, die in wichtigen IDEs und Texteditoren verwendet wird."
 
 #: src/basic-syntax.md:3
 msgid "Much of the Rust syntax will be familiar to you from C, C++ or Java:"
 msgstr "Ein Großteil der Rust-Syntax wird Ihnen aus C oder C++ bekannt sein:"
 
 #: src/basic-syntax.md:5
-msgid ""
-"* Blocks and scopes are delimited by curly braces.\n"
-"* Line comments are started with `//`, block comments are delimited by `/"
-"* ...\n"
-"  */`.\n"
-"* Keywords like `if` and `while` work the same.\n"
-"* Variable assignment is done with `=`, comparison is done with `==`."
+msgid "Blocks and scopes are delimited by curly braces."
 msgstr ""
-"* Blöcke und Bereiche (scopes) werden durch geschweifte Klammern getrennt.\n"
-"* Zeilenkommentare beginnen mit `//`, Blockkommentare werden mit `/* ... */` "
-"begrenzt\n"
-"* Schlüsselwörter (keywords) wie `if` und `while` funktionieren gleich.\n"
-"* Variablenzuweisung erfolgt mit `=`, Vergleich erfolgt mit `==`."
+"Blöcke und Bereiche (scopes) werden durch geschweifte Klammern getrennt."
 
-#: src/basic-syntax/scalar-types.md:1
-msgid "# Scalar Types"
-msgstr "# Skalare Typen"
-
-#: src/basic-syntax/scalar-types.md:3
+#: src/basic-syntax.md:6
 msgid ""
-"|                        | Types                                      | "
-"Literals                      |\n"
-"|------------------------|--------------------------------------------|-------------------------------|\n"
-"| Signed integers        | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Unsigned integers      | `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | `0`, "
-"`123`, `10u16`           |\n"
-"| Floating point numbers | `f32`, `f64`                               | "
-"`3.14`, `-10.0e20`, `2f32`    |\n"
-"| Strings                | `&str`                                     | "
-"`\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode scalar values  | `char`                                     | "
-"`'a'`, `'α'`, `'∞'`           |\n"
-"| Booleans               | `bool`                                     | "
-"`true`, `false`               |"
+"Line comments are started with `//`, block comments are delimited by `/* ... "
+"*/`."
 msgstr ""
-"| | Typen | Literale |\n"
-"|------------------------|--------------------------------------------|---------------------------------------|\n"
-"| Ganzzahlen mit Vorzeichen | `i8`, `i16`, `i32`, `i64`, `i128`, `isize` | "
-"`-10`, `0`, `1_000`, `123i64` |\n"
-"| Ganzzahlen ohne Vorzeichen  `u8`, `u16`, `u32`, `u64`, `u128`, `usize` | "
-"`0`, `123`, `10u16`           |\n"
-"| Fließkommazahlen | `f32`, `f64`                               | `3.14`, "
-"`-10.0e20`, `2f32`    |\n"
-"| Zeichenketten (Strings) | `&str`                                     | "
-"`\"foo\"`, `\"two\\nlines\"`       |\n"
-"| Unicode-Skalarwerte | `char`                                     | `'a'`, "
-"`'α'`, `'∞'`           \n"
-"| Wahrheitswerte (booleans)               | "
-"`bool`                                     | `true`, `false`               |"
+"Zeilenkommentare beginnen mit `//`, Blockkommentare werden mit `/* ... */` "
+"begrenzt"
+
+#: src/basic-syntax.md:8
+msgid "Keywords like `if` and `while` work the same."
+msgstr "Schlüsselwörter (keywords) wie `if` und `while` funktionieren gleich."
+
+#: src/basic-syntax.md:9
+msgid "Variable assignment is done with `=`, comparison is done with `==`."
+msgstr "Variablenzuweisung erfolgt mit `=`, Vergleich erfolgt mit `==`."
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+#, fuzzy
+msgid "Types"
+msgstr "Typen"
+
+#: src/basic-syntax/scalar-types.md:3 src/basic-syntax/compound-types.md:3
+#, fuzzy
+msgid "Literals"
+msgstr "Literale"
+
+#: src/basic-syntax/scalar-types.md:5
+#, fuzzy
+msgid "Signed integers"
+msgstr "Ganzzahlen mit Vorzeichen"
+
+#: src/basic-syntax/scalar-types.md:5
+#, fuzzy
+msgid "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+msgstr "`i8`, `i16`, `i32`, `i64`, `i128`, `isize`"
+
+#: src/basic-syntax/scalar-types.md:5
+#, fuzzy
+msgid "`-10`, `0`, `1_000`, `123i64`"
+msgstr "`-10`, `0`, `1_000`, `123i64`"
+
+#: src/basic-syntax/scalar-types.md:6
+#, fuzzy
+msgid "Unsigned integers"
+msgstr "Ganzzahlen ohne Vorzeichen  `u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+
+#: src/basic-syntax/scalar-types.md:6
+#, fuzzy
+msgid "`u8`, `u16`, `u32`, `u64`, `u128`, `usize`"
+msgstr "`0`, `123`, `10u16`"
+
+#: src/basic-syntax/scalar-types.md:6
+#, fuzzy
+msgid "`0`, `123`, `10u16`"
+msgstr "Fließkommazahlen"
+
+#: src/basic-syntax/scalar-types.md:7
+#, fuzzy
+msgid "Floating point numbers"
+msgstr "`f32`, `f64`"
+
+#: src/basic-syntax/scalar-types.md:7
+#, fuzzy
+msgid "`f32`, `f64`"
+msgstr "`3.14`, `-10.0e20`, `2f32`"
+
+#: src/basic-syntax/scalar-types.md:7
+#, fuzzy
+msgid "`3.14`, `-10.0e20`, `2f32`"
+msgstr "Zeichenketten (Strings)"
+
+#: src/basic-syntax/scalar-types.md:8
+#, fuzzy
+msgid "Strings"
+msgstr "`&str`"
+
+#: src/basic-syntax/scalar-types.md:8
+#, fuzzy
+msgid "`&str`"
+msgstr "`\"foo\"`, `\"two\\nlines\"`"
+
+#: src/basic-syntax/scalar-types.md:8
+#, fuzzy
+msgid "`\"foo\"`, `\"two\\nlines\"`"
+msgstr "Unicode-Skalarwerte"
+
+#: src/basic-syntax/scalar-types.md:9
+#, fuzzy
+msgid "Unicode scalar values"
+msgstr "`char`"
+
+#: src/basic-syntax/scalar-types.md:9
+#, fuzzy
+msgid "`char`"
+msgstr "`'a'`, `'α'`, `'∞'`"
+
+#: src/basic-syntax/scalar-types.md:9
+#, fuzzy
+msgid "`'a'`, `'α'`, `'∞'`"
+msgstr "Wahrheitswerte (booleans)"
+
+#: src/basic-syntax/scalar-types.md:10
+#, fuzzy
+msgid "Booleans"
+msgstr "`bool`"
+
+#: src/basic-syntax/scalar-types.md:10
+#, fuzzy
+msgid "`bool`"
+msgstr "`true`, `false`"
+
+#: src/basic-syntax/scalar-types.md:10
+msgid "`true`, `false`"
+msgstr ""
 
 #: src/basic-syntax/scalar-types.md:12
 msgid "The types have widths as follows:"
 msgstr "Die Typen haben folgende Breiten:"
 
 #: src/basic-syntax/scalar-types.md:14
-msgid ""
-"* `iN`, `uN`, and `fN` are _N_ bits wide,\n"
-"* `isize` and `usize` are the width of a pointer,\n"
-"* `char` is 32 bit wide,\n"
-"* `bool` is 8 bit wide."
-msgstr ""
-"* `iN`, `uN` und `fN` sind _N_ Bits breit,\n"
-"* `isize` und `usize` sind die Breite eines Zeigers,\n"
-"* `char` ist 32 Bit breit,\n"
-"* `bool` ist 8 Bit breit."
+msgid "`iN`, `uN`, and `fN` are _N_ bits wide,"
+msgstr "`iN`, `uN` und `fN` sind _N_ Bits breit,"
+
+#: src/basic-syntax/scalar-types.md:15
+msgid "`isize` and `usize` are the width of a pointer,"
+msgstr "`isize` und `usize` sind die Breite eines Zeigers,"
+
+#: src/basic-syntax/scalar-types.md:16
+msgid "`char` is 32 bit wide,"
+msgstr "`char` ist 32 Bit breit,"
+
+#: src/basic-syntax/scalar-types.md:17
+msgid "`bool` is 8 bit wide."
+msgstr "`bool` ist 8 Bit breit."
 
 #: src/basic-syntax/scalar-types.md:21
 msgid "There are a few syntaxes which are not shown above:"
@@ -2941,69 +2900,74 @@ msgstr "Es gibt einige Syntaxen, die oben nicht aufgeführt sind:"
 
 #: src/basic-syntax/scalar-types.md:23
 msgid ""
-"- Raw strings allow you to create a `&str` value with escapes disabled: "
-"`r\"\\n\"\n"
-"  == \"\\\\\\\\n\"`. You can embed double-quotes by using an equal amount of "
-"`#` on\n"
-"  either side of the quotes:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Byte strings allow you to create a `&[u8]` value directly:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Raw strings allow you to create a `&str` value with escapes disabled: "
+"`r\"\\n\" == \"\\\\n\"`. You can embed double-quotes by using an equal "
+"amount of `#` on either side of the quotes:"
 msgstr ""
-"- Mit puren Zeichenketten (raw strings) kannst Du einen `&str`-Wert mit "
+"Mit puren Zeichenketten (raw strings) kannst Du einen `&str`\\-Wert mit "
 "deaktivierten Escape-Zeichen erstellen: `r\"\\n\" == \"\\\\\\\\n\"`. Du "
 "kannst doppelte Anführungszeichen einbetten, indem Du auf beiden Seiten der "
-"Anführungszeichen die gleiche Anzahl von `#` verwendest:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
-"      println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
-"  }\n"
-"  ```\n"
-"\n"
-"- Mit Byte-Strings kannst Du direkt einen „&[u8]“-Wert erstellen:\n"
-"\n"
-"  ```rust,editable\n"
-"  fn main() {\n"
-"      println!(\"{:?}\", b\"abc\");\n"
-"      println!(\"{:?}\", &[97, 98, 99]);\n"
-"  }\n"
-"  ```"
+"Anführungszeichen die gleiche Anzahl von `#` verwendest:"
 
-#: src/basic-syntax/compound-types.md:1
-msgid "# Compound Types"
-msgstr "# Verbundtypen"
-
-#: src/basic-syntax/compound-types.md:3
+#: src/basic-syntax/scalar-types.md:27
 msgid ""
-"|        | Types                         | Literals                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tuples | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... "
-"|"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
 msgstr ""
-"|        | Typen                         | Literale                          "
-"|\n"
-"|--------|-------------------------------|-----------------------------------|\n"
-"| Arrays | `[T; N]`                      | `[20, 30, 40]`, `[0; 3]`          "
-"|\n"
-"| Tupel | `()`, `(T,)`, `(T1, T2)`, ... | `()`, `('x',)`, `('x', 1.2)`, ... |"
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(r#\"<a href=\"link.html\">link</a>\"#);\n"
+"    println!(\"<a href=\\\"link.html\\\">link</a>\");\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/scalar-types.md:34
+msgid "Byte strings allow you to create a `&[u8]` value directly:"
+msgstr "Mit Byte-Strings kannst Du direkt einen „&\\[u8\\]“-Wert erstellen:"
+
+#: src/basic-syntax/scalar-types.md:36
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", b\"abc\");\n"
+"    println!(\"{:?}\", &[97, 98, 99]);\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "Arrays"
+msgstr "Arrays"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[T; N]`"
+msgstr "`[T; N]`"
+
+#: src/basic-syntax/compound-types.md:5
+msgid "`[20, 30, 40]`, `[0; 3]`"
+msgstr "`[20, 30, 40]`, `[0; 3]`"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "Tuples"
+msgstr "Tupel"
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `(T,)`, `(T1, T2)`, ..."
+msgstr "`()`, `(T,)`, `(T1, T2)`, ..."
+
+#: src/basic-syntax/compound-types.md:6
+msgid "`()`, `('x',)`, `('x', 1.2)`, ..."
+msgstr "`()`, `('x',)`, `('x', 1.2)`, ..."
 
 #: src/basic-syntax/compound-types.md:8
 msgid "Array assignment and access:"
@@ -3041,38 +3005,38 @@ msgstr "Arrays:"
 
 #: src/basic-syntax/compound-types.md:34
 msgid ""
-"* Arrays have elements of the same type, `T`, and length, `N`, which is a "
-"compile-time constant.\n"
-"  Note that the length of the array is *part of its type*, which means that "
-"`[u8; 3]` and\n"
-"  `[u8; 4]` are considered two different types.\n"
-"\n"
-"* We can use literals to assign values to arrays.\n"
-"\n"
-"* In the main function, the print statement asks for the debug "
-"implementation with the `?` format\n"
-"  parameter: `{}` gives the default output, `{:?}` gives the debug output. "
-"We\n"
-"  could also have used `{a}` and `{a:?}` without specifying the value after "
-"the\n"
-"  format string.\n"
-"\n"
-"* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can "
-"be easier to read."
+"Arrays have elements of the same type, `T`, and length, `N`, which is a "
+"compile-time constant. Note that the length of the array is _part of its "
+"type_, which means that `[u8; 3]` and `[u8; 4]` are considered two different "
+"types."
 msgstr ""
-"* Arrays haben Elemente desselben Typs `T` und der Länge `N`, was eine "
+"Arrays haben Elemente desselben Typs `T` und der Länge `N`, was eine "
 "Konstante zur Kompilierungszeit ist. Beachten Sie, dass die Länge des Arrays "
-"*Teil seines Typs* ist, was bedeutet, dass `[u8; 3]` und `[u8; 4]` als zwei "
-"verschiedene Typen betrachtet werden.\n"
-"\n"
-"* Wir können Literale verwenden, um Arrays Werte zuzuweisen.\n"
-"\n"
-"* In der `main`-Funktion fragt die print-Anweisung mit dem Formatparameter `?"
+"_Teil seines Typs_ ist, was bedeutet, dass `[u8; 3]` und `[u8; 4]` als zwei "
+"verschiedene Typen betrachtet werden."
+
+#: src/basic-syntax/compound-types.md:38
+msgid "We can use literals to assign values to arrays."
+msgstr "Wir können Literale verwenden, um Arrays Werte zuzuweisen."
+
+#: src/basic-syntax/compound-types.md:40
+msgid ""
+"In the main function, the print statement asks for the debug implementation "
+"with the `?` format parameter: `{}` gives the default output, `{:?}` gives "
+"the debug output. We could also have used `{a}` and `{a:?}` without "
+"specifying the value after the format string."
+msgstr ""
+"In der `main`\\-Funktion fragt die print-Anweisung mit dem Formatparameter `?"
 "` nach der Debug-Implementierung: `{}` gibt die Standardausgabe aus, „{:?}“ "
 "gibt die Debug-Ausgabe aus. Wir hätten auch `{a}` und `{a:?}` verwenden "
-"können, ohne den Wert nach der Formatzeichenfolge anzugeben.\n"
-"\n"
-"* Das Hinzufügen von `#`, z. B. `{a:#?}`, ruft ein „hübsches "
+"können, ohne den Wert nach der Formatzeichenfolge anzugeben."
+
+#: src/basic-syntax/compound-types.md:45
+msgid ""
+"Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which can be "
+"easier to read."
+msgstr ""
+"Das Hinzufügen von `#`, z. B. `{a:#?}`, ruft ein „hübsches "
 "Druckformat“ (pretty print) auf, das einfacher zu lesen ist."
 
 #: src/basic-syntax/compound-types.md:47
@@ -3080,44 +3044,44 @@ msgid "Tuples:"
 msgstr "Tupel:"
 
 #: src/basic-syntax/compound-types.md:49
-msgid ""
-"* Like arrays, tuples have a fixed length.\n"
-"\n"
-"* Tuples group together values of different types into a compound type.\n"
-"\n"
-"* Fields of a tuple can be accessed by the period and the index of the "
-"value, e.g. `t.0`, `t.1`.\n"
-"\n"
-"* The empty tuple `()` is also known as the \"unit type\". It is both a "
-"type, and\n"
-"  the only valid value of that type - that is to say both the type and its "
-"value\n"
-"  are expressed as `()`. It is used to indicate, for example, that a "
-"function or\n"
-"  expression has no return value, as we'll see in a future slide. \n"
-"    * You can think of it as `void` that can be familiar to you from other \n"
-"      programming languages."
+msgid "Like arrays, tuples have a fixed length."
+msgstr "Wie Arrays haben Tupel eine feste Länge."
+
+#: src/basic-syntax/compound-types.md:51
+msgid "Tuples group together values of different types into a compound type."
 msgstr ""
-"* Wie Arrays haben Tupel eine feste Länge.\n"
-"\n"
-"* Tupel gruppieren Werte unterschiedlicher Typen zu einem zusammengesetzten "
-"Typ.\n"
-"\n"
-"* Auf Felder eines Tupels kann durch einen Punkt gefolgt von dem Index des "
-"Werts zugegriffen werden, z. B. „t.0“, „t.1“.\n"
-"\n"
-"* Das leere Tupel „()“ wird auch als „Einheitstyp“ (unit type) bezeichnet. "
-"Es ist sowohl ein Typ als auch der einzige gültige Wert dieses Typs – das "
+"Tupel gruppieren Werte unterschiedlicher Typen zu einem zusammengesetzten "
+"Typ."
+
+#: src/basic-syntax/compound-types.md:53
+msgid ""
+"Fields of a tuple can be accessed by the period and the index of the value, "
+"e.g. `t.0`, `t.1`."
+msgstr ""
+"Auf Felder eines Tupels kann durch einen Punkt gefolgt von dem Index des "
+"Werts zugegriffen werden, z. B. „t.0“, „t.1“."
+
+#: src/basic-syntax/compound-types.md:55
+msgid ""
+"The empty tuple `()` is also known as the \"unit type\". It is both a type, "
+"and the only valid value of that type - that is to say both the type and its "
+"value are expressed as `()`. It is used to indicate, for example, that a "
+"function or expression has no return value, as we'll see in a future slide. "
+msgstr ""
+"Das leere Tupel „()“ wird auch als „Einheitstyp“ (unit type) bezeichnet. Es "
+"ist sowohl ein Typ als auch der einzige gültige Wert dieses Typs – das "
 "heißt, sowohl der Typ als auch sein Wert werden als `()` ausgedrückt. Es "
 "wird beispielsweise verwendet, um anzuzeigen, dass eine Funktion oder ein "
 "Ausdruck keinen Rückgabewert hat, wie wir auf einer zukünftigen Folie sehen "
-"werden.\n"
-"     * Du kannst es Dir als `void` vorstellen, das Dir aus anderen "
-"Programmiersprachen bekannt sein könnte."
+"werden."
 
-#: src/basic-syntax/references.md:1
-msgid "# References"
-msgstr "# Verweise"
+#: src/basic-syntax/compound-types.md:59
+msgid ""
+"You can think of it as `void` that can be familiar to you from other  "
+"programming languages."
+msgstr ""
+"Du kannst es Dir als `void` vorstellen, das Dir aus anderen "
+"Programmiersprachen bekannt sein könnte."
 
 #: src/basic-syntax/references.md:3
 msgid "Like C++, Rust has references:"
@@ -3141,39 +3105,40 @@ msgstr "Einige Notizen:"
 
 #: src/basic-syntax/references.md:16
 msgid ""
-"* We must dereference `ref_x` when assigning to it, similar to C and C++ "
-"pointers.\n"
-"* Rust will auto-dereference in some cases, in particular when invoking\n"
-"  methods (try `ref_x.count_ones()`).\n"
-"* References that are declared as `mut` can be bound to different values "
-"over their lifetime."
+"We must dereference `ref_x` when assigning to it, similar to C and C++ "
+"pointers."
 msgstr ""
-"* Wir müssen `ref_x` beim Zuweisen dereferenzieren, ähnlich wie bei C und C+"
-"+-Zeigern.\n"
-"* Rust wird in einigen Fällen automatisch dereferenzieren, insbesondere beim "
-"Aufrufen von Methoden (probiere `ref_x.count_ones()`).\n"
-"* Referenzen, die als `mut` deklariert sind, können über ihre Lebensdauer an "
+"Wir müssen `ref_x` beim Zuweisen dereferenzieren, ähnlich wie bei C und C++-"
+"Zeigern."
+
+#: src/basic-syntax/references.md:17
+msgid ""
+"Rust will auto-dereference in some cases, in particular when invoking "
+"methods (try `ref_x.count_ones()`)."
+msgstr ""
+"Rust wird in einigen Fällen automatisch dereferenzieren, insbesondere beim "
+"Aufrufen von Methoden (probiere `ref_x.count_ones()`)."
+
+#: src/basic-syntax/references.md:19
+msgid ""
+"References that are declared as `mut` can be bound to different values over "
+"their lifetime."
+msgstr ""
+"Referenzen, die als `mut` deklariert sind, können über ihre Lebensdauer an "
 "unterschiedliche Werte gebunden werden."
 
 #: src/basic-syntax/references.md:25
 msgid ""
-"* Be sure to note the difference between `let mut ref_x: &i32` and `let "
-"ref_x:\n"
-"  &mut i32`. The first one represents a mutable reference which can be bound "
-"to\n"
-"  different values, while the second represents a reference to a mutable "
+"Be sure to note the difference between `let mut ref_x: &i32` and `let ref_x: "
+"&mut i32`. The first one represents a mutable reference which can be bound "
+"to different values, while the second represents a reference to a mutable "
 "value."
 msgstr ""
-"* Beachte unbedingt den Unterschied zwischen `let mut ref_x: &i32` und `let "
-"ref_x:\n"
-"  &mut i32`. Das erste stellt eine veränderliche Referenz (mutable "
-"reference) dar, an die unterschiedliche Werte gebunden werden können,\n"
-"  während das zweite Beispiel einen Verweis auf einen veränderlichen Wert "
+"Beachte unbedingt den Unterschied zwischen `let mut ref_x: &i32` und `let "
+"ref_x: &mut i32`. Das erste stellt eine veränderliche Referenz (mutable "
+"reference) dar, an die unterschiedliche Werte gebunden werden können, "
+"während das zweite Beispiel einen Verweis auf einen veränderlichen Wert "
 "darstellt."
-
-#: src/basic-syntax/references-dangling.md:1
-msgid "# Dangling References"
-msgstr "# Hängende-Referenzen (dangling references)"
 
 #: src/basic-syntax/references-dangling.md:3
 msgid "Rust will statically forbid dangling references:"
@@ -3194,22 +3159,23 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/references-dangling.md:16
-msgid ""
-"* A reference is said to \"borrow\" the value it refers to.\n"
-"* Rust is tracking the lifetimes of all references to ensure they live long\n"
-"  enough.\n"
-"* We will talk more about borrowing when we get to ownership."
+msgid "A reference is said to \"borrow\" the value it refers to."
 msgstr ""
-"* Eine Referenz \"leiht\" (borrows) sich den Wert, auf den sie sich "
-"bezieht, .\n"
-"* Rust verfolgt die Lebensdauer aller Referenzen, um sicherzustellen, dass "
-"sie lange genug leben\n"
-"* Wir werden mehr über das Ausleihen (borrowing) sprechen, wenn wir zum "
-"Eigentum (ownership) kommen."
+"Eine Referenz \"leiht\" (borrows) sich den Wert, auf den sie sich bezieht, ."
 
-#: src/basic-syntax/slices.md:1
-msgid "# Slices"
-msgstr "# Anteilstypen (Slices)"
+#: src/basic-syntax/references-dangling.md:17
+msgid ""
+"Rust is tracking the lifetimes of all references to ensure they live long "
+"enough."
+msgstr ""
+"Rust verfolgt die Lebensdauer aller Referenzen, um sicherzustellen, dass sie "
+"lange genug leben"
+
+#: src/basic-syntax/references-dangling.md:19
+msgid "We will talk more about borrowing when we get to ownership."
+msgstr ""
+"Wir werden mehr über das Ausleihen (borrowing) sprechen, wenn wir zum "
+"Eigentum (ownership) kommen."
 
 #: src/basic-syntax/slices.md:3
 msgid "A slice gives you a view into a larger collection:"
@@ -3231,73 +3197,82 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/slices.md:15
-msgid ""
-"* Slices borrow data from the sliced type.\n"
-"* Question: What happens if you modify `a[3]`?"
-msgstr ""
-"* Anteilstypen (slices) borgen (borrow) Daten vom Sliced-Typ.\n"
-"* Frage: Was passiert, wenn Du `a[3]` änderst?"
+msgid "Slices borrow data from the sliced type."
+msgstr "Anteilstypen (slices) borgen (borrow) Daten vom Sliced-Typ."
+
+#: src/basic-syntax/slices.md:16
+msgid "Question: What happens if you modify `a[3]`?"
+msgstr "Frage: Was passiert, wenn Du `a[3]` änderst?"
 
 #: src/basic-syntax/slices.md:20
 msgid ""
-"* We create a slice by borrowing `a` and specifying the starting and ending "
-"indexes in brackets.\n"
-"\n"
-"* If the slice starts at index 0, Rust’s range syntax allows us to drop the "
-"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-"identical.\n"
-"    \n"
-"* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
-"identical.\n"
-"\n"
-"* To easily create a slice of the full array, we can therefore use "
-"`&a[..]`.\n"
-"\n"
-"* `s` is a reference to a slice of `i32`s. Notice that the type of `s` "
-"(`&[i32]`) no longer mentions the array length. This allows us to perform "
-"computation on slices of different sizes.\n"
-" \n"
-"* Slices always borrow from another object. In this example, `a` has to "
-"remain 'alive' (in scope) for at least as long as our slice. \n"
-"    \n"
-"* The question about modifying `a[3]` can spark an interesting discussion, "
-"but the answer is that for memory safety reasons\n"
-"  you cannot do it through `a` after you created a slice, but you can read "
-"the data from both `a` and `s` safely. \n"
-"  More details will be explained in the borrow checker section."
+"We create a slice by borrowing `a` and specifying the starting and ending "
+"indexes in brackets."
 msgstr ""
-"* Wir erstellen ein Anteilstyp, indem wir `a` ausleihen (borrow) und den "
-"Start- und Endindex in Klammern angeben.\n"
-"\n"
-"* Wenn der Anteilstyp bei Index 0 beginnt, erlaubt uns die Range-Syntax von "
+"Wir erstellen ein Anteilstyp, indem wir `a` ausleihen (borrow) und den "
+"Start- und Endindex in Klammern angeben."
+
+#: src/basic-syntax/slices.md:22
+msgid ""
+"If the slice starts at index 0, Rust’s range syntax allows us to drop the "
+"starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
+"identical."
+msgstr ""
+"Wenn der Anteilstyp bei Index 0 beginnt, erlaubt uns die Range-Syntax von "
 "Rust, den Startindex wegzulassen, was bedeutet, dass `&a[0..a.len()]` und "
-"`&a[..a.len()]` identisch sind.\n"
-"    \n"
-"* Das Gleiche gilt für den letzten Index, daher sind `&a[2..a.len()]` und "
-"`&a[2..]` identisch.\n"
-"\n"
-"* Um einfach einen Anteilstyp des gesamten Arrays zu erstellen, können wir "
-"daher „&a[..]“ verwenden.\n"
-"\n"
-"* `s` ist ein Verweis (reference) auf einen Teil von `i32`. Beachte, dass "
-"der Typ `s` (`&[i32]`) die Array-Länge nicht mehr erwähnt. Dadurch können "
-"wir Berechnungen für Anteilstypen unterschiedlicher Größe durchführen.\n"
-" \n"
-"* Anteilstypen (slices) leihen (borrow) sich immer etwas von einem anderen "
+"`&a[..a.len()]` identisch sind."
+
+#: src/basic-syntax/slices.md:24
+msgid ""
+"The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` are "
+"identical."
+msgstr ""
+"Das Gleiche gilt für den letzten Index, daher sind `&a[2..a.len()]` und "
+"`&a[2..]` identisch."
+
+#: src/basic-syntax/slices.md:26
+msgid ""
+"To easily create a slice of the full array, we can therefore use `&a[..]`."
+msgstr ""
+"Um einfach einen Anteilstyp des gesamten Arrays zu erstellen, können wir "
+"daher „&a\\[..\\]“ verwenden."
+
+#: src/basic-syntax/slices.md:28
+msgid ""
+"`s` is a reference to a slice of `i32`s. Notice that the type of `s` "
+"(`&[i32]`) no longer mentions the array length. This allows us to perform "
+"computation on slices of different sizes."
+msgstr ""
+"`s` ist ein Verweis (reference) auf einen Teil von `i32`. Beachte, dass der "
+"Typ `s` (`&[i32]`) die Array-Länge nicht mehr erwähnt. Dadurch können wir "
+"Berechnungen für Anteilstypen unterschiedlicher Größe durchführen."
+
+#: src/basic-syntax/slices.md:30
+msgid ""
+"Slices always borrow from another object. In this example, `a` has to remain "
+"'alive' (in scope) for at least as long as our slice. "
+msgstr ""
+"Anteilstypen (slices) leihen (borrow) sich immer etwas von einem anderen "
 "Objekt aus. In diesem Beispiel muss `a` mindestens so lange (im "
-"Gültigkeitsbereich (scope)) „lebendig“ bleiben wie unser Anteilstyp.\n"
-"    \n"
-"* Die Frage nach einer Werteänderung durch `a[3]` kann eine interessante "
+"Gültigkeitsbereich (scope)) „lebendig“ bleiben wie unser Anteilstyp."
+
+#: src/basic-syntax/slices.md:32
+msgid ""
+"The question about modifying `a[3]` can spark an interesting discussion, but "
+"the answer is that for memory safety reasons you cannot do it through `a` "
+"after you created a slice, but you can read the data from both `a` and `s` "
+"safely.  More details will be explained in the borrow checker section."
+msgstr ""
+"Die Frage nach einer Werteänderung durch `a[3]` kann eine interessante "
 "Diskussion auslösen, aber die Antwort lautet: aus Gründen der "
 "Speichersicherheit kannst Du dies nicht über `a` tun, nachdem Du ein Slice "
 "erstellt hast. Allerdings kannst Du die Werte sowohl von `a` als auch von "
-"`s` sicher lesen.\n"
-"   Weitere Einzelheiten werden im Abschnitt „Ausleihenprüfer“ (borrow "
-"checker) erläutert."
+"`s` sicher lesen. Weitere Einzelheiten werden im Abschnitt "
+"„Ausleihenprüfer“ (borrow checker) erläutert."
 
 #: src/basic-syntax/string-slices.md:1
-msgid "# `String` vs `str`"
-msgstr "# `String` vs `str`"
+msgid "`String` vs `str`"
+msgstr "`String` vs `str`"
 
 #: src/basic-syntax/string-slices.md:3
 msgid "We can now understand the two string types in Rust:"
@@ -3326,72 +3301,73 @@ msgid "Rust terminology:"
 msgstr "Rust-Terminologie:"
 
 #: src/basic-syntax/string-slices.md:22
-msgid ""
-"* `&str` an immutable reference to a string slice.\n"
-"* `String` a mutable string buffer."
+msgid "`&str` an immutable reference to a string slice."
 msgstr ""
-"* `&str` eine unveränderliche (immutable) Referenz auf einen String-Slice.\n"
-"* `String` ein veränderlicher String-Puffer (mutable string buffer)."
+"`&str` eine unveränderliche (immutable) Referenz auf einen String-Slice."
+
+#: src/basic-syntax/string-slices.md:23
+msgid "`String` a mutable string buffer."
+msgstr "`String` ein veränderlicher String-Puffer (mutable string buffer)."
 
 #: src/basic-syntax/string-slices.md:27
 msgid ""
-"* `&str` introduces a string slice, which is an immutable reference to UTF-8 "
-"encoded string data \n"
-"  stored in a block of memory. String literals (`”Hello”`), are stored in "
-"the program’s binary.\n"
-"\n"
-"* Rust’s `String` type is a wrapper around a vector of bytes. As with a "
-"`Vec<T>`, it is owned.\n"
-"    \n"
-"* As with many other types `String::from()` creates a string from a string "
-"literal; `String::new()` \n"
-"  creates a new empty string, to which string data can be added using the "
-"`push()` and `push_str()` methods.\n"
-"\n"
-"* The `format!()` macro is a convenient way to generate an owned string from "
-"dynamic values. It \n"
-"  accepts the same format specification as `println!()`.\n"
-"    \n"
-"* You can borrow `&str` slices from `String` via `&` and optionally range "
-"selection.\n"
-"    \n"
-"* For C++ programmers: think of `&str` as `const char*` from C++, but the "
-"one that always points \n"
-"  to a valid string in memory. Rust `String` is a rough equivalent of `std::"
-"string` from C++ \n"
-"  (main difference: it can only contain UTF-8 encoded bytes and will never "
-"use a small-string optimization).\n"
-"    "
+"`&str` introduces a string slice, which is an immutable reference to UTF-8 "
+"encoded string data  stored in a block of memory. String literals "
+"(`”Hello”`), are stored in the program’s binary."
 msgstr ""
-"* `&str` führt einen String-Slice ein, der eine unveränderliche Referenz auf "
+"`&str` führt einen String-Slice ein, der eine unveränderliche Referenz auf "
 "UTF-8-codierte String-Daten ist, die in einem Speicherblock gespeichert "
 "sind. String-Literale (`\"Hallo\"`) werden in der Binärdatei des Programms "
-"gespeichert.\n"
-"\n"
-"* Der `String`-Typ von Rust ist eine Verpackung (wrapper) um einen Byte-"
-"Vektor. Wie bei einem `Vec<T>` ist es im Besitz.\n"
-"    \n"
-"* Wie bei vielen anderen Typen erstellt `String::from()` einen String aus "
+"gespeichert."
+
+#: src/basic-syntax/string-slices.md:30
+msgid ""
+"Rust’s `String` type is a wrapper around a vector of bytes. As with a "
+"`Vec<T>`, it is owned."
+msgstr ""
+"Der `String`\\-Typ von Rust ist eine Verpackung (wrapper) um einen Byte-"
+"Vektor. Wie bei einem `Vec<T>` ist es im Besitz."
+
+#: src/basic-syntax/string-slices.md:32
+msgid ""
+"As with many other types `String::from()` creates a string from a string "
+"literal; `String::new()`  creates a new empty string, to which string data "
+"can be added using the `push()` and `push_str()` methods."
+msgstr ""
+"Wie bei vielen anderen Typen erstellt `String::from()` einen String aus "
 "einem String-Literal; `String::new()` erstellt einen neuen leeren String, zu "
 "dem String-Daten mit den Methoden `push()` und `push_str()` hinzugefügt "
-"werden können.\n"
-"\n"
-"* Das Makro `format!()` ist eine praktische Möglichkeit, einen aneigenbaren "
+"werden können."
+
+#: src/basic-syntax/string-slices.md:35
+msgid ""
+"The `format!()` macro is a convenient way to generate an owned string from "
+"dynamic values. It  accepts the same format specification as `println!()`."
+msgstr ""
+"Das Makro `format!()` ist eine praktische Möglichkeit, einen aneigenbaren "
 "(owned) String aus dynamischen Werten zu generieren. Es akzeptiert die "
-"gleiche Formatspezifikation wie `println!()`.\n"
-"    \n"
-"* Du kannst `&str`-Slices von `String` über `&` und optional eine "
-"Bereichsauswahl (range selection) ausleihen.\n"
-"    \n"
-"* Für C++-Programmierer: Stell Dir `&str` als `const char*` aus C++ vor, der "
+"gleiche Formatspezifikation wie `println!()`."
+
+#: src/basic-syntax/string-slices.md:38
+msgid ""
+"You can borrow `&str` slices from `String` via `&` and optionally range "
+"selection."
+msgstr ""
+"Du kannst `&str`\\-Slices von `String` über `&` und optional eine "
+"Bereichsauswahl (range selection) ausleihen."
+
+#: src/basic-syntax/string-slices.md:40
+msgid ""
+"For C++ programmers: think of `&str` as `const char*` from C++, but the one "
+"that always points  to a valid string in memory. Rust `String` is a rough "
+"equivalent of `std::string` from C++  (main difference: it can only contain "
+"UTF-8 encoded bytes and will never use a small-string optimization)."
+msgstr ""
+"Für C++-Programmierer: Stell Dir `&str` als `const char*` aus C++ vor, der "
 "immer auf eine gültige Zeichenfolge im Speicher zeigt. Rust `String` ist ein "
 "grobes Äquivalent von `std::string` aus C++ (Hauptunterschied: Es kann nur "
 "UTF-8-codierte Bytes enthalten und wird niemals eine Optimierung für kleine "
 "Zeichenfolgen verwenden). "
-
-#: src/basic-syntax/functions.md:1
-msgid "# Functions"
-msgstr "# Funktionen"
 
 #: src/basic-syntax/functions.md:3
 msgid ""
@@ -3434,39 +3410,51 @@ msgstr ""
 
 #: src/basic-syntax/functions.md:35
 msgid ""
-"* We refer in `main` to a function written below. Neither forward "
-"declarations nor headers are necessary. \n"
-"* Declaration parameters are followed by a type (the reverse of some "
-"programming languages), then a return type.\n"
-"* The last expression in a function body (or any block) becomes the return "
-"value. Simply omit the `;` at the end of the expression.\n"
-"* Some functions have no return value, and return the 'unit type', `()`. The "
-"compiler will infer this if the `-> ()` return type is omitted.\n"
-"* The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
+"We refer in `main` to a function written below. Neither forward declarations "
+"nor headers are necessary. "
+msgstr ""
+"Wir beziehen uns in `main` auf eine unten beschriebene Funktion. Es sind "
+"weder Forward-Deklarationen noch Header erforderlich."
+
+#: src/basic-syntax/functions.md:36
+msgid ""
+"Declaration parameters are followed by a type (the reverse of some "
+"programming languages), then a return type."
+msgstr ""
+"Auf Deklarationsparameter folgt ein Typ (das Gegenteil einiger "
+"Programmiersprachen) und dann ein Rückgabetyp."
+
+#: src/basic-syntax/functions.md:37
+msgid ""
+"The last expression in a function body (or any block) becomes the return "
+"value. Simply omit the `;` at the end of the expression."
+msgstr ""
+"Der letzte Ausdruck in einem Funktionskörper (oder einem beliebigen Block) "
+"wird zum Rückgabewert. Lasse einfach das `;` am Ende des Ausdrucks weg."
+
+#: src/basic-syntax/functions.md:38
+msgid ""
+"Some functions have no return value, and return the 'unit type', `()`. The "
+"compiler will infer this if the `-> ()` return type is omitted."
+msgstr ""
+"Einige Funktionen haben keinen Rückgabewert und geben den `Einheitentyp` "
+"(Unittyp) `()` zurück. Der Compiler schließt daraus, wenn der Rückgabetyp `-"
+">()` weggelassen wird."
+
+#: src/basic-syntax/functions.md:39
+msgid ""
+"The range expression in the `for` loop in `print_fizzbuzz_to()` contains "
 "`=n`, which causes it to include the upper bound."
 msgstr ""
-"* Wir beziehen uns in `main` auf eine unten beschriebene Funktion. Es sind "
-"weder Forward-Deklarationen noch Header erforderlich.\n"
-"* Auf Deklarationsparameter folgt ein Typ (das Gegenteil einiger "
-"Programmiersprachen) und dann ein Rückgabetyp.\n"
-"* Der letzte Ausdruck in einem Funktionskörper (oder einem beliebigen Block) "
-"wird zum Rückgabewert. Lasse einfach das `;` am Ende des Ausdrucks weg.\n"
-"* Einige Funktionen haben keinen Rückgabewert und geben den `Einheitentyp` "
-"(Unittyp) `()` zurück. Der Compiler schließt daraus, wenn der Rückgabetyp `-"
-">()` weggelassen wird.\n"
-"* Der Bereichsausdruck (range expression) in der `for`-Schleife in "
+"Der Bereichsausdruck (range expression) in der `for`\\-Schleife in "
 "`print_fizzbuzz_to()` enthält `=n`, was dazu führt, dass die Obergrenze "
 "einschlossen wird."
-
-#: src/basic-syntax/rustdoc.md:1
-msgid "# Rustdoc"
-msgstr "# Rustdoc"
 
 #: src/basic-syntax/rustdoc.md:3
 msgid ""
 "All language items in Rust can be documented using special `///` syntax."
 msgstr ""
-"Alle Sprachelemente in Rust können mit der speziellen `///`-Syntax "
+"Alle Sprachelemente in Rust können mit der speziellen `///`\\-Syntax "
 "dokumentiert werden."
 
 #: src/basic-syntax/rustdoc.md:5
@@ -3488,10 +3476,9 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:17
 msgid ""
-"The contents are treated as Markdown. All published Rust library crates are\n"
-"automatically documented at [`docs.rs`](https://docs.rs) using the\n"
-"[rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It "
-"is\n"
+"The contents are treated as Markdown. All published Rust library crates are "
+"automatically documented at [`docs.rs`](https://docs.rs) using the [rustdoc]"
+"(https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) tool. It is "
 "idiomatic to document all public items in an API using this pattern."
 msgstr ""
 "Die Inhalte werden als Markdown behandelt. Alle veröffentlichten Rust-"
@@ -3502,39 +3489,36 @@ msgstr ""
 
 #: src/basic-syntax/rustdoc.md:24
 msgid ""
-"* Show students the generated docs for the `rand` crate at\n"
-"  [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* This course does not include rustdoc on slides, just to save space, but "
-"in\n"
-"  real code they should be present.\n"
-"\n"
-"* Inner doc comments are discussed later (in the page on modules) and need "
-"not\n"
-"  be addressed here."
+"Show students the generated docs for the `rand` crate at [`docs.rs/rand`]"
+"(https://docs.rs/rand)."
 msgstr ""
-"* Zeige den Schülern die generierten Dokumente für die Kiste (crate) `rand` "
-"unter [`docs.rs/rand`](https://docs.rs/rand).\n"
-"\n"
-"* Dieser Kurs enthält keine Rustdocs auf Folien, um Platz zu sparen, aber im "
-"echten Code sollten Rustdoc-Kommentare vorhanden sein.\n"
-"\n"
-"* Inner doc Kommentare werden später besprochen (auf der Seite zu Modulen) "
-"und müssen hier nicht behandelt werden."
+"Zeige den Schülern die generierten Dokumente für die Kiste (crate) `rand` "
+"unter [`docs.rs/rand`](https://docs.rs/rand)."
 
-#: src/basic-syntax/methods.md:1 src/methods.md:1
-msgid "# Methods"
-msgstr "# Methoden"
+#: src/basic-syntax/rustdoc.md:27
+msgid ""
+"This course does not include rustdoc on slides, just to save space, but in "
+"real code they should be present."
+msgstr ""
+"Dieser Kurs enthält keine Rustdocs auf Folien, um Platz zu sparen, aber im "
+"echten Code sollten Rustdoc-Kommentare vorhanden sein."
+
+#: src/basic-syntax/rustdoc.md:30
+msgid ""
+"Inner doc comments are discussed later (in the page on modules) and need not "
+"be addressed here."
+msgstr ""
+"Inner doc Kommentare werden später besprochen (auf der Seite zu Modulen) und "
+"müssen hier nicht behandelt werden."
 
 #: src/basic-syntax/methods.md:3
 msgid ""
 "Methods are functions associated with a type. The `self` argument of a "
-"method is\n"
-"an instance of the type it is associated with:"
+"method is an instance of the type it is associated with:"
 msgstr ""
-"Methoden sind Funktionen, die einem bestimmten Typ zugeordnet sind.\n"
-"Das `self`-Argument einer Methode ist die Instanz des Typs, dem sie "
-"zugeordnet ist:"
+"Methoden sind Funktionen, die einem bestimmten Typ zugeordnet sind. Das "
+"`self`\\-Argument einer Methode ist die Instanz des Typs, dem sie zugeordnet "
+"ist:"
 
 #: src/basic-syntax/methods.md:6
 msgid ""
@@ -3565,61 +3549,72 @@ msgstr ""
 
 #: src/basic-syntax/methods.md:30
 msgid ""
-"* We will look much more at methods in today's exercise and in tomorrow's "
+"We will look much more at methods in today's exercise and in tomorrow's "
 "class."
 msgstr ""
-"* Wir werden uns in der heutigen Übung und im morgigen Unterricht tiefer mit "
+"Wir werden uns in der heutigen Übung und im morgigen Unterricht tiefer mit "
 "Methoden befassen."
 
 #: src/basic-syntax/methods.md:34
-msgid ""
-"- Add a `Rectangle::new` constructor and call this from `main`:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"- Add a `Rectangle::new_square(width: u32)` constructor to illustrate that\n"
-"  constructors can take arbitrary parameters."
+msgid "Add a `Rectangle::new` constructor and call this from `main`:"
 msgstr ""
-"* Füge einen `Rectangle::new`-Konstruktor hinzu und rufe diesen von `main` "
-"aus auf:\n"
-"\n"
-"    ```rust,editable,compile_fail\n"
-"    fn new(width: u32, height: u32) -> Rectangle {\n"
-"        Rectangle { width, height }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Füge einen `Rectangle::new_square(width: u32)`-Konstruktor hinzu, um zu "
+"Füge einen `Rectangle::new`\\-Konstruktor hinzu und rufe diesen von `main` "
+"aus auf:"
+
+#: src/basic-syntax/methods.md:36
+msgid ""
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+msgstr ""
+"```rust,editable,compile_fail\n"
+"fn new(width: u32, height: u32) -> Rectangle {\n"
+"    Rectangle { width, height }\n"
+"}\n"
+"```"
+
+#: src/basic-syntax/methods.md:42
+msgid ""
+"Add a `Rectangle::new_square(width: u32)` constructor to illustrate that "
+"constructors can take arbitrary parameters."
+msgstr ""
+"Füge einen `Rectangle::new_square(width: u32)`\\-Konstruktor hinzu, um zu "
 "veranschaulichen, dass Konstruktoren beliebige Parameter annehmen können."
 
 #: src/basic-syntax/functions-interlude.md:1
-msgid "# Function Overloading"
-msgstr "# Funktionsüberladung"
+msgid "Function Overloading"
+msgstr "Funktionsüberladung"
 
 #: src/basic-syntax/functions-interlude.md:3
 msgid "Overloading is not supported:"
 msgstr "Überladen wird nicht unterstützt:"
 
 #: src/basic-syntax/functions-interlude.md:5
-msgid ""
-"* Each function has a single implementation:\n"
-"  * Always takes a fixed number of parameters.\n"
-"  * Always takes a single set of parameter types.\n"
-"* Default values are not supported:\n"
-"  * All call sites have the same number of arguments.\n"
-"  * Macros are sometimes used as an alternative."
+msgid "Each function has a single implementation:"
+msgstr "Jede Funktion hat eine einzige Implementierung:"
+
+#: src/basic-syntax/functions-interlude.md:6
+msgid "Always takes a fixed number of parameters."
+msgstr "Akzeptiert immer eine feste Anzahl von Parametern."
+
+#: src/basic-syntax/functions-interlude.md:7
+msgid "Always takes a single set of parameter types."
+msgstr "Akzeptiert immer einen einzelnen Satz von Parametertypen."
+
+#: src/basic-syntax/functions-interlude.md:8
+msgid "Default values are not supported:"
+msgstr "Standardwerte werden nicht unterstützt:"
+
+#: src/basic-syntax/functions-interlude.md:9
+msgid "All call sites have the same number of arguments."
 msgstr ""
-"* Jede Funktion hat eine einzige Implementierung:\n"
-"  * Akzeptiert immer eine feste Anzahl von Parametern.\n"
-"  * Akzeptiert immer einen einzelnen Satz von Parametertypen.\n"
-"* Standardwerte werden nicht unterstützt:\n"
-"  * Alle Aufrufstellen (call sites) haben die gleiche Anzahl von "
-"Argumenten.\n"
-"  * Makros werden manchmal als Alternative verwendet."
+"Alle Aufrufstellen (call sites) haben die gleiche Anzahl von Argumenten."
+
+#: src/basic-syntax/functions-interlude.md:10
+msgid "Macros are sometimes used as an alternative."
+msgstr "Makros werden manchmal als Alternative verwendet."
 
 #: src/basic-syntax/functions-interlude.md:12
 msgid "However, function parameters can be generic:"
@@ -3641,31 +3636,29 @@ msgstr ""
 
 #: src/basic-syntax/functions-interlude.md:27
 msgid ""
-"* When using generics, the standard library's `Into<T>` can provide a kind "
-"of limited\n"
-"  polymorphism on argument types. We will see more details in a later "
+"When using generics, the standard library's `Into<T>` can provide a kind of "
+"limited polymorphism on argument types. We will see more details in a later "
 "section."
 msgstr ""
-"* Bei Verwendung von Generika (generics) kann `Into<T>` der "
-"Standardbibliothek eine Art eingeschränkten Polymorphismus für Argumenttypen "
-"bereitstellen. Weitere Einzelheiten erfährst Du in einem späteren Abschnitt."
+"Bei Verwendung von Generika (generics) kann `Into<T>` der Standardbibliothek "
+"eine Art eingeschränkten Polymorphismus für Argumenttypen bereitstellen. "
+"Weitere Einzelheiten erfährst Du in einem späteren Abschnitt."
 
 #: src/exercises/day-1/morning.md:1
-msgid "# Day 1: Morning Exercises"
-msgstr "# Tag 1: Übungen am Morgen"
+msgid "Day 1: Morning Exercises"
+msgstr "Tag 1: Übungen am Morgen"
 
 #: src/exercises/day-1/morning.md:3
 msgid "In these exercises, we will explore two parts of Rust:"
 msgstr "In diesen Übungen werden wir zwei Teile von Rust erkunden:"
 
 #: src/exercises/day-1/morning.md:5
-msgid ""
-"* Implicit conversions between types.\n"
-"\n"
-"* Arrays and `for` loops."
-msgstr ""
-"* Implizite Konvertierungen zwischen Typen.\n"
-"* Arrays und `for`-Schleifen."
+msgid "Implicit conversions between types."
+msgstr "Implizite Konvertierungen zwischen Typen."
+
+#: src/exercises/day-1/morning.md:7
+msgid "Arrays and `for` loops."
+msgstr "Arrays und `for`\\-Schleifen."
 
 #: src/exercises/day-1/morning.md:11
 msgid "A few things to consider while solving the exercises:"
@@ -3673,29 +3666,25 @@ msgstr "Ein paar Dinge, die Du beim Lösen der Aufgaben beachten solltest:"
 
 #: src/exercises/day-1/morning.md:13
 msgid ""
-"* Use a local Rust installation, if possible. This way you can get\n"
-"  auto-completion in your editor. See the page about [Using Cargo] for "
-"details\n"
-"  on installing Rust.\n"
-"\n"
-"* Alternatively, use the Rust Playground."
+"Use a local Rust installation, if possible. This way you can get auto-"
+"completion in your editor. See the page about [Using Cargo](../../cargo.md) "
+"for details on installing Rust."
 msgstr ""
-"* Verwende nach Möglichkeit eine lokale Rust-Installation. Auf diese Weise "
-"kannst Du\n"
-"  Autovervollständigung in Deinem Editor erhalten. Weitere Informationen "
-"findest Du auf der Seite: [Cargo verwenden].\n"
-"\n"
-"* Alternativ kannst du den Rust Spielplatz verwenden."
+"Verwende nach Möglichkeit eine lokale Rust-Installation. Auf diese Weise "
+"kannst Du Autovervollständigung in Deinem Editor erhalten. Weitere "
+"Informationen findest Du auf der Seite: \\[Cargo verwenden\\]."
+
+#: src/exercises/day-1/morning.md:17
+msgid "Alternatively, use the Rust Playground."
+msgstr "Alternativ kannst du den Rust Spielplatz verwenden."
 
 #: src/exercises/day-1/morning.md:19
 msgid ""
-"The code snippets are not editable on purpose: the inline code snippets "
-"lose\n"
+"The code snippets are not editable on purpose: the inline code snippets lose "
 "their state if you navigate away from the page."
 msgstr ""
 "Die Code-Snippets sind absichtlich nicht editierbar: die Inline-Code-"
-"Snippets verlieren\n"
-"Deine Änderungen, sobald Du die Seite verlässt."
+"Snippets verlieren Deine Änderungen, sobald Du die Seite verlässt."
 
 #: src/exercises/day-1/morning.md:22 src/exercises/day-1/afternoon.md:11
 #: src/exercises/day-2/morning.md:11 src/exercises/day-2/afternoon.md:7
@@ -3704,24 +3693,20 @@ msgstr ""
 #: src/exercises/concurrency/morning.md:12
 #: src/exercises/concurrency/afternoon.md:13
 msgid ""
-"After looking at the exercises, you can look at the [solutions] provided."
+"After looking at the exercises, you can look at the \\[solutions\\] provided."
 msgstr ""
 "Nachdem Du Dir die Übungen angesehen hast, kannst Du Dir die "
-"bereitgestellten [Lösungen] ansehen."
-
-#: src/exercises/day-1/implicit-conversions.md:1
-msgid "# Implicit Conversions"
-msgstr "# Implizite Konvertierungen (implicit conversions)"
+"bereitgestellten \\[Lösungen\\] ansehen."
 
 #: src/exercises/day-1/implicit-conversions.md:3
 msgid ""
 "Rust will not automatically apply _implicit conversions_ between types "
-"([unlike\n"
-"C++][3]). You can see this in a program like this:"
+"([unlike C++](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). You can see this in a program like this:"
 msgstr ""
 "Rust wendet nicht automatisch _implizite Konvertierungen_ zwischen Typen an "
-"([anders als\n"
-"C++[3]). Das kannst Du an einem Programm wie diesem sehen:"
+"(\\[anders als C++[3](https://en.cppreference.com/w/cpp/language/"
+"implicit_conversion)). Das kannst Du an einem Programm wie diesem sehen:"
 
 #: src/exercises/day-1/implicit-conversions.md:6
 msgid ""
@@ -3741,78 +3726,73 @@ msgstr ""
 
 #: src/exercises/day-1/implicit-conversions.md:19
 msgid ""
-"The Rust integer types all implement the [`From<T>`][1] and [`Into<T>`][2]\n"
-"traits to let us convert between them. The `From<T>` trait has a single "
-"`from()`\n"
-"method and similarly, the `Into<T>` trait has a single `into()` method.\n"
-"Implementing these traits is how a type expresses that it can be converted "
-"into\n"
-"another type."
+"The Rust integer types all implement the [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html) and [`Into<T>`](https://doc.rust-lang.org/"
+"std/convert/trait.Into.html) traits to let us convert between them. The "
+"`From<T>` trait has a single `from()` method and similarly, the `Into<T>` "
+"trait has a single `into()` method. Implementing these traits is how a type "
+"expresses that it can be converted into another type."
 msgstr ""
-"Alle Rust-Integer-Typen implementieren die [`From<T>`][1]- und [`Into<T>`]"
-"[2]-Merkmale (traits), \n"
-"um zwischen ihnen umzuwandeln. Das `From<T>`-Merkmal (trait) hat eine "
-"einzige `from()`\n"
-"-Methode und ähnlicherweise hat das `Into<T>`-Merkmal auch nur eine einzige "
-"`into()`-Methode.\n"
-"Durch die Implementierung dieser Merkmale (traits) drückt ein Typ aus, zu "
-"welchen anderen Typen dieser umgewandelt werden kann."
+"Alle Rust-Integer-Typen implementieren die [`From<T>`](https://doc.rust-lang."
+"org/std/convert/trait.From.html)\\- und [`Into<T>`](https://doc.rust-lang."
+"org/std/convert/trait.Into.html)\\-Merkmale (traits),  um zwischen ihnen "
+"umzuwandeln. Das `From<T>`\\-Merkmal (trait) hat eine einzige `from()` \\-"
+"Methode und ähnlicherweise hat das `Into<T>`\\-Merkmal auch nur eine einzige "
+"`into()`\\-Methode. Durch die Implementierung dieser Merkmale (traits) "
+"drückt ein Typ aus, zu welchen anderen Typen dieser umgewandelt werden kann."
 
 #: src/exercises/day-1/implicit-conversions.md:25
 msgid ""
 "The standard library has an implementation of `From<i8> for i16`, which "
-"means\n"
-"that we can convert a variable `x` of type `i8` to an `i16` by calling \n"
-"`i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for i16`\n"
-"implementation automatically create an implementation of `Into<i16> for i8`."
+"means that we can convert a variable `x` of type `i8` to an `i16` by "
+"calling  `i16::from(x)`. Or, simpler, with `x.into()`, because `From<i8> for "
+"i16` implementation automatically create an implementation of `Into<i16> for "
+"i8`."
 msgstr ""
 "Die Standardbibliothek enthält eine Implementierung von `From<i8> for i16`, "
-"was bedeutet\n"
-"dass wir eine Variable `x` vom Typ `i8` in ein `i16` durch `i16::from(x)` "
-"umwandeln können. \n"
-"Alternativ geht dies mit `x.into()`, denn die `From<i8> for i16`-"
-"Implementierung \n"
-"erstellt automatisch eine `Into<i16> for i8`-Implementierung."
+"was bedeutet dass wir eine Variable `x` vom Typ `i8` in ein `i16` durch "
+"`i16::from(x)` umwandeln können.  Alternativ geht dies mit `x.into()`, denn "
+"die `From<i8> for i16`\\-Implementierung  erstellt automatisch eine "
+"`Into<i16> for i8`\\-Implementierung."
 
 #: src/exercises/day-1/implicit-conversions.md:30
 msgid ""
 "The same applies for your own `From` implementations for your own types, so "
-"it is\n"
-"sufficient to only implement `From` to get a respective `Into` "
+"it is sufficient to only implement `From` to get a respective `Into` "
 "implementation automatically."
 msgstr ""
-"Dasselbe gilt für `From`-Implementierungen für Deine eigenen "
-"Typen.\n"
-"Es reicht also aus, nur `From` zu implementieren, um automatisch eine "
-"entsprechende `Into`-Implementierung zu erhalten."
+"Dasselbe gilt für `From`\\-Implementierungen für Deine eigenen Typen. Es "
+"reicht also aus, nur `From` zu implementieren, um automatisch eine "
+"entsprechende `Into`\\-Implementierung zu erhalten."
 
 #: src/exercises/day-1/implicit-conversions.md:33
-msgid ""
-"1. Execute the above program and look at the compiler error.\n"
-"\n"
-"2. Update the code above to use `into()` to do the conversion.\n"
-"\n"
-"3. Change the types of `x` and `y` to other things (such as `f32`, `bool`,\n"
-"   `i128`) to see which types you can convert to which other types. Try\n"
-"   converting small types to big types and the other way around. Check the\n"
-"   [standard library documentation][1] to see if `From<T>` is implemented "
-"for\n"
-"   the pairs you check."
+msgid "Execute the above program and look at the compiler error."
+msgstr "Führe das obige Programm aus und schau Dir den Compiler-Fehler an."
+
+#: src/exercises/day-1/implicit-conversions.md:35
+msgid "Update the code above to use `into()` to do the conversion."
 msgstr ""
-"1. Führe das obige Programm aus und schau Dir den Compiler-Fehler an.\n"
-"\n"
-"2. Aktualisiere den obigen Code, um `into()` für die Konvertierung zu "
-"verwenden.\n"
-"\n"
-"3. Ändere die Typen von `x` und `y` in andere Typen (z. B. `f32`, `bool`, "
+"Aktualisiere den obigen Code, um `into()` für die Konvertierung zu verwenden."
+
+#: src/exercises/day-1/implicit-conversions.md:37
+msgid ""
+"Change the types of `x` and `y` to other things (such as `f32`, `bool`, "
+"`i128`) to see which types you can convert to which other types. Try "
+"converting small types to big types and the other way around. Check the "
+"[standard library documentation](https://doc.rust-lang.org/std/convert/trait."
+"From.html) to see if `From<T>` is implemented for the pairs you check."
+msgstr ""
+"Ändere die Typen von `x` und `y` in andere Typen (z. B. `f32`, `bool`, "
 "`i128`), um zu sehen, welche Typen Du in welche anderen Typen konvertieren "
 "kannst. Versuche, kleine Typen in große Typen umzuwandeln und umgekehrt. "
-"Schau in der [Standardbibliotheksdokumentation][1] nach, ob `From<T>` für "
-"die von Dir überprüften Paare implementiert sind."
+"Schau in der [Standardbibliotheksdokumentation](https://doc.rust-lang.org/"
+"std/convert/trait.From.html) nach, ob `From<T>` für die von Dir überprüften "
+"Paare implementiert sind."
 
 #: src/exercises/day-1/for-loops.md:1
-msgid "# Arrays and `for` Loops"
-msgstr "# Arrays und `for`-Schleifen"
+#: src/exercises/day-1/solutions-morning.md:3
+msgid "Arrays and `for` Loops"
+msgstr "Arrays und `for`\\-Schleifen"
 
 #: src/exercises/day-1/for-loops.md:3
 msgid "We saw that an array can be declared like this:"
@@ -3845,7 +3825,7 @@ msgstr ""
 
 #: src/exercises/day-1/for-loops.md:18
 msgid ""
-"Rust lets you iterate over things like arrays and ranges using the `for`\n"
+"Rust lets you iterate over things like arrays and ranges using the `for` "
 "keyword:"
 msgstr ""
 "Mit Rust kannst Du über Dinge wie Arrays und Ranges iterieren, indem Du "
@@ -3874,14 +3854,12 @@ msgstr ""
 #: src/exercises/day-1/for-loops.md:38
 msgid ""
 "Use the above to write a function `pretty_print` which pretty-print a matrix "
-"and\n"
-"a function `transpose` which will transpose a matrix (turn rows into "
+"and a function `transpose` which will transpose a matrix (turn rows into "
 "columns):"
 msgstr ""
 "Verwende den obigen Code, um eine Funktion `pretty_print` zu schreiben, die "
-"eine Matrix formatiert druckt und\n"
-"schreibe eine Funktion `transpose`, die eine Matrix transponiert (Zeilen in "
-"Spalten umwandelt):"
+"eine Matrix formatiert druckt und schreibe eine Funktion `transpose`, die "
+"eine Matrix transponiert (Zeilen in Spalten umwandelt):"
 
 #: src/exercises/day-1/for-loops.md:41
 msgid ""
@@ -3898,12 +3876,11 @@ msgstr "Beide Funktionen müssen dabei nur mit 3 × 3-Matrizen arbeiten."
 
 #: src/exercises/day-1/for-loops.md:49
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and implement the\n"
+"Copy the code below to <https://play.rust-lang.org/> and implement the "
 "functions:"
 msgstr ""
 "Kopiere den folgenden Code nach <https://play.rust-lang.org/> und "
-"implementiere die\n"
-"Funktionen:"
+"implementiere die Funktionen:"
 
 #: src/exercises/day-1/for-loops.md:52
 msgid ""
@@ -3937,47 +3914,39 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/for-loops.md:80
-msgid "## Bonus Question"
-msgstr "## Bonus-Frage"
+msgid "Bonus Question"
+msgstr "Bonus-Frage"
 
 #: src/exercises/day-1/for-loops.md:82
 msgid ""
-"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your\n"
-"argument and return types? Something like `&[&[i32]]` for a two-dimensional\n"
+"Could you use `&[i32]` slices instead of hard-coded 3 × 3 matrices for your "
+"argument and return types? Something like `&[&[i32]]` for a two-dimensional "
 "slice-of-slices. Why or why not?"
 msgstr ""
-"Könntest Du den `&[i32]`-Anteilstyp anstelle von fest codierten 3 × 3-Matrizen als\n"
-"Argument- und Rückgabetypen verwenden? Oder etwas wie `&[&[i32]]` für einen "
-"zweidimensionalen Anteilstyp? \n"
-"Warum oder warum nicht?"
+"Könntest Du den `&[i32]`\\-Anteilstyp anstelle von fest codierten 3 × 3-"
+"Matrizen als Argument- und Rückgabetypen verwenden? Oder etwas wie "
+"`&[&[i32]]` für einen zweidimensionalen Anteilstyp?  Warum oder warum nicht?"
 
 #: src/exercises/day-1/for-loops.md:87
 msgid ""
-"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production "
-"quality\n"
+"See the [`ndarray` crate](https://docs.rs/ndarray/) for a production quality "
 "implementation."
 msgstr ""
-"Teste die [`ndarray`-Kiste](https://docs.rs/ndarray/) für eine "
-"produktionsfertige\n"
-"Implementierung."
+"Teste die [`ndarray`\\-Kiste](https://docs.rs/ndarray/) für eine "
+"produktionsfertige Implementierung."
 
 #: src/exercises/day-1/for-loops.md:92
 msgid ""
-"The solution and the answer to the bonus section are available in the \n"
+"The solution and the answer to the bonus section are available in the  "
 "[Solution](solutions-morning.md#arrays-and-for-loops) section."
 msgstr ""
-"Die Lösung und die Antwort zum Bonusteil findest Du im\n"
-"Abschnitt [Lösung](solutions-morning.md#arrays-and-for-loops)."
-
-#: src/basic-syntax/variables.md:1
-msgid "# Variables"
-msgstr "# Variablen"
+"Die Lösung und die Antwort zum Bonusteil findest Du im Abschnitt [Lösung]"
+"(solutions-morning.md#arrays-and-for-loops)."
 
 #: src/basic-syntax/variables.md:3
 msgid ""
 "Rust provides type safety via static typing. Variable bindings are immutable "
-"by\n"
-"default:"
+"by default:"
 msgstr ""
 "Rust bietet Typsicherheit (type safety) durch statische Typisierung (static "
 "typing). Bindungen an Variablen (variable bindings) sind standardmäßig "
@@ -3997,21 +3966,21 @@ msgstr ""
 
 #: src/basic-syntax/variables.md:17
 msgid ""
-"* Due to type inference the `i32` is optional. We will gradually show the "
-"types less and less as the course progresses.\n"
-"* Note that since `println!` is a macro, `x` is not moved, even using the "
+"Due to type inference the `i32` is optional. We will gradually show the "
+"types less and less as the course progresses."
+msgstr ""
+"Aufgrund von Typ-Inferenz (type inference) ist `i32` optional. Wir werden "
+"die Typen nach und nach immer öfter weglassen, je weiter der Kurs "
+"fortschreitet."
+
+#: src/basic-syntax/variables.md:18
+msgid ""
+"Note that since `println!` is a macro, `x` is not moved, even using the "
 "function like syntax of `println!(\"x: {}\", x)`"
 msgstr ""
-"* Aufgrund von Typ-Inferenz (type inference) ist `i32` optional. Wir werden "
-"die Typen nach und nach immer öfter weglassen, je weiter der Kurs "
-"fortschreitet.\n"
-"* Beachte, dass, da `println!` ein Makro ist, `x` nicht verschoben (moved) "
+"Beachte, dass, da `println!` ein Makro ist, `x` nicht verschoben (moved) "
 "wird, selbst wenn die funktionsähnliche Syntax von `println!(\"x: {}\", x)` "
 "verwendet wird."
-
-#: src/basic-syntax/type-inference.md:1
-msgid "# Type Inference"
-msgstr "# Typ-Inferenz (type inference)"
 
 #: src/basic-syntax/type-inference.md:3
 msgid "Rust will look at how the variable is _used_ to determine the type:"
@@ -4052,17 +4021,16 @@ msgstr ""
 #: src/basic-syntax/type-inference.md:28
 msgid ""
 "It is very important to emphasize that variables declared like this are not "
-"of some sort of dynamic \"any type\" that can\n"
-"hold any data. The machine code generated by such declaration is identical "
-"to the explicit declaration of a type.\n"
-"The compiler does the job for us and helps us write more concise code."
+"of some sort of dynamic \"any type\" that can hold any data. The machine "
+"code generated by such declaration is identical to the explicit declaration "
+"of a type. The compiler does the job for us and helps us write more concise "
+"code."
 msgstr ""
 "Es ist sehr wichtig zu betonen, dass auf diese Weise deklarierte Variablen "
-"**nicht** von einem dynamischem \"beliebigen Typ\" sind, der\n"
-"beliebige Daten enthalten kann. Der durch eine solche Deklaration erzeugte "
-"Maschinencode ist identisch mit der expliziten Deklaration eines Typs.\n"
-"Der Compiler erledigt lediglich die Arbeit für uns und hilft uns "
-"prägnanteren Code zu schreiben."
+"**nicht** von einem dynamischem \"beliebigen Typ\" sind, der beliebige Daten "
+"enthalten kann. Der durch eine solche Deklaration erzeugte Maschinencode ist "
+"identisch mit der expliziten Deklaration eines Typs. Der Compiler erledigt "
+"lediglich die Arbeit für uns und hilft uns prägnanteren Code zu schreiben."
 
 #: src/basic-syntax/type-inference.md:32
 msgid ""
@@ -4100,8 +4068,8 @@ msgstr ""
 "(https://doc.rust-lang.org/std/iter/trait.FromIterator.html) implementiert."
 
 #: src/basic-syntax/static-and-const.md:1
-msgid "# Static and Constant Variables"
-msgstr "# Statische und konstante Variablen"
+msgid "Static and Constant Variables"
+msgstr "Statische und konstante Variablen"
 
 #: src/basic-syntax/static-and-const.md:3
 msgid "Global state is managed with static and constant variables."
@@ -4110,8 +4078,8 @@ msgstr ""
 "Variablen verwaltet."
 
 #: src/basic-syntax/static-and-const.md:5
-msgid "## `const`"
-msgstr "## `const`"
+msgid "`const`"
+msgstr "`const`"
 
 #: src/basic-syntax/static-and-const.md:7
 msgid "You can declare compile-time constants:"
@@ -4140,14 +4108,16 @@ msgid ""
 msgstr ""
 
 #: src/basic-syntax/static-and-const.md:27
-msgid "According to the [Rust RFC Book][1] these are inlined upon use."
+msgid ""
+"According to the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html) these are inlined upon use."
 msgstr ""
-"Gemäß dem [Rust RFC Book][1] werden diese bei der Verwendung eingefügt "
-"(inlined upon use)."
+"Gemäß dem [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-"
+"static.html) werden diese bei der Verwendung eingefügt (inlined upon use)."
 
 #: src/basic-syntax/static-and-const.md:29
-msgid "## `static`"
-msgstr "## `static`"
+msgid "`static`"
+msgstr "`static`"
 
 #: src/basic-syntax/static-and-const.md:31
 msgid "You can also declare static variables:"
@@ -4166,15 +4136,16 @@ msgstr ""
 
 #: src/basic-syntax/static-and-const.md:41
 msgid ""
-"As noted in the [Rust RFC Book][1], these are not inlined upon use and have "
-"an actual associated memory location.  This is useful for unsafe and "
-"embedded code, and the variable lives through the entirety of the program "
-"execution."
+"As noted in the [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-"
+"vs-static.html), these are not inlined upon use and have an actual "
+"associated memory location.  This is useful for unsafe and embedded code, "
+"and the variable lives through the entirety of the program execution."
 msgstr ""
-"Wie im [Rust RFC Book][1] erwähnt, werden diese bei der Verwendung nicht "
-"inliniert und haben einen tatsächlich zugeordneten Speicherort. Dies ist "
-"nützlich für unsicheren (unsafe) und eingebetteten (embedded) Code. Die "
-"Variable existiert während der gesamten Programmausführung."
+"Wie im [Rust RFC Book](https://rust-lang.github.io/rfcs/0246-const-vs-static."
+"html) erwähnt, werden diese bei der Verwendung nicht inliniert und haben "
+"einen tatsächlich zugeordneten Speicherort. Dies ist nützlich für unsicheren "
+"(unsafe) und eingebetteten (embedded) Code. Die Variable existiert während "
+"der gesamten Programmausführung."
 
 #: src/basic-syntax/static-and-const.md:44
 msgid ""
@@ -4185,34 +4156,35 @@ msgstr ""
 "mutierenden statischen Daten befassen."
 
 #: src/basic-syntax/static-and-const.md:48
-msgid ""
-"* Mention that `const` behaves semantically similar to C++'s `constexpr`.\n"
-"* `static`, on the other hand, is much more similar to a `const` or mutable "
-"global variable in C++.\n"
-"* It isn't super common that one would need a runtime evaluated constant, "
-"but it is helpful and safer than using a static."
+msgid "Mention that `const` behaves semantically similar to C++'s `constexpr`."
 msgstr ""
-"* Erwähne, dass sich `const` semantisch ähnlich wie `constexpr` in C++ "
-"verhält.\n"
-"* `static` hingegen ist einer `const` oder veränderlichen (mutable) globalen "
-"Variable in C++ viel ähnlicher.\n"
-"* Es kommt nicht sehr häufig vor, dass man eine zur Laufzeit ausgewertete "
+"Erwähne, dass sich `const` semantisch ähnlich wie `constexpr` in C++ verhält."
+
+#: src/basic-syntax/static-and-const.md:49
+msgid ""
+"`static`, on the other hand, is much more similar to a `const` or mutable "
+"global variable in C++."
+msgstr ""
+"`static` hingegen ist einer `const` oder veränderlichen (mutable) globalen "
+"Variable in C++ viel ähnlicher."
+
+#: src/basic-syntax/static-and-const.md:50
+msgid ""
+"It isn't super common that one would need a runtime evaluated constant, but "
+"it is helpful and safer than using a static."
+msgstr ""
+"Es kommt nicht sehr häufig vor, dass man eine zur Laufzeit ausgewertete "
 "Konstante benötigt, aber es ist hilfreich und sicherer als die Verwendung "
 "einer statischen."
-
-#: src/basic-syntax/scopes-shadowing.md:1
-msgid "# Scopes and Shadowing"
-msgstr "# Gültigkeitsbereiche (scopes) und Verschattungen (shadowing)"
 
 #: src/basic-syntax/scopes-shadowing.md:3
 msgid ""
 "You can shadow variables, both those from outer scopes and variables from "
-"the\n"
-"same scope:"
+"the same scope:"
 msgstr ""
 "Sie können Variablen verschatten (shadow), sowohl solche aus äußeren "
-"Gültigkeitsbereichen (outer scopes) als auch Variablen aus dem\n"
-"gleichen Gültigkeitsbereich:"
+"Gültigkeitsbereichen (outer scopes) als auch Variablen aus dem gleichen "
+"Gültigkeitsbereich:"
 
 #: src/basic-syntax/scopes-shadowing.md:6
 msgid ""
@@ -4236,24 +4208,34 @@ msgstr ""
 
 #: src/basic-syntax/scopes-shadowing.md:25
 msgid ""
-"* Definition: Shadowing is different from mutation, because after shadowing "
+"Definition: Shadowing is different from mutation, because after shadowing "
 "both variable's memory locations exist at the same time. Both are available "
-"under the same name, depending where you use it in the code. \n"
-"* A shadowing variable can have a different type. \n"
-"* Shadowing looks obscure at first, but is convenient for holding on to "
-"values after `.unwrap()`.\n"
-"* The following code demonstrates why the compiler can't simply reuse memory "
+"under the same name, depending where you use it in the code. "
+msgstr ""
+"Definition: Verschattung (shadowing) unterscheidet sich von Mutation, da "
+"nach der Verschattung die Speicherplätze beider Variablen gleichzeitig "
+"existieren. Beide Speicherplätze sind unter demselben Namen verfügbar, je "
+"nachdem, wo Sie die Variablen im Code verwenden."
+
+#: src/basic-syntax/scopes-shadowing.md:26
+msgid "A shadowing variable can have a different type. "
+msgstr "Eine Shadowing-Variable kann einen anderen Typ haben."
+
+#: src/basic-syntax/scopes-shadowing.md:27
+msgid ""
+"Shadowing looks obscure at first, but is convenient for holding on to values "
+"after `.unwrap()`."
+msgstr ""
+"Shadowing sieht zunächst obskur aus, ist aber praktisch, um Werte nach `."
+"unwrap()` festzuhalten."
+
+#: src/basic-syntax/scopes-shadowing.md:28
+msgid ""
+"The following code demonstrates why the compiler can't simply reuse memory "
 "locations when shadowing an immutable variable in a scope, even if the type "
 "does not change."
 msgstr ""
-"* Definition: Verschattung (shadowing) unterscheidet sich von Mutation, da "
-"nach der Verschattung die Speicherplätze beider Variablen gleichzeitig "
-"existieren. Beide Speicherplätze sind unter demselben Namen verfügbar, je nachdem, wo Sie "
-"die Variablen im Code verwenden.\n"
-"* Eine Shadowing-Variable kann einen anderen Typ haben.\n"
-"* Shadowing sieht zunächst obskur aus, ist aber praktisch, um Werte nach `."
-"unwrap()` festzuhalten.\n"
-"* Der folgende Code demonstriert, warum der Compiler Speicherorte nicht "
+"Der folgende Code demonstriert, warum der Compiler Speicherorte nicht "
 "einfach wiederverwenden kann, wenn er eine unveränderliche Variable in einem "
 "Bereich verschattet, selbst wenn sich der Typ nicht ändert."
 
@@ -4269,22 +4251,20 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/memory-management.md:1
-msgid "# Memory Management"
-msgstr "# Speicherverwaltung"
-
 #: src/memory-management.md:3
 msgid "Traditionally, languages have fallen into two broad categories:"
 msgstr "Traditionell fallen Sprachen in zwei grobe Kategorien:"
 
 #: src/memory-management.md:5
+msgid "Full control via manual memory management: C, C++, Pascal, ..."
+msgstr "Volle Kontrolle über manuelle Speicherverwaltung: C, C++, Pascal, ..."
+
+#: src/memory-management.md:6
 msgid ""
-"* Full control via manual memory management: C, C++, Pascal, ...\n"
-"* Full safety via automatic memory management at runtime: Java, Python, Go, "
+"Full safety via automatic memory management at runtime: Java, Python, Go, "
 "Haskell, ..."
 msgstr ""
-"* Volle Kontrolle über manuelle Speicherverwaltung: C, C++, Pascal, ...\n"
-"* Volle Sicherheit durch automatische Speicherverwaltung zur Laufzeit: Java, "
+"Volle Sicherheit durch automatische Speicherverwaltung zur Laufzeit: Java, "
 "Python, Go, Haskell, ..."
 
 #: src/memory-management.md:8
@@ -4293,10 +4273,10 @@ msgstr "Rust bietet eine neue Mischung:"
 
 #: src/memory-management.md:10
 msgid ""
-"> Full control *and* safety via compile time enforcement of correct memory\n"
-"> management."
+"Full control _and_ safety via compile time enforcement of correct memory "
+"management."
 msgstr ""
-"> Volle Kontrolle *und* Sicherheit durch Erzwingung des korrekten Speichers "
+"Volle Kontrolle _und_ Sicherheit durch Erzwingung des korrekten Speichers "
 "zur Kompilierzeit."
 
 #: src/memory-management.md:13
@@ -4311,48 +4291,53 @@ msgstr ""
 "Lasst uns zunächst die Funktionsweise der Speicherverwaltung auffrischen."
 
 #: src/memory-management/stack-vs-heap.md:1
-msgid "# The Stack vs The Heap"
-msgstr "# Stapel vs. Haufen"
+msgid "The Stack vs The Heap"
+msgstr "Stapel vs. Haufen"
 
 #: src/memory-management/stack-vs-heap.md:3
-msgid ""
-"* Stack: Continuous area of memory for local variables.\n"
-"  * Values have fixed sizes known at compile time.\n"
-"  * Extremely fast: just move a stack pointer.\n"
-"  * Easy to manage: follows function calls.\n"
-"  * Great memory locality.\n"
-"\n"
-"* Heap: Storage of values outside of function calls.\n"
-"  * Values have dynamic sizes determined at runtime.\n"
-"  * Slightly slower than the stack: some book-keeping needed.\n"
-"  * No guarantee of memory locality."
-msgstr ""
-"* Stack: Kontinuierlicher Speicherbereich für lokale Variablen.\n"
-"  * Werte haben feste Größen, die zur Kompilierzeit bekannt sind.\n"
-"  * Extrem schnell: Durch Bewegen eines Stapelzeigers.\n"
-"  * Einfach zu verwalten: folgt Funktionsaufrufen.\n"
-"  * Große Speicherlokalität (memory locality).\n"
-"\n"
-"* Heap: Speicherung von Werten außerhalb von Funktionsaufrufen.\n"
-"   * Werte haben dynamische Größen, die zur Laufzeit bestimmt werden.\n"
-"   * Etwas langsamer als der Stapel: Etwas Buchhaltung ist erforderlich.\n"
-"   * Keine Garantie für Speicherlokalität."
+msgid "Stack: Continuous area of memory for local variables."
+msgstr "Stack: Kontinuierlicher Speicherbereich für lokale Variablen."
 
-#: src/memory-management/stack.md:1
-#, fuzzy
-msgid "# Stack Memory"
-msgstr "# Stapelspeicher"
+#: src/memory-management/stack-vs-heap.md:4
+msgid "Values have fixed sizes known at compile time."
+msgstr "Werte haben feste Größen, die zur Kompilierzeit bekannt sind."
+
+#: src/memory-management/stack-vs-heap.md:5
+msgid "Extremely fast: just move a stack pointer."
+msgstr "Extrem schnell: Durch Bewegen eines Stapelzeigers."
+
+#: src/memory-management/stack-vs-heap.md:6
+msgid "Easy to manage: follows function calls."
+msgstr "Einfach zu verwalten: folgt Funktionsaufrufen."
+
+#: src/memory-management/stack-vs-heap.md:7
+msgid "Great memory locality."
+msgstr "Große Speicherlokalität (memory locality)."
+
+#: src/memory-management/stack-vs-heap.md:9
+msgid "Heap: Storage of values outside of function calls."
+msgstr "Heap: Speicherung von Werten außerhalb von Funktionsaufrufen."
+
+#: src/memory-management/stack-vs-heap.md:10
+msgid "Values have dynamic sizes determined at runtime."
+msgstr "Werte haben dynamische Größen, die zur Laufzeit bestimmt werden."
+
+#: src/memory-management/stack-vs-heap.md:11
+msgid "Slightly slower than the stack: some book-keeping needed."
+msgstr "Etwas langsamer als der Stapel: Etwas Buchhaltung ist erforderlich."
+
+#: src/memory-management/stack-vs-heap.md:12
+msgid "No guarantee of memory locality."
+msgstr "Keine Garantie für Speicherlokalität."
 
 #: src/memory-management/stack.md:3
 #, fuzzy
 msgid ""
-"Creating a `String` puts fixed-sized data on the stack and dynamically "
-"sized\n"
+"Creating a `String` puts fixed-sized data on the stack and dynamically sized "
 "data on the heap:"
 msgstr ""
 "Das Erstellen eines \"Strings\" legt Daten mit fester Größe auf den Stapel "
-"und dynamisch in der Größe\n"
-"Daten auf dem Haufen:"
+"und dynamisch in der Größe Daten auf dem Haufen:"
 
 #: src/memory-management/stack.md:6
 msgid ""
@@ -4382,39 +4367,43 @@ msgstr ""
 
 #: src/memory-management/stack.md:28
 msgid ""
-"* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-"length and can grow if mutable via reallocation on the heap.\n"
-"\n"
-"* If students ask about it, you can mention that the underlying memory is "
-"heap allocated using the [System Allocator] and custom allocators can be "
-"implemented using the [Allocator API]\n"
-"\n"
-"* We can inspect the memory layout with `unsafe` code. However, you should "
-"point out that this is rightfully unsafe!\n"
-"\n"
-"    ```rust,editable\n"
-"    fn main() {\n"
-"        let mut s1 = String::from(\"Hello\");\n"
-"        s1.push(' ');\n"
-"        s1.push_str(\"world\");\n"
-"        // DON'T DO THIS AT HOME! For educational purposes only.\n"
-"        // String provides no guarantees about its layout, so this could "
-"lead to\n"
-"        // undefined behavior.\n"
-"        unsafe {\n"
-"            let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
-"transmute(s1);\n"
-"            println!(\"ptr = {ptr:#x}, len = {len}, capacity = "
-"{capacity}\");\n"
-"        }\n"
-"    }\n"
-"    ```"
+"Mention that a `String` is backed by a `Vec`, so it has a capacity and "
+"length and can grow if mutable via reallocation on the heap."
 msgstr ""
 
-#: src/memory-management/manual.md:1
-#, fuzzy
-msgid "# Manual Memory Management"
-msgstr "# Manuelle Speicherverwaltung"
+#: src/memory-management/stack.md:30
+msgid ""
+"If students ask about it, you can mention that the underlying memory is heap "
+"allocated using the [System Allocator](https://doc.rust-lang.org/std/alloc/"
+"struct.System.html) and custom allocators can be implemented using the "
+"[Allocator API](https://doc.rust-lang.org/std/alloc/index.html)"
+msgstr ""
+
+#: src/memory-management/stack.md:32
+msgid ""
+"We can inspect the memory layout with `unsafe` code. However, you should "
+"point out that this is rightfully unsafe!"
+msgstr ""
+
+#: src/memory-management/stack.md:34
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    let mut s1 = String::from(\"Hello\");\n"
+"    s1.push(' ');\n"
+"    s1.push_str(\"world\");\n"
+"    // DON'T DO THIS AT HOME! For educational purposes only.\n"
+"    // String provides no guarantees about its layout, so this could lead "
+"to\n"
+"    // undefined behavior.\n"
+"    unsafe {\n"
+"        let (capacity, ptr, len): (usize, usize, usize) = std::mem::"
+"transmute(s1);\n"
+"        println!(\"ptr = {ptr:#x}, len = {len}, capacity = {capacity}\");\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
 
 #: src/memory-management/manual.md:3
 #, fuzzy
@@ -4432,8 +4421,8 @@ msgstr ""
 
 #: src/memory-management/manual.md:7
 #, fuzzy
-msgid "## C Example"
-msgstr "##C Beispiel"
+msgid "C Example"
+msgstr "\\##C Beispiel"
 
 #: src/memory-management/manual.md:9
 #, fuzzy
@@ -4458,17 +4447,11 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Memory is leaked if the function returns early between `malloc` and `free`: "
-"the\n"
-"pointer is lost and we cannot deallocate the memory."
+"the pointer is lost and we cannot deallocate the memory."
 msgstr ""
 "Speicherverlust, wenn die Funktion früh zwischen `malloc` und `free` "
-"zurückkehrt: the\n"
-"Zeiger geht verloren und wir können den Speicher nicht freigeben."
-
-#: src/memory-management/scope-based.md:1
-#, fuzzy
-msgid "# Scope-Based Memory Management"
-msgstr "# Bereichsbasierte Speicherverwaltung"
+"zurückkehrt: the Zeiger geht verloren und wir können den Speicher nicht "
+"freigeben."
 
 #: src/memory-management/scope-based.md:3
 #, fuzzy
@@ -4481,32 +4464,27 @@ msgstr ""
 #: src/memory-management/scope-based.md:5
 #, fuzzy
 msgid ""
-"By wrapping a pointer in an object, you can free memory when the object is\n"
+"By wrapping a pointer in an object, you can free memory when the object is "
 "destroyed. The compiler guarantees that this happens, even if an exception "
-"is\n"
-"raised."
+"is raised."
 msgstr ""
 "Indem Sie einen Zeiger in ein Objekt einschließen, können Sie Speicher "
-"freigeben, wenn das Objekt vorhanden ist\n"
-"zerstört. Der Compiler garantiert, dass dies geschieht, auch wenn es sich um "
-"eine Ausnahme handelt\n"
-"erzogen."
+"freigeben, wenn das Objekt vorhanden ist zerstört. Der Compiler garantiert, "
+"dass dies geschieht, auch wenn es sich um eine Ausnahme handelt erzogen."
 
 #: src/memory-management/scope-based.md:9
 #, fuzzy
 msgid ""
 "This is often called _resource acquisition is initialization_ (RAII) and "
-"gives\n"
-"you smart pointers."
+"gives you smart pointers."
 msgstr ""
 "Dies wird oft als _Ressourcenerwerb ist Initialisierung_ (RAII) bezeichnet "
-"und gibt\n"
-"ihr klugen zeiger."
+"und gibt ihr klugen zeiger."
 
 #: src/memory-management/scope-based.md:12
 #, fuzzy
-msgid "## C++ Example"
-msgstr "## C++-Beispiel"
+msgid "C++ Example"
+msgstr "C++-Beispiel"
 
 #: src/memory-management/scope-based.md:14
 msgid ""
@@ -4520,15 +4498,22 @@ msgstr ""
 #: src/memory-management/scope-based.md:20
 #, fuzzy
 msgid ""
-"* The `std::unique_ptr` object is allocated on the stack, and points to\n"
-"  memory allocated on the heap.\n"
-"* At the end of `say_hello`, the `std::unique_ptr` destructor will run.\n"
-"* The destructor frees the `Person` object it points to."
+"The `std::unique_ptr` object is allocated on the stack, and points to memory "
+"allocated on the heap."
 msgstr ""
-"* Das `std::unique_ptr`-Objekt wird auf dem Stack allokiert und zeigt auf\n"
-"  auf dem Heap zugewiesener Speicher.\n"
-"* Am Ende von `say_hello` wird der Destruktor `std::unique_ptr` ausgeführt.\n"
-"* Der Destruktor gibt das `Person`-Objekt frei, auf das er zeigt."
+"Das `std::unique_ptr`\\-Objekt wird auf dem Stack allokiert und zeigt auf "
+"auf dem Heap zugewiesener Speicher."
+
+#: src/memory-management/scope-based.md:22
+#, fuzzy
+msgid "At the end of `say_hello`, the `std::unique_ptr` destructor will run."
+msgstr ""
+"Am Ende von `say_hello` wird der Destruktor `std::unique_ptr` ausgeführt."
+
+#: src/memory-management/scope-based.md:23
+#, fuzzy
+msgid "The destructor frees the `Person` object it points to."
+msgstr "Der Destruktor gibt das `Person`\\-Objekt frei, auf das er zeigt."
 
 #: src/memory-management/scope-based.md:25
 #, fuzzy
@@ -4548,43 +4533,45 @@ msgstr ""
 
 #: src/memory-management/garbage-collection.md:1
 #, fuzzy
-msgid "# Automatic Memory Management"
-msgstr "# Automatische Speicherverwaltung"
+msgid "Automatic Memory Management"
+msgstr "Automatische Speicherverwaltung"
 
 #: src/memory-management/garbage-collection.md:3
 #, fuzzy
 msgid ""
 "An alternative to manual and scope-based memory management is automatic "
-"memory\n"
-"management:"
+"memory management:"
 msgstr ""
 "Eine Alternative zur manuellen und bereichsbasierten Speicherverwaltung ist "
-"der automatische Speicher\n"
-"Management:"
+"der automatische Speicher Management:"
 
 #: src/memory-management/garbage-collection.md:6
 #, fuzzy
+msgid "The programmer never allocates or deallocates memory explicitly."
+msgstr ""
+"Der Programmierer weist Speicher nie explizit zu oder gibt ihn nicht mehr "
+"frei."
+
+#: src/memory-management/garbage-collection.md:7
+#, fuzzy
 msgid ""
-"* The programmer never allocates or deallocates memory explicitly.\n"
-"* A garbage collector finds unused memory and deallocates it for the "
+"A garbage collector finds unused memory and deallocates it for the "
 "programmer."
 msgstr ""
-"* Der Programmierer weist Speicher nie explizit zu oder gibt ihn nicht mehr "
-"frei.\n"
-"* Ein Garbage Collector findet ungenutzten Speicher und gibt ihn für den "
+"Ein Garbage Collector findet ungenutzten Speicher und gibt ihn für den "
 "Programmierer frei."
 
 #: src/memory-management/garbage-collection.md:9
 #, fuzzy
-msgid "## Java Example"
-msgstr "## Java-Beispiel"
+msgid "Java Example"
+msgstr "Java-Beispiel"
 
 #: src/memory-management/garbage-collection.md:11
 #, fuzzy
 msgid "The `person` object is not deallocated after `sayHello` returns:"
 msgstr ""
-"Das `person`-Objekt wird nicht freigegeben, nachdem `sayHello` zurückgegeben "
-"wird:"
+"Das `person`\\-Objekt wird nicht freigegeben, nachdem `sayHello` "
+"zurückgegeben wird:"
 
 #: src/memory-management/garbage-collection.md:13
 msgid ""
@@ -4597,8 +4584,8 @@ msgstr ""
 
 #: src/memory-management/rust.md:1
 #, fuzzy
-msgid "# Memory Management in Rust"
-msgstr "# Speicherverwaltung in Rust"
+msgid "Memory Management in Rust"
+msgstr "Speicherverwaltung in Rust"
 
 #: src/memory-management/rust.md:3
 #, fuzzy
@@ -4607,23 +4594,35 @@ msgstr "Die Speicherverwaltung in Rust ist eine Mischung:"
 
 #: src/memory-management/rust.md:5
 #, fuzzy
+msgid "Safe and correct like Java, but without a garbage collector."
+msgstr "Sicher und korrekt wie Java, aber ohne Garbage Collector."
+
+#: src/memory-management/rust.md:6
+#, fuzzy
 msgid ""
-"* Safe and correct like Java, but without a garbage collector.\n"
-"* Depending on which abstraction (or combination of abstractions) you "
-"choose, can be a single unique pointer, reference counted, or atomically "
-"reference counted.\n"
-"* Scope-based like C++, but the compiler enforces full adherence.\n"
-"* A Rust user can choose the right abstraction for the situation, some even "
+"Depending on which abstraction (or combination of abstractions) you choose, "
+"can be a single unique pointer, reference counted, or atomically reference "
+"counted."
+msgstr ""
+"Je nachdem, welche Abstraktion (oder Kombination von Abstraktionen) Sie "
+"wählen, kann es sich um einen einzelnen eindeutigen Zeiger, eine "
+"Referenzzählung oder eine atomare Referenzzählung handeln."
+
+#: src/memory-management/rust.md:7
+#, fuzzy
+msgid "Scope-based like C++, but the compiler enforces full adherence."
+msgstr ""
+"Bereichsbasiert wie C++, aber der Compiler erzwingt die vollständige "
+"Einhaltung."
+
+#: src/memory-management/rust.md:8
+#, fuzzy
+msgid ""
+"A Rust user can choose the right abstraction for the situation, some even "
 "have no cost at runtime like C."
 msgstr ""
-"* Sicher und korrekt wie Java, aber ohne Garbage Collector.\n"
-"* Je nachdem, welche Abstraktion (oder Kombination von Abstraktionen) Sie "
-"wählen, kann es sich um einen einzelnen eindeutigen Zeiger, eine "
-"Referenzzählung oder eine atomare Referenzzählung handeln.\n"
-"* Bereichsbasiert wie C++, aber der Compiler erzwingt die vollständige "
-"Einhaltung.\n"
-"* Ein Rust-Benutzer kann die richtige Abstraktion für die Situation "
-"auswählen, einige haben sogar keine Kosten zur Laufzeit wie C."
+"Ein Rust-Benutzer kann die richtige Abstraktion für die Situation auswählen, "
+"einige haben sogar keine Kosten zur Laufzeit wie C."
 
 #: src/memory-management/rust.md:10
 #, fuzzy
@@ -4633,24 +4632,27 @@ msgstr "Dies wird erreicht, indem _Eigentum_ explizit modelliert wird."
 #: src/memory-management/rust.md:14
 #, fuzzy
 msgid ""
-"* If asked how at this point, you can mention that in Rust this is usually "
-"handled by RAII wrapper types such as [Box], [Vec], [Rc], or [Arc]. These "
-"encapsulate ownership and memory allocation via various means, and prevent "
-"the potential errors in C.\n"
-"\n"
-"* You may be asked about destructors here, the [Drop] trait is the Rust "
-"equivalent."
+"If asked how at this point, you can mention that in Rust this is usually "
+"handled by RAII wrapper types such as [Box](https://doc.rust-lang.org/std/"
+"boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html), or [Arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html). These encapsulate "
+"ownership and memory allocation via various means, and prevent the potential "
+"errors in C."
 msgstr ""
-"* Wenn Sie an dieser Stelle fragen, wie das geht, können Sie erwähnen, dass "
-"dies in Rust normalerweise von RAII-Wrapper-Typen wie [Box], [Vec], [Rc] "
-"oder [Arc] gehandhabt wird. Diese kapseln den Besitz und die "
-"Speicherzuweisung auf verschiedene Weise und verhindern die potenziellen "
-"Fehler in C."
+"Wenn Sie an dieser Stelle fragen, wie das geht, können Sie erwähnen, dass "
+"dies in Rust normalerweise von RAII-Wrapper-Typen wie [Box](https://doc.rust-"
+"lang.org/std/boxed/struct.Box.html), [Vec](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html), [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html) oder "
+"[Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html) gehandhabt wird. "
+"Diese kapseln den Besitz und die Speicherzuweisung auf verschiedene Weise "
+"und verhindern die potenziellen Fehler in C."
 
-#: src/memory-management/comparison.md:1
-#, fuzzy
-msgid "# Comparison"
-msgstr "# Vergleich"
+#: src/memory-management/rust.md:16
+msgid ""
+"You may be asked about destructors here, the [Drop](https://doc.rust-lang."
+"org/std/ops/trait.Drop.html) trait is the Rust equivalent."
+msgstr ""
 
 #: src/memory-management/comparison.md:3
 #, fuzzy
@@ -4659,89 +4661,121 @@ msgstr "Hier ist ein grober Vergleich der Speicherverwaltungstechniken."
 
 #: src/memory-management/comparison.md:5
 #, fuzzy
-msgid "## Pros of Different Memory Management Techniques"
-msgstr "## Vorteile verschiedener Speicherverwaltungstechniken"
+msgid "Pros of Different Memory Management Techniques"
+msgstr "Vorteile verschiedener Speicherverwaltungstechniken"
 
-#: src/memory-management/comparison.md:7
+#: src/memory-management/comparison.md:7 src/memory-management/comparison.md:22
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * No runtime overhead.\n"
-"* Automatic like Java:\n"
-"  * Fully automatic.\n"
-"  * Safe and correct.\n"
-"* Scope-based like C++:\n"
-"  * Partially automatic.\n"
-"  * No runtime overhead.\n"
-"* Compiler-enforced scope-based like Rust:\n"
-"  * Enforced by compiler.\n"
-"  * No runtime overhead.\n"
-"  * Safe and correct."
-msgstr ""
-"* Handbuch wie C:\n"
-"  * Kein Laufzeitaufwand.\n"
-"* Automatisch wie Java:\n"
-"  * Komplett automatisch.\n"
-"  * Sicher und korrekt.\n"
-"* Bereichsbasiert wie C++:\n"
-"  * Teilautomatisch.\n"
-"  * Kein Laufzeitaufwand.\n"
-"* Vom Compiler erzwungener Geltungsbereich wie Rust:\n"
-"  * Vom Compiler erzwungen.\n"
-"  * Kein Laufzeitaufwand.\n"
-"  * Sicher und korrekt."
+msgid "Manual like C:"
+msgstr "Handbuch wie C:"
+
+#: src/memory-management/comparison.md:8 src/memory-management/comparison.md:14
+#: src/memory-management/comparison.md:17
+#, fuzzy
+msgid "No runtime overhead."
+msgstr "Kein Laufzeitaufwand."
+
+#: src/memory-management/comparison.md:9 src/memory-management/comparison.md:26
+#, fuzzy
+msgid "Automatic like Java:"
+msgstr "Automatisch wie Java:"
+
+#: src/memory-management/comparison.md:10
+#, fuzzy
+msgid "Fully automatic."
+msgstr "Komplett automatisch."
+
+#: src/memory-management/comparison.md:11
+#: src/memory-management/comparison.md:18
+#, fuzzy
+msgid "Safe and correct."
+msgstr "Sicher und korrekt."
+
+#: src/memory-management/comparison.md:12
+#: src/memory-management/comparison.md:29
+#, fuzzy
+msgid "Scope-based like C++:"
+msgstr "Bereichsbasiert wie C++:"
+
+#: src/memory-management/comparison.md:13
+#, fuzzy
+msgid "Partially automatic."
+msgstr "Teilautomatisch."
+
+#: src/memory-management/comparison.md:15
+#, fuzzy
+msgid "Compiler-enforced scope-based like Rust:"
+msgstr "Vom Compiler erzwungener Geltungsbereich wie Rust:"
+
+#: src/memory-management/comparison.md:16
+#, fuzzy
+msgid "Enforced by compiler."
+msgstr "Vom Compiler erzwungen."
 
 #: src/memory-management/comparison.md:20
 #, fuzzy
-msgid "## Cons of Different Memory Management Techniques"
-msgstr "## Nachteile verschiedener Techniken zur Speicherverwaltung"
+msgid "Cons of Different Memory Management Techniques"
+msgstr "Nachteile verschiedener Techniken zur Speicherverwaltung"
 
-#: src/memory-management/comparison.md:22
+#: src/memory-management/comparison.md:23
 #, fuzzy
-msgid ""
-"* Manual like C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Memory leaks.\n"
-"* Automatic like Java:\n"
-"  * Garbage collection pauses.\n"
-"  * Destructor delays.\n"
-"* Scope-based like C++:\n"
-"  * Complex, opt-in by programmer.\n"
-"  * Potential for use-after-free.\n"
-"* Compiler-enforced and scope-based like Rust:\n"
-"  * Some upfront complexity.\n"
-"  * Can reject valid programs."
-msgstr ""
-"* Handbuch wie C:\n"
-"  * Use-after-free.\n"
-"  * Double-frees.\n"
-"  * Speicherlecks.\n"
-"* Automatisch wie Java:\n"
-"  * Garbage Collection pausiert.\n"
-"  * Destruktorverzögerungen.\n"
-"* Bereichsbasiert wie C++:\n"
-"  * Komplex, Opt-in durch Programmierer.\n"
-"  * Potenzial für die Nutzung nach dem Kostenlos.\n"
-"* Compiler-erzwungen und bereichsbasiert wie Rust:\n"
-"  * Etwas Komplexität im Voraus.\n"
-"  * Kann gültige Programme ablehnen."
+msgid "Use-after-free."
+msgstr "Use-after-free."
 
-#: src/ownership.md:1
+#: src/memory-management/comparison.md:24
 #, fuzzy
-msgid "# Ownership"
-msgstr "# Eigentum"
+msgid "Double-frees."
+msgstr "Double-frees."
+
+#: src/memory-management/comparison.md:25
+#, fuzzy
+msgid "Memory leaks."
+msgstr "Speicherlecks."
+
+#: src/memory-management/comparison.md:27
+#, fuzzy
+msgid "Garbage collection pauses."
+msgstr "Garbage Collection pausiert."
+
+#: src/memory-management/comparison.md:28
+#, fuzzy
+msgid "Destructor delays."
+msgstr "Destruktorverzögerungen."
+
+#: src/memory-management/comparison.md:30
+#, fuzzy
+msgid "Complex, opt-in by programmer."
+msgstr "Komplex, Opt-in durch Programmierer."
+
+#: src/memory-management/comparison.md:31
+#, fuzzy
+msgid "Potential for use-after-free."
+msgstr "Potenzial für die Nutzung nach dem Kostenlos."
+
+#: src/memory-management/comparison.md:32
+#, fuzzy
+msgid "Compiler-enforced and scope-based like Rust:"
+msgstr "Compiler-erzwungen und bereichsbasiert wie Rust:"
+
+#: src/memory-management/comparison.md:33
+#, fuzzy
+msgid "Some upfront complexity."
+msgstr "Etwas Komplexität im Voraus."
+
+#: src/memory-management/comparison.md:34
+#, fuzzy
+msgid "Can reject valid programs."
+msgstr "Kann gültige Programme ablehnen."
 
 #: src/ownership.md:3
 #, fuzzy
 msgid ""
 "All variable bindings have a _scope_ where they are valid and it is an error "
-"to\n"
-"use a variable outside its scope:"
+"to use a variable outside its scope:"
 msgstr ""
 "Alle Variablenbindungen haben einen _Geltungsbereich_, wo sie gültig sind "
-"und es ein Fehler ist\n"
-"Verwenden Sie eine Variable außerhalb ihres Gültigkeitsbereichs:"
+"und es ein Fehler ist Verwenden Sie eine Variable außerhalb ihres "
+"Gültigkeitsbereichs:"
 
 #: src/ownership.md:6
 msgid ""
@@ -4761,19 +4795,20 @@ msgstr ""
 #: src/ownership.md:18
 #, fuzzy
 msgid ""
-"* At the end of the scope, the variable is _dropped_ and the data is freed.\n"
-"* A destructor can run here to free up resources.\n"
-"* We say that the variable _owns_ the value."
+"At the end of the scope, the variable is _dropped_ and the data is freed."
 msgstr ""
-"* Am Ende des Gültigkeitsbereichs wird die Variable _gelöscht_ und die Daten "
-"werden freigegeben.\n"
-"* Hier kann ein Destruktor laufen, um Ressourcen freizugeben.\n"
-"* Wir sagen, dass die Variable den Wert _besitzt_."
+"Am Ende des Gültigkeitsbereichs wird die Variable _gelöscht_ und die Daten "
+"werden freigegeben."
 
-#: src/ownership/move-semantics.md:1
+#: src/ownership.md:19
 #, fuzzy
-msgid "# Move Semantics"
-msgstr "# Bewegungssemantik"
+msgid "A destructor can run here to free up resources."
+msgstr "Hier kann ein Destruktor laufen, um Ressourcen freizugeben."
+
+#: src/ownership.md:20
+#, fuzzy
+msgid "We say that the variable _owns_ the value."
+msgstr "Wir sagen, dass die Variable den Wert _besitzt_."
 
 #: src/ownership/move-semantics.md:3
 #, fuzzy
@@ -4794,38 +4829,46 @@ msgstr ""
 
 #: src/ownership/move-semantics.md:14
 #, fuzzy
-msgid ""
-"* The assignment of `s1` to `s2` transfers ownership.\n"
-"* The data was _moved_ from `s1` and `s1` is no longer accessible.\n"
-"* When `s1` goes out of scope, nothing happens: it has no ownership.\n"
-"* When `s2` goes out of scope, the string data is freed.\n"
-"* There is always _exactly_ one variable binding which owns a value."
+msgid "The assignment of `s1` to `s2` transfers ownership."
+msgstr "Die Zuweisung von `s1` an `s2` überträgt das Eigentum."
+
+#: src/ownership/move-semantics.md:15
+#, fuzzy
+msgid "The data was _moved_ from `s1` and `s1` is no longer accessible."
 msgstr ""
-"* Die Zuweisung von `s1` an `s2` überträgt das Eigentum.\n"
-"* Die Daten wurden von `s1` _verschoben_ und `s1` ist nicht mehr "
-"zugänglich.\n"
-"* Wenn `s1` den Gültigkeitsbereich verlässt, passiert nichts: Es hat keinen "
-"Besitz.\n"
-"* Wenn `s2` den Geltungsbereich verlässt, werden die String-Daten "
-"freigegeben.\n"
-"* Es gibt immer _genau_ eine Variablenbindung, die einen Wert besitzt."
+"Die Daten wurden von `s1` _verschoben_ und `s1` ist nicht mehr zugänglich."
+
+#: src/ownership/move-semantics.md:16
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens: it has no ownership."
+msgstr ""
+"Wenn `s1` den Gültigkeitsbereich verlässt, passiert nichts: Es hat keinen "
+"Besitz."
+
+#: src/ownership/move-semantics.md:17
+#, fuzzy
+msgid "When `s2` goes out of scope, the string data is freed."
+msgstr ""
+"Wenn `s2` den Geltungsbereich verlässt, werden die String-Daten freigegeben."
+
+#: src/ownership/move-semantics.md:18
+#, fuzzy
+msgid "There is always _exactly_ one variable binding which owns a value."
+msgstr "Es gibt immer _genau_ eine Variablenbindung, die einen Wert besitzt."
 
 #: src/ownership/move-semantics.md:22
 #, fuzzy
 msgid ""
-"* Mention that this is the opposite of the defaults in C++, which copies by "
-"value unless you use `std::move` (and the move constructor is defined!).\n"
-"\n"
-"* In Rust, clones are explicit (by using `clone`)."
+"Mention that this is the opposite of the defaults in C++, which copies by "
+"value unless you use `std::move` (and the move constructor is defined!)."
 msgstr ""
-"* Erwähnen Sie, dass dies das Gegenteil der Standardeinstellungen in C++ "
-"ist, die nach Wert kopieren, es sei denn, Sie verwenden `std::move` (und der "
-"Move-Konstruktor ist definiert!)."
+"Erwähnen Sie, dass dies das Gegenteil der Standardeinstellungen in C++ ist, "
+"die nach Wert kopieren, es sei denn, Sie verwenden `std::move` (und der Move-"
+"Konstruktor ist definiert!)."
 
-#: src/ownership/moved-strings-rust.md:1
-#, fuzzy
-msgid "# Moved Strings in Rust"
-msgstr "# Bewegte Saiten in Rost"
+#: src/ownership/move-semantics.md:24
+msgid "In Rust, clones are explicit (by using `clone`)."
+msgstr ""
 
 #: src/ownership/moved-strings-rust.md:3
 msgid ""
@@ -4839,12 +4882,14 @@ msgstr ""
 
 #: src/ownership/moved-strings-rust.md:10
 #, fuzzy
-msgid ""
-"* The heap data from `s1` is reused for `s2`.\n"
-"* When `s1` goes out of scope, nothing happens (it has been moved from)."
+msgid "The heap data from `s1` is reused for `s2`."
+msgstr "Die Heap-Daten von „s1“ werden für „s2“ wiederverwendet."
+
+#: src/ownership/moved-strings-rust.md:11
+#, fuzzy
+msgid "When `s1` goes out of scope, nothing happens (it has been moved from)."
 msgstr ""
-"* Die Heap-Daten von „s1“ werden für „s2“ wiederverwendet.\n"
-"* Wenn `s1` den Gültigkeitsbereich verlässt, passiert nichts (es wurde "
+"Wenn `s1` den Gültigkeitsbereich verlässt, passiert nichts (es wurde "
 "verschoben)."
 
 #: src/ownership/moved-strings-rust.md:13
@@ -4899,11 +4944,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/double-free-modern-cpp.md:1
-#, fuzzy
-msgid "# Double Frees in Modern C++"
-msgstr "# Double Frees in modernem C++"
-
 #: src/ownership/double-free-modern-cpp.md:3
 #, fuzzy
 msgid "Modern C++ solves this differently:"
@@ -4920,13 +4960,16 @@ msgstr ""
 #: src/ownership/double-free-modern-cpp.md:10
 #, fuzzy
 msgid ""
-"* The heap data from `s1` is duplicated and `s2` gets its own independent "
-"copy.\n"
-"* When `s1` and `s2` go out of scope, they each free their own memory."
+"The heap data from `s1` is duplicated and `s2` gets its own independent copy."
 msgstr ""
-"* Die Heap-Daten von `s1` werden dupliziert und `s2` bekommt seine eigene "
-"unabhängige Kopie.\n"
-"* Wenn `s1` und `s2` den Geltungsbereich verlassen, geben sie jeweils ihren "
+"Die Heap-Daten von `s1` werden dupliziert und `s2` bekommt seine eigene "
+"unabhängige Kopie."
+
+#: src/ownership/double-free-modern-cpp.md:11
+#, fuzzy
+msgid "When `s1` and `s2` go out of scope, they each free their own memory."
+msgstr ""
+"Wenn `s1` und `s2` den Geltungsbereich verlassen, geben sie jeweils ihren "
 "eigenen Speicher frei."
 
 #: src/ownership/double-free-modern-cpp.md:13
@@ -4980,20 +5023,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ownership/moves-function-calls.md:1
-#, fuzzy
-msgid "# Moves in Function Calls"
-msgstr "# Bewegungen in Funktionsaufrufen"
-
 #: src/ownership/moves-function-calls.md:3
 #, fuzzy
 msgid ""
-"When you pass a value to a function, the value is assigned to the function\n"
+"When you pass a value to a function, the value is assigned to the function "
 "parameter. This transfers ownership:"
 msgstr ""
 "Wenn Sie einer Funktion einen Wert übergeben, wird der Wert der Funktion "
-"zugewiesen\n"
-"Parameter. Dadurch wird das Eigentum übertragen:"
+"zugewiesen Parameter. Dadurch wird das Eigentum übertragen:"
 
 #: src/ownership/moves-function-calls.md:6
 msgid ""
@@ -5013,34 +5050,48 @@ msgstr ""
 #: src/ownership/moves-function-calls.md:20
 #, fuzzy
 msgid ""
-"* With the first call to `say_hello`, `main` gives up ownership of `name`. "
-"Afterwards, `name` cannot be used anymore within `main`.\n"
-"* The heap memory allocated for `name` will be freed at the end of the "
-"`say_hello` function.\n"
-"* `main` can retain ownership if it passes `name` as a reference (`&name`) "
-"and if `say_hello` accepts a reference as a parameter.\n"
-"* Alternatively, `main` can pass a clone of `name` in the first call (`name."
-"clone()`).\n"
-"* Rust makes it harder than C++ to inadvertently create copies by making "
-"move semantics the default, and by forcing programmers to make clones "
-"explicit."
+"With the first call to `say_hello`, `main` gives up ownership of `name`. "
+"Afterwards, `name` cannot be used anymore within `main`."
 msgstr ""
-"* Mit dem ersten Aufruf von `say_hello` gibt `main` den Besitz von `name` "
-"auf. Danach kann `name` nicht mehr innerhalb von `main` verwendet werden.\n"
-"* Der für `name` zugewiesene Heap-Speicher wird am Ende der `say_hello`-"
-"Funktion freigegeben.\n"
-"* `main` kann den Besitz behalten, wenn es `name` als Referenz (`&name`) "
-"übergibt und wenn `say_hello` eine Referenz als Parameter akzeptiert.\n"
-"* Alternativ kann `main` beim ersten Aufruf (`name.clone()`) einen Klon von "
-"`name` übergeben.\n"
-"* Rust macht es schwieriger als C++, versehentlich Kopien zu erstellen, "
-"indem es die Bewegungssemantik zum Standard macht und Programmierer dazu "
-"zwingt, Klone explizit zu machen."
+"Mit dem ersten Aufruf von `say_hello` gibt `main` den Besitz von `name` auf. "
+"Danach kann `name` nicht mehr innerhalb von `main` verwendet werden."
 
-#: src/ownership/copy-clone.md:1
+#: src/ownership/moves-function-calls.md:21
 #, fuzzy
-msgid "# Copying and Cloning"
-msgstr "# Kopieren und Klonen"
+msgid ""
+"The heap memory allocated for `name` will be freed at the end of the "
+"`say_hello` function."
+msgstr ""
+"Der für `name` zugewiesene Heap-Speicher wird am Ende der `say_hello`\\-"
+"Funktion freigegeben."
+
+#: src/ownership/moves-function-calls.md:22
+#, fuzzy
+msgid ""
+"`main` can retain ownership if it passes `name` as a reference (`&name`) and "
+"if `say_hello` accepts a reference as a parameter."
+msgstr ""
+"`main` kann den Besitz behalten, wenn es `name` als Referenz (`&name`) "
+"übergibt und wenn `say_hello` eine Referenz als Parameter akzeptiert."
+
+#: src/ownership/moves-function-calls.md:23
+#, fuzzy
+msgid ""
+"Alternatively, `main` can pass a clone of `name` in the first call (`name."
+"clone()`)."
+msgstr ""
+"Alternativ kann `main` beim ersten Aufruf (`name.clone()`) einen Klon von "
+"`name` übergeben."
+
+#: src/ownership/moves-function-calls.md:24
+#, fuzzy
+msgid ""
+"Rust makes it harder than C++ to inadvertently create copies by making move "
+"semantics the default, and by forcing programmers to make clones explicit."
+msgstr ""
+"Rust macht es schwieriger als C++, versehentlich Kopien zu erstellen, indem "
+"es die Bewegungssemantik zum Standard macht und Programmierer dazu zwingt, "
+"Klone explizit zu machen."
 
 #: src/ownership/copy-clone.md:3
 #, fuzzy
@@ -5065,7 +5116,7 @@ msgstr ""
 #: src/ownership/copy-clone.md:14
 #, fuzzy
 msgid "These types implement the `Copy` trait."
-msgstr "Diese Typen implementieren das `Copy`-Merkmal."
+msgstr "Diese Typen implementieren das `Copy`\\-Merkmal."
 
 #: src/ownership/copy-clone.md:16
 #, fuzzy
@@ -5091,12 +5142,15 @@ msgstr ""
 
 #: src/ownership/copy-clone.md:30
 #, fuzzy
-msgid ""
-"* After the assignment, both `p1` and `p2` own their own data.\n"
-"* We can also use `p1.clone()` to explicitly copy the data."
+msgid "After the assignment, both `p1` and `p2` own their own data."
 msgstr ""
-"* Nach der Zuweisung besitzen sowohl `p1` als auch `p2` ihre eigenen Daten.\n"
-"* Wir können auch `p1.clone()` verwenden, um die Daten explizit zu kopieren."
+"Nach der Zuweisung besitzen sowohl `p1` als auch `p2` ihre eigenen Daten."
+
+#: src/ownership/copy-clone.md:31
+#, fuzzy
+msgid "We can also use `p1.clone()` to explicitly copy the data."
+msgstr ""
+"Wir können auch `p1.clone()` verwenden, um die Daten explizit zu kopieren."
 
 #: src/ownership/copy-clone.md:35
 #, fuzzy
@@ -5106,22 +5160,35 @@ msgstr "Kopieren und Klonen sind nicht dasselbe:"
 #: src/ownership/copy-clone.md:37
 #, fuzzy
 msgid ""
-"* Copying refers to bitwise copies of memory regions and does not work on "
-"arbitrary objects.\n"
-"* Copying does not allow for custom logic (unlike copy constructors in C+"
-"+).\n"
-"* Cloning is a more general operation and also allows for custom behavior by "
-"implementing the `Clone` trait.\n"
-"* Copying does not work on types that implement the `Drop` trait."
+"Copying refers to bitwise copies of memory regions and does not work on "
+"arbitrary objects."
 msgstr ""
-"* Kopieren bezieht sich auf bitweises Kopieren von Speicherbereichen und "
-"funktioniert nicht mit beliebigen Objekten.\n"
-"* Beim Kopieren ist keine benutzerdefinierte Logik möglich (im Gegensatz zu "
-"Kopierkonstruktoren in C++).\n"
-"* Klonen ist eine allgemeinere Operation und ermöglicht auch "
+"Kopieren bezieht sich auf bitweises Kopieren von Speicherbereichen und "
+"funktioniert nicht mit beliebigen Objekten."
+
+#: src/ownership/copy-clone.md:38
+#, fuzzy
+msgid ""
+"Copying does not allow for custom logic (unlike copy constructors in C++)."
+msgstr ""
+"Beim Kopieren ist keine benutzerdefinierte Logik möglich (im Gegensatz zu "
+"Kopierkonstruktoren in C++)."
+
+#: src/ownership/copy-clone.md:39
+#, fuzzy
+msgid ""
+"Cloning is a more general operation and also allows for custom behavior by "
+"implementing the `Clone` trait."
+msgstr ""
+"Klonen ist eine allgemeinere Operation und ermöglicht auch "
 "benutzerdefiniertes Verhalten durch Implementieren der Eigenschaft "
-"\"Klonen\".\n"
-"* Das Kopieren funktioniert nicht bei Typen, die das `Drop`-Merkmal "
+"\"Klonen\"."
+
+#: src/ownership/copy-clone.md:40
+#, fuzzy
+msgid "Copying does not work on types that implement the `Drop` trait."
+msgstr ""
+"Das Kopieren funktioniert nicht bei Typen, die das `Drop`\\-Merkmal "
 "implementieren."
 
 #: src/ownership/copy-clone.md:42 src/ownership/lifetimes-function-calls.md:29
@@ -5132,45 +5199,45 @@ msgstr "Versuchen Sie im obigen Beispiel Folgendes:"
 #: src/ownership/copy-clone.md:44
 #, fuzzy
 msgid ""
-"* Add a `String` field to `struct Point`. It will not compile because "
-"`String` is not a `Copy` type.\n"
-"* Remove `Copy` from the `derive` attribute. The compiler error is now in "
-"the `println!` for  `p1`.\n"
-"* Show that it works if you clone `p1` instead."
+"Add a `String` field to `struct Point`. It will not compile because `String` "
+"is not a `Copy` type."
 msgstr ""
-"* Fügen Sie ein `String`-Feld zu `struct Point` hinzu. Es wird nicht "
-"kompiliert, da `String` kein `Copy`-Typ ist.\n"
-"* Entfernen Sie „Copy“ aus dem „derive“-Attribut. Der Compiler-Fehler steht "
-"jetzt im `println!` für `p1`.\n"
-"* Zeigen Sie, dass es funktioniert, wenn Sie stattdessen `p1` klonen."
+"Fügen Sie ein `String`\\-Feld zu `struct Point` hinzu. Es wird nicht "
+"kompiliert, da `String` kein `Copy`\\-Typ ist."
+
+#: src/ownership/copy-clone.md:45
+#, fuzzy
+msgid ""
+"Remove `Copy` from the `derive` attribute. The compiler error is now in the "
+"`println!` for  `p1`."
+msgstr ""
+"Entfernen Sie „Copy“ aus dem „derive“-Attribut. Der Compiler-Fehler steht "
+"jetzt im `println!` für `p1`."
+
+#: src/ownership/copy-clone.md:46
+#, fuzzy
+msgid "Show that it works if you clone `p1` instead."
+msgstr "Zeigen Sie, dass es funktioniert, wenn Sie stattdessen `p1` klonen."
 
 #: src/ownership/copy-clone.md:48
 #, fuzzy
 msgid ""
 "If students ask about `derive`, it is sufficient to say that this is a way "
-"to generate code in Rust\n"
-"at compile time. In this case the default implementations of `Copy` and "
-"`Clone` traits are generated."
+"to generate code in Rust at compile time. In this case the default "
+"implementations of `Copy` and `Clone` traits are generated."
 msgstr ""
 "Wenn Schüler nach „derive“ fragen, reicht es zu sagen, dass dies eine "
-"Möglichkeit ist, Code in Rust zu generieren\n"
-"zur Kompilierzeit. In diesem Fall werden die Standardimplementierungen der "
-"Merkmale „Kopieren“ und „Klonen“ generiert.\n"
-"    \n"
-"</details>"
-
-#: src/ownership/borrowing.md:1
-#, fuzzy
-msgid "# Borrowing"
-msgstr "# Ausleihen"
+"Möglichkeit ist, Code in Rust zu generieren zur Kompilierzeit. In diesem "
+"Fall werden die Standardimplementierungen der Merkmale „Kopieren“ und "
+"„Klonen“ generiert."
 
 #: src/ownership/borrowing.md:3
 #, fuzzy
 msgid ""
-"Instead of transferring ownership when calling a function, you can let a\n"
+"Instead of transferring ownership when calling a function, you can let a "
 "function _borrow_ the value:"
 msgstr ""
-"Anstatt den Besitz beim Aufruf einer Funktion zu übertragen, können Sie a\n"
+"Anstatt den Besitz beim Aufruf einer Funktion zu übertragen, können Sie a "
 "function _borrow_ den Wert:"
 
 #: src/ownership/borrowing.md:6
@@ -5194,55 +5261,62 @@ msgstr ""
 
 #: src/ownership/borrowing.md:22
 #, fuzzy
-msgid ""
-"* The `add` function _borrows_ two points and returns a new point.\n"
-"* The caller retains ownership of the inputs."
+msgid "The `add` function _borrows_ two points and returns a new point."
 msgstr ""
-"* Die `add`-Funktion _leiht_ zwei Punkte und gibt einen neuen Punkt zurück.\n"
-"* Der Aufrufer behält das Eigentum an den Eingaben."
+"Die `add`\\-Funktion _leiht_ zwei Punkte und gibt einen neuen Punkt zurück."
+
+#: src/ownership/borrowing.md:23
+#, fuzzy
+msgid "The caller retains ownership of the inputs."
+msgstr "Der Aufrufer behält das Eigentum an den Eingaben."
 
 #: src/ownership/borrowing.md:27
 #, fuzzy
 msgid "Notes on stack returns:"
-msgstr "Hinweise zur Stapelrückgabe:\n"
+msgstr "Hinweise zur Stapelrückgabe:"
 
 #: src/ownership/borrowing.md:28
 msgid ""
-"* Demonstrate that the return from `add` is cheap because the compiler can "
+"Demonstrate that the return from `add` is cheap because the compiler can "
 "eliminate the copy operation. Change the above code to print stack addresses "
-"and run it on the [Playground]. In the \"DEBUG\" optimization level, the "
-"addresses should change, while they stay the same when changing to the "
-"\"RELEASE\" setting:\n"
-"\n"
-"  ```rust,editable\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn add(p1: &Point, p2: &Point) -> Point {\n"
-"      let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
-"      println!(\"&p.0: {:p}\", &p.0);\n"
-"      p\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1 = Point(3, 4);\n"
-"      let p2 = Point(10, 20);\n"
-"      let p3 = add(&p1, &p2);\n"
-"      println!(\"&p3.0: {:p}\", &p3.0);\n"
-"      println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
-"  }\n"
-"  ```\n"
-"* The Rust compiler can do return value optimization (RVO).\n"
-"* In C++, copy elision has to be defined in the language specification "
-"because constructors can have side effects. In Rust, this is not an issue at "
-"all. If RVO did not happen, Rust will always performs a simple and efficient "
-"`memcpy` copy."
+"and run it on the [Playground](https://play.rust-lang.org/). In the "
+"\"DEBUG\" optimization level, the addresses should change, while they stay "
+"the same when changing to the \"RELEASE\" setting:"
 msgstr ""
 
-#: src/ownership/shared-unique-borrows.md:1
-#, fuzzy
-msgid "# Shared and Unique Borrows"
-msgstr "# Gemeinsame und einzigartige Ausleihen"
+#: src/ownership/borrowing.md:30
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn add(p1: &Point, p2: &Point) -> Point {\n"
+"    let p = Point(p1.0 + p2.0, p1.1 + p2.1);\n"
+"    println!(\"&p.0: {:p}\", &p.0);\n"
+"    p\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1 = Point(3, 4);\n"
+"    let p2 = Point(10, 20);\n"
+"    let p3 = add(&p1, &p2);\n"
+"    println!(\"&p3.0: {:p}\", &p3.0);\n"
+"    println!(\"{p1:?} + {p2:?} = {p3:?}\");\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/ownership/borrowing.md:48
+msgid "The Rust compiler can do return value optimization (RVO)."
+msgstr ""
+
+#: src/ownership/borrowing.md:49
+msgid ""
+"In C++, copy elision has to be defined in the language specification because "
+"constructors can have side effects. In Rust, this is not an issue at all. If "
+"RVO did not happen, Rust will always performs a simple and efficient "
+"`memcpy` copy."
+msgstr ""
 
 #: src/ownership/shared-unique-borrows.md:3
 #, fuzzy
@@ -5251,12 +5325,13 @@ msgstr "Rust schränkt die Art und Weise ein, wie Sie Werte ausleihen können:"
 
 #: src/ownership/shared-unique-borrows.md:5
 #, fuzzy
-msgid ""
-"* You can have one or more `&T` values at any given time, _or_\n"
-"* You can have exactly one `&mut T` value."
-msgstr ""
-"* Sie können jederzeit einen oder mehrere `&T`-Werte haben, _oder_\n"
-"* Sie können genau einen `&mut T`-Wert haben."
+msgid "You can have one or more `&T` values at any given time, _or_"
+msgstr "Sie können jederzeit einen oder mehrere `&T`\\-Werte haben, _oder_"
+
+#: src/ownership/shared-unique-borrows.md:6
+#, fuzzy
+msgid "You can have exactly one `&mut T` value."
+msgstr "Sie können genau einen `&mut T`\\-Wert haben."
 
 #: src/ownership/shared-unique-borrows.md:8
 msgid ""
@@ -5279,28 +5354,31 @@ msgstr ""
 #: src/ownership/shared-unique-borrows.md:25
 #, fuzzy
 msgid ""
-"* The above code does not compile because `a` is borrowed as mutable "
-"(through `c`) and as immutable (through `b`) at the same time.\n"
-"* Move the `println!` statement for `b` before the scope that introduces `c` "
-"to make the code compile.\n"
-"* After that change, the compiler realizes that `b` is only ever used before "
+"The above code does not compile because `a` is borrowed as mutable (through "
+"`c`) and as immutable (through `b`) at the same time."
+msgstr ""
+"Der obige Code lässt sich nicht kompilieren, da `a` gleichzeitig als "
+"veränderlich (durch `c`) und als unveränderlich (durch `b`) ausgeliehen wird."
+
+#: src/ownership/shared-unique-borrows.md:26
+#, fuzzy
+msgid ""
+"Move the `println!` statement for `b` before the scope that introduces `c` "
+"to make the code compile."
+msgstr ""
+"Verschieben Sie die `println!`\\-Anweisung für `b` vor den "
+"Gültigkeitsbereich, der `c` einführt, um den Code zu kompilieren."
+
+#: src/ownership/shared-unique-borrows.md:27
+#, fuzzy
+msgid ""
+"After that change, the compiler realizes that `b` is only ever used before "
 "the new mutable borrow of `a` through `c`. This is a feature of the borrow "
 "checker called \"non-lexical lifetimes\"."
 msgstr ""
-"* Der obige Code lässt sich nicht kompilieren, da `a` gleichzeitig als "
-"veränderlich (durch `c`) und als unveränderlich (durch `b`) ausgeliehen "
-"wird.\n"
-"* Verschieben Sie die `println!`-Anweisung für `b` vor den "
-"Gültigkeitsbereich, der `c` einführt, um den Code zu kompilieren.\n"
-"* Nach dieser Änderung erkennt der Compiler, dass `b` immer nur vor dem "
-"neuen änderbaren Borgen von `a` bis `c` verwendet wird. Dies ist eine "
-"Funktion des Borrow-Checkers, die als \"nicht-lexikalische Lebensdauern\" "
-"bezeichnet wird."
-
-#: src/ownership/lifetimes.md:1
-#, fuzzy
-msgid "# Lifetimes"
-msgstr "# Lebensdauer"
+"Nach dieser Änderung erkennt der Compiler, dass `b` immer nur vor dem neuen "
+"änderbaren Borgen von `a` bis `c` verwendet wird. Dies ist eine Funktion des "
+"Borrow-Checkers, die als \"nicht-lexikalische Lebensdauern\" bezeichnet wird."
 
 #: src/ownership/lifetimes.md:3
 #, fuzzy
@@ -5308,27 +5386,40 @@ msgid "A borrowed value has a _lifetime_:"
 msgstr "Ein geliehener Wert hat eine _Lebensdauer_:"
 
 #: src/ownership/lifetimes.md:5
-msgid ""
-"* The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`.\n"
-"* Lifetimes can also be explicit: `&'a Point`, `&'document str`.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"* Lifetimes are always inferred by the compiler: you cannot assign a "
-"lifetime\n"
-"  yourself.\n"
-"  * Lifetime annotations create constraints; the compiler verifies that "
-"there is\n"
-"    a valid solution.\n"
-"* Lifetimes for function arguments and return values must be fully "
-"specified,\n"
-"  but Rust allows these to be elided in most cases with [a few simple\n"
-"  rules](https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgid "The lifetime can be implicit: `add(p1: &Point, p2: &Point) -> Point`."
 msgstr ""
 
-#: src/ownership/lifetimes-function-calls.md:1
+#: src/ownership/lifetimes.md:6
+msgid "Lifetimes can also be explicit: `&'a Point`, `&'document str`."
+msgstr ""
+
+#: src/ownership/lifetimes.md:7 src/ownership/lifetimes-function-calls.md:23
 #, fuzzy
-msgid "# Lifetimes in Function Calls"
-msgstr "# Lebensdauer in Funktionsaufrufen"
+msgid ""
+"Read `&'a Point` as \"a borrowed `Point` which is valid for at least the "
+"lifetime `a`\"."
+msgstr ""
+"Lesen Sie `&'einen Punkt` als \"einen geliehenen `Punkt`, der mindestens für "
+"den gilt Lebenszeit `a`\"."
+
+#: src/ownership/lifetimes.md:9
+msgid ""
+"Lifetimes are always inferred by the compiler: you cannot assign a lifetime "
+"yourself."
+msgstr ""
+
+#: src/ownership/lifetimes.md:11
+msgid ""
+"Lifetime annotations create constraints; the compiler verifies that there is "
+"a valid solution."
+msgstr ""
+
+#: src/ownership/lifetimes.md:13
+msgid ""
+"Lifetimes for function arguments and return values must be fully specified, "
+"but Rust allows these to be elided in most cases with [a few simple rules]"
+"(https://doc.rust-lang.org/nomicon/lifetime-elision.html)."
+msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:3
 #, fuzzy
@@ -5360,77 +5451,98 @@ msgstr ""
 
 #: src/ownership/lifetimes-function-calls.md:21
 #, fuzzy
+msgid "`'a` is a generic parameter, it is inferred by the compiler."
+msgstr "„a“ ist ein generischer Parameter, er wird vom Compiler abgeleitet."
+
+#: src/ownership/lifetimes-function-calls.md:22
+#, fuzzy
+msgid "Lifetimes start with `'` and `'a` is a typical default name."
+msgstr "Lebensdauern beginnen mit `'` und `'a` ist ein typischer Standardname."
+
+#: src/ownership/lifetimes-function-calls.md:25
+#, fuzzy
 msgid ""
-"* `'a` is a generic parameter, it is inferred by the compiler.\n"
-"* Lifetimes start with `'` and `'a` is a typical default name.\n"
-"* Read `&'a Point` as \"a borrowed `Point` which is valid for at least the\n"
-"  lifetime `a`\".\n"
-"  * The _at least_ part is important when parameters are in different scopes."
+"The _at least_ part is important when parameters are in different scopes."
 msgstr ""
-"* „a“ ist ein generischer Parameter, er wird vom Compiler abgeleitet.\n"
-"* Lebensdauern beginnen mit `'` und `'a` ist ein typischer Standardname.\n"
-"* Lesen Sie `&'einen Punkt` als \"einen geliehenen `Punkt`, der mindestens "
-"für den gilt\n"
-"  Lebenszeit `a`\".\n"
-"  * Der Teil _at least_ ist wichtig, wenn sich Parameter in "
-"unterschiedlichen Geltungsbereichen befinden."
+"Der Teil _at least_ ist wichtig, wenn sich Parameter in unterschiedlichen "
+"Geltungsbereichen befinden."
 
 #: src/ownership/lifetimes-function-calls.md:31
 #, fuzzy
 msgid ""
-"* Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
-"resulting in the following code:\n"
-"  ```rust,ignore\n"
-"  #[derive(Debug)]\n"
-"  struct Point(i32, i32);\n"
-"\n"
-"  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-"      if p1.0 < p2.0 { p1 } else { p2 }\n"
-"  }\n"
-"\n"
-"  fn main() {\n"
-"      let p1: Point = Point(10, 10);\n"
-"      let p3: &Point;\n"
-"      {\n"
-"          let p2: Point = Point(20, 20);\n"
-"          p3 = left_most(&p1, &p2);\n"
-"      }\n"
-"      println!(\"left-most point: {:?}\", p3);\n"
-"  }\n"
-"  ```\n"
-"  Note how this does not compile since `p3` outlives `p2`.\n"
-"\n"
-"* Reset the workspace and change the function signature to `fn left_most<'a, "
-"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
-"because the relationship between the lifetimes `'a` and `'b` is unclear.\n"
-"* Another way to explain it:\n"
-"  * Two references to two values are borrowed by a function and the function "
-"returns\n"
-"    another reference.\n"
-"  * It must have come from one of those two inputs (or from a global "
-"variable).\n"
-"  * Which one is it? The compiler needs to know, so at the call site the "
-"returned reference is not used\n"
-"    for longer than a variable from where the reference came from."
+"Move the declaration of `p2` and `p3` into a new scope (`{ ... }`), "
+"resulting in the following code:"
 msgstr ""
-"* Setzen Sie den Arbeitsbereich zurück und ändern Sie die Funktionssignatur "
-"zu `fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. Dies "
-"wird nicht kompiliert, da die Beziehung zwischen den Lebensdauern „a“ und "
-"„b“ unklar ist.\n"
-"* Eine andere Möglichkeit, es zu erklären:\n"
-"  * Zwei Referenzen auf zwei Werte werden von einer Funktion ausgeliehen und "
-"die Funktion kehrt zurück\n"
-"    eine andere Referenz.\n"
-"  * Es muss von einem dieser beiden Eingänge stammen (oder von einer "
-"globalen Variablen).\n"
-"  * Welches ist es? Der Compiler muss es wissen, damit die zurückgegebene "
-"Referenz auf der Aufrufseite nicht verwendet wird\n"
-"    länger als eine Variable, von der die Referenz stammt."
+"Setzen Sie den Arbeitsbereich zurück und ändern Sie die Funktionssignatur zu "
+"`fn left_most<'a, 'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. Dies wird "
+"nicht kompiliert, da die Beziehung zwischen den Lebensdauern „a“ und „b“ "
+"unklar ist."
 
-#: src/ownership/lifetimes-data-structures.md:1
+#: src/ownership/lifetimes-function-calls.md:32
 #, fuzzy
-msgid "# Lifetimes in Data Structures"
-msgstr "# Lebensdauern in Datenstrukturen"
+msgid ""
+"```rust,ignore\n"
+"#[derive(Debug)]\n"
+"struct Point(i32, i32);\n"
+"\n"
+"fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
+"    if p1.0 < p2.0 { p1 } else { p2 }\n"
+"}\n"
+"\n"
+"fn main() {\n"
+"    let p1: Point = Point(10, 10);\n"
+"    let p3: &Point;\n"
+"    {\n"
+"        let p2: Point = Point(20, 20);\n"
+"        p3 = left_most(&p1, &p2);\n"
+"    }\n"
+"    println!(\"left-most point: {:?}\", p3);\n"
+"}\n"
+"```"
+msgstr "Eine andere Möglichkeit, es zu erklären:"
+
+#: src/ownership/lifetimes-function-calls.md:50
+#, fuzzy
+msgid "Note how this does not compile since `p3` outlives `p2`."
+msgstr ""
+"Zwei Referenzen auf zwei Werte werden von einer Funktion ausgeliehen und die "
+"Funktion kehrt zurück eine andere Referenz."
+
+#: src/ownership/lifetimes-function-calls.md:52
+#, fuzzy
+msgid ""
+"Reset the workspace and change the function signature to `fn left_most<'a, "
+"'b>(p1: &'a Point, p2: &'a Point) -> &'b Point`. This will not compile "
+"because the relationship between the lifetimes `'a` and `'b` is unclear."
+msgstr ""
+"Es muss von einem dieser beiden Eingänge stammen (oder von einer globalen "
+"Variablen)."
+
+#: src/ownership/lifetimes-function-calls.md:53
+#, fuzzy
+msgid "Another way to explain it:"
+msgstr ""
+"Welches ist es? Der Compiler muss es wissen, damit die zurückgegebene "
+"Referenz auf der Aufrufseite nicht verwendet wird länger als eine Variable, "
+"von der die Referenz stammt."
+
+#: src/ownership/lifetimes-function-calls.md:54
+msgid ""
+"Two references to two values are borrowed by a function and the function "
+"returns another reference."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:56
+msgid ""
+"It must have come from one of those two inputs (or from a global variable)."
+msgstr ""
+
+#: src/ownership/lifetimes-function-calls.md:57
+msgid ""
+"Which one is it? The compiler needs to know, so at the call site the "
+"returned reference is not used for longer than a variable from where the "
+"reference came from."
+msgstr ""
 
 #: src/ownership/lifetimes-data-structures.md:3
 #, fuzzy
@@ -5465,40 +5577,58 @@ msgstr ""
 #: src/ownership/lifetimes-data-structures.md:25
 #, fuzzy
 msgid ""
-"* In the above example, the annotation on `Highlight` enforces that the data "
+"In the above example, the annotation on `Highlight` enforces that the data "
 "underlying the contained `&str` lives at least as long as any instance of "
-"`Highlight` that uses that data.\n"
-"* If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
-"the borrow checker throws an error.\n"
-"* Types with borrowed data force users to hold on to the original data. This "
-"can be useful for creating lightweight views, but it generally makes them "
-"somewhat harder to use.\n"
-"* When possible, make data structures own their data directly.\n"
-"* Some structs with multiple references inside can have more than one "
-"lifetime annotation. This can be necessary if there is a need to describe "
-"lifetime relationships between the references themselves, in addition to the "
-"lifetime of the struct itself. Those are very advanced use cases."
+"`Highlight` that uses that data."
 msgstr ""
-"* Im obigen Beispiel erzwingt die Anmerkung zu `Highlight`, dass die Daten, "
+"Im obigen Beispiel erzwingt die Anmerkung zu `Highlight`, dass die Daten, "
 "die dem enthaltenen `&str` zugrunde liegen, mindestens so lange leben wie "
-"jede Instanz von `Highlight`, die diese Daten verwendet.\n"
-"* Wenn `text` vor dem Ende der Lebensdauer von `fox` (oder `dog`) verbraucht "
-"wird, wirft der Borrow-Checker einen Fehler.\n"
-"* Typen mit geliehenen Daten zwingen Benutzer, an den Originaldaten "
+"jede Instanz von `Highlight`, die diese Daten verwendet."
+
+#: src/ownership/lifetimes-data-structures.md:26
+#, fuzzy
+msgid ""
+"If `text` is consumed before the end of the lifetime of `fox` (or `dog`), "
+"the borrow checker throws an error."
+msgstr ""
+"Wenn `text` vor dem Ende der Lebensdauer von `fox` (oder `dog`) verbraucht "
+"wird, wirft der Borrow-Checker einen Fehler."
+
+#: src/ownership/lifetimes-data-structures.md:27
+#, fuzzy
+msgid ""
+"Types with borrowed data force users to hold on to the original data. This "
+"can be useful for creating lightweight views, but it generally makes them "
+"somewhat harder to use."
+msgstr ""
+"Typen mit geliehenen Daten zwingen Benutzer, an den Originaldaten "
 "festzuhalten. Dies kann nützlich sein, um einfache Ansichten zu erstellen, "
-"macht sie jedoch im Allgemeinen etwas schwieriger zu verwenden.\n"
-"* Wenn möglich, machen Sie Datenstrukturen direkt Eigentümer ihrer Daten.\n"
-"* Einige Strukturen mit mehreren darin enthaltenen Referenzen können mehr "
-"als eine lebenslange Anmerkung haben. Dies kann erforderlich sein, wenn "
+"macht sie jedoch im Allgemeinen etwas schwieriger zu verwenden."
+
+#: src/ownership/lifetimes-data-structures.md:28
+#, fuzzy
+msgid "When possible, make data structures own their data directly."
+msgstr ""
+"Wenn möglich, machen Sie Datenstrukturen direkt Eigentümer ihrer Daten."
+
+#: src/ownership/lifetimes-data-structures.md:29
+#, fuzzy
+msgid ""
+"Some structs with multiple references inside can have more than one lifetime "
+"annotation. This can be necessary if there is a need to describe lifetime "
+"relationships between the references themselves, in addition to the lifetime "
+"of the struct itself. Those are very advanced use cases."
+msgstr ""
+"Einige Strukturen mit mehreren darin enthaltenen Referenzen können mehr als "
+"eine lebenslange Anmerkung haben. Dies kann erforderlich sein, wenn "
 "zusätzlich zur Lebensdauer der Struktur selbst Lebensdauerbeziehungen "
 "zwischen den Referenzen selbst beschrieben werden müssen. Das sind sehr "
-"fortgeschrittene Anwendungsfälle.\n"
-"</Details>"
+"fortgeschrittene Anwendungsfälle."
 
 #: src/exercises/day-1/afternoon.md:1
 #, fuzzy
-msgid "# Day 1: Afternoon Exercises"
-msgstr "# Tag 1: Nachmittagsübungen"
+msgid "Day 1: Afternoon Exercises"
+msgstr "Tag 1: Nachmittagsübungen"
 
 #: src/exercises/day-1/afternoon.md:3
 #, fuzzy
@@ -5507,27 +5637,21 @@ msgstr "Wir werden uns zwei Dinge ansehen:"
 
 #: src/exercises/day-1/afternoon.md:5
 #, fuzzy
-msgid ""
-"* A small book library,\n"
-"\n"
-"* Iterators and ownership (hard)."
-msgstr "* Iteratoren und Besitz (schwer)."
+msgid "A small book library,"
+msgstr "Iteratoren und Besitz (schwer)."
 
-#: src/exercises/day-1/book-library.md:1
-#, fuzzy
-msgid "# Designing a Library"
-msgstr "# Entwerfen einer Bibliothek"
+#: src/exercises/day-1/afternoon.md:7
+msgid "Iterators and ownership (hard)."
+msgstr ""
 
 #: src/exercises/day-1/book-library.md:3
 #, fuzzy
 msgid ""
 "We will learn much more about structs and the `Vec<T>` type tomorrow. For "
-"now,\n"
-"you just need to know part of its API:"
+"now, you just need to know part of its API:"
 msgstr ""
 "Wir werden morgen viel mehr über Strukturen und den Typ `Vec<T>` lernen. Zur "
-"Zeit,\n"
-"Sie müssen nur einen Teil seiner API kennen:"
+"Zeit, Sie müssen nur einen Teil seiner API kennen:"
 
 #: src/exercises/day-1/book-library.md:6
 msgid ""
@@ -5547,13 +5671,12 @@ msgstr ""
 #: src/exercises/day-1/book-library.md:18
 #, fuzzy
 msgid ""
-"Use this to create a library application. Copy the code below to\n"
-"<https://play.rust-lang.org/> and update the types to make it compile:"
+"Use this to create a library application. Copy the code below to <https://"
+"play.rust-lang.org/> and update the types to make it compile:"
 msgstr ""
 "Verwenden Sie dies, um eine Bibliotheksanwendung zu erstellen. Kopieren Sie "
-"den folgenden Code nach\n"
-"<https://play.rust-lang.org/> und aktualisieren Sie die Typen, damit es "
-"kompiliert wird:"
+"den folgenden Code nach <https://play.rust-lang.org/> und aktualisieren Sie "
+"die Typen, damit es kompiliert wird:"
 
 #: src/exercises/day-1/book-library.md:21
 msgid ""
@@ -5644,44 +5767,34 @@ msgstr ""
 msgid "[Solution](solutions-afternoon.md#designing-a-library)"
 msgstr "[Lösung](solutions-afternoon.md#designing-a-library)"
 
-#: src/exercises/day-1/iterators-and-ownership.md:1
-#, fuzzy
-msgid "# Iterators and Ownership"
-msgstr "# Iteratoren und Eigentum"
-
 #: src/exercises/day-1/iterators-and-ownership.md:3
 #, fuzzy
 msgid ""
-"The ownership model of Rust affects many APIs. An example of this is the\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"The ownership model of Rust affects many APIs. An example of this is the "
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "traits."
 msgstr ""
 "Das Eigentumsmodell von Rust betrifft viele APIs. Ein Beispiel hierfür ist "
-"die\n"
-"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) und\n"
-"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator."
-"html)\n"
+"die [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) und "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
 "Züge."
 
-#: src/exercises/day-1/iterators-and-ownership.md:8
+#: src/exercises/day-1/iterators-and-ownership.md:8 src/bare-metal/no_std.md:28
 #, fuzzy
-msgid "## `Iterator`"
-msgstr "## `Iterator`"
+msgid "`Iterator`"
+msgstr "`Iterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:10
 #, fuzzy
 msgid ""
-"Traits are like interfaces: they describe behavior (methods) for a type. "
-"The\n"
+"Traits are like interfaces: they describe behavior (methods) for a type. The "
 "`Iterator` trait simply says that you can call `next` until you get `None` "
 "back:"
 msgstr ""
 "Merkmale sind wie Schnittstellen: Sie beschreiben das Verhalten (Methoden) "
-"für einen Typ. Der\n"
-"Das `Iterator`-Merkmal sagt einfach, dass Sie `next` aufrufen können, bis "
-"Sie `None` zurückbekommen:"
+"für einen Typ. Der Das `Iterator`\\-Merkmal sagt einfach, dass Sie `next` "
+"aufrufen können, bis Sie `None` zurückbekommen:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:13
 msgid ""
@@ -5738,20 +5851,19 @@ msgstr "Warum wird dieser Typ verwendet?"
 
 #: src/exercises/day-1/iterators-and-ownership.md:48
 #, fuzzy
-msgid "## `IntoIterator`"
-msgstr "## `IntoIterator`"
+msgid "`IntoIterator`"
+msgstr "`IntoIterator`"
 
 #: src/exercises/day-1/iterators-and-ownership.md:50
 #, fuzzy
 msgid ""
-"The `Iterator` trait tells you how to _iterate_ once you have created an\n"
+"The `Iterator` trait tells you how to _iterate_ once you have created an "
 "iterator. The related trait `IntoIterator` tells you how to create the "
 "iterator:"
 msgstr ""
 "Die Eigenschaft „Iterator“ sagt Ihnen, wie Sie _iteraten_, sobald Sie eine "
-"erstellt haben\n"
-"Iterator. Die zugehörige Eigenschaft `IntoIterator` sagt Ihnen, wie Sie den "
-"Iterator erstellen:"
+"erstellt haben Iterator. Die zugehörige Eigenschaft `IntoIterator` sagt "
+"Ihnen, wie Sie den Iterator erstellen:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:53
 msgid ""
@@ -5768,31 +5880,32 @@ msgstr ""
 #: src/exercises/day-1/iterators-and-ownership.md:62
 #, fuzzy
 msgid ""
-"The syntax here means that every implementation of `IntoIterator` must\n"
+"The syntax here means that every implementation of `IntoIterator` must "
 "declare two types:"
 msgstr ""
-"Die Syntax hier bedeutet, dass jede Implementierung von `IntoIterator` muss\n"
+"Die Syntax hier bedeutet, dass jede Implementierung von `IntoIterator` muss "
 "deklarieren Sie zwei Arten:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:65
 #, fuzzy
-msgid ""
-"* `Item`: the type we iterate over, such as `i8`,\n"
-"* `IntoIter`: the `Iterator` type returned by the `into_iter` method."
+msgid "`Item`: the type we iterate over, such as `i8`,"
+msgstr "`Item`: der Typ, über den wir iterieren, wie z. B. `i8`,"
+
+#: src/exercises/day-1/iterators-and-ownership.md:66
+#, fuzzy
+msgid "`IntoIter`: the `Iterator` type returned by the `into_iter` method."
 msgstr ""
-"* `Item`: der Typ, über den wir iterieren, wie z. B. `i8`,\n"
-"* `IntoIter`: der `Iterator`-Typ, der von der `into_iter`-Methode "
+"`IntoIter`: der `Iterator`\\-Typ, der von der `into_iter`\\-Methode "
 "zurückgegeben wird."
 
 #: src/exercises/day-1/iterators-and-ownership.md:68
 #, fuzzy
 msgid ""
-"Note that `IntoIter` and `Item` are linked: the iterator must have the same\n"
+"Note that `IntoIter` and `Item` are linked: the iterator must have the same "
 "`Item` type, which means that it returns `Option<Item>`"
 msgstr ""
 "Beachten Sie, dass „IntoIter“ und „Item“ verknüpft sind: Der Iterator muss "
-"dasselbe haben\n"
-"`Item`-Typ, was bedeutet, dass es `Option<Item>` zurückgibt"
+"dasselbe haben `Item`\\-Typ, was bedeutet, dass es `Option<Item>` zurückgibt"
 
 #: src/exercises/day-1/iterators-and-ownership.md:71
 #, fuzzy
@@ -5815,22 +5928,19 @@ msgstr ""
 
 #: src/exercises/day-1/iterators-and-ownership.md:83
 #, fuzzy
-msgid "## `for` Loops"
-msgstr "## `for`-Schleifen"
+msgid "`for` Loops"
+msgstr "`for`\\-Schleifen"
 
 #: src/exercises/day-1/iterators-and-ownership.md:85
 #, fuzzy
 msgid ""
 "Now that we know both `Iterator` and `IntoIterator`, we can build `for` "
-"loops.\n"
-"They call `into_iter()` on an expression and iterates over the resulting\n"
-"iterator:"
+"loops. They call `into_iter()` on an expression and iterates over the "
+"resulting iterator:"
 msgstr ""
 "Jetzt, da wir sowohl „Iterator“ als auch „IntoIterator“ kennen, können wir "
-"„for“-Schleifen bauen.\n"
-"Sie rufen `into_iter()` für einen Ausdruck auf und iterieren über das "
-"Ergebnis\n"
-"Iterator:"
+"„for“-Schleifen bauen. Sie rufen `into_iter()` für einen Ausdruck auf und "
+"iterieren über das Ergebnis Iterator:"
 
 #: src/exercises/day-1/iterators-and-ownership.md:89
 msgid ""
@@ -5858,30 +5968,23 @@ msgstr "Was ist die Art von „Wort“ in jeder Schleife?"
 #: src/exercises/day-1/iterators-and-ownership.md:105
 #, fuzzy
 msgid ""
-"Experiment with the code above and then consult the documentation for "
-"[`impl\n"
-"IntoIterator for\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"and [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"to check your answers."
+"Experiment with the code above and then consult the documentation for [`impl "
+"IntoIterator for &Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E) and [`impl "
+"IntoIterator for Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec."
+"html#impl-IntoIterator-for-Vec%3CT%2C%20A%3E) to check your answers."
 msgstr ""
 "Experimentieren Sie mit dem obigen Code und konsultieren Sie dann die "
-"Dokumentation für [`impl\n"
-"IntoIterator für\n"
-"&Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-"
-"IntoIterator-for-%26%27a%20Vec%3CT%2C%20A%3E)\n"
-"und [`impl IntoIterator for\n"
-"Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-"
-"for-Vec%3CT%2C%20A%3E)\n"
-"um Ihre Antworten zu überprüfen."
+"Dokumentation für [`impl IntoIterator für &Vec<T>`](https://doc.rust-lang."
+"org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
+"%26%27a%20Vec%3CT%2C%20A%3E) und [`impl IntoIterator for Vec<T>`](https://"
+"doc.rust-lang.org/std/vec/struct.Vec.html#impl-IntoIterator-for-"
+"Vec%3CT%2C%20A%3E) um Ihre Antworten zu überprüfen."
 
 #: src/welcome-day-2.md:1
 #, fuzzy
-msgid "# Welcome to Day 2"
-msgstr "# Willkommen zu Tag 2"
+msgid "Welcome to Day 2"
+msgstr "Willkommen zu Tag 2"
 
 #: src/welcome-day-2.md:3
 #, fuzzy
@@ -5890,26 +5993,28 @@ msgstr ""
 "Nachdem wir nun eine ganze Menge Rust gesehen haben, fahren wir fort mit:"
 
 #: src/welcome-day-2.md:5
-msgid ""
-"* Structs, enums, methods.\n"
-"\n"
-"* Pattern matching: destructuring enums, structs, and arrays.\n"
-"\n"
-"* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-"and\n"
-"  `continue`.\n"
-"\n"
-"* The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
-"`Rc`\n"
-"  and `Arc`.\n"
-"\n"
-"* Modules: visibility, paths, and filesystem hierarchy."
+msgid "Structs, enums, methods."
 msgstr ""
 
-#: src/structs.md:1
-#, fuzzy
-msgid "# Structs"
-msgstr "# Strukturen"
+#: src/welcome-day-2.md:7
+msgid "Pattern matching: destructuring enums, structs, and arrays."
+msgstr ""
+
+#: src/welcome-day-2.md:9
+msgid ""
+"Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, and "
+"`continue`."
+msgstr ""
+
+#: src/welcome-day-2.md:12
+msgid ""
+"The Standard Library: `String`, `Option` and `Result`, `Vec`, `HashMap`, "
+"`Rc` and `Arc`."
+msgstr ""
+
+#: src/welcome-day-2.md:15
+msgid "Modules: visibility, paths, and filesystem hierarchy."
+msgstr ""
 
 #: src/structs.md:3
 #, fuzzy
@@ -5951,28 +6056,48 @@ msgid "Key Points:"
 msgstr "Wichtige Punkte:"
 
 #: src/structs.md:33
+msgid "Structs work like in C or C++."
+msgstr ""
+
+#: src/structs.md:34
+msgid "Like in C++, and unlike in C, no typedef is needed to define a type."
+msgstr ""
+
+#: src/structs.md:35
+msgid "Unlike in C++, there is no inheritance between structs."
+msgstr ""
+
+#: src/structs.md:36
 msgid ""
-"* Structs work like in C or C++.\n"
-"  * Like in C++, and unlike in C, no typedef is needed to define a type.\n"
-"  * Unlike in C++, there is no inheritance between structs.\n"
-"* Methods are defined in an `impl` block, which we will see in following "
-"slides.\n"
-"* This may be a good time to let people know there are different types of "
-"structs. \n"
-"  * Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
+"Methods are defined in an `impl` block, which we will see in following "
+"slides."
+msgstr ""
+
+#: src/structs.md:37
+msgid ""
+"This may be a good time to let people know there are different types of "
+"structs. "
+msgstr ""
+
+#: src/structs.md:38
+msgid ""
+"Zero-sized structs `e.g., struct Foo;` might be used when implementing a "
 "trait on some type but don’t have any data that you want to store in the "
-"value itself. \n"
-"  * The next slide will introduce Tuple structs, used when the field names "
-"are not important.\n"
-"* The syntax `..peter` allows us to copy the majority of the fields from the "
+"value itself. "
+msgstr ""
+
+#: src/structs.md:39
+msgid ""
+"The next slide will introduce Tuple structs, used when the field names are "
+"not important."
+msgstr ""
+
+#: src/structs.md:40
+msgid ""
+"The syntax `..peter` allows us to copy the majority of the fields from the "
 "old struct without having to explicitly type it all out. It must always be "
 "the last element."
 msgstr ""
-
-#: src/structs/tuple-structs.md:1
-#, fuzzy
-msgid "# Tuple Structs"
-msgstr "# Tupelstrukturen"
 
 #: src/structs/tuple-structs.md:3
 #, fuzzy
@@ -6021,33 +6146,44 @@ msgstr ""
 
 #: src/structs/tuple-structs.md:37
 msgid ""
-"* Newtypes are a great way to encode additional information about the value "
-"in a primitive type, for example:\n"
-"  * The number is measured in some units: `Newtons` in the example above.\n"
-"  * The value passed some validation when it was created, so you no longer "
-"have to validate it again at every use: 'PhoneNumber(String)` or "
-"`OddNumber(u32)`.\n"
-"* Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
-"single field in the newtype.\n"
-"  *  Rust generally doesn’t like inexplicit things, like automatic "
-"unwrapping or for instance using booleans as integers.\n"
-"  *  Operator overloading is discussed on Day 3 (generics). "
+"Newtypes are a great way to encode additional information about the value in "
+"a primitive type, for example:"
 msgstr ""
 
-#: src/structs/field-shorthand.md:1
-#, fuzzy
-msgid "# Field Shorthand Syntax"
-msgstr "# Feld-Kurzsyntax"
+#: src/structs/tuple-structs.md:38
+msgid "The number is measured in some units: `Newtons` in the example above."
+msgstr ""
+
+#: src/structs/tuple-structs.md:39
+msgid ""
+"The value passed some validation when it was created, so you no longer have "
+"to validate it again at every use: 'PhoneNumber(String)`or`OddNumber(u32)\\`."
+msgstr ""
+
+#: src/structs/tuple-structs.md:40
+msgid ""
+"Demonstrate how to add a `f64` value to a `Newtons` type by accessing the "
+"single field in the newtype."
+msgstr ""
+
+#: src/structs/tuple-structs.md:41
+msgid ""
+"Rust generally doesn’t like inexplicit things, like automatic unwrapping or "
+"for instance using booleans as integers."
+msgstr ""
+
+#: src/structs/tuple-structs.md:42
+msgid "Operator overloading is discussed on Day 3 (generics). "
+msgstr ""
 
 #: src/structs/field-shorthand.md:3
 #, fuzzy
 msgid ""
-"If you already have variables with the right names, then you can create the\n"
+"If you already have variables with the right names, then you can create the "
 "struct using a shorthand:"
 msgstr ""
 "Wenn Sie bereits Variablen mit den richtigen Namen haben, können Sie die "
-"erstellen\n"
-"struct mit einer Abkürzung:"
+"erstellen struct mit einer Abkürzung:"
 
 #: src/structs/field-shorthand.md:6
 msgid ""
@@ -6073,69 +6209,83 @@ msgstr ""
 
 #: src/structs/field-shorthand.md:27
 msgid ""
-"*  The `new` function could be written using `Self` as a type, as it is "
-"interchangeable with the struct type name\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Person {\n"
-"         fn new(name: String, age: u8) -> Self {\n"
-"             Self { name, age }\n"
-"         }\n"
-"     }\n"
-"     ```    \n"
-"* Implement the `Default` trait for the struct. Define some fields and use "
-"the default values for the other fields.\n"
-"\n"
-"     ```rust,editable\n"
-"     #[derive(Debug)]\n"
-"     struct Person {\n"
-"         name: String,\n"
-"         age: u8,\n"
-"     }\n"
-"     impl Default for Person {\n"
-"         fn default() -> Person {\n"
-"             Person {\n"
-"                 name: \"Bot\".to_string(),\n"
-"                 age: 0,\n"
-"             }\n"
-"         }\n"
-"     }\n"
-"     fn create_default() {\n"
-"         let tmp = Person {\n"
-"             ..Default::default()\n"
-"         };\n"
-"         let tmp = Person {\n"
-"             name: \"Sam\".to_string(),\n"
-"             ..Default::default()\n"
-"         };\n"
-"     }\n"
-"     ```\n"
-"\n"
-"* Methods are defined in the `impl` block.\n"
-"* Use struct update syntax to define a new structure using `peter`. Note "
-"that the variable `peter` will no longer be accessible afterwards.\n"
-"* Use `{:#?}` when printing structs to request the `Debug` representation."
+"The `new` function could be written using `Self` as a type, as it is "
+"interchangeable with the struct type name"
 msgstr ""
 
-#: src/enums.md:1
-#, fuzzy
-msgid "# Enums"
-msgstr "# Aufzählungen"
+#: src/structs/field-shorthand.md:29
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Person {\n"
+"    fn new(name: String, age: u8) -> Self {\n"
+"        Self { name, age }\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:41
+msgid ""
+"Implement the `Default` trait for the struct. Define some fields and use the "
+"default values for the other fields."
+msgstr ""
+
+#: src/structs/field-shorthand.md:43
+msgid ""
+"```rust,editable\n"
+"#[derive(Debug)]\n"
+"struct Person {\n"
+"    name: String,\n"
+"    age: u8,\n"
+"}\n"
+"impl Default for Person {\n"
+"    fn default() -> Person {\n"
+"        Person {\n"
+"            name: \"Bot\".to_string(),\n"
+"            age: 0,\n"
+"        }\n"
+"    }\n"
+"}\n"
+"fn create_default() {\n"
+"    let tmp = Person {\n"
+"        ..Default::default()\n"
+"    };\n"
+"    let tmp = Person {\n"
+"        name: \"Sam\".to_string(),\n"
+"        ..Default::default()\n"
+"    };\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/structs/field-shorthand.md:68
+msgid "Methods are defined in the `impl` block."
+msgstr ""
+
+#: src/structs/field-shorthand.md:69
+msgid ""
+"Use struct update syntax to define a new structure using `peter`. Note that "
+"the variable `peter` will no longer be accessible afterwards."
+msgstr ""
+
+#: src/structs/field-shorthand.md:70
+msgid ""
+"Use `{:#?}` when printing structs to request the `Debug` representation."
+msgstr ""
 
 #: src/enums.md:3
 #, fuzzy
 msgid ""
-"The `enum` keyword allows the creation of a type which has a few\n"
-"different variants:"
+"The `enum` keyword allows the creation of a type which has a few different "
+"variants:"
 msgstr ""
 "Das Schlüsselwort „enum“ ermöglicht die Erstellung eines Typs, der mehrere "
-"hat\n"
-"verschiedene Varianten:"
+"hat verschiedene Varianten:"
 
 #: src/enums.md:6
 msgid ""
@@ -6168,49 +6318,63 @@ msgstr ""
 
 #: src/enums.md:36
 #, fuzzy
+msgid "Enumerations allow you to collect a set of values under one type"
+msgstr ""
+"Aufzählungen ermöglichen es Ihnen, eine Reihe von Werten unter einem Typ zu "
+"sammeln"
+
+#: src/enums.md:37
+#, fuzzy
 msgid ""
-"* Enumerations allow you to collect a set of values under one type\n"
-"* This page offers an enum type `CoinFlip` with two variants `Heads` and "
-"`Tail`. You might note the namespace when using variants.\n"
-"* This might be a good time to compare Structs and Enums:\n"
-"  * In both, you can have a simple version without fields (unit struct) or "
-"one with different types of fields (variant payloads). \n"
-"  * In both, associated functions are defined within an `impl` block.\n"
-"  * You could even implement the different variants of an enum with separate "
+"This page offers an enum type `CoinFlip` with two variants `Heads` and "
+"`Tail`. You might note the namespace when using variants."
+msgstr ""
+"Diese Seite bietet einen Aufzählungstyp `CoinFlip` mit zwei Varianten "
+"`Heads` und `Tail`. Beachten Sie bei der Verwendung von Varianten "
+"möglicherweise den Namensraum."
+
+#: src/enums.md:38
+#, fuzzy
+msgid "This might be a good time to compare Structs and Enums:"
+msgstr ""
+"Dies könnte ein guter Zeitpunkt sein, um Structs und Enums zu vergleichen:"
+
+#: src/enums.md:39
+#, fuzzy
+msgid ""
+"In both, you can have a simple version without fields (unit struct) or one "
+"with different types of fields (variant payloads). "
+msgstr ""
+"In beiden Fällen können Sie eine einfache Version ohne Felder (unit struct) "
+"oder eine mit unterschiedlichen Feldtypen (variant payloads) haben."
+
+#: src/enums.md:40
+#, fuzzy
+msgid "In both, associated functions are defined within an `impl` block."
+msgstr ""
+"In beiden werden zugehörige Funktionen innerhalb eines `impl`\\-Blocks "
+"definiert."
+
+#: src/enums.md:41
+#, fuzzy
+msgid ""
+"You could even implement the different variants of an enum with separate "
 "structs but then they wouldn’t be the same type as they would if they were "
 "all defined in an enum. "
 msgstr ""
-"* Aufzählungen ermöglichen es Ihnen, eine Reihe von Werten unter einem Typ "
-"zu sammeln\n"
-"* Diese Seite bietet einen Aufzählungstyp `CoinFlip` mit zwei Varianten "
-"`Heads` und `Tail`. Beachten Sie bei der Verwendung von Varianten "
-"möglicherweise den Namensraum.\n"
-"* Dies könnte ein guter Zeitpunkt sein, um Structs und Enums zu "
-"vergleichen:\n"
-"  * In beiden Fällen können Sie eine einfache Version ohne Felder (unit "
-"struct) oder eine mit unterschiedlichen Feldtypen (variant payloads) haben.\n"
-"  * In beiden werden zugehörige Funktionen innerhalb eines `impl`-Blocks "
-"definiert.\n"
-"  * Sie könnten sogar die verschiedenen Varianten einer Aufzählung mit "
-"separaten Structs implementieren, aber dann wären sie nicht vom gleichen "
-"Typ, wie wenn sie alle in einer Aufzählung definiert wären.\n"
-"</details>"
-
-#: src/enums/variant-payloads.md:1
-#, fuzzy
-msgid "# Variant Payloads"
-msgstr "# Variantennutzlasten"
+"Sie könnten sogar die verschiedenen Varianten einer Aufzählung mit separaten "
+"Structs implementieren, aber dann wären sie nicht vom gleichen Typ, wie wenn "
+"sie alle in einer Aufzählung definiert wären."
 
 #: src/enums/variant-payloads.md:3
 #, fuzzy
 msgid ""
 "You can define richer enums where the variants carry data. You can then use "
-"the\n"
-"`match` statement to extract the data from each variant:"
+"the `match` statement to extract the data from each variant:"
 msgstr ""
 "Sie können reichhaltigere Aufzählungen definieren, bei denen die Varianten "
-"Daten enthalten. Sie können dann die verwenden\n"
-"`match`-Anweisung, um die Daten aus jeder Variante zu extrahieren:"
+"Daten enthalten. Sie können dann die verwenden `match`\\-Anweisung, um die "
+"Daten aus jeder Variante zu extrahieren:"
 
 #: src/enums/variant-payloads.md:6
 msgid ""
@@ -6244,33 +6408,57 @@ msgstr ""
 
 #: src/enums/variant-payloads.md:35
 msgid ""
-"* The values in the enum variants can only be accessed after being pattern "
+"The values in the enum variants can only be accessed after being pattern "
 "matched. The pattern binds references to the fields in the \"match arm\" "
-"after the `=>`.\n"
-"  * The expression is matched against the patterns from top to bottom. There "
-"is no fall-through like in C or C++.\n"
-"  * The match expression has a value. The value is the last expression in "
-"the match arm which was executed.\n"
-"  * Starting from the top we look for what pattern matches the value then "
-"run the code following the arrow. Once we find a match, we stop. \n"
-"* Demonstrate what happens when the search is inexhaustive. Note the "
-"advantage the Rust compiler provides by confirming when all cases are "
-"handled. \n"
-"* `match` inspects a hidden discriminant field in the `enum`.\n"
-"* It is possible to retrieve the discriminant by calling `std::mem::"
-"discriminant()`\n"
-"  * This is useful, for example, if implementing `PartialEq` for structs "
-"where comparing field values doesn't affect equality.\n"
-"* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
-"cannot implement traits, for example.  \n"
-"  "
+"after the `=>`."
 msgstr ""
 
-#: src/enums/sizes.md:1
-#, fuzzy
-msgid "# Enum Sizes"
-msgstr "# Aufzählungsgrößen"
+#: src/enums/variant-payloads.md:36
+msgid ""
+"The expression is matched against the patterns from top to bottom. There is "
+"no fall-through like in C or C++."
+msgstr ""
+
+#: src/enums/variant-payloads.md:37
+msgid ""
+"The match expression has a value. The value is the last expression in the "
+"match arm which was executed."
+msgstr ""
+
+#: src/enums/variant-payloads.md:38
+msgid ""
+"Starting from the top we look for what pattern matches the value then run "
+"the code following the arrow. Once we find a match, we stop. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:39
+msgid ""
+"Demonstrate what happens when the search is inexhaustive. Note the advantage "
+"the Rust compiler provides by confirming when all cases are handled. "
+msgstr ""
+
+#: src/enums/variant-payloads.md:40
+msgid "`match` inspects a hidden discriminant field in the `enum`."
+msgstr ""
+
+#: src/enums/variant-payloads.md:41
+msgid ""
+"It is possible to retrieve the discriminant by calling `std::mem::"
+"discriminant()`"
+msgstr ""
+
+#: src/enums/variant-payloads.md:42
+msgid ""
+"This is useful, for example, if implementing `PartialEq` for structs where "
+"comparing field values doesn't affect equality."
+msgstr ""
+
+#: src/enums/variant-payloads.md:43
+msgid ""
+"`WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
+"Click(Click)` with a top level `struct Click { ... }`. The inlined version "
+"cannot implement traits, for example."
+msgstr ""
 
 #: src/enums/sizes.md:3
 #, fuzzy
@@ -6307,166 +6495,197 @@ msgstr ""
 #: src/enums/sizes.md:25
 #, fuzzy
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/type-layout."
 "html)."
 msgstr ""
-"* Siehe die [Rust-Referenz] (https://doc.rust-lang.org/reference/type-layout."
-"html)."
+"Siehe die \\[Rust-Referenz\\] (https://doc.rust-lang.org/reference/type-"
+"layout.html)."
 
 #: src/enums/sizes.md:31
 msgid ""
-" * Internally Rust is using a field (discriminant) to keep track of the enum "
-"variant.\n"
+"Internally Rust is using a field (discriminant) to keep track of the enum "
+"variant."
+msgstr ""
+
+#: src/enums/sizes.md:33
+msgid ""
+"You can control the discriminant if needed (e.g., for compatibility with C):"
+msgstr ""
+
+#: src/enums/sizes.md:35
+msgid ""
+"```rust,editable\n"
+"#[repr(u32)]\n"
+"enum Bar {\n"
+"    A,  // 0\n"
+"    B = 10000,\n"
+"    C,  // 10001\n"
+"}\n"
 "\n"
-" * You can control the discriminant if needed (e.g., for compatibility with "
-"C):\n"
-" \n"
-"     ```rust,editable\n"
-"     #[repr(u32)]\n"
-"     enum Bar {\n"
-"         A,  // 0\n"
-"         B = 10000,\n"
-"         C,  // 10001\n"
-"     }\n"
-"     \n"
-"     fn main() {\n"
-"         println!(\"A: {}\", Bar::A as u32);\n"
-"         println!(\"B: {}\", Bar::B as u32);\n"
-"         println!(\"C: {}\", Bar::C as u32);\n"
-"     }\n"
-"     ```\n"
+"fn main() {\n"
+"    println!(\"A: {}\", Bar::A as u32);\n"
+"    println!(\"B: {}\", Bar::B as u32);\n"
+"    println!(\"C: {}\", Bar::C as u32);\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:50
+msgid ""
+"Without `repr`, the discriminant type takes 2 bytes, because 10001 fits 2 "
+"bytes."
+msgstr ""
+
+#: src/enums/sizes.md:54
+msgid "Try out other types such as"
+msgstr ""
+
+#: src/enums/sizes.md:56
+msgid "`dbg_size!(bool)`: size 1 bytes, align: 1 bytes,"
+msgstr ""
+
+#: src/enums/sizes.md:57
+msgid ""
+"`dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche optimization, "
+"see below),"
+msgstr ""
+
+#: src/enums/sizes.md:58
+msgid "`dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit machine),"
+msgstr ""
+
+#: src/enums/sizes.md:59
+msgid ""
+"`dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
+"optimization, see below)."
+msgstr ""
+
+#: src/enums/sizes.md:61
+msgid ""
+"Niche optimization: Rust will merge use unused bit patterns for the enum "
+"discriminant."
+msgstr ""
+
+#: src/enums/sizes.md:64
+msgid ""
+"Null pointer optimization: For [some types](https://doc.rust-lang.org/std/"
+"option/#representation), Rust guarantees that `size_of::<T>()` equals "
+"`size_of::<Option<T>>()`."
+msgstr ""
+
+#: src/enums/sizes.md:68
+msgid ""
+"Example code if you want to show how the bitwise representation _may_ look "
+"like in practice. It's important to note that the compiler provides no "
+"guarantees regarding this representation, therefore this is totally unsafe."
+msgstr ""
+
+#: src/enums/sizes.md:71
+msgid ""
+"```rust,editable\n"
+"use std::mem::transmute;\n"
 "\n"
-"    Without `repr`, the discriminant type takes 2 bytes, because 10001 fits "
-"2\n"
-"    bytes.\n"
-"\n"
-"\n"
-" * Try out other types such as\n"
-" \n"
-"     * `dbg_size!(bool)`: size 1 bytes, align: 1 bytes,\n"
-"     * `dbg_size!(Option<bool>)`: size 1 bytes, align: 1 bytes (niche "
-"optimization, see below),\n"
-"     * `dbg_size!(&i32)`: size 8 bytes, align: 8 bytes (on a 64-bit "
-"machine),\n"
-"     * `dbg_size!(Option<&i32>)`: size 8 bytes, align: 8 bytes (null pointer "
-"optimization, see below).\n"
-"\n"
-" * Niche optimization: Rust will merge use unused bit patterns for the enum\n"
-"   discriminant.\n"
-"\n"
-" * Null pointer optimization: For [some\n"
-"   types](https://doc.rust-lang.org/std/option/#representation), Rust "
-"guarantees\n"
-"   that `size_of::<T>()` equals `size_of::<Option<T>>()`.\n"
-"\n"
-"     Example code if you want to show how the bitwise representation *may* "
-"look like in practice.\n"
-"     It's important to note that the compiler provides no guarantees "
-"regarding this representation, therefore this is totally unsafe.\n"
-"\n"
-"     ```rust,editable\n"
-"     use std::mem::transmute;\n"
-"\n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             println!(\"Bitwise representation of bool\");\n"
-"             dbg_bits!(false, u8);\n"
-"             dbg_bits!(true, u8);\n"
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        println!(\"Bitwise representation of bool\");\n"
+"        dbg_bits!(false, u8);\n"
+"        dbg_bits!(true, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<bool>\");\n"
-"             dbg_bits!(None::<bool>, u8);\n"
-"             dbg_bits!(Some(false), u8);\n"
-"             dbg_bits!(Some(true), u8);\n"
+"        println!(\"Bitwise representation of Option<bool>\");\n"
+"        dbg_bits!(None::<bool>, u8);\n"
+"        dbg_bits!(Some(false), u8);\n"
+"        dbg_bits!(Some(true), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<Option<bool>>\");\n"
-"             dbg_bits!(Some(Some(false)), u8);\n"
-"             dbg_bits!(Some(Some(true)), u8);\n"
-"             dbg_bits!(Some(None::<bool>), u8);\n"
-"             dbg_bits!(None::<Option<bool>>, u8);\n"
+"        println!(\"Bitwise representation of Option<Option<bool>>\");\n"
+"        dbg_bits!(Some(Some(false)), u8);\n"
+"        dbg_bits!(Some(Some(true)), u8);\n"
+"        dbg_bits!(Some(None::<bool>), u8);\n"
+"        dbg_bits!(None::<Option<bool>>, u8);\n"
 "\n"
-"             println!(\"Bitwise representation of Option<&i32>\");\n"
-"             dbg_bits!(None::<&i32>, usize);\n"
-"             dbg_bits!(Some(&0i32), usize);\n"
-"         }\n"
-"     }\n"
-"     ```\n"
+"        println!(\"Bitwise representation of Option<&i32>\");\n"
+"        dbg_bits!(None::<&i32>, usize);\n"
+"        dbg_bits!(Some(&0i32), usize);\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/enums/sizes.md:106
+msgid ""
+"More complex example if you want to discuss what happens when we chain more "
+"than 256 `Option`s together."
+msgstr ""
+
+#: src/enums/sizes.md:108
+msgid ""
+"```rust,editable\n"
+"#![recursion_limit = \"1000\"]\n"
 "\n"
-"     More complex example if you want to discuss what happens when we chain "
-"more than 256 `Option`s together.\n"
+"use std::mem::transmute;\n"
 "\n"
-"     ```rust,editable\n"
-"     #![recursion_limit = \"1000\"]\n"
-"\n"
-"     use std::mem::transmute;\n"
-"     \n"
-"     macro_rules! dbg_bits {\n"
-"         ($e:expr, $bit_type:ty) => {\n"
-"             println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
+"macro_rules! dbg_bits {\n"
+"    ($e:expr, $bit_type:ty) => {\n"
+"        println!(\"- {}: {:#x}\", stringify!($e), transmute::<_, "
 "$bit_type>($e));\n"
-"         };\n"
-"     }\n"
+"    };\n"
+"}\n"
 "\n"
-"     // Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
+"// Macro to wrap a value in 2^n Some() where n is the number of \"@\" "
 "signs.\n"
-"     // Increasing the recursion limit is required to evaluate this macro.\n"
-"     macro_rules! many_options {\n"
-"         ($value:expr) => { Some($value) };\n"
-"         ($value:expr, @) => {\n"
-"             Some(Some($value))\n"
-"         };\n"
-"         ($value:expr, @ $($more:tt)+) => {\n"
-"             many_options!(many_options!($value, $($more)+), $($more)+)\n"
-"         };\n"
-"     }\n"
+"// Increasing the recursion limit is required to evaluate this macro.\n"
+"macro_rules! many_options {\n"
+"    ($value:expr) => { Some($value) };\n"
+"    ($value:expr, @) => {\n"
+"        Some(Some($value))\n"
+"    };\n"
+"    ($value:expr, @ $($more:tt)+) => {\n"
+"        many_options!(many_options!($value, $($more)+), $($more)+)\n"
+"    };\n"
+"}\n"
 "\n"
-"     fn main() {\n"
-"         // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
-"         // representation of types.\n"
-"         unsafe {\n"
-"             assert_eq!(many_options!(false), Some(false));\n"
-"             assert_eq!(many_options!(false, @), Some(Some(false)));\n"
-"             assert_eq!(many_options!(false, @@), "
+"fn main() {\n"
+"    // TOTALLY UNSAFE. Rust provides no guarantees about the bitwise\n"
+"    // representation of types.\n"
+"    unsafe {\n"
+"        assert_eq!(many_options!(false), Some(false));\n"
+"        assert_eq!(many_options!(false, @), Some(Some(false)));\n"
+"        assert_eq!(many_options!(false, @@), "
 "Some(Some(Some(Some(false)))));\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 128 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
+"        println!(\"Bitwise representation of a chain of 128 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@), u8);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@), u8);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 256 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
+"        println!(\"Bitwise representation of a chain of 256 Option's.\");\n"
+"        dbg_bits!(many_options!(false, @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(true, @@@@@@@@), u16);\n"
 "\n"
-"             println!(\"Bitwise representation of a chain of 257 Option's."
-"\");\n"
-"             dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
-"             dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
-"         }\n"
-"     }\n"
-"     ```"
+"        println!(\"Bitwise representation of a chain of 257 Option's.\");\n"
+"        dbg_bits!(many_options!(Some(false), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(Some(true), @@@@@@@@), u16);\n"
+"        dbg_bits!(many_options!(None::<bool>, @@@@@@@@), u16);\n"
+"    }\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/methods.md:3
 #, fuzzy
 msgid ""
 "Rust allows you to associate functions with your new types. You do this with "
-"an\n"
-"`impl` block:"
+"an `impl` block:"
 msgstr ""
 "Mit Rust können Sie Ihren neuen Typen Funktionen zuordnen. Das machst du mit "
-"einem\n"
-"`impl`-Block:"
+"einem `impl`\\-Block:"
 
 #: src/methods.md:6
 msgid ""
@@ -6495,142 +6714,165 @@ msgstr ""
 
 #: src/methods.md:31
 #, fuzzy
-msgid ""
-"* It can be helpful to introduce methods by comparing them to functions.\n"
-"  * Methods are called on an instance of a type (such as a struct or enum), "
-"the first parameter represents the instance as `self`.\n"
-"  * Developers may choose to use methods to take advantage of method "
-"receiver syntax and to help keep them more organized. By using methods we "
-"can keep all the implementation code in one predictable place.\n"
-"* Point out the use of the keyword `self`, a method receiver. \n"
-"  * Show that it is an abbreviated term for `self:&Self` and perhaps show "
-"how the struct name could also be used. \n"
-"  * Explain that `Self` is a type alias for the type the `impl` block is in "
-"and can be used elsewhere in the block.\n"
-"  * Note how `self` is used like other structs and dot notation can be used "
-"to refer to individual fields.\n"
-"  * This might be a good time to demonstrate how the `&self` differs from "
-"`self` by modifying the code and trying to run say_hello twice.  \n"
-"* We describe the distinction between method receivers next.\n"
-"   "
+msgid "It can be helpful to introduce methods by comparing them to functions."
 msgstr ""
-"* Es kann hilfreich sein, Methoden einzuführen, indem man sie mit Funktionen "
-"vergleicht.\n"
-"  * Methoden werden für eine Instanz eines Typs aufgerufen (z. B. eine "
-"Struktur oder Aufzählung), der erste Parameter repräsentiert die Instanz als "
-"„self“.\n"
-"  * Entwickler können sich dafür entscheiden, Methoden zu verwenden, um die "
+"Es kann hilfreich sein, Methoden einzuführen, indem man sie mit Funktionen "
+"vergleicht."
+
+#: src/methods.md:32
+#, fuzzy
+msgid ""
+"Methods are called on an instance of a type (such as a struct or enum), the "
+"first parameter represents the instance as `self`."
+msgstr ""
+"Methoden werden für eine Instanz eines Typs aufgerufen (z. B. eine Struktur "
+"oder Aufzählung), der erste Parameter repräsentiert die Instanz als „self“."
+
+#: src/methods.md:33
+#, fuzzy
+msgid ""
+"Developers may choose to use methods to take advantage of method receiver "
+"syntax and to help keep them more organized. By using methods we can keep "
+"all the implementation code in one predictable place."
+msgstr ""
+"Entwickler können sich dafür entscheiden, Methoden zu verwenden, um die "
 "Methodenempfängersyntax zu nutzen und sie besser organisiert zu halten. "
 "Durch die Verwendung von Methoden können wir den gesamten "
-"Implementierungscode an einem vorhersehbaren Ort aufbewahren.\n"
-"* Weisen Sie auf die Verwendung des Schlüsselworts „self“ hin, einem "
-"Methodenempfänger.\n"
-"  * Zeigen Sie, dass es sich um eine Abkürzung für `self:&Self` handelt und "
-"zeigen Sie vielleicht, wie der Strukturname auch verwendet werden könnte.\n"
-"  * Erklären Sie, dass Self ein Typ-Alias für den Typ ist, in dem sich der "
-"„impl“-Block befindet, und an anderer Stelle im Block verwendet werden "
-"kann.\n"
-"  * Beachten Sie, dass self wie andere Strukturen verwendet wird und die "
-"Punktnotation verwendet werden kann, um auf einzelne Felder zu verweisen.\n"
-"  * Dies könnte ein guter Zeitpunkt sein, um zu demonstrieren, wie sich "
-"`&self` von `self` unterscheidet, indem Sie den Code ändern und versuchen, "
-"say_hello zweimal auszuführen.\n"
-"* Als nächstes beschreiben wir die Unterscheidung zwischen "
-"Methodenempfängern.\n"
-"   \n"
-"</details>"
+"Implementierungscode an einem vorhersehbaren Ort aufbewahren."
 
-#: src/methods/receiver.md:1
+#: src/methods.md:34
 #, fuzzy
-msgid "# Method Receiver"
-msgstr "# Methodenempfänger"
+msgid "Point out the use of the keyword `self`, a method receiver. "
+msgstr ""
+"Weisen Sie auf die Verwendung des Schlüsselworts „self“ hin, einem "
+"Methodenempfänger."
+
+#: src/methods.md:35
+#, fuzzy
+msgid ""
+"Show that it is an abbreviated term for `self:&Self` and perhaps show how "
+"the struct name could also be used. "
+msgstr ""
+"Zeigen Sie, dass es sich um eine Abkürzung für `self:&Self` handelt und "
+"zeigen Sie vielleicht, wie der Strukturname auch verwendet werden könnte."
+
+#: src/methods.md:36
+#, fuzzy
+msgid ""
+"Explain that `Self` is a type alias for the type the `impl` block is in and "
+"can be used elsewhere in the block."
+msgstr ""
+"Erklären Sie, dass Self ein Typ-Alias für den Typ ist, in dem sich der "
+"„impl“-Block befindet, und an anderer Stelle im Block verwendet werden kann."
+
+#: src/methods.md:37
+#, fuzzy
+msgid ""
+"Note how `self` is used like other structs and dot notation can be used to "
+"refer to individual fields."
+msgstr ""
+"Beachten Sie, dass self wie andere Strukturen verwendet wird und die "
+"Punktnotation verwendet werden kann, um auf einzelne Felder zu verweisen."
+
+#: src/methods.md:38
+#, fuzzy
+msgid ""
+"This might be a good time to demonstrate how the `&self` differs from `self` "
+"by modifying the code and trying to run say_hello twice."
+msgstr ""
+"Dies könnte ein guter Zeitpunkt sein, um zu demonstrieren, wie sich `&self` "
+"von `self` unterscheidet, indem Sie den Code ändern und versuchen, say_hello "
+"zweimal auszuführen."
+
+#: src/methods.md:39
+#, fuzzy
+msgid "We describe the distinction between method receivers next."
+msgstr ""
+"Als nächstes beschreiben wir die Unterscheidung zwischen Methodenempfängern."
 
 #: src/methods/receiver.md:3
 #, fuzzy
 msgid ""
 "The `&self` above indicates that the method borrows the object immutably. "
-"There\n"
-"are other possible receivers for a method:"
+"There are other possible receivers for a method:"
 msgstr ""
 "Das obige `&self` gibt an, dass die Methode das Objekt unveränderlich "
-"ausleiht. Dort\n"
-"sind weitere mögliche Empfänger für eine Methode:"
+"ausleiht. Dort sind weitere mögliche Empfänger für eine Methode:"
 
 #: src/methods/receiver.md:6
 #, fuzzy
 msgid ""
-"* `&self`: borrows the object from the caller using a shared and immutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `&mut self`: borrows the object from the caller using a unique and "
-"mutable\n"
-"  reference. The object can be used again afterwards.\n"
-"* `self`: takes ownership of the object and moves it away from the caller. "
-"The\n"
-"  method becomes the owner of the object. The object will be dropped "
-"(deallocated)\n"
-"  when the method returns, unless its ownership is explicitly\n"
-"  transmitted. Complete ownership does not automatically mean mutability.\n"
-"* `mut self`: same as above, but the method can mutate the object. \n"
-"* No receiver: this becomes a static method on the struct. Typically used "
-"to\n"
-"  create constructors which are called `new` by convention."
+"`&self`: borrows the object from the caller using a shared and immutable "
+"reference. The object can be used again afterwards."
 msgstr ""
-"* `&self`: leiht sich das Objekt vom Aufrufer unter Verwendung eines Shared "
-"und Immutable\n"
-"  Referenz. Das Objekt kann danach wieder verwendet werden.\n"
-"* `&mut self`: leiht sich das Objekt vom Aufrufer unter Verwendung eines "
-"Unique und Mutable\n"
-"  Referenz. Das Objekt kann danach wieder verwendet werden.\n"
-"* `self`: übernimmt den Besitz des Objekts und verschiebt es vom Aufrufer "
-"weg. Der\n"
-"  Die Methode wird Eigentümer des Objekts. Das Objekt wird gelöscht "
-"(deallocated)\n"
-"  wenn die Methode zurückkehrt, es sei denn, ihr Besitz ist explizit\n"
-"  übermittelt.\n"
-"* `mut self`: wie oben, aber während die Methode das Objekt besitzt, kann "
-"sie es\n"
-"  mutiere es auch. Vollständiges Eigentum bedeutet nicht automatisch "
-"Wandelbarkeit.\n"
-"* Kein Empfänger: Dies wird zu einer statischen Methode für die Struktur. "
-"Typischerweise gewohnt\n"
-"  Erstellen Sie Konstruktoren, die per Konvention \"neu\" genannt werden."
+"`&self`: leiht sich das Objekt vom Aufrufer unter Verwendung eines Shared "
+"und Immutable Referenz. Das Objekt kann danach wieder verwendet werden."
+
+#: src/methods/receiver.md:8
+#, fuzzy
+msgid ""
+"`&mut self`: borrows the object from the caller using a unique and mutable "
+"reference. The object can be used again afterwards."
+msgstr ""
+"`&mut self`: leiht sich das Objekt vom Aufrufer unter Verwendung eines "
+"Unique und Mutable Referenz. Das Objekt kann danach wieder verwendet werden."
+
+#: src/methods/receiver.md:10
+#, fuzzy
+msgid ""
+"`self`: takes ownership of the object and moves it away from the caller. The "
+"method becomes the owner of the object. The object will be dropped "
+"(deallocated) when the method returns, unless its ownership is explicitly "
+"transmitted. Complete ownership does not automatically mean mutability."
+msgstr ""
+"`self`: übernimmt den Besitz des Objekts und verschiebt es vom Aufrufer weg. "
+"Der Die Methode wird Eigentümer des Objekts. Das Objekt wird gelöscht "
+"(deallocated) wenn die Methode zurückkehrt, es sei denn, ihr Besitz ist "
+"explizit übermittelt."
+
+#: src/methods/receiver.md:14
+#, fuzzy
+msgid "`mut self`: same as above, but the method can mutate the object. "
+msgstr ""
+"`mut self`: wie oben, aber während die Methode das Objekt besitzt, kann sie "
+"es mutiere es auch. Vollständiges Eigentum bedeutet nicht automatisch "
+"Wandelbarkeit."
+
+#: src/methods/receiver.md:15
+#, fuzzy
+msgid ""
+"No receiver: this becomes a static method on the struct. Typically used to "
+"create constructors which are called `new` by convention."
+msgstr ""
+"Kein Empfänger: Dies wird zu einer statischen Methode für die Struktur. "
+"Typischerweise gewohnt Erstellen Sie Konstruktoren, die per Konvention "
+"\"neu\" genannt werden."
 
 #: src/methods/receiver.md:18
 #, fuzzy
 msgid ""
-"Beyond variants on `self`, there are also\n"
-"[special wrapper types](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"allowed to be receiver types, such as `Box<Self>`."
+"Beyond variants on `self`, there are also [special wrapper types](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) allowed to be "
+"receiver types, such as `Box<Self>`."
 msgstr ""
-"Neben Varianten von „self“ gibt es auch\n"
-"[spezielle Wrapper-Typen](https://doc.rust-lang.org/reference/special-types-"
-"and-traits.html)\n"
-"dürfen Empfängertypen sein, wie z. B. `Box<Self>`."
+"Neben Varianten von „self“ gibt es auch [spezielle Wrapper-Typen](https://"
+"doc.rust-lang.org/reference/special-types-and-traits.html) dürfen "
+"Empfängertypen sein, wie z. B. `Box<Self>`."
 
 #: src/methods/receiver.md:24
 #, fuzzy
 msgid ""
 "Consider emphasizing \"shared and immutable\" and \"unique and mutable\". "
-"These constraints always come\n"
-"together in Rust due to borrow checker rules, and `self` is no exception. It "
-"isn't possible to\n"
-"reference a struct from multiple locations and call a mutating (`&mut self`) "
-"method on it."
+"These constraints always come together in Rust due to borrow checker rules, "
+"and `self` is no exception. It isn't possible to reference a struct from "
+"multiple locations and call a mutating (`&mut self`) method on it."
 msgstr ""
 "Erwägen Sie, die Betonung auf „gemeinsam und unveränderlich“ und "
-"„einzigartig und veränderlich“ zu legen. Diese Einschränkungen kommen immer\n"
+"„einzigartig und veränderlich“ zu legen. Diese Einschränkungen kommen immer "
 "zusammen in Rust aufgrund der Borrow-Checker-Regeln, und `self` ist keine "
-"Ausnahme. Es wird nicht möglich sein\n"
-"Verweisen Sie auf eine Struktur von mehreren Stellen und rufen Sie eine "
-"Mutationsmethode (`&mut self`) darauf auf.\n"
-"  \n"
-"</details>"
-
-#: src/methods/example.md:1 src/concurrency/shared_state/example.md:1
-#, fuzzy
-msgid "# Example"
-msgstr "# Beispiel"
+"Ausnahme. Es wird nicht möglich sein Verweisen Sie auf eine Struktur von "
+"mehreren Stellen und rufen Sie eine Mutationsmethode (`&mut self`) darauf "
+"auf."
 
 #: src/methods/example.md:3
 msgid ""
@@ -6680,49 +6922,59 @@ msgstr ""
 
 #: src/methods/example.md:47
 #, fuzzy
+msgid "All four methods here use a different method receiver."
+msgstr "Alle vier Methoden hier verwenden einen anderen Methodenempfänger."
+
+#: src/methods/example.md:48
+#, fuzzy
 msgid ""
-"* All four methods here use a different method receiver.\n"
-"  * You can point out how that changes what the function can do with the "
-"variable values and if/how it can be used again in `main`.\n"
-"  * You can showcase the error that appears when trying to call `finish` "
-"twice.\n"
-"* Note that although the method receivers are different, the non-static "
+"You can point out how that changes what the function can do with the "
+"variable values and if/how it can be used again in `main`."
+msgstr ""
+"Sie können darauf hinweisen, wie sich das ändert, was die Funktion mit den "
+"Variablenwerten machen kann und ob/wie sie wieder in `main` verwendet werden "
+"kann."
+
+#: src/methods/example.md:49
+#, fuzzy
+msgid ""
+"You can showcase the error that appears when trying to call `finish` twice."
+msgstr ""
+"Sie können den Fehler zeigen, der auftritt, wenn Sie versuchen, zweimal "
+"„finish“ aufzurufen."
+
+#: src/methods/example.md:50
+#, fuzzy
+msgid ""
+"Note that although the method receivers are different, the non-static "
 "functions are called the same way in the main body. Rust enables automatic "
 "referencing and dereferencing when calling methods. Rust automatically adds "
-"in the `&`, `*`, `muts` so that that object matches the method signature.\n"
-"* You might point out that `print_laps` is using a vector that is iterated "
-"over. We describe vectors in more detail in the afternoon. "
+"in the `&`, `*`, `muts` so that that object matches the method signature."
 msgstr ""
-"* Alle vier Methoden hier verwenden einen anderen Methodenempfänger.\n"
-"  * Sie können darauf hinweisen, wie sich das ändert, was die Funktion mit "
-"den Variablenwerten machen kann und ob/wie sie wieder in `main` verwendet "
-"werden kann.\n"
-"  * Sie können den Fehler zeigen, der auftritt, wenn Sie versuchen, zweimal "
-"„finish“ aufzurufen.\n"
-"* Beachten Sie, dass, obwohl die Methodenempfänger unterschiedlich sind, die "
+"Beachten Sie, dass, obwohl die Methodenempfänger unterschiedlich sind, die "
 "nicht statischen Funktionen im Hauptteil auf die gleiche Weise aufgerufen "
 "werden. Rust ermöglicht die automatische Referenzierung und Dereferenzierung "
 "beim Methodenaufruf. Rust fügt automatisch die `&`, `*`, `muts` hinzu, "
-"sodass dieses Objekt mit der Methodensignatur übereinstimmt.\n"
-"* Sie könnten darauf hinweisen, dass `print_laps` einen Vektor verwendet, "
-"der iteriert wird. Am Nachmittag beschreiben wir Vektoren genauer."
+"sodass dieses Objekt mit der Methodensignatur übereinstimmt."
 
-#: src/pattern-matching.md:1
+#: src/methods/example.md:51
 #, fuzzy
-msgid "# Pattern Matching"
-msgstr "# Musterabgleich"
+msgid ""
+"You might point out that `print_laps` is using a vector that is iterated "
+"over. We describe vectors in more detail in the afternoon. "
+msgstr ""
+"Sie könnten darauf hinweisen, dass `print_laps` einen Vektor verwendet, der "
+"iteriert wird. Am Nachmittag beschreiben wir Vektoren genauer."
 
 #: src/pattern-matching.md:3
 #, fuzzy
 msgid ""
 "The `match` keyword let you match a value against one or more _patterns_. "
-"The\n"
-"comparisons are done from top to bottom and the first match wins."
+"The comparisons are done from top to bottom and the first match wins."
 msgstr ""
 "Mit dem Schlüsselwort „match“ können Sie einen Wert mit einem oder mehreren "
-"_Mustern_ abgleichen. Der\n"
-"Vergleiche werden von oben nach unten durchgeführt und das erste Match "
-"gewinnt."
+"_Mustern_ abgleichen. Der Vergleiche werden von oben nach unten durchgeführt "
+"und das erste Match gewinnt."
 
 #: src/pattern-matching.md:6
 #, fuzzy
@@ -6749,56 +7001,71 @@ msgstr ""
 #: src/pattern-matching.md:21
 #, fuzzy
 msgid "The `_` pattern is a wildcard pattern which matches any value."
-msgstr "Das `_`-Muster ist ein Platzhaltermuster, das jedem Wert entspricht."
+msgstr "Das `_`\\-Muster ist ein Platzhaltermuster, das jedem Wert entspricht."
 
 #: src/pattern-matching.md:26
 #, fuzzy
 msgid ""
-"* You might point out how some specific characters are being used when in a "
-"pattern\n"
-"  * `|` as an `or`\n"
-"  * `..` can expand as much as it needs to be\n"
-"  * `1..=5` represents an inclusive range\n"
-"  * `_` is a wild card\n"
-"* It can be useful to show how binding works, by for instance replacing a "
-"wildcard character with a variable, or removing the quotes around `q`.\n"
-"* You can demonstrate matching on a reference.\n"
-"* This might be a good time to bring up the concept of irrefutable patterns, "
-"as the term can show up in error messages.\n"
-"   "
+"You might point out how some specific characters are being used when in a "
+"pattern"
 msgstr ""
-"* Sie können darauf hinweisen, wie bestimmte Zeichen in einem Muster "
-"verwendet werden\n"
-"  * `|` als `oder`\n"
-"  * `..` kann beliebig erweitert werden\n"
-"  * „1..=5“ steht für einen inklusiven Bereich\n"
-"  * „_“ ist ein Platzhalter\n"
-"* Es kann nützlich sein, zu zeigen, wie die Bindung funktioniert, indem Sie "
-"zum Beispiel ein Platzhalterzeichen durch eine Variable ersetzen oder die "
-"Anführungszeichen um `q` entfernen.\n"
-"* Sie können die Übereinstimmung anhand einer Referenz nachweisen.\n"
-"* Dies könnte ein guter Zeitpunkt sein, um das Konzept der unwiderlegbaren "
-"Muster anzusprechen, da der Begriff in Fehlermeldungen auftauchen kann.\n"
-"   \n"
-"</Details>"
+"Sie können darauf hinweisen, wie bestimmte Zeichen in einem Muster verwendet "
+"werden"
 
-#: src/pattern-matching/destructuring-enums.md:1
+#: src/pattern-matching.md:27
 #, fuzzy
-msgid "# Destructuring Enums"
-msgstr "# Destrukturierung von Enums"
+msgid "`|` as an `or`"
+msgstr "`|` als `oder`"
+
+#: src/pattern-matching.md:28
+#, fuzzy
+msgid "`..` can expand as much as it needs to be"
+msgstr "`..` kann beliebig erweitert werden"
+
+#: src/pattern-matching.md:29
+#, fuzzy
+msgid "`1..=5` represents an inclusive range"
+msgstr "„1..=5“ steht für einen inklusiven Bereich"
+
+#: src/pattern-matching.md:30
+#, fuzzy
+msgid "`_` is a wild card"
+msgstr "„\\_“ ist ein Platzhalter"
+
+#: src/pattern-matching.md:31
+#, fuzzy
+msgid ""
+"It can be useful to show how binding works, by for instance replacing a "
+"wildcard character with a variable, or removing the quotes around `q`."
+msgstr ""
+"Es kann nützlich sein, zu zeigen, wie die Bindung funktioniert, indem Sie "
+"zum Beispiel ein Platzhalterzeichen durch eine Variable ersetzen oder die "
+"Anführungszeichen um `q` entfernen."
+
+#: src/pattern-matching.md:32
+#, fuzzy
+msgid "You can demonstrate matching on a reference."
+msgstr "Sie können die Übereinstimmung anhand einer Referenz nachweisen."
+
+#: src/pattern-matching.md:33
+#, fuzzy
+msgid ""
+"This might be a good time to bring up the concept of irrefutable patterns, "
+"as the term can show up in error messages."
+msgstr ""
+"Dies könnte ein guter Zeitpunkt sein, um das Konzept der unwiderlegbaren "
+"Muster anzusprechen, da der Begriff in Fehlermeldungen auftauchen kann."
 
 #: src/pattern-matching/destructuring-enums.md:3
 #, fuzzy
 msgid ""
 "Patterns can also be used to bind variables to parts of your values. This is "
-"how\n"
-"you inspect the structure of your types. Let us start with a simple `enum` "
-"type:"
+"how you inspect the structure of your types. Let us start with a simple "
+"`enum` type:"
 msgstr ""
 "Muster können auch verwendet werden, um Variablen an Teile Ihrer Werte zu "
-"binden. Das ist wie\n"
-"Sie inspizieren die Struktur Ihrer Typen. Beginnen wir mit einem einfachen "
-"`enum`-Typ:"
+"binden. Das ist wie Sie inspizieren die Struktur Ihrer Typen. Beginnen wir "
+"mit einem einfachen `enum`\\-Typ:"
 
 #: src/pattern-matching/destructuring-enums.md:6
 msgid ""
@@ -6829,38 +7096,35 @@ msgstr ""
 #: src/pattern-matching/destructuring-enums.md:29
 #, fuzzy
 msgid ""
-"Here we have used the arms to _destructure_ the `Result` value. In the "
-"first\n"
+"Here we have used the arms to _destructure_ the `Result` value. In the first "
 "arm, `half` is bound to the value inside the `Ok` variant. In the second "
-"arm,\n"
-"`msg` is bound to the error message."
+"arm, `msg` is bound to the error message."
 msgstr ""
 "Hier haben wir die Arme verwendet, um den „Result“-Wert zu "
-"_destrukturieren_. In der ersten\n"
-"arm, `half` ist an den Wert innerhalb der `Ok`-Variante gebunden. Im zweiten "
-"Arm,\n"
-"`msg` wird an die Fehlermeldung gebunden."
+"_destrukturieren_. In der ersten arm, `half` ist an den Wert innerhalb der "
+"`Ok`\\-Variante gebunden. Im zweiten Arm, `msg` wird an die Fehlermeldung "
+"gebunden."
 
 #: src/pattern-matching/destructuring-enums.md:36
 #, fuzzy
 msgid ""
-"* The `if`/`else` expression is returning an enum that is later unpacked "
-"with a `match`.\n"
-"* You can try adding a third variant to the enum definition and displaying "
-"the errors when running the code. Point out the places where your code is "
-"now inexhaustive and how the compiler tries to give you hints."
+"The `if`/`else` expression is returning an enum that is later unpacked with "
+"a `match`."
 msgstr ""
-"* Der `if`/`else`-Ausdruck gibt eine Aufzählung zurück, die später mit einem "
-"`match` entpackt wird.\n"
-"* Sie können versuchen, der Enum-Definition eine dritte Variante "
-"hinzuzufügen und die Fehler beim Ausführen des Codes anzuzeigen. Weisen Sie "
-"auf die Stellen hin, an denen Ihr Code jetzt unerschöpflich ist und wie der "
-"Compiler versucht, Ihnen Hinweise zu geben."
+"Der `if`/`else`\\-Ausdruck gibt eine Aufzählung zurück, die später mit einem "
+"`match` entpackt wird."
 
-#: src/pattern-matching/destructuring-structs.md:1
+#: src/pattern-matching/destructuring-enums.md:37
 #, fuzzy
-msgid "# Destructuring Structs"
-msgstr "# Destrukturierende Strukturen"
+msgid ""
+"You can try adding a third variant to the enum definition and displaying the "
+"errors when running the code. Point out the places where your code is now "
+"inexhaustive and how the compiler tries to give you hints."
+msgstr ""
+"Sie können versuchen, der Enum-Definition eine dritte Variante hinzuzufügen "
+"und die Fehler beim Ausführen des Codes anzuzeigen. Weisen Sie auf die "
+"Stellen hin, an denen Ihr Code jetzt unerschöpflich ist und wie der Compiler "
+"versucht, Ihnen Hinweise zu geben."
 
 #: src/pattern-matching/destructuring-structs.md:3
 #, fuzzy
@@ -6889,20 +7153,19 @@ msgid ""
 msgstr ""
 
 #: src/pattern-matching/destructuring-structs.md:23
-msgid ""
-"* Change the literal values in `foo` to match with the other patterns.\n"
-"* Add a new field to `Foo` and make changes to the pattern as needed.\n"
-"* The distinction between a capture and a constant expression can be hard "
-"to\n"
-"  spot. Try changing the `2` in the second arm to a variable, and see that "
-"it subtly\n"
-"  doesn't work. Change it to a `const` and see it working again."
+msgid "Change the literal values in `foo` to match with the other patterns."
 msgstr ""
 
-#: src/pattern-matching/destructuring-arrays.md:1
-#, fuzzy
-msgid "# Destructuring Arrays"
-msgstr "# Destrukturieren von Arrays"
+#: src/pattern-matching/destructuring-structs.md:24
+msgid "Add a new field to `Foo` and make changes to the pattern as needed."
+msgstr ""
+
+#: src/pattern-matching/destructuring-structs.md:25
+msgid ""
+"The distinction between a capture and a constant expression can be hard to "
+"spot. Try changing the `2` in the second arm to a variable, and see that it "
+"subtly doesn't work. Change it to a `const` and see it working again."
+msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:3
 #, fuzzy
@@ -6930,50 +7193,57 @@ msgstr ""
 
 #: src/pattern-matching/destructuring-arrays.md:21
 msgid ""
-"* Destructuring of slices of unknown length also works with patterns of "
-"fixed length.\n"
-"\n"
-"\n"
-"     ```rust,editable\n"
-"     fn main() {\n"
-"         inspect(&[0, -2, 3]);\n"
-"         inspect(&[0, -2, 3, 4]);\n"
-"     }\n"
-"\n"
-"     #[rustfmt::skip]\n"
-"     fn inspect(slice: &[i32]) {\n"
-"         println!(\"Tell me about {slice:?}\");\n"
-"         match slice {\n"
-"             &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
-"             &[1, ..]   => println!(\"First is 1 and the rest were "
-"ignored\"),\n"
-"             _          => println!(\"All elements were ignored\"),\n"
-"         }\n"
-"     }\n"
-"     ```\n"
-"  \n"
-"* Create a new pattern using `_` to represent an element. \n"
-"* Add more values to the array.\n"
-"* Point out that how `..` will expand to account for different number of "
-"elements.\n"
-"* Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+"Destructuring of slices of unknown length also works with patterns of fixed "
+"length."
 msgstr ""
 
-#: src/pattern-matching/match-guards.md:1
-#, fuzzy
-msgid "# Match Guards"
-msgstr "# Match Guards"
+#: src/pattern-matching/destructuring-arrays.md:24
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    inspect(&[0, -2, 3]);\n"
+"    inspect(&[0, -2, 3, 4]);\n"
+"}\n"
+"\n"
+"#[rustfmt::skip]\n"
+"fn inspect(slice: &[i32]) {\n"
+"    println!(\"Tell me about {slice:?}\");\n"
+"    match slice {\n"
+"        &[0, y, z] => println!(\"First is 0, y = {y}, and z = {z}\"),\n"
+"        &[1, ..]   => println!(\"First is 1 and the rest were ignored\"),\n"
+"        _          => println!(\"All elements were ignored\"),\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:41
+msgid "Create a new pattern using `_` to represent an element. "
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:42
+msgid "Add more values to the array."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:43
+msgid ""
+"Point out that how `..` will expand to account for different number of "
+"elements."
+msgstr ""
+
+#: src/pattern-matching/destructuring-arrays.md:44
+msgid "Show matching against the tail with patterns `[.., b]` and `[a@..,b]`"
+msgstr ""
 
 #: src/pattern-matching/match-guards.md:3
 #, fuzzy
 msgid ""
 "When matching, you can add a _guard_ to a pattern. This is an arbitrary "
-"Boolean\n"
-"expression which will be executed if the pattern matches:"
+"Boolean expression which will be executed if the pattern matches:"
 msgstr ""
 "Beim Abgleich können Sie einem Muster einen _Wächter_ hinzufügen. Dies ist "
-"ein beliebiger boolescher Wert\n"
-"Ausdruck, der ausgeführt wird, wenn das Muster übereinstimmt:"
+"ein beliebiger boolescher Wert Ausdruck, der ausgeführt wird, wenn das "
+"Muster übereinstimmt:"
 
 #: src/pattern-matching/match-guards.md:6
 msgid ""
@@ -6995,35 +7265,45 @@ msgstr ""
 #: src/pattern-matching/match-guards.md:23
 #, fuzzy
 msgid ""
-"* Match guards as a separate syntax feature are important and necessary when "
+"Match guards as a separate syntax feature are important and necessary when "
 "we wish to concisely express more complex ideas than patterns alone would "
-"allow.\n"
-"* They are not the same as separate `if` expression inside of the match arm. "
+"allow."
+msgstr "Match Guards als separates Syntax-Feature sind wichtig und notwendig."
+
+#: src/pattern-matching/match-guards.md:24
+#, fuzzy
+msgid ""
+"They are not the same as separate `if` expression inside of the match arm. "
 "An `if` expression inside of the branch block (after `=>`) happens after the "
 "match arm is selected. Failing the `if` condition inside of that block won't "
-"result in other arms\n"
-"of the original `match` expression being considered.  \n"
-"* You can use the variables defined in the pattern in your if expression.\n"
-"* The condition defined in the guard applies to every expression in a "
-"pattern with an `|`."
+"result in other arms of the original `match` expression being considered."
 msgstr ""
-"* Match Guards als separates Syntax-Feature sind wichtig und notwendig.\n"
-"* Sie sind nicht dasselbe wie ein separater „if“-Ausdruck innerhalb des "
-"Match-Arms. Ein „if“-Ausdruck innerhalb des Verzweigungsblocks (nach „=>“) "
+"Sie sind nicht dasselbe wie ein separater „if“-Ausdruck innerhalb des Match-"
+"Arms. Ein „if“-Ausdruck innerhalb des Verzweigungsblocks (nach „=>“) "
 "erfolgt, nachdem der Match-Arm ausgewählt wurde. Wenn die 'if'-Bedingung "
 "innerhalb dieses Blocks nicht bestanden wird, führt dies nicht zu anderen "
-"Armen\n"
-"des betrachteten ursprünglichen \"Match\"-Ausdrucks.\n"
-"* Sie können die im Muster definierten Variablen in Ihrem if-Ausdruck "
-"verwenden.\n"
-"* Die im Guard definierte Bedingung gilt für jeden Ausdruck in einem Muster "
-"mit einem `|`.\n"
-"</details>"
+"Armen des betrachteten ursprünglichen \"Match\"-Ausdrucks."
+
+#: src/pattern-matching/match-guards.md:26
+#, fuzzy
+msgid "You can use the variables defined in the pattern in your if expression."
+msgstr ""
+"Sie können die im Muster definierten Variablen in Ihrem if-Ausdruck "
+"verwenden."
+
+#: src/pattern-matching/match-guards.md:27
+#, fuzzy
+msgid ""
+"The condition defined in the guard applies to every expression in a pattern "
+"with an `|`."
+msgstr ""
+"Die im Guard definierte Bedingung gilt für jeden Ausdruck in einem Muster "
+"mit einem `|`."
 
 #: src/exercises/day-2/morning.md:1
 #, fuzzy
-msgid "# Day 2: Morning Exercises"
-msgstr "# Tag 2: Morgengymnastik"
+msgid "Day 2: Morning Exercises"
+msgstr "Tag 2: Morgengymnastik"
 
 #: src/exercises/day-2/morning.md:3
 #, fuzzy
@@ -7032,52 +7312,41 @@ msgstr "Wir werden Implementierungsmethoden in zwei Kontexten betrachten:"
 
 #: src/exercises/day-2/morning.md:5
 #, fuzzy
-msgid ""
-"* Simple struct which tracks health statistics.\n"
-"\n"
-"* Multiple structs and enums for a drawing library."
-msgstr "* Mehrere Strukturen und Aufzählungen für eine Zeichnungsbibliothek."
+msgid "Simple struct which tracks health statistics."
+msgstr "Mehrere Strukturen und Aufzählungen für eine Zeichnungsbibliothek."
 
-#: src/exercises/day-2/health-statistics.md:1
-#, fuzzy
-msgid "# Health Statistics"
-msgstr "# Gesundheitsstatistik"
+#: src/exercises/day-2/morning.md:7
+msgid "Multiple structs and enums for a drawing library."
+msgstr ""
 
 #: src/exercises/day-2/health-statistics.md:3
 #, fuzzy
 msgid ""
 "You're working on implementing a health-monitoring system. As part of that, "
-"you\n"
-"need to keep track of users' health statistics."
+"you need to keep track of users' health statistics."
 msgstr ""
 "Sie arbeiten an der Implementierung eines Gesundheitsüberwachungssystems. "
-"Als Teil davon Sie\n"
-"müssen die Gesundheitsstatistiken der Benutzer verfolgen."
+"Als Teil davon Sie müssen die Gesundheitsstatistiken der Benutzer verfolgen."
 
 #: src/exercises/day-2/health-statistics.md:6
 #, fuzzy
 msgid ""
 "You'll start with some stubbed functions in an `impl` block as well as a "
-"`User`\n"
-"struct definition. Your goal is to implement the stubbed out methods on the\n"
-"`User` `struct` defined in the `impl` block."
+"`User` struct definition. Your goal is to implement the stubbed out methods "
+"on the `User` `struct` defined in the `impl` block."
 msgstr ""
-"Sie beginnen mit einigen Stub-Funktionen in einem `impl`-Block sowie einem "
-"`User`\n"
-"Strukturdefinition. Ihr Ziel ist es, die Stubbed-out-Methoden auf dem zu "
-"implementieren\n"
-"`User` `struct` definiert im `impl` Block."
+"Sie beginnen mit einigen Stub-Funktionen in einem `impl`\\-Block sowie einem "
+"`User` Strukturdefinition. Ihr Ziel ist es, die Stubbed-out-Methoden auf dem "
+"zu implementieren `User` `struct` definiert im `impl` Block."
 
 #: src/exercises/day-2/health-statistics.md:10
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "methods:"
 msgstr ""
 "Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
-"füllen Sie die fehlenden aus\n"
-"Methoden:"
+"füllen Sie die fehlenden aus Methoden:"
 
 #: src/exercises/day-2/health-statistics.md:13
 msgid ""
@@ -7140,23 +7409,19 @@ msgstr ""
 
 #: src/exercises/day-2/points-polygons.md:1
 #, fuzzy
-msgid "# Polygon Struct"
-msgstr "# Polygonstruktur"
+msgid "Polygon Struct"
+msgstr "Polygonstruktur"
 
 #: src/exercises/day-2/points-polygons.md:3
 #, fuzzy
 msgid ""
 "We will create a `Polygon` struct which contain some points. Copy the code "
-"below\n"
-"to <https://play.rust-lang.org/> and fill in the missing methods to make "
-"the\n"
-"tests pass:"
+"below to <https://play.rust-lang.org/> and fill in the missing methods to "
+"make the tests pass:"
 msgstr ""
 "Wir werden eine \"Polygon\"-Struktur erstellen, die einige Punkte enthält. "
-"Kopieren Sie den Code unten\n"
-"zu <https://play.rust-lang.org/> und füllen Sie die fehlenden Methoden aus, "
-"um die\n"
-"Tests bestehen:"
+"Kopieren Sie den Code unten zu <https://play.rust-lang.org/> und füllen Sie "
+"die fehlenden Methoden aus, um die Tests bestehen:"
 
 #: src/exercises/day-2/points-polygons.md:7
 msgid ""
@@ -7273,70 +7538,56 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Since the method signatures are missing from the problem statements, the key "
-"part\n"
-"of the exercise is to specify those correctly. You don't have to modify the "
-"tests."
+"part of the exercise is to specify those correctly. You don't have to modify "
+"the tests."
 msgstr ""
 "Da die Methodensignaturen in den Problembeschreibungen fehlen, ist der "
-"Schlüsselteil\n"
-"der Übung ist es, diese richtig anzugeben."
+"Schlüsselteil der Übung ist es, diese richtig anzugeben."
 
 #: src/exercises/day-2/points-polygons.md:120
 #, fuzzy
 msgid "Other interesting parts of the exercise:"
-msgstr "Weitere interessante Teile der Übung:\n"
+msgstr "Weitere interessante Teile der Übung:"
 
 #: src/exercises/day-2/points-polygons.md:122
 #, fuzzy
 msgid ""
-"* Derive a `Copy` trait for some structs, as in tests the methods sometimes "
-"don't borrow their arguments.\n"
-"* Discover that `Add` trait must be implemented for two objects to be "
-"addable via \"+\". Note that we do not discuss generics until Day 3."
+"Derive a `Copy` trait for some structs, as in tests the methods sometimes "
+"don't borrow their arguments."
 msgstr ""
-"* Leiten Sie ein `Copy`-Merkmal für einige Strukturen ab, da die Methoden in "
-"Tests ihre Argumente manchmal nicht ausleihen.\n"
-"* Entdecken Sie, dass die Eigenschaft „Hinzufügen“ implementiert werden "
-"muss, damit zwei Objekte über „+“ hinzugefügt werden können."
+"Leiten Sie ein `Copy`\\-Merkmal für einige Strukturen ab, da die Methoden in "
+"Tests ihre Argumente manchmal nicht ausleihen."
 
-#: src/control-flow.md:1
+#: src/exercises/day-2/points-polygons.md:123
 #, fuzzy
-msgid "# Control Flow"
-msgstr "# Kontrollfluss"
+msgid ""
+"Discover that `Add` trait must be implemented for two objects to be addable "
+"via \"+\". Note that we do not discuss generics until Day 3."
+msgstr ""
+"Entdecken Sie, dass die Eigenschaft „Hinzufügen“ implementiert werden muss, "
+"damit zwei Objekte über „+“ hinzugefügt werden können."
 
 #: src/control-flow.md:3
 #, fuzzy
 msgid ""
-"As we have seen, `if` is an expression in Rust. It is used to conditionally\n"
+"As we have seen, `if` is an expression in Rust. It is used to conditionally "
 "evaluate one of two blocks, but the blocks can have a value which then "
-"becomes\n"
-"the value of the `if` expression. Other control flow expressions work "
-"similarly\n"
-"in Rust."
+"becomes the value of the `if` expression. Other control flow expressions "
+"work similarly in Rust."
 msgstr ""
-"Wie wir gesehen haben, ist `if` ein Ausdruck in Rust. Es ist bedingt "
-"gewohnt\n"
+"Wie wir gesehen haben, ist `if` ein Ausdruck in Rust. Es ist bedingt gewohnt "
 "einen von zwei Blöcken auswerten, aber die Blöcke können einen Wert haben, "
-"der dann wird\n"
-"der Wert des `if`-Ausdrucks. Andere Ablaufsteuerungsausdrücke funktionieren "
-"ähnlich\n"
-"in Rost."
-
-#: src/control-flow/blocks.md:1
-#, fuzzy
-msgid "# Blocks"
-msgstr "# Blöcke"
+"der dann wird der Wert des `if`\\-Ausdrucks. Andere "
+"Ablaufsteuerungsausdrücke funktionieren ähnlich in Rost."
 
 #: src/control-flow/blocks.md:3
 #, fuzzy
 msgid ""
 "A block in Rust has a value and a type: the value is the last expression of "
-"the\n"
-"block:"
+"the block:"
 msgstr ""
 "Ein Block in Rust hat einen Wert und einen Typ: Der Wert ist der letzte "
-"Ausdruck der\n"
-"Block:"
+"Ausdruck der Block:"
 
 #: src/control-flow/blocks.md:6
 msgid ""
@@ -7363,11 +7614,10 @@ msgstr ""
 #: src/control-flow/blocks.md:25
 #, fuzzy
 msgid ""
-"The same rule is used for functions: the value of the function body is the\n"
+"The same rule is used for functions: the value of the function body is the "
 "return value:"
 msgstr ""
-"Die gleiche Regel gilt für Funktionen: Der Wert des Funktionskörpers ist "
-"der\n"
+"Die gleiche Regel gilt für Funktionen: Der Wert des Funktionskörpers ist der "
 "Rückgabewert:"
 
 #: src/control-flow/blocks.md:28
@@ -7392,32 +7642,31 @@ msgstr ""
 #: src/control-flow/blocks.md:43
 #, fuzzy
 msgid ""
-"* The point of this slide is to show that blocks have a type and value in "
-"Rust. \n"
-"* You can show how the value of the block changes by changing the last line "
-"in the block. For instance, adding/removing a semicolon or using a "
-"`return`.\n"
-"   "
+"The point of this slide is to show that blocks have a type and value in "
+"Rust. "
 msgstr ""
-"* Der Zweck dieser Folie ist es zu zeigen, dass Blöcke in Rust einen Typ und "
-"einen Wert haben.\n"
-"* Sie können zeigen, wie sich der Wert des Blocks ändert, indem Sie die "
-"letzte Zeile im Block ändern. Zum Beispiel das Hinzufügen/Entfernen eines "
-"Semikolons oder die Verwendung eines `Return`.\n"
-"   \n"
-"</Details>"
+"Der Zweck dieser Folie ist es zu zeigen, dass Blöcke in Rust einen Typ und "
+"einen Wert haben."
+
+#: src/control-flow/blocks.md:44
+#, fuzzy
+msgid ""
+"You can show how the value of the block changes by changing the last line in "
+"the block. For instance, adding/removing a semicolon or using a `return`."
+msgstr ""
+"Sie können zeigen, wie sich der Wert des Blocks ändert, indem Sie die letzte "
+"Zeile im Block ändern. Zum Beispiel das Hinzufügen/Entfernen eines "
+"Semikolons oder die Verwendung eines `Return`."
 
 #: src/control-flow/if-expressions.md:1
 #, fuzzy
-msgid "# `if` expressions"
-msgstr "# `if`-Ausdrücke"
+msgid "`if` expressions"
+msgstr "`if`\\-Ausdrücke"
 
 #: src/control-flow/if-expressions.md:3
 msgid ""
-"You use [`if`\n"
-"expressions](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"expressions)\n"
-"exactly like `if` statements in other languages:"
+"You use [`if` expressions](https://doc.rust-lang.org/reference/expressions/"
+"if-expr.html#if-expressions) exactly like `if` statements in other languages:"
 msgstr ""
 
 #: src/control-flow/if-expressions.md:7
@@ -7437,7 +7686,7 @@ msgstr ""
 #: src/control-flow/if-expressions.md:18
 #, fuzzy
 msgid ""
-"In addition, you can use `if` as an expression. The last expression of each\n"
+"In addition, you can use `if` as an expression. The last expression of each "
 "block becomes the value of the `if` expression:"
 msgstr ""
 "Darüber hinaus können Sie es als Ausdruck verwenden. Das macht dasselbe wie "
@@ -7466,16 +7715,14 @@ msgstr ""
 
 #: src/control-flow/if-let-expressions.md:1
 #, fuzzy
-msgid "# `if let` expressions"
-msgstr "# `if let`-Ausdrücke"
+msgid "`if let` expressions"
+msgstr "`if let`\\-Ausdrücke"
 
 #: src/control-flow/if-let-expressions.md:3
 msgid ""
-"The [`if let`\n"
-"expression](https://doc.rust-lang.org/reference/expressions/if-expr.html#if-"
-"let-expressions)\n"
-"lets you execute different code depending on whether a value matches a "
-"pattern:"
+"The [`if let` expression](https://doc.rust-lang.org/reference/expressions/if-"
+"expr.html#if-let-expressions) lets you execute different code depending on "
+"whether a value matches a pattern:"
 msgstr ""
 
 #: src/control-flow/if-let-expressions.md:7
@@ -7498,49 +7745,60 @@ msgstr ""
 #, fuzzy
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
-"in\n"
-"Rust."
+"in Rust."
 msgstr ""
 "Siehe [pattern matching](../pattern-matching.md) für weitere Details zu "
-"Mustern in\n"
-"Rost."
+"Mustern in Rost."
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
-"* `if let` can be more concise than `match`, e.g., when only one case is "
-"interesting. In contrast, `match` requires all branches to be covered.\n"
-"* A common usage is handling `Some` values when working with `Option`.\n"
-"* Unlike `match`, `if let` does not support guard clauses for pattern "
-"matching.\n"
-"* Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
+"`if let` can be more concise than `match`, e.g., when only one case is "
+"interesting. In contrast, `match` requires all branches to be covered."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:24
+msgid "A common usage is handling `Some` values when working with `Option`."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:25
+msgid ""
+"Unlike `match`, `if let` does not support guard clauses for pattern matching."
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:26
+msgid ""
+"Since 1.65, a similar [let-else](https://doc.rust-lang.org/rust-by-example/"
 "flow_control/let_else.html) construct allows to do a destructuring "
 "assignment, or if it fails, have a non-returning block branch (panic/return/"
-"break/continue):\n"
-"\n"
-"   ```rust,editable\n"
-"   fn main() {\n"
-"       println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
-"   }\n"
-"    \n"
-"   fn second_word_to_upper(s: &str) -> Option<String> {\n"
-"       let mut it = s.split(' ');\n"
-"       let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
-"           return None;\n"
-"       };\n"
-"       Some(item.to_uppercase())\n"
-"   }"
+"break/continue):"
+msgstr ""
+
+#: src/control-flow/if-let-expressions.md:28
+msgid ""
+"```rust,editable\n"
+"fn main() {\n"
+"    println!(\"{:?}\", second_word_to_upper(\"foo bar\"));\n"
+"}\n"
+" \n"
+"fn second_word_to_upper(s: &str) -> Option<String> {\n"
+"    let mut it = s.split(' ');\n"
+"    let (Some(_), Some(item)) = (it.next(), it.next()) else {\n"
+"        return None;\n"
+"    };\n"
+"    Some(item.to_uppercase())\n"
+"}\n"
+"```"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:1
 #, fuzzy
-msgid "# `while` loops"
-msgstr "# `while`-Ausdrücke"
+msgid "`while` loops"
+msgstr "`while`\\-Ausdrücke"
 
 #: src/control-flow/while-expressions.md:3
 msgid ""
 "The [`while` keyword](https://doc.rust-lang.org/reference/expressions/loop-"
-"expr.html#predicate-loops)\n"
-"works very similar to other languages:"
+"expr.html#predicate-loops) works very similar to other languages:"
 msgstr ""
 
 #: src/control-flow/while-expressions.md:6
@@ -7562,19 +7820,18 @@ msgstr ""
 
 #: src/control-flow/while-let-expressions.md:1
 #, fuzzy
-msgid "# `while let` loops"
-msgstr "# `while let`-Ausdrücke"
+msgid "`while let` loops"
+msgstr "`while let`\\-Ausdrücke"
 
 #: src/control-flow/while-let-expressions.md:3
 #, fuzzy
 msgid ""
 "Like with `if let`, there is a [`while let`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#predicate-pattern-loops)\n"
-"variant which repeatedly tests a value against a pattern:"
+"reference/expressions/loop-expr.html#predicate-pattern-loops) variant which "
+"repeatedly tests a value against a pattern:"
 msgstr ""
-"Wie bei `if` gibt es eine `while let`-Variante, die einen Wert wiederholt "
-"testet\n"
-"gegen ein Muster:"
+"Wie bei `if` gibt es eine `while let`\\-Variante, die einen Wert wiederholt "
+"testet gegen ein Muster:"
 
 #: src/control-flow/while-let-expressions.md:6
 msgid ""
@@ -7594,49 +7851,49 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Here the iterator returned by `v.iter()` will return a `Option<i32>` on "
-"every\n"
-"call to `next()`. It returns `Some(x)` until it is done, after which it "
-"will\n"
-"return `None`. The `while let` lets us keep iterating through all items."
+"every call to `next()`. It returns `Some(x)` until it is done, after which "
+"it will return `None`. The `while let` lets us keep iterating through all "
+"items."
 msgstr ""
 "Hier gibt der von `v.iter()` zurückgegebene Iterator bei jedem eine "
-"`Option<i32>` zurück\n"
-"Aufruf von `next()`. Es gibt `Some(x)` zurück, bis es fertig ist, danach "
-"wird es\n"
-"gibt \"Keine\" zurück. Das `while let` lässt uns alle Elemente durchlaufen."
+"`Option<i32>` zurück Aufruf von `next()`. Es gibt `Some(x)` zurück, bis es "
+"fertig ist, danach wird es gibt \"Keine\" zurück. Das `while let` lässt uns "
+"alle Elemente durchlaufen."
 
 #: src/control-flow/while-let-expressions.md:26
 #, fuzzy
 msgid ""
-"* Point out that the `while let` loop will keep going as long as the value "
-"matches the pattern.\n"
-"* You could rewrite the `while let` loop as an infinite loop with an if "
-"statement that breaks when there is no value to unwrap for `iter.next()`. "
-"The `while let` provides syntactic sugar for the above scenario.\n"
-"    "
+"Point out that the `while let` loop will keep going as long as the value "
+"matches the pattern."
 msgstr ""
-"* Weisen Sie darauf hin, dass die „while let“-Schleife so lange läuft, wie "
-"der Wert mit dem Muster übereinstimmt.\n"
-"* Sie könnten die „while let“-Schleife als Endlosschleife mit einer if-"
+"Weisen Sie darauf hin, dass die „while let“-Schleife so lange läuft, wie der "
+"Wert mit dem Muster übereinstimmt."
+
+#: src/control-flow/while-let-expressions.md:27
+#, fuzzy
+msgid ""
+"You could rewrite the `while let` loop as an infinite loop with an if "
+"statement that breaks when there is no value to unwrap for `iter.next()`. "
+"The `while let` provides syntactic sugar for the above scenario."
+msgstr ""
+"Sie könnten die „while let“-Schleife als Endlosschleife mit einer if-"
 "Anweisung umschreiben, die abbricht, wenn es keinen Wert zum Auspacken für "
 "„iter.next()“ gibt. Das `while let` liefert syntaktischen Zucker für das "
-"obige Szenario.\n"
-"    \n"
-"</details>"
+"obige Szenario."
 
 #: src/control-flow/for-expressions.md:1
 #, fuzzy
-msgid "# `for` loops"
-msgstr "## `for`-Schleifen"
+msgid "`for` loops"
+msgstr "`for`\\-Schleifen"
 
 #: src/control-flow/for-expressions.md:3
 #, fuzzy
 msgid ""
-"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely\n"
-"related to the [`while let` loop](while-let-expression.md). It will\n"
+"The [`for` loop](https://doc.rust-lang.org/std/keyword.for.html) is closely "
+"related to the [`while let` loop](while-let-expression.md). It will "
 "automatically call `into_iter()` on the expression and then iterate over it:"
 msgstr ""
-"Der „for“-Ausdruck ist eng verwandt mit dem „while let“-Ausdruck. Es wird\n"
+"Der „for“-Ausdruck ist eng verwandt mit dem „while let“-Ausdruck. Es wird "
 "Rufen Sie automatisch `into_iter()` für den Ausdruck auf und iterieren Sie "
 "dann darüber:"
 
@@ -7664,31 +7921,39 @@ msgstr "Sie können hier wie gewohnt `break` und `continue` verwenden."
 
 #: src/control-flow/for-expressions.md:25
 #, fuzzy
+msgid "Index iteration is not a special syntax in Rust for just that case."
+msgstr ""
+"Index-Iteration ist in Rust keine spezielle Syntax für genau diesen Fall."
+
+#: src/control-flow/for-expressions.md:26
+#, fuzzy
+msgid "`(0..10)` is a range that implements an `Iterator` trait. "
+msgstr "„(0..10)“ ist ein Bereich, der ein „Iterator“-Merkmal implementiert."
+
+#: src/control-flow/for-expressions.md:27
+#, fuzzy
 msgid ""
-"* Index iteration is not a special syntax in Rust for just that case.\n"
-"* `(0..10)` is a range that implements an `Iterator` trait. \n"
-"* `step_by` is a method that returns another `Iterator` that skips every "
-"other element. \n"
-"* Modify the elements in the vector and explain the compiler errors. Change "
+"`step_by` is a method that returns another `Iterator` that skips every other "
+"element. "
+msgstr ""
+"„step_by“ ist eine Methode, die einen weiteren „Iterator“ zurückgibt, der "
+"jedes andere Element überspringt."
+
+#: src/control-flow/for-expressions.md:28
+msgid ""
+"Modify the elements in the vector and explain the compiler errors. Change "
 "vector `v` to be mutable and the for loop to `for x in v.iter_mut()`."
 msgstr ""
-"* Index-Iteration ist in Rust keine spezielle Syntax für genau diesen Fall.\n"
-"* „(0..10)“ ist ein Bereich, der ein „Iterator“-Merkmal implementiert.\n"
-"* „step_by“ ist eine Methode, die einen weiteren „Iterator“ zurückgibt, der "
-"jedes andere Element überspringt.\n"
-"    \n"
-"</details>"
 
 #: src/control-flow/loop-expressions.md:1
 #, fuzzy
-msgid "# `loop` expressions"
-msgstr "# `loop`-Ausdrücke"
+msgid "`loop` expressions"
+msgstr "`loop`\\-Ausdrücke"
 
 #: src/control-flow/loop-expressions.md:3
 msgid ""
 "Finally, there is a [`loop` keyword](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#infinite-loops)\n"
-"which creates an endless loop."
+"expressions/loop-expr.html#infinite-loops) which creates an endless loop."
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:6
@@ -7696,8 +7961,8 @@ msgstr ""
 msgid "Here you must either `break` or `return` to stop the loop:"
 msgstr ""
 "Schließlich gibt es noch ein „loop“-Schlüsselwort, das eine Endlosschleife "
-"erzeugt. Hier müssen Sie\n"
-"entweder `break` oder `return`, um die Schleife zu stoppen:"
+"erzeugt. Hier müssen Sie entweder `break` oder `return`, um die Schleife zu "
+"stoppen:"
 
 #: src/control-flow/loop-expressions.md:8
 msgid ""
@@ -7720,32 +7985,31 @@ msgid ""
 msgstr ""
 
 #: src/control-flow/loop-expressions.md:27
+msgid "Break the `loop` with a value (e.g. `break 8`) and print it out."
+msgstr ""
+
+#: src/control-flow/loop-expressions.md:28
 msgid ""
-"* Break the `loop` with a value (e.g. `break 8`) and print it out.\n"
-"* Note that `loop` is the only looping construct which returns a non-"
-"trivial\n"
-"  value. This is because it's guaranteed to be entered at least once "
-"(unlike\n"
-"  `while` and `for` loops)."
+"Note that `loop` is the only looping construct which returns a non-trivial "
+"value. This is because it's guaranteed to be entered at least once (unlike "
+"`while` and `for` loops)."
 msgstr ""
 
 #: src/control-flow/match-expressions.md:1
 #, fuzzy
-msgid "# `match` expressions"
-msgstr "# `Match`-Ausdrücke"
+msgid "`match` expressions"
+msgstr "`Match`\\-Ausdrücke"
 
 #: src/control-flow/match-expressions.md:3
 #, fuzzy
 msgid ""
 "The [`match` keyword](https://doc.rust-lang.org/reference/expressions/match-"
-"expr.html)\n"
-"is used to match a value against one or more patterns. In that sense, it "
-"works\n"
-"like a series of `if let` expressions:"
+"expr.html) is used to match a value against one or more patterns. In that "
+"sense, it works like a series of `if let` expressions:"
 msgstr ""
 "Das Schlüsselwort „match“ wird verwendet, um einen Wert mit einem oder "
-"mehreren Mustern abzugleichen. In\n"
-"In diesem Sinne funktioniert es wie eine Reihe von `if let`-Ausdrücken:"
+"mehreren Mustern abzugleichen. In In diesem Sinne funktioniert es wie eine "
+"Reihe von `if let`\\-Ausdrücken:"
 
 #: src/control-flow/match-expressions.md:7
 msgid ""
@@ -7766,51 +8030,65 @@ msgstr ""
 #: src/control-flow/match-expressions.md:20
 #, fuzzy
 msgid ""
-"Like `if let`, each match arm must have the same type. The type is the last\n"
+"Like `if let`, each match arm must have the same type. The type is the last "
 "expression of the block, if any. In the example above, the type is `()`."
 msgstr ""
 "Wie bei „if let“ muss jeder Match-Arm denselben Typ haben. Der Typ ist der "
-"letzte\n"
-"Ausdruck des Blocks, falls vorhanden. Im obigen Beispiel ist der Typ `()`."
+"letzte Ausdruck des Blocks, falls vorhanden. Im obigen Beispiel ist der Typ "
+"`()`."
 
 #: src/control-flow/match-expressions.md:28
+msgid "Save the match expression to a variable and print it out."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:29
+msgid "Remove `.as_deref()` and explain the error."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:30
 msgid ""
-"* Save the match expression to a variable and print it out.\n"
-"* Remove `.as_deref()` and explain the error.\n"
-"    * `std::env::args().next()` returns an `Option<String>`, but we cannot "
-"match against `String`.\n"
-"    * `as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our "
-"case, this turns `Option<String>` into `Option<&str>`.\n"
-"    * We can now use pattern matching to match against the `&str` inside "
-"`Option`."
+"`std::env::args().next()` returns an `Option<String>`, but we cannot match "
+"against `String`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:31
+msgid ""
+"`as_deref()` transforms an `Option<T>` to `Option<&T::Target>`. In our case, "
+"this turns `Option<String>` into `Option<&str>`."
+msgstr ""
+
+#: src/control-flow/match-expressions.md:32
+msgid ""
+"We can now use pattern matching to match against the `&str` inside `Option`."
 msgstr ""
 
 #: src/control-flow/break-continue.md:1
 #, fuzzy
-msgid "# `break` and `continue`"
-msgstr "# `break` und `continue`"
+msgid "`break` and `continue`"
+msgstr "`break` und `continue`"
 
 #: src/control-flow/break-continue.md:3
 msgid ""
-"- If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
-"reference/expressions/loop-expr.html#break-expressions),\n"
-"- If you want to immediately start\n"
-"the next iteration use [`continue`](https://doc.rust-lang.org/reference/"
-"expressions/loop-expr.html#continue-expressions)."
+"If you want to exit a loop early, use [`break`](https://doc.rust-lang.org/"
+"reference/expressions/loop-expr.html#break-expressions),"
+msgstr ""
+
+#: src/control-flow/break-continue.md:4
+msgid ""
+"If you want to immediately start the next iteration use [`continue`](https://"
+"doc.rust-lang.org/reference/expressions/loop-expr.html#continue-expressions)."
 msgstr ""
 
 #: src/control-flow/break-continue.md:7
 #, fuzzy
 msgid ""
 "Both `continue` and `break` can optionally take a label argument which is "
-"used\n"
-"to break out of nested loops:"
+"used to break out of nested loops:"
 msgstr ""
 "Wenn Sie eine Schleife vorzeitig verlassen möchten, verwenden Sie `break`, "
-"wenn Sie sofort beginnen möchten\n"
-"Verwenden Sie für die nächste Iteration \"Continue\". Sowohl `Continue` als "
-"auch `Break` können optional verwendet werden\n"
-"Nehmen Sie ein Label-Argument, das zum Ausbrechen aus verschachtelten "
+"wenn Sie sofort beginnen möchten Verwenden Sie für die nächste Iteration "
+"\"Continue\". Sowohl `Continue` als auch `Break` können optional verwendet "
+"werden Nehmen Sie ein Label-Argument, das zum Ausbrechen aus verschachtelten "
 "Schleifen verwendet wird:"
 
 #: src/control-flow/break-continue.md:10
@@ -7842,25 +8120,17 @@ msgstr ""
 "In diesem Fall brechen wir die äußere Schleife nach 3 Iterationen der "
 "inneren Schleife."
 
-#: src/std.md:1
-#, fuzzy
-msgid "# Standard Library"
-msgstr "# Standardbibliothek"
-
 #: src/std.md:3
 #, fuzzy
 msgid ""
 "Rust comes with a standard library which helps establish a set of common "
-"types\n"
-"used by Rust library and programs. This way, two libraries can work "
-"together\n"
-"smoothly because they both use the same `String` type."
+"types used by Rust library and programs. This way, two libraries can work "
+"together smoothly because they both use the same `String` type."
 msgstr ""
 "Rust wird mit einer Standardbibliothek geliefert, die dabei hilft, eine "
-"Reihe gängiger Typen zu erstellen\n"
-"Wird von Rust-Bibliotheken und -Programmen verwendet. Auf diese Weise können "
-"zwei Bibliotheken zusammenarbeiten\n"
-"reibungslos, da beide den gleichen `String`-Typ verwenden."
+"Reihe gängiger Typen zu erstellen Wird von Rust-Bibliotheken und -Programmen "
+"verwendet. Auf diese Weise können zwei Bibliotheken zusammenarbeiten "
+"reibungslos, da beide den gleichen `String`\\-Typ verwenden."
 
 #: src/std.md:7
 #, fuzzy
@@ -7869,49 +8139,73 @@ msgstr "Zu den gängigen Wortschatztypen gehören:"
 
 #: src/std.md:9
 msgid ""
-"* [`Option` and `Result`](std/option-result.md) types: used for optional "
-"values\n"
-"  and [error handling](error-handling.md).\n"
-"\n"
-"* [`String`](std/string.md): the default string type used for owned data.\n"
-"\n"
-"* [`Vec`](std/vec.md): a standard extensible vector.\n"
-"\n"
-"* [`HashMap`](std/hashmap.md): a hash map type with a configurable hashing\n"
-"  algorithm.\n"
-"\n"
-"* [`Box`](std/box.md): an owned pointer for heap-allocated data.\n"
-"\n"
-"* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
+"[`Option` and `Result`](std/option-result.md) types: used for optional "
+"values and [error handling](error-handling.md)."
+msgstr ""
+
+#: src/std.md:12
+msgid "[`String`](std/string.md): the default string type used for owned data."
+msgstr ""
+
+#: src/std.md:14
+msgid "[`Vec`](std/vec.md): a standard extensible vector."
+msgstr ""
+
+#: src/std.md:16
+msgid ""
+"[`HashMap`](std/hashmap.md): a hash map type with a configurable hashing "
+"algorithm."
+msgstr ""
+
+#: src/std.md:19
+msgid "[`Box`](std/box.md): an owned pointer for heap-allocated data."
+msgstr ""
+
+#: src/std.md:21
+msgid ""
+"[`Rc`](std/rc.md): a shared reference-counted pointer for heap-allocated "
 "data."
 msgstr ""
 
 #: src/std.md:25
 #, fuzzy
 msgid ""
-"  * In fact, Rust contains several layers of the Standard Library: `core`, "
-"`alloc` and `std`. \n"
-"  * `core` includes the most basic types and functions that don't depend on "
-"`libc`, allocator or\n"
-"    even the presence of an operating system. \n"
-"  * `alloc` includes types which require a global heap allocator, such as "
-"`Vec`, `Box` and `Arc`.\n"
-"  * Embedded Rust applications often only use `core`, and sometimes `alloc`."
+"In fact, Rust contains several layers of the Standard Library: `core`, "
+"`alloc` and `std`. "
 msgstr ""
-"  * Tatsächlich enthält Rust mehrere Schichten der Standardbibliothek: "
-"`core`, `alloc` und `std`.\n"
-"  * `core` enthält die grundlegendsten Typen und Funktionen, die nicht von "
-"`libc`, allocator oder abhängen\n"
-"    sogar das Vorhandensein eines Betriebssystems.\n"
-"  * „alloc“ umfasst Typen, die einen globalen Heap-Zuordner erfordern, wie "
-"etwa „Vec“, „Box“ und „Arc“.\n"
-"  * Eingebettete Rust-Anwendungen verwenden oft nur `core` und manchmal "
-"`alloc`."
+"Tatsächlich enthält Rust mehrere Schichten der Standardbibliothek: `core`, "
+"`alloc` und `std`."
+
+#: src/std.md:26
+#, fuzzy
+msgid ""
+"`core` includes the most basic types and functions that don't depend on "
+"`libc`, allocator or even the presence of an operating system. "
+msgstr ""
+"`core` enthält die grundlegendsten Typen und Funktionen, die nicht von "
+"`libc`, allocator oder abhängen sogar das Vorhandensein eines "
+"Betriebssystems."
+
+#: src/std.md:28
+#, fuzzy
+msgid ""
+"`alloc` includes types which require a global heap allocator, such as `Vec`, "
+"`Box` and `Arc`."
+msgstr ""
+"„alloc“ umfasst Typen, die einen globalen Heap-Zuordner erfordern, wie etwa "
+"„Vec“, „Box“ und „Arc“."
+
+#: src/std.md:29
+#, fuzzy
+msgid ""
+"Embedded Rust applications often only use `core`, and sometimes `alloc`."
+msgstr ""
+"Eingebettete Rust-Anwendungen verwenden oft nur `core` und manchmal `alloc`."
 
 #: src/std/option-result.md:1
 #, fuzzy
-msgid "# `Option` and `Result`"
-msgstr "# `Option` und `Ergebnis`"
+msgid "`Option` and `Result`"
+msgstr "`Option` und `Ergebnis`"
 
 #: src/std/option-result.md:3
 #, fuzzy
@@ -7934,39 +8228,54 @@ msgstr ""
 
 #: src/std/option-result.md:18
 #, fuzzy
-msgid ""
-"* `Option` and `Result` are widely used not just in the standard library.\n"
-"* `Option<&T>` has zero space overhead compared to `&T`.\n"
-"* `Result` is the standard type to implement error handling as we will see "
-"on Day 3.\n"
-"* `binary_search` returns `Result<usize, usize>`.\n"
-"  * If found, `Result::Ok` holds the index where the element is found.\n"
-"  * Otherwise, `Result::Err` contains the index where such an element should "
-"be inserted."
+msgid "`Option` and `Result` are widely used not just in the standard library."
 msgstr ""
-"* „Option“ und „Ergebnis“ werden nicht nur in der Standardbibliothek häufig "
-"verwendet.\n"
-"* `Option<&T>` hat im Vergleich zu `&T` keinen Speicherplatz-Overhead.\n"
-"* „Ergebnis“ ist der Standardtyp zur Implementierung der Fehlerbehandlung, "
-"wie wir an Tag 3 sehen werden.\n"
-"* `binary_search` gibt `Result<usize, usesize>` zurück.\n"
-"  * Falls gefunden, enthält `Result::Ok` den Index, wo das Element gefunden "
-"wurde.\n"
-"  * Andernfalls enthält `Result::Err` den Index, wo ein solches Element "
-"eingefügt werden soll."
+"„Option“ und „Ergebnis“ werden nicht nur in der Standardbibliothek häufig "
+"verwendet."
 
-#: src/std/string.md:1
+#: src/std/option-result.md:19
 #, fuzzy
-msgid "# String"
-msgstr "# Zeichenfolge"
+msgid "`Option<&T>` has zero space overhead compared to `&T`."
+msgstr "`Option<&T>` hat im Vergleich zu `&T` keinen Speicherplatz-Overhead."
+
+#: src/std/option-result.md:20
+#, fuzzy
+msgid ""
+"`Result` is the standard type to implement error handling as we will see on "
+"Day 3."
+msgstr ""
+"„Ergebnis“ ist der Standardtyp zur Implementierung der Fehlerbehandlung, wie "
+"wir an Tag 3 sehen werden."
+
+#: src/std/option-result.md:21
+#, fuzzy
+msgid "`binary_search` returns `Result<usize, usize>`."
+msgstr "`binary_search` gibt `Result<usize, usesize>` zurück."
+
+#: src/std/option-result.md:22
+#, fuzzy
+msgid "If found, `Result::Ok` holds the index where the element is found."
+msgstr ""
+"Falls gefunden, enthält `Result::Ok` den Index, wo das Element gefunden "
+"wurde."
+
+#: src/std/option-result.md:23
+#, fuzzy
+msgid ""
+"Otherwise, `Result::Err` contains the index where such an element should be "
+"inserted."
+msgstr ""
+"Andernfalls enthält `Result::Err` den Index, wo ein solches Element "
+"eingefügt werden soll."
 
 #: src/std/string.md:3
 #, fuzzy
 msgid ""
-"[`String`][1] is the standard heap-allocated growable UTF-8 string buffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) is the "
+"standard heap-allocated growable UTF-8 string buffer:"
 msgstr ""
-"[`String`][1] ist der Standard-Heap-zugewiesene erweiterbare UTF-8-String-"
-"Puffer:"
+"[`String`](https://doc.rust-lang.org/std/string/struct.String.html) ist der "
+"Standard-Heap-zugewiesene erweiterbare UTF-8-String-Puffer:"
 
 #: src/std/string.md:5
 msgid ""
@@ -7991,50 +8300,92 @@ msgstr ""
 #: src/std/string.md:22
 #, fuzzy
 msgid ""
-"`String` implements [`Deref<Target = str>`][2], which means that you can "
-"call all\n"
-"`str` methods on a `String`."
+"`String` implements [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), which means that you can call "
+"all `str` methods on a `String`."
 msgstr ""
-"`String` implementiert [`Deref<Target = str>`][2], was bedeutet, dass Sie "
-"alle aufrufen können\n"
-"`str`-Methoden auf einem `String`."
+"`String` implementiert [`Deref<Target = str>`](https://doc.rust-lang.org/std/"
+"string/struct.String.html#deref-methods-str), was bedeutet, dass Sie alle "
+"aufrufen können `str`\\-Methoden auf einem `String`."
 
 #: src/std/string.md:30
 msgid ""
-"* `String::new` returns a new empty string, use `String::with_capacity` when "
-"you know how much data you want to push to the string.\n"
-"* `String::len` returns the size of the `String` in bytes (which can be "
-"different from its length in characters).\n"
-"* `String::chars` returns an iterator over the actual characters. Note that "
-"a `char` can be different from what a human will consider a \"character\" "
-"due to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
-"unicode_segmentation/struct.Graphemes.html).\n"
-"*  When people refer to strings they could either be talking about `&str` or "
-"`String`.  \n"
-"* When a type implements `Deref<Target = T>`, the compiler will let you "
-"transparently call methods from `T`.\n"
-"    * `String` implements `Deref<Target = str>` which transparently gives it "
-"access to `str`'s methods.\n"
-"    * Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;.\n"
-"* `String` is implemented as a wrapper around a vector of bytes, many of the "
+"`String::new` returns a new empty string, use `String::with_capacity` when "
+"you know how much data you want to push to the string."
+msgstr ""
+
+#: src/std/string.md:31
+msgid ""
+"`String::len` returns the size of the `String` in bytes (which can be "
+"different from its length in characters)."
+msgstr ""
+
+#: src/std/string.md:32
+msgid ""
+"`String::chars` returns an iterator over the actual characters. Note that a "
+"`char` can be different from what a human will consider a \"character\" due "
+"to [grapheme clusters](https://docs.rs/unicode-segmentation/latest/"
+"unicode_segmentation/struct.Graphemes.html)."
+msgstr ""
+
+#: src/std/string.md:33
+msgid ""
+"When people refer to strings they could either be talking about `&str` or "
+"`String`."
+msgstr ""
+
+#: src/std/string.md:34
+msgid ""
+"When a type implements `Deref<Target = T>`, the compiler will let you "
+"transparently call methods from `T`."
+msgstr ""
+
+#: src/std/string.md:35
+msgid ""
+"`String` implements `Deref<Target = str>` which transparently gives it "
+"access to `str`'s methods."
+msgstr ""
+
+#: src/std/string.md:36
+msgid "Write and compare `let s3 = s1.deref();` and  `let s3 = &*s1`;."
+msgstr ""
+
+#: src/std/string.md:37
+msgid ""
+"`String` is implemented as a wrapper around a vector of bytes, many of the "
 "operations you see supported on vectors are also supported on `String`, but "
-"with some extra guarantees.\n"
-"* Compare the different ways to index a `String`:\n"
-"    * To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-"
-"bound, out-of-bounds.\n"
-"    * To a substring by using `s3[0..4]`, where that slice is on character "
+"with some extra guarantees."
+msgstr ""
+
+#: src/std/string.md:38
+msgid "Compare the different ways to index a `String`:"
+msgstr ""
+
+#: src/std/string.md:39
+msgid ""
+"To a character by using `s3.chars().nth(i).unwrap()` where `i` is in-bound, "
+"out-of-bounds."
+msgstr ""
+
+#: src/std/string.md:40
+msgid ""
+"To a substring by using `s3[0..4]`, where that slice is on character "
 "boundaries or not."
 msgstr ""
 
 #: src/std/vec.md:1
 #, fuzzy
-msgid "# `Vec`"
-msgstr "# `Vec`"
+msgid "`Vec`"
+msgstr "`Vec`"
 
 #: src/std/vec.md:3
 #, fuzzy
-msgid "[`Vec`][1] is the standard resizable heap-allocated buffer:"
-msgstr "[`Vec`][1] ist der Standardpuffer mit anpassbarer Heapzuweisung:"
+msgid ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) is the standard "
+"resizable heap-allocated buffer:"
+msgstr ""
+"[`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html) ist der "
+"Standardpuffer mit anpassbarer Heapzuweisung:"
 
 #: src/std/vec.md:5
 msgid ""
@@ -8066,40 +8417,51 @@ msgstr ""
 #: src/std/vec.md:29
 #, fuzzy
 msgid ""
-"`Vec` implements [`Deref<Target = [T]>`][2], which means that you can call "
-"slice\n"
+"`Vec` implements [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/vec/"
+"struct.Vec.html#deref-methods-%5BT%5D), which means that you can call slice "
 "methods on a `Vec`."
 msgstr ""
-"`Vec` implementiert [`Deref<Target = [T]>`][2], was bedeutet, dass Sie Slice "
-"aufrufen können\n"
-"Methoden auf einem `Vec`."
+"`Vec` implementiert [`Deref<Target = [T]>`](https://doc.rust-lang.org/std/"
+"vec/struct.Vec.html#deref-methods-%5BT%5D), was bedeutet, dass Sie Slice "
+"aufrufen können Methoden auf einem `Vec`."
 
 #: src/std/vec.md:37
 msgid ""
-"* `Vec` is a type of collection, along with `String` and `HashMap`. The data "
-"it contains is stored\n"
-"  on the heap. This means the amount of data doesn't need to be  known at "
-"compile time. It can grow\n"
-"  or shrink at runtime.\n"
-"* Notice how `Vec<T>` is a generic type too, but you don't have to specify "
-"`T` explicitly. As always\n"
-"  with Rust type inference, the `T` was established during the first `push` "
-"call.\n"
-"* `vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
-"supports adding initial\n"
-"  elements to the vector.\n"
-"* To index the vector you use `[` `]`, but they will panic if out of bounds. "
-"Alternatively, using\n"
-"  `get` will return an `Option`. The `pop` function will remove the last "
-"element.\n"
-"* Show iterating over a vector and mutating the value:\n"
-"  `for e in &mut v { *e += 50; }`"
+"`Vec` is a type of collection, along with `String` and `HashMap`. The data "
+"it contains is stored on the heap. This means the amount of data doesn't "
+"need to be  known at compile time. It can grow or shrink at runtime."
 msgstr ""
 
-#: src/std/hashmap.md:1
+#: src/std/vec.md:40
+msgid ""
+"Notice how `Vec<T>` is a generic type too, but you don't have to specify `T` "
+"explicitly. As always with Rust type inference, the `T` was established "
+"during the first `push` call."
+msgstr ""
+
+#: src/std/vec.md:42
+msgid ""
+"`vec![...]` is a canonical macro to use instead of `Vec::new()` and it "
+"supports adding initial elements to the vector."
+msgstr ""
+
+#: src/std/vec.md:44
+msgid ""
+"To index the vector you use `[` `]`, but they will panic if out of bounds. "
+"Alternatively, using `get` will return an `Option`. The `pop` function will "
+"remove the last element."
+msgstr ""
+
+#: src/std/vec.md:46
+msgid ""
+"Show iterating over a vector and mutating the value: `for e in &mut v { *e "
+"+= 50; }`"
+msgstr ""
+
+#: src/std/hashmap.md:1 src/bare-metal/no_std.md:46
 #, fuzzy
-msgid "# `HashMap`"
-msgstr "# `HashMap`"
+msgid "`HashMap`"
+msgstr "`HashMap`"
 
 #: src/std/hashmap.md:3
 #, fuzzy
@@ -8146,50 +8508,82 @@ msgstr ""
 
 #: src/std/hashmap.md:38
 msgid ""
-"* `HashMap` is not defined in the prelude and needs to be brought into "
-"scope.\n"
-"* Try the following lines of code. The first line will see if a book is in "
-"the hashmap and if not return an alternative value. The second line will "
-"insert the alternative value in the hashmap if the book is not found.\n"
-"\n"
-"     ```rust,ignore\n"
-"       let pc1 = page_counts\n"
-"           .get(\"Harry Potter and the Sorcerer's Stone \")\n"
-"           .unwrap_or(&336);\n"
-"       let pc2 = page_counts\n"
-"           .entry(\"The Hunger Games\".to_string())\n"
-"           .or_insert(374);\n"
-"       ```\n"
-"* Unlike `vec!`, there is unfortunately no standard `hashmap!` macro.\n"
-"  * Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`][1], "
-"which allows us to easily initialize a hash map from a literal array:\n"
-"\n"
-"     ```rust,ignore\n"
-"       let page_counts = HashMap::from([\n"
-"         (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
-"         (\"The Hunger Games\".to_string(), 374),\n"
-"       ]);\n"
-"       ```\n"
-"\n"
-" * Alternatively HashMap can be built from any `Iterator` which yields key-"
-"value tuples.\n"
-"* We are showing `HashMap<String, i32>`, and avoid using `&str` as key to "
-"make examples easier. Using references in collections can, of course, be "
-"done,\n"
-"  but it can lead into complications with the borrow checker.\n"
-"  * Try removing `to_string()` from the example above and see if it still "
+"`HashMap` is not defined in the prelude and needs to be brought into scope."
+msgstr ""
+
+#: src/std/hashmap.md:39
+msgid ""
+"Try the following lines of code. The first line will see if a book is in the "
+"hashmap and if not return an alternative value. The second line will insert "
+"the alternative value in the hashmap if the book is not found."
+msgstr ""
+
+#: src/std/hashmap.md:41
+msgid ""
+"```rust,ignore\n"
+"  let pc1 = page_counts\n"
+"      .get(\"Harry Potter and the Sorcerer's Stone \")\n"
+"      .unwrap_or(&336);\n"
+"  let pc2 = page_counts\n"
+"      .entry(\"The Hunger Games\".to_string())\n"
+"      .or_insert(374);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:49
+msgid "Unlike `vec!`, there is unfortunately no standard `hashmap!` macro."
+msgstr ""
+
+#: src/std/hashmap.md:50
+msgid ""
+"Although, since Rust 1.56, HashMap implements [`From<[(K, V); N]>`](https://"
+"doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#impl-"
+"From%3C%5B(K,+V);+N%5D%3E-for-HashMap%3CK,+V,+RandomState%3E), which allows "
+"us to easily initialize a hash map from a literal array:"
+msgstr ""
+
+#: src/std/hashmap.md:52
+msgid ""
+"```rust,ignore\n"
+"  let page_counts = HashMap::from([\n"
+"    (\"Harry Potter and the Sorcerer's Stone\".to_string(), 336),\n"
+"    (\"The Hunger Games\".to_string(), 374),\n"
+"  ]);\n"
+"```"
+msgstr ""
+
+#: src/std/hashmap.md:59
+msgid ""
+"Alternatively HashMap can be built from any `Iterator` which yields key-"
+"value tuples."
+msgstr ""
+
+#: src/std/hashmap.md:60
+msgid ""
+"We are showing `HashMap<String, i32>`, and avoid using `&str` as key to make "
+"examples easier. Using references in collections can, of course, be done, "
+"but it can lead into complications with the borrow checker."
+msgstr ""
+
+#: src/std/hashmap.md:62
+msgid ""
+"Try removing `to_string()` from the example above and see if it still "
 "compiles. Where do you think we might run into issues?"
 msgstr ""
 
 #: src/std/box.md:1
 #, fuzzy
-msgid "# `Box`"
-msgstr "# `Kasten`"
+msgid "`Box`"
+msgstr "`Kasten`"
 
 #: src/std/box.md:3
 #, fuzzy
-msgid "[`Box`][1] is an owned pointer to data on the heap:"
-msgstr "[`Box`][1] ist ein eigener Zeiger auf Daten auf dem Heap:"
+msgid ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is an owned "
+"pointer to data on the heap:"
+msgstr ""
+"[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) ist ein eigener "
+"Zeiger auf Daten auf dem Heap:"
 
 #: src/std/box.md:5
 msgid ""
@@ -8221,31 +8615,46 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`Box<T>` implements `Deref<Target = T>`, which means that you can [call "
-"methods\n"
-"from `T` directly on a `Box<T>`][2]."
+"methods from `T` directly on a `Box<T>`](https://doc.rust-lang.org/std/ops/"
+"trait.Deref.html#more-on-deref-coercion)."
 msgstr ""
 "`Box<T>` implementiert `Deref<Target = T>`, was bedeutet, dass Sie [Methoden "
-"aufrufen können\n"
-"von `T` direkt auf eine `Box<T>`][2]."
+"aufrufen können von `T` direkt auf eine `Box<T>`](https://doc.rust-lang.org/"
+"std/ops/trait.Deref.html#more-on-deref-coercion)."
 
 #: src/std/box.md:34
 msgid ""
-"* `Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
-"not null. \n"
-"* In the above example, you can even leave out the `*` in the `println!` "
-"statement thanks to `Deref`. \n"
-"* A `Box` can be useful when you:\n"
-"   * have a type whose size that can't be known at compile time, but the "
-"Rust compiler wants to know an exact size.\n"
-"   * want to transfer ownership of a large amount of data. To avoid copying "
-"large amounts of data on the stack, instead store the data on the heap in a "
-"`Box` so only the pointer is moved."
+"`Box` is like `std::unique_ptr` in C++, except that it's guaranteed to be "
+"not null. "
+msgstr ""
+
+#: src/std/box.md:35
+msgid ""
+"In the above example, you can even leave out the `*` in the `println!` "
+"statement thanks to `Deref`. "
+msgstr ""
+
+#: src/std/box.md:36
+msgid "A `Box` can be useful when you:"
+msgstr ""
+
+#: src/std/box.md:37
+msgid ""
+"have a type whose size that can't be known at compile time, but the Rust "
+"compiler wants to know an exact size."
+msgstr ""
+
+#: src/std/box.md:38
+msgid ""
+"want to transfer ownership of a large amount of data. To avoid copying large "
+"amounts of data on the stack, instead store the data on the heap in a `Box` "
+"so only the pointer is moved."
 msgstr ""
 
 #: src/std/box-recursive.md:1
 #, fuzzy
-msgid "# Box with Recursive Data Structures"
-msgstr "# Box mit rekursiven Datenstrukturen"
+msgid "Box with Recursive Data Structures"
+msgstr "Box mit rekursiven Datenstrukturen"
 
 #: src/std/box-recursive.md:3
 #, fuzzy
@@ -8296,36 +8705,32 @@ msgstr ""
 
 #: src/std/box-recursive.md:33
 msgid ""
-"* If the `Box` was not used here and we attempted to embed a `List` directly "
-"into the `List`,\n"
-"the compiler would not compute a fixed size of the struct in memory, it "
-"would look infinite.\n"
-"\n"
-"* `Box` solves this problem as it has the same size as a regular pointer and "
-"just points at the next\n"
-"element of the `List` in the heap.\n"
-"\n"
-"* Remove the `Box` in the List definition and show the compiler error. "
-"\"Recursive with indirection\" is a hint you might want to use a Box or "
-"reference of some kind, instead of storing a value directly.   \n"
-"    "
+"If the `Box` was not used here and we attempted to embed a `List` directly "
+"into the `List`, the compiler would not compute a fixed size of the struct "
+"in memory, it would look infinite."
 msgstr ""
 
-#: src/std/box-niche.md:1
-#, fuzzy
-msgid "# Niche Optimization"
-msgstr "# Nischenoptimierung"
+#: src/std/box-recursive.md:36
+msgid ""
+"`Box` solves this problem as it has the same size as a regular pointer and "
+"just points at the next element of the `List` in the heap."
+msgstr ""
+
+#: src/std/box-recursive.md:39
+msgid ""
+"Remove the `Box` in the List definition and show the compiler error. "
+"\"Recursive with indirection\" is a hint you might want to use a Box or "
+"reference of some kind, instead of storing a value directly."
+msgstr ""
 
 #: src/std/box-niche.md:16
 #, fuzzy
 msgid ""
-"A `Box` cannot be empty, so the pointer is always valid and non-`null`. "
-"This\n"
+"A `Box` cannot be empty, so the pointer is always valid and non-`null`. This "
 "allows the compiler to optimize the memory layout:"
 msgstr ""
 "Eine „Box“ kann nicht leer sein, daher ist der Zeiger immer gültig und nicht "
-"„null“. Das\n"
-"ermöglicht dem Compiler, das Speicherlayout zu optimieren:"
+"„null“. Das ermöglicht dem Compiler, das Speicherlayout zu optimieren:"
 
 #: src/std/box-niche.md:19
 msgid ""
@@ -8351,19 +8756,19 @@ msgstr ""
 
 #: src/std/rc.md:1
 #, fuzzy
-msgid "# `Rc`"
-msgstr "# `Rc`"
+msgid "`Rc`"
+msgstr "`Rc`"
 
 #: src/std/rc.md:3
 #, fuzzy
 msgid ""
-"[`Rc`][1] is a reference-counted shared pointer. Use this when you need to "
-"refer\n"
-"to the same data from multiple places:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) is a reference-"
+"counted shared pointer. Use this when you need to refer to the same data "
+"from multiple places:"
 msgstr ""
-"[`Rc`][1] ist ein referenzgezählter gemeinsamer Zeiger. Verwenden Sie dies, "
-"wenn Sie verweisen müssen\n"
-"auf dieselben Daten von mehreren Orten:"
+"[`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) ist ein "
+"referenzgezählter gemeinsamer Zeiger. Verwenden Sie dies, wenn Sie verweisen "
+"müssen auf dieselben Daten von mehreren Orten:"
 
 #: src/std/rc.md:6
 msgid ""
@@ -8383,38 +8788,65 @@ msgstr ""
 #: src/std/rc.md:18
 #, fuzzy
 msgid ""
-"* If you need to mutate the data inside an `Rc`, you will need to wrap the "
-"data in\n"
-"  a type such as [`Cell` or `RefCell`][2].\n"
-"* See [`Arc`][3] if you are in a multi-threaded context.\n"
-"* You can *downgrade* a shared pointer into a [`Weak`][4] pointer to create "
-"cycles\n"
-"  that will get dropped."
+"If you need to mutate the data inside an `Rc`, you will need to wrap the "
+"data in a type such as [`Cell` or `RefCell`](../concurrency/shared_state/arc."
+"md)."
 msgstr ""
 "Wenn Sie die Daten innerhalb eines „Rc“ mutieren müssen, müssen Sie die "
-"Daten einschließen\n"
-"ein Typ wie [`Cell` oder `RefCell`][2]. Siehe [`Arc`][3], wenn Sie sich in "
-"einem Multithreading befinden\n"
-"Kontext."
+"Daten einschließen ein Typ wie [`Cell` oder `RefCell`](../concurrency/"
+"shared_state/arc.md). Siehe [`Arc`](https://doc.rust-lang.org/std/sync/"
+"struct.Mutex.html), wenn Sie sich in einem Multithreading befinden Kontext."
+
+#: src/std/rc.md:20
+msgid ""
+"See [`Arc`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) if you are "
+"in a multi-threaded context."
+msgstr ""
+
+#: src/std/rc.md:21
+msgid ""
+"You can _downgrade_ a shared pointer into a [`Weak`](https://doc.rust-lang."
+"org/std/rc/struct.Weak.html) pointer to create cycles that will get dropped."
+msgstr ""
 
 #: src/std/rc.md:31
 msgid ""
-"* `Rc`'s count ensures that its contained value is valid for as long as "
-"there are references.\n"
-"* Like C++'s `std::shared_ptr`.\n"
-"* `Rc::clone` is cheap: it creates a pointer to the same allocation and "
+"`Rc`'s count ensures that its contained value is valid for as long as there "
+"are references."
+msgstr ""
+
+#: src/std/rc.md:32
+msgid "Like C++'s `std::shared_ptr`."
+msgstr ""
+
+#: src/std/rc.md:33
+msgid ""
+"`Rc::clone` is cheap: it creates a pointer to the same allocation and "
 "increases the reference count. Does not make a deep clone and can generally "
-"be ignored when looking for performance issues in code.\n"
-"* `make_mut` actually clones the inner value if necessary (\"clone-on-"
-"write\") and returns a mutable reference.\n"
-"* Use `Rc::strong_count` to check the reference count.\n"
-"* Compare the different datatypes mentioned. `Box` enables (im)mutable "
-"borrows that are enforced at compile time. `RefCell` enables (im)mutable "
-"borrows that are enforced at run time and will panic if it fails at "
-"runtime.\n"
-"* `Rc::downgrade` gives you a *weakly reference-counted* object to\n"
-"  create cycles that will be dropped properly (likely in combination with\n"
-"  `RefCell`)."
+"be ignored when looking for performance issues in code."
+msgstr ""
+
+#: src/std/rc.md:34
+msgid ""
+"`make_mut` actually clones the inner value if necessary (\"clone-on-write\") "
+"and returns a mutable reference."
+msgstr ""
+
+#: src/std/rc.md:35
+msgid "Use `Rc::strong_count` to check the reference count."
+msgstr ""
+
+#: src/std/rc.md:36
+msgid ""
+"Compare the different datatypes mentioned. `Box` enables (im)mutable borrows "
+"that are enforced at compile time. `RefCell` enables (im)mutable borrows "
+"that are enforced at run time and will panic if it fails at runtime."
+msgstr ""
+
+#: src/std/rc.md:37
+msgid ""
+"`Rc::downgrade` gives you a _weakly reference-counted_ object to create "
+"cycles that will be dropped properly (likely in combination with `RefCell`)."
 msgstr ""
 
 #: src/std/rc.md:41
@@ -8448,16 +8880,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/modules.md:1
-#, fuzzy
-msgid "# Modules"
-msgstr "# Module"
-
 #: src/modules.md:3
 #, fuzzy
 msgid "We have seen how `impl` blocks let us namespace functions to a type."
 msgstr ""
-"Wir haben gesehen, wie `impl`-Blöcke Namensraumfunktionen zu einem Typ "
+"Wir haben gesehen, wie `impl`\\-Blöcke Namensraumfunktionen zu einem Typ "
 "machen."
 
 #: src/modules.md:5
@@ -8489,17 +8916,19 @@ msgstr ""
 
 #: src/modules.md:28
 msgid ""
-"* Packages provide functionality and include a `Cargo.toml` file that "
-"describes how to build a bundle of 1+ crates.\n"
-"* Crates are a tree of modules, where a binary crate creates an executable "
-"and a library crate compiles to a library.\n"
-"* Modules define organization, scope, and are the focus of this section."
+"Packages provide functionality and include a `Cargo.toml` file that "
+"describes how to build a bundle of 1+ crates."
 msgstr ""
 
-#: src/modules/visibility.md:1
-#, fuzzy
-msgid "# Visibility"
-msgstr "# Sichtbarkeit"
+#: src/modules.md:29
+msgid ""
+"Crates are a tree of modules, where a binary crate creates an executable and "
+"a library crate compiles to a library."
+msgstr ""
+
+#: src/modules.md:30
+msgid "Modules define organization, scope, and are the focus of this section."
+msgstr ""
 
 #: src/modules/visibility.md:3
 #, fuzzy
@@ -8508,16 +8937,20 @@ msgstr "Module sind eine Datenschutzgrenze:"
 
 #: src/modules/visibility.md:5
 #, fuzzy
-msgid ""
-"* Module items are private by default (hides implementation details).\n"
-"* Parent and sibling items are always visible.\n"
-"* In other words, if an item is visible in module `foo`, it's visible in all "
-"the\n"
-"  descendants of `foo`."
+msgid "Module items are private by default (hides implementation details)."
 msgstr ""
-"* Modulelemente sind standardmäßig privat (versteckt "
-"Implementierungsdetails).\n"
-"* Übergeordnete und gleichgeordnete Elemente sind immer sichtbar."
+"Modulelemente sind standardmäßig privat (versteckt Implementierungsdetails)."
+
+#: src/modules/visibility.md:6
+#, fuzzy
+msgid "Parent and sibling items are always visible."
+msgstr "Übergeordnete und gleichgeordnete Elemente sind immer sichtbar."
+
+#: src/modules/visibility.md:7
+msgid ""
+"In other words, if an item is visible in module `foo`, it's visible in all "
+"the descendants of `foo`."
+msgstr ""
 
 #: src/modules/visibility.md:10
 msgid ""
@@ -8550,7 +8983,7 @@ msgid ""
 msgstr ""
 
 #: src/modules/visibility.md:39
-msgid "* Use the `pub` keyword to make modules public."
+msgid "Use the `pub` keyword to make modules public."
 msgstr ""
 
 #: src/modules/visibility.md:41
@@ -8561,18 +8994,23 @@ msgstr ""
 
 #: src/modules/visibility.md:43
 msgid ""
-"* See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-"
-"and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself).\n"
-"* Configuring `pub(crate)` visibility is a common pattern.\n"
-"* Less commonly, you can give visibility to a specific path.\n"
-"* In any case, visibility must be granted to an ancestor module (and all of "
-"its descendants)."
+"See the [Rust Reference](https://doc.rust-lang.org/reference/visibility-and-"
+"privacy.html#pubin-path-pubcrate-pubsuper-and-pubself)."
 msgstr ""
 
-#: src/modules/paths.md:1
-#, fuzzy
-msgid "# Paths"
-msgstr "# Pfade"
+#: src/modules/visibility.md:44
+msgid "Configuring `pub(crate)` visibility is a common pattern."
+msgstr ""
+
+#: src/modules/visibility.md:45
+msgid "Less commonly, you can give visibility to a specific path."
+msgstr ""
+
+#: src/modules/visibility.md:46
+msgid ""
+"In any case, visibility must be granted to an ancestor module (and all of "
+"its descendants)."
+msgstr ""
 
 #: src/modules/paths.md:3
 #, fuzzy
@@ -8581,24 +9019,36 @@ msgstr "Pfade werden wie folgt aufgelöst:"
 
 #: src/modules/paths.md:5
 #, fuzzy
-msgid ""
-"1. As a relative path:\n"
-"   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-"   * `super::foo` refers to `foo` in the parent module.\n"
-"\n"
-"2. As an absolute path:\n"
-"   * `crate::foo` refers to `foo` in the root of the current crate,\n"
-"   * `bar::foo` refers to `foo` in the `bar` crate."
+msgid "As a relative path:"
+msgstr "Als absoluter Pfad:"
+
+#: src/modules/paths.md:6
+#, fuzzy
+msgid "`foo` or `self::foo` refers to `foo` in the current module,"
 msgstr ""
-"2. Als absoluter Pfad:\n"
-"   * `crate::foo` bezieht sich auf `foo` im Stammverzeichnis der aktuellen "
-"Kiste,\n"
-"   * `bar::foo` bezieht sich auf `foo` in der `bar`-Crate."
+"`crate::foo` bezieht sich auf `foo` im Stammverzeichnis der aktuellen Kiste,"
+
+#: src/modules/paths.md:7
+#, fuzzy
+msgid "`super::foo` refers to `foo` in the parent module."
+msgstr "`bar::foo` bezieht sich auf `foo` in der `bar`\\-Crate."
+
+#: src/modules/paths.md:9
+msgid "As an absolute path:"
+msgstr ""
+
+#: src/modules/paths.md:10
+msgid "`crate::foo` refers to `foo` in the root of the current crate,"
+msgstr ""
+
+#: src/modules/paths.md:11
+msgid "`bar::foo` refers to `foo` in the `bar` crate."
+msgstr ""
 
 #: src/modules/paths.md:13
 msgid ""
-"A module can bring symbols from another module into scope with `use`.\n"
-"You will typically see something like this at the top of each module:"
+"A module can bring symbols from another module into scope with `use`. You "
+"will typically see something like this at the top of each module:"
 msgstr ""
 
 #: src/modules/paths.md:16
@@ -8608,11 +9058,6 @@ msgid ""
 "use std::mem::transmute;\n"
 "```"
 msgstr ""
-
-#: src/modules/filesystem.md:1
-#, fuzzy
-msgid "# Filesystem Hierarchy"
-msgstr "# Dateisystemhierarchie"
 
 #: src/modules/filesystem.md:3
 #, fuzzy
@@ -8633,27 +9078,30 @@ msgstr "Die Inhalte des Moduls „Garten“ finden Sie unter:"
 
 #: src/modules/filesystem.md:11
 #, fuzzy
-msgid ""
-"* `src/garden.rs` (modern Rust 2018 style)\n"
-"* `src/garden/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden.rs` (moderner Rust 2018-Stil)\n"
-"* `src/garden/mod.rs` (älterer Rust 2015-Stil)"
+msgid "`src/garden.rs` (modern Rust 2018 style)"
+msgstr "`src/garden.rs` (moderner Rust 2018-Stil)"
+
+#: src/modules/filesystem.md:12
+#, fuzzy
+msgid "`src/garden/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/mod.rs` (älterer Rust 2015-Stil)"
 
 #: src/modules/filesystem.md:14
 #, fuzzy
 msgid "Similarly, a `garden::vegetables` module can be found at:"
 msgstr ""
-"In ähnlicher Weise kann ein `garden::vegetables`-Modul gefunden werden unter:"
+"In ähnlicher Weise kann ein `garden::vegetables`\\-Modul gefunden werden "
+"unter:"
 
 #: src/modules/filesystem.md:16
 #, fuzzy
-msgid ""
-"* `src/garden/vegetables.rs` (modern Rust 2018 style)\n"
-"* `src/garden/vegetables/mod.rs` (older Rust 2015 style)"
-msgstr ""
-"* `src/garden/vegetables.rs` (moderner Rust 2018-Stil)\n"
-"* `src/garden/vegetables/mod.rs` (älterer Rust 2015 Stil)"
+msgid "`src/garden/vegetables.rs` (modern Rust 2018 style)"
+msgstr "`src/garden/vegetables.rs` (moderner Rust 2018-Stil)"
+
+#: src/modules/filesystem.md:17
+#, fuzzy
+msgid "`src/garden/vegetables/mod.rs` (older Rust 2015 style)"
+msgstr "`src/garden/vegetables/mod.rs` (älterer Rust 2015 Stil)"
 
 #: src/modules/filesystem.md:19
 #, fuzzy
@@ -8662,18 +9110,19 @@ msgstr "Die „Kiste“-Wurzel befindet sich in:"
 
 #: src/modules/filesystem.md:21
 #, fuzzy
-msgid ""
-"* `src/lib.rs` (for a library crate)\n"
-"* `src/main.rs` (for a binary crate)"
-msgstr ""
-"* `src/lib.rs` (für eine Bibliothekskiste)\n"
-"* `src/main.rs` (für eine Binärkiste)"
+msgid "`src/lib.rs` (for a library crate)"
+msgstr "`src/lib.rs` (für eine Bibliothekskiste)"
+
+#: src/modules/filesystem.md:22
+#, fuzzy
+msgid "`src/main.rs` (for a binary crate)"
+msgstr "`src/main.rs` (für eine Binärkiste)"
 
 #: src/modules/filesystem.md:24
 msgid ""
 "Modules defined in files can be documented, too, using \"inner doc "
-"comments\".\n"
-"These document the item that contains them -- in this case, a module."
+"comments\". These document the item that contains them -- in this case, a "
+"module."
 msgstr ""
 
 #: src/modules/filesystem.md:27
@@ -8697,42 +9146,55 @@ msgstr ""
 
 #: src/modules/filesystem.md:44
 msgid ""
-"* The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
-"submodules in Rust 2018.\n"
-"  (It was mandatory in Rust 2015.)\n"
-"\n"
-"  The following is valid:\n"
-"\n"
-"  ```ignore\n"
-"  src/\n"
-"  ├── main.rs\n"
-"  ├── top_module.rs\n"
-"  └── top_module/\n"
-"      └── sub_module.rs\n"
-"  ```\n"
-"\n"
-"* The main reason for the change is to prevent many files named `mod.rs`, "
-"which can be hard\n"
-"  to distinguish in IDEs.\n"
-"\n"
-"* Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
-"this can be changed\n"
-"  with a compiler directive:\n"
-"\n"
-"  ```rust,ignore\n"
-"  #[path = \"some/path.rs\"]\n"
-"  mod some_module { }\n"
-"  ```\n"
-"\n"
-"  This is useful, for example, if you would like to place tests for a module "
-"in a file named\n"
-"  `some_module_test.rs`, similar to the convention in Go."
+"The change from `module/mod.rs` to `module.rs` doesn't preclude the use of "
+"submodules in Rust 2018. (It was mandatory in Rust 2015.)"
+msgstr ""
+
+#: src/modules/filesystem.md:47
+msgid "The following is valid:"
+msgstr ""
+
+#: src/modules/filesystem.md:49
+msgid ""
+"```ignore\n"
+"src/\n"
+"├── main.rs\n"
+"├── top_module.rs\n"
+"└── top_module/\n"
+"    └── sub_module.rs\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:57
+msgid ""
+"The main reason for the change is to prevent many files named `mod.rs`, "
+"which can be hard to distinguish in IDEs."
+msgstr ""
+
+#: src/modules/filesystem.md:60
+msgid ""
+"Rust will look for modules in `modulename/mod.rs` and `modulename.rs`, but "
+"this can be changed with a compiler directive:"
+msgstr ""
+
+#: src/modules/filesystem.md:63
+msgid ""
+"```rust,ignore\n"
+"#[path = \"some/path.rs\"]\n"
+"mod some_module { }\n"
+"```"
+msgstr ""
+
+#: src/modules/filesystem.md:68
+msgid ""
+"This is useful, for example, if you would like to place tests for a module "
+"in a file named `some_module_test.rs`, similar to the convention in Go."
 msgstr ""
 
 #: src/exercises/day-2/afternoon.md:1
 #, fuzzy
-msgid "# Day 2: Afternoon Exercises"
-msgstr "# Tag 2: Nachmittagsübungen"
+msgid "Day 2: Afternoon Exercises"
+msgstr "Tag 2: Nachmittagsübungen"
 
 #: src/exercises/day-2/afternoon.md:3
 #, fuzzy
@@ -8741,52 +9203,50 @@ msgstr ""
 "Die Übungen für diesen Nachmittag konzentrieren sich auf Strings und "
 "Iteratoren."
 
-#: src/exercises/day-2/luhn.md:1
-#, fuzzy
-msgid "# Luhn Algorithm"
-msgstr "# Luhn-Algorithmus"
-
 #: src/exercises/day-2/luhn.md:3
 #, fuzzy
 msgid ""
 "The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is used "
-"to\n"
-"validate credit card numbers. The algorithm takes a string as input and does "
-"the\n"
-"following to validate the credit card number:"
+"to validate credit card numbers. The algorithm takes a string as input and "
+"does the following to validate the credit card number:"
 msgstr ""
 "Dazu dient der [Luhn-Algorithmus](https://en.wikipedia.org/wiki/"
-"Luhn_algorithm).\n"
-"Kreditkartennummern validieren. Der Algorithmus nimmt eine Zeichenfolge als "
-"Eingabe und führt die aus\n"
-"Folgendes, um die Kreditkartennummer zu validieren:"
+"Luhn_algorithm). Kreditkartennummern validieren. Der Algorithmus nimmt eine "
+"Zeichenfolge als Eingabe und führt die aus Folgendes, um die "
+"Kreditkartennummer zu validieren:"
 
 #: src/exercises/day-2/luhn.md:7
+msgid "Ignore all spaces. Reject number with less than two digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:9
 msgid ""
-"* Ignore all spaces. Reject number with less than two digits.\n"
-"\n"
-"* Moving from right to left, double every second digit: for the number "
-"`1234`,\n"
-"  we double `3` and `1`.\n"
-"\n"
-"* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-"which\n"
-"  becomes `5`.\n"
-"\n"
-"* Sum all the undoubled and doubled digits.\n"
-"\n"
-"* The credit card number is valid if the sum ends with `0`."
+"Moving from right to left, double every second digit: for the number `1234`, "
+"we double `3` and `1`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:12
+msgid ""
+"After doubling a digit, sum the digits. So doubling `7` becomes `14` which "
+"becomes `5`."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:15
+msgid "Sum all the undoubled and doubled digits."
+msgstr ""
+
+#: src/exercises/day-2/luhn.md:17
+msgid "The credit card number is valid if the sum ends with `0`."
 msgstr ""
 
 #: src/exercises/day-2/luhn.md:19
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and implement the\n"
+"Copy the following code to <https://play.rust-lang.org/> and implement the "
 "function:"
 msgstr ""
 "Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
-"implementieren Sie die\n"
-"Funktion:"
+"implementieren Sie die Funktion:"
 
 #: src/exercises/day-2/luhn.md:23
 msgid ""
@@ -8840,38 +9300,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/strings-iterators.md:1
-#, fuzzy
-msgid "# Strings and Iterators"
-msgstr "# Strings und Iteratoren"
-
 #: src/exercises/day-2/strings-iterators.md:3
 #, fuzzy
 msgid ""
 "In this exercise, you are implementing a routing component of a web server. "
-"The\n"
-"server is configured with a number of _path prefixes_ which are matched "
-"against\n"
-"_request paths_. The path prefixes can contain a wildcard character which\n"
-"matches a full segment. See the unit tests below."
+"The server is configured with a number of _path prefixes_ which are matched "
+"against _request paths_. The path prefixes can contain a wildcard character "
+"which matches a full segment. See the unit tests below."
 msgstr ""
 "In dieser Übung implementieren Sie eine Routing-Komponente eines Webservers. "
-"Der\n"
-"Der Server ist mit einer Reihe von _Pfadpräfixen_ konfiguriert, die "
-"abgeglichen werden\n"
-"_Anfragepfade_. Die Pfadpräfixe können ein Platzhalterzeichen enthalten, "
-"das\n"
-"entspricht einem vollständigen Segment. Siehe die Unit-Tests unten."
+"Der Der Server ist mit einer Reihe von _Pfadpräfixen_ konfiguriert, die "
+"abgeglichen werden _Anfragepfade_. Die Pfadpräfixe können ein "
+"Platzhalterzeichen enthalten, das entspricht einem vollständigen Segment. "
+"Siehe die Unit-Tests unten."
 
 #: src/exercises/day-2/strings-iterators.md:8
 #, fuzzy
 msgid ""
-"Copy the following code to <https://play.rust-lang.org/> and make the tests\n"
+"Copy the following code to <https://play.rust-lang.org/> and make the tests "
 "pass. Try avoiding allocating a `Vec` for your intermediate results:"
 msgstr ""
 "Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
-"führen Sie die Tests durch\n"
-"passieren. Versuchen Sie, Ihren Zwischenergebnissen kein „Vec“ zuzuweisen:"
+"führen Sie die Tests durch passieren. Versuchen Sie, Ihren "
+"Zwischenergebnissen kein „Vec“ zuzuweisen:"
 
 #: src/exercises/day-2/strings-iterators.md:12
 msgid ""
@@ -8924,8 +9375,8 @@ msgstr ""
 
 #: src/welcome-day-3.md:1
 #, fuzzy
-msgid "# Welcome to Day 3"
-msgstr "# Willkommen zu Tag 3"
+msgid "Welcome to Day 3"
+msgstr "Willkommen zu Tag 3"
 
 #: src/welcome-day-3.md:3
 #, fuzzy
@@ -8934,41 +9385,38 @@ msgstr "Heute werden wir einige fortgeschrittenere Themen von Rust behandeln:"
 
 #: src/welcome-day-3.md:5
 msgid ""
-"* Traits: deriving traits, default methods, and important standard library\n"
-"  traits.\n"
-"\n"
-"* Generics: generic data types, generic methods, monomorphization, and "
-"trait\n"
-"  objects.\n"
-"\n"
-"* Error handling: panics, `Result`, and the try operator `?`.\n"
-"\n"
-"* Testing: unit tests, documentation tests, and integration tests.\n"
-"\n"
-"* Unsafe Rust: raw pointers, static variables, unsafe functions, and extern\n"
-"  functions."
+"Traits: deriving traits, default methods, and important standard library "
+"traits."
 msgstr ""
 
-#: src/generics.md:1
-#, fuzzy
-msgid "# Generics"
-msgstr "# Generika"
+#: src/welcome-day-3.md:8
+msgid ""
+"Generics: generic data types, generic methods, monomorphization, and trait "
+"objects."
+msgstr ""
+
+#: src/welcome-day-3.md:11
+msgid "Error handling: panics, `Result`, and the try operator `?`."
+msgstr ""
+
+#: src/welcome-day-3.md:13
+msgid "Testing: unit tests, documentation tests, and integration tests."
+msgstr ""
+
+#: src/welcome-day-3.md:15
+msgid ""
+"Unsafe Rust: raw pointers, static variables, unsafe functions, and extern "
+"functions."
+msgstr ""
 
 #: src/generics.md:3
 #, fuzzy
 msgid ""
 "Rust support generics, which lets you abstract an algorithm (such as "
-"sorting)\n"
-"over the types used in the algorithm."
+"sorting) over the types used in the algorithm."
 msgstr ""
 "Rust unterstützt Generika, mit denen Sie einen Algorithmus abstrahieren "
-"können (z. B. Sortieren)\n"
-"über die im Algorithmus verwendeten Typen."
-
-#: src/generics/data-types.md:1
-#, fuzzy
-msgid "# Generic Data Types"
-msgstr "# Generische Datentypen"
+"können (z. B. Sortieren) über die im Algorithmus verwendeten Typen."
 
 #: src/generics/data-types.md:3
 #, fuzzy
@@ -8993,21 +9441,17 @@ msgid ""
 msgstr ""
 
 #: src/generics/data-types.md:21
-msgid ""
-"* Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`.\n"
-"\n"
-"* Fix the code to allow points that have elements of different types."
+msgid "Try declaring a new variable `let p = Point { x: 5, y: 10.0 };`."
 msgstr ""
 
-#: src/generics/methods.md:1
-#, fuzzy
-msgid "# Generic Methods"
-msgstr "# Generische Methoden"
+#: src/generics/data-types.md:23
+msgid "Fix the code to allow points that have elements of different types."
+msgstr ""
 
 #: src/generics/methods.md:3
 #, fuzzy
 msgid "You can declare a generic type on your `impl` block:"
-msgstr "Sie können einen generischen Typ in Ihrem `impl`-Block deklarieren:"
+msgstr "Sie können einen generischen Typ in Ihrem `impl`\\-Block deklarieren:"
 
 #: src/generics/methods.md:5
 msgid ""
@@ -9033,29 +9477,43 @@ msgstr ""
 #: src/generics/methods.md:25
 #, fuzzy
 msgid ""
-"* *Q:* Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
-"redundant?\n"
-"    * This is because it is a generic implementation section for generic "
-"type. They are independently generic.\n"
-"    * It means these methods are defined for any `T`.\n"
-"    * It is possible to write `impl Point<u32> { .. }`. \n"
-"      * `Point` is still generic and you can use `Point<f64>`, but methods "
-"in this block will only be available for `Point<u32>`."
+"_Q:_ Why `T` is specified twice in `impl<T> Point<T> {}`? Isn't that "
+"redundant?"
 msgstr ""
-"* *F:* Warum wird `T` zweimal in `impl<T> Point<T> {}` angegeben? Ist das "
-"nicht überflüssig?\n"
-"    * Dies liegt daran, dass es sich um einen generischen "
-"Implementierungsabschnitt für einen generischen Typ handelt. Sie sind "
-"unabhängig generisch.\n"
-"    * Dies bedeutet, dass diese Methoden für jedes `T` definiert sind.\n"
-"    * Es ist möglich `impl Point<u32> { .. }` zu schreiben.\n"
-"      * „Point“ ist immer noch generisch und Sie können „Point<f64>“ "
-"verwenden, aber Methoden in diesem Block sind nur für „Point<u32>“ verfügbar."
+"_F:_ Warum wird `T` zweimal in `impl<T> Point<T> {}` angegeben? Ist das "
+"nicht überflüssig?"
 
-#: src/generics/monomorphization.md:1
+#: src/generics/methods.md:26
 #, fuzzy
-msgid "# Monomorphization"
-msgstr "# Monomorphisierung"
+msgid ""
+"This is because it is a generic implementation section for generic type. "
+"They are independently generic."
+msgstr ""
+"Dies liegt daran, dass es sich um einen generischen "
+"Implementierungsabschnitt für einen generischen Typ handelt. Sie sind "
+"unabhängig generisch."
+
+#: src/generics/methods.md:27
+#, fuzzy
+msgid "It means these methods are defined for any `T`."
+msgstr "Dies bedeutet, dass diese Methoden für jedes `T` definiert sind."
+
+#: src/generics/methods.md:28
+#, fuzzy
+msgid "It is possible to write `impl Point<u32> { .. }`. "
+msgstr "Es ist möglich `impl Point<u32> { .. }` zu schreiben."
+
+#: src/generics/methods.md:29
+#, fuzzy
+msgid ""
+"`Point` is still generic and you can use `Point<f64>`, but methods in this "
+"block will only be available for `Point<u32>`."
+msgstr ""
+"„Point“ ist immer noch generisch und Sie können „Point\n"
+"\n"
+"“ verwenden, aber Methoden in diesem Block sind nur für „Point\n"
+"\n"
+"“ verfügbar."
 
 #: src/generics/monomorphization.md:3
 #, fuzzy
@@ -9103,17 +9561,11 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is a zero-cost abstraction: you get exactly the same result as if you "
-"had\n"
-"hand-coded the data structures without the abstraction."
+"had hand-coded the data structures without the abstraction."
 msgstr ""
 "Dies ist eine Null-Kosten-Abstraktion: Sie erhalten genau das gleiche "
-"Ergebnis, als ob Sie es hätten\n"
-"die Datenstrukturen ohne die Abstraktion von Hand codiert."
-
-#: src/traits.md:1
-#, fuzzy
-msgid "# Traits"
-msgstr "# Züge"
+"Ergebnis, als ob Sie es hätten die Datenstrukturen ohne die Abstraktion von "
+"Hand codiert."
 
 #: src/traits.md:3
 #, fuzzy
@@ -9162,11 +9614,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/trait-objects.md:1
-#, fuzzy
-msgid "# Trait Objects"
-msgstr "# Eigenschaftsobjekte"
 
 #: src/traits/trait-objects.md:3
 msgid ""
@@ -9272,41 +9719,54 @@ msgstr ""
 #: src/traits/trait-objects.md:72
 #, fuzzy
 msgid ""
-"* Types that implement a given trait may be of different sizes. This makes "
-"it impossible to have things like `Vec<Pet>` in the example above.\n"
-"* `dyn Pet` is a way to tell the compiler about a dynamically sized type "
-"that implements `Pet`.\n"
-"* In the example, `pets` holds *fat pointers* to objects that implement "
-"`Pet`. The fat pointer consists of two components, a pointer to the actual "
-"object and a pointer to the virtual method table for the `Pet` "
-"implementation of that particular object.\n"
-"* Compare these outputs in the above example:\n"
-"     ```rust,ignore\n"
-"         println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
-"<Cat>());\n"
-"         println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
-"<&Cat>());\n"
-"         println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
-"         println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
-"     ```"
+"Types that implement a given trait may be of different sizes. This makes it "
+"impossible to have things like `Vec<Pet>` in the example above."
 msgstr ""
-"* Merkmale können vorimplementierte (Standard-)Methoden und Methoden "
+"Merkmale können vorimplementierte (Standard-)Methoden und Methoden "
 "spezifizieren, die Benutzer selbst implementieren müssen. Methoden mit "
-"Standardimplementierungen können sich auf erforderliche Methoden stützen.\n"
-"* Typen, die ein bestimmtes Merkmal implementieren, können unterschiedlich "
+"Standardimplementierungen können sich auf erforderliche Methoden stützen."
+
+#: src/traits/trait-objects.md:73
+#, fuzzy
+msgid ""
+"`dyn Pet` is a way to tell the compiler about a dynamically sized type that "
+"implements `Pet`."
+msgstr ""
+"Typen, die ein bestimmtes Merkmal implementieren, können unterschiedlich "
 "groß sein. Das macht es unmöglich Dinge wie `Vec<Greet>` im obigen Beispiel "
-"zu haben.\n"
-"* „dyn Greet“ ist eine Möglichkeit, dem Compiler einen Typ mit dynamischer "
-"Größe mitzuteilen, der „Greet“ implementiert.\n"
-"* Im Beispiel enthält `pets` Fat Pointer auf Objekte, die `Greet` "
+"zu haben."
+
+#: src/traits/trait-objects.md:74
+#, fuzzy
+msgid ""
+"In the example, `pets` holds _fat pointers_ to objects that implement `Pet`. "
+"The fat pointer consists of two components, a pointer to the actual object "
+"and a pointer to the virtual method table for the `Pet` implementation of "
+"that particular object."
+msgstr ""
+"„dyn Greet“ ist eine Möglichkeit, dem Compiler einen Typ mit dynamischer "
+"Größe mitzuteilen, der „Greet“ implementiert."
+
+#: src/traits/trait-objects.md:75
+#, fuzzy
+msgid "Compare these outputs in the above example:"
+msgstr ""
+"Im Beispiel enthält `pets` Fat Pointer auf Objekte, die `Greet` "
 "implementieren. Der Fat Pointer besteht aus zwei Komponenten, einem Zeiger "
 "auf das tatsächliche Objekt und einem Zeiger auf die virtuelle "
 "Methodentabelle für die \"Greet\"-Implementierung dieses bestimmten Objekts."
 
-#: src/traits/deriving-traits.md:1
-#, fuzzy
-msgid "# Deriving Traits"
-msgstr "# Ableitung von Merkmalen"
+#: src/traits/trait-objects.md:76
+msgid ""
+"```rust,ignore\n"
+"    println!(\"{} {}\", std::mem::size_of::<Dog>(), std::mem::size_of::"
+"<Cat>());\n"
+"    println!(\"{} {}\", std::mem::size_of::<&Dog>(), std::mem::size_of::"
+"<&Cat>());\n"
+"    println!(\"{}\", std::mem::size_of::<&dyn Pet>());\n"
+"    println!(\"{}\", std::mem::size_of::<Box<dyn Pet>>());\n"
+"```"
+msgstr ""
 
 #: src/traits/deriving-traits.md:3
 #, fuzzy
@@ -9331,11 +9791,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/traits/default-methods.md:1
-#, fuzzy
-msgid "# Default Methods"
-msgstr "# Standardmethoden"
 
 #: src/traits/default-methods.md:3
 #, fuzzy
@@ -9373,54 +9828,63 @@ msgstr ""
 
 #: src/traits/default-methods.md:32
 msgid ""
-"* Traits may specify pre-implemented (default) methods and methods that "
-"users are required to\n"
-"  implement themselves. Methods with default implementations can rely on "
-"required methods.\n"
-"\n"
-"* Move method `not_equal` to a new trait `NotEqual`.\n"
-"\n"
-"* Make `NotEqual` a super trait for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"\n"
-"* Provide a blanket implementation of `NotEqual` for `Equal`.\n"
-"    ```rust,editable,compile_fail\n"
-"    trait NotEqual {\n"
-"        fn not_equal(&self, other: &Self) -> bool;\n"
-"    }\n"
-"\n"
-"    impl<T> NotEqual for T where T: Equals {\n"
-"        fn not_equal(&self, other: &Self) -> bool {\n"
-"            !self.equal(other)\n"
-"        }\n"
-"    }\n"
-"    ```\n"
-"  * With the blanket implementation, you no longer need `NotEqual` as a "
-"super trait for `Equal`.\n"
-"    "
+"Traits may specify pre-implemented (default) methods and methods that users "
+"are required to implement themselves. Methods with default implementations "
+"can rely on required methods."
 msgstr ""
 
-#: src/traits/trait-bounds.md:1
-#, fuzzy
-msgid "# Trait Bounds"
-msgstr "# Eigenschaftsgrenzen"
+#: src/traits/default-methods.md:35
+msgid "Move method `not_equal` to a new trait `NotEqual`."
+msgstr ""
+
+#: src/traits/default-methods.md:37
+msgid "Make `NotEqual` a super trait for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:38
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:46
+msgid "Provide a blanket implementation of `NotEqual` for `Equal`."
+msgstr ""
+
+#: src/traits/default-methods.md:47
+msgid ""
+"```rust,editable,compile_fail\n"
+"trait NotEqual {\n"
+"    fn not_equal(&self, other: &Self) -> bool;\n"
+"}\n"
+"\n"
+"impl<T> NotEqual for T where T: Equals {\n"
+"    fn not_equal(&self, other: &Self) -> bool {\n"
+"        !self.equal(other)\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/traits/default-methods.md:58
+msgid ""
+"With the blanket implementation, you no longer need `NotEqual` as a super "
+"trait for `Equal`."
+msgstr ""
 
 #: src/traits/trait-bounds.md:3
 #, fuzzy
 msgid ""
-"When working with generics, you often want to require the types to "
-"implement\n"
+"When working with generics, you often want to require the types to implement "
 "some trait, so that you can call this trait's methods."
 msgstr ""
 "Wenn Sie mit Generika arbeiten, möchten Sie häufig die Typen einschränken. "
-"Du kannst das\n"
-"mit `T:Trait` oder `impl Trait`:"
+"Du kannst das mit `T:Trait` oder `impl Trait`:"
 
 #: src/traits/trait-bounds.md:6
 msgid "You can do this with `T: Trait` or `impl Trait`:"
@@ -9472,34 +9936,36 @@ msgstr ""
 
 #: src/traits/trait-bounds.md:46
 #, fuzzy
+msgid "It declutters the function signature if you have many parameters."
+msgstr "Es entrümpelt die Funktionssignatur, wenn Sie viele Parameter haben."
+
+#: src/traits/trait-bounds.md:47
+#, fuzzy
+msgid "It has additional features making it more powerful."
+msgstr "Es hat zusätzliche Funktionen, die es leistungsfähiger machen."
+
+#: src/traits/trait-bounds.md:48
+#, fuzzy
 msgid ""
-"* It declutters the function signature if you have many parameters.\n"
-"* It has additional features making it more powerful.\n"
-"    * If someone asks, the extra feature is that the type on the left of \":"
-"\" can be arbitrary, like `Option<T>`.\n"
-"    "
+"If someone asks, the extra feature is that the type on the left of \":\" can "
+"be arbitrary, like `Option<T>`."
 msgstr ""
-"* Es entrümpelt die Funktionssignatur, wenn Sie viele Parameter haben.\n"
-"* Es hat zusätzliche Funktionen, die es leistungsfähiger machen.\n"
-"    * Wenn jemand fragt, das zusätzliche Feature ist, dass der Typ links von "
-"\":\" beliebig sein kann, wie `Option<T>`.\n"
-"    \n"
-"</Details>"
+"Wenn jemand fragt, das zusätzliche Feature ist, dass der Typ links von \":\" "
+"beliebig sein kann, wie `Option<T>`."
 
 #: src/traits/impl-trait.md:1
 #, fuzzy
-msgid "# `impl Trait`"
-msgstr "# `imple Merkmal`"
+msgid "`impl Trait`"
+msgstr "`imple Merkmal`"
 
 #: src/traits/impl-trait.md:3
 #, fuzzy
 msgid ""
-"Similar to trait bounds, an `impl Trait` syntax can be used in function\n"
+"Similar to trait bounds, an `impl Trait` syntax can be used in function "
 "arguments and return values:"
 msgstr ""
 "Ähnlich wie Merkmalsgrenzen kann eine \"impl Trait\"-Syntax in Funktion "
-"verwendet werden\n"
-"Argumente und Rückgabewerte:"
+"verwendet werden Argumente und Rückgabewerte:"
 
 #: src/traits/impl-trait.md:6
 msgid ""
@@ -9519,10 +9985,11 @@ msgstr ""
 
 #: src/traits/impl-trait.md:19
 #, fuzzy
-msgid "* `impl Trait` allows you to work with types which you cannot name."
+msgid "`impl Trait` allows you to work with types which you cannot name."
 msgstr ""
-"* `impl Trait` kann nicht mit der `::<>` Turbofish-Syntax verwendet werden.\n"
-"* `impl Trait` ermöglicht es Ihnen, mit Typen zu arbeiten, die Sie nicht "
+"`impl Trait` kann nicht mit der `::<>` Turbofish-Syntax verwendet werden.\n"
+"\n"
+"`impl Trait` ermöglicht es Ihnen, mit Typen zu arbeiten, die Sie nicht "
 "benennen können."
 
 #: src/traits/impl-trait.md:23
@@ -9536,65 +10003,54 @@ msgstr ""
 #: src/traits/impl-trait.md:25
 #, fuzzy
 msgid ""
-"* For a parameter, `impl Trait` is like an anonymous generic parameter with "
-"a trait bound.\n"
-"\n"
-"* For a return type, it means that the return type is some concrete type "
-"that implements the trait,\n"
-"  without naming the type. This can be useful when you don't want to expose "
-"the concrete type in a\n"
-"  public API.\n"
-"\n"
-"  Inference is hard in return position. A function returning `impl Foo` "
-"picks\n"
-"  the concrete type it returns, without writing it out in the source. A "
-"function\n"
-"  returning a generic type like `collect<B>() -> B` can return any type\n"
-"  satisfying `B`, and the caller may need to choose one, such as with `let "
-"x:\n"
-"  Vec<_> = foo.collect()` or with the turbofish, `foo.collect::<Vec<_>>()`."
+"For a parameter, `impl Trait` is like an anonymous generic parameter with a "
+"trait bound."
 msgstr ""
-"* Für einen Parameter ist `impl Trait` wie ein anonymer generischer "
-"Parameter mit einer Eigenschaftsbindung.\n"
-"* Für einen Rückgabetyp bedeutet dies, dass der Rückgabetyp ein konkreter "
-"Typ ist, der die Eigenschaft implementiert,\n"
-"  ohne den Typ zu nennen. Dies kann nützlich sein, wenn Sie den konkreten "
-"Typ in a nicht verfügbar machen möchten\n"
-"  öffentliche API."
+"Für einen Parameter ist `impl Trait` wie ein anonymer generischer Parameter "
+"mit einer Eigenschaftsbindung."
+
+#: src/traits/impl-trait.md:27
+#, fuzzy
+msgid ""
+"For a return type, it means that the return type is some concrete type that "
+"implements the trait, without naming the type. This can be useful when you "
+"don't want to expose the concrete type in a public API."
+msgstr ""
+"Für einen Rückgabetyp bedeutet dies, dass der Rückgabetyp ein konkreter Typ "
+"ist, der die Eigenschaft implementiert, ohne den Typ zu nennen. Dies kann "
+"nützlich sein, wenn Sie den konkreten Typ in a nicht verfügbar machen "
+"möchten öffentliche API."
+
+#: src/traits/impl-trait.md:31
+msgid ""
+"Inference is hard in return position. A function returning `impl Foo` picks "
+"the concrete type it returns, without writing it out in the source. A "
+"function returning a generic type like `collect<B>() -> B` can return any "
+"type satisfying `B`, and the caller may need to choose one, such as with "
+"`let x: Vec<_> = foo.collect()` or with the turbofish, `foo.collect::"
+"<Vec<_>>()`."
+msgstr ""
 
 #: src/traits/impl-trait.md:37
 #, fuzzy
 msgid ""
 "This example is great, because it uses `impl Display` twice. It helps to "
-"explain that\n"
-"nothing here enforces that it is _the same_ `impl Display` type. If we used "
-"a single \n"
-"`T: Display`, it would enforce the constraint that input `T` and return `T` "
-"type are the same type.\n"
-"It would not work for this particular function, as the type we expect as "
-"input is likely not\n"
-"what `format!` returns. If we wanted to do the same via `: Display` syntax, "
-"we'd need two\n"
-"independent generic parameters."
+"explain that nothing here enforces that it is _the same_ `impl Display` "
+"type. If we used a single  `T: Display`, it would enforce the constraint "
+"that input `T` and return `T` type are the same type. It would not work for "
+"this particular function, as the type we expect as input is likely not what "
+"`format!` returns. If we wanted to do the same via `: Display` syntax, we'd "
+"need two independent generic parameters."
 msgstr ""
 "Dieses Beispiel ist großartig, weil es `impl Display` zweimal verwendet. Es "
-"hilft, das zu erklären\n"
-"nichts hier erzwingt, dass es _derselbe_ `impl Display`-Typ ist. Wenn wir "
-"eine Single benutzten\n"
-"`T: Display`, es würde die Einschränkung erzwingen, dass der Eingabe-`T`- "
-"und der Rückgabe-`T-Typ derselbe Typ sind.\n"
-"Es würde für diese spezielle Funktion nicht funktionieren, da der Typ, den "
-"wir als Eingabe erwarten, wahrscheinlich nicht der Fall ist\n"
-"welches `format!` zurückgibt. Wenn wir dasselbe über die `: Display`-Syntax "
-"machen wollten, bräuchten wir zwei\n"
-"unabhängige generische Parameter.\n"
-"    \n"
-"</details>"
-
-#: src/traits/important-traits.md:1
-#, fuzzy
-msgid "# Important Traits"
-msgstr "# Wichtige Eigenschaften"
+"hilft, das zu erklären nichts hier erzwingt, dass es _derselbe_ `impl "
+"Display`\\-Typ ist. Wenn wir eine Single benutzten `T: Display`, es würde "
+"die Einschränkung erzwingen, dass der Eingabe-`T`\\- und der Rückgabe-`T-Typ "
+"derselbe Typ sind. Es würde für diese spezielle Funktion nicht "
+"funktionieren, da der Typ, den wir als Eingabe erwarten, wahrscheinlich "
+"nicht der Fall ist welches `format!`zurückgibt. Wenn wir dasselbe über die`: "
+"Display\\`\\-Syntax machen wollten, bräuchten wir zwei unabhängige "
+"generische Parameter."
 
 #: src/traits/important-traits.md:3
 #, fuzzy
@@ -9608,29 +10064,59 @@ msgstr ""
 #: src/traits/important-traits.md:5
 #, fuzzy
 msgid ""
-"* [`Iterator`][1] and [`IntoIterator`][2] used in `for` loops,\n"
-"* [`From`][3] and [`Into`][4] used to convert values,\n"
-"* [`Read`][5] and [`Write`][6] used for IO,\n"
-"* [`Add`][7], [`Mul`][8], ... used for operator overloading, and\n"
-"* [`Drop`][9] used for defining destructors.\n"
-"* [`Default`][10] used to construct a default instance of a type."
+"[`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and "
+"[`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) "
+"used in `for` loops,"
+msgstr "`Iterator` und `IntoIterator` werden in `for`\\-Schleifen verwendet,"
+
+#: src/traits/important-traits.md:6
+#, fuzzy
+msgid ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`]"
+"(https://doc.rust-lang.org/std/convert/trait.Into.html) used to convert "
+"values,"
+msgstr "`From` und `Into` werden verwendet, um Werte zu konvertieren,"
+
+#: src/traits/important-traits.md:7
+#, fuzzy
+msgid ""
+"[`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and [`Write`]"
+"(https://doc.rust-lang.org/std/io/trait.Write.html) used for IO,"
+msgstr "`Lesen` und `Schreiben` für IO verwendet,"
+
+#: src/traits/important-traits.md:8
+#, fuzzy
+msgid ""
+"[`Add`](https://doc.rust-lang.org/std/ops/trait.Add.html), [`Mul`](https://"
+"doc.rust-lang.org/std/ops/trait.Mul.html), ... used for operator "
+"overloading, and"
+msgstr "`Add`, `Mul`, ... wird zum Überladen von Operatoren verwendet, und"
+
+#: src/traits/important-traits.md:9
+#, fuzzy
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) used for "
+"defining destructors."
+msgstr "`Drop` wird zum Definieren von Destruktoren verwendet."
+
+#: src/traits/important-traits.md:10
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) used "
+"to construct a default instance of a type."
 msgstr ""
-"* `Iterator` und `IntoIterator` werden in `for`-Schleifen verwendet,\n"
-"* `From` und `Into` werden verwendet, um Werte zu konvertieren,\n"
-"* `Lesen` und `Schreiben` für IO verwendet,\n"
-"* `Add`, `Mul`, ... wird zum Überladen von Operatoren verwendet, und\n"
-"* `Drop` wird zum Definieren von Destruktoren verwendet."
 
 #: src/traits/iterator.md:1
 #, fuzzy
-msgid "# Iterators"
-msgstr "# Iteratoren"
+msgid "Iterators"
+msgstr "Iteratoren"
 
 #: src/traits/iterator.md:3
 #, fuzzy
-msgid "You can implement the [`Iterator`][1] trait on your own types:"
+msgid ""
+"You can implement the [`Iterator`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html) trait on your own types:"
 msgstr ""
-"Sie können das `Iterator`-Merkmal für Ihre eigenen Typen implementieren:"
+"Sie können das `Iterator`\\-Merkmal für Ihre eigenen Typen implementieren:"
 
 #: src/traits/iterator.md:5
 msgid ""
@@ -9662,31 +10148,27 @@ msgstr ""
 
 #: src/traits/iterator.md:32
 msgid ""
-"* The `Iterator` trait implements many common functional programming "
-"operations over collections \n"
-"  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-"find all the documentation\n"
-"  about them. In Rust these functions should produce the code as efficient "
-"as equivalent imperative\n"
-"  implementations.\n"
-"    \n"
-"* `IntoIterator` is the trait that makes for loops work. It is implemented "
-"by collection types such as\n"
-"  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges also "
-"implement it. This is why\n"
-"  you can iterate over a vector with `for i in some_vec { .. }` but\n"
-"  `some_vec.next()` doesn't exist."
+"The `Iterator` trait implements many common functional programming "
+"operations over collections  (e.g. `map`, `filter`, `reduce`, etc). This is "
+"the trait where you can find all the documentation about them. In Rust these "
+"functions should produce the code as efficient as equivalent imperative "
+"implementations."
 msgstr ""
 
-#: src/traits/from-iterator.md:1
-#, fuzzy
-msgid "# FromIterator"
-msgstr "# FromIterator"
+#: src/traits/iterator.md:37
+msgid ""
+"`IntoIterator` is the trait that makes for loops work. It is implemented by "
+"collection types such as `Vec<T>` and references to them such as `&Vec<T>` "
+"and `&[T]`. Ranges also implement it. This is why you can iterate over a "
+"vector with `for i in some_vec { .. }` but `some_vec.next()` doesn't exist."
+msgstr ""
 
 #: src/traits/from-iterator.md:3
 #, fuzzy
 msgid ""
-"[`FromIterator`][1] lets you build a collection from an [`Iterator`][2]."
+"[`FromIterator`](https://doc.rust-lang.org/std/iter/trait.FromIterator.html) "
+"lets you build a collection from an [`Iterator`](https://doc.rust-lang.org/"
+"std/iter/trait.Iterator.html)."
 msgstr ""
 "Mit „FromIterator“ können Sie eine Sammlung aus einem „Iterator“ erstellen."
 
@@ -9706,36 +10188,33 @@ msgstr ""
 #: src/traits/from-iterator.md:17
 #, fuzzy
 msgid ""
-"`Iterator` implements\n"
-"`fn collect<B>(self) -> B\n"
-"where\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Self: Sized`"
+"`Iterator` implements `fn collect<B>(self) -> B where B: FromIterator<Self::"
+"Item>, Self: Sized`"
 msgstr ""
-"`Iterator`-Implementierungen\n"
-"`fn collect<B>(selbst) -> B\n"
-"Wo\n"
-"    B: FromIterator<Self::Item>,\n"
-"    Selbst: Sized'"
+"`Iterator`\\-Implementierungen \\`fn collect\n"
+"\n"
+"(selbst) -> B Wo B: FromIterator<Self::Item>, Selbst: Sized'"
 
 #: src/traits/from-iterator.md:23
 #, fuzzy
 msgid ""
-"There are also implementations which let you do cool things like convert an\n"
+"There are also implementations which let you do cool things like convert an "
 "`Iterator<Item = Result<V, E>>` into a `Result<Vec<V>, E>`."
 msgstr ""
-"Es gibt auch Implementierungen, mit denen Sie coole Dinge tun können, wie z\n"
+"Es gibt auch Implementierungen, mit denen Sie coole Dinge tun können, wie z "
 "`Iterator<Item = Result<V, E>>` in ein `Result<Vec<V>, E>`."
 
 #: src/traits/from-into.md:1
 #, fuzzy
-msgid "# `From` and `Into`"
-msgstr "# `Von` und `Nach`"
+msgid "`From` and `Into`"
+msgstr "`Von` und `Nach`"
 
 #: src/traits/from-into.md:3
 #, fuzzy
 msgid ""
-"Types implement [`From`][1] and [`Into`][2] to facilitate type conversions:"
+"Types implement [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html) and [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) to "
+"facilitate type conversions:"
 msgstr ""
 "Typen implementieren „From“ und „Into“, um Typkonvertierungen zu erleichtern:"
 
@@ -9755,7 +10234,9 @@ msgstr ""
 #: src/traits/from-into.md:15
 #, fuzzy
 msgid ""
-"[`Into`][2] is automatically implemented when [`From`][1] is implemented:"
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) is "
+"automatically implemented when [`From`](https://doc.rust-lang.org/std/"
+"convert/trait.From.html) is implemented:"
 msgstr "„Into“ wird automatisch implementiert, wenn „From“ implementiert wird:"
 
 #: src/traits/from-into.md:17
@@ -9774,34 +10255,37 @@ msgstr ""
 #: src/traits/from-into.md:29
 #, fuzzy
 msgid ""
-"* That's why it is common to only implement `From`, as your type will get "
-"`Into` implementation too.\n"
-"* When declaring a function argument input type like \"anything that can be "
-"converted into a `String`\", the rule is opposite, you should use `Into`.\n"
-"  Your function will accept types that implement `From` and those that "
-"_only_ implement `Into`.\n"
-"    "
+"That's why it is common to only implement `From`, as your type will get "
+"`Into` implementation too."
 msgstr ""
-"* Aus diesem Grund ist es üblich, nur `From` zu implementieren, da Ihr Typ "
-"auch die `Into`-Implementierung erhält.\n"
-"* Beim Deklarieren eines Funktionsargument-Eingabetyps wie „alles, was in "
+"Aus diesem Grund ist es üblich, nur `From` zu implementieren, da Ihr Typ "
+"auch die `Into`\\-Implementierung erhält."
+
+#: src/traits/from-into.md:30
+#, fuzzy
+msgid ""
+"When declaring a function argument input type like \"anything that can be "
+"converted into a `String`\", the rule is opposite, you should use `Into`. "
+"Your function will accept types that implement `From` and those that _only_ "
+"implement `Into`."
+msgstr ""
+"Beim Deklarieren eines Funktionsargument-Eingabetyps wie „alles, was in "
 "einen „String“ konvertiert werden kann“, ist die Regel umgekehrt, Sie "
-"sollten „Into“ verwenden.\n"
-"  Ihre Funktion akzeptiert Typen, die `From` implementieren, und solche, die "
-"_nur_ `Into` implementieren.\n"
-"    \n"
-"</Details>"
+"sollten „Into“ verwenden. Ihre Funktion akzeptiert Typen, die `From` "
+"implementieren, und solche, die _nur_ `Into` implementieren."
 
 #: src/traits/read-write.md:1
 #, fuzzy
-msgid "# `Read` and `Write`"
-msgstr "# `Lesen` und `Schreiben`"
+msgid "`Read` and `Write`"
+msgstr "`Lesen` und `Schreiben`"
 
 #: src/traits/read-write.md:3
 #, fuzzy
 msgid ""
-"Using [`Read`][1] and [`BufRead`][2], you can abstract over `u8` sources:"
-msgstr "Mit `Read` und `BufRead` können Sie über `u8`-Quellen abstrahieren:"
+"Using [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) and "
+"[`BufRead`](https://doc.rust-lang.org/std/io/trait.BufRead.html), you can "
+"abstract over `u8` sources:"
+msgstr "Mit `Read` und `BufRead` können Sie über `u8`\\-Quellen abstrahieren:"
 
 #: src/traits/read-write.md:5
 msgid ""
@@ -9826,7 +10310,9 @@ msgstr ""
 
 #: src/traits/read-write.md:23
 #, fuzzy
-msgid "Similarly, [`Write`][3] lets you abstract over `u8` sinks:"
+msgid ""
+"Similarly, [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) lets "
+"you abstract over `u8` sinks:"
 msgstr ""
 "In ähnlicher Weise können Sie mit \"Write\" über \"u8\"-Senken abstrahieren:"
 
@@ -9852,14 +10338,14 @@ msgstr ""
 
 #: src/traits/drop.md:1
 #, fuzzy
-msgid "# The `Drop` Trait"
-msgstr "# Die `Drop`-Eigenschaft"
+msgid "The `Drop` Trait"
+msgstr "Die `Drop`\\-Eigenschaft"
 
 #: src/traits/drop.md:3
 #, fuzzy
 msgid ""
-"Values which implement [`Drop`][1] can specify code to run when they go out "
-"of scope:"
+"Values which implement [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop."
+"html) can specify code to run when they go out of scope:"
 msgstr ""
 "Werte, die \"Drop\" implementieren, können Code angeben, der ausgeführt "
 "werden soll, wenn sie den Gültigkeitsbereich verlassen:"
@@ -9901,29 +10387,33 @@ msgstr "Diskussionspunkte:"
 
 #: src/traits/drop.md:36
 #, fuzzy
+msgid "Why doesn't `Drop::drop` take `self`?"
+msgstr "Warum nimmt `Drop::drop` nicht `self`?"
+
+#: src/traits/drop.md:37
+#, fuzzy
 msgid ""
-"* Why doesn't `Drop::drop` take `self`?\n"
-"    * Short-answer: If it did, `std::mem::drop` would be called at the end "
-"of\n"
-"        the block, resulting in another call to `Drop::drop`, and a stack\n"
-"        overflow!\n"
-"* Try replacing `drop(a)` with `a.drop()`."
+"Short-answer: If it did, `std::mem::drop` would be called at the end of the "
+"block, resulting in another call to `Drop::drop`, and a stack overflow!"
 msgstr ""
-"* Warum nimmt `Drop::drop` nicht `self`?\n"
-"    * Kurzantwort: Wenn ja, würde `std::mem::drop` am Ende von aufgerufen "
-"werden\n"
-"        den Block, was zu einem weiteren Aufruf von `Drop::drop` und einem "
-"Stack führt\n"
-"        Überlauf!\n"
-"* Versuchen Sie, `drop(a)` durch `a.drop()` zu ersetzen."
+"Kurzantwort: Wenn ja, würde `std::mem::drop` am Ende von aufgerufen werden "
+"den Block, was zu einem weiteren Aufruf von `Drop::drop` und einem Stack "
+"führt Überlauf!"
+
+#: src/traits/drop.md:40
+#, fuzzy
+msgid "Try replacing `drop(a)` with `a.drop()`."
+msgstr "Versuchen Sie, `drop(a)` durch `a.drop()` zu ersetzen."
 
 #: src/traits/default.md:1
 #, fuzzy
-msgid "# The `Default` Trait"
-msgstr "# Die `Drop`-Eigenschaft"
+msgid "The `Default` Trait"
+msgstr "Die `Drop`\\-Eigenschaft"
 
 #: src/traits/default.md:3
-msgid "[`Default`][1] trait produces a default value for a type."
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) trait "
+"produces a default value for a type."
 msgstr ""
 
 #: src/traits/default.md:5
@@ -9964,26 +10454,45 @@ msgstr ""
 
 #: src/traits/default.md:40
 msgid ""
-"  * It can be implemented directly or it can be derived via "
-"`#[derive(Default)]`.\n"
-"  * Derived implementation will produce an instance where all fields are set "
-"to their default values.\n"
-"    * This means all types in the struct must implement `Default` too.\n"
-"  * Standard Rust types often implement `Default` with reasonable values (e."
-"g. `0`, `\"\"`, etc).\n"
-"  * The partial struct copy works nicely with default.\n"
-"  * Rust standard library is aware that types can implement `Default` and "
+"It can be implemented directly or it can be derived via `#[derive(Default)]`."
+msgstr ""
+
+#: src/traits/default.md:41
+msgid ""
+"Derived implementation will produce an instance where all fields are set to "
+"their default values."
+msgstr ""
+
+#: src/traits/default.md:42
+msgid "This means all types in the struct must implement `Default` too."
+msgstr ""
+
+#: src/traits/default.md:43
+msgid ""
+"Standard Rust types often implement `Default` with reasonable values (e.g. "
+"`0`, `\"\"`, etc)."
+msgstr ""
+
+#: src/traits/default.md:44
+msgid "The partial struct copy works nicely with default."
+msgstr ""
+
+#: src/traits/default.md:45
+msgid ""
+"Rust standard library is aware that types can implement `Default` and "
 "provides convenience methods that use it."
 msgstr ""
 
 #: src/traits/operators.md:1
 #, fuzzy
-msgid "# `Add`, `Mul`, ..."
-msgstr "# `Hinzufügen`, `Mul`, ..."
+msgid "`Add`, `Mul`, ..."
+msgstr "`Hinzufügen`, `Mul`, ..."
 
 #: src/traits/operators.md:3
 #, fuzzy
-msgid "Operator overloading is implemented via traits in [`std::ops`][1]:"
+msgid ""
+"Operator overloading is implemented via traits in [`std::ops`](https://doc."
+"rust-lang.org/std/ops/index.html):"
 msgstr ""
 "Das Überladen von Operatoren wird über Traits in `std::ops` implementiert:"
 
@@ -10012,60 +10521,66 @@ msgstr ""
 #: src/traits/operators.md:28
 #, fuzzy
 msgid ""
-"* You could implement `Add` for `&Point`. In which situations is that "
-"useful? \n"
-"    * Answer: `Add:add` consumes `self`. If type `T` for which you are\n"
-"        overloading the operator is not `Copy`, you should consider "
-"overloading\n"
-"        the operator for `&T` as well. This avoids unnecessary cloning on "
-"the\n"
-"        call site.\n"
-"* Why is `Output` an associated type? Could it be made a type parameter of "
-"the method?\n"
-"    * Short answer: Function type parameters are controlled by the caller, "
-"but\n"
-"        associated types (like `Output`) are controlled by the implementor "
-"of a\n"
-"        trait.\n"
-"* You could implement `Add` for two different types, e.g.\n"
-"  `impl Add<(i32, i32)> for Point` would add a tuple to a `Point`."
+"You could implement `Add` for `&Point`. In which situations is that useful? "
 msgstr ""
-"* Sie könnten `Add` für `&Point` implementieren. In welchen Situationen ist "
-"das sinnvoll?\n"
-"    * Antwort: `Add:add` verbraucht `self`. Geben Sie \"T\" ein, für das Sie "
-"sind\n"
-"        Das Überladen des Operators ist nicht \"Kopieren\", Sie sollten das "
-"Überladen in Betracht ziehen\n"
-"        auch der Operator für `&T`. Dies vermeidet unnötiges Klonen auf der\n"
-"        Website aufrufen.\n"
-"* Warum ist `Output` ein assoziierter Typ? Könnte es ein Typparameter "
-"gemacht werden?\n"
-"    * Kurze Antwort: Typparameter werden vom Aufrufer gesteuert, aber\n"
-"        Zugehörige Typen (wie `Output`) werden vom Implementierer von a "
-"gesteuert\n"
-"        Merkmal."
+"Sie könnten `Add` für `&Point` implementieren. In welchen Situationen ist "
+"das sinnvoll?"
+
+#: src/traits/operators.md:29
+#, fuzzy
+msgid ""
+"Answer: `Add:add` consumes `self`. If type `T` for which you are overloading "
+"the operator is not `Copy`, you should consider overloading the operator for "
+"`&T` as well. This avoids unnecessary cloning on the call site."
+msgstr ""
+"Antwort: `Add:add` verbraucht `self`. Geben Sie \"T\" ein, für das Sie sind "
+"Das Überladen des Operators ist nicht \"Kopieren\", Sie sollten das "
+"Überladen in Betracht ziehen auch der Operator für `&T`. Dies vermeidet "
+"unnötiges Klonen auf der Website aufrufen."
+
+#: src/traits/operators.md:33
+#, fuzzy
+msgid ""
+"Why is `Output` an associated type? Could it be made a type parameter of the "
+"method?"
+msgstr ""
+"Warum ist `Output` ein assoziierter Typ? Könnte es ein Typparameter gemacht "
+"werden?"
+
+#: src/traits/operators.md:34
+#, fuzzy
+msgid ""
+"Short answer: Function type parameters are controlled by the caller, but "
+"associated types (like `Output`) are controlled by the implementor of a "
+"trait."
+msgstr ""
+"Kurze Antwort: Typparameter werden vom Aufrufer gesteuert, aber Zugehörige "
+"Typen (wie `Output`) werden vom Implementierer von a gesteuert Merkmal."
+
+#: src/traits/operators.md:37
+msgid ""
+"You could implement `Add` for two different types, e.g. `impl Add<(i32, "
+"i32)> for Point` would add a tuple to a `Point`."
+msgstr ""
 
 #: src/traits/closures.md:1
 #, fuzzy
-msgid "# Closures"
-msgstr "# Schließungen"
+msgid "Closures"
+msgstr "Schließungen"
 
 #: src/traits/closures.md:3
 #, fuzzy
 msgid ""
 "Closures or lambda expressions have types which cannot be named. However, "
-"they\n"
-"implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and\n"
+"they implement special [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn."
+"html), [`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html), and "
 "[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) traits:"
 msgstr ""
 "Closures oder Lambda-Ausdrücke haben Typen, die nicht benannt werden können. "
-"Allerdings sie\n"
-"spezielles [`Fn`] implementieren (https://doc.rust-lang.org/std/ops/trait.Fn."
-"html),\n"
-"[`FnMut`](https://doc.rust-lang.org/std/ops/trait.FnMut.html) und\n"
-"[`FnOnce`](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) "
-"Eigenschaften:"
+"Allerdings sie spezielles \\[`Fn`\\] implementieren (https://doc.rust-lang."
+"org/std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-lang.org/std/ops/"
+"trait.FnMut.html) und [`FnOnce`](https://doc.rust-lang.org/std/ops/trait."
+"FnOnce.html) Eigenschaften:"
 
 #: src/traits/closures.md:8
 msgid ""
@@ -10107,37 +10622,33 @@ msgstr ""
 #, fuzzy
 msgid ""
 "An `Fn` neither consumes nor mutates captured values, or perhaps captures "
-"nothing at all, so it can\n"
-"be called multiple times concurrently."
+"nothing at all, so it can be called multiple times concurrently."
 msgstr ""
 "Ein „Fn“ verbraucht oder mutiert erfasste Werte nicht oder erfasst "
-"vielleicht gar nichts, also kann es das\n"
-"mehrmals gleichzeitig aufgerufen werden."
+"vielleicht gar nichts, also kann es das mehrmals gleichzeitig aufgerufen "
+"werden."
 
 #: src/traits/closures.md:32
 #, fuzzy
 msgid ""
 "`FnMut` is a subtype of `FnOnce`. `Fn` is a subtype of `FnMut` and `FnOnce`. "
-"I.e. you can use an\n"
-"`FnMut` wherever an `FnOnce` is called for, and you can use an `Fn` wherever "
-"an `FnMut` or `FnOnce`\n"
-"is called for."
+"I.e. you can use an `FnMut` wherever an `FnOnce` is called for, and you can "
+"use an `Fn` wherever an `FnMut` or `FnOnce` is called for."
 msgstr ""
 "`FnMut` ist ein Untertyp von `FnOnce`. „Fn“ ist ein Untertyp von „FnMut“ und "
-"„FnOnce“. D.h. Sie können eine verwenden\n"
-"„FnMut“, wo immer ein „FnOnce“ verlangt wird, und Sie können ein „Fn“ "
-"überall dort verwenden, wo ein „FnMut“ oder „FnOnce“ steht\n"
-"ist angesagt."
+"„FnOnce“. D.h. Sie können eine verwenden „FnMut“, wo immer ein „FnOnce“ "
+"verlangt wird, und Sie können ein „Fn“ überall dort verwenden, wo ein "
+"„FnMut“ oder „FnOnce“ steht ist angesagt."
 
 #: src/traits/closures.md:36
 #, fuzzy
 msgid "`move` closures only implement `FnOnce`."
-msgstr "`move`-Closures implementieren nur `FnOnce`."
+msgstr "`move`\\-Closures implementieren nur `FnOnce`."
 
 #: src/exercises/day-3/morning.md:1
 #, fuzzy
-msgid "# Day 3: Morning Exercises"
-msgstr "# Tag 3: Morgengymnastik"
+msgid "Day 3: Morning Exercises"
+msgstr "Tag 3: Morgengymnastik"
 
 #: src/exercises/day-3/morning.md:3
 #, fuzzy
@@ -10146,20 +10657,14 @@ msgstr ""
 "Wir werden Traits und Trait-Objekte einer klassischen GUI-Bibliothek "
 "entwerfen."
 
-#: src/exercises/day-3/simple-gui.md:1
-#, fuzzy
-msgid "# A Simple GUI Library"
-msgstr "# Eine einfache GUI-Bibliothek"
-
 #: src/exercises/day-3/simple-gui.md:3
 #, fuzzy
 msgid ""
-"Let us design a classical GUI library using our new knowledge of traits and\n"
+"Let us design a classical GUI library using our new knowledge of traits and "
 "trait objects."
 msgstr ""
 "Lassen Sie uns eine klassische GUI-Bibliothek mit unserem neuen Wissen über "
-"Traits und entwerfen\n"
-"Eigenschaftsobjekte."
+"Traits und entwerfen Eigenschaftsobjekte."
 
 #: src/exercises/day-3/simple-gui.md:6
 #, fuzzy
@@ -10168,17 +10673,22 @@ msgstr "Wir werden eine Reihe von Widgets in unserer Bibliothek haben:"
 
 #: src/exercises/day-3/simple-gui.md:8
 #, fuzzy
+msgid "`Window`: has a `title` and contains other widgets."
+msgstr "„Fenster“: hat einen „Titel“ und enthält andere Widgets."
+
+#: src/exercises/day-3/simple-gui.md:9
+#, fuzzy
 msgid ""
-"* `Window`: has a `title` and contains other widgets.\n"
-"* `Button`: has a `label` and a callback function which is invoked when the\n"
-"  button is pressed.\n"
-"* `Label`: has a `label`."
+"`Button`: has a `label` and a callback function which is invoked when the "
+"button is pressed."
 msgstr ""
-"* „Fenster“: hat einen „Titel“ und enthält andere Widgets.\n"
-"* `Button`: hat ein `Label` und eine Callback-Funktion, die aufgerufen wird, "
-"wenn die\n"
-"  Taste gedrückt wird.\n"
-"* `Label`: hat ein `Label`."
+"`Button`: hat ein `Label` und eine Callback-Funktion, die aufgerufen wird, "
+"wenn die Taste gedrückt wird."
+
+#: src/exercises/day-3/simple-gui.md:11
+#, fuzzy
+msgid "`Label`: has a `label`."
+msgstr "`Label`: hat ein `Label`."
 
 #: src/exercises/day-3/simple-gui.md:13
 #, fuzzy
@@ -10188,12 +10698,12 @@ msgstr "Die Widgets implementieren ein „Widget“-Merkmal, siehe unten."
 #: src/exercises/day-3/simple-gui.md:15
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/>, fill in the missing\n"
+"Copy the code below to <https://play.rust-lang.org/>, fill in the missing "
 "`draw_into` methods so that you implement the `Widget` trait:"
 msgstr ""
 "Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
-"füllen Sie die fehlenden aus\n"
-"`draw_into`-Methoden, sodass Sie das `Widget`-Merkmal implementieren:"
+"füllen Sie die fehlenden aus `draw_into`\\-Methoden, sodass Sie das "
+"`Widget`\\-Merkmal implementieren:"
 
 #: src/exercises/day-3/simple-gui.md:18
 msgid ""
@@ -10332,18 +10842,16 @@ msgstr ""
 #: src/exercises/day-3/simple-gui.md:142
 #, fuzzy
 msgid ""
-"If you want to draw aligned text, you can use the\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
-"formatting operators. In particular, notice how you can pad with different\n"
-"characters (here a `'/'`) and how you can control alignment:"
+"If you want to draw aligned text, you can use the [fill/alignment](https://"
+"doc.rust-lang.org/std/fmt/index.html#fillalignment) formatting operators. In "
+"particular, notice how you can pad with different characters (here a `'/'`) "
+"and how you can control alignment:"
 msgstr ""
-"Wenn Sie ausgerichteten Text zeichnen möchten, können Sie die verwenden\n"
-"[fill/alignment](https://doc.rust-lang.org/std/fmt/index."
-"html#fillalignment)\n"
+"Wenn Sie ausgerichteten Text zeichnen möchten, können Sie die verwenden "
+"[fill/alignment](https://doc.rust-lang.org/std/fmt/index.html#fillalignment) "
 "Formatierungsoperatoren. Beachten Sie insbesondere, wie Sie mit "
-"verschiedenen auffüllen können\n"
-"Zeichen (hier ein `'/'`) und wie Sie die Ausrichtung steuern können:"
+"verschiedenen auffüllen können Zeichen (hier ein `'/'`) und wie Sie die "
+"Ausrichtung steuern können:"
 
 #: src/exercises/day-3/simple-gui.md:147
 msgid ""
@@ -10379,11 +10887,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/error-handling.md:1
-#, fuzzy
-msgid "# Error Handling"
-msgstr "# Fehlerbehandlung"
-
 #: src/error-handling.md:3
 #, fuzzy
 msgid "Error handling in Rust is done using explicit control flow:"
@@ -10392,18 +10895,14 @@ msgstr ""
 
 #: src/error-handling.md:5
 #, fuzzy
-msgid ""
-"* Functions that can have errors list this in their return type,\n"
-"* There are no exceptions."
+msgid "Functions that can have errors list this in their return type,"
 msgstr ""
-"* Funktionen, die Fehler haben können, führen dies in ihrem Rückgabetyp "
-"auf,\n"
-"* Es gibt keine Ausnahmen."
+"Funktionen, die Fehler haben können, führen dies in ihrem Rückgabetyp auf,"
 
-#: src/error-handling/panics.md:1
+#: src/error-handling.md:6
 #, fuzzy
-msgid "# Panics"
-msgstr "# Panik"
+msgid "There are no exceptions."
+msgstr "Es gibt keine Ausnahmen."
 
 #: src/error-handling/panics.md:3
 #, fuzzy
@@ -10424,20 +10923,26 @@ msgstr ""
 
 #: src/error-handling/panics.md:12
 #, fuzzy
+msgid "Panics are for unrecoverable and unexpected errors."
+msgstr "Paniken sind für nicht behebbare und unerwartete Fehler."
+
+#: src/error-handling/panics.md:13
+#, fuzzy
+msgid "Panics are symptoms of bugs in the program."
+msgstr "Paniken sind Symptome von Fehlern im Programm."
+
+#: src/error-handling/panics.md:14
+#, fuzzy
 msgid ""
-"* Panics are for unrecoverable and unexpected errors.\n"
-"  * Panics are symptoms of bugs in the program.\n"
-"* Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
+"Use non-panicking APIs (such as `Vec::get`) if crashing is not acceptable."
 msgstr ""
-"* Paniken sind für nicht behebbare und unerwartete Fehler.\n"
-"  * Paniken sind Symptome von Fehlern im Programm.\n"
-"* Verwenden Sie Anti-Panik-APIs (wie `Vec::get`), wenn ein Absturz nicht "
+"Verwenden Sie Anti-Panik-APIs (wie `Vec::get`), wenn ein Absturz nicht "
 "akzeptabel ist."
 
 #: src/error-handling/panic-unwind.md:1
 #, fuzzy
-msgid "# Catching the Stack Unwinding"
-msgstr "# Auffangen des Stapels beim Abwickeln"
+msgid "Catching the Stack Unwinding"
+msgstr "Auffangen des Stapels beim Abwickeln"
 
 #: src/error-handling/panic-unwind.md:3
 #, fuzzy
@@ -10468,31 +10973,32 @@ msgstr ""
 #: src/error-handling/panic-unwind.md:19
 #, fuzzy
 msgid ""
-"* This can be useful in servers which should keep running even if a single\n"
-"  request crashes.\n"
-"* This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+"This can be useful in servers which should keep running even if a single "
+"request crashes."
 msgstr ""
-"* Dies kann bei Servern nützlich sein, die auch bei einem einzigen "
-"weiterlaufen sollen\n"
-"  Anfrage stürzt ab.\n"
-"* Dies funktioniert nicht, wenn in Ihrer `Cargo.toml` `panic = 'abort'` "
+"Dies kann bei Servern nützlich sein, die auch bei einem einzigen "
+"weiterlaufen sollen Anfrage stürzt ab."
+
+#: src/error-handling/panic-unwind.md:21
+#, fuzzy
+msgid "This does not work if `panic = 'abort'` is set in your `Cargo.toml`."
+msgstr ""
+"Dies funktioniert nicht, wenn in Ihrer `Cargo.toml` `panic = 'abort'` "
 "gesetzt ist."
 
 #: src/error-handling/result.md:1
 #, fuzzy
-msgid "# Structured Error Handling with `Result`"
-msgstr "# Strukturierte Fehlerbehandlung mit `Result`"
+msgid "Structured Error Handling with `Result`"
+msgstr "Strukturierte Fehlerbehandlung mit `Result`"
 
 #: src/error-handling/result.md:3
 #, fuzzy
 msgid ""
 "We have already seen the `Result` enum. This is used pervasively when errors "
-"are\n"
-"expected as part of normal operation:"
+"are expected as part of normal operation:"
 msgstr ""
 "Wir haben bereits die Aufzählung `Result` gesehen. Dies wird häufig "
-"verwendet, wenn Fehler vorhanden sind\n"
-"erwartet im Rahmen des Normalbetriebs:"
+"verwendet, wenn Fehler vorhanden sind erwartet im Rahmen des Normalbetriebs:"
 
 #: src/error-handling/result.md:6
 msgid ""
@@ -10519,46 +11025,41 @@ msgstr ""
 #: src/error-handling/result.md:27
 #, fuzzy
 msgid ""
-"  * As with `Option`, the successful value sits inside of `Result`, forcing "
-"the developer to\n"
-"    explicitly extract it. This encourages error checking. In the case where "
-"an error should never happen,\n"
-"    `unwrap()` or `expect()` can be called, and this is a signal of the "
-"developer intent too.  \n"
-"  * `Result` documentation is a recommended read. Not during the course, but "
-"it is worth mentioning. \n"
-"    It contains a lot of convenience methods and functions that help "
-"functional-style programming. \n"
-"    "
+"As with `Option`, the successful value sits inside of `Result`, forcing the "
+"developer to explicitly extract it. This encourages error checking. In the "
+"case where an error should never happen, `unwrap()` or `expect()` can be "
+"called, and this is a signal of the developer intent too."
 msgstr ""
-"  * Wie bei `Option` befindet sich der erfolgreiche Wert innerhalb von "
-"`Result`, was den Entwickler dazu zwingt\n"
-"    explizit extrahieren. Dies fördert die Fehlerprüfung. Für den Fall, dass "
-"niemals ein Fehler passieren sollte,\n"
-"    `unwrap()` oder `expect()` können aufgerufen werden, und dies ist auch "
-"ein Signal für die Absicht des Entwicklers.\n"
-"  * Die `Result`-Dokumentation ist eine empfohlene Lektüre. Nicht während "
-"des Kurses, aber es ist erwähnenswert.\n"
-"    Es enthält viele bequeme Methoden und Funktionen, die bei der "
-"funktionalen Programmierung helfen.\n"
-"    \n"
-"</Details>"
+"Wie bei `Option` befindet sich der erfolgreiche Wert innerhalb von `Result`, "
+"was den Entwickler dazu zwingt explizit extrahieren. Dies fördert die "
+"Fehlerprüfung. Für den Fall, dass niemals ein Fehler passieren sollte, "
+"`unwrap()` oder `expect()` können aufgerufen werden, und dies ist auch ein "
+"Signal für die Absicht des Entwicklers."
+
+#: src/error-handling/result.md:30
+#, fuzzy
+msgid ""
+"`Result` documentation is a recommended read. Not during the course, but it "
+"is worth mentioning.  It contains a lot of convenience methods and functions "
+"that help functional-style programming. "
+msgstr ""
+"Die `Result`\\-Dokumentation ist eine empfohlene Lektüre. Nicht während des "
+"Kurses, aber es ist erwähnenswert. Es enthält viele bequeme Methoden und "
+"Funktionen, die bei der funktionalen Programmierung helfen."
 
 #: src/error-handling/try-operator.md:1
 #, fuzzy
-msgid "# Propagating Errors with `?`"
-msgstr "# Propagieren von Fehlern mit `?`"
+msgid "Propagating Errors with `?`"
+msgstr "Propagieren von Fehlern mit `?`"
 
 #: src/error-handling/try-operator.md:3
 #, fuzzy
 msgid ""
 "The try-operator `?` is used to return errors to the caller. It lets you "
-"turn\n"
-"the common"
+"turn the common"
 msgstr ""
 "Der Try-Operator `?` wird verwendet, um Fehler an den Aufrufer "
-"zurückzugeben. Es lässt dich drehen\n"
-"das gemeine"
+"zurückzugeben. Es lässt dich drehen das gemeine"
 
 #: src/error-handling/try-operator.md:6
 msgid ""
@@ -10619,21 +11120,19 @@ msgstr ""
 #: src/error-handling/try-operator.md:50
 #: src/error-handling/converting-error-types-example.md:52
 #, fuzzy
-msgid ""
-"* The `username` variable can be either `Ok(string)` or `Err(error)`.\n"
-"* Use the `fs::write` call to test out the different scenarios: no file, "
-"empty file, file with username."
+msgid "The `username` variable can be either `Ok(string)` or `Err(error)`."
 msgstr ""
-"* Die Variable „username“ kann entweder „Ok(string)“ oder „Err(error)“ "
-"sein.\n"
-"* Verwenden Sie den `fs::write`-Aufruf, um die verschiedenen Szenarien zu "
-"testen: keine Datei, leere Datei, Datei mit Benutzername."
+"Die Variable „username“ kann entweder „Ok(string)“ oder „Err(error)“ sein."
 
-#: src/error-handling/converting-error-types.md:1
-#: src/error-handling/converting-error-types-example.md:1
+#: src/error-handling/try-operator.md:51
+#: src/error-handling/converting-error-types-example.md:53
 #, fuzzy
-msgid "# Converting Error Types"
-msgstr "# Konvertieren von Fehlertypen"
+msgid ""
+"Use the `fs::write` call to test out the different scenarios: no file, empty "
+"file, file with username."
+msgstr ""
+"Verwenden Sie den `fs::write`\\-Aufruf, um die verschiedenen Szenarien zu "
+"testen: keine Datei, leere Datei, Datei mit Benutzername."
 
 #: src/error-handling/converting-error-types.md:3
 #, fuzzy
@@ -10669,13 +11168,11 @@ msgstr ""
 #: src/error-handling/converting-error-types.md:18
 #, fuzzy
 msgid ""
-"The `From::from` call here means we attempt to convert the error type to "
-"the\n"
+"The `From::from` call here means we attempt to convert the error type to the "
 "type returned by the function:"
 msgstr ""
-"Der `From::from`-Aufruf hier bedeutet, dass wir versuchen, den Fehlertyp in "
-"den zu konvertieren\n"
-"Typ, der von der Funktion zurückgegeben wird:"
+"Der `From::from`\\-Aufruf hier bedeutet, dass wir versuchen, den Fehlertyp "
+"in den zu konvertieren Typ, der von der Funktion zurückgegeben wird:"
 
 #: src/error-handling/converting-error-types-example.md:3
 msgid ""
@@ -10730,36 +11227,26 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice for all error types to implement `std::error::Error`, "
-"which requires `Debug` and\n"
-"`Display`. It's generally helpful for them to implement `Clone` and `Eq` too "
-"where possible, to make\n"
-"life easier for tests and consumers of your library. In this case we can't "
-"easily do so, because\n"
+"which requires `Debug` and `Display`. It's generally helpful for them to "
+"implement `Clone` and `Eq` too where possible, to make life easier for tests "
+"and consumers of your library. In this case we can't easily do so, because "
 "`io::Error` doesn't implement them."
 msgstr ""
 "Es ist eine gute Praxis für alle Fehlertypen, `std::error::Error` zu "
-"implementieren, was `Debug` und erfordert\n"
-"\"Anzeigen\". Es ist im Allgemeinen hilfreich für sie, `Clone` und `Eq` zu "
-"implementieren, wo es möglich ist, zu machen\n"
-"das Leben einfacher für Tests und Benutzer Ihrer Bibliothek. In diesem Fall "
-"können wir das nicht so einfach tun, weil\n"
-"`io::Error` implementiert sie nicht."
-
-#: src/error-handling/deriving-error-enums.md:1
-#, fuzzy
-msgid "# Deriving Error Enums"
-msgstr "# Fehleraufzählungen ableiten"
+"implementieren, was `Debug` und erfordert \"Anzeigen\". Es ist im "
+"Allgemeinen hilfreich für sie, `Clone` und `Eq` zu implementieren, wo es "
+"möglich ist, zu machen das Leben einfacher für Tests und Benutzer Ihrer "
+"Bibliothek. In diesem Fall können wir das nicht so einfach tun, weil `io::"
+"Error` implementiert sie nicht."
 
 #: src/error-handling/deriving-error-enums.md:3
 #, fuzzy
 msgid ""
 "The [thiserror](https://docs.rs/thiserror/) crate is a popular way to create "
-"an\n"
-"error enum like we did on the previous page:"
+"an error enum like we did on the previous page:"
 msgstr ""
 "Die Kiste [thiserror](https://docs.rs/thiserror/) ist eine beliebte Methode "
-"zum Erstellen einer\n"
-"error enum wie auf der vorherigen Seite:"
+"zum Erstellen einer error enum wie auf der vorherigen Seite:"
 
 #: src/error-handling/deriving-error-enums.md:6
 msgid ""
@@ -10799,16 +11286,13 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`thiserror`'s derive macro automatically implements `std::error::Error`, and "
-"optionally `Display`\n"
-"(if the `#[error(...)]` attributes are provided) and `From` (if the "
-"`#[from]` attribute is added).\n"
-"It also works for structs."
+"optionally `Display` (if the `#[error(...)]` attributes are provided) and "
+"`From` (if the `#[from]` attribute is added). It also works for structs."
 msgstr ""
 "Das Ableitungsmakro von `thiserror` implementiert automatisch `std::error::"
-"Error` und optional `Display`\n"
-"(wenn die `#[error(...)]`-Attribute bereitgestellt werden) und `From` (wenn "
-"das `#[from]`-Attribut hinzugefügt wird).\n"
-"Es funktioniert auch für Strukturen."
+"Error` und optional `Display` (wenn die `#[error(...)]`\\-Attribute "
+"bereitgestellt werden) und `From` (wenn das `#[from]`\\-Attribut hinzugefügt "
+"wird). Es funktioniert auch für Strukturen."
 
 #: src/error-handling/deriving-error-enums.md:43
 #, fuzzy
@@ -10817,21 +11301,16 @@ msgstr ""
 "Es wirkt sich nicht auf Ihre öffentliche API aus, was es gut für "
 "Bibliotheken macht."
 
-#: src/error-handling/dynamic-errors.md:1
-#, fuzzy
-msgid "# Dynamic Error Types"
-msgstr "# Dynamische Fehlertypen"
-
 #: src/error-handling/dynamic-errors.md:3
 #, fuzzy
 msgid ""
 "Sometimes we want to allow any type of error to be returned without writing "
-"our own enum covering\n"
-"all the different possibilities. `std::error::Error` makes this easy."
+"our own enum covering all the different possibilities. `std::error::Error` "
+"makes this easy."
 msgstr ""
 "Manchmal möchten wir zulassen, dass jede Art von Fehler zurückgegeben wird, "
-"ohne unsere eigene Enum-Abdeckung zu schreiben\n"
-"all die verschiedenen Möglichkeiten. `std::error::Error` macht das einfach."
+"ohne unsere eigene Enum-Abdeckung zu schreiben all die verschiedenen "
+"Möglichkeiten. `std::error::Error` macht das einfach."
 
 #: src/error-handling/dynamic-errors.md:6
 msgid ""
@@ -10868,38 +11347,27 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This saves on code, but gives up the ability to cleanly handle different "
-"error cases differently in\n"
-"the program. As such it's generally not a good idea to use `Box<dyn Error>` "
-"in the public API of a\n"
-"library, but it can be a good option in a program where you just want to "
-"display the error message\n"
+"error cases differently in the program. As such it's generally not a good "
+"idea to use `Box<dyn Error>` in the public API of a library, but it can be a "
+"good option in a program where you just want to display the error message "
 "somewhere."
 msgstr ""
 "Dies spart Code, gibt aber die Möglichkeit auf, verschiedene Fehlerfälle "
-"sauber unterschiedlich zu behandeln\n"
-"das Programm. Daher ist es im Allgemeinen keine gute Idee, `Box<dyn Error>` "
-"in der öffentlichen API von a zu verwenden\n"
-"Bibliothek, aber es kann eine gute Option in einem Programm sein, in dem Sie "
-"nur die Fehlermeldung anzeigen möchten\n"
-"irgendwo."
-
-#: src/error-handling/error-contexts.md:1
-#, fuzzy
-msgid "# Adding Context to Errors"
-msgstr "# Hinzufügen von Kontext zu Fehlern"
+"sauber unterschiedlich zu behandeln das Programm. Daher ist es im "
+"Allgemeinen keine gute Idee, `Box<dyn Error>` in der öffentlichen API von a "
+"zu verwenden Bibliothek, aber es kann eine gute Option in einem Programm "
+"sein, in dem Sie nur die Fehlermeldung anzeigen möchten irgendwo."
 
 #: src/error-handling/error-contexts.md:3
 #, fuzzy
 msgid ""
-"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add\n"
-"contextual information to your errors and allows you to have fewer\n"
-"custom error types:"
+"The widely used [anyhow](https://docs.rs/anyhow/) crate can help you add "
+"contextual information to your errors and allows you to have fewer custom "
+"error types:"
 msgstr ""
 "Die weit verbreitete Kiste [anyhow](https://docs.rs/anyhow/) kann Ihnen beim "
-"Hinzufügen helfen\n"
-"Kontextinformationen zu Ihren Fehlern und ermöglicht es Ihnen, weniger zu "
-"haben\n"
-"benutzerdefinierte Fehlertypen:"
+"Hinzufügen helfen Kontextinformationen zu Ihren Fehlern und ermöglicht es "
+"Ihnen, weniger zu haben benutzerdefinierte Fehlertypen:"
 
 #: src/error-handling/error-contexts.md:7
 msgid ""
@@ -10932,33 +11400,38 @@ msgstr ""
 
 #: src/error-handling/error-contexts.md:35
 #, fuzzy
-msgid ""
-"* `anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
-"it's again generally not\n"
-"  a good choice for the public API of a library, but is widely used in "
-"applications.\n"
-"* Actual error type inside of it can be extracted for examination if "
-"necessary.\n"
-"* Functionality provided by `anyhow::Result<T>` may be familiar to Go "
-"developers, as it provides\n"
-"  similar usage patterns and ergonomics to `(T, error)` from Go."
-msgstr ""
-"* `anyhow::Result<V>` ist ein Typ-Alias für `Result<V, anyhow::Error>`.\n"
-"* `anyhow::Error` ist im Wesentlichen ein Wrapper um `Box<dyn Error>`. Als "
-"solches ist es wieder im Allgemeinen nicht\n"
-"  eine gute Wahl für die öffentliche API einer Bibliothek, wird aber häufig "
-"in Anwendungen verwendet.\n"
-"* Der darin enthaltene tatsächliche Fehlertyp kann bei Bedarf zur "
-"Untersuchung extrahiert werden.\n"
-"* Die von `anyhow::Result<T>` bereitgestellte Funktionalität ist Go-"
-"Entwicklern möglicherweise vertraut, da sie bereitgestellt wird\n"
-"  ähnliche Nutzungsmuster und Ergonomie wie `(T, error)` von Go."
+msgid "`anyhow::Result<V>` is a type alias for `Result<V, anyhow::Error>`."
+msgstr "`anyhow::Result<V>` ist ein Typ-Alias für `Result<V, anyhow::Error>`."
 
-#: src/testing.md:1
+#: src/error-handling/error-contexts.md:36
 #, fuzzy
-msgid "# Testing"
-msgstr "# Testen"
+msgid ""
+"`anyhow::Error` is essentially a wrapper around `Box<dyn Error>`. As such "
+"it's again generally not a good choice for the public API of a library, but "
+"is widely used in applications."
+msgstr ""
+"`anyhow::Error` ist im Wesentlichen ein Wrapper um `Box<dyn Error>`. Als "
+"solches ist es wieder im Allgemeinen nicht eine gute Wahl für die "
+"öffentliche API einer Bibliothek, wird aber häufig in Anwendungen verwendet."
+
+#: src/error-handling/error-contexts.md:38
+#, fuzzy
+msgid ""
+"Actual error type inside of it can be extracted for examination if necessary."
+msgstr ""
+"Der darin enthaltene tatsächliche Fehlertyp kann bei Bedarf zur Untersuchung "
+"extrahiert werden."
+
+#: src/error-handling/error-contexts.md:39
+#, fuzzy
+msgid ""
+"Functionality provided by `anyhow::Result<T>` may be familiar to Go "
+"developers, as it provides similar usage patterns and ergonomics to `(T, "
+"error)` from Go."
+msgstr ""
+"Die von `anyhow::Result<T>` bereitgestellte Funktionalität ist Go-"
+"Entwicklern möglicherweise vertraut, da sie bereitgestellt wird ähnliche "
+"Nutzungsmuster und Ergonomie wie `(T, error)` von Go."
 
 #: src/testing.md:3
 #, fuzzy
@@ -10967,16 +11440,12 @@ msgstr "Rust und Cargo verfügen über ein einfaches Unit-Test-Framework:"
 
 #: src/testing.md:5
 #, fuzzy
-msgid ""
-"* Unit tests are supported throughout your code.\n"
-"\n"
-"* Integration tests are supported via the `tests/` directory."
-msgstr "* Integrationstests werden über das Verzeichnis „tests/“ unterstützt."
+msgid "Unit tests are supported throughout your code."
+msgstr "Integrationstests werden über das Verzeichnis „tests/“ unterstützt."
 
-#: src/testing/unit-tests.md:1
-#, fuzzy
-msgid "# Unit Tests"
-msgstr "# Einheitentests"
+#: src/testing.md:7
+msgid "Integration tests are supported via the `tests/` directory."
+msgstr ""
 
 #: src/testing/unit-tests.md:3
 #, fuzzy
@@ -11017,18 +11486,13 @@ msgstr ""
 "Verwenden Sie \"Cargo Test\", um die Komponententests zu finden und "
 "auszuführen."
 
-#: src/testing/test-modules.md:1
-#, fuzzy
-msgid "# Test Modules"
-msgstr "# Testmodule"
-
 #: src/testing/test-modules.md:3
 #, fuzzy
 msgid ""
-"Unit tests are often put in a nested module (run tests on the\n"
-"[Playground](https://play.rust-lang.org/)):"
+"Unit tests are often put in a nested module (run tests on the [Playground]"
+"(https://play.rust-lang.org/)):"
 msgstr ""
-"Unit-Tests werden oft in ein verschachteltes Modul eingefügt (Tests auf der\n"
+"Unit-Tests werden oft in ein verschachteltes Modul eingefügt (Tests auf der "
 "[Spielplatz](https://play.rust-lang.org/)):"
 
 #: src/testing/test-modules.md:6
@@ -11056,17 +11520,14 @@ msgstr ""
 
 #: src/testing/test-modules.md:26
 #, fuzzy
-msgid ""
-"* This lets you unit test private helpers.\n"
-"* The `#[cfg(test)]` attribute is only active when you run `cargo test`."
-msgstr ""
-"* Damit können Sie private Helfer testen.\n"
-"* Das Attribut `#[cfg(test)]` ist nur aktiv, wenn Sie `cargo test` ausführen."
+msgid "This lets you unit test private helpers."
+msgstr "Damit können Sie private Helfer testen."
 
-#: src/testing/doc-tests.md:1
+#: src/testing/test-modules.md:27
 #, fuzzy
-msgid "# Documentation Tests"
-msgstr "# Dokumentationstests"
+msgid "The `#[cfg(test)]` attribute is only active when you run `cargo test`."
+msgstr ""
+"Das Attribut `#[cfg(test)]` ist nur aktiv, wenn Sie `cargo test` ausführen."
 
 #: src/testing/doc-tests.md:3
 #, fuzzy
@@ -11091,23 +11552,23 @@ msgstr ""
 
 #: src/testing/doc-tests.md:18
 #, fuzzy
+msgid "Code blocks in `///` comments are automatically seen as Rust code."
+msgstr ""
+"Codeblöcke in `///`\\-Kommentaren werden automatisch als Rust-Code angesehen."
+
+#: src/testing/doc-tests.md:19
+#, fuzzy
+msgid "The code will be compiled and executed as part of `cargo test`."
+msgstr "Der Code wird im Rahmen von „Cargo Test“ kompiliert und ausgeführt."
+
+#: src/testing/doc-tests.md:20
+#, fuzzy
 msgid ""
-"* Code blocks in `///` comments are automatically seen as Rust code.\n"
-"* The code will be compiled and executed as part of `cargo test`.\n"
-"* Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
+"Test the above code on the [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
 msgstr ""
-"* Codeblöcke in `///`-Kommentaren werden automatisch als Rust-Code "
-"angesehen.\n"
-"* Der Code wird im Rahmen von „Cargo Test“ kompiliert und ausgeführt.\n"
-"* Testen Sie den obigen Code auf [Rust Playground](https://play.rust-lang."
-"org/?"
+"Testen Sie den obigen Code auf [Rust Playground](https://play.rust-lang.org/?"
 "version=stable&mode=debug&edition=2021&gist=3ce2ad13ea1302f6572cb15cd96becf0)."
-
-#: src/testing/integration-tests.md:1
-#, fuzzy
-msgid "# Integration Tests"
-msgstr "# Integrationstests"
 
 #: src/testing/integration-tests.md:3
 #, fuzzy
@@ -11119,7 +11580,7 @@ msgstr ""
 #: src/testing/integration-tests.md:5
 #, fuzzy
 msgid "Create a `.rs` file under `tests/`:"
-msgstr "Erstellen Sie eine `.rs`-Datei unter `tests/`:"
+msgstr "Erstellen Sie eine `.rs`\\-Datei unter `tests/`:"
 
 #: src/testing/integration-tests.md:7
 msgid ""
@@ -11139,7 +11600,7 @@ msgid "These tests only have access to the public API of your crate."
 msgstr "Diese Tests haben nur Zugriff auf die öffentliche API Ihrer Crate."
 
 #: src/testing/useful-crates.md:1
-msgid "## Useful crates for writing tests"
+msgid "Useful crates for writing tests"
 msgstr ""
 
 #: src/testing/useful-crates.md:3
@@ -11153,17 +11614,19 @@ msgstr ""
 
 #: src/testing/useful-crates.md:7
 msgid ""
-"* [googletest](https://docs.rs/googletest): Comprehensive test assertion "
-"library in the tradition of GoogleTest for C++.\n"
-"* [proptest](https://docs.rs/proptest): Property-based testing for Rust.\n"
-"* [rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
-"tests."
+"[googletest](https://docs.rs/googletest): Comprehensive test assertion "
+"library in the tradition of GoogleTest for C++."
 msgstr ""
 
-#: src/unsafe.md:1
-#, fuzzy
-msgid "# Unsafe Rust"
-msgstr "# Unsicherer Rost"
+#: src/testing/useful-crates.md:8
+msgid "[proptest](https://docs.rs/proptest): Property-based testing for Rust."
+msgstr ""
+
+#: src/testing/useful-crates.md:9
+msgid ""
+"[rstest](https://docs.rs/rstest): Support for fixtures and parameterised "
+"tests."
+msgstr ""
 
 #: src/unsafe.md:3
 #, fuzzy
@@ -11172,37 +11635,36 @@ msgstr "Die Rust-Sprache besteht aus zwei Teilen:"
 
 #: src/unsafe.md:5
 #, fuzzy
+msgid "**Safe Rust:** memory safe, no undefined behavior possible."
+msgstr "**Safe Rust:** Speichersicher, kein undefiniertes Verhalten möglich."
+
+#: src/unsafe.md:6
+#, fuzzy
 msgid ""
-"* **Safe Rust:** memory safe, no undefined behavior possible.\n"
-"* **Unsafe Rust:** can trigger undefined behavior if preconditions are "
+"**Unsafe Rust:** can trigger undefined behavior if preconditions are "
 "violated."
 msgstr ""
-"* **Safe Rust:** Speichersicher, kein undefiniertes Verhalten möglich.\n"
-"* **Unsicherer Rost:** kann undefiniertes Verhalten auslösen, wenn "
+"**Unsicherer Rost:** kann undefiniertes Verhalten auslösen, wenn "
 "Vorbedingungen verletzt werden."
 
 #: src/unsafe.md:8
 #, fuzzy
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
-"know\n"
-"what Unsafe Rust is."
+"know what Unsafe Rust is."
 msgstr ""
 "Wir werden in diesem Kurs hauptsächlich sicheres Rust sehen, aber es ist "
-"wichtig zu wissen\n"
-"was unsicherer Rost ist."
+"wichtig zu wissen was unsicherer Rost ist."
 
 #: src/unsafe.md:11
 #, fuzzy
 msgid ""
 "Unsafe code is usually small and isolated, and its correctness should be "
-"carefully\n"
-"documented. It is usually wrapped in a safe abstraction layer."
+"carefully documented. It is usually wrapped in a safe abstraction layer."
 msgstr ""
 "Unsicherer Code ist normalerweise klein und isoliert, und seine Korrektheit "
-"sollte sorgfältig geprüft werden\n"
-"dokumentiert. Es ist normalerweise in eine sichere Abstraktionsschicht "
-"eingeschlossen."
+"sollte sorgfältig geprüft werden dokumentiert. Es ist normalerweise in eine "
+"sichere Abstraktionsschicht eingeschlossen."
 
 #: src/unsafe.md:14
 #, fuzzy
@@ -11211,55 +11673,54 @@ msgstr "Unsafe Rust bietet Ihnen Zugriff auf fünf neue Funktionen:"
 
 #: src/unsafe.md:16
 #, fuzzy
-msgid ""
-"* Dereference raw pointers.\n"
-"* Access or modify mutable static variables.\n"
-"* Access `union` fields.\n"
-"* Call `unsafe` functions, including `extern` functions.\n"
-"* Implement `unsafe` traits."
+msgid "Dereference raw pointers."
+msgstr "Rohzeiger dereferenzieren."
+
+#: src/unsafe.md:17
+#, fuzzy
+msgid "Access or modify mutable static variables."
 msgstr ""
-"* Rohzeiger dereferenzieren.\n"
-"* Greifen Sie auf veränderliche statische Variablen zu oder ändern Sie "
-"diese.\n"
-"* Greifen Sie auf `Union`-Felder zu.\n"
-"* „Unsichere“ Funktionen aufrufen, einschließlich „externer“ Funktionen.\n"
-"* Implementieren Sie \"unsichere\" Eigenschaften."
+"Greifen Sie auf veränderliche statische Variablen zu oder ändern Sie diese."
+
+#: src/unsafe.md:18
+#, fuzzy
+msgid "Access `union` fields."
+msgstr "Greifen Sie auf `Union`\\-Felder zu."
+
+#: src/unsafe.md:19
+#, fuzzy
+msgid "Call `unsafe` functions, including `extern` functions."
+msgstr "„Unsichere“ Funktionen aufrufen, einschließlich „externer“ Funktionen."
+
+#: src/unsafe.md:20
+#, fuzzy
+msgid "Implement `unsafe` traits."
+msgstr "Implementieren Sie \"unsichere\" Eigenschaften."
 
 #: src/unsafe.md:22
 #, fuzzy
 msgid ""
-"We will briefly cover unsafe capabilities next. For full details, please "
-"see\n"
+"We will briefly cover unsafe capabilities next. For full details, please see "
 "[Chapter 19.1 in the Rust Book](https://doc.rust-lang.org/book/ch19-01-"
-"unsafe-rust.html)\n"
-"and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
+"unsafe-rust.html) and the [Rustonomicon](https://doc.rust-lang.org/nomicon/)."
 msgstr ""
 "Als nächstes werden wir uns kurz mit unsicheren Fähigkeiten befassen. "
-"Ausführliche Informationen finden Sie unter\n"
-"[Kapitel 19.1 im Rust-Buch](https://doc.rust-lang.org/book/ch19-01-unsafe-"
-"rust.html)\n"
-"und das [Rustonomicon] (https://doc.rust-lang.org/nomicon/)."
+"Ausführliche Informationen finden Sie unter [Kapitel 19.1 im Rust-Buch]"
+"(https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) und das "
+"\\[Rustonomicon\\] (https://doc.rust-lang.org/nomicon/)."
 
 #: src/unsafe.md:28
 #, fuzzy
 msgid ""
 "Unsafe Rust does not mean the code is incorrect. It means that developers "
-"have\n"
-"turned off the compiler safety features and have to write correct code by\n"
-"themselves. It means the compiler no longer enforces Rust's memory-safety "
+"have turned off the compiler safety features and have to write correct code "
+"by themselves. It means the compiler no longer enforces Rust's memory-safety "
 "rules."
 msgstr ""
 "Unsicherer Rost bedeutet nicht, dass der Code falsch ist. Es bedeutet, dass "
-"Entwickler haben\n"
-"die Compiler-Sicherheitsfunktionen ausgeschaltet haben und korrekten Code "
-"schreiben müssen\n"
-"sich. Das bedeutet, dass der Compiler die Speichersicherheitsregeln von Rust "
-"nicht mehr erzwingt."
-
-#: src/unsafe/raw-pointers.md:1
-#, fuzzy
-msgid "# Dereferencing Raw Pointers"
-msgstr "# Rohzeiger dereferenzieren"
+"Entwickler haben die Compiler-Sicherheitsfunktionen ausgeschaltet haben und "
+"korrekten Code schreiben müssen sich. Das bedeutet, dass der Compiler die "
+"Speichersicherheitsregeln von Rust nicht mehr erzwingt."
 
 #: src/unsafe/raw-pointers.md:3
 #, fuzzy
@@ -11296,57 +11757,62 @@ msgstr ""
 #, fuzzy
 msgid ""
 "It is good practice (and required by the Android Rust style guide) to write "
-"a comment for each\n"
-"`unsafe` block explaining how the code inside it satisfies the safety "
-"requirements of the unsafe\n"
-"operations it is doing."
+"a comment for each `unsafe` block explaining how the code inside it "
+"satisfies the safety requirements of the unsafe operations it is doing."
 msgstr ""
 "Es ist eine gute Praxis (und vom Android Rust Styleguide vorgeschrieben), "
-"für jeden einen Kommentar zu schreiben\n"
-"\"unsicherer\" Block, der erklärt, wie der darin enthaltene Code die "
-"Sicherheitsanforderungen des unsicheren Codes erfüllt\n"
-"Operationen, die es tut."
+"für jeden einen Kommentar zu schreiben \"unsicherer\" Block, der erklärt, "
+"wie der darin enthaltene Code die Sicherheitsanforderungen des unsicheren "
+"Codes erfüllt Operationen, die es tut."
 
 #: src/unsafe/raw-pointers.md:31
 #, fuzzy
 msgid ""
-"In the case of pointer dereferences, this means that the pointers must be\n"
+"In the case of pointer dereferences, this means that the pointers must be "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), i.e.:"
 msgstr ""
-"Im Fall von Zeigerdereferenzen bedeutet dies, dass die Zeiger sein müssen\n"
+"Im Fall von Zeigerdereferenzen bedeutet dies, dass die Zeiger sein müssen "
 "[_valid_](https://doc.rust-lang.org/std/ptr/index.html#safety), also:"
 
 #: src/unsafe/raw-pointers.md:34
 #, fuzzy
+msgid "The pointer must be non-null."
+msgstr "Der Zeiger darf nicht null sein."
+
+#: src/unsafe/raw-pointers.md:35
+#, fuzzy
 msgid ""
-" * The pointer must be non-null.\n"
-" * The pointer must be _dereferenceable_ (within the bounds of a single "
-"allocated object).\n"
-" * The object must not have been deallocated.\n"
-" * There must not be concurrent accesses to the same location.\n"
-" * If the pointer was obtained by casting a reference, the underlying object "
-"must be live and no\n"
-"   reference may be used to access the memory."
+"The pointer must be _dereferenceable_ (within the bounds of a single "
+"allocated object)."
 msgstr ""
-" * Der Zeiger darf nicht null sein.\n"
-" * Der Zeiger muss _dereferenzierbar_ sein (innerhalb der Grenzen eines "
-"einzelnen zugewiesenen Objekts).\n"
-" * Das Objekt darf nicht freigegeben worden sein.\n"
-" * Es darf nicht gleichzeitig auf denselben Standort zugegriffen werden.\n"
-" * Wenn der Zeiger durch Casting einer Referenz erhalten wurde, muss das "
-"zugrunde liegende Objekt live sein und nein\n"
-"   Referenz kann verwendet werden, um auf den Speicher zuzugreifen."
+"Der Zeiger muss _dereferenzierbar_ sein (innerhalb der Grenzen eines "
+"einzelnen zugewiesenen Objekts)."
+
+#: src/unsafe/raw-pointers.md:36
+#, fuzzy
+msgid "The object must not have been deallocated."
+msgstr "Das Objekt darf nicht freigegeben worden sein."
+
+#: src/unsafe/raw-pointers.md:37
+#, fuzzy
+msgid "There must not be concurrent accesses to the same location."
+msgstr "Es darf nicht gleichzeitig auf denselben Standort zugegriffen werden."
+
+#: src/unsafe/raw-pointers.md:38
+#, fuzzy
+msgid ""
+"If the pointer was obtained by casting a reference, the underlying object "
+"must be live and no reference may be used to access the memory."
+msgstr ""
+"Wenn der Zeiger durch Casting einer Referenz erhalten wurde, muss das "
+"zugrunde liegende Objekt live sein und nein Referenz kann verwendet werden, "
+"um auf den Speicher zuzugreifen."
 
 #: src/unsafe/raw-pointers.md:41
 #, fuzzy
 msgid "In most cases the pointer must also be properly aligned."
 msgstr ""
 "In den meisten Fällen muss auch der Zeiger richtig ausgerichtet werden."
-
-#: src/unsafe/mutable-static-variables.md:1
-#, fuzzy
-msgid "# Mutable Static Variables"
-msgstr "# Veränderliche statische Variablen"
 
 #: src/unsafe/mutable-static-variables.md:3
 #, fuzzy
@@ -11367,12 +11833,11 @@ msgstr ""
 #: src/unsafe/mutable-static-variables.md:13
 #, fuzzy
 msgid ""
-"However, since data races can occur, it is unsafe to read and write mutable\n"
+"However, since data races can occur, it is unsafe to read and write mutable "
 "static variables:"
 msgstr ""
 "Da es jedoch zu Datenrennen kommen kann, ist es unsicher, änderbar zu lesen "
-"und zu schreiben\n"
-"statische Variablen:"
+"und zu schreiben statische Variablen:"
 
 #: src/unsafe/mutable-static-variables.md:16
 msgid ""
@@ -11395,19 +11860,13 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Using a mutable static is generally a bad idea, but there are some cases "
-"where it might make sense\n"
-"in low-level `no_std` code, such as implementing a heap allocator or working "
-"with some C APIs."
+"where it might make sense in low-level `no_std` code, such as implementing a "
+"heap allocator or working with some C APIs."
 msgstr ""
 "Die Verwendung eines änderbaren statischen Werts ist im Allgemeinen eine "
-"schlechte Idee, aber es gibt einige Fälle, in denen es sinnvoll sein könnte\n"
-"in `no_std`-Code auf niedriger Ebene, wie z. B. die Implementierung eines "
+"schlechte Idee, aber es gibt einige Fälle, in denen es sinnvoll sein könnte "
+"in `no_std`\\-Code auf niedriger Ebene, wie z. B. die Implementierung eines "
 "Heap-Allokators oder die Arbeit mit einigen C-APIs."
-
-#: src/unsafe/unions.md:1
-#, fuzzy
-msgid "# Unions"
-msgstr "# Gewerkschaften"
 
 #: src/unsafe/unions.md:3
 #, fuzzy
@@ -11437,43 +11896,34 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Unions are very rarely needed in Rust as you can usually use an enum. They "
-"are occasionally needed\n"
-"for interacting with C library APIs."
+"are occasionally needed for interacting with C library APIs."
 msgstr ""
 "Unions werden in Rust sehr selten benötigt, da Sie normalerweise eine "
-"Aufzählung verwenden können. Sie werden gelegentlich benötigt\n"
-"für die Interaktion mit C-Bibliotheks-APIs."
+"Aufzählung verwenden können. Sie werden gelegentlich benötigt für die "
+"Interaktion mit C-Bibliotheks-APIs."
 
 #: src/unsafe/unions.md:24
 #, fuzzy
 msgid ""
-"If you just want to reinterpret bytes as a different type, you probably "
-"want\n"
+"If you just want to reinterpret bytes as a different type, you probably want "
 "[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) or a safe\n"
-"wrapper such as the [`zerocopy`](https://crates.io/crates/zerocopy) crate."
+"transmute.html) or a safe wrapper such as the [`zerocopy`](https://crates.io/"
+"crates/zerocopy) crate."
 msgstr ""
 "Wenn Sie Bytes nur als einen anderen Typ neu interpretieren möchten, möchten "
-"Sie dies wahrscheinlich tun\n"
-"[`std::mem::transmute`](https://doc.rust-lang.org/stable/std/mem/fn."
-"transmute.html) oder einen Safe\n"
-"Wrapper wie die Kiste [`zerocopy`](https://crates.io/crates/zerocopy)."
-
-#: src/unsafe/calling-unsafe-functions.md:1
-#, fuzzy
-msgid "# Calling Unsafe Functions"
-msgstr "# Aufruf unsicherer Funktionen"
+"Sie dies wahrscheinlich tun [`std::mem::transmute`](https://doc.rust-lang."
+"org/stable/std/mem/fn.transmute.html) oder einen Safe Wrapper wie die Kiste "
+"[`zerocopy`](https://crates.io/crates/zerocopy)."
 
 #: src/unsafe/calling-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "A function or method can be marked `unsafe` if it has extra preconditions "
-"you\n"
-"must uphold to avoid undefined behaviour:"
+"you must uphold to avoid undefined behaviour:"
 msgstr ""
 "Eine Funktion oder Methode kann als „unsicher“ gekennzeichnet werden, wenn "
-"sie zusätzliche Voraussetzungen für Sie hat\n"
-"muss eingehalten werden, um undefiniertes Verhalten zu vermeiden:"
+"sie zusätzliche Voraussetzungen für Sie hat muss eingehalten werden, um "
+"undefiniertes Verhalten zu vermeiden:"
 
 #: src/unsafe/calling-unsafe-functions.md:6
 msgid ""
@@ -11505,21 +11955,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/unsafe/writing-unsafe-functions.md:1
-#, fuzzy
-msgid "# Writing Unsafe Functions"
-msgstr "# Unsichere Funktionen schreiben"
-
 #: src/unsafe/writing-unsafe-functions.md:3
 #, fuzzy
 msgid ""
 "You can mark your own functions as `unsafe` if they require particular "
-"conditions to avoid undefined\n"
-"behaviour."
+"conditions to avoid undefined behaviour."
 msgstr ""
 "Sie können Ihre eigenen Funktionen als \"unsicher\" markieren, wenn sie "
-"bestimmte Bedingungen erfordern, um undefined zu vermeiden\n"
-"Verhalten."
+"bestimmte Bedingungen erfordern, um undefined zu vermeiden Verhalten."
 
 #: src/unsafe/writing-unsafe-functions.md:6
 msgid ""
@@ -11562,30 +12005,27 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Note that unsafe code is allowed within an unsafe function without an "
-"`unsafe` block. We can\n"
-"prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. Try adding it and see "
-"what happens."
+"`unsafe` block. We can prohibit this with `#[deny(unsafe_op_in_unsafe_fn)]`. "
+"Try adding it and see what happens."
 msgstr ""
 "Beachten Sie, dass unsicherer Code innerhalb einer unsicheren Funktion ohne "
-"einen „unsicheren“ Block zulässig ist. Wir können\n"
-"verbieten Sie dies mit `#[deny(unsafe_op_in_unsafe_fn)]`. Versuchen Sie es "
-"hinzuzufügen und sehen Sie, was passiert."
+"einen „unsicheren“ Block zulässig ist. Wir können verbieten Sie dies mit "
+"`#[deny(unsafe_op_in_unsafe_fn)]`. Versuchen Sie es hinzuzufügen und sehen "
+"Sie, was passiert."
 
 #: src/unsafe/extern-functions.md:1
 #, fuzzy
-msgid "# Calling External Code"
-msgstr "# Externer Code aufrufen"
+msgid "Calling External Code"
+msgstr "Externer Code aufrufen"
 
 #: src/unsafe/extern-functions.md:3
 #, fuzzy
 msgid ""
-"Functions from other languages might violate the guarantees of Rust. "
-"Calling\n"
+"Functions from other languages might violate the guarantees of Rust. Calling "
 "them is thus unsafe:"
 msgstr ""
 "Funktionen aus anderen Sprachen könnten die Garantien von Rust verletzen. "
-"Berufung\n"
-"sie ist somit unsicher:"
+"Berufung sie ist somit unsicher:"
 
 #: src/unsafe/extern-functions.md:6
 msgid ""
@@ -11607,51 +12047,39 @@ msgstr ""
 #, fuzzy
 msgid ""
 "This is usually only a problem for extern functions which do things with "
-"pointers which might\n"
-"violate Rust's memory model, but in general any C function might have "
-"undefined behaviour under any\n"
-"arbitrary circumstances."
+"pointers which might violate Rust's memory model, but in general any C "
+"function might have undefined behaviour under any arbitrary circumstances."
 msgstr ""
 "Dies ist normalerweise nur ein Problem für externe Funktionen, die "
-"möglicherweise Dinge mit Zeigern tun\n"
-"verletzen das Speichermodell von Rust, aber im Allgemeinen kann jede C-"
-"Funktion undefiniertes Verhalten unter jeder haben\n"
-"willkürliche Umstände."
+"möglicherweise Dinge mit Zeigern tun verletzen das Speichermodell von Rust, "
+"aber im Allgemeinen kann jede C-Funktion undefiniertes Verhalten unter jeder "
+"haben willkürliche Umstände."
 
 #: src/unsafe/extern-functions.md:25
 msgid ""
-"The `\"C\"` in this example is the ABI;\n"
-"[other ABIs are available too](https://doc.rust-lang.org/reference/items/"
-"external-blocks.html)."
+"The `\"C\"` in this example is the ABI; [other ABIs are available too]"
+"(https://doc.rust-lang.org/reference/items/external-blocks.html)."
 msgstr ""
-
-#: src/unsafe/unsafe-traits.md:1
-#, fuzzy
-msgid "# Implementing Unsafe Traits"
-msgstr "# Unsichere Merkmale implementieren"
 
 #: src/unsafe/unsafe-traits.md:3
 #, fuzzy
 msgid ""
 "Like with functions, you can mark a trait as `unsafe` if the implementation "
-"must guarantee\n"
-"particular conditions to avoid undefined behaviour."
+"must guarantee particular conditions to avoid undefined behaviour."
 msgstr ""
 "Wie bei Funktionen können Sie ein Merkmal als \"unsicher\" markieren, wenn "
-"die Implementierung dies gewährleisten muss\n"
-"besondere Bedingungen, um undefiniertes Verhalten zu vermeiden."
+"die Implementierung dies gewährleisten muss besondere Bedingungen, um "
+"undefiniertes Verhalten zu vermeiden."
 
 #: src/unsafe/unsafe-traits.md:6
 #, fuzzy
 msgid ""
-"For example, the `zerocopy` crate has an unsafe trait that looks\n"
-"[something like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"For example, the `zerocopy` crate has an unsafe trait that looks [something "
+"like this](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html):"
 msgstr ""
 "Zum Beispiel hat die „Nullkopie“-Kiste eine unsichere Eigenschaft, die "
-"aussieht\n"
-"[etwas in der Art](https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes."
-"html):"
+"aussieht [etwas in der Art](https://docs.rs/zerocopy/latest/zerocopy/trait."
+"AsBytes.html):"
 
 #: src/unsafe/unsafe-traits.md:9
 #, fuzzy
@@ -11676,29 +12104,20 @@ msgid ""
 "unsafe impl AsBytes for u32 {}\n"
 "```"
 msgstr ""
-"/// ...\n"
-"/// # Sicherheit\n"
-"/// Der Typ muss eine definierte Darstellung haben und darf nicht aufgefüllt "
-"werden.\n"
-"pub unsichere Eigenschaft AsBytes {\n"
-"    fn as_bytes(&self) -> &[u8] {\n"
-"        unsicher {\n"
-"            Slice::from_raw_parts(self als *const Self als *const u8, "
-"size_of_val(self))\n"
-"        }\n"
-"    }\n"
-"}"
+"/// ... /// # Sicherheit /// Der Typ muss eine definierte Darstellung haben "
+"und darf nicht aufgefüllt werden. pub unsichere Eigenschaft AsBytes { fn "
+"as_bytes(&self) -> &\\[u8\\] { unsicher { Slice::from_raw_parts(self als "
+"\\*const Self als \\*const u8, size_of_val(self)) } } }"
 
 #: src/unsafe/unsafe-traits.md:30
 #, fuzzy
 msgid ""
 "There should be a `# Safety` section on the Rustdoc for the trait explaining "
-"the requirements for\n"
-"the trait to be safely implemented."
+"the requirements for the trait to be safely implemented."
 msgstr ""
 "Es sollte einen Abschnitt „# Sicherheit“ im Rustdoc für das Merkmal geben, "
-"in dem die Anforderungen für erklärt werden\n"
-"die sicher zu implementierende Eigenschaft."
+"in dem die Anforderungen für erklärt werden die sicher zu implementierende "
+"Eigenschaft."
 
 #: src/unsafe/unsafe-traits.md:33
 #, fuzzy
@@ -11717,8 +12136,8 @@ msgstr ""
 
 #: src/exercises/day-3/afternoon.md:1
 #, fuzzy
-msgid "# Day 3: Afternoon Exercises"
-msgstr "# Tag 3: Nachmittagsübungen"
+msgid "Day 3: Afternoon Exercises"
+msgstr "Tag 3: Nachmittagsübungen"
 
 #: src/exercises/day-3/afternoon.md:3
 #, fuzzy
@@ -11729,29 +12148,24 @@ msgstr ""
 
 #: src/exercises/day-3/afternoon.md:7
 #, fuzzy
-msgid "After looking at the exercise, you can look at the [solution] provided."
+msgid ""
+"After looking at the exercise, you can look at the [solution](solutions-"
+"afternoon.md) provided."
 msgstr ""
 "Nachdem Sie sich die Übung angesehen haben, können Sie sich die "
-"bereitgestellte [Lösung] ansehen."
-
-#: src/exercises/day-3/safe-ffi-wrapper.md:1
-#, fuzzy
-msgid "# Safe FFI Wrapper"
-msgstr "# Sicherer FFI-Wrapper"
+"bereitgestellte \\[Lösung\\] ansehen."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:3
 #, fuzzy
 msgid ""
-"Rust has great support for calling functions through a _foreign function\n"
-"interface_ (FFI). We will use this to build a safe wrapper for the `libc`\n"
+"Rust has great support for calling functions through a _foreign function "
+"interface_ (FFI). We will use this to build a safe wrapper for the `libc` "
 "functions you would use from C to read the filenames of a directory."
 msgstr ""
 "Rust bietet großartige Unterstützung für den Aufruf von Funktionen über eine "
-"_foreign-Funktion\n"
-"Schnittstelle_ (FFI). Wir werden dies verwenden, um einen sicheren Wrapper "
-"für die `libc` zu erstellen\n"
-"Funktionen, die Sie von C verwenden würden, um die Dateinamen eines "
-"Verzeichnisses zu lesen."
+"_foreign-Funktion Schnittstelle_ (FFI). Wir werden dies verwenden, um einen "
+"sicheren Wrapper für die `libc` zu erstellen Funktionen, die Sie von C "
+"verwenden würden, um die Dateinamen eines Verzeichnisses zu lesen."
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:7
 #, fuzzy
@@ -11760,33 +12174,74 @@ msgstr "Sie werden die Handbuchseiten konsultieren wollen:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:9
 #, fuzzy
-msgid ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
-msgstr ""
-"* [`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)\n"
-"* [`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)\n"
-"* [`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgid "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+msgstr "[`opendir(3)`](https://man7.org/linux/man-pages/man3/opendir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:10
+#, fuzzy
+msgid "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+msgstr "[`readdir(3)`](https://man7.org/linux/man-pages/man3/readdir.3.html)"
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:11
+#, fuzzy
+msgid "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
+msgstr "[`closedir(3)`](https://man7.org/linux/man-pages/man3/closedir.3.html)"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:13
 msgid ""
-"You will also want to browse the [`std::ffi`] module. There you find a "
-"number of\n"
-"string types which you need for the exercise:"
+"You will also want to browse the [`std::ffi`](https://doc.rust-lang.org/std/"
+"ffi/) module. There you find a number of string types which you need for the "
+"exercise:"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Encoding"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:16
+msgid "Use"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
 msgid ""
-"| Types                      | Encoding       | "
-"Use                            |\n"
-"|----------------------------|----------------|--------------------------------|\n"
-"| [`str`] and [`String`]     | UTF-8          | Text processing in "
-"Rust        |\n"
-"| [`CStr`] and [`CString`]   | NUL-terminated | Communicating with C "
-"functions |\n"
-"| [`OsStr`] and [`OsString`] | OS-specific    | Communicating with the "
-"OS      |"
+"[`str`](https://doc.rust-lang.org/std/primitive.str.html) and [`String`]"
+"(https://doc.rust-lang.org/std/string/struct.String.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "UTF-8"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:18
+msgid "Text processing in Rust"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid ""
+"[`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html) and [`CString`]"
+"(https://doc.rust-lang.org/std/ffi/struct.CString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "NUL-terminated"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:19
+msgid "Communicating with C functions"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid ""
+"[`OsStr`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and "
+"[`OsString`](https://doc.rust-lang.org/std/ffi/struct.OsString.html)"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "OS-specific"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:20
+msgid "Communicating with the OS"
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:22
@@ -11795,36 +12250,52 @@ msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:24
 msgid ""
-"- `&str` to `CString`: you need to allocate space for a trailing `\\0` "
-"character,\n"
-"- `CString` to `*const i8`: you need a pointer to call C functions,\n"
-"- `*const i8` to `&CStr`: you need something which can find the trailing "
-"`\\0` character,\n"
-"- `&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
-"unknow data\",\n"
-"- `&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use\n"
-"  [`OsStrExt`](https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt."
-"html)\n"
-"  to create it,\n"
-"- `&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able "
-"to return it and call\n"
-"  `readdir` again."
+"`&str` to `CString`: you need to allocate space for a trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:25
+msgid "`CString` to `*const i8`: you need a pointer to call C functions,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:26
+msgid ""
+"`*const i8` to `&CStr`: you need something which can find the trailing `\\0` "
+"character,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:27
+msgid ""
+"`&CStr` to `&[u8]`: a slice of bytes is the universal interface for \"some "
+"unknow data\","
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:28
+msgid ""
+"`&[u8]` to `&OsStr`: `&OsStr` is a step towards `OsString`, use [`OsStrExt`]"
+"(https://doc.rust-lang.org/std/os/unix/ffi/trait.OsStrExt.html) to create it,"
+msgstr ""
+
+#: src/exercises/day-3/safe-ffi-wrapper.md:31
+msgid ""
+"`&OsStr` to `OsString`: you need to clone the data in `&OsStr` to be able to "
+"return it and call `readdir` again."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:34
-msgid "The [Nomicon] also has a very useful chapter about FFI."
+msgid ""
+"The [Nomicon](https://doc.rust-lang.org/nomicon/ffi.html) also has a very "
+"useful chapter about FFI."
 msgstr ""
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:45
 #, fuzzy
 msgid ""
-"Copy the code below to <https://play.rust-lang.org/> and fill in the "
-"missing\n"
+"Copy the code below to <https://play.rust-lang.org/> and fill in the missing "
 "functions and methods:"
 msgstr ""
 "Kopieren Sie den folgenden Code nach <https://play.rust-lang.org/> und "
-"füllen Sie die fehlenden aus\n"
-"Funktionen und Methoden:"
+"füllen Sie die fehlenden aus Funktionen und Methoden:"
 
 #: src/exercises/day-3/safe-ffi-wrapper.md:48
 msgid ""
@@ -11918,56 +12389,43 @@ msgstr ""
 
 #: src/android.md:1
 #, fuzzy
-msgid "# Welcome to Rust in Android"
-msgstr "# Willkommen zu Tag 1"
+msgid "Welcome to Rust in Android"
+msgstr "Willkommen zu Tag 1"
 
 #: src/android.md:3
 #, fuzzy
 msgid ""
 "Rust is supported for native platform development on Android. This means "
-"that\n"
-"you can write new operating system services in Rust, as well as extending\n"
-"existing services."
+"that you can write new operating system services in Rust, as well as "
+"extending existing services."
 msgstr ""
 "Rust wird für die native Plattformentwicklung auf Android unterstützt. Das "
-"bedeutet, dass\n"
-"Sie können neue Betriebssystemdienste in Rust schreiben und erweitern\n"
-"bestehende Dienste."
+"bedeutet, dass Sie können neue Betriebssystemdienste in Rust schreiben und "
+"erweitern bestehende Dienste."
 
 #: src/android.md:7
 #, fuzzy
 msgid ""
-"> We will attempt to call Rust from one of your own projects today. So try "
-"to\n"
-"> find a little corner of your code base where we can move some lines of "
-"code to\n"
-"> Rust. The fewer dependencies and \"exotic\" types the better. Something "
-"that\n"
-"> parses some raw bytes would be ideal."
+"We will attempt to call Rust from one of your own projects today. So try to "
+"find a little corner of your code base where we can move some lines of code "
+"to Rust. The fewer dependencies and \"exotic\" types the better. Something "
+"that parses some raw bytes would be ideal."
 msgstr ""
-"> Wir werden heute versuchen, Rust aus einem Ihrer eigenen Projekte "
-"anzurufen. Versuchen Sie es also\n"
-"> Finden Sie eine kleine Ecke Ihrer Codebasis, in die wir einige Codezeilen "
-"verschieben können\n"
-"> Rost. Je weniger Abhängigkeiten und \"exotische\" Typen, desto besser. "
-"Etwas das\n"
-"> parst einige rohe Bytes wäre ideal."
-
-#: src/android/setup.md:1
-#, fuzzy
-msgid "# Setup"
-msgstr "# Aufstellen"
+"Wir werden heute versuchen, Rust aus einem Ihrer eigenen Projekte anzurufen. "
+"Versuchen Sie es also Finden Sie eine kleine Ecke Ihrer Codebasis, in die "
+"wir einige Codezeilen verschieben können Rost. Je weniger Abhängigkeiten und "
+"\"exotische\" Typen, desto besser. Etwas das parst einige rohe Bytes wäre "
+"ideal."
 
 #: src/android/setup.md:3
 #, fuzzy
 msgid ""
 "We will be using an Android Virtual Device to test our code. Make sure you "
-"have\n"
-"access to one or create a new one with:"
+"have access to one or create a new one with:"
 msgstr ""
 "Wir werden ein Android Virtual Device verwenden, um unseren Code zu testen. "
-"Stell sicher dass du hast\n"
-"Greifen Sie auf eines zu oder erstellen Sie ein neues mit:"
+"Stell sicher dass du hast Greifen Sie auf eines zu oder erstellen Sie ein "
+"neues mit:"
 
 #: src/android/setup.md:6
 msgid ""
@@ -11981,16 +12439,11 @@ msgstr ""
 #: src/android/setup.md:12
 #, fuzzy
 msgid ""
-"Please see the [Android Developer\n"
-"Codelab](https://source.android.com/docs/setup/start) for details."
+"Please see the [Android Developer Codelab](https://source.android.com/docs/"
+"setup/start) for details."
 msgstr ""
-"Bitte lesen Sie die [Android Developer\n"
-"Codelab] (https://source.android.com/docs/setup/start) für Details."
-
-#: src/android/build-rules.md:1
-#, fuzzy
-msgid "# Build Rules"
-msgstr "# Bauregeln"
+"Bitte lesen Sie die \\[Android Developer Codelab\\] (https://source.android."
+"com/docs/setup/start) für Details."
 
 #: src/android/build-rules.md:3
 #, fuzzy
@@ -12001,47 +12454,113 @@ msgstr ""
 
 #: src/android/build-rules.md:5
 #, fuzzy
-msgid ""
-"| Module Type       | "
-"Description                                                                                        "
-"|\n"
-"|-------------------|----------------------------------------------------------------------------------------------------|\n"
-"| `rust_binary`     | Produces a Rust "
-"binary.                                                                            "
-"|\n"
-"| `rust_library`    | Produces a Rust library, and provides both `rlib` and "
-"`dylib` variants.                            |\n"
-"| `rust_ffi`        | Produces a Rust C library usable by `cc` modules, and "
-"provides both static and shared variants.    |\n"
-"| `rust_proc_macro` | Produces a `proc-macro` Rust library. These are "
-"analogous to compiler plugins.                     |\n"
-"| `rust_test`       | Produces a Rust test binary that uses the standard "
-"Rust test harness.                              |\n"
-"| `rust_fuzz`       | Produces a Rust fuzz binary leveraging "
-"`libfuzzer`.                                                |\n"
-"| `rust_protobuf`   | Generates source and produces a Rust library that "
-"provides an interface for a particular protobuf. |\n"
-"| `rust_bindgen`    | Generates source and produces a Rust library "
-"containing Rust bindings to C libraries.              |"
+msgid "Module Type"
+msgstr "Modultyp"
+
+#: src/android/build-rules.md:5
+#, fuzzy
+msgid "Description"
+msgstr "Beschreibung"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "`rust_binary`"
+msgstr "`rust_binary`"
+
+#: src/android/build-rules.md:7
+#, fuzzy
+msgid "Produces a Rust binary."
+msgstr "Erzeugt eine Rust-Binärdatei."
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "`rust_library`"
+msgstr "`rust_library`"
+
+#: src/android/build-rules.md:8
+#, fuzzy
+msgid "Produces a Rust library, and provides both `rlib` and `dylib` variants."
 msgstr ""
-"| Modultyp | Beschreibung |\n"
-"|-------------------|------------------------ "
-"-------------------------------------------------- ---------------------|\n"
-"| `rust_binary` | Erzeugt eine Rust-Binärdatei. |\n"
-"| `rust_library` | Erzeugt eine Rust-Bibliothek und bietet sowohl `rlib`- "
-"als auch `dylib`-Varianten. |\n"
-"| `rust_ffi` | Erzeugt eine Rust-C-Bibliothek, die von `cc`-Modulen "
-"verwendet werden kann, und bietet sowohl statische als auch gemeinsam "
-"genutzte Varianten. |\n"
-"| `rust_proc_macro` | Erzeugt eine `proc-macro` Rust-Bibliothek. Diese sind "
-"analog zu Compiler-Plugins. |\n"
-"| `rust_test` | Erzeugt eine Rust-Test-Binärdatei, die die standardmäßige "
-"Rust-Testumgebung verwendet. |\n"
-"| `rust_fuzz` | Erzeugt eine Rust-Fuzz-Binärdatei, die `libfuzzer` nutzt. |\n"
-"| `rust_protobuf` | Generiert Quellcode und erstellt eine Rust-Bibliothek, "
-"die eine Schnittstelle für einen bestimmten Protobuf bereitstellt. |\n"
-"| `rust_bindgen` | Generiert Quellcode und erstellt eine Rust-Bibliothek, "
-"die Rust-Bindungen an C-Bibliotheken enthält. |"
+"Erzeugt eine Rust-Bibliothek und bietet sowohl `rlib`\\- als auch `dylib`\\-"
+"Varianten."
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid "`rust_ffi`"
+msgstr "`rust_ffi`"
+
+#: src/android/build-rules.md:9
+#, fuzzy
+msgid ""
+"Produces a Rust C library usable by `cc` modules, and provides both static "
+"and shared variants."
+msgstr ""
+"Erzeugt eine Rust-C-Bibliothek, die von `cc`\\-Modulen verwendet werden "
+"kann, und bietet sowohl statische als auch gemeinsam genutzte Varianten."
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid "`rust_proc_macro`"
+msgstr "`rust_proc_macro`"
+
+#: src/android/build-rules.md:10
+#, fuzzy
+msgid ""
+"Produces a `proc-macro` Rust library. These are analogous to compiler "
+"plugins."
+msgstr ""
+"Erzeugt eine `proc-macro` Rust-Bibliothek. Diese sind analog zu Compiler-"
+"Plugins."
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "`rust_test`"
+msgstr "`rust_test`"
+
+#: src/android/build-rules.md:11
+#, fuzzy
+msgid "Produces a Rust test binary that uses the standard Rust test harness."
+msgstr ""
+"Erzeugt eine Rust-Test-Binärdatei, die die standardmäßige Rust-Testumgebung "
+"verwendet."
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "`rust_fuzz`"
+msgstr "`rust_fuzz`"
+
+#: src/android/build-rules.md:12
+#, fuzzy
+msgid "Produces a Rust fuzz binary leveraging `libfuzzer`."
+msgstr "Erzeugt eine Rust-Fuzz-Binärdatei, die `libfuzzer` nutzt."
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid "`rust_protobuf`"
+msgstr "`rust_protobuf`"
+
+#: src/android/build-rules.md:13
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library that provides an interface for "
+"a particular protobuf."
+msgstr ""
+"Generiert Quellcode und erstellt eine Rust-Bibliothek, die eine "
+"Schnittstelle für einen bestimmten Protobuf bereitstellt."
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid "`rust_bindgen`"
+msgstr "`rust_bindgen`"
+
+#: src/android/build-rules.md:14
+#, fuzzy
+msgid ""
+"Generates source and produces a Rust library containing Rust bindings to C "
+"libraries."
+msgstr ""
+"Generiert Quellcode und erstellt eine Rust-Bibliothek, die Rust-Bindungen an "
+"C-Bibliotheken enthält."
 
 #: src/android/build-rules.md:16
 #, fuzzy
@@ -12050,19 +12569,17 @@ msgstr "Als nächstes schauen wir uns `rust_binary` und `rust_library` an."
 
 #: src/android/build-rules/binary.md:1
 #, fuzzy
-msgid "# Rust Binaries"
-msgstr "# Rust-Binärdateien"
+msgid "Rust Binaries"
+msgstr "Rust-Binärdateien"
 
 #: src/android/build-rules/binary.md:3
 #, fuzzy
 msgid ""
 "Let us start with a simple application. At the root of an AOSP checkout, "
-"create\n"
-"the following files:"
+"create the following files:"
 msgstr ""
 "Beginnen wir mit einer einfachen Anwendung. Erstellen Sie im "
-"Stammverzeichnis eines AOSP-Checkouts\n"
-"folgende Dateien:"
+"Stammverzeichnis eines AOSP-Checkouts folgende Dateien:"
 
 #: src/android/build-rules/binary.md:6 src/android/build-rules/library.md:13
 #, fuzzy
@@ -12114,8 +12631,8 @@ msgstr ""
 
 #: src/android/build-rules/library.md:1
 #, fuzzy
-msgid "# Rust Libraries"
-msgstr "# Rust-Bibliotheken"
+msgid "Rust Libraries"
+msgstr "Rust-Bibliotheken"
 
 #: src/android/build-rules/library.md:3
 #, fuzzy
@@ -12131,14 +12648,19 @@ msgstr "Hier deklarieren wir eine Abhängigkeit von zwei Bibliotheken:"
 
 #: src/android/build-rules/library.md:7
 #, fuzzy
+msgid "`libgreeting`, which we define below,"
+msgstr "`libgreeting`, das wir unten definieren,"
+
+#: src/android/build-rules/library.md:8
+#, fuzzy
 msgid ""
-"* `libgreeting`, which we define below,\n"
-"* `libtextwrap`, which is a crate already vendored in\n"
-"  [`external/rust/crates/`][crates]."
+"`libtextwrap`, which is a crate already vendored in [`external/rust/crates/`]"
+"(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
+"crates/)."
 msgstr ""
-"* `libgreeting`, das wir unten definieren,\n"
-"* `libtextwrap`, das ist eine Kiste, in der bereits verkauft wird\n"
-"  [`extern/rust/crates/`][crates]."
+"`libtextwrap`, das ist eine Kiste, in der bereits verkauft wird [`extern/"
+"rust/crates/`](https://cs.android.com/android/platform/superproject/+/master:"
+"external/rust/crates/)."
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -12211,35 +12733,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl.md:1
-#, fuzzy
-msgid "# AIDL"
-msgstr "# AIDL"
-
 #: src/android/aidl.md:3
 #, fuzzy
 msgid ""
-"The [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) is supported in "
-"Rust:"
+"The [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) is supported in Rust:"
 msgstr ""
-"Die [Android Interface Definition Language\n"
-"(AIDL)](https://developer.android.com/guide/components/aidl) wird in Rust "
-"unterstützt:"
+"Die [Android Interface Definition Language (AIDL)](https://developer.android."
+"com/guide/components/aidl) wird in Rust unterstützt:"
 
 #: src/android/aidl.md:6
 #, fuzzy
-msgid ""
-"* Rust code can call existing AIDL servers,\n"
-"* You can create new AIDL servers in Rust."
-msgstr ""
-"* Rust-Code kann bestehende AIDL-Server aufrufen,\n"
-"* Sie können neue AIDL-Server in Rust erstellen."
+msgid "Rust code can call existing AIDL servers,"
+msgstr "Rust-Code kann bestehende AIDL-Server aufrufen,"
+
+#: src/android/aidl.md:7
+#, fuzzy
+msgid "You can create new AIDL servers in Rust."
+msgstr "Sie können neue AIDL-Server in Rust erstellen."
 
 #: src/android/aidl/interface.md:1
 #, fuzzy
-msgid "# AIDL Interfaces"
-msgstr "# AIDL-Schnittstellen"
+msgid "AIDL Interfaces"
+msgstr "AIDL-Schnittstellen"
 
 #: src/android/aidl/interface.md:3
 #, fuzzy
@@ -12249,9 +12765,9 @@ msgstr "Sie deklarieren die API Ihres Dienstes über eine AIDL-Schnittstelle:"
 #: src/android/aidl/interface.md:5
 #, fuzzy
 msgid ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 msgstr ""
-"*birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl*:"
+"_birthday_service/aidl/com/example/birthdayservice/IBirthdayService.aidl_:"
 
 #: src/android/aidl/interface.md:7
 msgid ""
@@ -12268,8 +12784,8 @@ msgstr ""
 
 #: src/android/aidl/interface.md:17
 #, fuzzy
-msgid "*birthday_service/aidl/Android.bp*:"
-msgstr "*birthday_service/aidl/Android.bp*:"
+msgid "_birthday_service/aidl/Android.bp_:"
+msgstr "_birthday_service/aidl/Android.bp_:"
 
 #: src/android/aidl/interface.md:19
 msgid ""
@@ -12291,17 +12807,15 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Add `vendor_available: true` if your AIDL file is used by a binary in the "
-"vendor\n"
-"partition."
+"vendor partition."
 msgstr ""
 "Fügen Sie „vendor_available: true“ hinzu, wenn Ihre AIDL-Datei von einer "
-"Binärdatei des Anbieters verwendet wird\n"
-"Partition."
+"Binärdatei des Anbieters verwendet wird Partition."
 
 #: src/android/aidl/implementation.md:1
 #, fuzzy
-msgid "# Service Implementation"
-msgstr "# Dienstimplementierung"
+msgid "Service Implementation"
+msgstr "Dienstimplementierung"
 
 #: src/android/aidl/implementation.md:3
 #, fuzzy
@@ -12310,8 +12824,8 @@ msgstr "Wir können jetzt den AIDL-Dienst implementieren:"
 
 #: src/android/aidl/implementation.md:5
 #, fuzzy
-msgid "*birthday_service/src/lib.rs*:"
-msgstr "*birthday_service/src/lib.rs*:"
+msgid "_birthday_service/src/lib.rs_:"
+msgstr "_birthday_service/src/lib.rs_:"
 
 #: src/android/aidl/implementation.md:7
 msgid ""
@@ -12341,8 +12855,8 @@ msgstr ""
 #: src/android/aidl/implementation.md:26 src/android/aidl/server.md:28
 #: src/android/aidl/client.md:37
 #, fuzzy
-msgid "*birthday_service/Android.bp*:"
-msgstr "*birthday_service/Android.bp*:"
+msgid "_birthday_service/Android.bp_:"
+msgstr "_birthday_service/Android.bp_:"
 
 #: src/android/aidl/implementation.md:28
 msgid ""
@@ -12361,8 +12875,8 @@ msgstr ""
 
 #: src/android/aidl/server.md:1
 #, fuzzy
-msgid "# AIDL Server"
-msgstr "# AIDL-Server"
+msgid "AIDL Server"
+msgstr "AIDL-Server"
 
 #: src/android/aidl/server.md:3
 #, fuzzy
@@ -12373,8 +12887,8 @@ msgstr ""
 
 #: src/android/aidl/server.md:5
 #, fuzzy
-msgid "*birthday_service/src/server.rs*:"
-msgstr "*birthday_service/src/server.rs*:"
+msgid "_birthday_service/src/server.rs_:"
+msgstr "_birthday_service/src/server.rs_:"
 
 #: src/android/aidl/server.md:7
 msgid ""
@@ -12418,11 +12932,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/android/aidl/deploy.md:1
-#, fuzzy
-msgid "# Deploy"
-msgstr "# Einsetzen"
 
 #: src/android/aidl/deploy.md:3
 #, fuzzy
@@ -12476,8 +12985,8 @@ msgstr ""
 
 #: src/android/aidl/client.md:1
 #, fuzzy
-msgid "# AIDL Client"
-msgstr "# AIDL-Client"
+msgid "AIDL Client"
+msgstr "AIDL-Client"
 
 #: src/android/aidl/client.md:3
 #, fuzzy
@@ -12487,8 +12996,8 @@ msgstr ""
 
 #: src/android/aidl/client.md:5
 #, fuzzy
-msgid "*birthday_service/src/client.rs*:"
-msgstr "*birthday_service/src/client.rs*:"
+msgid "_birthday_service/src/client.rs_:"
+msgstr "_birthday_service/src/client.rs_:"
 
 #: src/android/aidl/client.md:7
 msgid ""
@@ -12563,21 +13072,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/aidl/changing.md:1
-#, fuzzy
-msgid "# Changing API"
-msgstr "# Ändern der API"
-
 #: src/android/aidl/changing.md:3
 #, fuzzy
 msgid ""
 "Let us extend the API with more functionality: we want to let clients "
-"specify a\n"
-"list of lines for the birthday card:"
+"specify a list of lines for the birthday card:"
 msgstr ""
 "Lassen Sie uns die API um mehr Funktionalität erweitern: Wir möchten, dass "
-"Kunden a angeben\n"
-"Liste der Zeilen für die Geburtstagskarte:"
+"Kunden a angeben Liste der Zeilen für die Geburtstagskarte:"
 
 #: src/android/aidl/changing.md:6
 msgid ""
@@ -12592,21 +13094,14 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/logging.md:1 src/bare-metal/aps/logging.md:1
-#, fuzzy
-msgid "# Logging"
-msgstr "# Protokollierung"
-
 #: src/android/logging.md:3
 #, fuzzy
 msgid ""
 "You should use the `log` crate to automatically log to `logcat` (on-device) "
-"or\n"
-"`stdout` (on-host):"
+"or `stdout` (on-host):"
 msgstr ""
-"Sie sollten die `log`-Crate verwenden, um sich automatisch bei `logcat` (auf "
-"dem Gerät) anzumelden oder\n"
-"`stdout` (auf dem Host):"
+"Sie sollten die `log`\\-Crate verwenden, um sich automatisch bei `logcat` "
+"(auf dem Gerät) anzumelden oder `stdout` (auf dem Host):"
 
 #: src/android/logging.md:6
 #, fuzzy
@@ -12690,55 +13185,48 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/android/interoperability.md:1
-#, fuzzy
-msgid "# Interoperability"
-msgstr "# Interoperabilität"
-
 #: src/android/interoperability.md:3
 #, fuzzy
 msgid ""
 "Rust has excellent support for interoperability with other languages. This "
-"means\n"
-"that you can:"
+"means that you can:"
 msgstr ""
 "Rust bietet eine hervorragende Unterstützung für die Interoperabilität mit "
-"anderen Sprachen. Das heisst\n"
-"dass du kannst:"
+"anderen Sprachen. Das heisst dass du kannst:"
 
 #: src/android/interoperability.md:6
 #, fuzzy
-msgid ""
-"* Call Rust functions from other languages.\n"
-"* Call functions written in other languages from Rust."
-msgstr ""
-"* Rufen Sie Rust-Funktionen aus anderen Sprachen auf.\n"
-"* Rufen Sie in anderen Sprachen geschriebene Funktionen von Rust auf."
+msgid "Call Rust functions from other languages."
+msgstr "Rufen Sie Rust-Funktionen aus anderen Sprachen auf."
+
+#: src/android/interoperability.md:7
+#, fuzzy
+msgid "Call functions written in other languages from Rust."
+msgstr "Rufen Sie in anderen Sprachen geschriebene Funktionen von Rust auf."
 
 #: src/android/interoperability.md:9
 #, fuzzy
 msgid ""
-"When you call functions in a foreign language we say that you're using a\n"
+"When you call functions in a foreign language we say that you're using a "
 "_foreign function interface_, also known as FFI."
 msgstr ""
 "Wenn Sie Funktionen in einer Fremdsprache aufrufen, sagen wir, dass Sie a "
-"verwenden\n"
-"_Fremdfunktionsschnittstelle_, auch bekannt als FFI."
+"verwenden _Fremdfunktionsschnittstelle_, auch bekannt als FFI."
 
 #: src/android/interoperability/with-c.md:1
 #, fuzzy
-msgid "# Interoperability with C"
-msgstr "# Interoperabilität mit C"
+msgid "Interoperability with C"
+msgstr "Interoperabilität mit C"
 
 #: src/android/interoperability/with-c.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for linking object files with a C calling convention.\n"
+"Rust has full support for linking object files with a C calling convention. "
 "Similarly, you can export Rust functions and call them from C."
 msgstr ""
 "Rust bietet volle Unterstützung für das Linken von Objektdateien mit einer C-"
-"Aufrufkonvention.\n"
-"Ebenso können Sie Rust-Funktionen exportieren und von C aus aufrufen."
+"Aufrufkonvention. Ebenso können Sie Rust-Funktionen exportieren und von C "
+"aus aufrufen."
 
 #: src/android/interoperability/with-c.md:6
 #, fuzzy
@@ -12763,21 +13251,20 @@ msgstr ""
 #: src/android/interoperability/with-c.md:20
 #, fuzzy
 msgid ""
-"We already saw this in the [Safe FFI Wrapper\n"
-"exercise](../../exercises/day-3/safe-ffi-wrapper.md)."
+"We already saw this in the [Safe FFI Wrapper exercise](../../exercises/day-3/"
+"safe-ffi-wrapper.md)."
 msgstr ""
-"Wir haben dies bereits im [Safe FFI Wrapper\n"
-"Übung](../../Übungen/Tag-3/safe-ffi-wrapper.md)."
+"Wir haben dies bereits im [Safe FFI Wrapper Übung](../../Übungen/Tag-3/safe-"
+"ffi-wrapper.md)."
 
 #: src/android/interoperability/with-c.md:23
 #, fuzzy
 msgid ""
-"> This assumes full knowledge of the target platform. Not recommended for\n"
-"> production."
+"This assumes full knowledge of the target platform. Not recommended for "
+"production."
 msgstr ""
-"> Dies setzt vollständige Kenntnisse der Zielplattform voraus. Nicht "
-"empfehlenswert für\n"
-"> Produktion."
+"Dies setzt vollständige Kenntnisse der Zielplattform voraus. Nicht "
+"empfehlenswert für Produktion."
 
 #: src/android/interoperability/with-c.md:26
 #, fuzzy
@@ -12786,19 +13273,17 @@ msgstr "Wir werden uns als nächstes bessere Optionen ansehen."
 
 #: src/android/interoperability/with-c/bindgen.md:1
 #, fuzzy
-msgid "# Using Bindgen"
-msgstr "# Verwenden von Bindgen"
+msgid "Using Bindgen"
+msgstr "Verwenden von Bindgen"
 
 #: src/android/interoperability/with-c/bindgen.md:3
 #, fuzzy
 msgid ""
 "The [bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) "
-"tool\n"
-"can auto-generate bindings from a C header file."
+"tool can auto-generate bindings from a C header file."
 msgstr ""
 "Das Tool [bindgen](https://rust-lang.github.io/rust-bindgen/introduction."
-"html).\n"
-"kann Bindungen aus einer C-Header-Datei automatisch generieren."
+"html). kann Bindungen aus einer C-Header-Datei automatisch generieren."
 
 #: src/android/interoperability/with-c/bindgen.md:6
 #, fuzzy
@@ -12845,7 +13330,7 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:33
 #, fuzzy
 msgid "Add this to your `Android.bp` file:"
-msgstr "Fügen Sie dies zu Ihrer `Android.bp`-Datei hinzu:"
+msgstr "Fügen Sie dies zu Ihrer `Android.bp`\\-Datei hinzu:"
 
 #: src/android/interoperability/with-c/bindgen.md:35
 #: src/android/interoperability/with-c/bindgen.md:55
@@ -12868,10 +13353,10 @@ msgstr ""
 #: src/android/interoperability/with-c/bindgen.md:44
 #, fuzzy
 msgid ""
-"Create a wrapper header file for the library (not strictly needed in this\n"
+"Create a wrapper header file for the library (not strictly needed in this "
 "example):"
 msgstr ""
-"Erstellen Sie eine Wrapper-Header-Datei für die Bibliothek (in this\n"
+"Erstellen Sie eine Wrapper-Header-Datei für die Bibliothek (in this "
 "Beispiel):"
 
 #: src/android/interoperability/with-c/bindgen.md:47
@@ -12987,8 +13472,8 @@ msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:1
 #, fuzzy
-msgid "# Calling Rust"
-msgstr "# Rust anrufen"
+msgid "Calling Rust"
+msgstr "Rust anrufen"
 
 #: src/android/interoperability/with-c/rust.md:3
 #, fuzzy
@@ -13109,63 +13594,52 @@ msgstr ""
 #, fuzzy
 msgid ""
 "`#[no_mangle]` disables Rust's usual name mangling, so the exported symbol "
-"will just be the name of\n"
-"the function. You can also use `#[export_name = \"some_name\"]` to specify "
-"whatever name you want."
+"will just be the name of the function. You can also use `#[export_name = "
+"\"some_name\"]` to specify whatever name you want."
 msgstr ""
 "`#[no_mangle]` deaktiviert Rusts übliches Namensverstümmeln, so dass das "
-"exportierte Symbol nur der Name von ist\n"
-"die Funktion. Sie können auch `#[export_name = \"some_name\"]` verwenden, um "
-"einen beliebigen Namen anzugeben."
-
-#: src/android/interoperability/cpp.md:1
-#, fuzzy
-msgid "# With C++"
-msgstr "# Mit C++"
+"exportierte Symbol nur der Name von ist die Funktion. Sie können auch "
+"`#[export_name = \"some_name\"]` verwenden, um einen beliebigen Namen "
+"anzugeben."
 
 #: src/android/interoperability/cpp.md:3
 #, fuzzy
 msgid ""
-"The [CXX crate][1] makes it possible to do safe interoperability between "
-"Rust\n"
-"and C++."
+"The [CXX crate](https://cxx.rs/) makes it possible to do safe "
+"interoperability between Rust and C++."
 msgstr ""
-"Die [CXX-Kiste][1] ermöglicht eine sichere Interoperabilität zwischen Rust\n"
-"und C++."
+"Die [CXX-Kiste](https://cxx.rs/) ermöglicht eine sichere Interoperabilität "
+"zwischen Rust und C++."
 
 #: src/android/interoperability/cpp.md:6
 #, fuzzy
 msgid "The overall approach looks like this:"
 msgstr "Der Gesamtansatz sieht wie folgt aus:"
 
-#: src/android/interoperability/cpp.md:8
-#, fuzzy
-msgid "<img src=\"cpp/overview.svg\">"
-msgstr "<img src=\"cpp/overview.svg\">"
-
 #: src/android/interoperability/cpp.md:10
 #, fuzzy
-msgid "See the [CXX tutorial][2] for an full example of using this."
+msgid ""
+"See the [CXX tutorial](https://cxx.rs/tutorial.html) for an full example of "
+"using this."
 msgstr ""
-"Ein vollständiges Beispiel für die Verwendung finden Sie im [CXX-Tutorial] "
-"[2]."
+"Ein vollständiges Beispiel für die Verwendung finden Sie im \\[CXX-"
+"Tutorial\\] [2](https://cxx.rs/tutorial.html)."
 
 #: src/android/interoperability/java.md:1
 #, fuzzy
-msgid "# Interoperability with Java"
-msgstr "# Interoperabilität mit Java"
+msgid "Interoperability with Java"
+msgstr "Interoperabilität mit Java"
 
 #: src/android/interoperability/java.md:3
 #, fuzzy
 msgid ""
-"Java can load shared objects via [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). The [`jni`\n"
-"crate](https://docs.rs/jni/) allows you to create a compatible library."
+"Java can load shared objects via [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). The [`jni` crate](https://docs.rs/"
+"jni/) allows you to create a compatible library."
 msgstr ""
-"Java kann gemeinsame Objekte über [Java Native Interface\n"
-"(JNI)](https://en.wikipedia.org/wiki/Java_Native_Interface). Die [`jni`\n"
-"crate](https://docs.rs/jni/) ermöglicht es Ihnen, eine kompatible Bibliothek "
-"zu erstellen."
+"Java kann gemeinsame Objekte über [Java Native Interface (JNI)](https://en."
+"wikipedia.org/wiki/Java_Native_Interface). Die [`jni` crate](https://docs.rs/"
+"jni/) ermöglicht es Ihnen, eine kompatible Bibliothek zu erstellen."
 
 #: src/android/interoperability/java.md:7
 #, fuzzy
@@ -13275,83 +13749,78 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/android/morning.md:1 src/exercises/bare-metal/morning.md:1
-#: src/exercises/bare-metal/afternoon.md:1
-#: src/exercises/concurrency/morning.md:1
-#: src/exercises/concurrency/afternoon.md:1
-#, fuzzy
-msgid "# Exercises"
-msgstr "# Übungen"
-
 #: src/exercises/android/morning.md:3
 #, fuzzy
 msgid ""
 "This is a group exercise: We will look at one of the projects you work with "
-"and\n"
-"try to integrate some Rust into it. Some suggestions:"
+"and try to integrate some Rust into it. Some suggestions:"
 msgstr ""
 "Für die letzte Übung schauen wir uns eines der Projekte an, mit denen Sie "
-"arbeiten. Lassen Sie uns\n"
-"gruppiert euch und macht das gemeinsam. Einige Vorschläge:"
+"arbeiten. Lassen Sie uns gruppiert euch und macht das gemeinsam. Einige "
+"Vorschläge:"
 
 #: src/exercises/android/morning.md:6
 #, fuzzy
-msgid ""
-"* Call your AIDL service with a client written in Rust.\n"
-"\n"
-"* Move a function from your project to Rust and call it."
+msgid "Call your AIDL service with a client written in Rust."
 msgstr ""
-"* Verschieben Sie eine Funktion aus Ihrem Projekt nach Rust und rufen Sie "
-"sie auf."
+"Verschieben Sie eine Funktion aus Ihrem Projekt nach Rust und rufen Sie sie "
+"auf."
+
+#: src/exercises/android/morning.md:8
+msgid "Move a function from your project to Rust and call it."
+msgstr ""
 
 #: src/exercises/android/morning.md:12
 #, fuzzy
 msgid ""
 "No solution is provided here since this is open-ended: it relies on someone "
-"in\n"
-"the class having a piece of code which you can turn in to Rust on the fly."
+"in the class having a piece of code which you can turn in to Rust on the fly."
 msgstr ""
 "Hier wird keine Lösung bereitgestellt, da dies offen ist: Es hängt von "
-"jemandem ab\n"
-"Die Klasse hat einen Code, den Sie spontan an Rust übergeben können."
+"jemandem ab Die Klasse hat einen Code, den Sie spontan an Rust übergeben "
+"können."
 
 #: src/bare-metal.md:1
 #, fuzzy
-msgid "# Welcome to Bare Metal Rust"
-msgstr "# Willkommen bei Comprehensive Rust 🦀"
+msgid "Welcome to Bare Metal Rust"
+msgstr "Willkommen bei Comprehensive Rust 🦀"
 
 #: src/bare-metal.md:3
 msgid ""
 "This is a standalone one-day course about bare-metal Rust, aimed at people "
-"who are familiar with the\n"
-"basics of Rust (perhaps from completing the Comprehensive Rust course), and "
-"ideally also have some\n"
-"experience with bare-metal programming in some other language such as C."
+"who are familiar with the basics of Rust (perhaps from completing the "
+"Comprehensive Rust course), and ideally also have some experience with bare-"
+"metal programming in some other language such as C."
 msgstr ""
 
 #: src/bare-metal.md:7
 msgid ""
 "Today we will talk about 'bare-metal' Rust: running Rust code without an OS "
-"underneath us. This will\n"
-"be divided into several parts:"
+"underneath us. This will be divided into several parts:"
 msgstr ""
 
 #: src/bare-metal.md:10
-msgid ""
-"- What is `no_std` Rust?\n"
-"- Writing firmware for microcontrollers.\n"
-"- Writing bootloader / kernel code for application processors.\n"
-"- Some useful crates for bare-metal Rust development."
+msgid "What is `no_std` Rust?"
+msgstr ""
+
+#: src/bare-metal.md:11
+msgid "Writing firmware for microcontrollers."
+msgstr ""
+
+#: src/bare-metal.md:12
+msgid "Writing bootloader / kernel code for application processors."
+msgstr ""
+
+#: src/bare-metal.md:13
+msgid "Some useful crates for bare-metal Rust development."
 msgstr ""
 
 #: src/bare-metal.md:15
 msgid ""
 "For the microcontroller part of the course we will use the [BBC micro:bit]"
-"(https://microbit.org/) v2\n"
-"as an example. It's a [development board](https://tech.microbit.org/"
-"hardware/) based on the Nordic\n"
-"nRF51822 microcontroller with some LEDs and buttons, an I2C-connected "
-"accelerometer and compass, and\n"
+"(https://microbit.org/) v2 as an example. It's a [development board](https://"
+"tech.microbit.org/hardware/) based on the Nordic nRF51822 microcontroller "
+"with some LEDs and buttons, an I2C-connected accelerometer and compass, and "
 "an on-board SWD debugger."
 msgstr ""
 
@@ -13405,27 +13874,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/no_std.md:1
-msgid "# `no_std`"
-msgstr ""
-
-#: src/bare-metal/no_std.md:3
-msgid ""
-"<table>\n"
-"<tr>\n"
-"<th>"
+msgid "`no_std`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:7
 msgid "`core`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:9 src/bare-metal/no_std.md:14
-msgid ""
-"</th>\n"
-"<th>"
-msgstr ""
-
-#: src/bare-metal/no_std.md:12
+#: src/bare-metal/no_std.md:12 src/bare-metal/alloc.md:1
 msgid "`alloc`"
 msgstr ""
 
@@ -13433,72 +13889,100 @@ msgstr ""
 msgid "`std`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:19
-msgid ""
-"</th>\n"
-"</tr>\n"
-"<tr valign=\"top\">\n"
-"<td>"
-msgstr ""
-
 #: src/bare-metal/no_std.md:24
-msgid ""
-"* Slices, `&str`, `CStr`\n"
-"* `NonZeroU8`...\n"
-"* `Option`, `Result`\n"
-"* `Display`, `Debug`, `write!`...\n"
-"* `Iterator`\n"
-"* `panic!`, `assert_eq!`...\n"
-"* `NonNull` and all the usual pointer-related functions\n"
-"* `Future` and `async`/`await`\n"
-"* `fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`...\n"
-"* `Duration`"
+msgid "Slices, `&str`, `CStr`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:35 src/bare-metal/no_std.md:42
-msgid ""
-"</td>\n"
-"<td>"
+#: src/bare-metal/no_std.md:25
+msgid "`NonZeroU8`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:26
+msgid "`Option`, `Result`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:27
+msgid "`Display`, `Debug`, `write!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:29
+msgid "`panic!`, `assert_eq!`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:30
+msgid "`NonNull` and all the usual pointer-related functions"
+msgstr ""
+
+#: src/bare-metal/no_std.md:31
+msgid "`Future` and `async`/`await`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:32
+msgid "`fence`, `AtomicBool`, `AtomicPtr`, `AtomicU32`..."
+msgstr ""
+
+#: src/bare-metal/no_std.md:33
+msgid "`Duration`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:38
-msgid ""
-"* `Box`, `Cow`, `Arc`, `Rc`\n"
-"* `Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`\n"
-"* `String`, `CString`, `format!`"
+msgid "`Box`, `Cow`, `Arc`, `Rc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:39
+msgid "`Vec`, `BinaryHeap`, `BtreeMap`, `LinkedList`, `VecDeque`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:40
+msgid "`String`, `CString`, `format!`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:45
-msgid ""
-"* `Error`\n"
-"* `HashMap`\n"
-"* `Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`\n"
-"* `File` and the rest of `fs`\n"
-"* `println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`\n"
-"* `Path`, `OsString`\n"
-"* `net`\n"
-"* `Command`, `Child`, `ExitCode`\n"
-"* `spawn`, `sleep` and the rest of `thread`\n"
-"* `SystemTime`, `Instant`"
+msgid "`Error`"
 msgstr ""
 
-#: src/bare-metal/no_std.md:56
-msgid ""
-"</td>\n"
-"</tr>\n"
-"</table>\n"
-"\n"
-"<details>"
+#: src/bare-metal/no_std.md:47
+msgid "`Mutex`, `Condvar`, `Barrier`, `Once`, `RwLock`, `mpsc`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:48
+msgid "`File` and the rest of `fs`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:49
+msgid "`println!`, `Read`, `Write`, `Stdin`, `Stdout` and the rest of `io`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:50
+msgid "`Path`, `OsString`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:51
+msgid "`net`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:52
+msgid "`Command`, `Child`, `ExitCode`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:53
+msgid "`spawn`, `sleep` and the rest of `thread`"
+msgstr ""
+
+#: src/bare-metal/no_std.md:54
+msgid "`SystemTime`, `Instant`"
 msgstr ""
 
 #: src/bare-metal/no_std.md:62
-msgid ""
-"* `HashMap` depends on RNG.\n"
-"* `std` re-exports the contents of both `core` and `alloc`."
+msgid "`HashMap` depends on RNG."
+msgstr ""
+
+#: src/bare-metal/no_std.md:63
+msgid "`std` re-exports the contents of both `core` and `alloc`."
 msgstr ""
 
 #: src/bare-metal/minimal.md:1
-msgid "# A minimal `no_std` program"
+msgid "A minimal `no_std` program"
 msgstr ""
 
 #: src/bare-metal/minimal.md:3
@@ -13517,29 +14001,34 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/minimal.md:17
-msgid ""
-"* This will compile to an empty binary.\n"
-"* `std` provides a panic handler; without it we must provide our own.\n"
-"* It can also be provided by another crate, such as `panic-halt`.\n"
-"* Depending on the target, you may need to compile with `panic = \"abort\"` "
-"to avoid an error about\n"
-"  `eh_personality`.\n"
-"* Note that there is no `main` or any other entry point; it's up to you to "
-"define your own entry\n"
-"  point. This will typically involve a linker script and some assembly code "
-"to set things up ready\n"
-"  for Rust code to run."
+msgid "This will compile to an empty binary."
 msgstr ""
 
-#: src/bare-metal/alloc.md:1
-msgid "# `alloc`"
+#: src/bare-metal/minimal.md:18
+msgid "`std` provides a panic handler; without it we must provide our own."
+msgstr ""
+
+#: src/bare-metal/minimal.md:19
+msgid "It can also be provided by another crate, such as `panic-halt`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:20
+msgid ""
+"Depending on the target, you may need to compile with `panic = \"abort\"` to "
+"avoid an error about `eh_personality`."
+msgstr ""
+
+#: src/bare-metal/minimal.md:22
+msgid ""
+"Note that there is no `main` or any other entry point; it's up to you to "
+"define your own entry point. This will typically involve a linker script and "
+"some assembly code to set things up ready for Rust code to run."
 msgstr ""
 
 #: src/bare-metal/alloc.md:3
 msgid ""
-"To use `alloc` you must implement a\n"
-"[global (heap) allocator](https://doc.rust-lang.org/stable/std/alloc/trait."
-"GlobalAlloc.html)."
+"To use `alloc` you must implement a [global (heap) allocator](https://doc."
+"rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html)."
 msgstr ""
 
 #: src/bare-metal/alloc.md:6
@@ -13579,25 +14068,32 @@ msgstr ""
 
 #: src/bare-metal/alloc.md:39
 msgid ""
-"* `buddy_system_allocator` is a third-party crate implementing a basic buddy "
-"system allocator. Other\n"
-"  crates are available, or you can write your own or hook into your existing "
-"allocator.\n"
-"* The const parameter of `LockedHeap` is the max order of the allocator; i."
-"e. in this case it can\n"
-"  allocate regions of up to 2**32 bytes.\n"
-"* If any crate in your dependency tree depends on `alloc` then you must have "
-"exactly one global\n"
-"  allocator defined in your binary. Usually this is done in the top-level "
-"binary crate.\n"
-"* `extern crate panic_halt as _` is necessary to ensure that the "
-"`panic_halt` crate is linked in so\n"
-"  we get its panic handler.\n"
-"* This example will build but not run, as it doesn't have an entry point."
+"`buddy_system_allocator` is a third-party crate implementing a basic buddy "
+"system allocator. Other crates are available, or you can write your own or "
+"hook into your existing allocator."
 msgstr ""
 
-#: src/bare-metal/microcontrollers.md:1
-msgid "# Microcontrollers"
+#: src/bare-metal/alloc.md:41
+msgid ""
+"The const parameter of `LockedHeap` is the max order of the allocator; i.e. "
+"in this case it can allocate regions of up to 2\\*\\*32 bytes."
+msgstr ""
+
+#: src/bare-metal/alloc.md:43
+msgid ""
+"If any crate in your dependency tree depends on `alloc` then you must have "
+"exactly one global allocator defined in your binary. Usually this is done in "
+"the top-level binary crate."
+msgstr ""
+
+#: src/bare-metal/alloc.md:45
+msgid ""
+"`extern crate panic_halt as _` is necessary to ensure that the `panic_halt` "
+"crate is linked in so we get its panic handler."
+msgstr ""
+
+#: src/bare-metal/alloc.md:47
+msgid "This example will build but not run, as it doesn't have an entry point."
 msgstr ""
 
 #: src/bare-metal/microcontrollers.md:3
@@ -13633,21 +14129,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers.md:25
 msgid ""
-"* The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
-"> !`, because returning\n"
-"  to the reset handler doesn't make sense.\n"
-"* Run the example with `cargo embed --bin minimal`"
+"The `cortex_m_rt::entry` macro requires that the function have type `fn() -"
+"> !`, because returning to the reset handler doesn't make sense."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/mmio.md:1
-msgid "# Raw MMIO"
+#: src/bare-metal/microcontrollers.md:27
+msgid "Run the example with `cargo embed --bin minimal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:3
 msgid ""
 "Most microcontrollers access peripherals via memory-mapped IO. Let's try "
-"turning on an LED on our\n"
-"micro:bit:"
+"turning on an LED on our micro:bit:"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:6
@@ -13717,8 +14210,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:64
 msgid ""
-"* GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin "
-"28 to the first row."
+"GPIO 0 pin 21 is connected to the first column of the LED matrix, and pin 28 "
+"to the first row."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/mmio.md:66
@@ -13736,16 +14229,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:1
-msgid "# Peripheral Access Crates"
+msgid "Peripheral Access Crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:3
 msgid ""
 "[`svd2rust`](https://crates.io/crates/svd2rust) generates mostly-safe Rust "
-"wrappers for\n"
-"memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/pack/doc/"
-"CMSIS/SVD/html/index.html)\n"
-"files."
+"wrappers for memory-mapped peripherals from [CMSIS-SVD](https://www.keil.com/"
+"pack/doc/CMSIS/SVD/html/index.html) files."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:7
@@ -13793,19 +14284,31 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:49
 msgid ""
-"* SVD (System View Description) files are XML files typically provided by "
-"silicon vendors which\n"
-"  describe the memory map of the device.\n"
-"  * They are organised by peripheral, register, field and value, with names, "
-"descriptions, addresses\n"
-"    and so on.\n"
-"  * SVD files are often buggy and incomplete, so there are various projects "
-"which patch the\n"
-"    mistakes, add missing details, and publish the generated crates.\n"
-"* `cortex-m-rt` provides the vector table, among other things.\n"
-"* If you `cargo install cargo-binutils` then you can run\n"
-"  `cargo objdump --bin pac -- -d --no-show-raw-insn` to see the resulting "
-"binary."
+"SVD (System View Description) files are XML files typically provided by "
+"silicon vendors which describe the memory map of the device."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:51
+msgid ""
+"They are organised by peripheral, register, field and value, with names, "
+"descriptions, addresses and so on."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:53
+msgid ""
+"SVD files are often buggy and incomplete, so there are various projects "
+"which patch the mistakes, add missing details, and publish the generated "
+"crates."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:55
+msgid "`cortex-m-rt` provides the vector table, among other things."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/pacs.md:56
+msgid ""
+"If you `cargo install cargo-binutils` then you can run `cargo objdump --bin "
+"pac -- -d --no-show-raw-insn` to see the resulting binary."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/pacs.md:61
@@ -13816,16 +14319,15 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:1
-msgid "# HAL crates"
+msgid "HAL crates"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:3
 msgid ""
 "[HAL crates](https://github.com/rust-embedded/awesome-embedded-rust#hal-"
-"implementation-crates) for\n"
-"many microcontrollers provide wrappers around various peripherals. These "
-"generally implement traits\n"
-"from [`embedded-hal`](https://crates.io/crates/embedded-hal)."
+"implementation-crates) for many microcontrollers provide wrappers around "
+"various peripherals. These generally implement traits from [`embedded-hal`]"
+"(https://crates.io/crates/embedded-hal)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:7
@@ -13863,11 +14365,13 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:39
 msgid ""
-" * `set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` "
-"trait.\n"
-" * HAL crates exist for many Cortex-M and RISC-V devices, including various "
-"STM32, GD32, nRF, NXP,\n"
-"   MSP430, AVR and PIC microcontrollers."
+"`set_low` and `set_high` are methods on the `embedded_hal` `OutputPin` trait."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/hals.md:40
+msgid ""
+"HAL crates exist for many Cortex-M and RISC-V devices, including various "
+"STM32, GD32, nRF, NXP, MSP430, AVR and PIC microcontrollers."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/hals.md:45
@@ -13879,8 +14383,8 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:1
 #, fuzzy
-msgid "# Board support crates"
-msgstr "# Tastaturkürzel"
+msgid "Board support crates"
+msgstr "Tastaturkürzel"
 
 #: src/bare-metal/microcontrollers/board-support.md:3
 msgid ""
@@ -13914,13 +14418,18 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:28
 msgid ""
-" * In this case the board support crate is just providing more useful names, "
-"and a bit of\n"
-"   initialisation.\n"
-" * The crate may also include drivers for some on-board devices outside of "
-"the microcontroller\n"
-"   itself.\n"
-"   * `microbit-v2` includes a simple driver for the LED matrix."
+"In this case the board support crate is just providing more useful names, "
+"and a bit of initialisation."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:30
+msgid ""
+"The crate may also include drivers for some on-board devices outside of the "
+"microcontroller itself."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/board-support.md:32
+msgid "`microbit-v2` includes a simple driver for the LED matrix."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/board-support.md:36
@@ -13931,7 +14440,7 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:1
-msgid "# The type state pattern"
+msgid "The type state pattern"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:3
@@ -13969,120 +14478,178 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/type-state.md:32
 msgid ""
-" * Pins don't implement `Copy` or `Clone`, so only one instance of each can "
-"exist. Once a pin is\n"
-"   moved out of the port struct nobody else can take it.\n"
-" * Changing the configuration of a pin consumes the old pin instance, so you "
-"can’t keep use the old\n"
-"   instance afterwards.\n"
-" * The type of a value indicates the state that it is in: e.g. in this case, "
-"the configuration state\n"
-"   of a GPIO pin. This encodes the state machine into the type system, and "
-"ensures that you don't\n"
-"   try to use a pin in a certain way without properly configuring it first. "
-"Illegal state\n"
-"   transitions are caught at compile time.\n"
-" * You can call `is_high` on an input pin and `set_high` on an output pin, "
-"but not vice-versa.\n"
-" * Many HAL crates follow this pattern."
+"Pins don't implement `Copy` or `Clone`, so only one instance of each can "
+"exist. Once a pin is moved out of the port struct nobody else can take it."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:34
+msgid ""
+"Changing the configuration of a pin consumes the old pin instance, so you "
+"can’t keep use the old instance afterwards."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:36
+msgid ""
+"The type of a value indicates the state that it is in: e.g. in this case, "
+"the configuration state of a GPIO pin. This encodes the state machine into "
+"the type system, and ensures that you don't try to use a pin in a certain "
+"way without properly configuring it first. Illegal state transitions are "
+"caught at compile time."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:40
+msgid ""
+"You can call `is_high` on an input pin and `set_high` on an output pin, but "
+"not vice-versa."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/type-state.md:41
+msgid "Many HAL crates follow this pattern."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:1
-msgid "# `embedded-hal`"
+msgid "`embedded-hal`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:3
 msgid ""
 "The [`embedded-hal`](https://crates.io/crates/embedded-hal) crate provides a "
-"number of traits\n"
-"covering common microcontroller peripherals."
+"number of traits covering common microcontroller peripherals."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:6
-msgid ""
-" * GPIO\n"
-" * ADC\n"
-" * I2C, SPI, UART, CAN\n"
-" * RNG\n"
-" * Timers\n"
-" * Watchdogs"
+msgid "GPIO"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:7
+msgid "ADC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:8
+msgid "I2C, SPI, UART, CAN"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:9
+msgid "RNG"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:10
+msgid "Timers"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:11
+msgid "Watchdogs"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:13
 msgid ""
-"Other crates then implement\n"
-"[drivers](https://github.com/rust-embedded/awesome-embedded-rust#driver-"
-"crates) in terms of these\n"
-"traits, e.g. an accelerometer driver might need an I2C or SPI bus "
-"implementation."
+"Other crates then implement [drivers](https://github.com/rust-embedded/"
+"awesome-embedded-rust#driver-crates) in terms of these traits, e.g. an "
+"accelerometer driver might need an I2C or SPI bus implementation."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/embedded-hal.md:19
 msgid ""
-" * There are implementations for many microcontrollers, as well as other "
-"platforms such as Linux on\n"
-"Raspberry Pi.\n"
-" * There is work in progress on an `async` version of `embedded-hal`, but it "
+"There are implementations for many microcontrollers, as well as other "
+"platforms such as Linux on Raspberry Pi."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/embedded-hal.md:21
+msgid ""
+"There is work in progress on an `async` version of `embedded-hal`, but it "
 "isn't stable yet."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:1
-msgid "# `probe-rs`, `cargo-embed`"
+msgid "`probe-rs`, `cargo-embed`"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:3
 msgid ""
 "[probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, "
-"like OpenOCD but better\n"
-"integrated."
+"like OpenOCD but better integrated."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:6
-msgid ""
-"* <abbr title=\"Serial Wire Debug\">SWD</abbr> and JTAG via CMSIS-DAP, ST-"
-"Link and J-Link probes\n"
-"* GDB stub and Microsoft <abbr title=\"Debug Adapter Protocol\">DAP</abbr> "
-"server\n"
-"* Cargo integration"
+msgid "SWD"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:6
+msgid " and JTAG via CMSIS-DAP, ST-Link and J-Link probes"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "GDB stub and Microsoft "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid "DAP"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:7
+msgid " server"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:8
+msgid "Cargo integration"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:10
+msgid "`cargo-embed` is a cargo subcommand to build and flash binaries, log "
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
+msgid "RTT"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:11
 msgid ""
-"`cargo-embed` is a cargo subcommand to build and flash binaries, log\n"
-"<abbr title=\"Real Time Transfers\">RTT</abbr> output and connect GDB. It's "
-"configured by an\n"
-"`Embed.toml` file in your project directory."
+" output and connect GDB. It's configured by an `Embed.toml` file in your "
+"project directory."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/probe-rs.md:16
 msgid ""
-"* [CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
-"an Arm standard\n"
-"  protocol over USB for an in-circuit debugger to access the CoreSight Debug "
-"Access Port of various\n"
-"  Arm Cortex processors. It's what the on-board debugger on the BBC micro:"
-"bit uses.\n"
-"* ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-"
-"Link is a range from\n"
-"  SEGGER.\n"
-"* The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
-"Serial Wire Debug.\n"
-"* probe-rs is a library which you can integrate into your own tools if you "
-"want to.\n"
-"* The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
-"adapter-protocol/) lets\n"
-"  VSCode and other IDEs debug code running on any supported "
-"microcontroller.\n"
-"* cargo-embed is a binary built using the probe-rs library.\n"
-"* RTT (Real Time Transfers) is a mechanism to transfer data between the "
-"debug host and the target\n"
-"  through a number of ringbuffers."
+"[CMSIS-DAP](https://arm-software.github.io/CMSIS_5/DAP/html/index.html) is "
+"an Arm standard protocol over USB for an in-circuit debugger to access the "
+"CoreSight Debug Access Port of various Arm Cortex processors. It's what the "
+"on-board debugger on the BBC micro:bit uses."
 msgstr ""
 
-#: src/bare-metal/microcontrollers/debugging.md:1
-#, fuzzy
-msgid "# Debugging"
-msgstr "# Protokollierung"
+#: src/bare-metal/microcontrollers/probe-rs.md:19
+msgid ""
+"ST-Link is a range of in-circuit debuggers from ST Microelectronics, J-Link "
+"is a range from SEGGER."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:21
+msgid ""
+"The Debug Access Port is usually either a 5-pin JTAG interface or 2-pin "
+"Serial Wire Debug."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:22
+msgid ""
+"probe-rs is a library which you can integrate into your own tools if you "
+"want to."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:23
+msgid ""
+"The [Microsoft Debug Adapter Protocol](https://microsoft.github.io/debug-"
+"adapter-protocol/) lets VSCode and other IDEs debug code running on any "
+"supported microcontroller."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:25
+msgid "cargo-embed is a binary built using the probe-rs library."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/probe-rs.md:26
+msgid ""
+"RTT (Real Time Transfers) is a mechanism to transfer data between the debug "
+"host and the target through a number of ringbuffers."
+msgstr ""
 
 #: src/bare-metal/microcontrollers/debugging.md:3
 msgid "Embed.toml:"
@@ -14142,39 +14709,86 @@ msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:1
 #: src/bare-metal/aps/other-projects.md:1
-msgid "# Other projects"
+msgid "Other projects"
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:3
+msgid "[RTIC](https://rtic.rs/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:4
+msgid "\"Real-Time Interrupt-driven Concurrency\""
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:5
 msgid ""
-" * [RTIC](https://rtic.rs/)\n"
-"   * \"Real-Time Interrupt-driven Concurrency\"\n"
-"   * Shared resource management, message passing, task scheduling, timer "
-"queue\n"
-" * [Embassy](https://embassy.dev/)\n"
-"   * `async` executors with priorities, timers, networking, USB\n"
-" * [TockOS](https://www.tockos.org/documentation/getting-started)\n"
-"   * Security-focused RTOS with preemptive scheduling and Memory Protection "
-"Unit support\n"
-" * [Hubris](https://hubris.oxide.computer/)\n"
-"   * Microkernel RTOS from Oxide Computer Company with memory protection, "
-"unprivileged drivers, IPC\n"
-" * [Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)\n"
-" * Some platforms have `std` implementations, e.g.\n"
-"   [esp-idf](https://esp-rs.github.io/book/overview/using-the-standard-"
-"library.html)."
+"Shared resource management, message passing, task scheduling, timer queue"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:6
+msgid "[Embassy](https://embassy.dev/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:7
+msgid "`async` executors with priorities, timers, networking, USB"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:8
+msgid "[TockOS](https://www.tockos.org/documentation/getting-started)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:9
+msgid ""
+"Security-focused RTOS with preemptive scheduling and Memory Protection Unit "
+"support"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:10
+msgid "[Hubris](https://hubris.oxide.computer/)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:11
+msgid ""
+"Microkernel RTOS from Oxide Computer Company with memory protection, "
+"unprivileged drivers, IPC"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:12
+msgid "[Bindings for FreeRTOS](https://github.com/lobaro/FreeRTOS-rust)"
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:13
+msgid ""
+"Some platforms have `std` implementations, e.g. [esp-idf](https://esp-rs."
+"github.io/book/overview/using-the-standard-library.html)."
 msgstr ""
 
 #: src/bare-metal/microcontrollers/other-projects.md:18
+msgid "RTIC can be considered either an RTOS or a concurrency framework."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:19
+msgid "It doesn't include any HALs."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:20
 msgid ""
-" * RTIC can be considered either an RTOS or a concurrency framework.\n"
-"   * It doesn't include any HALs.\n"
-"   * It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
-"scheduling rather than a\n"
-"     proper kernel.\n"
-"   * Cortex-M only.\n"
-" * Google uses TockOS on the Haven microcontroller for Titan security keys.\n"
-" * FreeRTOS is mostly written in C, but there are Rust bindings for writing "
+"It uses the Cortex-M NVIC (Nested Virtual Interrupt Controller) for "
+"scheduling rather than a proper kernel."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:22
+msgid "Cortex-M only."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:23
+msgid ""
+"Google uses TockOS on the Haven microcontroller for Titan security keys."
+msgstr ""
+
+#: src/bare-metal/microcontrollers/other-projects.md:24
+msgid ""
+"FreeRTOS is mostly written in C, but there are Rust bindings for writing "
 "applications."
 msgstr ""
 
@@ -14184,16 +14798,11 @@ msgid ""
 "serial port."
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:1
-#, fuzzy
-msgid "# Compass"
-msgstr "# Vergleich"
-
 #: src/exercises/bare-metal/compass.md:3
 msgid ""
 "We will read the direction from an I2C compass, and log the readings to a "
-"serial port. If you have\n"
-"time, try displaying it on the LEDs somehow too, or use the buttons somehow."
+"serial port. If you have time, try displaying it on the LEDs somehow too, or "
+"use the buttons somehow."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:6
@@ -14202,47 +14811,52 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:8
 msgid ""
-"- Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
-"latest/lsm303agr/) and\n"
-"  [`microbit-v2`](https://docs.rs/microbit-v2/latest/microbit/) crates, as "
-"well as the\n"
-"  [micro:bit hardware](https://tech.microbit.org/hardware/).\n"
-"- The LSM303AGR Inertial Measurement Unit is connected to the internal I2C "
-"bus.\n"
-"- TWI is another name for I2C, so the I2C master peripheral is called TWIM.\n"
-"- The LSM303AGR driver needs something implementing the `embedded_hal::"
-"blocking::i2c::WriteRead`\n"
-"  trait. The\n"
-"  [`microbit::hal::Twim`](https://docs.rs/microbit-v2/latest/microbit/hal/"
-"struct.Twim.html) struct\n"
-"  implements this.\n"
-"- You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
-"struct.Board.html)\n"
-"  struct with fields for the various pins and peripherals.\n"
-"- You can also look at the\n"
-"  [nRF52833 datasheet](https://infocenter.nordicsemi.com/pdf/"
-"nRF52833_PS_v1.5.pdf) if you want, but\n"
-"  it shouldn't be necessary for this exercise."
+"Check the documentation for the [`lsm303agr`](https://docs.rs/lsm303agr/"
+"latest/lsm303agr/) and [`microbit-v2`](https://docs.rs/microbit-v2/latest/"
+"microbit/) crates, as well as the [micro:bit hardware](https://tech.microbit."
+"org/hardware/)."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:11
+msgid ""
+"The LSM303AGR Inertial Measurement Unit is connected to the internal I2C bus."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:12
+msgid ""
+"TWI is another name for I2C, so the I2C master peripheral is called TWIM."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:13
+msgid ""
+"The LSM303AGR driver needs something implementing the `embedded_hal::"
+"blocking::i2c::WriteRead` trait. The [`microbit::hal::Twim`](https://docs.rs/"
+"microbit-v2/latest/microbit/hal/struct.Twim.html) struct implements this."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:17
+msgid ""
+"You have a [`microbit::Board`](https://docs.rs/microbit-v2/latest/microbit/"
+"struct.Board.html) struct with fields for the various pins and peripherals."
+msgstr ""
+
+#: src/exercises/bare-metal/compass.md:19
+msgid ""
+"You can also look at the [nRF52833 datasheet](https://infocenter.nordicsemi."
+"com/pdf/nRF52833_PS_v1.5.pdf) if you want, but it shouldn't be necessary for "
+"this exercise."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:23
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `compass`\n"
-"directory for the following files."
+"look in the `compass` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:26 src/exercises/bare-metal/rtc.md:19
 #, fuzzy
 msgid "`src/main.rs`:"
 msgstr "_hello_rust/src/main.rs_:"
-
-#: src/exercises/bare-metal/compass.md:28 src/exercises/bare-metal/rtc.md:21
-#: src/exercises/concurrency/dining-philosophers.md:17
-#: src/exercises/concurrency/link-checker.md:55
-#: src/exercises/concurrency/dining-philosophers-async.md:11
-msgid "<!-- File src/main.rs -->"
-msgstr ""
 
 #: src/exercises/bare-metal/compass.md:30
 msgid ""
@@ -14285,14 +14899,6 @@ msgstr ""
 msgid "`Cargo.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:66 src/exercises/bare-metal/rtc.md:387
-#: src/exercises/concurrency/dining-philosophers.md:63
-#: src/exercises/concurrency/link-checker.md:35
-#: src/exercises/concurrency/dining-philosophers-async.md:60
-#: src/exercises/concurrency/chat-app.md:17
-msgid "<!-- File Cargo.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:68
 msgid ""
 "```toml\n"
@@ -14317,10 +14923,6 @@ msgstr ""
 msgid "`Embed.toml` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/compass.md:87
-msgid "<!-- File Embed.toml -->"
-msgstr ""
-
 #: src/exercises/bare-metal/compass.md:89
 msgid ""
 "```toml\n"
@@ -14337,10 +14939,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/compass.md:100 src/exercises/bare-metal/rtc.md:985
 msgid "`.cargo/config.toml` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/compass.md:102 src/exercises/bare-metal/rtc.md:987
-msgid "<!-- File .cargo/config.toml -->"
 msgstr ""
 
 #: src/exercises/bare-metal/compass.md:104
@@ -14382,39 +14980,47 @@ msgid "Use Ctrl+A Ctrl+Q to quit picocom."
 msgstr ""
 
 #: src/bare-metal/aps.md:1
-msgid "# Application processors"
+msgid "Application processors"
 msgstr ""
 
 #: src/bare-metal/aps.md:3
 msgid ""
 "So far we've talked about microcontrollers, such as the Arm Cortex-M series. "
-"Now let's try writing\n"
-"something for Cortex-A. For simplicity we'll just work with QEMU's aarch64\n"
-"['virt'](https://qemu-project.gitlab.io/qemu/system/arm/virt.html) board."
+"Now let's try writing something for Cortex-A. For simplicity we'll just work "
+"with QEMU's aarch64 ['virt'](https://qemu-project.gitlab.io/qemu/system/arm/"
+"virt.html) board."
 msgstr ""
 
 #: src/bare-metal/aps.md:9
 msgid ""
-"* Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
-"privilege (exception\n"
-"  levels on Arm CPUs, rings on x86), while application processors do.\n"
-"* QEMU supports emulating various different machines or board models for "
-"each architecture. The\n"
-"  'virt' board doesn't correspond to any particular real hardware, but is "
-"designed purely for\n"
-"  virtual machines."
+"Broadly speaking, microcontrollers don't have an MMU or multiple levels of "
+"privilege (exception levels on Arm CPUs, rings on x86), while application "
+"processors do."
+msgstr ""
+
+#: src/bare-metal/aps.md:11
+msgid ""
+"QEMU supports emulating various different machines or board models for each "
+"architecture. The 'virt' board doesn't correspond to any particular real "
+"hardware, but is designed purely for virtual machines."
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:1
-msgid "# Inline assembly"
+msgid "Inline assembly"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:3
 msgid ""
 "Sometimes we need to use assembly to do things that aren't possible with "
-"Rust code. For example,\n"
-"to make an <abbr title=\"hypervisor call\">HVC</abbr> to tell the firmware "
-"to power off the system:"
+"Rust code. For example, to make an "
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid "HVC"
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:4
+msgid " to tell the firmware to power off the system:"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:6
@@ -14455,74 +15061,99 @@ msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:39
 msgid ""
-"(If you actually want to do this, use the [`smccc`][1] crate which has "
-"wrappers for all these functions.)"
+"(If you actually want to do this, use the [`smccc`](https://crates.io/crates/"
+"smccc) crate which has wrappers for all these functions.)"
 msgstr ""
 
 #: src/bare-metal/aps/inline-assembly.md:43
 msgid ""
-"* PSCI is the Arm Power State Coordination Interface, a standard set of "
-"functions to manage system\n"
-"  and CPU power states, among other things. It is implemented by EL3 "
-"firmware and hypervisors on\n"
-"  many systems.\n"
-"* The `0 => _` syntax means initialise the register to 0 before running the "
-"inline assembly code,\n"
-"  and ignore its contents afterwards. We need to use `inout` rather than "
-"`in` because the call could\n"
-"  potentially clobber the contents of the registers.\n"
-"* This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
-"it is called from our\n"
-"  entry point in `entry.S`.\n"
-"* `_x0`–`_x3` are the values of registers `x0`–`x3`, which are "
-"conventionally used by the bootloader\n"
-"  to pass things like a pointer to the device tree. According to the "
-"standard aarch64 calling\n"
-"  convention (which is what `extern \"C\"` specifies to use), registers `x0`–"
-"`x7` are used for the\n"
-"  first 8 arguments passed to a function, so `entry.S` doesn't need to do "
-"anything special except\n"
-"  make sure it doesn't change these registers.\n"
-"* Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
+"PSCI is the Arm Power State Coordination Interface, a standard set of "
+"functions to manage system and CPU power states, among other things. It is "
+"implemented by EL3 firmware and hypervisors on many systems."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:46
+msgid ""
+"The `0 => _` syntax means initialise the register to 0 before running the "
+"inline assembly code, and ignore its contents afterwards. We need to use "
+"`inout` rather than `in` because the call could potentially clobber the "
+"contents of the registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:49
+msgid ""
+"This `main` function needs to be `#[no_mangle]` and `extern \"C\"` because "
+"it is called from our entry point in `entry.S`."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:51
+msgid ""
+"`_x0`–`_x3` are the values of registers `x0`–`x3`, which are conventionally "
+"used by the bootloader to pass things like a pointer to the device tree. "
+"According to the standard aarch64 calling convention (which is what `extern "
+"\"C\"` specifies to use), registers `x0`–`x7` are used for the first 8 "
+"arguments passed to a function, so `entry.S` doesn't need to do anything "
+"special except make sure it doesn't change these registers."
+msgstr ""
+
+#: src/bare-metal/aps/inline-assembly.md:56
+msgid ""
+"Run the example in QEMU with `make qemu_psci` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:1
-msgid "# Volatile memory access for MMIO"
+msgid "Volatile memory access for MMIO"
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:3
+msgid "Use `pointer::read_volatile` and `pointer::write_volatile`."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:4
+msgid "Never hold a reference."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:5
 msgid ""
-" * Use `pointer::read_volatile` and `pointer::write_volatile`.\n"
-" * Never hold a reference.\n"
-" * `addr_of!` lets you get fields of structs without creating an "
-"intermediate reference."
+"`addr_of!` lets you get fields of structs without creating an intermediate "
+"reference."
 msgstr ""
 
 #: src/bare-metal/aps/mmio.md:9
 msgid ""
-" * Volatile access: read or write operations may have side-effects, so "
-"prevent the compiler or\n"
-"   hardware from reordering, duplicating or eliding them.\n"
-"   * Usually if you write and then read, e.g. via a mutable reference, the "
-"compiler may assume that\n"
-"     the value read is the same as the value just written, and not bother "
-"actually reading memory.\n"
-" * Some existing crates for volatile access to hardware do hold references, "
-"but this is unsound.\n"
-"   Whenever a reference exist, the compiler may choose to dereference it.\n"
-" * Use the `addr_of!` macro to get struct field pointers from a pointer to "
-"the struct."
+"Volatile access: read or write operations may have side-effects, so prevent "
+"the compiler or hardware from reordering, duplicating or eliding them."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:11
+msgid ""
+"Usually if you write and then read, e.g. via a mutable reference, the "
+"compiler may assume that the value read is the same as the value just "
+"written, and not bother actually reading memory."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:13
+msgid ""
+"Some existing crates for volatile access to hardware do hold references, but "
+"this is unsound. Whenever a reference exist, the compiler may choose to "
+"dereference it."
+msgstr ""
+
+#: src/bare-metal/aps/mmio.md:15
+msgid ""
+"Use the `addr_of!` macro to get struct field pointers from a pointer to the "
+"struct."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:1
-msgid "# Let's write a UART driver"
+msgid "Let's write a UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:3
 msgid ""
-"The QEMU 'virt' machine has a [PL011][1] UART, so let's write a driver for "
-"that."
+"The QEMU 'virt' machine has a [PL011](https://developer.arm.com/"
+"documentation/ddi0183/g) UART, so let's write a driver for that."
 msgstr ""
 
 #: src/bare-metal/aps/uart.md:5
@@ -14582,34 +15213,32 @@ msgstr ""
 
 #: src/bare-metal/aps/uart.md:55
 msgid ""
-"* Note that `Uart::new` is unsafe while the other methods are safe. This is "
-"because as long as the\n"
-"  caller of `Uart::new` guarantees that its safety requirements are met (i."
-"e. that there is only\n"
-"  ever one instance of the driver for a given UART, and nothing else "
-"aliasing its address space),\n"
-"  then it is always safe to call `write_byte` later because we can assume "
-"the necessary\n"
-"  preconditions.\n"
-"* We could have done it the other way around (making `new` safe but "
-"`write_byte` unsafe), but that\n"
-"  would be much less convenient to use as every place that calls "
-"`write_byte` would need to reason\n"
-"  about the safety\n"
-"* This is a common pattern for writing safe wrappers of unsafe code: moving "
-"the burden of proof for\n"
-"  soundness from a large number of places to a smaller number of places."
+"Note that `Uart::new` is unsafe while the other methods are safe. This is "
+"because as long as the caller of `Uart::new` guarantees that its safety "
+"requirements are met (i.e. that there is only ever one instance of the "
+"driver for a given UART, and nothing else aliasing its address space), then "
+"it is always safe to call `write_byte` later because we can assume the "
+"necessary preconditions."
 msgstr ""
 
-#: src/bare-metal/aps/uart.md:66
-#, fuzzy
-msgid "</detais>"
-msgstr "</details>"
+#: src/bare-metal/aps/uart.md:60
+msgid ""
+"We could have done it the other way around (making `new` safe but "
+"`write_byte` unsafe), but that would be much less convenient to use as every "
+"place that calls `write_byte` would need to reason about the safety"
+msgstr ""
+
+#: src/bare-metal/aps/uart.md:63
+msgid ""
+"This is a common pattern for writing safe wrappers of unsafe code: moving "
+"the burden of proof for soundness from a large number of places to a smaller "
+"number of places."
+msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:1
 #, fuzzy
-msgid "# More traits"
-msgstr "# Züge"
+msgid "More traits"
+msgstr "Züge"
 
 #: src/bare-metal/aps/uart/traits.md:3
 msgid ""
@@ -14639,51 +15268,188 @@ msgstr ""
 
 #: src/bare-metal/aps/uart/traits.md:24
 msgid ""
-"* Implementing `Write` lets us use the `write!` and `writeln!` macros with "
-"our `Uart` type.\n"
-"* Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
+"Implementing `Write` lets us use the `write!` and `writeln!` macros with our "
+"`Uart` type."
+msgstr ""
+
+#: src/bare-metal/aps/uart/traits.md:25
+msgid ""
+"Run the example in QEMU with `make qemu_minimal` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:1
-msgid "# A better UART driver"
+msgid "A better UART driver"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:3
 msgid ""
-"The PL011 actually has [a bunch more registers][1], and adding offsets to "
-"construct pointers to access\n"
-"them is error-prone and hard to read. Plus, some of them are bit fields "
-"which would be nice to\n"
-"access in a structured way."
+"The PL011 actually has [a bunch more registers](https://developer.arm.com/"
+"documentation/ddi0183/g/programmers-model/summary-of-registers), and adding "
+"offsets to construct pointers to access them is error-prone and hard to "
+"read. Plus, some of them are bit fields which would be nice to access in a "
+"structured way."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:7
-msgid ""
-"| Offset | Register name | Width |\n"
-"| ------ | ------------- | ----- |\n"
-"| 0x00   | DR            | 12    |\n"
-"| 0x04   | RSR           | 4     |\n"
-"| 0x18   | FR            | 9     |\n"
-"| 0x20   | ILPR          | 8     |\n"
-"| 0x24   | IBRD          | 16    |\n"
-"| 0x28   | FBRD          | 6     |\n"
-"| 0x2c   | LCR_H         | 8     |\n"
-"| 0x30   | CR            | 16    |\n"
-"| 0x34   | IFLS          | 6     |\n"
-"| 0x38   | IMSC          | 11    |\n"
-"| 0x3c   | RIS           | 11    |\n"
-"| 0x40   | MIS           | 11    |\n"
-"| 0x44   | ICR           | 11    |\n"
-"| 0x48   | DMACR         | 3     |"
+msgid "Offset"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Register name"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:7
+msgid "Width"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "0x00"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "DR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:9
+msgid "12"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "0x04"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "RSR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:10
+msgid "4"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "0x18"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "FR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:11
+msgid "9"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "0x20"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12
+msgid "ILPR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:12 src/bare-metal/aps/better-uart.md:15
+msgid "8"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "0x24"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13
+msgid "IBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:13 src/bare-metal/aps/better-uart.md:16
+msgid "16"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "0x28"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14
+msgid "FBRD"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:14 src/bare-metal/aps/better-uart.md:17
+msgid "6"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "0x2c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:15
+msgid "LCR_H"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "0x30"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:16
+msgid "CR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "0x34"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:17
+msgid "IFLS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "0x38"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18
+msgid "IMSC"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:18 src/bare-metal/aps/better-uart.md:19
+#: src/bare-metal/aps/better-uart.md:20 src/bare-metal/aps/better-uart.md:21
+msgid "11"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "0x3c"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:19
+msgid "RIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "0x40"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:20
+msgid "MIS"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "0x44"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:21
+msgid "ICR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "0x48"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "DMACR"
+msgstr ""
+
+#: src/bare-metal/aps/better-uart.md:22
+msgid "3"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart.md:26
-msgid "- There are also some ID registers which have been omitted for brevity."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/bitflags.md:1
-msgid "# Bitflags"
+msgid "There are also some ID registers which have been omitted for brevity."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:3
@@ -14727,13 +15493,12 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/bitflags.md:37
 msgid ""
-"* The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
-"with a bunch of method\n"
-"  implementations to get and set flags."
+"The `bitflags!` macro creates a newtype something like `Flags(u16)`, along "
+"with a bunch of method implementations to get and set flags."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:1
-msgid "# Multiple registers"
+msgid "Multiple registers"
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:3
@@ -14780,17 +15545,11 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/registers.md:41
 msgid ""
-"* [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
-"representation) tells\n"
-"  the compiler to lay the struct fields out in order, following the same "
-"rules as C. This is\n"
-"  necessary for our struct to have a predictable layout, as default Rust "
-"representation allows the\n"
-"  compiler to (among other things) reorder fields however it sees fit."
-msgstr ""
-
-#: src/bare-metal/aps/better-uart/driver.md:1
-msgid "# Driver"
+"[`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-"
+"representation) tells the compiler to lay the struct fields out in order, "
+"following the same rules as C. This is necessary for our struct to have a "
+"predictable layout, as default Rust representation allows the compiler to "
+"(among other things) reorder fields however it sees fit."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:3
@@ -14864,22 +15623,20 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/driver.md:64
 msgid ""
-"* Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
-"fields without creating\n"
-"  an intermediate reference, which would be unsound."
+"Note the use of `addr_of!` / `addr_of_mut!` to get pointers to individual "
+"fields without creating an intermediate reference, which would be unsound."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:1
 #: src/bare-metal/aps/logging/using.md:1
 #, fuzzy
-msgid "# Using it"
-msgstr "# Verwenden von Bindgen"
+msgid "Using it"
+msgstr "Verwenden von Bindgen"
 
 #: src/bare-metal/aps/better-uart/using.md:3
 msgid ""
 "Let's write a small program using our driver to write to the serial console, "
-"and echo incoming\n"
-"bytes."
+"and echo incoming bytes."
 msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:6
@@ -14931,18 +15688,21 @@ msgstr ""
 
 #: src/bare-metal/aps/better-uart/using.md:51
 msgid ""
-"* As in the [inline assembly](../inline-assembly.md) example, this `main` "
-"function is called from our\n"
-"  entry point code in `entry.S`. See the speaker notes there for details.\n"
-"* Run the example in QEMU with `make qemu` under `src/bare-metal/aps/"
-"examples`."
+"As in the [inline assembly](../inline-assembly.md) example, this `main` "
+"function is called from our entry point code in `entry.S`. See the speaker "
+"notes there for details."
+msgstr ""
+
+#: src/bare-metal/aps/better-uart/using.md:53
+msgid ""
+"Run the example in QEMU with `make qemu` under `src/bare-metal/aps/examples`."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:3
 msgid ""
-"It would be nice to be able to use the logging macros from the [`log`][1] "
-"crate. We can do this by\n"
-"implementing the `Log` trait."
+"It would be nice to be able to use the logging macros from the [`log`]"
+"(https://crates.io/crates/log) crate. We can do this by implementing the "
+"`Log` trait."
 msgstr ""
 
 #: src/bare-metal/aps/logging.md:6
@@ -14993,7 +15753,7 @@ msgstr ""
 
 #: src/bare-metal/aps/logging.md:50
 msgid ""
-"* The unwrap in `log` is safe because we initialise `LOGGER` before calling "
+"The unwrap in `log` is safe because we initialise `LOGGER` before calling "
 "`set_logger`."
 msgstr ""
 
@@ -15045,29 +15805,53 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/aps/logging/using.md:46
+msgid "Note that our panic handler can now log details of panics."
+msgstr ""
+
+#: src/bare-metal/aps/logging/using.md:47
 msgid ""
-"* Note that our panic handler can now log details of panics.\n"
-"* Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
+"Run the example in QEMU with `make qemu_logger` under `src/bare-metal/aps/"
 "examples`."
 msgstr ""
 
 #: src/bare-metal/aps/other-projects.md:3
-msgid ""
-" * [oreboot](https://github.com/oreboot/oreboot)\n"
-"   * \"coreboot without the C\"\n"
-"   * Supports x86, aarch64 and RISC-V.\n"
-"   * Relies on LinuxBoot rather than having many drivers itself.\n"
-" * [Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
-"raspberrypi-OS-tutorials)\n"
-"   * Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
-"exception handling, page tables\n"
-"   * Not all very well written, so beware.\n"
-" * [`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)\n"
-"   * Static analysis to determine maximum stack usage."
+msgid "[oreboot](https://github.com/oreboot/oreboot)"
 msgstr ""
 
-#: src/bare-metal/useful-crates.md:1
-msgid "# Useful crates"
+#: src/bare-metal/aps/other-projects.md:4
+msgid "\"coreboot without the C\""
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:5
+msgid "Supports x86, aarch64 and RISC-V."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:6
+msgid "Relies on LinuxBoot rather than having many drivers itself."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:7
+msgid ""
+"[Rust RaspberryPi OS tutorial](https://github.com/rust-embedded/rust-"
+"raspberrypi-OS-tutorials)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:8
+msgid ""
+"Initialisation, UART driver, simple bootloader, JTAG, exception levels, "
+"exception handling, page tables"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:9
+msgid "Not all very well written, so beware."
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:10
+msgid "[`cargo-call-stack`](https://crates.io/crates/cargo-call-stack)"
+msgstr ""
+
+#: src/bare-metal/aps/other-projects.md:11
+msgid "Static analysis to determine maximum stack usage."
 msgstr ""
 
 #: src/bare-metal/useful-crates.md:3
@@ -15077,14 +15861,14 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:1
-msgid "# `zerocopy`"
+msgid "`zerocopy`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:3
 msgid ""
-"The [`zerocopy`][1] crate (from Fuchsia) provides traits and macros for "
-"safely converting between\n"
-"byte sequences and other types."
+"The [`zerocopy`](https://docs.rs/zerocopy/) crate (from Fuchsia) provides "
+"traits and macros for safely converting between byte sequences and other "
+"types."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:6
@@ -15127,34 +15911,44 @@ msgstr ""
 #: src/bare-metal/useful-crates/zerocopy.md:40
 msgid ""
 "This is not suitable for MMIO (as it doesn't use volatile reads and writes), "
-"but can be useful for\n"
-"working with structures shared with hardware e.g. by DMA, or sent over some "
-"external interface."
+"but can be useful for working with structures shared with hardware e.g. by "
+"DMA, or sent over some external interface."
 msgstr ""
 
 #: src/bare-metal/useful-crates/zerocopy.md:45
 msgid ""
-"* `FromBytes` can be implemented for types for which any byte pattern is "
-"valid, and so can safely be\n"
-"  converted from an untrusted sequence of bytes.\n"
-"* Attempting to derive `FromBytes` for these types would fail, because "
-"`RequestType` doesn't use all\n"
-"  possible u32 values as discriminants, so not all byte patterns are valid.\n"
-"* `zerocopy::byteorder` has types for byte-order aware numeric primitives.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"zerocopy-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"`FromBytes` can be implemented for types for which any byte pattern is "
+"valid, and so can safely be converted from an untrusted sequence of bytes."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:47
+msgid ""
+"Attempting to derive `FromBytes` for these types would fail, because "
+"`RequestType` doesn't use all possible u32 values as discriminants, so not "
+"all byte patterns are valid."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:49
+msgid ""
+"`zerocopy::byteorder` has types for byte-order aware numeric primitives."
+msgstr ""
+
+#: src/bare-metal/useful-crates/zerocopy.md:50
+msgid ""
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"zerocopy-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:1
-msgid "# `aarch64-paging`"
+msgid "`aarch64-paging`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:3
 msgid ""
-"The [`aarch64-paging`][1] crate lets you create page tables according to the "
-"AArch64 Virtual Memory\n"
-"System Architecture."
+"The [`aarch64-paging`](https://crates.io/crates/aarch64-paging) crate lets "
+"you create page tables according to the AArch64 Virtual Memory System "
+"Architecture."
 msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:6
@@ -15182,27 +15976,37 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/aarch64-paging.md:28
 msgid ""
-"* For now it only supports EL1, but support for other exception levels "
-"should be straightforward to\n"
-"  add.\n"
-"* This is used in Android for the [Protected VM Firmware][2].\n"
-"* There's no easy way to run this example, as it needs to run on real "
-"hardware or under QEMU."
+"For now it only supports EL1, but support for other exception levels should "
+"be straightforward to add."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:30
+msgid ""
+"This is used in Android for the [Protected VM Firmware](https://cs.android."
+"com/android/platform/superproject/+/master:packages/modules/Virtualization/"
+"pvmfw/)."
+msgstr ""
+
+#: src/bare-metal/useful-crates/aarch64-paging.md:31
+msgid ""
+"There's no easy way to run this example, as it needs to run on real hardware "
+"or under QEMU."
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:1
-msgid "# `buddy_system_allocator`"
+msgid "`buddy_system_allocator`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:3
 msgid ""
-"[`buddy_system_allocator`][1] is a third-party crate implementing a basic "
-"buddy system allocator.\n"
-"It can be used both for [`LockedHeap`][2] implementing [`GlobalAlloc`][3] so "
-"you can use the\n"
-"standard `alloc` crate (as we saw [before][4]), or for allocating other "
-"address space. For example,\n"
-"we might want to allocate MMIO space for PCI BARs:"
+"[`buddy_system_allocator`](https://crates.io/crates/buddy_system_allocator) "
+"is a third-party crate implementing a basic buddy system allocator. It can "
+"be used both for [`LockedHeap`](https://docs.rs/buddy_system_allocator/0.9.0/"
+"buddy_system_allocator/struct.LockedHeap.html) implementing [`GlobalAlloc`]"
+"(https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html) so you can use "
+"the standard `alloc` crate (as we saw [before](../alloc.md)), or for "
+"allocating other address space. For example, we might want to allocate MMIO "
+"space for PCI BARs:"
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:8
@@ -15225,26 +16029,27 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/buddy_system_allocator.md:26
+msgid "PCI BARs always have alignment equal to their size."
+msgstr ""
+
+#: src/bare-metal/useful-crates/buddy_system_allocator.md:27
 msgid ""
-"* PCI BARs always have alignment equal to their size.\n"
-"* Run the example with `cargo run` under `src/bare-metal/useful-crates/"
-"allocator-example/`. (It won't\n"
-"  run in the Playground because of the crate dependency.)"
+"Run the example with `cargo run` under `src/bare-metal/useful-crates/"
+"allocator-example/`. (It won't run in the Playground because of the crate "
+"dependency.)"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:1
-msgid "# `tinyvec`"
+msgid "`tinyvec`"
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:3
 msgid ""
 "Sometimes you want something which can be resized like a `Vec`, but without "
-"heap allocation.\n"
-"[`tinyvec`][1] provides this: a vector backed by an array or slice, which "
-"could be statically\n"
+"heap allocation. [`tinyvec`](https://crates.io/crates/tinyvec) provides "
+"this: a vector backed by an array or slice, which could be statically "
 "allocated or on the stack, which keeps track of how many elements are used "
-"and panics if you try to\n"
-"use more than are allocated."
+"and panics if you try to use more than are allocated."
 msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:8
@@ -15265,30 +16070,31 @@ msgstr ""
 
 #: src/bare-metal/useful-crates/tinyvec.md:23
 msgid ""
-"* `tinyvec` requires that the element type implement `Default` for "
-"initialisation.\n"
-"* The Rust Playground includes `tinyvec`, so this example will run fine "
-"inline."
+"`tinyvec` requires that the element type implement `Default` for "
+"initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/tinyvec.md:24
+msgid ""
+"The Rust Playground includes `tinyvec`, so this example will run fine inline."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:1
 #, fuzzy
-msgid "# `spin`"
-msgstr "## `statisch`"
+msgid "`spin`"
+msgstr "`statisch`"
 
 #: src/bare-metal/useful-crates/spin.md:3
 msgid ""
 "`std::sync::Mutex` and the other synchronisation primitives from `std::sync` "
-"are not available in\n"
-"`core` or `alloc`. How can we manage synchronisation or interior mutability, "
-"such as for sharing\n"
-"state between different CPUs?"
+"are not available in `core` or `alloc`. How can we manage synchronisation or "
+"interior mutability, such as for sharing state between different CPUs?"
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:7
 msgid ""
-"The [`spin`][1] crate provides spinlock-based equivalents of many of these "
-"primitives."
+"The [`spin`](https://crates.io/crates/spin) crate provides spinlock-based "
+"equivalents of many of these primitives."
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:9
@@ -15307,29 +16113,33 @@ msgid ""
 msgstr ""
 
 #: src/bare-metal/useful-crates/spin.md:23
-msgid ""
-"* Be careful to avoid deadlock if you take locks in interrupt handlers.\n"
-"* `spin` also has a ticket lock mutex implementation; equivalents of "
-"`RwLock`, `Barrier` and `Once`\n"
-"  from `std::sync`;  and `Lazy` for lazy initialisation.\n"
-"* The [`once_cell`][2] crate also has some useful types for late "
-"initialisation with a slightly\n"
-"  different approach to `spin::once::Once`.\n"
-"* The Rust Playground includes `spin`, so this example will run fine inline."
+msgid "Be careful to avoid deadlock if you take locks in interrupt handlers."
 msgstr ""
 
-#: src/bare-metal/android.md:1
-#, fuzzy
-msgid "# Android"
-msgstr "# Android"
+#: src/bare-metal/useful-crates/spin.md:24
+msgid ""
+"`spin` also has a ticket lock mutex implementation; equivalents of `RwLock`, "
+"`Barrier` and `Once` from `std::sync`;  and `Lazy` for lazy initialisation."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:26
+msgid ""
+"The [`once_cell`](https://crates.io/crates/once_cell) crate also has some "
+"useful types for late initialisation with a slightly different approach to "
+"`spin::once::Once`."
+msgstr ""
+
+#: src/bare-metal/useful-crates/spin.md:28
+msgid ""
+"The Rust Playground includes `spin`, so this example will run fine inline."
+msgstr ""
 
 #: src/bare-metal/android.md:3
 msgid ""
 "To build a bare-metal Rust binary in AOSP, you need to use a "
-"`rust_ffi_static` Soong rule to build\n"
-"your Rust code, then a `cc_binary` with a linker script to produce the "
-"binary itself, and then a\n"
-"`raw_binary` to convert the ELF to a raw binary ready to be run."
+"`rust_ffi_static` Soong rule to build your Rust code, then a `cc_binary` "
+"with a linker script to produce the binary itself, and then a `raw_binary` "
+"to convert the ELF to a raw binary ready to be run."
 msgstr ""
 
 #: src/bare-metal/android.md:7
@@ -15374,16 +16184,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/bare-metal/android/vmbase.md:1
-msgid "# vmbase"
-msgstr ""
-
 #: src/bare-metal/android/vmbase.md:3
 msgid ""
-"For VMs running under crosvm on aarch64, the [vmbase][1] library provides a "
-"linker script and useful\n"
-"defaults for the build rules, along with an entry point, UART console "
-"logging and more."
+"For VMs running under crosvm on aarch64, the [vmbase](https://android."
+"googlesource.com/platform/packages/modules/Virtualization/+/refs/heads/"
+"master/vmbase/) library provides a linker script and useful defaults for the "
+"build rules, along with an entry point, UART console logging and more."
 msgstr ""
 
 #: src/bare-metal/android/vmbase.md:6
@@ -15404,11 +16210,14 @@ msgstr ""
 
 #: src/bare-metal/android/vmbase.md:21
 msgid ""
-"* The `main!` macro marks your main function, to be called from the `vmbase` "
-"entry point.\n"
-"* The `vmbase` entry point handles console initialisation, and issues a "
-"PSCI_SYSTEM_OFF to shutdown\n"
-"  the VM if your main function returns."
+"The `main!` macro marks your main function, to be called from the `vmbase` "
+"entry point."
+msgstr ""
+
+#: src/bare-metal/android/vmbase.md:22
+msgid ""
+"The `vmbase` entry point handles console initialisation, and issues a "
+"PSCI_SYSTEM_OFF to shutdown the VM if your main function returns."
 msgstr ""
 
 #: src/exercises/bare-metal/afternoon.md:3
@@ -15416,40 +16225,51 @@ msgid "We will write a driver for the PL031 real-time clock device."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:1
-msgid "# RTC driver"
+#: src/exercises/bare-metal/solutions-afternoon.md:3
+msgid "RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:3
 msgid ""
-"The QEMU aarch64 virt machine has a [PL031][1] real-time clock at 0x9010000. "
-"For this exercise, you\n"
-"should write a driver for it."
+"The QEMU aarch64 virt machine has a [PL031](https://developer.arm.com/"
+"documentation/ddi0224/c) real-time clock at 0x9010000. For this exercise, "
+"you should write a driver for it."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:6
 msgid ""
-"1. Use it to print the current time to the serial console. You can use the "
-"[`chrono`][2] crate for\n"
-"   date/time formatting.\n"
-"2. Use the match register and raw interrupt status to busy-wait until a "
-"given time, e.g. 3 seconds\n"
-"   in the future. (Call [`core::hint::spin_loop`][3] inside the loop.)\n"
-"3. _Extension if you have time:_ Enable and handle the interrupt generated "
-"by the RTC match. You can\n"
-"   use the driver provided in the [`arm-gic`][4] crate to configure the Arm "
-"Generic Interrupt Controller.\n"
-"   - Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`.\n"
-"   - Once the interrupt is enabled, you can put the core to sleep via "
-"`arm_gic::wfi()`, which will cause the core to sleep until it receives an "
-"interrupt.\n"
-"   "
+"Use it to print the current time to the serial console. You can use the "
+"[`chrono`](https://crates.io/crates/chrono) crate for date/time formatting."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:8
+msgid ""
+"Use the match register and raw interrupt status to busy-wait until a given "
+"time, e.g. 3 seconds in the future. (Call [`core::hint::spin_loop`](https://"
+"doc.rust-lang.org/core/hint/fn.spin_loop.html) inside the loop.)"
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:10
+msgid ""
+"_Extension if you have time:_ Enable and handle the interrupt generated by "
+"the RTC match. You can use the driver provided in the [`arm-gic`](https://"
+"docs.rs/arm-gic/) crate to configure the Arm Generic Interrupt Controller."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:12
+msgid "Use the RTC interrupt, which is wired to the GIC as `IntId::spi(2)`."
+msgstr ""
+
+#: src/exercises/bare-metal/rtc.md:13
+msgid ""
+"Once the interrupt is enabled, you can put the core to sleep via `arm_gic::"
+"wfi()`, which will cause the core to sleep until it receives an interrupt."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:16
 msgid ""
 "Download the [exercise template](../../comprehensive-rust-exercises.zip) and "
-"look in the `rtc`\n"
-"directory for the following files."
+"look in the `rtc` directory for the following files."
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:23
@@ -15514,10 +16334,6 @@ msgstr ""
 msgid ""
 "`src/exceptions.rs` (you should only need to change this for the 3rd part of "
 "the exercise):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:77
-msgid "<!-- File src/exceptions.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:79
@@ -15598,10 +16414,6 @@ msgstr ""
 msgid "`src/logger.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:151
-msgid "<!-- File src/logger.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:153
 msgid ""
 "```rust,compile_fail\n"
@@ -15665,10 +16477,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:210
 msgid "`src/pl011.rs` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:212
-msgid "<!-- File src/pl011.rs -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:214
@@ -15878,10 +16686,6 @@ msgstr ""
 msgid "`build.rs` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:412
-msgid "<!-- File build.rs -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:414
 msgid ""
 "```rust,compile_fail\n"
@@ -15919,10 +16723,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:446
 msgid "`entry.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:448
-msgid "<!-- File entry.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:450
@@ -16089,10 +16889,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:595
 msgid "`exceptions.S` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:597
-msgid "<!-- File exceptions.S -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:599
@@ -16293,10 +17089,6 @@ msgstr ""
 msgid "`idmap.S` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:782
-msgid "<!-- File idmap.S -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:784
 msgid ""
 "```armasm\n"
@@ -16348,10 +17140,6 @@ msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:829
 msgid "`image.ld` (you shouldn't need to change this):"
-msgstr ""
-
-#: src/exercises/bare-metal/rtc.md:831
-msgid "<!-- File image.ld -->"
 msgstr ""
 
 #: src/exercises/bare-metal/rtc.md:833
@@ -16469,10 +17257,6 @@ msgstr ""
 msgid "`Makefile` (you shouldn't need to change this):"
 msgstr ""
 
-#: src/exercises/bare-metal/rtc.md:942
-msgid "<!-- File Makefile -->"
-msgstr ""
-
 #: src/exercises/bare-metal/rtc.md:944
 msgid ""
 "```makefile\n"
@@ -16533,39 +17317,29 @@ msgstr ""
 
 #: src/concurrency.md:1
 #, fuzzy
-msgid "# Welcome to Concurrency in Rust"
-msgstr "# Willkommen bei Comprehensive Rust 🦀"
+msgid "Welcome to Concurrency in Rust"
+msgstr "Willkommen bei Comprehensive Rust 🦀"
 
 #: src/concurrency.md:3
 #, fuzzy
 msgid ""
-"Rust has full support for concurrency using OS threads with mutexes and\n"
+"Rust has full support for concurrency using OS threads with mutexes and "
 "channels."
 msgstr ""
 "Rust bietet volle Unterstützung für Parallelität unter Verwendung von "
-"Betriebssystem-Threads mit Mutexes und\n"
-"Kanäle."
+"Betriebssystem-Threads mit Mutexes und Kanäle."
 
 #: src/concurrency.md:6
 #, fuzzy
 msgid ""
-"The Rust type system plays an important role in making many concurrency "
-"bugs\n"
+"The Rust type system plays an important role in making many concurrency bugs "
 "compile time bugs. This is often referred to as _fearless concurrency_ since "
-"you\n"
-"can rely on the compiler to ensure correctness at runtime."
+"you can rely on the compiler to ensure correctness at runtime."
 msgstr ""
 "Das Rust-Typsystem spielt eine wichtige Rolle bei der Entstehung vieler "
-"Nebenläufigkeitsfehler\n"
-"Kompilierzeitfehler. Dies wird seit Ihnen oft als _furchtlose Parallelität_ "
-"bezeichnet\n"
-"kann sich auf den Compiler verlassen, um die Korrektheit zur Laufzeit "
-"sicherzustellen."
-
-#: src/concurrency/threads.md:1
-#, fuzzy
-msgid "# Threads"
-msgstr "# Threads"
+"Nebenläufigkeitsfehler Kompilierzeitfehler. Dies wird seit Ihnen oft als "
+"_furchtlose Parallelität_ bezeichnet kann sich auf den Compiler verlassen, "
+"um die Korrektheit zur Laufzeit sicherzustellen."
 
 #: src/concurrency/threads.md:3
 #, fuzzy
@@ -16596,37 +17370,44 @@ msgstr ""
 
 #: src/concurrency/threads.md:24
 #, fuzzy
-msgid ""
-"* Threads are all daemon threads, the main thread does not wait for them.\n"
-"* Thread panics are independent of each other.\n"
-"  * Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgid "Threads are all daemon threads, the main thread does not wait for them."
 msgstr ""
-"* Threads sind alle Daemon-Threads, der Haupt-Thread wartet nicht auf sie.\n"
-"* Thread-Panics sind voneinander unabhängig.\n"
-"  * Paniken können eine Nutzlast tragen, die mit `downcast_ref` entpackt "
-"werden kann."
+"Threads sind alle Daemon-Threads, der Haupt-Thread wartet nicht auf sie."
+
+#: src/concurrency/threads.md:25
+#, fuzzy
+msgid "Thread panics are independent of each other."
+msgstr "Thread-Panics sind voneinander unabhängig."
+
+#: src/concurrency/threads.md:26
+#, fuzzy
+msgid "Panics can carry a payload, which can be unpacked with `downcast_ref`."
+msgstr ""
+"Paniken können eine Nutzlast tragen, die mit `downcast_ref` entpackt werden "
+"kann."
 
 #: src/concurrency/threads.md:32
 msgid ""
-"* Notice that the thread is stopped before it reaches 10 — the main thread "
-"is\n"
-"  not waiting.\n"
-"\n"
-"* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-"for\n"
-"  the thread to finish.\n"
-"\n"
-"* Trigger a panic in the thread, notice how this doesn't affect `main`.\n"
-"\n"
-"* Use the `Result` return value from `handle.join()` to get access to the "
-"panic\n"
-"  payload. This is a good time to talk about [`Any`]."
+"Notice that the thread is stopped before it reaches 10 — the main thread is "
+"not waiting."
 msgstr ""
 
-#: src/concurrency/scoped-threads.md:1
-#, fuzzy
-msgid "# Scoped Threads"
-msgstr "# Bereichsbezogene Threads"
+#: src/concurrency/threads.md:35
+msgid ""
+"Use `let handle = thread::spawn(...)` and later `handle.join()` to wait for "
+"the thread to finish."
+msgstr ""
+
+#: src/concurrency/threads.md:38
+msgid "Trigger a panic in the thread, notice how this doesn't affect `main`."
+msgstr ""
+
+#: src/concurrency/threads.md:40
+msgid ""
+"Use the `Result` return value from `handle.join()` to get access to the "
+"panic payload. This is a good time to talk about [`Any`](https://doc.rust-"
+"lang.org/std/any/index.html)."
+msgstr ""
 
 #: src/concurrency/scoped-threads.md:3
 #, fuzzy
@@ -16650,8 +17431,12 @@ msgstr ""
 
 #: src/concurrency/scoped-threads.md:17
 #, fuzzy
-msgid "However, you can use a [scoped thread][1] for this:"
-msgstr "Sie können dafür jedoch einen [Scoped Thread][1] verwenden:"
+msgid ""
+"However, you can use a [scoped thread](https://doc.rust-lang.org/std/thread/"
+"fn.scope.html) for this:"
+msgstr ""
+"Sie können dafür jedoch einen [Scoped Thread](https://doc.rust-lang.org/std/"
+"thread/fn.scope.html) verwenden:"
 
 #: src/concurrency/scoped-threads.md:19
 msgid ""
@@ -16673,37 +17458,32 @@ msgstr ""
 #: src/concurrency/scoped-threads.md:37
 #, fuzzy
 msgid ""
-"* The reason for that is that when the `thread::scope` function completes, "
-"all the threads are guaranteed to be joined, so they can return borrowed "
-"data.\n"
-"* Normal Rust borrowing rules apply: you can either borrow mutably by one "
-"thread, or immutably by any number of threads.\n"
-"    "
+"The reason for that is that when the `thread::scope` function completes, all "
+"the threads are guaranteed to be joined, so they can return borrowed data."
 msgstr ""
-"* Der Grund dafür ist, dass nach Abschluss der `thread::scope`-Funktion "
+"Der Grund dafür ist, dass nach Abschluss der `thread::scope`\\-Funktion "
 "garantiert alle Threads verbunden sind, sodass sie geliehene Daten "
-"zurückgeben können.\n"
-"* Es gelten die normalen Rust-Ausleihregeln: Sie können entweder "
-"veränderlich von einem Thread ausleihen oder unveränderlich von einer "
-"beliebigen Anzahl von Threads.\n"
-"    \n"
-"</Details>"
+"zurückgeben können."
 
-#: src/concurrency/channels.md:1
+#: src/concurrency/scoped-threads.md:38
 #, fuzzy
-msgid "# Channels"
-msgstr "# Kanäle"
+msgid ""
+"Normal Rust borrowing rules apply: you can either borrow mutably by one "
+"thread, or immutably by any number of threads."
+msgstr ""
+"Es gelten die normalen Rust-Ausleihregeln: Sie können entweder veränderlich "
+"von einem Thread ausleihen oder unveränderlich von einer beliebigen Anzahl "
+"von Threads."
 
 #: src/concurrency/channels.md:3
 #, fuzzy
 msgid ""
 "Rust channels have two parts: a `Sender<T>` and a `Receiver<T>`. The two "
-"parts\n"
-"are connected via the channel, but you only see the end-points."
+"parts are connected via the channel, but you only see the end-points."
 msgstr ""
 "Rust-Kanäle bestehen aus zwei Teilen: einem `Sender<T>` und einem "
-"`Receiver<T>`. Die zwei Teile\n"
-"über den Kanal verbunden sind, aber Sie sehen nur die Endpunkte."
+"`Receiver<T>`. Die zwei Teile über den Kanal verbunden sind, aber Sie sehen "
+"nur die Endpunkte."
 
 #: src/concurrency/channels.md:6
 msgid ""
@@ -16730,24 +17510,23 @@ msgstr ""
 #: src/concurrency/channels.md:27
 #, fuzzy
 msgid ""
-"* `mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and "
-"`SyncSender` implement `Clone` (so\n"
-"  you can make multiple producers) but `Receiver` does not.\n"
-"* `send()` and `recv()` return `Result`. If they return `Err`, it means the "
-"counterpart `Sender` or\n"
-"  `Receiver` is dropped and the channel is closed."
+"`mpsc` stands for Multi-Producer, Single-Consumer. `Sender` and `SyncSender` "
+"implement `Clone` (so you can make multiple producers) but `Receiver` does "
+"not."
 msgstr ""
-"* „mpsc“ steht für Multi-Producer, Single-Consumer. `Sender` und "
-"`SyncSender` implementieren `Clone` (also\n"
-"  Sie können mehrere Producer erstellen), aber 'Receiver' nicht.\n"
-"* `send()` und `recv()` geben `Result` zurück. Wenn sie `Err` zurückgeben, "
-"bedeutet dies das Gegenstück `Sender` bzw\n"
-"  „Receiver“ wird fallen gelassen und der Kanal wird geschlossen."
+"„mpsc“ steht für Multi-Producer, Single-Consumer. `Sender` und `SyncSender` "
+"implementieren `Clone` (also Sie können mehrere Producer erstellen), aber "
+"'Receiver' nicht."
 
-#: src/concurrency/channels/unbounded.md:1
+#: src/concurrency/channels.md:29
 #, fuzzy
-msgid "# Unbounded Channels"
-msgstr "# Unbegrenzte Kanäle"
+msgid ""
+"`send()` and `recv()` return `Result`. If they return `Err`, it means the "
+"counterpart `Sender` or `Receiver` is dropped and the channel is closed."
+msgstr ""
+"`send()` und `recv()` geben `Result` zurück. Wenn sie `Err` zurückgeben, "
+"bedeutet dies das Gegenstück `Sender` bzw „Receiver“ wird fallen gelassen "
+"und der Kanal wird geschlossen."
 
 #: src/concurrency/channels/unbounded.md:3
 #, fuzzy
@@ -16781,11 +17560,6 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#: src/concurrency/channels/bounded.md:1
-#, fuzzy
-msgid "# Bounded Channels"
-msgstr "# Gebundene Kanäle"
 
 #: src/concurrency/channels/bounded.md:3
 #, fuzzy
@@ -16823,8 +17597,8 @@ msgstr ""
 
 #: src/concurrency/send-sync.md:1
 #, fuzzy
-msgid "# `Send` and `Sync`"
-msgstr "# `Senden` und `Synchronisieren`"
+msgid "`Send` and `Sync`"
+msgstr "`Senden` und `Synchronisieren`"
 
 #: src/concurrency/send-sync.md:3
 #, fuzzy
@@ -16838,101 +17612,98 @@ msgstr ""
 #: src/concurrency/send-sync.md:5
 #, fuzzy
 msgid ""
-"* [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a "
-"thread\n"
-"  boundary.\n"
-"* [`Sync`][2]: a type `T` is `Sync` if it is safe to move a `&T` across a "
-"thread\n"
-"  boundary."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): a type `T` "
+"is `Send` if it is safe to move a `T` across a thread boundary."
 msgstr ""
-"* [`Send`][1]: ein Typ `T` ist `Send`, wenn es sicher ist, ein `T` über "
-"einen Thread zu bewegen\n"
-"  Grenze.\n"
-"* [`Sync`][2]: ein Typ `T` ist `Sync`, wenn es sicher ist, ein `&T` über "
-"einen Thread zu verschieben\n"
-"  Grenze."
+"[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html): ein Typ `T` "
+"ist `Send`, wenn es sicher ist, ein `T` über einen Thread zu bewegen Grenze."
+
+#: src/concurrency/send-sync.md:7
+#, fuzzy
+msgid ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): a type `T` "
+"is `Sync` if it is safe to move a `&T` across a thread boundary."
+msgstr ""
+"[`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html): ein Typ `T` "
+"ist `Sync`, wenn es sicher ist, ein `&T` über einen Thread zu verschieben "
+"Grenze."
 
 #: src/concurrency/send-sync.md:10
 #, fuzzy
 msgid ""
-"`Send` and `Sync` are [unsafe traits][3]. The compiler will automatically "
-"derive them for your types\n"
-"as long as they only contain `Send` and `Sync` types. You can also implement "
-"them manually when you\n"
-"know it is valid."
+"`Send` and `Sync` are [unsafe traits](../unsafe/unsafe-traits.md). The "
+"compiler will automatically derive them for your types as long as they only "
+"contain `Send` and `Sync` types. You can also implement them manually when "
+"you know it is valid."
 msgstr ""
-"„Senden“ und „Synchronisieren“ sind [unsichere Eigenschaften][3]. Der "
-"Compiler leitet sie automatisch für Ihre Typen ab\n"
+"„Senden“ und „Synchronisieren“ sind [unsichere Eigenschaften](../unsafe/"
+"unsafe-traits.md). Der Compiler leitet sie automatisch für Ihre Typen ab "
 "solange sie nur die Typen `Send` und `Sync` enthalten. Sie können sie auch "
-"manuell implementieren, wenn Sie\n"
-"wissen, dass es gültig ist."
+"manuell implementieren, wenn Sie wissen, dass es gültig ist."
 
 #: src/concurrency/send-sync.md:20
 #, fuzzy
 msgid ""
-"* One can think of these traits as markers that the type has certain thread-"
-"safety properties.\n"
-"* They can be used in the generic constraints as normal traits.\n"
-"  "
+"One can think of these traits as markers that the type has certain thread-"
+"safety properties."
 msgstr ""
-"* Man kann sich diese Eigenschaften als Markierungen dafür vorstellen, dass "
-"der Typ bestimmte Thread-Sicherheitseigenschaften hat.\n"
-"* Sie können in den generischen Einschränkungen als normale Merkmale "
-"verwendet werden.\n"
-"  \n"
-"</Details>"
+"Man kann sich diese Eigenschaften als Markierungen dafür vorstellen, dass "
+"der Typ bestimmte Thread-Sicherheitseigenschaften hat."
+
+#: src/concurrency/send-sync.md:21
+#, fuzzy
+msgid "They can be used in the generic constraints as normal traits."
+msgstr ""
+"Sie können in den generischen Einschränkungen als normale Merkmale verwendet "
+"werden."
 
 #: src/concurrency/send-sync/send.md:1
 #, fuzzy
-msgid "# `Send`"
-msgstr "# `Senden`"
+msgid "`Send`"
+msgstr "`Senden`"
 
 #: src/concurrency/send-sync/send.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Send`][1] if it is safe to move a `T` value to another "
-"thread."
+"A type `T` is [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html) "
+"if it is safe to move a `T` value to another thread."
 msgstr ""
-"> Ein Typ `T` ist [`Send`][1], wenn es sicher ist, einen `T`-Wert in einen "
-"anderen Thread zu verschieben."
+"Ein Typ `T` ist [`Send`](https://doc.rust-lang.org/std/marker/trait.Send."
+"html), wenn es sicher ist, einen `T`\\-Wert in einen anderen Thread zu "
+"verschieben."
 
 #: src/concurrency/send-sync/send.md:5
 #, fuzzy
 msgid ""
 "The effect of moving ownership to another thread is that _destructors_ will "
-"run\n"
-"in that thread. So the question is when you can allocate a value in one "
-"thread\n"
-"and deallocate it in another."
+"run in that thread. So the question is when you can allocate a value in one "
+"thread and deallocate it in another."
 msgstr ""
 "Das Verschieben der Eigentümerschaft auf einen anderen Thread hat zur Folge, "
-"dass _destructors_ ausgeführt wird\n"
-"in diesem Thread. Die Frage ist also, wann Sie einen Wert in einem Thread "
-"zuweisen können\n"
-"und es in einem anderen freigeben."
+"dass _destructors_ ausgeführt wird in diesem Thread. Die Frage ist also, "
+"wann Sie einen Wert in einem Thread zuweisen können und es in einem anderen "
+"freigeben."
 
 #: src/concurrency/send-sync/send.md:13
 msgid ""
 "As an example, a connection to the SQLite library must only be accessed from "
-"a\n"
-"single thread."
+"a single thread."
 msgstr ""
 
 #: src/concurrency/send-sync/sync.md:1
 #, fuzzy
-msgid "# `Sync`"
-msgstr "# `Synchronisieren`"
+msgid "`Sync`"
+msgstr "`Synchronisieren`"
 
 #: src/concurrency/send-sync/sync.md:3
 #, fuzzy
 msgid ""
-"> A type `T` is [`Sync`][1] if it is safe to access a `T` value from "
-"multiple\n"
-"> threads at the same time."
+"A type `T` is [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) "
+"if it is safe to access a `T` value from multiple threads at the same time."
 msgstr ""
-"> Ein Typ `T` ist [`Sync`][1], wenn es sicher ist, von mehreren auf einen "
-"`T`-Wert zuzugreifen\n"
-"> Threads gleichzeitig."
+"Ein Typ `T` ist [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync."
+"html), wenn es sicher ist, von mehreren auf einen `T`\\-Wert zuzugreifen "
+"Threads gleichzeitig."
 
 #: src/concurrency/send-sync/sync.md:6
 #, fuzzy
@@ -16941,8 +17712,8 @@ msgstr "Genauer gesagt lautet die Definition:"
 
 #: src/concurrency/send-sync/sync.md:8
 #, fuzzy
-msgid "> `T` is `Sync` if and only if `&T` is `Send`"
-msgstr "> `T` ist `Sync` genau dann, wenn `&T` `Send` ist"
+msgid "`T` is `Sync` if and only if `&T` is `Send`"
+msgstr "`T` ist `Sync` genau dann, wenn `&T` `Send` ist"
 
 #: src/concurrency/send-sync/sync.md:14
 #, fuzzy
@@ -16971,15 +17742,10 @@ msgstr ""
 "anderen Thread verschoben werden, da auf die Daten, auf die er verweist, von "
 "jedem Thread aus sicher zugegriffen werden kann."
 
-#: src/concurrency/send-sync/examples.md:1
-#, fuzzy
-msgid "# Examples"
-msgstr "# Beispiele"
-
 #: src/concurrency/send-sync/examples.md:3
 #, fuzzy
-msgid "## `Send + Sync`"
-msgstr "## `Senden + Synchronisieren`"
+msgid "`Send + Sync`"
+msgstr "`Senden + Synchronisieren`"
 
 #: src/concurrency/send-sync/examples.md:5
 #, fuzzy
@@ -16987,57 +17753,76 @@ msgid "Most types you come across are `Send + Sync`:"
 msgstr "Die meisten Typen, auf die Sie stoßen, sind „Send + Sync“:"
 
 #: src/concurrency/send-sync/examples.md:7
-msgid ""
-"* `i8`, `f32`, `bool`, `char`, `&str`, ...\n"
-"* `(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ...\n"
-"* `String`, `Option<T>`, `Vec<T>`, `Box<T>`, ...\n"
-"* `Arc<T>`: Explicitly thread-safe via atomic reference count.\n"
-"* `Mutex<T>`: Explicitly thread-safe via internal locking.\n"
-"* `AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
+msgid "`i8`, `f32`, `bool`, `char`, `&str`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:8
+msgid "`(T1, T2)`, `[T; N]`, `&[T]`, `struct { x: T }`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:9
+msgid "`String`, `Option<T>`, `Vec<T>`, `Box<T>`, ..."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:10
+msgid "`Arc<T>`: Explicitly thread-safe via atomic reference count."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:11
+msgid "`Mutex<T>`: Explicitly thread-safe via internal locking."
+msgstr ""
+
+#: src/concurrency/send-sync/examples.md:12
+msgid "`AtomicBool`, `AtomicU8`, ...: Uses special atomic instructions."
 msgstr ""
 
 #: src/concurrency/send-sync/examples.md:14
 #, fuzzy
 msgid ""
-"The generic types are typically `Send + Sync` when the type parameters are\n"
+"The generic types are typically `Send + Sync` when the type parameters are "
 "`Send + Sync`."
 msgstr ""
 "Die generischen Typen sind typischerweise `Send + Sync`, wenn es die "
-"Typparameter sind\n"
-"„Senden + Synchronisieren“."
+"Typparameter sind „Senden + Synchronisieren“."
 
 #: src/concurrency/send-sync/examples.md:17
 #, fuzzy
-msgid "## `Send + !Sync`"
-msgstr "## `Senden + !Sync`"
+msgid "`Send + !Sync`"
+msgstr "`Senden + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:19
 #, fuzzy
 msgid ""
-"These types can be moved to other threads, but they're not thread-safe.\n"
+"These types can be moved to other threads, but they're not thread-safe. "
 "Typically because of interior mutability:"
 msgstr ""
 "Diese Typen können in andere Threads verschoben werden, sind aber nicht "
-"Thread-sicher.\n"
-"Typischerweise wegen innerer Mutabilität:"
+"Thread-sicher. Typischerweise wegen innerer Mutabilität:"
 
 #: src/concurrency/send-sync/examples.md:22
 #, fuzzy
-msgid ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Cell<T>`\n"
-"* `RefCell<T>`"
-msgstr ""
-"* `mpsc::Sender<T>`\n"
-"* `mpsc::Receiver<T>`\n"
-"* `Zelle<T>`\n"
-"* `RefCell<T>`"
+msgid "`mpsc::Sender<T>`"
+msgstr "`mpsc::Sender<T>`"
+
+#: src/concurrency/send-sync/examples.md:23
+#, fuzzy
+msgid "`mpsc::Receiver<T>`"
+msgstr "`mpsc::Receiver<T>`"
+
+#: src/concurrency/send-sync/examples.md:24
+#, fuzzy
+msgid "`Cell<T>`"
+msgstr "`Zelle<T>`"
+
+#: src/concurrency/send-sync/examples.md:25
+#, fuzzy
+msgid "`RefCell<T>`"
+msgstr "`RefCell<T>`"
 
 #: src/concurrency/send-sync/examples.md:27
 #, fuzzy
-msgid "## `!Send + Sync`"
-msgstr "## `!Senden + Synchronisieren`"
+msgid "`!Send + Sync`"
+msgstr "`!Senden + Synchronisieren`"
 
 #: src/concurrency/send-sync/examples.md:29
 #, fuzzy
@@ -17050,18 +17835,16 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:31
 #, fuzzy
 msgid ""
-"* `MutexGuard<T>`: Uses OS level primitives which must be deallocated on "
-"the\n"
-"  thread which created them."
+"`MutexGuard<T>`: Uses OS level primitives which must be deallocated on the "
+"thread which created them."
 msgstr ""
-"* `MutexGuard<T>`: Verwendet Primitive auf Betriebssystemebene, die auf dem "
-"freigegeben werden müssen\n"
-"  Thread, der sie erstellt hat."
+"`MutexGuard<T>`: Verwendet Primitive auf Betriebssystemebene, die auf dem "
+"freigegeben werden müssen Thread, der sie erstellt hat."
 
 #: src/concurrency/send-sync/examples.md:34
 #, fuzzy
-msgid "## `!Send + !Sync`"
-msgstr "## `!Senden + !Sync`"
+msgid "`!Send + !Sync`"
+msgstr "`!Senden + !Sync`"
 
 #: src/concurrency/send-sync/examples.md:36
 #, fuzzy
@@ -17073,60 +17856,64 @@ msgstr ""
 #: src/concurrency/send-sync/examples.md:38
 #, fuzzy
 msgid ""
-"* `Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a\n"
-"  non-atomic reference count.\n"
-"* `*const T`, `*mut T`: Rust assumes raw pointers may have special\n"
-"  concurrency considerations."
+"`Rc<T>`: each `Rc<T>` has a reference to an `RcBox<T>`, which contains a non-"
+"atomic reference count."
 msgstr ""
-"* `Rc<T>`: Jedes `Rc<T>` hat eine Referenz auf eine `RcBox<T>`, die eine "
-"enthält\n"
-"  nicht-atomarer Referenzzähler.\n"
-"* `*const T`, `*mut T`: Rust geht davon aus, dass Rohzeiger möglicherweise "
-"etwas Besonderes haben\n"
-"  Parallelitätsüberlegungen."
+"`Rc<T>`: Jedes `Rc<T>` hat eine Referenz auf eine `RcBox<T>`, die eine "
+"enthält nicht-atomarer Referenzzähler."
 
-#: src/concurrency/shared_state.md:1
+#: src/concurrency/send-sync/examples.md:40
 #, fuzzy
-msgid "# Shared State"
-msgstr "# Geteilter Zustand"
+msgid ""
+"`*const T`, `*mut T`: Rust assumes raw pointers may have special concurrency "
+"considerations."
+msgstr ""
+"`*const T`, `*mut T`: Rust geht davon aus, dass Rohzeiger möglicherweise "
+"etwas Besonderes haben Parallelitätsüberlegungen."
 
 #: src/concurrency/shared_state.md:3
 #, fuzzy
 msgid ""
-"Rust uses the type system to enforce synchronization of shared data. This "
-"is\n"
+"Rust uses the type system to enforce synchronization of shared data. This is "
 "primarily done via two types:"
 msgstr ""
 "Rust verwendet das Typsystem, um die Synchronisierung gemeinsam genutzter "
-"Daten zu erzwingen. Das ist\n"
-"hauptsächlich über zwei Arten:"
+"Daten zu erzwingen. Das ist hauptsächlich über zwei Arten:"
 
 #: src/concurrency/shared_state.md:6
 #, fuzzy
 msgid ""
-"* [`Arc<T>`][1], atomic reference counted `T`: handles sharing between "
-"threads and\n"
-"  takes care to deallocate `T` when the last reference is dropped,\n"
-"* [`Mutex<T>`][2]: ensures mutually exclusive access to the `T` value."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), atomic "
+"reference counted `T`: handles sharing between threads and takes care to "
+"deallocate `T` when the last reference is dropped,"
 msgstr ""
-"* [`Arc<T>`][1], Atomic Reference Counted `T`: handhabt die gemeinsame "
-"Nutzung zwischen Threads und\n"
-"  sorgt dafür, dass `T` freigegeben wird, wenn die letzte Referenz gelöscht "
-"wird,\n"
-"* [`Mutex<T>`][2]: sorgt für den sich gegenseitig ausschließenden Zugriff "
-"auf den `T`-Wert."
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html), Atomic "
+"Reference Counted `T`: handhabt die gemeinsame Nutzung zwischen Threads und "
+"sorgt dafür, dass `T` freigegeben wird, wenn die letzte Referenz gelöscht "
+"wird,"
+
+#: src/concurrency/shared_state.md:8
+#, fuzzy
+msgid ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): ensures "
+"mutually exclusive access to the `T` value."
+msgstr ""
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html): sorgt "
+"für den sich gegenseitig ausschließenden Zugriff auf den `T`\\-Wert."
 
 #: src/concurrency/shared_state/arc.md:1
 #, fuzzy
-msgid "# `Arc`"
-msgstr "# `Bogen`"
+msgid "`Arc`"
+msgstr "`Bogen`"
 
 #: src/concurrency/shared_state/arc.md:3
 #, fuzzy
-msgid "[`Arc<T>`][1] allows shared read-only access via `Arc::clone`:"
+msgid ""
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) allows shared "
+"read-only access via `Arc::clone`:"
 msgstr ""
-"[`Arc<T>`][1] ermöglicht den gemeinsamen Nur-Lese-Zugriff über seine `clone`-"
-"Methode:"
+"[`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) ermöglicht "
+"den gemeinsamen Nur-Lese-Zugriff über seine `clone`\\-Methode:"
 
 #: src/concurrency/shared_state/arc.md:5
 msgid ""
@@ -17154,46 +17941,59 @@ msgstr ""
 #: src/concurrency/shared_state/arc.md:29
 #, fuzzy
 msgid ""
-"* `Arc` stands for \"Atomic Reference Counted\", a thread safe version of "
-"`Rc` that uses atomic\n"
-"  operations.\n"
-"* `Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
-"and `Sync` iff `T`\n"
-"  implements them both.\n"
-"* `Arc::clone()` has the cost of atomic operations that get executed, but "
-"after that the use of the\n"
-"  `T` is free.\n"
-"* Beware of reference cycles, `Arc` does not use a garbage collector to "
-"detect them.\n"
-"    * `std::sync::Weak` can help."
+"`Arc` stands for \"Atomic Reference Counted\", a thread safe version of `Rc` "
+"that uses atomic operations."
 msgstr ""
-"* `Arc` steht für \"Atomic Reference Counted\", eine Thread-sichere Version "
-"von `Rc`, die atomar verwendet\n"
-"  Operationen.\n"
-"* `Arc<T>` implementiert `Clone` unabhängig davon, ob `T` dies tut oder "
-"nicht. Es implementiert `Send` und `Sync` iff `T`\n"
-"  setzt sie beide um.\n"
-"* `Arc::clone()` hat die Kosten für atomare Operationen, die ausgeführt "
-"werden, aber danach die Verwendung der\n"
-"  „T“ ist frei.\n"
-"* Hüten Sie sich vor Referenzzyklen, `Arc` verwendet keinen Garbage "
-"Collector, um sie zu erkennen.\n"
-"    * `std::sync::Weak` kann helfen."
+"`Arc` steht für \"Atomic Reference Counted\", eine Thread-sichere Version "
+"von `Rc`, die atomar verwendet Operationen."
+
+#: src/concurrency/shared_state/arc.md:31
+#, fuzzy
+msgid ""
+"`Arc<T>` implements `Clone` whether or not `T` does. It implements `Send` "
+"and `Sync` iff `T` implements them both."
+msgstr ""
+"`Arc<T>` implementiert `Clone` unabhängig davon, ob `T` dies tut oder nicht. "
+"Es implementiert `Send` und `Sync` iff `T` setzt sie beide um."
+
+#: src/concurrency/shared_state/arc.md:33
+#, fuzzy
+msgid ""
+"`Arc::clone()` has the cost of atomic operations that get executed, but "
+"after that the use of the `T` is free."
+msgstr ""
+"`Arc::clone()` hat die Kosten für atomare Operationen, die ausgeführt "
+"werden, aber danach die Verwendung der „T“ ist frei."
+
+#: src/concurrency/shared_state/arc.md:35
+#, fuzzy
+msgid ""
+"Beware of reference cycles, `Arc` does not use a garbage collector to detect "
+"them."
+msgstr ""
+"Hüten Sie sich vor Referenzzyklen, `Arc` verwendet keinen Garbage Collector, "
+"um sie zu erkennen."
+
+#: src/concurrency/shared_state/arc.md:36
+#, fuzzy
+msgid "`std::sync::Weak` can help."
+msgstr "`std::sync::Weak` kann helfen."
 
 #: src/concurrency/shared_state/mutex.md:1
 #, fuzzy
-msgid "# `Mutex`"
-msgstr "# `Mutex`"
+msgid "`Mutex`"
+msgstr "`Mutex`"
 
 #: src/concurrency/shared_state/mutex.md:3
 #, fuzzy
 msgid ""
-"[`Mutex<T>`][1] ensures mutual exclusion _and_ allows mutable access to `T`\n"
-"behind a read-only interface:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) ensures "
+"mutual exclusion _and_ allows mutable access to `T` behind a read-only "
+"interface:"
 msgstr ""
-"[`Mutex<T>`][1] sorgt für gegenseitigen Ausschluss _und_ erlaubt "
-"veränderlichen Zugriff auf `T`\n"
-"hinter einer Nur-Lese-Schnittstelle:"
+"[`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) sorgt für "
+"gegenseitigen Ausschluss _und_ erlaubt veränderlichen Zugriff auf `T` hinter "
+"einer Nur-Lese-Schnittstelle:"
 
 #: src/concurrency/shared_state/mutex.md:6
 msgid ""
@@ -17217,52 +18017,74 @@ msgstr ""
 #: src/concurrency/shared_state/mutex.md:22
 #, fuzzy
 msgid ""
-"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`][2] blanket\n"
+"Notice how we have a [`impl<T: Send> Sync for Mutex<T>`](https://doc.rust-"
+"lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) blanket "
 "implementation."
 msgstr ""
-"Beachten Sie, wie wir eine [`impl<T: Send> Sync for Mutex<T>`][2] Blanket "
-"haben\n"
-"Implementierung."
+"Beachten Sie, wie wir eine [`impl<T: Send> Sync for Mutex<T>`](https://doc."
+"rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) Blanket "
+"haben Implementierung."
 
 #: src/concurrency/shared_state/mutex.md:31
 #, fuzzy
 msgid ""
-"* `Mutex` in Rust looks like a collection with just one element - the "
-"protected data.\n"
-"    * It is not possible to forget to acquire the mutex before accessing the "
-"protected data.\n"
-"* You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
-"`MutexGuard` ensures that the\n"
-"  `&mut T` doesn't outlive the lock being held.\n"
-"* `Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`.\n"
-"* A read-write lock counterpart - `RwLock`.\n"
-"* Why does `lock()` return a `Result`? \n"
-"    * If the thread that held the `Mutex` panicked, the `Mutex` becomes "
-"\"poisoned\" to signal that\n"
-"      the data it protected might be in an inconsistent state. Calling "
-"`lock()` on a poisoned mutex\n"
-"      fails with a [`PoisonError`]. You can call `into_inner()` on the error "
-"to recover the data\n"
-"      regardless."
+"`Mutex` in Rust looks like a collection with just one element - the "
+"protected data."
 msgstr ""
-"* `Mutex` in Rust sieht aus wie eine Sammlung mit nur einem Element - den "
-"geschützten Daten.\n"
-"    * Es ist nicht möglich, das Abrufen des Mutex zu vergessen, bevor auf "
-"die geschützten Daten zugegriffen wird.\n"
-"* Sie können ein `&mut T` von einem `&Mutex<T>` erhalten, indem Sie die "
-"Sperre nehmen. Der `MutexGuard` sorgt dafür, dass die\n"
-"  `&mut T` überlebt die gehaltene Sperre nicht.\n"
-"* `Mutex<T>` implementiert sowohl `Send` als auch `Sync`, wenn `T` `Send` "
-"implementiert.\n"
-"* Ein Gegenstück zur Lese-Schreib-Sperre - `RwLock`.\n"
-"* Warum gibt `lock()` ein `Result` zurück?\n"
-"    * Wenn der Thread, der den `Mutex` enthielt, in Panik geriet, wird der "
-"`Mutex` \"vergiftet\", um dies zu signalisieren\n"
-"      Die geschützten Daten befinden sich möglicherweise in einem "
-"inkonsistenten Zustand. Aufruf von `lock()` auf einem vergifteten Mutex\n"
-"      schlägt mit einem [`PoisonError`] fehl. Sie können `into_inner()` für "
-"den Fehler aufrufen, um die Daten wiederherzustellen\n"
-"      trotzdem."
+"`Mutex` in Rust sieht aus wie eine Sammlung mit nur einem Element - den "
+"geschützten Daten."
+
+#: src/concurrency/shared_state/mutex.md:32
+#, fuzzy
+msgid ""
+"It is not possible to forget to acquire the mutex before accessing the "
+"protected data."
+msgstr ""
+"Es ist nicht möglich, das Abrufen des Mutex zu vergessen, bevor auf die "
+"geschützten Daten zugegriffen wird."
+
+#: src/concurrency/shared_state/mutex.md:33
+#, fuzzy
+msgid ""
+"You can get an `&mut T` from an `&Mutex<T>` by taking the lock. The "
+"`MutexGuard` ensures that the `&mut T` doesn't outlive the lock being held."
+msgstr ""
+"Sie können ein `&mut T` von einem `&Mutex<T>` erhalten, indem Sie die Sperre "
+"nehmen. Der `MutexGuard` sorgt dafür, dass die `&mut T` überlebt die "
+"gehaltene Sperre nicht."
+
+#: src/concurrency/shared_state/mutex.md:35
+#, fuzzy
+msgid "`Mutex<T>` implements both `Send` and `Sync` iff `T` implements `Send`."
+msgstr ""
+"`Mutex<T>` implementiert sowohl `Send` als auch `Sync`, wenn `T` `Send` "
+"implementiert."
+
+#: src/concurrency/shared_state/mutex.md:36
+#, fuzzy
+msgid "A read-write lock counterpart - `RwLock`."
+msgstr "Ein Gegenstück zur Lese-Schreib-Sperre - `RwLock`."
+
+#: src/concurrency/shared_state/mutex.md:37
+#, fuzzy
+msgid "Why does `lock()` return a `Result`? "
+msgstr "Warum gibt `lock()` ein `Result` zurück?"
+
+#: src/concurrency/shared_state/mutex.md:38
+#, fuzzy
+msgid ""
+"If the thread that held the `Mutex` panicked, the `Mutex` becomes "
+"\"poisoned\" to signal that the data it protected might be in an "
+"inconsistent state. Calling `lock()` on a poisoned mutex fails with a "
+"[`PoisonError`](https://doc.rust-lang.org/std/sync/struct.PoisonError.html). "
+"You can call `into_inner()` on the error to recover the data regardless."
+msgstr ""
+"Wenn der Thread, der den `Mutex` enthielt, in Panik geriet, wird der `Mutex` "
+"\"vergiftet\", um dies zu signalisieren Die geschützten Daten befinden sich "
+"möglicherweise in einem inkonsistenten Zustand. Aufruf von `lock()` auf "
+"einem vergifteten Mutex schlägt mit einem [`PoisonError`](https://doc.rust-"
+"lang.org/std/sync/struct.PoisonError.html) fehl. Sie können `into_inner()` "
+"für den Fehler aufrufen, um die Daten wiederherzustellen trotzdem."
 
 #: src/concurrency/shared_state/example.md:3
 #, fuzzy
@@ -17326,25 +18148,41 @@ msgstr ""
 #: src/concurrency/shared_state/example.md:51
 #, fuzzy
 msgid ""
-"* `v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
-"orthogonal.\n"
-"  * Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable "
-"state between threads.\n"
-"* `v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
-"thread. Note `move` was added to the lambda signature.\n"
-"* Blocks are introduced to narrow the scope of the `LockGuard` as much as "
+"`v` is wrapped in both `Arc` and `Mutex`, because their concerns are "
+"orthogonal."
+msgstr ""
+"`v` ist sowohl in `Arc` als auch in `Mutex` eingeschlossen, weil ihre "
+"Anliegen orthogonal sind."
+
+#: src/concurrency/shared_state/example.md:52
+#, fuzzy
+msgid ""
+"Wrapping a `Mutex` in an `Arc` is a common pattern to share mutable state "
+"between threads."
+msgstr ""
+"Das Umhüllen eines `Mutex` in einen `Arc` ist ein gängiges Muster, um einen "
+"veränderlichen Zustand zwischen Threads zu teilen."
+
+#: src/concurrency/shared_state/example.md:53
+#, fuzzy
+msgid ""
+"`v: Arc<_>` needs to be cloned as `v2` before it can be moved into another "
+"thread. Note `move` was added to the lambda signature."
+msgstr ""
+"„v: Arc\\<\\_\\>“ muss als „v2“ geklont werden, bevor es in einen anderen "
+"Thread verschoben werden kann. Der Lambda-Signatur wurde der Hinweis „move“ "
+"hinzugefügt."
+
+#: src/concurrency/shared_state/example.md:54
+#, fuzzy
+msgid ""
+"Blocks are introduced to narrow the scope of the `LockGuard` as much as "
 "possible."
 msgstr ""
-"* `v` ist sowohl in `Arc` als auch in `Mutex` eingeschlossen, weil ihre "
-"Anliegen orthogonal sind.\n"
-"  * Das Umhüllen eines `Mutex` in einen `Arc` ist ein gängiges Muster, um "
-"einen veränderlichen Zustand zwischen Threads zu teilen.\n"
-"* „v: Arc<_>“ muss als „v2“ geklont werden, bevor es in einen anderen Thread "
-"verschoben werden kann. Der Lambda-Signatur wurde der Hinweis „move“ "
-"hinzugefügt.\n"
-"* Blöcke werden eingeführt, um den Anwendungsbereich von `LockGuard` so weit "
+"Blöcke werden eingeführt, um den Anwendungsbereich von `LockGuard` so weit "
 "wie möglich einzuschränken.\n"
-"* Wir müssen noch den `Mutex` erwerben, um unseren `Vec` zu drucken."
+"\n"
+"Wir müssen noch den `Mutex` erwerben, um unseren `Vec` zu drucken."
 
 #: src/exercises/concurrency/morning.md:3
 #, fuzzy
@@ -17353,20 +18191,16 @@ msgstr "Lassen Sie uns unsere neuen Nebenläufigkeitsfähigkeiten mit üben"
 
 #: src/exercises/concurrency/morning.md:5
 #, fuzzy
-msgid ""
-"* Dining philosophers: a classic problem in concurrency.\n"
-"\n"
-"* Multi-threaded link checker: a larger project where you'll use Cargo to\n"
-"  download dependencies and then check links in parallel."
+msgid "Dining philosophers: a classic problem in concurrency."
 msgstr ""
-"* Multithreaded Link Checker: ein größeres Projekt, für das Sie Cargo "
-"verwenden werden\n"
-"  Abhängigkeiten herunterladen und dann parallel Links prüfen."
+"Multithreaded Link Checker: ein größeres Projekt, für das Sie Cargo "
+"verwenden werden Abhängigkeiten herunterladen und dann parallel Links prüfen."
 
-#: src/exercises/concurrency/dining-philosophers.md:1
-#, fuzzy
-msgid "# Dining Philosophers"
-msgstr "# Speisende Philosophen"
+#: src/exercises/concurrency/morning.md:7
+msgid ""
+"Multi-threaded link checker: a larger project where you'll use Cargo to "
+"download dependencies and then check links in parallel."
+msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers.md:3
 #, fuzzy
@@ -17377,49 +18211,36 @@ msgstr ""
 #: src/exercises/concurrency/dining-philosophers.md:5
 #, fuzzy
 msgid ""
-"> Five philosophers dine together at the same table. Each philosopher has "
-"their\n"
-"> own place at the table. There is a fork between each plate. The dish "
-"served is\n"
-"> a kind of spaghetti which has to be eaten with two forks. Each philosopher "
-"can\n"
-"> only alternately think and eat. Moreover, a philosopher can only eat "
-"their\n"
-"> spaghetti when they have both a left and right fork. Thus two forks will "
-"only\n"
-"> be available when their two nearest neighbors are thinking, not eating. "
-"After\n"
-"> an individual philosopher finishes eating, they will put down both forks."
+"Five philosophers dine together at the same table. Each philosopher has "
+"their own place at the table. There is a fork between each plate. The dish "
+"served is a kind of spaghetti which has to be eaten with two forks. Each "
+"philosopher can only alternately think and eat. Moreover, a philosopher can "
+"only eat their spaghetti when they have both a left and right fork. Thus two "
+"forks will only be available when their two nearest neighbors are thinking, "
+"not eating. After an individual philosopher finishes eating, they will put "
+"down both forks."
 msgstr ""
-"> Fünf Philosophen speisen gemeinsam am selben Tisch. Jeder Philosoph hat "
-"seine\n"
-"> eigener Platz am Tisch. Zwischen jedem Teller befindet sich eine Gabel. "
-"Das servierte Gericht ist\n"
-"> eine Art Spaghetti, die mit zwei Gabeln gegessen werden muss. Jeder "
-"Philosoph kann\n"
-"> nur abwechselnd denken und essen. Außerdem kann ein Philosoph nur ihre "
-"essen\n"
-"> Spaghetti, wenn sie sowohl eine linke als auch eine rechte Gabel haben. "
-"Also zwei Gabeln werden nur\n"
-"> verfügbar sein, wenn ihre beiden nächsten Nachbarn nachdenken, nicht "
-"essen. Nach\n"
-"> ein einzelner Philosoph mit dem Essen fertig ist, legen sie beide Gabeln "
-"weg."
+"Fünf Philosophen speisen gemeinsam am selben Tisch. Jeder Philosoph hat "
+"seine eigener Platz am Tisch. Zwischen jedem Teller befindet sich eine "
+"Gabel. Das servierte Gericht ist eine Art Spaghetti, die mit zwei Gabeln "
+"gegessen werden muss. Jeder Philosoph kann nur abwechselnd denken und essen. "
+"Außerdem kann ein Philosoph nur ihre essen Spaghetti, wenn sie sowohl eine "
+"linke als auch eine rechte Gabel haben. Also zwei Gabeln werden nur "
+"verfügbar sein, wenn ihre beiden nächsten Nachbarn nachdenken, nicht essen. "
+"Nach ein einzelner Philosoph mit dem Essen fertig ist, legen sie beide "
+"Gabeln weg."
 
 #: src/exercises/concurrency/dining-philosophers.md:13
 #, fuzzy
 msgid ""
 "You will need a local [Cargo installation](../../cargo/running-locally.md) "
-"for\n"
-"this exercise. Copy the code below to a file called `src/main.rs`, fill out "
-"the\n"
-"blanks, and test that `cargo run` does not deadlock:"
+"for this exercise. Copy the code below to a file called `src/main.rs`, fill "
+"out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 "Dazu benötigen Sie eine lokale [Cargo-Installation](../../cargo/running-"
-"locally.md).\n"
-"diese Übung. Kopieren Sie den folgenden Code in die Datei `src/main.rs`, "
-"füllen Sie die Lücken aus,\n"
-"und teste, dass `cargo run` keinen Deadlock verursacht:"
+"locally.md). diese Übung. Kopieren Sie den folgenden Code in die Datei `src/"
+"main.rs`, füllen Sie die Lücken aus, und teste, dass `cargo run` keinen "
+"Deadlock verursacht:"
 
 #: src/exercises/concurrency/dining-philosophers.md:19
 msgid ""
@@ -17480,37 +18301,29 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:1
-#, fuzzy
-msgid "# Multi-threaded Link Checker"
-msgstr "# Multithreaded Link Checker"
-
 #: src/exercises/concurrency/link-checker.md:3
 #, fuzzy
 msgid ""
 "Let us use our new knowledge to create a multi-threaded link checker. It "
-"should\n"
-"start at a webpage and check that links on the page are valid. It should\n"
-"recursively check other pages on the same domain and keep doing this until "
-"all\n"
-"pages have been validated."
+"should start at a webpage and check that links on the page are valid. It "
+"should recursively check other pages on the same domain and keep doing this "
+"until all pages have been validated."
 msgstr ""
 "Lassen Sie uns unser neues Wissen nutzen, um einen Multithread-Link-Checker "
-"zu erstellen. Es sollte\n"
-"Starten Sie auf einer Webseite und prüfen Sie, ob die Links auf der Seite "
-"gültig sind. Es sollte\n"
-"Überprüfen Sie rekursiv andere Seiten auf derselben Domain und tun Sie dies "
-"so lange, bis alle\n"
+"zu erstellen. Es sollte Starten Sie auf einer Webseite und prüfen Sie, ob "
+"die Links auf der Seite gültig sind. Es sollte Überprüfen Sie rekursiv "
+"andere Seiten auf derselben Domain und tun Sie dies so lange, bis alle "
 "Seiten wurden validiert."
 
 #: src/exercises/concurrency/link-checker.md:8
 #, fuzzy
 msgid ""
-"For this, you will need an HTTP client such as [`reqwest`][1]. Create a new\n"
-"Cargo project and `reqwest` it as a dependency with:"
+"For this, you will need an HTTP client such as [`reqwest`](https://docs.rs/"
+"reqwest/). Create a new Cargo project and `reqwest` it as a dependency with:"
 msgstr ""
-"Dazu benötigen Sie einen HTTP-Client wie [`reqwest`][1]. Erstelle eine neue\n"
-"Frachtprojekt und `reqwest` es als Abhängigkeit mit:"
+"Dazu benötigen Sie einen HTTP-Client wie [`reqwest`](https://docs.rs/"
+"reqwest/). Erstelle eine neue Frachtprojekt und `reqwest` es als "
+"Abhängigkeit mit:"
 
 #: src/exercises/concurrency/link-checker.md:11
 msgid ""
@@ -17524,22 +18337,21 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:17
 #, fuzzy
 msgid ""
-"> If `cargo add` fails with `error: no such subcommand`, then please edit "
-"the\n"
-"> `Cargo.toml` file by hand. Add the dependencies listed below."
+"If `cargo add` fails with `error: no such subcommand`, then please edit the "
+"`Cargo.toml` file by hand. Add the dependencies listed below."
 msgstr ""
-"> Wenn `cargo add` mit `error: no such subcommand` fehlschlägt, dann "
-"bearbeiten Sie bitte die\n"
-"> `Cargo.toml`-Datei von Hand. Fügen Sie die unten aufgeführten "
-"Abhängigkeiten hinzu."
+"Wenn `cargo add` mit `error: no such subcommand` fehlschlägt, dann "
+"bearbeiten Sie bitte die `Cargo.toml`\\-Datei von Hand. Fügen Sie die unten "
+"aufgeführten Abhängigkeiten hinzu."
 
 #: src/exercises/concurrency/link-checker.md:20
 #, fuzzy
 msgid ""
-"You will also need a way to find links. We can use [`scraper`][2] for that:"
+"You will also need a way to find links. We can use [`scraper`](https://docs."
+"rs/scraper/) for that:"
 msgstr ""
 "Sie benötigen auch eine Möglichkeit, Links zu finden. Dafür können wir "
-"[`scraper`][2] verwenden:"
+"[`scraper`](https://docs.rs/scraper/) verwenden:"
 
 #: src/exercises/concurrency/link-checker.md:22
 msgid ""
@@ -17551,13 +18363,11 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:26
 #, fuzzy
 msgid ""
-"Finally, we'll need some way of handling errors. We use [`thiserror`][3] "
-"for\n"
-"that:"
+"Finally, we'll need some way of handling errors. We use [`thiserror`]"
+"(https://docs.rs/thiserror/) for that:"
 msgstr ""
 "Schließlich brauchen wir eine Möglichkeit, mit Fehlern umzugehen. Wir "
-"verwenden [`thiserror`][3] für\n"
-"Das:"
+"verwenden [`thiserror`](https://docs.rs/thiserror/) für Das:"
 
 #: src/exercises/concurrency/link-checker.md:29
 msgid ""
@@ -17571,8 +18381,8 @@ msgstr ""
 msgid ""
 "The `cargo add` calls will update the `Cargo.toml` file to look like this:"
 msgstr ""
-"Die `cargo add`-Aufrufe aktualisieren die `Cargo.toml`-Datei so, dass sie "
-"wie folgt aussieht:"
+"Die `cargo add`\\-Aufrufe aktualisieren die `Cargo.toml`\\-Datei so, dass "
+"sie wie folgt aussieht:"
 
 #: src/exercises/concurrency/link-checker.md:37
 msgid ""
@@ -17594,17 +18404,16 @@ msgstr ""
 #: src/exercises/concurrency/link-checker.md:50
 #, fuzzy
 msgid ""
-"You can now download the start page. Try with a small site such as\n"
-"`https://www.google.org/`."
+"You can now download the start page. Try with a small site such as `https://"
+"www.google.org/`."
 msgstr ""
 "Sie können nun die Startseite herunterladen. Versuchen Sie es mit einer "
-"kleinen Website wie z\n"
-"`https://www.google.org/`."
+"kleinen Website wie z `https://www.google.org/`."
 
 #: src/exercises/concurrency/link-checker.md:53
 #, fuzzy
 msgid "Your `src/main.rs` file should look something like this:"
-msgstr "Ihre `src/main.rs`-Datei sollte in etwa so aussehen:"
+msgstr "Ihre `src/main.rs`\\-Datei sollte in etwa so aussehen:"
 
 #: src/exercises/concurrency/link-checker.md:57
 msgid ""
@@ -17665,87 +18474,76 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/concurrency/link-checker.md:106
-#: src/exercises/concurrency/chat-app.md:140
-#, fuzzy
-msgid "## Tasks"
-msgstr "## Aufgaben"
-
 #: src/exercises/concurrency/link-checker.md:108
 #, fuzzy
 msgid ""
-"* Use threads to check the links in parallel: send the URLs to be checked to "
-"a\n"
-"  channel and let a few threads check the URLs in parallel.\n"
-"* Extend this to recursively extract links from all pages on the\n"
-"  `www.google.org` domain. Put an upper limit of 100 pages or so so that "
-"you\n"
-"  don't end up being blocked by the site."
+"Use threads to check the links in parallel: send the URLs to be checked to a "
+"channel and let a few threads check the URLs in parallel."
 msgstr ""
-"* Verwenden Sie Threads, um die Links parallel zu prüfen: Senden Sie die zu "
-"prüfenden URLs an a\n"
-"  Channel und lass ein paar Threads parallel die URLs prüfen.\n"
-"* Erweitern Sie dies, um Links von allen Seiten rekursiv zu extrahieren\n"
-"  `www.google.org`-Domain. Setzen Sie eine Obergrenze von 100 Seiten oder "
-"so, dass Sie\n"
-"  am Ende nicht von der Seite blockiert werden."
+"Verwenden Sie Threads, um die Links parallel zu prüfen: Senden Sie die zu "
+"prüfenden URLs an a Channel und lass ein paar Threads parallel die URLs "
+"prüfen."
+
+#: src/exercises/concurrency/link-checker.md:110
+#, fuzzy
+msgid ""
+"Extend this to recursively extract links from all pages on the `www.google."
+"org` domain. Put an upper limit of 100 pages or so so that you don't end up "
+"being blocked by the site."
+msgstr ""
+"Erweitern Sie dies, um Links von allen Seiten rekursiv zu extrahieren `www."
+"google.org`\\-Domain. Setzen Sie eine Obergrenze von 100 Seiten oder so, "
+"dass Sie am Ende nicht von der Seite blockiert werden."
 
 #: src/async.md:1
 #, fuzzy
-msgid "# Async Rust"
-msgstr "# Warum Rost?"
+msgid "Async Rust"
+msgstr "Warum Rost?"
 
 #: src/async.md:3
 msgid ""
 "\"Async\" is a concurrency model where multiple tasks are executed "
-"concurrently by\n"
-"executing each task until it would block, then switching to another task "
-"that is\n"
-"ready to make progress. The model allows running a larger number of tasks on "
-"a\n"
-"limited number of threads. This is because the per-task overhead is "
-"typically\n"
-"very low and operating systems provide primitives for efficiently "
-"identifying\n"
-"I/O that is able to proceed."
+"concurrently by executing each task until it would block, then switching to "
+"another task that is ready to make progress. The model allows running a "
+"larger number of tasks on a limited number of threads. This is because the "
+"per-task overhead is typically very low and operating systems provide "
+"primitives for efficiently identifying I/O that is able to proceed."
 msgstr ""
 
 #: src/async.md:10
 msgid ""
 "Rust's asynchronous operation is based on \"futures\", which represent work "
-"that\n"
-"may be completed in the future. Futures are \"polled\" until they signal "
-"that\n"
-"they are complete."
+"that may be completed in the future. Futures are \"polled\" until they "
+"signal that they are complete."
 msgstr ""
 
 #: src/async.md:14
 msgid ""
-"Futures are polled by an async runtime, and several different runtimes are\n"
+"Futures are polled by an async runtime, and several different runtimes are "
 "available."
 msgstr ""
 
 #: src/async.md:17
 #, fuzzy
-msgid "## Comparisons"
-msgstr "# Vergleich"
+msgid "Comparisons"
+msgstr "Vergleich"
 
 #: src/async.md:19
 msgid ""
-" * Python has a similar model in its `asyncio`. However, its `Future` type "
-"is\n"
-"   callback-based, and not polled. Async Python programs require a "
-"\"loop\",\n"
-"   similar to a runtime in Rust.\n"
-"\n"
-" * JavaScript's `Promise` is similar, but again callback-based. The "
-"language\n"
-"   runtime implements the event loop, so many of the details of Promise\n"
-"   resolution are hidden."
+"Python has a similar model in its `asyncio`. However, its `Future` type is "
+"callback-based, and not polled. Async Python programs require a \"loop\", "
+"similar to a runtime in Rust."
+msgstr ""
+
+#: src/async.md:23
+msgid ""
+"JavaScript's `Promise` is similar, but again callback-based. The language "
+"runtime implements the event loop, so many of the details of Promise "
+"resolution are hidden."
 msgstr ""
 
 #: src/async/async-await.md:1
-msgid "# `async`/`await`"
+msgid "`async`/`await`"
 msgstr ""
 
 #: src/async/async-await.md:3
@@ -17777,45 +18575,54 @@ msgstr ""
 
 #: src/async/async-await.md:27
 msgid ""
-"* Note that this is a simplified example to show the syntax. There is no "
-"long\n"
-"  running operation or any real concurrency in it!\n"
-"\n"
-"* What is the return type of an async call?\n"
-"  * Use `let future: () = async_main(10);` in `main` to see the type.\n"
-"\n"
-"* The \"async\" keyword is syntactic sugar. The compiler replaces the return "
-"type\n"
-"  with a future. \n"
-"\n"
-"* You cannot make `main` async, without additional instructions to the "
-"compiler\n"
-"  on how to use the returned future.\n"
-"\n"
-"* You need an executor to run async code. `block_on` blocks the current "
-"thread\n"
-"  until the provided future has run to completion. \n"
-"\n"
-"* `.await` asynchronously waits for the completion of another operation. "
-"Unlike\n"
-"  `block_on`, `.await` doesn't block the current thread.\n"
-"\n"
-"* `.await` can only be used inside an `async` function (or block; these are\n"
-"  introduced later). "
+"Note that this is a simplified example to show the syntax. There is no long "
+"running operation or any real concurrency in it!"
 msgstr ""
 
-#: src/async/futures.md:1
-#, fuzzy
-msgid "# Futures"
-msgstr "# Schließungen"
+#: src/async/async-await.md:30
+msgid "What is the return type of an async call?"
+msgstr ""
+
+#: src/async/async-await.md:31
+msgid "Use `let future: () = async_main(10);` in `main` to see the type."
+msgstr ""
+
+#: src/async/async-await.md:33
+msgid ""
+"The \"async\" keyword is syntactic sugar. The compiler replaces the return "
+"type with a future. "
+msgstr ""
+
+#: src/async/async-await.md:36
+msgid ""
+"You cannot make `main` async, without additional instructions to the "
+"compiler on how to use the returned future."
+msgstr ""
+
+#: src/async/async-await.md:39
+msgid ""
+"You need an executor to run async code. `block_on` blocks the current thread "
+"until the provided future has run to completion. "
+msgstr ""
+
+#: src/async/async-await.md:42
+msgid ""
+"`.await` asynchronously waits for the completion of another operation. "
+"Unlike `block_on`, `.await` doesn't block the current thread."
+msgstr ""
+
+#: src/async/async-await.md:45
+msgid ""
+"`.await` can only be used inside an `async` function (or block; these are "
+"introduced later). "
+msgstr ""
 
 #: src/async/futures.md:3
 msgid ""
-"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html)\n"
-"is a trait, implemented by objects that represent an operation that may not "
-"be\n"
-"complete yet. A future can be polled, and `poll` returns a\n"
-"[`Poll`](https://doc.rust-lang.org/std/task/enum.Poll.html)."
+"[`Future`](https://doc.rust-lang.org/std/future/trait.Future.html) is a "
+"trait, implemented by objects that represent an operation that may not be "
+"complete yet. A future can be polled, and `poll` returns a [`Poll`](https://"
+"doc.rust-lang.org/std/task/enum.Poll.html)."
 msgstr ""
 
 #: src/async/futures.md:8
@@ -17840,87 +18647,86 @@ msgstr ""
 #: src/async/futures.md:23
 msgid ""
 "An async function returns an `impl Future`. It's also possible (but "
-"uncommon) to\n"
-"implement `Future` for your own types. For example, the `JoinHandle` "
-"returned\n"
-"from `tokio::spawn` implements `Future` to allow joining to it."
+"uncommon) to implement `Future` for your own types. For example, the "
+"`JoinHandle` returned from `tokio::spawn` implements `Future` to allow "
+"joining to it."
 msgstr ""
 
 #: src/async/futures.md:27
 msgid ""
 "The `.await` keyword, applied to a Future, causes the current async function "
-"to\n"
-"pause until that Future is ready, and then evaluates to its output."
+"to pause until that Future is ready, and then evaluates to its output."
 msgstr ""
 
 #: src/async/futures.md:32
 msgid ""
-"* The `Future` and `Poll` types are implemented exactly as shown; click the\n"
-"  links to show the implementations in the docs.\n"
-"\n"
-"* We will not get to `Pin` and `Context`, as we will focus on writing async\n"
-"  code, rather than building new async primitives. Briefly:\n"
-"\n"
-"  * `Context` allows a Future to schedule itself to be polled again when an\n"
-"    event occurs.\n"
-"\n"
-"  * `Pin` ensures that the Future isn't moved in memory, so that pointers "
-"into\n"
-"    that future remain valid. This is required to allow references to "
-"remain\n"
-"    valid after an `.await`."
+"The `Future` and `Poll` types are implemented exactly as shown; click the "
+"links to show the implementations in the docs."
 msgstr ""
 
-#: src/async/runtimes.md:1
-#, fuzzy
-msgid "# Runtimes"
-msgstr "Laufzeiten"
+#: src/async/futures.md:35
+msgid ""
+"We will not get to `Pin` and `Context`, as we will focus on writing async "
+"code, rather than building new async primitives. Briefly:"
+msgstr ""
+
+#: src/async/futures.md:38
+msgid ""
+"`Context` allows a Future to schedule itself to be polled again when an "
+"event occurs."
+msgstr ""
+
+#: src/async/futures.md:41
+msgid ""
+"`Pin` ensures that the Future isn't moved in memory, so that pointers into "
+"that future remain valid. This is required to allow references to remain "
+"valid after an `.await`."
+msgstr ""
 
 #: src/async/runtimes.md:3
 msgid ""
-"A *runtime* provides support for performing operations asynchronously (a\n"
-"*reactor*) and is responsible for executing futures (an *executor*). Rust "
-"does not have a\n"
-"\"built-in\" runtime, but several options are available:"
+"A _runtime_ provides support for performing operations asynchronously (a "
+"_reactor_) and is responsible for executing futures (an _executor_). Rust "
+"does not have a \"built-in\" runtime, but several options are available:"
 msgstr ""
 
 #: src/async/runtimes.md:7
 msgid ""
-" * [Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem "
-"of\n"
-"   functionality like [Hyper](https://hyper.rs/) for HTTP or\n"
-"   [Tonic](https://github.com/hyperium/tonic) for gRPC.\n"
-" * [async-std](https://async.rs/) - aims to be a \"std for async\", and "
-"includes a\n"
-"   basic runtime in `async::task`.\n"
-" * [smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
+"[Tokio](https://tokio.rs/) - performant, with a well-developed ecosystem of "
+"functionality like [Hyper](https://hyper.rs/) for HTTP or [Tonic](https://"
+"github.com/hyperium/tonic) for gRPC."
+msgstr ""
+
+#: src/async/runtimes.md:10
+msgid ""
+"[async-std](https://async.rs/) - aims to be a \"std for async\", and "
+"includes a basic runtime in `async::task`."
+msgstr ""
+
+#: src/async/runtimes.md:12
+msgid "[smol](https://docs.rs/smol/latest/smol/) - simple and lightweight"
 msgstr ""
 
 #: src/async/runtimes.md:14
 msgid ""
-"Several larger applications have their own runtimes. For example,\n"
-"[Fuchsia](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/"
-"fuchsia-async/src/lib.rs)\n"
-"already has one."
+"Several larger applications have their own runtimes. For example, [Fuchsia]"
+"(https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/lib/fuchsia-"
+"async/src/lib.rs) already has one."
 msgstr ""
 
 #: src/async/runtimes.md:20
 msgid ""
-"* Note that of the listed runtimes, only Tokio is supported in the Rust\n"
-"  playground. The playground also does not permit any I/O, so most "
-"interesting\n"
-"  async things can't run in the playground.\n"
-"\n"
-"* Futures are \"inert\" in that they do not do anything (not even start an I/"
-"O\n"
-"  operation) unless there is an executor polling them. This differs from JS\n"
-"  Promises, for example, which will run to completion even if they are "
-"never\n"
-"  used."
+"Note that of the listed runtimes, only Tokio is supported in the Rust "
+"playground. The playground also does not permit any I/O, so most interesting "
+"async things can't run in the playground."
 msgstr ""
 
-#: src/async/runtimes/tokio.md:1
-msgid "# Tokio"
+#: src/async/runtimes.md:24
+msgid ""
+"Futures are \"inert\" in that they do not do anything (not even start an I/O "
+"operation) unless there is an executor polling them. This differs from JS "
+"Promises, for example, which will run to completion even if they are never "
+"used."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:4
@@ -17928,10 +18734,15 @@ msgid "Tokio provides: "
 msgstr ""
 
 #: src/async/runtimes/tokio.md:6
-msgid ""
-"* A multi-threaded runtime for executing asynchronous code.\n"
-"* An asynchronous version of the standard library.\n"
-"* A large ecosystem of libraries."
+msgid "A multi-threaded runtime for executing asynchronous code."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:7
+msgid "An asynchronous version of the standard library."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:8
+msgid "A large ecosystem of libraries."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:10
@@ -17959,12 +18770,15 @@ msgid ""
 msgstr ""
 
 #: src/async/runtimes/tokio.md:33
-msgid ""
-"* With the `tokio::main` macro we can now make `main` async.\n"
-"\n"
-"* The `spawn` function creates a new, concurrent \"task\".\n"
-"\n"
-"* Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
+msgid "With the `tokio::main` macro we can now make `main` async."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:35
+msgid "The `spawn` function creates a new, concurrent \"task\"."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:37
+msgid "Note: `spawn` takes a `Future`, you don't call `.await` on `count_to`."
 msgstr ""
 
 #: src/async/runtimes/tokio.md:39
@@ -17973,36 +18787,32 @@ msgstr ""
 
 #: src/async/runtimes/tokio.md:41
 msgid ""
-"* Why does `count_to` not (usually) get to 10? This is an example of async\n"
-"  cancellation. `tokio::spawn` returns a handle which can be awaited to "
-"wait\n"
-"  until it finishes.\n"
-"\n"
-"* Try `count_to(10).await` instead of spawning.\n"
-"\n"
-"* Try awaiting the task returned from `tokio::spawn`."
+"Why does `count_to` not (usually) get to 10? This is an example of async "
+"cancellation. `tokio::spawn` returns a handle which can be awaited to wait "
+"until it finishes."
 msgstr ""
 
-#: src/async/tasks.md:1
-#, fuzzy
-msgid "# Tasks"
-msgstr "## Aufgaben"
+#: src/async/runtimes/tokio.md:45
+msgid "Try `count_to(10).await` instead of spawning."
+msgstr ""
+
+#: src/async/runtimes/tokio.md:47
+msgid "Try awaiting the task returned from `tokio::spawn`."
+msgstr ""
 
 #: src/async/tasks.md:3
 msgid ""
-"Runtimes have the concept of a \"task\", similar to a thread but much\n"
-"less resource-intensive."
+"Runtimes have the concept of a \"task\", similar to a thread but much less "
+"resource-intensive."
 msgstr ""
 
 #: src/async/tasks.md:6
 msgid ""
 "A task has a single top-level future which the executor polls to make "
-"progress.\n"
-"That future may have one or more nested futures that its `poll` method "
-"polls,\n"
-"corresponding loosely to a call stack. Concurrency within a task is possible "
-"by\n"
-"polling multiple child futures, such as racing a timer and an I/O operation."
+"progress. That future may have one or more nested futures that its `poll` "
+"method polls, corresponding loosely to a call stack. Concurrency within a "
+"task is possible by polling multiple child futures, such as racing a timer "
+"and an I/O operation."
 msgstr ""
 
 #: src/async/tasks.md:11
@@ -18056,22 +18866,22 @@ msgstr ""
 
 #: src/async/tasks.md:55
 msgid ""
-"* Ask students to visualize what the state of the example server would be "
-"with a\n"
-"  few connected clients. What tasks exist? What are their Futures?\n"
-"\n"
-"* This is the first time we've seen an `async` block. This is similar to a\n"
-"  closure, but does not take any arguments. Its return value is a Future,\n"
-"  similar to an `async fn`. \n"
-"\n"
-"* Refactor the async block into a function, and improve the error handling "
-"using `?`."
+"Ask students to visualize what the state of the example server would be with "
+"a few connected clients. What tasks exist? What are their Futures?"
 msgstr ""
 
-#: src/async/channels.md:1
-#, fuzzy
-msgid "# Async Channels"
-msgstr "# Kanäle"
+#: src/async/tasks.md:58
+msgid ""
+"This is the first time we've seen an `async` block. This is similar to a "
+"closure, but does not take any arguments. Its return value is a Future, "
+"similar to an `async fn`. "
+msgstr ""
+
+#: src/async/tasks.md:62
+msgid ""
+"Refactor the async block into a function, and improve the error handling "
+"using `?`."
+msgstr ""
 
 #: src/async/channels.md:3
 msgid ""
@@ -18112,50 +18922,57 @@ msgid ""
 msgstr ""
 
 #: src/async/channels.md:35
+msgid "Change the channel size to `3` and see how it affects the execution."
+msgstr ""
+
+#: src/async/channels.md:37
 msgid ""
-"* Change the channel size to `3` and see how it affects the execution.\n"
-"\n"
-"* Overall, the interface is similar to the `sync` channels as seen in the\n"
-"  [morning class](concurrency/channels.md).\n"
-"\n"
-"* Try removing the `std::mem::drop` call. What happens? Why?\n"
-"\n"
-"* The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that\n"
-"  implement both `sync` and `async` `send` and `recv`. This can be "
-"convenient\n"
-"  for complex applications with both IO and heavy CPU processing tasks.\n"
-"\n"
-"* What makes working with `async` channels preferable is the ability to "
-"combine\n"
-"  them with other `future`s to combine them and create complex control flow."
+"Overall, the interface is similar to the `sync` channels as seen in the "
+"[morning class](concurrency/channels.md)."
+msgstr ""
+
+#: src/async/channels.md:40
+msgid "Try removing the `std::mem::drop` call. What happens? Why?"
+msgstr ""
+
+#: src/async/channels.md:42
+msgid ""
+"The [Flume](https://docs.rs/flume/latest/flume/) crate has channels that "
+"implement both `sync` and `async` `send` and `recv`. This can be convenient "
+"for complex applications with both IO and heavy CPU processing tasks."
+msgstr ""
+
+#: src/async/channels.md:46
+msgid ""
+"What makes working with `async` channels preferable is the ability to "
+"combine them with other `future`s to combine them and create complex control "
+"flow."
 msgstr ""
 
 #: src/async/control-flow.md:1
 #, fuzzy
-msgid "# Futures Control Flow"
-msgstr "# Kontrollfluss"
+msgid "Futures Control Flow"
+msgstr "Kontrollfluss"
 
 #: src/async/control-flow.md:3
 msgid ""
 "Futures can be combined together to produce concurrent compute flow graphs. "
-"We\n"
-"have already seen tasks, that function as independent threads of execution."
+"We have already seen tasks, that function as independent threads of "
+"execution."
 msgstr ""
 
 #: src/async/control-flow.md:6
-msgid ""
-"- [Join](control-flow/join.md)\n"
-"- [Select](control-flow/select.md)"
+msgid "[Join](control-flow/join.md)"
 msgstr ""
 
-#: src/async/control-flow/join.md:1
-msgid "# Join"
+#: src/async/control-flow.md:7
+msgid "[Select](control-flow/select.md)"
 msgstr ""
 
 #: src/async/control-flow/join.md:3
 msgid ""
-"A join operation waits until all of a set of futures are ready, and\n"
-"returns a collection of their results. This is similar to `Promise.all` in\n"
+"A join operation waits until all of a set of futures are ready, and returns "
+"a collection of their results. This is similar to `Promise.all` in "
 "JavaScript or `asyncio.gather` in Python."
 msgstr ""
 
@@ -18191,44 +19008,39 @@ msgstr ""
 
 #: src/async/control-flow/join.md:38
 msgid ""
-"* For multiple futures of disjoint types, you can use `std::future::join!` "
-"but\n"
-"  you must know how many futures you will have at compile time. This is\n"
-"  currently in the `futures` crate, soon to be stabilised in `std::future`.\n"
-"\n"
-"* The risk of `join` is that one of the futures may never resolve, this "
-"would\n"
-"  cause your program to stall. \n"
-"\n"
-"* You can also combine `join_all` with `join!` for instance to join all "
-"requests\n"
-"  to an http service as well as a database query. Try adding a\n"
-"  `tokio::time::sleep` to the future, using `futures::join!`. This is not a\n"
-"  timeout (that requires `select!`, explained in the next chapter), but "
-"demonstrates `join!`."
+"For multiple futures of disjoint types, you can use `std::future::join!` but "
+"you must know how many futures you will have at compile time. This is "
+"currently in the `futures` crate, soon to be stabilised in `std::future`."
 msgstr ""
 
-#: src/async/control-flow/select.md:1
-#, fuzzy
-msgid "# Select"
-msgstr "# Aufstellen"
+#: src/async/control-flow/join.md:42
+msgid ""
+"The risk of `join` is that one of the futures may never resolve, this would "
+"cause your program to stall. "
+msgstr ""
+
+#: src/async/control-flow/join.md:45
+msgid ""
+"You can also combine `join_all` with `join!` for instance to join all "
+"requests to an http service as well as a database query. Try adding a "
+"`tokio::time::sleep` to the future, using `futures::join!`. This is not a "
+"timeout (that requires `select!`, explained in the next chapter), but "
+"demonstrates `join!`."
+msgstr ""
 
 #: src/async/control-flow/select.md:3
 msgid ""
 "A select operation waits until any of a set of futures is ready, and "
-"responds to\n"
-"that future's result. In JavaScript, this is similar to `Promise.race`. In\n"
-"Python, it compares to `asyncio.wait(task_set,\n"
-"return_when=asyncio.FIRST_COMPLETED)`."
+"responds to that future's result. In JavaScript, this is similar to `Promise."
+"race`. In Python, it compares to `asyncio.wait(task_set, return_when=asyncio."
+"FIRST_COMPLETED)`."
 msgstr ""
 
 #: src/async/control-flow/select.md:8
 msgid ""
 "This is usually a macro, similar to match, with each arm of the form "
-"`pattern =\n"
-"future => statement`. When the future is ready, the statement is executed "
-"with the\n"
-"variable bound to the future's result."
+"`pattern = future => statement`. When the future is ready, the statement is "
+"executed with the variable bound to the future's result."
 msgstr ""
 
 #: src/async/control-flow/select.md:12
@@ -18283,29 +19095,34 @@ msgstr ""
 
 #: src/async/control-flow/select.md:61
 msgid ""
-"* In this example, we have a race between a cat and a dog.\n"
-"  `first_animal_to_finish_race` listens to both channels and will pick "
-"whichever\n"
-"  arrives first. Since the dog takes 50ms, it wins against the cat that\n"
-"  take 500ms seconds.\n"
-"\n"
-"* You can use `oneshot` channels in this example as the channels are "
-"supposed to\n"
-"  receive only one `send`.\n"
-"\n"
-"* Try adding a deadline to the race, demonstrating selecting different sorts "
-"of\n"
-"  futures.\n"
-"\n"
-"* Note that `select!` moves the values it is given. It is easiest to use\n"
-"  when every execution of `select!` creates new futures. An alternative is "
-"to\n"
-"  pass `&mut future` instead of the future itself, but this can lead to\n"
-"  issues, further discussed in the pinning slide."
+"In this example, we have a race between a cat and a dog. "
+"`first_animal_to_finish_race` listens to both channels and will pick "
+"whichever arrives first. Since the dog takes 50ms, it wins against the cat "
+"that take 500ms seconds."
+msgstr ""
+
+#: src/async/control-flow/select.md:66
+msgid ""
+"You can use `oneshot` channels in this example as the channels are supposed "
+"to receive only one `send`."
+msgstr ""
+
+#: src/async/control-flow/select.md:69
+msgid ""
+"Try adding a deadline to the race, demonstrating selecting different sorts "
+"of futures."
+msgstr ""
+
+#: src/async/control-flow/select.md:72
+msgid ""
+"Note that `select!` moves the values it is given. It is easiest to use when "
+"every execution of `select!` creates new futures. An alternative is to pass "
+"`&mut future` instead of the future itself, but this can lead to issues, "
+"further discussed in the pinning slide."
 msgstr ""
 
 #: src/async/pitfalls.md:1
-msgid "# Pitfalls of async/await"
+msgid "Pitfalls of async/await"
 msgstr ""
 
 #: src/async/pitfalls.md:3
@@ -18317,22 +19134,27 @@ msgid ""
 msgstr ""
 
 #: src/async/pitfalls.md:5
-msgid ""
-"- [Blocking the Executor](pitfalls/blocking-executor.md)\n"
-"- [Pin](pitfalls/pin.md)\n"
-"- [Async Traits](pitfall/async-traits.md)"
+msgid "[Blocking the Executor](pitfalls/blocking-executor.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:6
+msgid "[Pin](pitfalls/pin.md)"
+msgstr ""
+
+#: src/async/pitfalls.md:7
+msgid "[Async Traits](pitfall/async-traits.md)"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:1
-msgid "# Blocking the executor"
+msgid "Blocking the executor"
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:3
 msgid ""
-"Most async runtimes only allow IO tasks to run concurrently.\n"
-"This means that CPU blocking tasks will block the executor and prevent other "
-"tasks from being executed.\n"
-"An easy workaround is to use async equivalent methods where possible."
+"Most async runtimes only allow IO tasks to run concurrently. This means that "
+"CPU blocking tasks will block the executor and prevent other tasks from "
+"being executed. An easy workaround is to use async equivalent methods where "
+"possible."
 msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:7
@@ -18360,58 +19182,57 @@ msgstr ""
 
 #: src/async/pitfalls/blocking-executor.md:29
 msgid ""
-"* Run the code and see that the sleeps happen consecutively rather than\n"
-"  concurrently.\n"
-"\n"
-"* The `\"current_thread\"` flavor puts all tasks on a single thread. This "
-"makes the\n"
-"  effect more obvious, but the bug is still present in the multi-threaded\n"
-"  flavor.\n"
-"\n"
-"* Switch the `std::thread::sleep` to `tokio::time::sleep` and await its "
-"result.\n"
-"\n"
-"* Another fix would be to `tokio::task::spawn_blocking` which spawns an "
-"actual\n"
-"  thread and transforms its handle into a future without blocking the "
-"executor.\n"
-"\n"
-"* You should not think of tasks as OS threads. They do not map 1 to 1 and "
-"most\n"
-"  executors will allow many tasks to run on a single OS thread. This is\n"
-"  particularly problematic when interacting with other libraries via FFI, "
-"where\n"
-"  that library might depend on thread-local storage or map to specific OS\n"
-"  threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
-"situations.\n"
-"\n"
-"* Use sync mutexes with care. Holding a mutex over an `.await` may cause "
-"another\n"
-"  task to block, and that task may be running on the same thread."
+"Run the code and see that the sleeps happen consecutively rather than "
+"concurrently."
 msgstr ""
 
-#: src/async/pitfalls/pin.md:1
-msgid "# Pin"
+#: src/async/pitfalls/blocking-executor.md:32
+msgid ""
+"The `\"current_thread\"` flavor puts all tasks on a single thread. This "
+"makes the effect more obvious, but the bug is still present in the multi-"
+"threaded flavor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:36
+msgid ""
+"Switch the `std::thread::sleep` to `tokio::time::sleep` and await its result."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:38
+msgid ""
+"Another fix would be to `tokio::task::spawn_blocking` which spawns an actual "
+"thread and transforms its handle into a future without blocking the executor."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:41
+msgid ""
+"You should not think of tasks as OS threads. They do not map 1 to 1 and most "
+"executors will allow many tasks to run on a single OS thread. This is "
+"particularly problematic when interacting with other libraries via FFI, "
+"where that library might depend on thread-local storage or map to specific "
+"OS threads (e.g., CUDA). Prefer `tokio::task::spawn_blocking` in such "
+"situations."
+msgstr ""
+
+#: src/async/pitfalls/blocking-executor.md:47
+msgid ""
+"Use sync mutexes with care. Holding a mutex over an `.await` may cause "
+"another task to block, and that task may be running on the same thread."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:3
 msgid ""
 "When you await a future, all local variables (that would ordinarily be "
-"stored on\n"
-"a stack frame) are instead stored in the Future for the current async block. "
-"If your\n"
-"future has pointers to data on the stack, those pointers might get "
-"invalidated.\n"
-"This is unsafe."
+"stored on a stack frame) are instead stored in the Future for the current "
+"async block. If your future has pointers to data on the stack, those "
+"pointers might get invalidated. This is unsafe."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:8
 msgid ""
-"Therefore, you must guarantee that the addresses your future points to "
-"don't\n"
+"Therefore, you must guarantee that the addresses your future points to don't "
 "change. That is why we need to `pin` futures. Using the same future "
-"repeatedly\n"
-"in a `select!` often leads to issues with pinned values."
+"repeatedly in a `select!` often leads to issues with pinned values."
 msgstr ""
 
 #: src/async/pitfalls/pin.md:12
@@ -18473,62 +19294,79 @@ msgstr ""
 
 #: src/async/pitfalls/pin.md:68
 msgid ""
-"* You may recognize this as an example of the actor pattern. Actors\n"
-"  typically call `select!` in a loop.\n"
-"\n"
-"* This serves as a summation of a few of the previous lessons, so take your "
-"time\n"
-"  with it.\n"
-"\n"
-"    * Naively add a `_ = sleep(Duration::from_millis(100)) => { println!"
-"(..) }`\n"
-"      to the `select!`. This will never execute. Why?\n"
-"\n"
-"    * Instead, add a `timeout_fut` containing that future outside of the "
-"`loop`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = sleep(Duration::from_millis(100));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"    * This still doesn't work. Follow the compiler errors, adding `&mut` to "
-"the\n"
-"      `timeout_fut` in the `select!` to work around the move, then using\n"
-"      `Box::pin`:\n"
-"\n"
-"        ```rust,compile_fail\n"
-"        let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
-"        loop {\n"
-"            select! {\n"
-"                ..,\n"
-"                _ = &mut timeout_fut => { println!(..); },\n"
-"            }\n"
-"        }\n"
-"        ```\n"
-"\n"
-"    * This compiles, but once the timeout expires it is `Poll::Ready` on "
-"every\n"
-"      iteration (a fused future would help with this). Update to reset\n"
-"      `timeout_fut` every time it expires.\n"
-"\n"
-"* Box allocates on the heap. In some cases, `std::pin::pin!` (only recently\n"
-"  stabilized, with older code often using `tokio::pin!`) is also an option, "
-"but\n"
-"  that is difficult to use for a future that is reassigned.\n"
-"\n"
-"* Another alternative is to not use `pin` at all but spawn another task that "
-"will send to a `oneshot` channel every 100ms."
+"You may recognize this as an example of the actor pattern. Actors typically "
+"call `select!` in a loop."
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:1
-#, fuzzy
-msgid "# Async Traits"
-msgstr "# Züge"
+#: src/async/pitfalls/pin.md:71
+msgid ""
+"This serves as a summation of a few of the previous lessons, so take your "
+"time with it."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:74
+msgid ""
+"Naively add a `_ = sleep(Duration::from_millis(100)) => { println!(..) }` to "
+"the `select!`. This will never execute. Why?"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:77
+msgid ""
+"Instead, add a `timeout_fut` containing that future outside of the `loop`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:79
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = sleep(Duration::from_millis(100));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:88
+msgid ""
+"This still doesn't work. Follow the compiler errors, adding `&mut` to the "
+"`timeout_fut` in the `select!` to work around the move, then using `Box::"
+"pin`:"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:92
+msgid ""
+"```rust,compile_fail\n"
+"let mut timeout_fut = Box::pin(sleep(Duration::from_millis(100)));\n"
+"loop {\n"
+"    select! {\n"
+"        ..,\n"
+"        _ = &mut timeout_fut => { println!(..); },\n"
+"    }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/async/pitfalls/pin.md:102
+msgid ""
+"This compiles, but once the timeout expires it is `Poll::Ready` on every "
+"iteration (a fused future would help with this). Update to reset "
+"`timeout_fut` every time it expires."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:106
+msgid ""
+"Box allocates on the heap. In some cases, `std::pin::pin!` (only recently "
+"stabilized, with older code often using `tokio::pin!`) is also an option, "
+"but that is difficult to use for a future that is reassigned."
+msgstr ""
+
+#: src/async/pitfalls/pin.md:110
+msgid ""
+"Another alternative is to not use `pin` at all but spawn another task that "
+"will send to a `oneshot` channel every 100ms."
+msgstr ""
 
 #: src/async/pitfalls/async-traits.md:3
 msgid ""
@@ -18590,27 +19428,25 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/async/pitfalls/async-traits.md:49
-#, fuzzy
-msgid "<details>  "
-msgstr "<details>"
-
 #: src/async/pitfalls/async-traits.md:51
 msgid ""
-"* `async_trait` is easy to use, but note that it's using heap allocations "
-"to\n"
-"  achieve this. This heap allocation has performance overhead.\n"
-"\n"
-"* The challenges in language support for `async trait` are deep Rust and\n"
-"  probably not worth describing in-depth. Niko Matsakis did a good job of\n"
-"  explaining them in [this\n"
-"  post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-"
-"traits-are-hard/)\n"
-"  if you are interested in digging deeper.\n"
-"\n"
-"* Try creating a new sleeper struct that will sleep for a random amount of "
-"time\n"
-"  and adding it to the Vec."
+"`async_trait` is easy to use, but note that it's using heap allocations to "
+"achieve this. This heap allocation has performance overhead."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:54
+msgid ""
+"The challenges in language support for `async trait` are deep Rust and "
+"probably not worth describing in-depth. Niko Matsakis did a good job of "
+"explaining them in [this post](https://smallcultfollowing.com/babysteps/"
+"blog/2019/10/26/async-fn-in-traits-are-hard/) if you are interested in "
+"digging deeper."
+msgstr ""
+
+#: src/async/pitfalls/async-traits.md:60
+msgid ""
+"Try creating a new sleeper struct that will sleep for a random amount of "
+"time and adding it to the Vec."
 msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:3
@@ -18620,40 +19456,39 @@ msgstr ""
 
 #: src/exercises/concurrency/afternoon.md:5
 msgid ""
-"* Dining philosophers: we already saw this problem in the morning. This "
-"time\n"
-"  you are going to implement it with Async Rust.\n"
-"\n"
-"* A Broadcast Chat Application: this is a larger project that allows you\n"
-"  experiment with more advanced Async Rust features."
+"Dining philosophers: we already saw this problem in the morning. This time "
+"you are going to implement it with Async Rust."
+msgstr ""
+
+#: src/exercises/concurrency/afternoon.md:8
+msgid ""
+"A Broadcast Chat Application: this is a larger project that allows you "
+"experiment with more advanced Async Rust features."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:1
+#: src/exercises/concurrency/solutions-afternoon.md:3
 #, fuzzy
-msgid "# Dining Philosophers - Async"
-msgstr "# Speisende Philosophen"
+msgid "Dining Philosophers - Async"
+msgstr "Speisende Philosophen"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
-"See [dining philosophers](dining-philosophers.md) for a description of the\n"
+"See [dining philosophers](dining-philosophers.md) for a description of the "
 "problem."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:6
 #, fuzzy
 msgid ""
-"As before, you will need a local\n"
-"[Cargo installation](../../cargo/running-locally.md) for this exercise. "
-"Copy\n"
-"the code below to a file called `src/main.rs`, fill out the blanks, and "
-"test\n"
-"that `cargo run` does not deadlock:"
+"As before, you will need a local [Cargo installation](../../cargo/running-"
+"locally.md) for this exercise. Copy the code below to a file called `src/"
+"main.rs`, fill out the blanks, and test that `cargo run` does not deadlock:"
 msgstr ""
 "Dazu benötigen Sie eine lokale [Cargo-Installation](../../cargo/running-"
-"locally.md).\n"
-"diese Übung. Kopieren Sie den folgenden Code in die Datei `src/main.rs`, "
-"füllen Sie die Lücken aus,\n"
-"und teste, dass `cargo run` keinen Deadlock verursacht:"
+"locally.md). diese Übung. Kopieren Sie den folgenden Code in die Datei `src/"
+"main.rs`, füllen Sie die Lücken aus, und teste, dass `cargo run` keinen "
+"Deadlock verursacht:"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:13
 msgid ""
@@ -18705,7 +19540,7 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:57
 msgid ""
-"Since this time you are using Async Rust, you'll need a `tokio` dependency.\n"
+"Since this time you are using Async Rust, you'll need a `tokio` dependency. "
 "You can use the following `Cargo.toml`:"
 msgstr ""
 
@@ -18725,33 +19560,29 @@ msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:72
 msgid ""
-"Also note that this time you have to use the `Mutex` and the `mpsc` module\n"
+"Also note that this time you have to use the `Mutex` and the `mpsc` module "
 "from the `tokio` crate."
 msgstr ""
 
 #: src/exercises/concurrency/dining-philosophers-async.md:77
-msgid "* Can you make your implementation single-threaded? "
-msgstr ""
-
-#: src/exercises/concurrency/chat-app.md:1
-msgid "# Broadcast Chat Application"
+msgid "Can you make your implementation single-threaded? "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:3
 msgid ""
-"In this exercise, we want to use our new knowledge to implement a broadcast\n"
+"In this exercise, we want to use our new knowledge to implement a broadcast "
 "chat application. We have a chat server that the clients connect to and "
-"publish\n"
-"their messages. The client reads user messages from the standard input, and\n"
-"sends them to the server. The chat server broadcasts each message that it\n"
-"receives to all the clients."
+"publish their messages. The client reads user messages from the standard "
+"input, and sends them to the server. The chat server broadcasts each message "
+"that it receives to all the clients."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:9
 msgid ""
-"For this, we use [a broadcast channel][1] on the server, and\n"
-"[`tokio_websockets`][2] for the communication between the client and the\n"
-"server."
+"For this, we use [a broadcast channel](https://docs.rs/tokio/latest/tokio/"
+"sync/broadcast/fn.channel.html) on the server, and [`tokio_websockets`]"
+"(https://docs.rs/tokio-websockets/0.3.2/tokio_websockets/) for the "
+"communication between the client and the server."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:13
@@ -18779,48 +19610,64 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:32
-msgid "## The required APIs"
+msgid "The required APIs"
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:33
 msgid ""
-"You are going to need the following functions from `tokio` and\n"
-"[`tokio_websockets`][2]. Spend a few minutes to familiarize yourself with "
-"the\n"
+"You are going to need the following functions from `tokio` and "
+"[`tokio_websockets`](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/). Spend a few minutes to familiarize yourself with the "
 "API. "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:37
 msgid ""
-"- [WebsocketStream::next()][3]: for asynchronously reading messages from a\n"
-"  Websocket Stream.\n"
-"- [SinkExt::send()][4] implemented by `WebsocketStream`: for asynchronously\n"
-"  sending messages on a Websocket Stream.\n"
-"- [BufReader::read_line()][5]: for asynchronously reading user messages\n"
-"  from the standard input.\n"
-"- [Sender::subscribe()][6]: for subscribing to a broadcast channel."
+"[WebsocketStream::next()](https://docs.rs/tokio-websockets/0.3.2/"
+"tokio_websockets/proto/struct.WebsocketStream.html#method.next): for "
+"asynchronously reading messages from a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:39
+msgid ""
+"[SinkExt::send()](https://docs.rs/futures-util/0.3.28/futures_util/sink/"
+"trait.SinkExt.html#method.send) implemented by `WebsocketStream`: for "
+"asynchronously sending messages on a Websocket Stream."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:41
+msgid ""
+"[BufReader::read_line()](https://docs.rs/tokio/latest/tokio/io/struct.Lines."
+"html#method.next_line): for asynchronously reading user messages from the "
+"standard input."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:43
+msgid ""
+"[Sender::subscribe()](https://docs.rs/tokio/latest/tokio/sync/broadcast/"
+"struct.Sender.html#method.subscribe): for subscribing to a broadcast channel."
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
 #, fuzzy
-msgid "## Two binaries"
-msgstr "# Rust-Binärdateien"
+msgid "Two binaries"
+msgstr "Rust-Binärdateien"
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
-"Normally in a Cargo project, you can have only one binary, and one\n"
-"`src/main.rs` file. In this project, we need two binaries. One for the "
-"client,\n"
-"and one for the server. You could potentially make them two separate Cargo\n"
-"projects, but we are going to put them in a single Cargo project with two\n"
-"binaries. For this to work, the client and the server code should go under\n"
-"`src/bin` (see the [documentation][7]). "
+"Normally in a Cargo project, you can have only one binary, and one `src/main."
+"rs` file. In this project, we need two binaries. One for the client, and one "
+"for the server. You could potentially make them two separate Cargo projects, "
+"but we are going to put them in a single Cargo project with two binaries. "
+"For this to work, the client and the server code should go under `src/bin` "
+"(see the [documentation](https://doc.rust-lang.org/cargo/reference/cargo-"
+"targets.html#binaries)). "
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:55
 msgid ""
-"Copy the following server and client code into `src/bin/server.rs` and\n"
-"`src/bin/client.rs`, respectively. Your task is to complete these files as\n"
+"Copy the following server and client code into `src/bin/server.rs` and `src/"
+"bin/client.rs`, respectively. Your task is to complete these files as "
 "described below. "
 msgstr ""
 
@@ -18829,10 +19676,6 @@ msgstr ""
 #, fuzzy
 msgid "`src/bin/server.rs`:"
 msgstr "_hello_rust/src/main.rs_:"
-
-#: src/exercises/concurrency/chat-app.md:61
-msgid "<!-- File src/bin/server.rs -->"
-msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:63
 msgid ""
@@ -18882,10 +19725,6 @@ msgstr ""
 msgid "`src/bin/client.rs`:"
 msgstr "_hello_rust/src/main.rs_:"
 
-#: src/exercises/concurrency/chat-app.md:104
-msgid "<!-- File src/bin/client.rs -->"
-msgstr ""
-
 #: src/exercises/concurrency/chat-app.md:106
 msgid ""
 "```rust,compile_fail\n"
@@ -18913,8 +19752,8 @@ msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:127
 #, fuzzy
-msgid "## Running the binaries"
-msgstr "# Ablauf des Kurses"
+msgid "Running the binaries"
+msgstr "Ablauf des Kurses"
 
 #: src/exercises/concurrency/chat-app.md:128
 msgid "Run the server with:"
@@ -18939,79 +19778,74 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:142
-msgid ""
-"* Implement the `handle_connection` function in `src/bin/server.rs`.\n"
-"  * Hint: Use `tokio::select!` for concurrently performing two tasks in a\n"
-"    continuous loop. One task receives messages from the client and "
-"broadcasts\n"
-"    them. The other sends messages received by the server to the client.\n"
-"* Complete the main function in `src/bin/client.rs`.\n"
-"  * Hint: As before, use `tokio::select!` in a continuous loop for "
-"concurrently\n"
-"    performing two tasks: (1) reading user messages from standard input and\n"
-"    sending them to the server, and (2) receiving messages from the server, "
-"and\n"
-"    displaying them for the user.\n"
-"* Optional: Once you are done, change the code to broadcast messages to all\n"
-"  clients, but the sender of the message."
+msgid "Implement the `handle_connection` function in `src/bin/server.rs`."
 msgstr ""
 
-#: src/thanks.md:1
-#, fuzzy
-msgid "# Thanks!"
-msgstr "# Danke!"
+#: src/exercises/concurrency/chat-app.md:143
+msgid ""
+"Hint: Use `tokio::select!` for concurrently performing two tasks in a "
+"continuous loop. One task receives messages from the client and broadcasts "
+"them. The other sends messages received by the server to the client."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:146
+msgid "Complete the main function in `src/bin/client.rs`."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:147
+msgid ""
+"Hint: As before, use `tokio::select!` in a continuous loop for concurrently "
+"performing two tasks: (1) reading user messages from standard input and "
+"sending them to the server, and (2) receiving messages from the server, and "
+"displaying them for the user."
+msgstr ""
+
+#: src/exercises/concurrency/chat-app.md:151
+msgid ""
+"Optional: Once you are done, change the code to broadcast messages to all "
+"clients, but the sender of the message."
+msgstr ""
 
 #: src/thanks.md:3
 #, fuzzy
 msgid ""
 "_Thank you for taking Comprehensive Rust 🦀!_ We hope you enjoyed it and "
-"that it\n"
-"was useful."
+"that it was useful."
 msgstr ""
 "_Vielen Dank, dass Sie Comprehensive Rust 🦀 genommen haben!_ Wir hoffen, "
-"dass es Ihnen gefallen hat und dass es\n"
-"war nützlich."
+"dass es Ihnen gefallen hat und dass es war nützlich."
 
 #: src/thanks.md:6
 #, fuzzy
 msgid ""
 "We've had a lot of fun putting the course together. The course is not "
-"perfect,\n"
-"so if you spotted any mistakes or have ideas for improvements, please get "
-"in\n"
-"[contact with us on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). We would "
-"love\n"
-"to hear from you."
+"perfect, so if you spotted any mistakes or have ideas for improvements, "
+"please get in [contact with us on GitHub](https://github.com/google/"
+"comprehensive-rust/discussions). We would love to hear from you."
 msgstr ""
 "Es hat uns viel Spaß gemacht, den Kurs zusammenzustellen. Der Kurs ist nicht "
-"perfekt,\n"
-"Wenn Sie also Fehler entdeckt haben oder Verbesserungsvorschläge haben, "
-"melden Sie sich bitte\n"
-"[Kontakt mit uns auf\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Wir "
-"würden lieben\n"
-"von dir zu hören."
+"perfekt, Wenn Sie also Fehler entdeckt haben oder Verbesserungsvorschläge "
+"haben, melden Sie sich bitte [Kontakt mit uns auf GitHub](https://github.com/"
+"google/comprehensive-rust/discussions). Wir würden lieben von dir zu hören."
 
 #: src/other-resources.md:1
 #, fuzzy
-msgid "# Other Rust Resources"
-msgstr "# Andere Rostressourcen"
+msgid "Other Rust Resources"
+msgstr "Andere Rostressourcen"
 
 #: src/other-resources.md:3
 #, fuzzy
 msgid ""
-"The Rust community has created a wealth of high-quality and free resources\n"
+"The Rust community has created a wealth of high-quality and free resources "
 "online."
 msgstr ""
 "Die Rust-Community hat eine Fülle hochwertiger und kostenloser Ressourcen "
-"geschaffen\n"
-"online."
+"geschaffen online."
 
 #: src/other-resources.md:6
 #, fuzzy
-msgid "## Official Documentation"
-msgstr "## Offizielle Dokumentation"
+msgid "Official Documentation"
+msgstr "Offizielle Dokumentation"
 
 #: src/other-resources.md:8
 #, fuzzy
@@ -19023,40 +19857,45 @@ msgstr ""
 #: src/other-resources.md:10
 #, fuzzy
 msgid ""
-"* [The Rust Programming Language](https://doc.rust-lang.org/book/): the\n"
-"  canonical free book about Rust. Covers the language in detail and includes "
-"a\n"
-"  few projects for people to build.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
-"Rust\n"
-"  syntax via a series of examples which showcase different constructs. "
-"Sometimes\n"
-"  includes small exercises where you are asked to expand on the code in the\n"
-"  examples.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): full "
-"documentation of\n"
-"  the standard library for Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
-"book\n"
-"  which describes the Rust grammar and memory model."
+"[The Rust Programming Language](https://doc.rust-lang.org/book/): the "
+"canonical free book about Rust. Covers the language in detail and includes a "
+"few projects for people to build."
 msgstr ""
-"* [Die Programmiersprache Rust](https://doc.rust-lang.org/book/): die\n"
-"  Kanonisches kostenloses Buch über Rust. Deckt die Sprache im Detail ab und "
-"enthält a\n"
-"  wenige Projekte für Menschen zu bauen.\n"
-"* [Rust By Example](https://doc.rust-lang.org/rust-by-example/): deckt den "
-"Rust ab\n"
-"  Syntax über eine Reihe von Beispielen, die verschiedene Konstrukte "
-"demonstrieren. Manchmal\n"
-"  enthält kleine Übungen, in denen Sie aufgefordert werden, den Code in der "
-"zu erweitern\n"
-"  Beispiele.\n"
-"* [Rust Standard Library](https://doc.rust-lang.org/std/): vollständige "
-"Dokumentation von\n"
-"  die Standardbibliothek für Rust.\n"
-"* [The Rust Reference](https://doc.rust-lang.org/reference/): ein "
-"unvollständiges Buch\n"
-"  das die Rust-Grammatik und das Speichermodell beschreibt."
+"[Die Programmiersprache Rust](https://doc.rust-lang.org/book/): die "
+"Kanonisches kostenloses Buch über Rust. Deckt die Sprache im Detail ab und "
+"enthält a wenige Projekte für Menschen zu bauen."
+
+#: src/other-resources.md:13
+#, fuzzy
+msgid ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
+"Rust syntax via a series of examples which showcase different constructs. "
+"Sometimes includes small exercises where you are asked to expand on the code "
+"in the examples."
+msgstr ""
+"[Rust By Example](https://doc.rust-lang.org/rust-by-example/): deckt den "
+"Rust ab Syntax über eine Reihe von Beispielen, die verschiedene Konstrukte "
+"demonstrieren. Manchmal enthält kleine Übungen, in denen Sie aufgefordert "
+"werden, den Code in der zu erweitern Beispiele."
+
+#: src/other-resources.md:17
+#, fuzzy
+msgid ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): full documentation "
+"of the standard library for Rust."
+msgstr ""
+"[Rust Standard Library](https://doc.rust-lang.org/std/): vollständige "
+"Dokumentation von die Standardbibliothek für Rust."
+
+#: src/other-resources.md:19
+#, fuzzy
+msgid ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): an incomplete "
+"book which describes the Rust grammar and memory model."
+msgstr ""
+"[The Rust Reference](https://doc.rust-lang.org/reference/): ein "
+"unvollständiges Buch das die Rust-Grammatik und das Speichermodell "
+"beschreibt."
 
 #: src/other-resources.md:22
 #, fuzzy
@@ -19068,38 +19907,40 @@ msgstr ""
 #: src/other-resources.md:24
 #, fuzzy
 msgid ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe "
-"Rust,\n"
-"  including working with raw pointers and interfacing with other languages\n"
-"  (FFI).\n"
-"* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  covers the new asynchronous programming model which was introduced after "
-"the\n"
-"  Rust Book was written.\n"
-"* [The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
-"an\n"
-"  introduction to using Rust on embedded devices without an operating system."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
+"including working with raw pointers and interfacing with other languages "
+"(FFI)."
 msgstr ""
-"* [The Rustonomicon](https://doc.rust-lang.org/nomicon/): deckt unsicheres "
-"Rust ab,\n"
-"  einschließlich der Arbeit mit rohen Zeigern und der Anbindung an andere "
-"Sprachen\n"
-"  (FFI).\n"
-"* [Asynchrone Programmierung in Rust](https://rust-lang.github.io/async-"
-"book/):\n"
-"  deckt das neue asynchrone Programmiermodell ab, das nach dem eingeführt "
-"wurde\n"
-"  Rust Book wurde geschrieben.\n"
-"* [Das eingebettete Rust-Buch] (https://doc.rust-lang.org/stable/embedded-"
-"book/): an\n"
-"  Einführung in die Verwendung von Rust auf eingebetteten Geräten ohne "
-"Betriebssystem."
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/): deckt unsicheres "
+"Rust ab, einschließlich der Arbeit mit rohen Zeigern und der Anbindung an "
+"andere Sprachen (FFI)."
+
+#: src/other-resources.md:27
+#, fuzzy
+msgid ""
+"[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
+"covers the new asynchronous programming model which was introduced after the "
+"Rust Book was written."
+msgstr ""
+"[Asynchrone Programmierung in Rust](https://rust-lang.github.io/async-"
+"book/): deckt das neue asynchrone Programmiermodell ab, das nach dem "
+"eingeführt wurde Rust Book wurde geschrieben."
+
+#: src/other-resources.md:30
+#, fuzzy
+msgid ""
+"[The Embedded Rust Book](https://doc.rust-lang.org/stable/embedded-book/): "
+"an introduction to using Rust on embedded devices without an operating "
+"system."
+msgstr ""
+"\\[Das eingebettete Rust-Buch\\] (https://doc.rust-lang.org/stable/embedded-"
+"book/): an Einführung in die Verwendung von Rust auf eingebetteten Geräten "
+"ohne Betriebssystem."
 
 #: src/other-resources.md:33
 #, fuzzy
-msgid "## Unofficial Learning Material"
-msgstr "## Inoffizielles Lernmaterial"
+msgid "Unofficial Learning Material"
+msgstr "Inoffizielles Lernmaterial"
 
 #: src/other-resources.md:35
 #, fuzzy
@@ -19109,181 +19950,158 @@ msgstr "Eine kleine Auswahl an weiteren Guides und Tutorials für Rust:"
 #: src/other-resources.md:37
 #, fuzzy
 msgid ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers "
-"Rust\n"
-"  from the perspective of low-level C programmers.\n"
-"* [Rust for Embedded C\n"
-"  Programmers](https://docs.opentitan.org/doc/ug/rust_for_c/): covers Rust "
-"from\n"
-"  the perspective of developers who write firmware in C.\n"
-"* [Rust for professionals](https://overexact.com/rust-for-professionals/):\n"
-"  covers the syntax of Rust using side-by-side comparisons with other "
-"languages\n"
-"  such as C, C++, Java, JavaScript, and Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to "
-"help\n"
-"  you learn Rust.\n"
-"* [Ferrous Teaching\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  series of small presentations covering both basic and advanced part of "
-"the\n"
-"  Rust language. Other topics such as WebAssembly, and async/await are also\n"
-"  covered.\n"
-"* [Beginner's Series to\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"and\n"
-"  [Take your first steps with\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"two\n"
-"  Rust guides aimed at new developers. The first is a set of 35 videos and "
-"the\n"
-"  second is a set of 11 modules which covers Rust syntax and basic "
-"constructs.\n"
-"* [Learn Rust With Entirely Too Many Linked\n"
-"  Lists](https://rust-unofficial.github.io/too-many-lists/): in-depth\n"
-"  exploration of Rust's memory management rules, through implementing a few\n"
-"  different types of list structures."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): covers Rust "
+"from the perspective of low-level C programmers."
 msgstr ""
-"* [Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): deckt "
-"Rust ab\n"
-"  aus der Perspektive von Low-Level-C-Programmierern.\n"
-"* [Rost für eingebettetes C\n"
-"  Programmierer] (https://docs.opentitan.org/doc/ug/rust_for_c/): deckt Rust "
-"ab\n"
-"  die Perspektive von Entwicklern, die Firmware in C schreiben.\n"
-"* [Rost für Profis](https://overexact.com/rust-for-professionals/):\n"
-"  deckt die Syntax von Rust durch Side-by-Side-Vergleiche mit anderen "
-"Sprachen ab\n"
-"  wie C, C++, Java, JavaScript und Python.\n"
-"* [Rust on Exercism](https://exercism.org/tracks/rust): Über 100 hilfreiche "
-"Übungen\n"
-"  Sie lernen Rost.\n"
-"* [Eisenlehre\n"
-"  Material](https://ferrous-systems.github.io/teaching-material/index.html): "
-"a\n"
-"  Reihe von kleinen Präsentationen, die sowohl den grundlegenden als auch "
-"den fortgeschrittenen Teil des\n"
-"  Rostige Sprache. Andere Themen wie WebAssembly und async/await sind "
-"ebenfalls enthalten\n"
-"  bedeckt.\n"
-"* [Anfängerserie bis\n"
-"  Rust](https://docs.microsoft.com/en-us/shows/beginners-series-to-rust/) "
-"und\n"
-"  [Machen Sie Ihre ersten Schritte mit\n"
-"  Rust](https://docs.microsoft.com/en-us/learn/paths/rust-first-steps/): "
-"zwei\n"
-"  Rust-Leitfäden für neue Entwickler. Die erste ist eine Reihe von 35 Videos "
-"und die\n"
-"  Das zweite ist ein Satz von 11 Modulen, der die Rust-Syntax und "
-"grundlegende Konstrukte abdeckt."
+"[Learn Rust the Dangerous Way](http://cliffle.com/p/dangerust/): deckt Rust "
+"ab aus der Perspektive von Low-Level-C-Programmierern."
+
+#: src/other-resources.md:39
+#, fuzzy
+msgid ""
+"[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
+"rust_for_c/): covers Rust from the perspective of developers who write "
+"firmware in C."
+msgstr ""
+"\\[Rost für eingebettetes C Programmierer\\] (https://docs.opentitan.org/doc/"
+"ug/rust_for_c/): deckt Rust ab die Perspektive von Entwicklern, die Firmware "
+"in C schreiben."
+
+#: src/other-resources.md:42
+#, fuzzy
+msgid ""
+"[Rust for professionals](https://overexact.com/rust-for-professionals/): "
+"covers the syntax of Rust using side-by-side comparisons with other "
+"languages such as C, C++, Java, JavaScript, and Python."
+msgstr ""
+"[Rost für Profis](https://overexact.com/rust-for-professionals/): deckt die "
+"Syntax von Rust durch Side-by-Side-Vergleiche mit anderen Sprachen ab wie C, "
+"C++, Java, JavaScript und Python."
+
+#: src/other-resources.md:45
+#, fuzzy
+msgid ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): 100+ exercises to help "
+"you learn Rust."
+msgstr ""
+"[Rust on Exercism](https://exercism.org/tracks/rust): Über 100 hilfreiche "
+"Übungen Sie lernen Rost."
+
+#: src/other-resources.md:47
+#, fuzzy
+msgid ""
+"[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
+"material/index.html): a series of small presentations covering both basic "
+"and advanced part of the Rust language. Other topics such as WebAssembly, "
+"and async/await are also covered."
+msgstr ""
+"[Eisenlehre Material](https://ferrous-systems.github.io/teaching-material/"
+"index.html): a Reihe von kleinen Präsentationen, die sowohl den "
+"grundlegenden als auch den fortgeschrittenen Teil des Rostige Sprache. "
+"Andere Themen wie WebAssembly und async/await sind ebenfalls enthalten "
+"bedeckt."
+
+#: src/other-resources.md:52
+#, fuzzy
+msgid ""
+"[Beginner's Series to Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) and [Take your first steps with Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): two Rust guides aimed at "
+"new developers. The first is a set of 35 videos and the second is a set of "
+"11 modules which covers Rust syntax and basic constructs."
+msgstr ""
+"[Anfängerserie bis Rust](https://docs.microsoft.com/en-us/shows/beginners-"
+"series-to-rust/) und [Machen Sie Ihre ersten Schritte mit Rust](https://docs."
+"microsoft.com/en-us/learn/paths/rust-first-steps/): zwei Rust-Leitfäden für "
+"neue Entwickler. Die erste ist eine Reihe von 35 Videos und die Das zweite "
+"ist ein Satz von 11 Modulen, der die Rust-Syntax und grundlegende Konstrukte "
+"abdeckt."
+
+#: src/other-resources.md:58
+msgid ""
+"[Learn Rust With Entirely Too Many Linked Lists](https://rust-unofficial."
+"github.io/too-many-lists/): in-depth exploration of Rust's memory management "
+"rules, through implementing a few different types of list structures."
+msgstr ""
 
 #: src/other-resources.md:63
 #, fuzzy
 msgid ""
 "Please see the [Little Book of Rust Books](https://lborb.github.io/book/) "
-"for\n"
-"even more Rust books."
+"for even more Rust books."
 msgstr ""
-"Weitere Informationen finden Sie im [Little Book of Rust Books] (https://"
-"lborb.github.io/book/).\n"
-"noch mehr Rust-Bücher."
-
-#: src/credits.md:1
-#, fuzzy
-msgid "# Credits"
-msgstr "# Credits"
+"Weitere Informationen finden Sie im \\[Little Book of Rust Books\\] (https://"
+"lborb.github.io/book/). noch mehr Rust-Bücher."
 
 #: src/credits.md:3
 #, fuzzy
 msgid ""
 "The material here builds on top of the many great sources of Rust "
-"documentation.\n"
-"See the page on [other resources](other-resources.md) for a full list of "
-"useful\n"
-"resources."
+"documentation. See the page on [other resources](other-resources.md) for a "
+"full list of useful resources."
 msgstr ""
 "Das Material hier baut auf den vielen großartigen Quellen der Rust-"
-"Dokumentation auf.\n"
-"Auf der Seite [andere Ressourcen] (other-resources.md) finden Sie eine "
-"vollständige Liste nützlicher Ressourcen\n"
-"Ressourcen."
+"Dokumentation auf. Auf der Seite \\[andere Ressourcen\\] (other-resources."
+"md) finden Sie eine vollständige Liste nützlicher Ressourcen Ressourcen."
 
 #: src/credits.md:7
 #, fuzzy
 msgid ""
 "The material of Comprehensive Rust is licensed under the terms of the Apache "
-"2.0\n"
-"license, please see [`LICENSE`](../LICENSE) for details."
+"2.0 license, please see [`LICENSE`](../LICENSE) for details."
 msgstr ""
 "Das Material von Comprehensive Rust ist unter den Bedingungen von Apache 2.0 "
-"lizenziert\n"
-"Lizenz finden Sie unter [`LICENSE`](../LICENSE) für Einzelheiten."
+"lizenziert Lizenz finden Sie unter [`LICENSE`](../LICENSE) für Einzelheiten."
 
 #: src/credits.md:10
 #, fuzzy
-msgid "## Rust by Example"
-msgstr "## Rost zum Beispiel"
+msgid "Rust by Example"
+msgstr "Rost zum Beispiel"
 
 #: src/credits.md:12
 #, fuzzy
 msgid ""
-"Some examples and exercises have been copied and adapted from [Rust by\n"
-"Example](https://doc.rust-lang.org/rust-by-example/). Please see the\n"
-"`third_party/rust-by-example/` directory for details, including the license\n"
+"Some examples and exercises have been copied and adapted from [Rust by "
+"Example](https://doc.rust-lang.org/rust-by-example/). Please see the "
+"`third_party/rust-by-example/` directory for details, including the license "
 "terms."
 msgstr ""
-"Einige Beispiele und Übungen wurden aus [Rust by\n"
-"Beispiel](https://doc.rust-lang.org/rust-by-example/). Bitte sehen Sie "
-"sich ... an\n"
-"`third_party/rust-by-example/`-Verzeichnis für Details, einschließlich der "
-"Lizenz\n"
-"Bedingungen."
+"Einige Beispiele und Übungen wurden aus [Rust by Beispiel](https://doc.rust-"
+"lang.org/rust-by-example/). Bitte sehen Sie sich ... an `third_party/rust-by-"
+"example/`\\-Verzeichnis für Details, einschließlich der Lizenz Bedingungen."
 
 #: src/credits.md:17
 #, fuzzy
-msgid "## Rust on Exercism"
-msgstr "## Rost auf Übung"
+msgid "Rust on Exercism"
+msgstr "Rost auf Übung"
 
 #: src/credits.md:19
 #, fuzzy
 msgid ""
-"Some exercises have been copied and adapted from [Rust on\n"
-"Exercism](https://exercism.org/tracks/rust). Please see the\n"
-"`third_party/rust-on-exercism/` directory for details, including the "
-"license\n"
-"terms."
+"Some exercises have been copied and adapted from [Rust on Exercism](https://"
+"exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
+"directory for details, including the license terms."
 msgstr ""
-"Einige Übungen wurden von [Rust on\n"
-"Übung] (https://exercism.org/tracks/rust). Bitte sehen Sie sich ... an\n"
-"`third_party/rust-on-exercism/`-Verzeichnis für Details, einschließlich der "
-"Lizenz\n"
-"Bedingungen."
+"Einige Übungen wurden von \\[Rust on Übung\\] (https://exercism.org/tracks/"
+"rust). Bitte sehen Sie sich ... an `third_party/rust-on-exercism/`\\-"
+"Verzeichnis für Details, einschließlich der Lizenz Bedingungen."
 
 #: src/credits.md:24
 #, fuzzy
-msgid "## CXX"
-msgstr "##CXX"
+msgid "CXX"
+msgstr "\\##CXX"
 
 #: src/credits.md:26
 #, fuzzy
 msgid ""
 "The [Interoperability with C++](android/interoperability/cpp.md) section "
-"uses an\n"
-"image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
-"directory\n"
-"for details, including the license terms."
+"uses an image from [CXX](https://cxx.rs/). Please see the `third_party/cxx/` "
+"directory for details, including the license terms."
 msgstr ""
 "Der Abschnitt [Interoperability with C++](android/interoperability/cpp.md) "
-"verwendet eine\n"
-"Bild von [CXX](https://cxx.rs/). Bitte sehen Sie sich das Verzeichnis "
-"`third_party/cxx/` an\n"
-"für Details, einschließlich der Lizenzbedingungen."
-
-#: src/exercises/solutions.md:1
-#, fuzzy
-msgid "# Solutions"
-msgstr "# Lösungen"
+"verwendet eine Bild von [CXX](https://cxx.rs/). Bitte sehen Sie sich das "
+"Verzeichnis `third_party/cxx/` an für Details, einschließlich der "
+"Lizenzbedingungen."
 
 #: src/exercises/solutions.md:3
 #, fuzzy
@@ -19292,37 +20110,28 @@ msgstr "Auf den folgenden Seiten finden Sie Lösungen zu den Aufgaben."
 
 #: src/exercises/solutions.md:5
 msgid ""
-"Feel free to ask questions about the solutions [on\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions). Let us "
-"know\n"
-"if you have a different or better solution than what is presented here."
+"Feel free to ask questions about the solutions [on GitHub](https://github."
+"com/google/comprehensive-rust/discussions). Let us know if you have a "
+"different or better solution than what is presented here."
 msgstr ""
-"Habe keine falsche Scheu, fragen zu den Lösungen [auf\n"
-"GitHub](https://github.com/google/comprehensive-rust/discussions) zu "
-"stellen. Lass uns wissen\n"
-"wenn Du eine andere oder bessere Lösung als die hier vorgestellte hast."
+"Habe keine falsche Scheu, fragen zu den Lösungen [auf GitHub](https://github."
+"com/google/comprehensive-rust/discussions) zu stellen. Lass uns wissen wenn "
+"Du eine andere oder bessere Lösung als die hier vorgestellte hast."
 
 #: src/exercises/solutions.md:10
 msgid ""
-"> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`\n"
-"> comments you see in the solutions. They are there to make it possible to\n"
-"> re-use parts of the solutions as the exercises."
+"**Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label` "
+"comments you see in the solutions. They are there to make it possible to re-"
+"use parts of the solutions as the exercises."
 msgstr ""
-"> **Hinweis:** Bitte ignoriere `// ANCHOR: label` und `// ANCHOR_END: "
-"label`\n"
-"> Kommentare, die Du in den Lösungen siehst. Sie sind da, um es zu "
-"ermöglichen\n"
-"> Teile der Lösungen als Aufgaben wiederverwenden."
+"**Hinweis:** Bitte ignoriere `// ANCHOR: label` und `// ANCHOR_END: label` "
+"Kommentare, die Du in den Lösungen siehst. Sie sind da, um es zu ermöglichen "
+"Teile der Lösungen als Aufgaben wiederverwenden."
 
 #: src/exercises/day-1/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 1 Morning Exercises"
-msgstr "# Tag 1 Morgengymnastik"
-
-#: src/exercises/day-1/solutions-morning.md:3
-#, fuzzy
-msgid "## Arrays and `for` Loops"
-msgstr "## Arrays und „for“-Schleifen"
+msgid "Day 1 Morning Exercises"
+msgstr "Tag 1 Morgengymnastik"
 
 #: src/exercises/day-1/solutions-morning.md:5
 #, fuzzy
@@ -19405,7 +20214,7 @@ msgid ""
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:78
-msgid "### Bonus question"
+msgid "Bonus question"
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:80
@@ -19436,7 +20245,8 @@ msgstr ""
 #: src/exercises/day-1/solutions-morning.md:84
 msgid ""
 "Once we get to traits and generics, we'll be able to use the [`std::convert::"
-"AsRef`][1] trait to abstract over anything that can be referenced as a slice."
+"AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) trait to "
+"abstract over anything that can be referenced as a slice."
 msgstr ""
 
 #: src/exercises/day-1/solutions-morning.md:86
@@ -19481,13 +20291,8 @@ msgstr ""
 
 #: src/exercises/day-1/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 1 Afternoon Exercises"
-msgstr "# Tag 1 Nachmittagsübungen"
-
-#: src/exercises/day-1/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Designing a Library"
-msgstr "## Entwerfen einer Bibliothek"
+msgid "Day 1 Afternoon Exercises"
+msgstr "Tag 1 Nachmittagsübungen"
 
 #: src/exercises/day-1/solutions-afternoon.md:5
 #, fuzzy
@@ -19691,13 +20496,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 2 Morning Exercises"
-msgstr "# Tag 2 Morgengymnastik"
-
-#: src/exercises/day-2/solutions-morning.md:3
-#, fuzzy
-msgid "## Points and Polygons"
-msgstr "## Punkte und Polygone"
+msgid "Day 2 Morning Exercises"
+msgstr "Tag 2 Morgengymnastik"
 
 #: src/exercises/day-2/solutions-morning.md:5
 #, fuzzy
@@ -19938,13 +20738,8 @@ msgstr ""
 
 #: src/exercises/day-2/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 2 Afternoon Exercises"
-msgstr "# Tag 2 Nachmittagsübungen"
-
-#: src/exercises/day-2/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Luhn Algorithm"
-msgstr "## Luhn-Algorithmus"
+msgid "Day 2 Afternoon Exercises"
+msgstr "Tag 2 Nachmittagsübungen"
 
 #: src/exercises/day-2/solutions-afternoon.md:5
 #, fuzzy
@@ -20045,11 +20840,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/exercises/day-2/solutions-afternoon.md:97
-#, fuzzy
-msgid "## Strings and Iterators"
-msgstr "## Strings und Iteratoren"
-
 #: src/exercises/day-2/solutions-afternoon.md:99
 #, fuzzy
 msgid "([back to exercise](strings-iterators.md))"
@@ -20139,13 +20929,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-morning.md:1
 #, fuzzy
-msgid "# Day 3 Morning Exercise"
-msgstr "# Tag 3 Morgengymnastik"
-
-#: src/exercises/day-3/solutions-morning.md:3
-#, fuzzy
-msgid "## A Simple GUI Library"
-msgstr "## Eine einfache GUI-Bibliothek"
+msgid "Day 3 Morning Exercise"
+msgstr "Tag 3 Morgengymnastik"
 
 #: src/exercises/day-3/solutions-morning.md:5
 #, fuzzy
@@ -20326,13 +21111,8 @@ msgstr ""
 
 #: src/exercises/day-3/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Day 3 Afternoon Exercises"
-msgstr "# Tag 3 Nachmittagsübungen"
-
-#: src/exercises/day-3/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Safe FFI Wrapper"
-msgstr "## Sicherer FFI-Wrapper"
+msgid "Day 3 Afternoon Exercises"
+msgstr "Tag 3 Nachmittagsübungen"
 
 #: src/exercises/day-3/solutions-afternoon.md:5
 #, fuzzy
@@ -20516,13 +21296,8 @@ msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
 #, fuzzy
-msgid "# Bare Metal Rust Morning Exercise"
-msgstr "# Tag 3 Morgengymnastik"
-
-#: src/exercises/bare-metal/solutions-morning.md:3
-#, fuzzy
-msgid "## Compass"
-msgstr "# Vergleich"
+msgid "Bare Metal Rust Morning Exercise"
+msgstr "Tag 3 Morgengymnastik"
 
 #: src/exercises/bare-metal/solutions-morning.md:5
 #, fuzzy
@@ -20694,14 +21469,6 @@ msgid ""
 "    max(min_value, min(value, max_value))\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:1
-msgid "# Bare Metal Rust Afternoon"
-msgstr ""
-
-#: src/exercises/bare-metal/solutions-afternoon.md:3
-msgid "## RTC driver"
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-afternoon.md:5
@@ -21000,13 +21767,8 @@ msgstr ""
 
 #: src/exercises/concurrency/solutions-morning.md:1
 #, fuzzy
-msgid "# Concurrency Morning Exercise"
-msgstr "# Tag 3 Morgengymnastik"
-
-#: src/exercises/concurrency/solutions-morning.md:3
-#, fuzzy
-msgid "## Dining Philosophers"
-msgstr "## Essende Philosophen"
+msgid "Concurrency Morning Exercise"
+msgstr "Tag 3 Morgengymnastik"
 
 #: src/exercises/concurrency/solutions-morning.md:5
 #, fuzzy
@@ -21115,13 +21877,8 @@ msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:1
 #, fuzzy
-msgid "# Concurrency Afternoon Exercise"
-msgstr "# Tag 1 Nachmittagsübungen"
-
-#: src/exercises/concurrency/solutions-afternoon.md:3
-#, fuzzy
-msgid "## Dining Philosophers - Async"
-msgstr "## Essende Philosophen"
+msgid "Concurrency Afternoon Exercise"
+msgstr "Tag 1 Nachmittagsübungen"
 
 #: src/exercises/concurrency/solutions-afternoon.md:5
 #, fuzzy
@@ -21240,10 +21997,6 @@ msgid ""
 "    }\n"
 "}\n"
 "```"
-msgstr ""
-
-#: src/exercises/concurrency/solutions-afternoon.md:113
-msgid "## Broadcast Chat Application"
 msgstr ""
 
 #: src/exercises/concurrency/solutions-afternoon.md:115
@@ -21398,3118 +22151,3 @@ msgid ""
 "}\n"
 "```"
 msgstr ""
-
-#~ msgid "Day 4"
-#~ msgstr "Der vierte Tag"
-
-#~ msgid "Closures"
-#~ msgstr "Funktionsabschlüsse"
-
-#~ msgid "Day 4: Morning"
-#~ msgstr "Tag 4: Morgens"
-
-#~ msgid "Day 4: Afternoon (Android)"
-#~ msgstr "Tag 4: Nachmittags (Android)"
-
-#~ msgid "Day 4: Afternoon (Async)"
-#~ msgstr "Tag 4: Nachmittags (Async)"
-
-#~ msgid "Day 4 Morning"
-#~ msgstr "Tag 4 Morgens"
-
-#~ msgid "On Day 4, we will cover Android-specific things such as:"
-#~ msgstr "An Tag 4 behandeln wir Android-spezifische Dinge wie:"
-
-#~ msgid ""
-#~ "* Building Android components in Rust.\n"
-#~ "* AIDL servers and clients.\n"
-#~ "* Interoperability with C, C++, and Java."
-#~ msgstr ""
-#~ "* Erstellen von Android-Komponenten in Rust.\n"
-#~ "* AIDL-Server und -Klienten.\n"
-#~ "* Interoperabilität mit C, C++ und Java."
-
-#~ msgid ""
-#~ "It is important to note that this course does not cover Android "
-#~ "**application** \n"
-#~ "development in Rust, and that the Android-specific parts are specifically "
-#~ "about\n"
-#~ "writing code for Android itself, the operating system. "
-#~ msgstr ""
-#~ "Es ist wichtig zu beachten, dass dieser Kurs keine Android "
-#~ "**Anwendungsentwicklung** abdeckt \n"
-#~ "und dass es bei den Android-spezifischen Teilen um das \n"
-#~ "Schreiben von Code für das Betriebssystem Android geht. "
-
-#~ msgid ""
-#~ "* Learn how to use async Rust --- we'll only mention async Rust when\n"
-#~ "  covering traditional concurrency primitives. Please see [Asynchronous\n"
-#~ "  Programming in Rust](https://rust-lang.github.io/async-book/) instead "
-#~ "for\n"
-#~ "  details on this topic.\n"
-#~ "* Learn how to develop macros, please see [Chapter 19.5 in the Rust\n"
-#~ "  Book](https://doc.rust-lang.org/book/ch19-06-macros.html) and [Rust by\n"
-#~ "  Example](https://doc.rust-lang.org/rust-by-example/macros.html) instead."
-#~ msgstr ""
-#~ "* Lernen, wie man asynchrones Rust verwendet – wir erwähnen asynchrones "
-#~ "Rust nur dann, wenn\n"
-#~ "  wir traditionelle Nebenläufigkeitsprimitive abdecken. Siehe "
-#~ "[Asynchronous\n"
-#~ "  Programmierung in Rust](https://rust-lang.github.io/async-book/) für\n"
-#~ "  Details zu diesem Thema.\n"
-#~ "* Lernen, wie man Makros entwickelt, siehe [Kapitel 19.5 im Rust\n"
-#~ "  Buch](https://rust-lang-de.github.io/rustbook-de/ch19-06-macros.html) "
-#~ "und [Rust by\n"
-#~ "  Example](https://doc.rust-lang.org/rust-by-example/macros.html)."
-
-#~ msgid "# Day 4"
-#~ msgstr "# Tag 4"
-
-#~ msgid ""
-#~ "The afternoon of the fourth day should cover a topic of your choice. "
-#~ "Include\n"
-#~ "the topic in the announcement of the course, so that participants know "
-#~ "what to\n"
-#~ "expect."
-#~ msgstr ""
-#~ "Der Nachmittag des vierten Tages sollte ein von dir ausgewähltes Thema "
-#~ "behandeln.\n"
-#~ "Erwähne das ausgewählte Thema in der Kursankündigung, sodass Teilnehmer "
-#~ "wissen was auf sie zukommt."
-
-#~ msgid ""
-#~ "This phase of the course is a chance for participants to see Rust in "
-#~ "action on a\n"
-#~ "codebase they might be familiar with. You can choose from the topics "
-#~ "already\n"
-#~ "defined here, or plan your own."
-#~ msgstr ""
-#~ "Dieser Abschnitt des Kurses ermöglicht es Teilnehmern Rust in einer "
-#~ "Codebasis zu sehen die siemöglicherweise schon kennen. Du kannst entweder "
-#~ "von den hier vorgeschlagenen Themen wählen, oder dein eigenes Thema "
-#~ "planen."
-
-#~ msgid "Some topics need additional preparation:"
-#~ msgstr "Manche Themen benötigen eine besondere Vorbereitung:"
-
-#~ msgid "## Async"
-#~ msgstr "## Async"
-
-#, fuzzy
-#~ msgid ""
-#~ "<details>\n"
-#~ "Key points:"
-#~ msgstr "Kernpunkte:"
-
-#, fuzzy
-#~ msgid ""
-#~ "```rust,editable\n"
-#~ "fn main() {\n"
-#~ "    fizzbuzz_to(20);   // Defined below, no forward declaration needed\n"
-#~ "}\n"
-#~ "\n"
-#~ "fn is_divisible_by(lhs: u32, rhs: u32) -> bool {\n"
-#~ "    if rhs == 0 {\n"
-#~ "        return false;  // Corner case, early return\n"
-#~ "    }\n"
-#~ "    lhs % rhs == 0     // The last expression in a block is the return "
-#~ "value\n"
-#~ "}\n"
-#~ "\n"
-#~ "fn fizzbuzz(n: u32) -> () {  // No return value means returning the unit "
-#~ "type `()`\n"
-#~ "    match (is_divisible_by(n, 3), is_divisible_by(n, 5)) {\n"
-#~ "        (true,  true)  => println!(\"fizzbuzz\"),\n"
-#~ "        (true,  false) => println!(\"fizz\"),\n"
-#~ "        (false, true)  => println!(\"buzz\"),\n"
-#~ "        (false, false) => println!(\"{n}\"),\n"
-#~ "    }\n"
-#~ "}\n"
-#~ "\n"
-#~ "fn fizzbuzz_to(n: u32) {  // `-> ()` is normally omitted\n"
-#~ "    for i in 1..=n {\n"
-#~ "        fizzbuzz(i);\n"
-#~ "    }\n"
-#~ "}\n"
-#~ "```"
-#~ msgstr ""
-#~ "fn fizzbuzz(n: u32) -> () { // Kein Rückgabewert bedeutet Rückgabe des "
-#~ "Einheitentyps `()`\n"
-#~ "    Übereinstimmung (ist_teilbar_durch(n, 3), ist_teilbar_durch(n, 5)) {\n"
-#~ "        (true, true) => println!(\"fizzbuzz\"),\n"
-#~ "        (wahr, falsch) => println!(\"fizz\"),\n"
-#~ "        (falsch, wahr) => println!(\"summen\"),\n"
-#~ "        (falsch, falsch) => println!(\"{n}\"),\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "</defails>"
-#~ msgstr "</defails>"
-
-#, fuzzy
-#~ msgid ""
-#~ "<details>\n"
-#~ "Key Points: "
-#~ msgstr "Wichtige Punkte:"
-
-#, fuzzy
-#~ msgid "You use `if` very similarly to how you would in other languages:"
-#~ msgstr "Sie verwenden \"if\" sehr ähnlich wie in anderen Sprachen:"
-
-#, fuzzy
-#~ msgid ""
-#~ "If you want to match a value against a pattern, you can use `if let`:"
-#~ msgstr ""
-#~ "Wenn Sie einen Wert mit einem Muster abgleichen möchten, können Sie `if "
-#~ "let` verwenden:"
-
-#, fuzzy
-#~ msgid "The `while` keyword works very similar to other languages:"
-#~ msgstr ""
-#~ "Das Schlüsselwort „while“ funktioniert sehr ähnlich wie in anderen "
-#~ "Sprachen:"
-
-#, fuzzy
-#~ msgid "# `for` expressions"
-#~ msgstr "# `for`-Ausdrücke"
-
-#, fuzzy
-#~ msgid ""
-#~ "You will also want to browse the [`std::ffi`] module, particular for "
-#~ "[`CStr`]\n"
-#~ "and [`CString`] types which are used to hold NUL-terminated strings "
-#~ "coming from\n"
-#~ "C. The [Nomicon] also has a very useful chapter about FFI."
-#~ msgstr ""
-#~ "Sie sollten auch das Modul [`std::ffi`] durchsuchen, insbesondere nach "
-#~ "[`CStr`]\n"
-#~ "und [`CString`]-Typen, die verwendet werden, um NUL-terminierte "
-#~ "Zeichenfolgen zu halten, die von kommen\n"
-#~ "C. Das [Nomicon] hat auch ein sehr nützliches Kapitel über FFI."
-
-#, fuzzy
-#~ msgid "# Welcome to Day 4"
-#~ msgstr "# Willkommen zu Tag 4"
-
-#, fuzzy
-#~ msgid "# Fearless Concurrency"
-#~ msgstr "# Furchtlose Parallelität"
-
-#, fuzzy
-#~ msgid "# Runtimes and Tasks"
-#~ msgstr "# Laufzeitgarantien"
-
-#, fuzzy
-#~ msgid "## Getting Started"
-#~ msgstr "# Destrukturierende Strukturen"
-
-#, fuzzy
-#~ msgid "`src/controller.rs`:"
-#~ msgstr "_hello_rust/src/main.rs_:"
-
-#, fuzzy
-#~ msgid "Use `cargo run` to run the elevator simulation."
-#~ msgstr ""
-#~ "Verwenden Sie \"Cargo Test\", um die Komponententests zu finden und "
-#~ "auszuführen."
-
-#, fuzzy
-#~ msgid "## Exercises"
-#~ msgstr "# Übungen"
-
-#, fuzzy
-#~ msgid "# Day 4 Morning Exercise"
-#~ msgstr "# Tag 4 Morgengymnastik"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `if let` can be more concise than `match`, e.g., when only one case is "
-#~ "interesting. In contrast, `match` requires all branches to be covered.\n"
-#~ "    * For the similar use case consider demonstrating a newly stabilized "
-#~ "[`let else`](https://github.com/rust-lang/rust/pull/93628) feature.\n"
-#~ "* A common usage is handling `Some` values when working with `Option`.\n"
-#~ "* Unlike `match`, `if let` does not support guard clauses for pattern "
-#~ "matching."
-#~ msgstr ""
-#~ "* `if let` kann prägnanter sein als `match`, z. B. wenn nur ein Fall "
-#~ "interessant ist. Im Gegensatz dazu erfordert \"Match\", dass alle Zweige "
-#~ "abgedeckt werden.\n"
-#~ "    * Ziehen Sie für einen ähnlichen Anwendungsfall in Betracht, eine neu "
-#~ "stabilisierte [`let else`](https://github.com/rust-lang/rust/pull/93628)-"
-#~ "Funktion zu demonstrieren.\n"
-#~ "* Eine übliche Verwendung ist die Handhabung von `Some`-Werten bei der "
-#~ "Arbeit mit `Option`.\n"
-#~ "* Im Gegensatz zu `match` unterstützt `if let` keine Schutzklauseln für "
-#~ "den Mustervergleich."
-
-#, fuzzy
-#~ msgid ""
-#~ "We've seen how a function can take arguments which implement a trait:"
-#~ msgstr ""
-#~ "Wir haben gesehen, wie eine Funktion Argumente annehmen kann, die ein "
-#~ "Merkmal implementieren:"
-
-#, fuzzy
-#~ msgid ""
-#~ "However, how can we store a collection of mixed types which implement "
-#~ "`Display`?"
-#~ msgstr ""
-#~ "Wie können wir jedoch eine Sammlung gemischter Typen speichern, die "
-#~ "\"Display\" implementieren?"
-
-#, fuzzy
-#~ msgid "For this, we need _trait objects_:"
-#~ msgstr "Dafür brauchen wir _trait objects_:"
-
-#, fuzzy
-#~ msgid ""
-#~ "Similarly, you need a trait object if you want to return different types\n"
-#~ "implementing a trait:"
-#~ msgstr ""
-#~ "Ebenso benötigen Sie ein Trait-Objekt, wenn Sie andere Werte zurückgeben "
-#~ "möchten\n"
-#~ "Implementieren eines Merkmals:"
-
-#~ msgid ""
-#~ "1. Make yourself familiar with the course material. We've included "
-#~ "speaker notes\n"
-#~ "   on some of the pages to help highlight the key points (please help us "
-#~ "by\n"
-#~ "   contributing more speaker notes!). You should make sure to open the "
-#~ "speaker\n"
-#~ "   notes in a popup (click the link with a little arrow next to "
-#~ "\"Speaker\n"
-#~ "   Notes\"). This way you have a clean screen to present to the class."
-#~ msgstr ""
-#~ "1. Mach dich mit dem Kursmaterial vertraut. Wir haben Sprechernotizen an "
-#~ "einigen \n"
-#~ "   Stellen hinzugefügt, um die wichtigsten Punkte hervorzuheben (du "
-#~ "hilfts uns sehr, \n"
-#~ "   wenn du weitere Sprechernotizen beisteuerst!). Du solltest die "
-#~ "Sprechernotizeb in \n"
-#~ "   einem Popup öffnen (klicke dazu auf dem Link mit einem kleinen Pfeil "
-#~ "neben \n"
-#~ "   \"Sprechernotizen\"). Auf diese Weise präsentierst du den "
-#~ "Kursteilnehmern nur \n"
-#~ "   das Kursmaterial."
-
-#~ msgid ""
-#~ "2. Decide on the dates. Since the course is large, we recommend that you\n"
-#~ "   schedule the four days over two weeks. Course participants have said "
-#~ "that\n"
-#~ "   they find it helpful to have a gap in the course since it helps them "
-#~ "process\n"
-#~ "   all the information we give them."
-#~ msgstr ""
-#~ "2. Lege die Termine fest. Da der Kurs recht lang ist, empfehlen wir die 4 "
-#~ "Tage \n"
-#~ "   verteilt über 2 Wochen zu legen. Bisherige Kursteilnehmer fanden es "
-#~ "hilfreich, \n"
-#~ "   eine Lücke zwischen Kurstage zu haben, um das Material zu "
-#~ "verinnerlichern."
-
-#~ msgid ""
-#~ "3. Find a room large enough for your in-person participants. We recommend "
-#~ "a\n"
-#~ "   class size of 15-20 people. That's small enough that people are "
-#~ "comfortable\n"
-#~ "   asking questions --- it's also small enough that one instructor will "
-#~ "have\n"
-#~ "   time to answer the questions."
-#~ msgstr ""
-#~ "3. Finde einen Raum, der groß genug für alle in Person anwesenden "
-#~ "Teilnehmer ist. \n"
-#~ "   Wir empfehlen eine Kursgröße von 15-20 Personen. Das ist klein genug, "
-#~ "dass sich \n"
-#~ "   die Leute wohlfühlen Fragen stellen --- und es ist auch klein genug, "
-#~ "dass der \n"
-#~ "   Lehrende Zeit hat alle Fragen zu beantworten."
-
-#~ msgid ""
-#~ "4. On the day of your course, show up to the room a little early to set "
-#~ "things\n"
-#~ "   up. We recommend presenting directly using `mdbook serve` running on "
-#~ "your\n"
-#~ "   laptop. This ensures optimal performance with no lag as you change "
-#~ "pages.\n"
-#~ "   Using your laptop will also allow you to fix typos as you or the "
-#~ "course\n"
-#~ "   participants spot them."
-#~ msgstr ""
-#~ "4. Erscheine am Tag des Kurses etwas früher in dem Raum, um alles "
-#~ "vorzubereiten. \n"
-#~ "   Wir empfehlen, direkt `mdbook serve` auf deinem Laptop laufen zu "
-#~ "lassen, und so \n"
-#~ "   den Kurz zu präsentieren. Das minimiert Verzögerungen beim "
-#~ "Seitenwechsel und \n"
-#~ "   ermöglicht es, Tippfehler, die von Teilnehmern entdeckt werden, gleich "
-#~ "währende\n"
-#~ "   des Kurses zu korrigieren."
-
-#~ msgid ""
-#~ "5. Let people solve the exercises by themselves or in small groups. Make "
-#~ "sure to\n"
-#~ "   ask people if they're stuck or if there is anything you can help with. "
-#~ "When\n"
-#~ "   you see that several people have the same problem, call it out to the "
-#~ "class\n"
-#~ "   and offer a solution, e.g., by showing people where to find the "
-#~ "relevant\n"
-#~ "   information in the standard library."
-#~ msgstr ""
-#~ "5. Lass die Teilnehmer die Übungen alleine oder in kleinen Gruppen lösen. "
-#~ "Frage ab und zu nach,\n"
-#~ "   ob jemand nicht weiterkommt und ob es etwas gibt, wo du helfen kannst. "
-#~ "Wenn du merkst,\n"
-#~ "   dass mehrere Personen die gleichen Probleme haben, solltest du dies im "
-#~ "Kurs ansprechen\n"
-#~ "   und Hinweise geben, wo relevante Informationen (wie z.B. Teile der "
-#~ "Standardbibliothek) zu \n"
-#~ "   finden sind."
-
-#~ msgid ""
-#~ "[1]: https://source.android.com/docs/setup/download/downloading\n"
-#~ "[2]: https://github.com/google/comprehensive-rust\n"
-#~ "[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
-#~ "[4]: https://github.com/google/comprehensive-rust/discussions/100"
-#~ msgstr ""
-#~ "[1]: https://source.android.com/docs/setup/download/downloading\n"
-#~ "[2]: https://github.com/google/comprehensive-rust\n"
-#~ "[3]: https://github.com/google/comprehensive-rust/discussions/86\n"
-#~ "[4]: https://github.com/google/comprehensive-rust/discussions/100"
-
-#~ msgid ""
-#~ "> **Exercise for Day 4:** Do you interface with some C/C++ code in your "
-#~ "project\n"
-#~ "> which we could attempt to move to Rust? The fewer dependencies the "
-#~ "better.\n"
-#~ "> Parsing code would be ideal."
-#~ msgstr ""
-#~ "> **Übung für Tag 4:** Arbeitest du in deinem Projekt mit C/C++-Code,\n"
-#~ "> den wir versuchen könnten nach Rust zu verschieben? Je weniger "
-#~ "Abhängigkeiten, desto besser.\n"
-#~ "> Parser-Code wäre ideal."
-
-#~ msgid ""
-#~ "[1]: https://rust-analyzer.github.io/\n"
-#~ "[2]: https://code.visualstudio.com/\n"
-#~ "[3]: https://rustup.rs/\n"
-#~ "[4]: https://www.jetbrains.com/clion/\n"
-#~ "[5]: https://www.jetbrains.com/rust/"
-#~ msgstr ""
-#~ "[1]: https://rust-analyzer.github.io/\n"
-#~ "[2]: https://code.visualstudio.com/\n"
-#~ "[3]: https://rustup.rs/\n"
-#~ "[4]: https://www.jetbrains.com/clion/\n"
-#~ "[5]: https://www.jetbrains.com/rust/"
-
-#~ msgid ""
-#~ "* `rustc`: the Rust compiler which turns `.rs` files into binaries and "
-#~ "other\n"
-#~ "  intermediate formats[^rustc]."
-#~ msgstr ""
-#~ "* „rustc“: der Rust-Compiler, der „.rs“-Dateien in Binärdateien und "
-#~ "andere \n"
-#~ "  Zwischenformate umwandelt [^rustc]."
-
-#, fuzzy
-#~ msgid ""
-#~ "* `cargo`: the Rust dependency manager and build tool. Cargo knows how "
-#~ "to\n"
-#~ "  download dependencies hosted on <https://crates.io> and it will pass "
-#~ "them to\n"
-#~ "  `rustc` when building your project. Cargo also comes with a built-in "
-#~ "test\n"
-#~ "  runner which is used to execute unit tests[^cargo]."
-#~ msgstr ""
-#~ "* `cargo`: der Rust-Abhängigkeitsmanager und Build-Tool. Cargo weiß, wie "
-#~ "es geht\n"
-#~ "  Laden Sie Abhängigkeiten herunter, die auf <https://crates.io> gehostet "
-#~ "werden, und es wird sie an sie weitergeben\n"
-#~ "  `rustc`, wenn Sie Ihr Projekt erstellen. Cargo kommt auch mit einem "
-#~ "eingebauten Test\n"
-#~ "  Runner, der zum Ausführen von Unit-Tests[^cargo] verwendet wird."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust has a rapid release schedule with a new release coming out\n"
-#~ "  every six weeks. New releases maintain backwards compatibility with\n"
-#~ "  old releases --- plus they enable new functionality."
-#~ msgstr ""
-#~ "* Rust hat einen schnellen Veröffentlichungszeitplan mit einer neuen "
-#~ "Veröffentlichung, die herauskommt\n"
-#~ "  alle sechs Wochen. Neue Releases behalten die Abwärtskompatibilität "
-#~ "mit\n"
-#~ "  alte Versionen --- und sie ermöglichen neue Funktionen."
-
-#, fuzzy
-#~ msgid ""
-#~ "* There are three release channels: \"stable\", \"beta\", and \"nightly\"."
-#~ msgstr ""
-#~ "* Es gibt drei Veröffentlichungskanäle: „Stable“, „Beta“ und „Nightly“."
-
-#, fuzzy
-#~ msgid ""
-#~ "* New features are being tested on \"nightly\", \"beta\" is what becomes\n"
-#~ "  \"stable\" every six weeks."
-#~ msgstr ""
-#~ "* Neue Funktionen werden auf \"Nightly\" getestet, \"Beta\" ist das, was "
-#~ "wird\n"
-#~ "  \"stabil\" alle sechs Wochen."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust also has [editions]: the current edition is Rust 2021. Previous\n"
-#~ "  editions were Rust 2015 and Rust 2018."
-#~ msgstr ""
-#~ "* Rust hat auch [Editionen]: Die aktuelle Edition ist Rust 2021. Zurück\n"
-#~ "  Editionen waren Rust 2015 und Rust 2018."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * The editions are allowed to make backwards incompatible changes to\n"
-#~ "    the language."
-#~ msgstr ""
-#~ "  * Die Editionen dürfen rückwärtsinkompatible Änderungen vornehmen\n"
-#~ "    die Sprache."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * To prevent breaking code, editions are opt-in: you select the\n"
-#~ "    edition for your crate via the `Cargo.toml` file."
-#~ msgstr ""
-#~ "  * Um das Brechen von Code zu verhindern, sind Editionen Opt-in: Sie "
-#~ "wählen die aus\n"
-#~ "    Edition für Ihre Kiste über die Datei `Cargo.toml`."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * To avoid splitting the ecosystem, Rust compilers can mix code\n"
-#~ "    written for different editions."
-#~ msgstr ""
-#~ "  * Um eine Aufspaltung des Ökosystems zu vermeiden, können Rust-Compiler "
-#~ "Code mischen\n"
-#~ "    für verschiedene Editionen geschrieben."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * Mention that it is quite rare to ever use the compiler directly not "
-#~ "through `cargo` (most users never do)."
-#~ msgstr ""
-#~ "  * Erwähnen Sie, dass es ziemlich selten vorkommt, den Compiler jemals "
-#~ "direkt zu verwenden, nicht über `cargo` (die meisten Benutzer tun dies "
-#~ "nie)."
-
-#, fuzzy
-#~ msgid ""
-#~ "  * It might be worth alluding that Cargo itself is an extremely powerful "
-#~ "and comprehensive tool.  It is capable of many advanced features "
-#~ "including but not limited to: \n"
-#~ "      * Project/package structure\n"
-#~ "      * [workspaces]\n"
-#~ "      * Dev Dependencies and Runtime Dependency management/caching\n"
-#~ "      * [build scripting]\n"
-#~ "      * [global installation]\n"
-#~ "      * It is also extensible with sub command plugins as well (such as "
-#~ "[cargo clippy]).\n"
-#~ "  * Read more from the [official Cargo Book]"
-#~ msgstr ""
-#~ "  * Es könnte erwähnenswert sein, dass Cargo selbst ein äußerst "
-#~ "leistungsfähiges und umfassendes Werkzeug ist. Es verfügt über viele "
-#~ "erweiterte Funktionen, einschließlich, aber nicht beschränkt auf:\n"
-#~ "      * Projekt-/Paketstruktur\n"
-#~ "      * [Arbeitsbereiche]\n"
-#~ "      * Verwaltung/Caching von Entwicklungsabhängigkeiten und "
-#~ "Laufzeitabhängigkeiten\n"
-#~ "      * [Skript erstellen]\n"
-#~ "      * [globale Installation]\n"
-#~ "      * Es ist auch mit Unterbefehls-Plugins erweiterbar (wie [cargo "
-#~ "clippy]).\n"
-#~ "  * Lesen Sie mehr aus dem [offiziellen Frachtbuch]"
-
-#, fuzzy
-#~ msgid "[editions]: https://doc.rust-lang.org/edition-guide/"
-#~ msgstr "[Ausgaben]: https://doc.rust-lang.org/edition-guide/"
-
-#, fuzzy
-#~ msgid ""
-#~ "[workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html"
-#~ msgstr ""
-#~ "[Arbeitsbereiche]: https://doc.rust-lang.org/cargo/reference/workspaces."
-#~ "html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[build scripting]: https://doc.rust-lang.org/cargo/reference/build-"
-#~ "scripts.html"
-#~ msgstr ""
-#~ "[Build-Scripting]: https://doc.rust-lang.org/cargo/reference/build-"
-#~ "scripts.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[global installation]: https://doc.rust-lang.org/cargo/commands/cargo-"
-#~ "install.html"
-#~ msgstr ""
-#~ "[globale Installation]: https://doc.rust-lang.org/cargo/commands/cargo-"
-#~ "install.html"
-
-#, fuzzy
-#~ msgid "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
-#~ msgstr "[cargo clippy]: https://github.com/rust-lang/rust-clippy"
-
-#, fuzzy
-#~ msgid "[official Cargo Book]: https://doc.rust-lang.org/cargo/"
-#~ msgstr "[offizielles Frachtbuch]: https://doc.rust-lang.org/cargo/"
-
-#, fuzzy
-#~ msgid ""
-#~ "* The embedded playgrounds cannot execute unit tests. Copy-paste the\n"
-#~ "  code and open it in the real Playground to demonstrate unit tests."
-#~ msgstr ""
-#~ "* Die eingebetteten Playgrounds können keine Unit-Tests ausführen. "
-#~ "Kopieren Sie die\n"
-#~ "  code und öffnen Sie ihn im realen Playground, um Unit-Tests zu "
-#~ "demonstrieren."
-
-#, fuzzy
-#~ msgid ""
-#~ "1. Click the \"Copy to clipboard\" button on the example you want to copy."
-#~ msgstr ""
-#~ "1. Klicken Sie bei dem Beispiel, das Sie kopieren möchten, auf die "
-#~ "Schaltfläche \"In die Zwischenablage kopieren\"."
-
-#, fuzzy
-#~ msgid ""
-#~ "2. Use `cargo new exercise` to create a new `exercise/` directory for "
-#~ "your code:"
-#~ msgstr ""
-#~ "2. Verwenden Sie `cargo new Exercise`, um ein neues `exercise/`-"
-#~ "Verzeichnis für Ihren Code zu erstellen:"
-
-#, fuzzy
-#~ msgid ""
-#~ "3. Navigate into `exercise/` and use `cargo run` to build and run your "
-#~ "binary:"
-#~ msgstr ""
-#~ "3. Navigieren Sie zu „exercise/“ und verwenden Sie „cargo run“, um Ihre "
-#~ "Binärdatei zu erstellen und auszuführen:"
-
-#, fuzzy
-#~ msgid ""
-#~ "4. Replace the boiler-plate code in `src/main.rs` with your own code. "
-#~ "For\n"
-#~ "   example, using the example on the previous page, make `src/main.rs` "
-#~ "look like"
-#~ msgstr ""
-#~ "4. Ersetzen Sie den Standardcode in `src/main.rs` durch Ihren eigenen "
-#~ "Code. Für\n"
-#~ "   Verwenden Sie beispielsweise das Beispiel auf der vorherigen Seite und "
-#~ "lassen Sie `src/main.rs` so aussehen"
-
-#, fuzzy
-#~ msgid "5. Use `cargo run` to build and run your updated binary:"
-#~ msgstr ""
-#~ "5. Verwenden Sie „cargo run“, um Ihre aktualisierte Binärdatei zu "
-#~ "erstellen und auszuführen:"
-
-#, fuzzy
-#~ msgid ""
-#~ "6. Use `cargo check` to quickly check your project for errors, use `cargo "
-#~ "build`\n"
-#~ "   to compile it without running it. You will find the output in `target/"
-#~ "debug/`\n"
-#~ "   for a normal debug build. Use `cargo build --release` to produce an "
-#~ "optimized\n"
-#~ "   release build in `target/release/`."
-#~ msgstr ""
-#~ "6. Verwenden Sie „Cargo Check“, um Ihr Projekt schnell auf Fehler zu "
-#~ "überprüfen, verwenden Sie „Cargo Build“.\n"
-#~ "   um es zu kompilieren, ohne es auszuführen. Die Ausgabe finden Sie in "
-#~ "`target/debug/`\n"
-#~ "   für einen normalen Debug-Build. Verwenden Sie `cargo build --release`, "
-#~ "um eine optimierte\n"
-#~ "   Release-Build in `target/release/`."
-
-#, fuzzy
-#~ msgid ""
-#~ "7. You can add dependencies for your project by editing `Cargo.toml`. "
-#~ "When you\n"
-#~ "   run `cargo` commands, it will automatically download and compile "
-#~ "missing\n"
-#~ "   dependencies for you."
-#~ msgstr ""
-#~ "7. Sie können Abhängigkeiten für Ihr Projekt hinzufügen, indem Sie `Cargo."
-#~ "toml` bearbeiten. Wenn du\n"
-#~ "   Führen Sie \"Cargo\"-Befehle aus, es wird automatisch heruntergeladen "
-#~ "und kompiliert\n"
-#~ "   Abhängigkeiten für Sie."
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/book/ch01-01-installation.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Basic Rust syntax: variables, scalar and compound types, enums, "
-#~ "structs,\n"
-#~ "  references, functions, and methods."
-#~ msgstr ""
-#~ "* Grundlegende Rust-Syntax: Variablen, skalare und zusammengesetzte "
-#~ "Typen, Aufzählungen, Strukturen,\n"
-#~ "  Referenzen, Funktionen und Methoden."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Memory management: stack vs heap, manual memory management, scope-based "
-#~ "memory\n"
-#~ "  management, and garbage collection."
-#~ msgstr ""
-#~ "* Speicherverwaltung: Stack vs. Heap, manuelle Speicherverwaltung, "
-#~ "bereichsbasierter Speicher\n"
-#~ "  Verwaltung und Garbage Collection."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Ownership: move semantics, copying and cloning, borrowing, and "
-#~ "lifetimes."
-#~ msgstr ""
-#~ "* Eigentum: Verschieben von Semantik, Kopieren und Klonen, Ausleihen und "
-#~ "Lebensdauern."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust is very much like other languages in the C/C++/Java tradition. It "
-#~ "is\n"
-#~ "  imperative (not functional) and it doesn't try to reinvent things "
-#~ "unless\n"
-#~ "  absolutely necessary."
-#~ msgstr ""
-#~ "* Rust ist anderen Sprachen in der C/C++/Java-Tradition sehr ähnlich. Es "
-#~ "ist\n"
-#~ "  Imperativ (nicht funktional) und es versucht nicht, Dinge neu zu "
-#~ "erfinden, es sei denn\n"
-#~ "  absolut notwendig."
-
-#, fuzzy
-#~ msgid "* Rust is modern with full support for things like Unicode."
-#~ msgstr "* Rust ist modern mit voller Unterstützung für Dinge wie Unicode."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Rust uses macros for situations where you want to have a variable "
-#~ "number of\n"
-#~ "  arguments (no function [overloading](basic-syntax/functions-interlude."
-#~ "md))."
-#~ msgstr ""
-#~ "* Rust verwendet Makros für Situationen, in denen Sie eine variable "
-#~ "Anzahl von Makros haben möchten\n"
-#~ "  Argumente (keine Funktion [Überladen] (Grundsyntax/Funktionen-"
-#~ "Zwischenspiel.md))."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Explain that all variables are statically typed. Try removing `i32` to "
-#~ "trigger\n"
-#~ "  type inference. Try with `i8` instead and trigger a runtime integer "
-#~ "overflow."
-#~ msgstr ""
-#~ "* Erklären Sie, dass alle Variablen statisch typisiert sind. Versuchen "
-#~ "Sie, „i32“ zu entfernen, um auszulösen\n"
-#~ "  Typ Inferenz. Versuchen Sie es stattdessen mit \"i8\" und lösen Sie "
-#~ "einen Integer-Überlauf zur Laufzeit aus."
-
-#, fuzzy
-#~ msgid "* Change `let mut x` to `let x`, discuss the compiler error."
-#~ msgstr "* Ändere `let mut x` in `let x`, diskutiere den Compiler-Fehler."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Show how `print!` gives a compilation error if the arguments don't "
-#~ "match the\n"
-#~ "  format string."
-#~ msgstr ""
-#~ "* Zeigen Sie, wie `print!` einen Kompilierungsfehler ausgibt, wenn die "
-#~ "Argumente nicht übereinstimmen\n"
-#~ "  Zeichenfolge formatieren."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Show how you need to use `{}` as a placeholder if you want to print an\n"
-#~ "  expression which is more complex than just a single variable."
-#~ msgstr ""
-#~ "* Zeigen Sie, wie Sie `{}` als Platzhalter verwenden müssen, wenn Sie "
-#~ "eine drucken möchten\n"
-#~ "  Ausdruck, der komplexer ist als nur eine einzelne Variable."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Show the students the standard library, show them how to search for "
-#~ "`std::fmt`\n"
-#~ "  which has the rules of the formatting mini-language. It's important "
-#~ "that the\n"
-#~ "  students become familiar with searching in the standard library."
-#~ msgstr ""
-#~ "* Zeigen Sie den Schülern die Standardbibliothek, zeigen Sie ihnen, wie "
-#~ "man nach `std::fmt` sucht\n"
-#~ "  die die Regeln der Formatierungsminisprache hat. Wichtig ist, dass die\n"
-#~ "  Die Schüler lernen die Suche in der Standardbibliothek kennen."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Experience with C or C++: Rust eliminates a whole class of _runtime "
-#~ "errors_\n"
-#~ "  via the borrow checker. You get performance like in C and C++, but you "
-#~ "don't\n"
-#~ "  have the memory unsafety issues. In addition, you get a modern language "
-#~ "with\n"
-#~ "  constructs like pattern matching and built-in dependency management."
-#~ msgstr ""
-#~ "* Erfahrung mit C oder C++: Rust eliminiert eine ganze Klasse von "
-#~ "_Laufzeitfehlern_\n"
-#~ "  über den Ausleihprüfer. Sie erhalten eine Leistung wie in C und C++, "
-#~ "aber Sie tun es nicht\n"
-#~ "  habe die Speicherunsicherheitsprobleme. Außerdem bekommt man eine "
-#~ "moderne Sprache mit\n"
-#~ "  Konstrukte wie Musterabgleich und integriertes Abhängigkeitsmanagement."
-
-#, fuzzy
-#~ msgid ""
-#~ "[`Box::leak`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
-#~ "leak\n"
-#~ "[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-#~ "[reference cycle]: https://doc.rust-lang.org/book/ch15-06-reference-"
-#~ "cycles.html"
-#~ msgstr ""
-#~ "[`Box::leak`]: https://doc.rust-lang.org/std/boxed/struct.Box.html#method."
-#~ "leak\n"
-#~ "[`std::mem::forget`]: https://doc.rust-lang.org/std/mem/fn.forget.html\n"
-#~ "[Referenzzyklus]: https://doc.rust-lang.org/book/ch15-06-reference-cycles."
-#~ "html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Bounds checking cannot be disabled with a compiler flag. It can also\n"
-#~ "  not be disabled directly with the `unsafe` keyword. However,\n"
-#~ "  `unsafe` allows you to call functions such as `slice::get_unchecked`\n"
-#~ "  which does not do bounds checking."
-#~ msgstr ""
-#~ "* Die Begrenzungsprüfung kann nicht mit einem Compiler-Flag deaktiviert "
-#~ "werden. Es kann auch\n"
-#~ "  nicht direkt mit dem Schlüsselwort „unsafe“ deaktiviert werden. "
-#~ "Jedoch,\n"
-#~ "  `unsafe` erlaubt Ihnen, Funktionen wie `slice::get_unchecked` "
-#~ "aufzurufen\n"
-#~ "  die keine Begrenzungsprüfung durchführt."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Zero-cost abstractions, similar to C++, means that you don't have to "
-#~ "'pay'\n"
-#~ "  for higher-level programming constructs with memory or CPU. For "
-#~ "example,\n"
-#~ "  writing a loop using `for` should result in roughly the same low level\n"
-#~ "  instructions as using the `.iter().fold()` construct."
-#~ msgstr ""
-#~ "* Zero-Cost-Abstraktionen, ähnlich wie C++, bedeutet, dass Sie nicht "
-#~ "„bezahlen“ müssen\n"
-#~ "  für übergeordnete Programmierkonstrukte mit Speicher oder CPU. Zum "
-#~ "Beispiel,\n"
-#~ "  Das Schreiben einer Schleife mit `for` sollte ungefähr den gleichen "
-#~ "niedrigen Pegel ergeben\n"
-#~ "  Anweisungen wie die Verwendung des `.iter().fold()`-Konstrukts."
-
-#, fuzzy
-#~ msgid ""
-#~ "* It may be worth mentioning that Rust enums are 'Algebraic Data Types', "
-#~ "also\n"
-#~ "  known as 'sum types', which allow the type system to express things "
-#~ "like\n"
-#~ "  `Option<T>` and `Result<T, E>`."
-#~ msgstr ""
-#~ "* Es sollte erwähnt werden, dass Rust-Enumerationen auch 'algebraische "
-#~ "Datentypen' sind\n"
-#~ "  bekannt als \"Summentypen\", die es dem Typsystem ermöglichen, Dinge "
-#~ "wie auszudrücken\n"
-#~ "  `Option<T>` und `Ergebnis<T, E>`."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Remind people to read the errors --- many developers have gotten used "
-#~ "to\n"
-#~ "  ignore lengthy compiler output. The Rust compiler is significantly "
-#~ "more\n"
-#~ "  talkative than other compilers. It will often provide you with "
-#~ "_actionable_\n"
-#~ "  feedback, ready to copy-paste into your code."
-#~ msgstr ""
-#~ "* Erinnere die Leute daran, die Fehler zu lesen --- viele Entwickler "
-#~ "haben sich daran gewöhnt\n"
-#~ "  Ignoriere lange Compiler-Ausgaben. Der Rust-Compiler ist deutlich mehr\n"
-#~ "  gesprächiger als andere Compiler. Es wird Ihnen oft _umsetzbare_\n"
-#~ "  Feedback, bereit zum Kopieren und Einfügen in Ihren Code."
-
-#, fuzzy
-#~ msgid ""
-#~ "* The Rust standard library is small compared to languages like Java, "
-#~ "Python,\n"
-#~ "  and Go. Rust does not come with several things you might consider "
-#~ "standard and\n"
-#~ "  essential:"
-#~ msgstr ""
-#~ "* Die Rust-Standardbibliothek ist klein im Vergleich zu Sprachen wie "
-#~ "Java, Python,\n"
-#~ "  Los geht. Rust kommt nicht mit einigen Dingen, die Sie als Standard "
-#~ "betrachten könnten und\n"
-#~ "  essentiell:"
-
-#, fuzzy
-#~ msgid ""
-#~ "  * a random number generator, but see [rand].\n"
-#~ "  * support for SSL or TLS, but see [rusttls].\n"
-#~ "  * support for JSON, but see [serde_json]."
-#~ msgstr ""
-#~ "  * ein Zufallszahlengenerator, aber siehe [rand].\n"
-#~ "  * Unterstützung für SSL oder TLS, aber siehe [rusttls].\n"
-#~ "  * Unterstützung für JSON, aber siehe [serde_json]."
-
-#, fuzzy
-#~ msgid ""
-#~ "  The reasoning behind this is that functionality in the standard library "
-#~ "cannot\n"
-#~ "  go away, so it has to be very stable. For the examples above, the Rust\n"
-#~ "  community is still working on finding the best solution --- and perhaps "
-#~ "there\n"
-#~ "  isn't a single \"best solution\" for some of these things."
-#~ msgstr ""
-#~ "  Der Grund dafür ist, dass die Funktionalität in der Standardbibliothek "
-#~ "dies nicht kann\n"
-#~ "  weggehen, also muss es sehr stabil sein. Für die obigen Beispiele ist "
-#~ "die Rust\n"
-#~ "  Die Community arbeitet immer noch daran, die beste Lösung zu finden --- "
-#~ "und vielleicht gibt es sie\n"
-#~ "  ist für einige dieser Dinge keine einzige \"beste Lösung\"."
-
-#, fuzzy
-#~ msgid ""
-#~ "  Rust comes with a built-in package manager in the form of Cargo and "
-#~ "this makes\n"
-#~ "  it trivial to download and compile third-party crates. A consequence of "
-#~ "this\n"
-#~ "  is that the standard library can be smaller."
-#~ msgstr ""
-#~ "  Rust kommt mit einem eingebauten Paketmanager in Form von Cargo und "
-#~ "macht das\n"
-#~ "  Es ist trivial, Crates von Drittanbietern herunterzuladen und zu "
-#~ "kompilieren. Eine Folge davon\n"
-#~ "  ist, dass die Standardbibliothek kleiner sein kann."
-
-#, fuzzy
-#~ msgid ""
-#~ "  Discovering good third-party crates can be a problem. Sites like\n"
-#~ "  <https://lib.rs/> help with this by letting you compare health metrics "
-#~ "for\n"
-#~ "  crates to find a good and trusted one.\n"
-#~ "  \n"
-#~ "* [rust-analyzer] is a well supported LSP implementation used in major\n"
-#~ "  IDEs and text editors."
-#~ msgstr ""
-#~ "  Das Entdecken guter Kisten von Drittanbietern kann ein Problem sein. "
-#~ "Seiten wie\n"
-#~ "  <https://lib.rs/> hilft dabei, indem es Ihnen ermöglicht, "
-#~ "Gesundheitsmetriken für zu vergleichen\n"
-#~ "  Kisten, um eine gute und vertrauenswürdige zu finden.\n"
-#~ "  \n"
-#~ "* [rust-analyzer] ist eine gut unterstützte LSP-Implementierung, die in "
-#~ "Major verwendet wird\n"
-#~ "  IDEs und Texteditoren."
-
-#, fuzzy
-#~ msgid ""
-#~ "[rand]: https://docs.rs/rand/\n"
-#~ "[rusttls]: https://docs.rs/rustls/\n"
-#~ "[serde_json]: https://docs.rs/serde_json/\n"
-#~ "[rust-analyzer]: https://rust-analyzer.github.io/"
-#~ msgstr ""
-#~ "[rand]: https://docs.rs/rand/\n"
-#~ "[rusttls]: https://docs.rs/rustls/\n"
-#~ "[serde_json]: https://docs.rs/serde_json/\n"
-#~ "[Rostanalyzer]: https://rust-analyzer.github.io/"
-
-#, fuzzy
-#~ msgid "* We can use literals to assign values to arrays."
-#~ msgstr "* Wir können Literale verwenden, um Arrays Werte zuzuweisen."
-
-#, fuzzy
-#~ msgid ""
-#~ "* In the main function, the print statement asks for the debug "
-#~ "implementation with the `?` format\n"
-#~ "  parameter: `{}` gives the default output, `{:?}` gives the debug "
-#~ "output. We\n"
-#~ "  could also have used `{a}` and `{a:?}` without specifying the value "
-#~ "after the\n"
-#~ "  format string."
-#~ msgstr ""
-#~ "* In der main-Funktion fragt die print-Anweisung nach der Debug-"
-#~ "Implementierung mit dem `?`-Format\n"
-#~ "  Parameter: `{}` gibt die Standardausgabe, `{:?}` gibt die Debug-"
-#~ "Ausgabe. Wir\n"
-#~ "  hätte auch `{a}` und `{a:?}` verwenden können, ohne den Wert nach dem "
-#~ "anzugeben\n"
-#~ "  Zeichenfolge formatieren."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Adding `#`, eg `{a:#?}`, invokes a \"pretty printing\" format, which "
-#~ "can be easier to read."
-#~ msgstr ""
-#~ "* Das Hinzufügen von `#`, z. B. `{a:#?}`, ruft ein \"hübsches "
-#~ "Druckformat\" auf, das einfacher zu lesen sein kann."
-
-#, fuzzy
-#~ msgid "* Like arrays, tuples have a fixed length."
-#~ msgstr "* Tupel haben wie Arrays eine feste Länge."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Tuples group together values of different types into a compound type."
-#~ msgstr ""
-#~ "* Tupel fassen Werte verschiedener Typen zu einem zusammengesetzten Typ "
-#~ "zusammen."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Fields of a tuple can be accessed by the period and the index of the "
-#~ "value, e.g. `t.0`, `t.1`."
-#~ msgstr ""
-#~ "* Auf Felder eines Tupels kann über den Punkt und den Index des Werts "
-#~ "zugegriffen werden, z. „t.0“, „t.1“."
-
-#, fuzzy
-#~ msgid ""
-#~ "* We create a slice by borrowing `a` and specifying the starting and "
-#~ "ending indexes in brackets."
-#~ msgstr ""
-#~ "* Wir erstellen einen Slice, indem wir `a` ausleihen und den Anfangs- und "
-#~ "Endindex in Klammern angeben."
-
-#, fuzzy
-#~ msgid ""
-#~ "* If the slice starts at index 0, Rust’s range syntax allows us to drop "
-#~ "the starting index, meaning that `&a[0..a.len()]` and `&a[..a.len()]` are "
-#~ "identical.\n"
-#~ "    \n"
-#~ "* The same is true for the last index, so `&a[2..a.len()]` and `&a[2..]` "
-#~ "are identical."
-#~ msgstr ""
-#~ "* Wenn der Slice bei Index 0 beginnt, erlaubt uns die Range-Syntax von "
-#~ "Rust, den Startindex wegzulassen, was bedeutet, dass `&a[0..a.len()]` und "
-#~ "`&a[..a.len()]` identisch sind .\n"
-#~ "    \n"
-#~ "* Dasselbe gilt für den letzten Index, also sind `&a[2..a.len()]` und "
-#~ "`&a[2..]` identisch."
-
-#, fuzzy
-#~ msgid ""
-#~ "* To easily create a slice of the full array, we can therefore use "
-#~ "`&a[..]`."
-#~ msgstr ""
-#~ "* Um einfach einen Teil des gesamten Arrays zu erstellen, können wir "
-#~ "daher `&a[..]` verwenden."
-
-#, fuzzy
-#~ msgid ""
-#~ "* `&str` introduces a string slice, which is an immutable reference to "
-#~ "UTF-8 encoded string data \n"
-#~ "  stored in a block of memory. String literals (`”Hello”`), are stored in "
-#~ "the program’s binary."
-#~ msgstr ""
-#~ "* `&str` führt ein String-Slice ein, das eine unveränderliche Referenz "
-#~ "auf UTF-8-codierte String-Daten ist\n"
-#~ "  in einem Speicherblock gespeichert. String-Literale (`”Hallo”`) werden "
-#~ "in der Binärdatei des Programms gespeichert."
-
-#, fuzzy
-#~ msgid "  (Type annotations added for clarity, but they can be elided.)"
-#~ msgstr ""
-#~ "  (Typ-Anmerkungen wurden der Übersichtlichkeit halber hinzugefügt, "
-#~ "können aber entfernt werden.)"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Rectangle {\n"
-#~ "    fn area(&self) -> u32 {\n"
-#~ "        self.width * self.height\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Rechteck {\n"
-#~ "    fn-Bereich(&self) -> u32 {\n"
-#~ "        selbst.Breite * selbst.Höhe\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid "* Arrays and `for` loops."
-#~ msgstr "* Arrays und „for“-Schleifen."
-
-#, fuzzy
-#~ msgid "* Alternatively, use the Rust Playground."
-#~ msgstr "* Benutze alternativ den Rust Playground."
-
-#, fuzzy
-#~ msgid "[solutions]: solutions-morning.md"
-#~ msgstr "[Lösungen]: Lösungen-Morgen.md"
-
-#, fuzzy
-#~ msgid "[Using Cargo]: ../../cargo.md"
-#~ msgstr "[Fracht verwenden]: ../../cargo.md"
-
-#, fuzzy
-#~ msgid "1. Execute the above program and look at the compiler error."
-#~ msgstr ""
-#~ "1. Führen Sie das obige Programm aus und sehen Sie sich den Compiler-"
-#~ "Fehler an."
-
-#, fuzzy
-#~ msgid "2. Update the code above to use `into()` to do the conversion."
-#~ msgstr ""
-#~ "2. Aktualisieren Sie den obigen Code, um `into()` zu verwenden, um die "
-#~ "Konvertierung durchzuführen."
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-#~ "[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/convert/trait.From.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/convert/trait.Into.html\n"
-#~ "[3]: https://en.cppreference.com/w/cpp/language/implicit_conversion"
-
-#, fuzzy
-#~ msgid "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
-#~ msgstr "[1]: https://rust-lang.github.io/rfcs/0246-const-vs-static.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Heap: Storage of values outside of function calls.\n"
-#~ "  * Values have dynamic sizes determined at runtime.\n"
-#~ "  * Slightly slower than the stack: some book-keeping needed.\n"
-#~ "  * No guarantee of memory locality."
-#~ msgstr ""
-#~ "* Heap: Speicherung von Werten außerhalb von Funktionsaufrufen.\n"
-#~ "  * Werte haben dynamische Größen, die zur Laufzeit bestimmt werden.\n"
-#~ "  * Etwas langsamer als der Stapel: Etwas Buchhaltung erforderlich.\n"
-#~ "  * Keine Garantie auf Speicherort."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Mention that a `String` is backed by a `Vec`, so it has a capacity and "
-#~ "length and can grow if mutable via reallocation on the heap."
-#~ msgstr ""
-#~ "* Erwähnen Sie, dass ein `String` von einem `Vec` unterstützt wird, "
-#~ "sodass er eine Kapazität und Länge hat und wachsen kann, wenn er durch "
-#~ "Neuzuweisung auf dem Haufen veränderbar ist."
-
-#, fuzzy
-#~ msgid ""
-#~ "* If students ask about it, you can mention that the underlying memory is "
-#~ "heap allocated using the [System Allocator] and custom allocators can be "
-#~ "implemented using the [Allocator API]"
-#~ msgstr ""
-#~ "* Wenn die Schüler danach fragen, können Sie erwähnen, dass der zugrunde "
-#~ "liegende Speicher mit dem [System Allocator] Heap zugewiesen wird und "
-#~ "benutzerdefinierte Allokatoren mit der [Allocator API] implementiert "
-#~ "werden können."
-
-#, fuzzy
-#~ msgid ""
-#~ "[System Allocator]: https://doc.rust-lang.org/std/alloc/struct.System."
-#~ "html\n"
-#~ "[Allocator API]: https://doc.rust-lang.org/std/alloc/index.html"
-#~ msgstr ""
-#~ "[Systemzuordner]: https://doc.rust-lang.org/std/alloc/struct.System.html\n"
-#~ "[Allocator-API]: https://doc.rust-lang.org/std/alloc/index.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "* You may be asked about destructors here, the [Drop] trait is the Rust "
-#~ "equivalent."
-#~ msgstr ""
-#~ "* Möglicherweise werden Sie hier nach Destruktoren gefragt, die "
-#~ "Eigenschaft [Drop] ist das Rust-Äquivalent."
-
-#, fuzzy
-#~ msgid ""
-#~ "[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-#~ msgstr ""
-#~ "[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[Vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[Bogen]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[Drop]: https://doc.rust-lang.org/std/ops/trait.Drop.html"
-
-#, fuzzy
-#~ msgid "* In Rust, you clones are explicit (by using `clone`)."
-#~ msgstr "* In Rust sind Klone explizit (durch Verwendung von `clone`)."
-
-#, fuzzy
-#~ msgid ""
-#~ "fn add(p1: &Point, p2: &Point) -> Point {\n"
-#~ "    Point(p1.0 + p2.0, p1.1 + p2.1)\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn add(p1: &Punkt, p2: &Punkt) -> Punkt {\n"
-#~ "    Punkt(p1.0 + p2.0, p1.1 + p2.1)\n"
-#~ "}"
-
-#~ msgid ""
-#~ "* Demonstrate that the return from `add` is cheap because the compiler "
-#~ "can eliminate the copy operation. Change the above code to print stack "
-#~ "addresses and run it on the [Playground]. In the \"DEBUG\" optimization "
-#~ "level, the addresses should change, while the stay the same when changing "
-#~ "to the \"RELEASE\" setting:"
-#~ msgstr ""
-#~ "* Zeigen Sie, dass die Rückgabe von `add` billig ist, weil der Compiler "
-#~ "den Kopiervorgang eliminieren kann. Ändern Sie den obigen Code, um "
-#~ "Stapeladressen zu drucken, und führen Sie ihn auf dem [Playground] aus. "
-#~ "In der Optimierungsstufe „DEBUG“ sollen sich die Adressen ändern, während "
-#~ "sie beim Wechsel in die Einstellung „RELEASE“ gleich bleiben:"
-
-#, fuzzy
-#~ msgid "[Playground]: https://play.rust-lang.org/"
-#~ msgstr "[Spielplatz]: https://play.rust-lang.org/"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-#~ "    if p1.0 < p2.0 { p1 } else { p2 }\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn left_most<'a>(p1: &'a Punkt, p2: &'a Punkt) -> &'a Punkt {\n"
-#~ "    wenn p1.0 < p2.0 { p1 } sonst { p2 }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "  fn left_most<'a>(p1: &'a Point, p2: &'a Point) -> &'a Point {\n"
-#~ "      if p1.0 < p2.0 { p1 } else { p2 }\n"
-#~ "  }"
-#~ msgstr ""
-#~ "  fn left_most<'a>(p1: &'a Punkt, p2: &'a Punkt) -> &'a Punkt {\n"
-#~ "      wenn p1.0 < p2.0 { p1 } sonst { p2 }\n"
-#~ "  }"
-
-#, fuzzy
-#~ msgid "* A small book library,"
-#~ msgstr "* Eine kleine Buchbibliothek,"
-
-#, fuzzy
-#~ msgid "[solutions]: solutions-afternoon.md"
-#~ msgstr "[Lösungen]: Lösungen-Nachmittag.md"
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Library {\n"
-#~ "    books: Vec<Book>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "Struktur Bibliothek {\n"
-#~ "    Bücher: Vec<Buch>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Book {\n"
-#~ "    title: String,\n"
-#~ "    year: u16,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Buch {\n"
-#~ "    Titel: Zeichenkette,\n"
-#~ "    Jahr: u16,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Book {\n"
-#~ "    // This is a constructor, used below.\n"
-#~ "    fn new(title: &str, year: u16) -> Book {\n"
-#~ "        Book {\n"
-#~ "            title: String::from(title),\n"
-#~ "            year,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Buch {\n"
-#~ "    // Dies ist ein Konstruktor, der unten verwendet wird.\n"
-#~ "    fn neu(titel: &str, jahr: u16) -> Buch {\n"
-#~ "        Buch {\n"
-#~ "            Titel: Zeichenkette::von(Titel),\n"
-#~ "            Jahr,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// This makes it possible to print Book values with {}.\n"
-#~ "impl std::fmt::Display for Book {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-#~ "        write!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "// Dadurch ist es möglich, Buchwerte mit {} zu drucken.\n"
-#~ "impl std::fmt::Anzeige für Buch {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-#~ "        schreibe!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Library {\n"
-#~ "    fn new() -> Library {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl-Bibliothek {\n"
-#~ "    fn new() -> Bibliothek {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn len(self) -> usize {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn len(self) -> verwenden {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn add_book(self, book: Book) {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn add_book(selbst, Buch: Buch) {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn print_books(self) {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}"
-#~ msgstr ""
-#~ "    //fn print_books(selbst) {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    //fn oldest_book(self) -> Option<&Book> {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "}"
-#~ msgstr ""
-#~ "    //fn ältestes_buch(selbst) -> Option<&Buch> {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "* Structs, enums, methods."
-#~ msgstr "* Strukturen, Aufzählungen, Methoden."
-
-#, fuzzy
-#~ msgid "* Pattern matching: destructuring enums, structs, and arrays."
-#~ msgstr ""
-#~ "* Mustervergleich: Destrukturierung von Aufzählungen, Strukturen und "
-#~ "Arrays."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Control flow constructs: `if`, `if let`, `while`, `while let`, `break`, "
-#~ "and\n"
-#~ "  `continue`."
-#~ msgstr ""
-#~ "* Kontrollflusskonstrukte: `if`, `if let`, `while`, `while let`, `break` "
-#~ "und\n"
-#~ "  \"weitermachen\"."
-
-#, fuzzy
-#~ msgid ""
-#~ "* The Standard Library: `String`, `Option` and `Result`, `Vec`, "
-#~ "`HashMap`, `Rc`\n"
-#~ "  and `Arc`."
-#~ msgstr ""
-#~ "* Die Standardbibliothek: `String`, `Option` und `Result`, `Vec`, "
-#~ "`HashMap`, `Rc`\n"
-#~ "  und \"Bogen\"."
-
-#, fuzzy
-#~ msgid "* Modules: visibility, paths, and filesystem hierarchy."
-#~ msgstr "* Module: Sichtbarkeit, Pfade und Dateisystemhierarchie."
-
-#, fuzzy
-#~ msgid ""
-#~ "fn compute_thruster_force() -> PoundOfForce {\n"
-#~ "    todo!(\"Ask a rocket scientist at NASA\")\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn compute_thruster_force() -> PoundOfForce {\n"
-#~ "    todo! (\"Fragen Sie einen Raketenwissenschaftler bei der NASA\")\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn set_thruster_force(force: Newtons) {\n"
-#~ "    // ...\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn set_thruster_force(Kraft: Newton) {\n"
-#~ "    // ...\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "Newtypes are a great way to encode additional information about the value "
-#~ "in a primitive type, for example:\n"
-#~ msgstr ""
-#~ "Newtypes sind eine großartige Möglichkeit, zusätzliche Informationen über "
-#~ "den Wert in einem primitiven Typ zu codieren, zum Beispiel:\n"
-
-#~ msgid ""
-#~ "  * The number is measured in some units: `Newtons` in the example "
-#~ "above.\n"
-#~ "  * The value passed some validation when it was created, so you no "
-#~ "longer have to validate it again at every use: 'PhoneNumber(String)` or "
-#~ "`OddNumber(u32)`.\n"
-#~ "    \n"
-#~ "</details>"
-#~ msgstr ""
-#~ "  * Die Zahl wird in einigen Einheiten gemessen: „Newton“ im obigen "
-#~ "Beispiel.\n"
-#~ "  * Der Wert hat bei seiner Erstellung einige Validierungen durchlaufen, "
-#~ "sodass Sie ihn nicht mehr bei jeder Verwendung erneut validieren müssen: "
-#~ "'PhoneNumber(String)' oder 'OddNumber(u32)'.\n"
-#~ "    \n"
-#~ "</Details>"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Person {\n"
-#~ "    fn new(name: String, age: u8) -> Person {\n"
-#~ "        Person { name, age }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Person {\n"
-#~ "    fn new(name: String, age: u8) -> Person {\n"
-#~ "        Person { Name, Alter }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "The `new` function could be written using `Self` as a type, as it is "
-#~ "interchangeable with the struct type name"
-#~ msgstr ""
-#~ "Die „neue“ Funktion könnte unter Verwendung von „Self“ als Typ "
-#~ "geschrieben werden, da sie mit dem Namen des Strukturtyps austauschbar ist"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "enum CoinFlip {\n"
-#~ "    Heads,\n"
-#~ "    Tails,\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[ableiten(Debuggen)]\n"
-#~ "enum CoinFlip {\n"
-#~ "    Köpfe,\n"
-#~ "    Schwänze,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[rustfmt::skip]\n"
-#~ "fn inspect(event: WebEvent) {\n"
-#~ "    match event {\n"
-#~ "        WebEvent::PageLoad       => println!(\"page loaded\"),\n"
-#~ "        WebEvent::KeyPress(c)    => println!(\"pressed '{c}'\"),\n"
-#~ "        WebEvent::Click { x, y } => println!(\"clicked at x={x}, "
-#~ "y={y}\"),\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[rustfmt::skip]\n"
-#~ "fn inspect(event: WebEvent) {\n"
-#~ "    Spielereignis {\n"
-#~ "        WebEvent::PageLoad => println!(\"Seite geladen\"),\n"
-#~ "        WebEvent::KeyPress(c) => println!(\"pressed '{c}'\"),\n"
-#~ "        WebEvent::Click { x, y } => println!(\"clicked at x={x}, "
-#~ "y={y}\"),\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "* In the above example, accessing the `char` in `KeyPress`, or `x` and "
-#~ "`y` in `Click` only works within a `match` statement.\n"
-#~ "* `match` inspects a hidden discriminant field in the `enum`.\n"
-#~ "* `WebEvent::Click { ... }` is not exactly the same as `WebEvent::"
-#~ "Click(Click)` with a top level `struct Click { ... }`. The inlined "
-#~ "version cannot implement traits, for example."
-#~ msgstr ""
-#~ "* Im obigen Beispiel funktioniert der Zugriff auf „char“ in „KeyPress“ "
-#~ "oder „x“ und „y“ in „Click“ nur innerhalb einer „match“-Anweisung.\n"
-#~ "* „match“ untersucht ein verstecktes Diskriminanzfeld in „enum“.\n"
-#~ "* `WebEvent::Click { ... }` ist nicht genau dasselbe wie `WebEvent::"
-#~ "Click(Click)` mit einem Top-Level-`struct Click { ... }`. Die Inline-"
-#~ "Version kann beispielsweise keine Traits implementieren."
-
-#, fuzzy
-#~ msgid ""
-#~ "enum Foo {\n"
-#~ "    A,\n"
-#~ "    B,\n"
-#~ "}"
-#~ msgstr ""
-#~ "Aufzählung Foo {\n"
-#~ "    A,\n"
-#~ "    B,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[repr(u32)]\n"
-#~ "enum Bar {\n"
-#~ "    A,  // 0\n"
-#~ "    B = 10000,\n"
-#~ "    C,  // 10001\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[repr(u32)]\n"
-#~ "Aufzählungsbalken {\n"
-#~ "    A, // 0\n"
-#~ "    B = 10000,\n"
-#~ "    C, // 10001\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ " * Internally Rust is using a field (discriminant) to keep track of the "
-#~ "enum variant.\n"
-#~ " * `Bar` enum demonstrates that there is a way to control the "
-#~ "discriminant value and type. If `repr` is removed, the discriminant type "
-#~ "takes 2 bytes, becuase 10001 fits 2 bytes.\n"
-#~ " * As a niche optimization an enum discriminant is merged with the "
-#~ "pointer so that `Option<&Foo>` is the same size as `&Foo`.\n"
-#~ " * `Option<bool>` is another example of tight packing.\n"
-#~ " * For [some types](https://doc.rust-lang.org/std/option/"
-#~ "#representation), Rust guarantees that `size_of::<T>()` equals `size_of::"
-#~ "<Option<T>>()`.\n"
-#~ " * Zero-sized types allow for efficient implementation of `HashSet` using "
-#~ "`HashMap` with `()` as the value."
-#~ msgstr ""
-#~ " * Rust verwendet intern ein Feld (Discriminant), um die Enum-Variante zu "
-#~ "verfolgen.\n"
-#~ " * `Bar` enum demonstriert, dass es eine Möglichkeit gibt, den "
-#~ "Diskriminanzwert und -typ zu steuern. Wenn \"repr\" entfernt wird, nimmt "
-#~ "der Diskriminantentyp 2 Bytes ein, da 10001 auf 2 Bytes passt.\n"
-#~ " * Als Nischenoptimierung wird eine Enum-Diskriminante mit dem Zeiger "
-#~ "zusammengeführt, sodass `Option<&Foo>` die gleiche Größe wie `&Foo` hat.\n"
-#~ " * `Option<bool>` ist ein weiteres Beispiel für Tight Packing.\n"
-#~ " * Für [einige Typen](https://doc.rust-lang.org/std/option/"
-#~ "#representation) garantiert Rust, dass „size_of::<T>()“ gleich „size_of::"
-#~ "<Option<T>“ ist >()`.\n"
-#~ " * Typen mit der Größe Null ermöglichen eine effiziente Implementierung "
-#~ "von `HashSet` unter Verwendung von `HashMap` mit `()` als Wert."
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Race {\n"
-#~ "    fn new(name: &str) -> Race {  // No receiver, a static method\n"
-#~ "        Race { name: String::from(name), laps: Vec::new() }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Rennen {\n"
-#~ "    fn new(name: &str) -> Race { // Kein Empfänger, eine statische "
-#~ "Methode\n"
-#~ "        Rennen { Name: String::from(Name), Runden: Vec::new() }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn divide_in_two(n: i32) -> Result {\n"
-#~ "    if n % 2 == 0 {\n"
-#~ "        Result::Ok(n / 2)\n"
-#~ "    } else {\n"
-#~ "        Result::Err(format!(\"cannot divide {} into two equal parts\", "
-#~ "n))\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn divide_in_two(n: i32) -> Ergebnis {\n"
-#~ "    wenn n % 2 == 0 {\n"
-#~ "        Ergebnis::Okay(n / 2)\n"
-#~ "    } anders {\n"
-#~ "        Ergebnis::Err(format!(\"kann {} nicht in zwei gleiche Teile "
-#~ "teilen\", n))\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "* Simple struct which tracks health statistics."
-#~ msgstr "* Einfache Struktur, die Gesundheitsstatistiken verfolgt."
-
-#, fuzzy
-#~ msgid ""
-#~ "struct User {\n"
-#~ "    name: String,\n"
-#~ "    age: u32,\n"
-#~ "    weight: f32,\n"
-#~ "}"
-#~ msgstr ""
-#~ "Struktur Benutzer {\n"
-#~ "    Name: Zeichenfolge,\n"
-#~ "    Alter: u32,\n"
-#~ "    Gewicht: f32,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl User {\n"
-#~ "    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl Benutzer {\n"
-#~ "    pub fn new(name: String, age: u32, weight: f32) -> Self {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn name(&self) -> &str {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn name(&self) -> &str {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn age(&self) -> u32 {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn alter(&selbst) -> u32 {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn weight(&self) -> f32 {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn Gewicht(&self) -> f32 {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn set_age(&mut self, new_age: u32) {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn set_age(&mut selbst, new_age: u32) {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn set_weight(&mut self, new_weight: f32) {\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    pub fn set_weight(&mut self, new_weight: f32) {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Point {\n"
-#~ "    // add fields\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Punkt {\n"
-#~ "    // Felder hinzufügen\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Point {\n"
-#~ "    // add methods\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Punkt {\n"
-#~ "    // Methoden hinzufügen\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Polygon {\n"
-#~ "    // add fields\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Polygon {\n"
-#~ "    // Felder hinzufügen\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Polygon {\n"
-#~ "    // add methods\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Polygon {\n"
-#~ "    // Methoden hinzufügen\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Circle {\n"
-#~ "    // add fields\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Kreis {\n"
-#~ "    // Felder hinzufügen\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Circle {\n"
-#~ "    // add methods\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Kreis {\n"
-#~ "    // Methoden hinzufügen\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub enum Shape {\n"
-#~ "    Polygon(Polygon),\n"
-#~ "    Circle(Circle),\n"
-#~ "}"
-#~ msgstr ""
-#~ "Pub-Aufzählung Form {\n"
-#~ "    Vieleck(Vieleck),\n"
-#~ "    Kreis (Kreis),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn round_two_digits(x: f64) -> f64 {\n"
-#~ "        (x * 100.0).round() / 100.0\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    fn round_two_digits(x: f64) -> f64 {\n"
-#~ "        (x * 100.0).round() / 100.0\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`Option` and `Result`](std/option-result.md) types: used for optional "
-#~ "values\n"
-#~ "  and [error handling](error-handling.md)."
-#~ msgstr ""
-#~ "* Typen von [`Option` und `Result`](std/option-result.md): Wird für "
-#~ "optionale Werte verwendet\n"
-#~ "  und [Fehlerbehandlung](error-handling.md)."
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`String`](std/string.md): the default string type used for owned data."
-#~ msgstr ""
-#~ "* [`String`](std/string.md): der Standard-String-Typ, der für eigene "
-#~ "Daten verwendet wird."
-
-#, fuzzy
-#~ msgid "* [`Vec`](std/vec.md): a standard extensible vector."
-#~ msgstr "* [`Vec`](std/vec.md): ein erweiterbarer Standardvektor."
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`HashMap`](std/hashmap.md): a hash map type with a configurable "
-#~ "hashing\n"
-#~ "  algorithm."
-#~ msgstr ""
-#~ "* [`HashMap`](std/hashmap.md): ein Hash-Map-Typ mit konfigurierbarem "
-#~ "Hashing\n"
-#~ "  Algorithmus."
-
-#, fuzzy
-#~ msgid "* [`Box`](std/box.md): an owned pointer for heap-allocated data."
-#~ msgstr ""
-#~ "* [`Box`](std/box.md): ein eigener Zeiger für Heap-zugewiesene Daten."
-
-#, fuzzy
-#~ msgid ""
-#~ "* [`Rc`](std/rc.md): a shared reference-counted pointer for heap-"
-#~ "allocated data."
-#~ msgstr ""
-#~ "* [`Rc`](std/rc.md): ein gemeinsam genutzter referenzgezählter Zeiger für "
-#~ "Heap-zugeordnete Daten."
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/string/struct.String.html#deref-"
-#~ "methods-str"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/string/struct.String.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/string/struct.String.html#deref-"
-#~ "methods-str"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `len` returns the size of the `String` in bytes, not its length in "
-#~ "characters.\n"
-#~ "* `chars` returns an iterator over the actual characters.\n"
-#~ "* `String` implements `Deref<Target = str>` which transparently gives it "
-#~ "access to `str`'s methods."
-#~ msgstr ""
-#~ "* `len` gibt die Größe des `String` in Bytes zurück, nicht seine Länge in "
-#~ "Zeichen.\n"
-#~ "* `chars` gibt einen Iterator über die eigentlichen Zeichen zurück.\n"
-#~ "* `String` implementiert `Deref<Target = str>`, wodurch es transparent "
-#~ "Zugriff auf die Methoden von `str` erhält."
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/vec/struct.Vec.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/vec/struct.Vec.html#deref-methods-[T]"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-"
-#~ "coercion"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/boxed/struct.Box.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-"
-#~ "coercion"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `Box` is like `std::unique_ptr` in C++.\n"
-#~ "* In the above example, you can even leave out the `*` in the `println!` "
-#~ "statement thanks to `Deref`."
-#~ msgstr ""
-#~ "* `Box` ist wie `std::unique_ptr` in C++.\n"
-#~ "* Im obigen Beispiel können Sie dank `Deref` sogar das `*` in der "
-#~ "`println!`-Anweisung weglassen."
-
-#, fuzzy
-#~ msgid ""
-#~ "If the `Box` was not used here and we attempted to embed a `List` "
-#~ "directly into the `List`,\n"
-#~ "the compiler would not compute a fixed size of the struct in memory, it "
-#~ "would look infinite.\n"
-#~ msgstr ""
-#~ "`Box` löst dieses Problem, da es die gleiche Größe wie ein normaler "
-#~ "Zeiger hat und nur auf den nächsten zeigt\n"
-#~ "Element der `Liste` im Heap.\n"
-
-#~ msgid ""
-#~ "`Box` solves this problem as it has the same size as a regular pointer "
-#~ "and just points at the next\n"
-#~ "element of the `List` in the heap.    \n"
-#~ msgstr ""
-#~ "Wenn die `Box` hier nicht verwendet wurde und wir versucht haben, eine "
-#~ "`List` direkt in die `List` einzubetten,\n"
-#~ "Der Compiler würde keine feste Größe der Struktur im Speicher berechnen, "
-#~ "es würde unendlich aussehen.\n"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/cell/index.html\n"
-#~ "[3]: ../concurrency/shared_state/arc.md"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/rc/struct.Rc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/cell/index.html\n"
-#~ "[3]: ../concurrency/shared_state/arc.md"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Like C++'s `std::shared_ptr`.\n"
-#~ "* `clone` is cheap: creates a pointer to the same allocation and "
-#~ "increases the reference count.\n"
-#~ "* `make_mut` actually clones the inner value if necessary (\"clone-on-"
-#~ "write\") and returns a mutable reference."
-#~ msgstr ""
-#~ "* Wie `std::shared_ptr` von C++.\n"
-#~ "* `clone` ist billig: erstellt einen Zeiger auf die gleiche Zuweisung und "
-#~ "erhöht die Referenzanzahl.\n"
-#~ "* `make_mut` klont bei Bedarf tatsächlich den inneren Wert (\"clone-on-"
-#~ "write\") und gibt eine veränderliche Referenz zurück."
-
-#, fuzzy
-#~ msgid ""
-#~ "1. As a relative path:\n"
-#~ "   * `foo` or `self::foo` refers to `foo` in the current module,\n"
-#~ "   * `super::foo` refers to `foo` in the parent module."
-#~ msgstr ""
-#~ "1. Als relativer Pfad:\n"
-#~ "   * `foo` oder `self::foo` bezieht sich auf `foo` im aktuellen Modul,\n"
-#~ "   * „super::foo“ bezieht sich auf „foo“ im übergeordneten Modul."
-
-#, fuzzy
-#~ msgid "* Ignore all spaces. Reject number with less than two digits."
-#~ msgstr ""
-#~ "* Ignoriere alle Leerzeichen. Ablehnungsnummer mit weniger als zwei "
-#~ "Ziffern."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Moving from right to left, double every second digit: for the number "
-#~ "`1234`,\n"
-#~ "  we double `3` and `1`."
-#~ msgstr ""
-#~ "* Bewegen Sie sich von rechts nach links, verdoppeln Sie jede zweite "
-#~ "Ziffer: für die Zahl \"1234\",\n"
-#~ "  wir verdoppeln `3` und `1`."
-
-#, fuzzy
-#~ msgid ""
-#~ "* After doubling a digit, sum the digits. So doubling `7` becomes `14` "
-#~ "which\n"
-#~ "  becomes `5`."
-#~ msgstr ""
-#~ "* Nachdem Sie eine Ziffer verdoppelt haben, addieren Sie die Ziffern. Das "
-#~ "Verdoppeln von '7' wird also zu '14', was\n"
-#~ "  wird \"5\"."
-
-#, fuzzy
-#~ msgid "* Sum all the undoubled and doubled digits."
-#~ msgstr "* Summiere alle unverdoppelten und verdoppelten Ziffern."
-
-#, fuzzy
-#~ msgid "* The credit card number is valid if the sum ends with `0`."
-#~ msgstr "* Die Kreditkartennummer ist gültig, wenn die Summe mit `0` endet."
-
-#, fuzzy
-#~ msgid ""
-#~ "pub fn luhn(cc_number: &str) -> bool {\n"
-#~ "    unimplemented!()\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub fn luhn(cc_number: &str) -> bool {\n"
-#~ "    nicht implementiert!()\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-#~ "    unimplemented!()\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {\n"
-#~ "    nicht implementiert!()\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "* Traits: deriving traits, default methods, and important standard "
-#~ "library\n"
-#~ "  traits."
-#~ msgstr ""
-#~ "* Merkmale: Ableitung von Merkmalen, Standardmethoden und wichtige "
-#~ "Standardbibliothek\n"
-#~ "  Züge."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Generics: generic data types, generic methods, monomorphization, and "
-#~ "trait\n"
-#~ "  objects."
-#~ msgstr ""
-#~ "* Generics: generische Datentypen, generische Methoden, Monomorphisierung "
-#~ "und Eigenschaften\n"
-#~ "  Objekte."
-
-#, fuzzy
-#~ msgid "* Error handling: panics, `Result`, and the try operator `?`."
-#~ msgstr "* Fehlerbehandlung: Panics, `Result` und der Try-Operator `?`."
-
-#, fuzzy
-#~ msgid "* Testing: unit tests, documentation tests, and integration tests."
-#~ msgstr ""
-#~ "* Testen: Einheitentests, Dokumentationstests und Integrationstests."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Unsafe Rust: raw pointers, static variables, unsafe functions, and "
-#~ "extern\n"
-#~ "  functions."
-#~ msgstr ""
-#~ "* Unsicherer Rost: rohe Zeiger, statische Variablen, unsichere Funktionen "
-#~ "und extern\n"
-#~ "  Funktionen."
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Dog {\n"
-#~ "    name: String,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Hund {\n"
-#~ "    Name: Zeichenfolge,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Equals for Centimeter {\n"
-#~ "    fn equal(&self, other: &Centimeter) -> bool {\n"
-#~ "        self.0 == other.0\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Gleich für Zentimeter {\n"
-#~ "    fn gleich(&selbst, andere: &Zentimeter) -> bool {\n"
-#~ "        self.0 == andere.0\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "* `IntoIterator` is the trait that makes for loops work. It is "
-#~ "implemented by collection types such as\n"
-#~ "  `Vec<T>` and references to them such as `&Vec<T>` and `&[T]`. Ranges "
-#~ "also implement it.\n"
-#~ "* The `Iterator` trait implements many common functional programming "
-#~ "operations over collections \n"
-#~ "  (e.g. `map`, `filter`, `reduce`, etc). This is the trait where you can "
-#~ "find all the documentation\n"
-#~ "  about them. In Rust these functions should produce the code as "
-#~ "efficient as equivalent imperative\n"
-#~ "  implementations.\n"
-#~ "    \n"
-#~ "</details>"
-#~ msgstr ""
-#~ "* `IntoIterator` ist die Eigenschaft, die dafür sorgt, dass for-Schleifen "
-#~ "funktionieren. Es wird durch Sammlungstypen wie implementiert\n"
-#~ "  `Vec<T>` und Verweise darauf wie `&Vec<T>` und `&[T]`. Ranges "
-#~ "implementieren es auch.\n"
-#~ "* Die Eigenschaft „Iterator“ implementiert viele gängige funktionale "
-#~ "Programmieroperationen über Sammlungen\n"
-#~ "  (z. B. `map`, `filter`, `reduce`, etc). Dies ist die Eigenschaft, in "
-#~ "der Sie die gesamte Dokumentation finden können\n"
-#~ "  über sie. In Rust sollten diese Funktionen den Code so effizient wie "
-#~ "gleichwertig erzeugen\n"
-#~ "  Implementierungen.\n"
-#~ "    \n"
-#~ "</Details>"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn add(self, other: Self) -> Self {\n"
-#~ "        Self {x: self.x + other.x, y: self.y + other.y}\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn add(self, other: Self) -> Self {\n"
-#~ "        Selbst {x: selbst.x + andere.x, y: selbst.y + andere.y}\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl<T> Point<T> {\n"
-#~ "    fn x(&self) -> &T {\n"
-#~ "        &self.0  // + 10\n"
-#~ "    }"
-#~ msgstr ""
-#~ "imple<T> Punkt<T> {\n"
-#~ "    fn x(&selbst) -> &T {\n"
-#~ "        &self.0 // + 10\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // fn set_x(&mut self, x: T)\n"
-#~ "}"
-#~ msgstr ""
-#~ "    // fn set_x(&mut selbst, x: T)\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn get_x(name: impl Display) -> impl Display {\n"
-#~ "    format!(\"Hello {name}\")\n"
-#~ "}"
-#~ msgstr ""
-#~ "fn get_x(name: impl Display) -> impl Display {\n"
-#~ "    format!(\"Hallo {Name}\")\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "enum Option_f64 {\n"
-#~ "    Some(f64),\n"
-#~ "    None,\n"
-#~ "}"
-#~ msgstr ""
-#~ "Aufzählung Option_f64 {\n"
-#~ "    Einige (f64),\n"
-#~ "    Keiner,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Label {\n"
-#~ "    label: String,\n"
-#~ "}"
-#~ msgstr ""
-#~ "Pub-Struktur Label {\n"
-#~ "    Label: Zeichenkette,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Label {\n"
-#~ "    fn new(label: &str) -> Label {\n"
-#~ "        Label {\n"
-#~ "            label: label.to_owned(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Label {\n"
-#~ "    fn new(label: &str) -> Label {\n"
-#~ "        Etikett {\n"
-#~ "            Bezeichnung: label.to_owned(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Button {\n"
-#~ "    label: Label,\n"
-#~ "    callback: Box<dyn FnMut()>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Schaltfläche {\n"
-#~ "    Etikett: Etikett,\n"
-#~ "    Rückruf: Box<dyn FnMut()>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Button {\n"
-#~ "    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
-#~ "        Button {\n"
-#~ "            label: Label::new(label),\n"
-#~ "            callback,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl-Schaltfläche {\n"
-#~ "    fn new(label: &str, callback: Box<dyn FnMut()>) -> Button {\n"
-#~ "        Taste {\n"
-#~ "            Label: Label::neu(Label),\n"
-#~ "            Ruf zurück,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "pub struct Window {\n"
-#~ "    title: String,\n"
-#~ "    widgets: Vec<Box<dyn Widget>>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "pub struct Fenster {\n"
-#~ "    Titel: Zeichenkette,\n"
-#~ "    Widgets: Vec<Box<dyn Widget>>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Window {\n"
-#~ "    fn new(title: &str) -> Window {\n"
-#~ "        Window {\n"
-#~ "            title: title.to_owned(),\n"
-#~ "            widgets: Vec::new(),\n"
-#~ "        }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl-Fenster {\n"
-#~ "    fn new(title: &str) -> Fenster {\n"
-#~ "        Fenster {\n"
-#~ "            Titel: title.to_owned(),\n"
-#~ "            Widgets: Vec::new(),\n"
-#~ "        }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Widget for Label {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl-Widget für Label {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn draw_into(&self, buffer: &mut dyn std::fmt::Write) {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Widget for Button {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl-Widget für Schaltfläche {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Widget for Window {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        unimplemented!()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "impl-Widget für Fenster {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid "This is a small text GUI demo."
-#~ msgstr "Dies ist eine kleine Text-GUI-Demo."
-
-#, fuzzy
-#~ msgid ""
-#~ "    match username_file.read_to_string(&mut username) {\n"
-#~ "        Ok(_) => Ok(username),\n"
-#~ "        Err(e) => Err(e),\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    match username_file.read_to_string(&mut username) {\n"
-#~ "        Ok(_) => Ok(Benutzername),\n"
-#~ "        Fehler(e) => Fehler(e),\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    IoError(io::Error),\n"
-#~ "    EmptyUsername(String),\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[ableiten(Debuggen)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    IoError(io::Fehler),\n"
-#~ "    LeererBenutzername(String),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "impl Error for ReadUsernameError {}"
-#~ msgstr "impl-Fehler für ReadUsernameError {}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Display for ReadUsernameError {\n"
-#~ "    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-#~ "        match self {\n"
-#~ "            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
-#~ "            Self::EmptyUsername(filename) => write!(f, \"Found no "
-#~ "username in {}\", filename),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Anzeige für ReadUsernameError {\n"
-#~ "    fn fmt(&self, f: &mut Formatter) -> fmt::Result {\n"
-#~ "        mit sich selbst übereinstimmen {\n"
-#~ "            Self::IoError(e) => write!(f, \"IO error: {}\", e),\n"
-#~ "            Self::EmptyUsername(filename) => write!(f, \"Keinen "
-#~ "Benutzernamen gefunden in {}\", filename),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl From<io::Error> for ReadUsernameError {\n"
-#~ "    fn from(err: io::Error) -> ReadUsernameError {\n"
-#~ "        ReadUsernameError::IoError(err)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl From<io::Error> für ReadUsernameError {\n"
-#~ "    fn from(err: io::Error) -> ReadUsernameError {\n"
-#~ "        ReadUsernameError::IoError(err)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug, Error)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    #[error(\"Could not read: {0}\")]\n"
-#~ "    IoError(#[from] io::Error),\n"
-#~ "    #[error(\"Found no username in {0}\")]\n"
-#~ "    EmptyUsername(String),\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[ableiten(Debug, Fehler)]\n"
-#~ "enum ReadUsernameError {\n"
-#~ "    #[error(\"Konnte nicht gelesen werden: {0}\")]\n"
-#~ "    IoError(#[von] io::Fehler),\n"
-#~ "    #[error(\"Keinen Benutzernamen in {0} gefunden\")]\n"
-#~ "    LeererBenutzername(String),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "* Unit tests are supported throughout your code."
-#~ msgstr "* Komponententests werden im gesamten Code unterstützt."
-
-#, fuzzy
-#~ msgid "[solution]: solutions-afternoon.md"
-#~ msgstr "[Lösung]: Lösungen-Nachmittag.md"
-
-#, fuzzy
-#~ msgid ""
-#~ "[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
-#~ "[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
-#~ "[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
-#~ "[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
-#~ msgstr ""
-#~ "[`std::ffi`]: https://doc.rust-lang.org/std/ffi/\n"
-#~ "[`CStr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html\n"
-#~ "[`CString`]: https://doc.rust-lang.org/std/ffi/struct.CString.html\n"
-#~ "[Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    path: CString,\n"
-#~ "    dir: *mut ffi::DIR,\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[ableiten(Debuggen)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    Pfad: CString,\n"
-#~ "    dir: *mut ffi::DIR,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl DirectoryIterator {\n"
-#~ "    fn new(path: &str) -> Result<DirectoryIterator, String> {\n"
-#~ "        // Call opendir and return a Ok value if that worked,\n"
-#~ "        // otherwise return Err with a message.\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl DirectoryIterator {\n"
-#~ "    fn new(path: &str) -> Ergebnis<DirectoryIterator, String> {\n"
-#~ "        // Opendir aufrufen und einen Ok-Wert zurückgeben, wenn das "
-#~ "funktioniert hat,\n"
-#~ "        // andernfalls Err mit einer Nachricht zurückgeben.\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Drop for DirectoryIterator {\n"
-#~ "    fn drop(&mut self) {\n"
-#~ "        // Call closedir as needed.\n"
-#~ "        unimplemented!()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Drop für DirectoryIterator {\n"
-#~ "    fn drop(&mut self) {\n"
-#~ "        // Gegebenenfalls closedir aufrufen.\n"
-#~ "        nicht implementiert!()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "Today we will look at two main topics:"
-#~ msgstr "Heute werden wir uns mit zwei Hauptthemen befassen:"
-
-#, fuzzy
-#~ msgid "* Concurrency: threads, channels, shared state, `Send` and `Sync`."
-#~ msgstr ""
-#~ "* Gleichzeitigkeit: Threads, Kanäle, gemeinsamer Status, „Senden“ und "
-#~ "„Synchronisieren“."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Android: building binaries and libraries, using AIDL, logging, and\n"
-#~ "  interoperability with C, C++, and Java."
-#~ msgstr ""
-#~ "* Android: Erstellung von Binärdateien und Bibliotheken, Verwendung von "
-#~ "AIDL, Protokollierung und\n"
-#~ "  Interoperabilität mit C, C++ und Java."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Notice that the thread is stopped before it reaches 10 — the main "
-#~ "thread is\n"
-#~ "  not waiting."
-#~ msgstr ""
-#~ "* Beachten Sie, dass der Thread gestoppt wird, bevor er 10 erreicht – der "
-#~ "Haupt-Thread ist es\n"
-#~ "  nicht warten."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Use `let handle = thread::spawn(...)` and later `handle.join()` to wait "
-#~ "for\n"
-#~ "  the thread to finish."
-#~ msgstr ""
-#~ "* Verwenden Sie `let handle = thread::spawn(...)` und später `handle."
-#~ "join()`, um darauf zu warten\n"
-#~ "  den Thread zu beenden."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Trigger a panic in the thread, notice how this doesn't affect `main`."
-#~ msgstr ""
-#~ "* Lösen Sie eine Panik im Thread aus, beachten Sie, dass dies `main` "
-#~ "nicht betrifft."
-
-#, fuzzy
-#~ msgid ""
-#~ "* Use the `Result` return value from `handle.join()` to get access to the "
-#~ "panic\n"
-#~ "  payload. This is a good time to talk about [`Any`]."
-#~ msgstr ""
-#~ "* Verwenden Sie den `Result`-Rückgabewert von `handle.join()`, um Zugriff "
-#~ "auf die Panik zu erhalten\n"
-#~ "  Nutzlast. Dies ist ein guter Zeitpunkt, um über [`Any`] zu sprechen."
-
-#, fuzzy
-#~ msgid "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
-#~ msgstr "[`Any`]: https://doc.rust-lang.org/std/any/index.html"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/thread/fn.scope.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-"
-#~ "Mutex%3CT%3E\n"
-#~ "[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/sync/struct.Mutex.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-"
-#~ "Mutex%3CT%3E\n"
-#~ "[3]: https://doc.rust-lang.org/std/sync/struct.Arc.html"
-
-#, fuzzy
-#~ msgid ""
-#~ "[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError."
-#~ "html  \n"
-#~ "    \n"
-#~ "</details>"
-#~ msgstr ""
-#~ "[`PoisonError`]: https://doc.rust-lang.org/std/sync/struct.PoisonError."
-#~ "html\n"
-#~ "    \n"
-#~ "</details>"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
-#~ "[3]: ../unsafe/unsafe-traits.md"
-#~ msgstr ""
-#~ "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html\n"
-#~ "[2]: https://doc.rust-lang.org/std/marker/trait.Sync.html\n"
-#~ "[3]: ../unsafe/unsafe-traits.md"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Send.html"
-
-#, fuzzy
-#~ msgid "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
-#~ msgstr "[1]: https://doc.rust-lang.org/std/marker/trait.Sync.html"
-
-#, fuzzy
-#~ msgid "* Dining philosophers: a classic problem in concurrency."
-#~ msgstr "* Speisephilosophen: ein klassisches Problem der Nebenläufigkeit."
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Philosopher {\n"
-#~ "    name: String,\n"
-#~ "    // left_fork: ...\n"
-#~ "    // right_fork: ...\n"
-#~ "    // thoughts: ...\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Philosoph {\n"
-#~ "    Name: Zeichenfolge,\n"
-#~ "    // left_fork: ...\n"
-#~ "    // right_fork: ...\n"
-#~ "    // Gedanken: ...\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "fn main() {\n"
-#~ "    // Create forks"
-#~ msgstr ""
-#~ "fn Haupt() {\n"
-#~ "    // Gabeln erstellen"
-
-#, fuzzy
-#~ msgid "    // Create philosophers"
-#~ msgstr "    // Philosophen erstellen"
-
-#, fuzzy
-#~ msgid "    // Make them think and eat"
-#~ msgstr "    // Lass sie denken und essen"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Error, Debug)]\n"
-#~ "enum Error {\n"
-#~ "    #[error(\"request error: {0}\")]\n"
-#~ "    ReqwestError(#[from] reqwest::Error),\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[ableiten(Fehler, Debug)]\n"
-#~ "Aufzählungsfehler {\n"
-#~ "    #[error(\"Anforderungsfehler: {0}\")]\n"
-#~ "    ReqwestError(#[from]reqwest::Error),\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    Ok(valid_urls)\n"
-#~ "}"
-#~ msgstr ""
-#~ "    Okay (valid_urls)\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://docs.rs/reqwest/\n"
-#~ "[2]: https://docs.rs/scraper/\n"
-#~ "[3]: https://docs.rs/thiserror/"
-#~ msgstr ""
-#~ "[1]: https://docs.rs/reqwest/\n"
-#~ "[2]: https://docs.rs/scraper/\n"
-#~ "[3]: https://docs.rs/thiserror/"
-
-#, fuzzy
-#~ msgid ""
-#~ "[crates]: https://cs.android.com/android/platform/superproject/+/master:"
-#~ "external/rust/crates/"
-#~ msgstr ""
-#~ "[Kisten]: https://cs.android.com/android/platform/superproject/+/master:"
-#~ "external/rust/crates/"
-
-#, fuzzy
-#~ msgid "impl binder::Interface for BirthdayService {}"
-#~ msgstr "impl binder::Interface für BirthdayService {}"
-
-#, fuzzy
-#~ msgid ""
-#~ "/// Connect to the BirthdayService.\n"
-#~ "pub fn connect() -> Result<binder::Strong<dyn IBirthdayService>, binder::"
-#~ "StatusCode> {\n"
-#~ "    binder::get_interface(SERVICE_IDENTIFIER)\n"
-#~ "}"
-#~ msgstr ""
-#~ "/// Mit dem Geburtstagsdienst verbinden.\n"
-#~ "pub fn connect() -> Ergebnis<binder::Strong<dyn IBirthdayService>, "
-#~ "binder::StatusCode> {\n"
-#~ "    binder::get_interface(SERVICE_IDENTIFIER)\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "[1]: https://cxx.rs/\n"
-#~ "[2]: https://cxx.rs/tutorial.html"
-#~ msgstr ""
-#~ "[1]: https://cxx.rs/\n"
-#~ "[2]: https://cxx.rs/tutorial.html"
-
-#, fuzzy
-#~ msgid "* Call your AIDL service with a client written in Rust."
-#~ msgstr ""
-#~ "* Rufen Sie Ihren AIDL-Service mit einem in Rust geschriebenen Client an."
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: setup\n"
-#~ "struct Library {\n"
-#~ "    books: Vec<Book>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "// ANKER: einrichten\n"
-#~ "Struktur Bibliothek {\n"
-#~ "    Bücher: Vec<Buch>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// This makes it possible to print Book values with {}.\n"
-#~ "impl std::fmt::Display for Book {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-#~ "        write!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}\n"
-#~ "// ANCHOR_END: setup"
-#~ msgstr ""
-#~ "// Dadurch ist es möglich, Buchwerte mit {} zu drucken.\n"
-#~ "impl std::fmt::Anzeige für Buch {\n"
-#~ "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n"
-#~ "        schreibe!(f, \"{} ({})\", self.title, self.year)\n"
-#~ "    }\n"
-#~ "}\n"
-#~ "// ANCHOR_END: Einrichtung"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Library_new\n"
-#~ "impl Library {\n"
-#~ "    fn new() -> Library {\n"
-#~ "        // ANCHOR_END: Library_new\n"
-#~ "        Library { books: Vec::new() }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ANKER: Bibliothek_neu\n"
-#~ "impl-Bibliothek {\n"
-#~ "    fn new() -> Bibliothek {\n"
-#~ "        // ANCHOR_END: Bibliothek_neu\n"
-#~ "        Bibliothek { Bücher: Vec::new() }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_len\n"
-#~ "    //fn len(self) -> usize {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_len\n"
-#~ "    fn len(&self) -> usize {\n"
-#~ "        self.books.len()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    // ANKER: Library_len\n"
-#~ "    //fn len(self) -> verwenden {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_len\n"
-#~ "    fn len(&self) -> verwenden {\n"
-#~ "        self.books.len()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_is_empty\n"
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_is_empty\n"
-#~ "    fn is_empty(&self) -> bool {\n"
-#~ "        self.books.is_empty()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    // ANKER: Bibliothek_ist_leer\n"
-#~ "    //fn is_empty(self) -> bool {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Bibliothek_ist_leer\n"
-#~ "    fn is_empty(&self) -> bool {\n"
-#~ "        self.books.is_empty()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_add_book\n"
-#~ "    //fn add_book(self, book: Book) {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_add_book\n"
-#~ "    fn add_book(&mut self, book: Book) {\n"
-#~ "        self.books.push(book)\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    // ANKER: Library_add_book\n"
-#~ "    //fn add_book(selbst, Buch: Buch) {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_add_book\n"
-#~ "    fn add_book(&mut self, book: Buch) {\n"
-#~ "        self.books.push(Buch)\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    // ANCHOR: Library_oldest_book\n"
-#~ "    //fn oldest_book(self) -> Option<&Book> {\n"
-#~ "    //    unimplemented!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Library_oldest_book\n"
-#~ "    fn oldest_book(&self) -> Option<&Book> {\n"
-#~ "        self.books.iter().min_by_key(|book| book.year)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    // ANKER: Library_oldest_book\n"
-#~ "    //fn ältestes_buch(selbst) -> Option<&Buch> {\n"
-#~ "    // nicht implementiert!()\n"
-#~ "    //}\n"
-#~ "    // ANCHOR_END: Bibliothek_ältestes_Buch\n"
-#~ "    fn ältestes_buch(&self) -> Option<&Buch> {\n"
-#~ "        self.books.iter().min_by_key(|Buch| Buch.Jahr)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-#~ "// ANCHOR: Point\n"
-#~ "pub struct Point {\n"
-#~ "    // ANCHOR_END: Point\n"
-#~ "    x: i32,\n"
-#~ "    y: i32,\n"
-#~ "}"
-#~ msgstr ""
-#~ "#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n"
-#~ "// Ankerpunkt\n"
-#~ "pub struct Punkt {\n"
-#~ "    // ANCHOR_END: Punkt\n"
-#~ "    x: i32,\n"
-#~ "    y: i32,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Point-impl\n"
-#~ "impl Point {\n"
-#~ "    // ANCHOR_END: Point-impl\n"
-#~ "    pub fn new(x: i32, y: i32) -> Point {\n"
-#~ "        Point { x, y }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ANCHOR: Punkt-impl\n"
-#~ "impl Punkt {\n"
-#~ "    // ANCHOR_END: Punkt-impl\n"
-#~ "    pub fn neu(x: i32, y: i32) -> Punkt {\n"
-#~ "        Punkt { x, y }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn magnitude(self) -> f64 {\n"
-#~ "        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    Pub fn Magnitude (selbst) -> f64 {\n"
-#~ "        f64::from(self.x.pow(2) + self.y.pow(2)).sqrt()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn dist(self, other: Point) -> f64 {\n"
-#~ "        (self - other).magnitude()\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    pub fn dist(self, other: Point) -> f64 {\n"
-#~ "        (selbst - andere).magnitude()\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn add(self, other: Self) -> Self::Output {\n"
-#~ "        Self {\n"
-#~ "            x: self.x + other.x,\n"
-#~ "            y: self.y + other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn add(self, other: Self) -> Self::Output {\n"
-#~ "        Selbst {\n"
-#~ "            x: selbst.x + andere.x,\n"
-#~ "            y: self.y + other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    fn sub(self, other: Self) -> Self::Output {\n"
-#~ "        Self {\n"
-#~ "            x: self.x - other.x,\n"
-#~ "            y: self.y - other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    fn sub(self, other: Self) -> Self::Output {\n"
-#~ "        Selbst {\n"
-#~ "            x: self.x - other.x,\n"
-#~ "            y: self.y - other.y,\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Polygon\n"
-#~ "pub struct Polygon {\n"
-#~ "    // ANCHOR_END: Polygon\n"
-#~ "    points: Vec<Point>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "// ANKER: Vieleck\n"
-#~ "pub struct Polygon {\n"
-#~ "    // ANCHOR_END: Vieleck\n"
-#~ "    Punkte: Vec<Punkt>,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Polygon-impl\n"
-#~ "impl Polygon {\n"
-#~ "    // ANCHOR_END: Polygon-impl\n"
-#~ "    pub fn new() -> Polygon {\n"
-#~ "        Polygon { points: Vec::new() }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ANCHOR: Polygon-Impl\n"
-#~ "impl Polygon {\n"
-#~ "    // ANCHOR_END: Polygon-Impl\n"
-#~ "    pub fn new() -> Polygon {\n"
-#~ "        Vieleck { Punkte: Vec::new() }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn left_most_point(&self) -> Option<Point> {\n"
-#~ "        self.points.iter().min_by_key(|p| p.x).copied()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn left_most_point(&self) -> Option<Punkt> {\n"
-#~ "        self.points.iter().min_by_key(|p| p.x).kopiert()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-#~ "        self.points.iter()\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn iter(&self) -> impl Iterator<Item = &Point> {\n"
-#~ "        self.points.iter()\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Circle\n"
-#~ "pub struct Circle {\n"
-#~ "    // ANCHOR_END: Circle\n"
-#~ "    center: Point,\n"
-#~ "    radius: i32,\n"
-#~ "}"
-#~ msgstr ""
-#~ "// ANKER: Kreis\n"
-#~ "pub struct Kreis {\n"
-#~ "    // ANCHOR_END: Kreis\n"
-#~ "    Mittelpunkt,\n"
-#~ "    Radius: i32,\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Circle-impl\n"
-#~ "impl Circle {\n"
-#~ "    // ANCHOR_END: Circle-impl\n"
-#~ "    pub fn new(center: Point, radius: i32) -> Circle {\n"
-#~ "        Circle { center, radius }\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ANCHOR: Kreis-Impl\n"
-#~ "impl Kreis {\n"
-#~ "    // ANCHOR_END: Kreis-Impl\n"
-#~ "    pub fn neu (Zentrum: Punkt, Radius: i32) -> Kreis {\n"
-#~ "        Kreis { Mittelpunkt, Radius }\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn circumference(&self) -> f64 {\n"
-#~ "        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-#~ "    }"
-#~ msgstr ""
-#~ "    pub fn Umfang(&self) -> f64 {\n"
-#~ "        2.0 * std::f64::consts::PI * f64::from(self.radius)\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "    pub fn dist(&self, other: &Self) -> f64 {\n"
-#~ "        self.center.dist(other.center)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "    pub fn dist(&selbst, andere: &selbst) -> f64 {\n"
-#~ "        self.center.dist(anderes.center)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Shape\n"
-#~ "pub enum Shape {\n"
-#~ "    Polygon(Polygon),\n"
-#~ "    Circle(Circle),\n"
-#~ "}\n"
-#~ "// ANCHOR_END: Shape"
-#~ msgstr ""
-#~ "// ANKER: Form\n"
-#~ "Pub-Aufzählung Form {\n"
-#~ "    Vieleck(Vieleck),\n"
-#~ "    Kreis (Kreis),\n"
-#~ "}\n"
-#~ "// ANCHOR_END: Form"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl From<Polygon> for Shape {\n"
-#~ "    fn from(poly: Polygon) -> Self {\n"
-#~ "        Shape::Polygon(poly)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl From<Polygon> für Form {\n"
-#~ "    fn from(poly: Polygon) -> Self {\n"
-#~ "        Form::Polygon (poly)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl From<Circle> for Shape {\n"
-#~ "    fn from(circle: Circle) -> Self {\n"
-#~ "        Shape::Circle(circle)\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "impl Von<Kreis> für Form {\n"
-#~ "    fn from(Kreis: Kreis) -> Selbst {\n"
-#~ "        Form :: Kreis (Kreis)\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "impl Shape {\n"
-#~ "    pub fn perimeter(&self) -> f64 {\n"
-#~ "        match self {\n"
-#~ "            Shape::Polygon(poly) => poly.length(),\n"
-#~ "            Shape::Circle(circle) => circle.circumference(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-#~ msgstr ""
-#~ "Impl-Form {\n"
-#~ "    pub fn perimeter(&self) -> f64 {\n"
-#~ "        mit sich selbst übereinstimmen {\n"
-#~ "            Shape::Polygon(poly) => poly.length(),\n"
-#~ "            Form::Kreis(Kreis) => Kreis.Umfang(),\n"
-#~ "        }\n"
-#~ "    }\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid ""
-#~ "    sum % 10 == 0\n"
-#~ "}"
-#~ msgstr ""
-#~ "    Summe % 10 == 0\n"
-#~ "}"
-
-#, fuzzy
-#~ msgid "// ANCHOR_END: setup"
-#~ msgstr "// ANCHOR_END: Einrichtung"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Window-width\n"
-#~ "impl Widget for Window {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        // ANCHOR_END: Window-width\n"
-#~ "        std::cmp::max(\n"
-#~ "            self.title.chars().count(),\n"
-#~ "            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-#~ "        )\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ANCHOR: Fensterbreite\n"
-#~ "impl-Widget für Fenster {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        // ANCHOR_END: Fensterbreite\n"
-#~ "        std::cmp::max(\n"
-#~ "            self.title.chars().count(),\n"
-#~ "            self.widgets.iter().map(|w| w.width()).max().unwrap_or(0),\n"
-#~ "        )\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Button-width\n"
-#~ "impl Widget for Button {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        // ANCHOR_END: Button-width\n"
-#~ "        self.label.width() + 8 // add a bit of padding\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ANCHOR: Button-Breite\n"
-#~ "impl-Widget für Schaltfläche {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        // ANCHOR_END: Button-Breite\n"
-#~ "        self.label.width() + 8 // etwas Polsterung hinzufügen\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "// ANCHOR: Label-width\n"
-#~ "impl Widget for Label {\n"
-#~ "    fn width(&self) -> usize {\n"
-#~ "        // ANCHOR_END: Label-width\n"
-#~ "        self.label\n"
-#~ "            .lines()\n"
-#~ "            .map(|line| line.chars().count())\n"
-#~ "            .max()\n"
-#~ "            .unwrap_or(0)\n"
-#~ "    }"
-#~ msgstr ""
-#~ "// ANCHOR: Etikettenbreite\n"
-#~ "impl-Widget für Label {\n"
-#~ "    fn width(&self) -> use {\n"
-#~ "        // ANCHOR_END: Etikettenbreite\n"
-#~ "        self.label\n"
-#~ "            .Linien()\n"
-#~ "            .map(|line| line.chars().count())\n"
-#~ "            .max()\n"
-#~ "            .unwrap_or(0)\n"
-#~ "    }"
-
-#, fuzzy
-#~ msgid ""
-#~ "#[derive(Debug)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    path: CString,\n"
-#~ "    dir: *mut ffi::DIR,\n"
-#~ "}\n"
-#~ "// ANCHOR_END: ffi"
-#~ msgstr ""
-#~ "#[ableiten(Debuggen)]\n"
-#~ "struct DirectoryIterator {\n"
-#~ "    Pfad: CString,\n"
-#~ "    dir: *mut ffi::DIR,\n"
-#~ "}\n"
-#~ "// ANCHOR_END: ffi"
-
-#, fuzzy
-#~ msgid ""
-#~ "struct Philosopher {\n"
-#~ "    name: String,\n"
-#~ "    // ANCHOR_END: Philosopher\n"
-#~ "    left_fork: Arc<Mutex<Fork>>,\n"
-#~ "    right_fork: Arc<Mutex<Fork>>,\n"
-#~ "    thoughts: mpsc::SyncSender<String>,\n"
-#~ "}"
-#~ msgstr ""
-#~ "struct Philosoph {\n"
-#~ "    Name: Zeichenfolge,\n"
-#~ "    // ANCHOR_END: Philosoph\n"
-#~ "    left_fork: Arc<Mutex<Fork>>,\n"
-#~ "    right_fork: Arc<Mutex<Fork>>,\n"
-#~ "    Gedanken: mpsc::SyncSender<String>,\n"
-#~ "}"


### PR DESCRIPTION
Before, po/de.po had these statistics:

    410 translated messages, 697 fuzzy translations, 674 untranslated messages.

Afterwards, the statistics for po/de.po is:

    556 translated messages, 814 fuzzy translations, 1097 untranslated messages.

The number of translated messages stayed at 23%.

With this change, it becomes important to use the latest version of mdbook-i18n-helpers when viewing the translation locally. To update to the latest version, run

    cargo install mdbook-i18n-helpers

You will now be able to serve the translation locally.

Part of #330.