### PR TITLE
Corrected Luhn's Algorithm Step 3

### DIFF
--- a/src/exercises/day-1/luhn.md
+++ b/src/exercises/day-1/luhn.md
@@ -9,8 +9,8 @@ following to validate the credit card number:
 * Moving from **right to left**, double every second digit: for the number `1234`,
   we double `3` and `1`. For the number `98765`, we double `6` and `8`.
 
-* After doubling a digit, sum the digits. So doubling `7` becomes `14` which
-  becomes `5`.
+* After doubling a digit, sum the digits if the result is greater than 9. So doubling `7` becomes `14` which
+  becomes `1 + 4 = 5`.
 
 * Sum all the undoubled and doubled digits.
 


### PR DESCRIPTION
In the exercise guideline for the Luhn's algorithm (Day 1, Afternoon exercise), I made a correction to step 3 to provide a more accurate explanation. Instead of stating that doubling 7 becomes 14, I clarified that doubling 7 results in 14, and we should sum the individual digits of 14 to get the correct value of 5.