### PR TITLE
Bump proc-macro2 from 1.0.50 to 1.0.66 in /src/bare-metal/microcontro…

### DIFF
--- a/src/bare-metal/microcontrollers/examples/Cargo.lock
+++ b/src/bare-metal/microcontrollers/examples/Cargo.lock
@@ -257,9 +257,9 @@ checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
…llers/examples

The proc-macro2 dependency at 1.0.50 results in a build error mentioning an unknown feature `proc_macro_span_shrink` that no longer exists in nightly. Per https://github.com/rust-lang/rust/issues/113152, updating proc-macro2 to the latest version fixes the error.

The build error I saw before updating the proc-macro2 dependency was the following:

```
> cargo build --bin minimal
   Compiling proc-macro2 v1.0.50
   Compiling bare-metal v0.2.5
   Compiling typenum v1.16.0
   Compiling nrf52833-hal v0.14.1
error[E0635]: unknown feature `proc_macro_span_shrink`
  --> /home/chcl/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.50/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^

   Compiling cortex-m v0.7.7
For more information about this error, try `rustc --explain E0635`.
error: could not compile `proc-macro2` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```