### PR TITLE
Update mdbook-i18n-helpers to latest version

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
 
     - name: Install mdbook-i18n-helpers
-      run: cargo install mdbook-i18n-helpers --locked --version 0.1.0
+      run: cargo install mdbook-i18n-helpers --locked --version 0.2.2
       shell: bash
 
     - name: Install exerciser


### PR DESCRIPTION
I have created PRs to normalize all PO files to the new version of mdbook-i18n-helpers. Simultaneously, we need to update the version used to publish the course.

This is indirectly part of #330.