### PR TITLE
Insert `<link rel="canonical">` elements

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -142,6 +142,33 @@
             }
         </script>
 
+        {{! Move to template code after fixing this issue:
+            https://github.com/google/mdbook-i18n-helpers/issues/70 }}
+        <script>
+          (function () {
+              // See these pages for details:
+              // https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+              // https://developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics
+              let base = "https://google.github.io/comprehensive-rust";
+              {{#if (eq language "en")}}
+              let canonical_href = `${base}/{{ path }}`;
+              {{else}}
+              let canonical_href = `${base}/{{ language }}/{{ path }}`;
+              {{/if}}
+
+              // mdbook gives us a string ending in ".md", we replace it with ".html":
+              canonical_href = canonical_href.slice(0, -"md".length) + "html";
+              if (canonical_href.endsWith("/index.html")) {
+                  canonical_href = canonical_href.slice(0, -"index.html".length);
+              }
+
+              let link = document.createElement("link");
+              link.rel = "canonical";
+              link.href = canonical_href;
+              document.head.appendChild(link);
+          })()
+        </script>
+
         <div id="page-wrapper" class="page-wrapper">
 
             <div class="page">


### PR DESCRIPTION
This prevents duplicate search results in case copies of the material is being left visible on the web. See the [Search Central documentation](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) for details.

The implementation here is very simple and should go away when https://github.com/google/mdbook-i18n-helpers/issues/70 is implemented.