### PR TITLE
Update deep-dive titles in course structure

### DIFF
--- a/src/running-the-course/course-structure.md
+++ b/src/running-the-course/course-structure.md
@@ -15,7 +15,7 @@ specialized topics:
 
 ### Android
 
-The [Android Deep Dive](../android.md) is a half-day course on using Rust for
+The [Rust in Android](../android.md) deep dive is a half-day course on using Rust for
 Android platform development. This includes interoperability with C, C++, and
 Java.
 
@@ -33,7 +33,7 @@ commands it runs and make sure they work when you run them by hand.
 
 ### Bare-Metal
 
-The [Bare-Metal Deep Dive](../bare-metal.md): a full day class on using Rust for
+The [Bare-Metal Rust](../bare-metal.md) deep dive is a full day class on using Rust for
 bare-metal (embedded) development. Both microcontrollers and application
 processors are covered.
 
@@ -44,7 +44,7 @@ page](../bare-metal.md).
 
 ### Concurrency
 
-The [Concurrency Deep Dive](../concurrency.md) is a full day class on classical
+The [Concurrency in Rust](../concurrency.md) deep dive is a full day class on classical
 as well as `async`/`await` concurrency.
 
 You will need a fresh crate set up and the dependencies downloaded and ready to

--- a/src/running-the-course/course-structure.md
+++ b/src/running-the-course/course-structure.md
@@ -13,7 +13,7 @@ The course is fast paced and covers a lot of ground:
 In addition to the 3-day class on Rust Fundamentals, we cover some more
 specialized topics:
 
-### Android
+### Rust in Android
 
 The [Rust in Android](../android.md) deep dive is a half-day course on using Rust for
 Android platform development. This includes interoperability with C, C++, and
@@ -31,7 +31,7 @@ commands it runs and make sure they work when you run them by hand.
 [1]: https://source.android.com/docs/setup/download/downloading
 [2]: https://github.com/google/comprehensive-rust
 
-### Bare-Metal
+### Bare-Metal Rust
 
 The [Bare-Metal Rust](../bare-metal.md) deep dive is a full day class on using Rust for
 bare-metal (embedded) development. Both microcontrollers and application
@@ -42,7 +42,7 @@ micro:bit](https://microbit.org/) v2 development board ahead of time. Everybody
 will need to install a number of packages as described on the [welcome
 page](../bare-metal.md).
 
-### Concurrency
+### Concurrency in Rust
 
 The [Concurrency in Rust](../concurrency.md) deep dive is a full day class on classical
 as well as `async`/`await` concurrency.


### PR DESCRIPTION
I'm trying to align on these names for the additional material:

- Rust in Android
- Bare-Metal Rust
- Concurrency in Rust

It's not perfectly reflected everywhere, but this brings us a bit closer to that.