### PR TITLE
Add a link back to the canonical home

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -8,6 +8,10 @@ This is a free Rust course developed by the Android team at Google. The course c
 the full spectrum of Rust, from basic syntax to advanced topics like generics
 and error handling.
 
+> The latest version of the course can be found at
+> <https://google.github.io/comprehensive-rust/>. If you are reading
+> somewhere else, please check there for updates.
+
 The goal of the course is to teach you Rust. We assume you don't know anything
 about Rust and hope to:
 


### PR DESCRIPTION
This is a follow-up to #1140 to further ensure that people can find the canonical home for the course.