### PR TITLE
Add test case for invalid non digit cc number

### DIFF
--- a/src/exercises/day-1/luhn.rs
+++ b/src/exercises/day-1/luhn.rs
@@ -51,6 +51,7 @@ fn main() {
 #[test]
 fn test_non_digit_cc_number() {
     assert!(!luhn("foo"));
+    assert!(!luhn("foo 0 0"));
 }
 
 #[test]


### PR DESCRIPTION
Adding this test case to handle case where we have non-numeric cc number along with a valid cc number. This is discovered when we filter with is_numeric() instead of !is_whitespace() all test case does pass. To handle such scenario adding this test case.