### PR TITLE
Trim off licenses when showing solutions

### DIFF
--- a/src/exercises/bare-metal/compass/src/main.rs
+++ b/src/exercises/bare-metal/compass/src/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: top
 #![no_main]
 #![no_std]

--- a/src/exercises/bare-metal/rtc/src/main.rs
+++ b/src/exercises/bare-metal/rtc/src/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: top
 #![no_main]
 #![no_std]

--- a/src/exercises/bare-metal/rtc/src/pl031.rs
+++ b/src/exercises/bare-metal/rtc/src/pl031.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 use core::ptr::{addr_of, addr_of_mut};
 
 #[repr(C, align(4))]

--- a/src/exercises/bare-metal/solutions-afternoon.md
+++ b/src/exercises/bare-metal/solutions-afternoon.md
@@ -7,11 +7,11 @@
 `main.rs`:
 
 ```rust,compile_fail
-{{#include rtc/src/main.rs}}
+{{#include rtc/src/main.rs:solution}}
 ```
 
 `pl031.rs`:
 
 ```rust
-{{#include rtc/src/pl031.rs}}
+{{#include rtc/src/pl031.rs:solution}}
 ```

--- a/src/exercises/bare-metal/solutions-morning.md
+++ b/src/exercises/bare-metal/solutions-morning.md
@@ -5,5 +5,5 @@
 ([back to exercise](compass.md))
 
 ```rust,compile_fail
-{{#include compass/src/main.rs}}
+{{#include compass/src/main.rs:solution}}
 ```

--- a/src/exercises/concurrency/chat-async/src/bin/client.rs
+++ b/src/exercises/concurrency/chat-async/src/bin/client.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: setup
 use futures_util::stream::StreamExt;
 use futures_util::SinkExt;

--- a/src/exercises/concurrency/chat-async/src/bin/server.rs
+++ b/src/exercises/concurrency/chat-async/src/bin/server.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: setup
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;

--- a/src/exercises/concurrency/dining-philosophers-async.rs
+++ b/src/exercises/concurrency/dining-philosophers-async.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: Philosopher
 use std::sync::Arc;
 use tokio::time;

--- a/src/exercises/concurrency/dining-philosophers.rs
+++ b/src/exercises/concurrency/dining-philosophers.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: Philosopher
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;

--- a/src/exercises/concurrency/link-checker.rs
+++ b/src/exercises/concurrency/link-checker.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 use std::{sync::Arc, sync::Mutex, sync::mpsc, thread};
 
 // ANCHOR: setup

--- a/src/exercises/concurrency/solutions-afternoon.md
+++ b/src/exercises/concurrency/solutions-afternoon.md
@@ -5,7 +5,7 @@
 ([back to exercise](dining-philosophers-async.md))
 
 ```rust,compile_fail
-{{#include dining-philosophers-async.rs}}
+{{#include dining-philosophers-async.rs:solution}}
 ```
 
 ## Broadcast Chat Application
@@ -15,12 +15,12 @@
 `src/bin/server.rs`:
 
 ```rust,compile_fail
-{{#include chat-async/src/bin/server.rs}}
+{{#include chat-async/src/bin/server.rs:solution}}
 ```
 
 `src/bin/client.rs`:
 
 ```rust,compile_fail
-{{#include chat-async/src/bin/client.rs}}
+{{#include chat-async/src/bin/client.rs:solution}}
 ```
 

--- a/src/exercises/concurrency/solutions-morning.md
+++ b/src/exercises/concurrency/solutions-morning.md
@@ -5,7 +5,7 @@
 ([back to exercise](dining-philosophers.md))
 
 ```rust
-{{#include dining-philosophers.rs}}
+{{#include dining-philosophers.rs:solution}}
 ```
 
 ## Link Checker
@@ -13,5 +13,5 @@
 ([back to exercise](link-checker.md))
 
 ```rust,compile_fail
-{{#include link-checker.rs}}
+{{#include link-checker.rs:solution}}
 ```

--- a/src/exercises/day-1/for-loops.rs
+++ b/src/exercises/day-1/for-loops.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: transpose
 fn transpose(matrix: [[i32; 3]; 3]) -> [[i32; 3]; 3] {
     // ANCHOR_END: transpose

--- a/src/exercises/day-1/luhn.rs
+++ b/src/exercises/day-1/luhn.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: luhn
 pub fn luhn(cc_number: &str) -> bool {
     // ANCHOR_END: luhn

--- a/src/exercises/day-1/solutions-afternoon.md
+++ b/src/exercises/day-1/solutions-afternoon.md
@@ -5,7 +5,7 @@
 ([back to exercise](luhn.md))
 
 ```rust
-{{#include luhn.rs}}
+{{#include luhn.rs:solution}}
 ```
 
 ## Pattern matching

--- a/src/exercises/day-1/solutions-morning.md
+++ b/src/exercises/day-1/solutions-morning.md
@@ -5,7 +5,7 @@
 ([back to exercise](for-loops.md))
 
 ```rust
-{{#include for-loops.rs}}
+{{#include for-loops.rs:solution}}
 ```
 ### Bonus question
 

--- a/src/exercises/day-2/book-library.rs
+++ b/src/exercises/day-2/book-library.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: setup
 struct Library {
     books: Vec<Book>,

--- a/src/exercises/day-2/solutions-afternoon.md
+++ b/src/exercises/day-2/solutions-afternoon.md
@@ -5,5 +5,5 @@
 ([back to exercise](strings-iterators.md))
 
 ```rust
-{{#include strings-iterators.rs}}
+{{#include strings-iterators.rs:solution}}
 ```

--- a/src/exercises/day-2/solutions-morning.md
+++ b/src/exercises/day-2/solutions-morning.md
@@ -5,5 +5,5 @@
 ([back to exercise](book-library.md))
 
 ```rust
-{{#include book-library.rs}}
+{{#include book-library.rs:solution}}
 ```

--- a/src/exercises/day-2/strings-iterators.rs
+++ b/src/exercises/day-2/strings-iterators.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: prefix_matches
 pub fn prefix_matches(prefix: &str, request_path: &str) -> bool {
     // ANCHOR_END: prefix_matches

--- a/src/exercises/day-3/points-polygons.rs
+++ b/src/exercises/day-3/points-polygons.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 // ANCHOR: Point
 pub struct Point {

--- a/src/exercises/day-3/safe-ffi-wrapper.rs
+++ b/src/exercises/day-3/safe-ffi-wrapper.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: ffi
 mod ffi {
     use std::os::raw::{c_char, c_int};

--- a/src/exercises/day-3/simple-gui.rs
+++ b/src/exercises/day-3/simple-gui.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ANCHOR: solution
 // ANCHOR: setup
 pub trait Widget {
     /// Natural width of `self`.

--- a/src/exercises/day-3/solutions-afternoon.md
+++ b/src/exercises/day-3/solutions-afternoon.md
@@ -5,5 +5,5 @@
 ([back to exercise](safe-ffi-wrapper.md))
 
 ```rust
-{{#include safe-ffi-wrapper.rs}}
+{{#include safe-ffi-wrapper.rs:solution}}
 ```

--- a/src/exercises/day-3/solutions-morning.md
+++ b/src/exercises/day-3/solutions-morning.md
@@ -5,7 +5,7 @@
 ([back to exercise](simple-gui.md))
 
 ```rust
-{{#include simple-gui.rs}}
+{{#include simple-gui.rs:solution}}
 ```
 
 ## Points and Polygons
@@ -13,5 +13,5 @@
 ([back to exercise](points-polygons.md))
 
 ```rust
-{{#include points-polygons.rs}}
+{{#include points-polygons.rs:solution}}
 ```

--- a/src/exercises/solutions.md
+++ b/src/exercises/solutions.md
@@ -5,8 +5,3 @@ You will find solutions to the exercises on the following pages.
 Feel free to ask questions about the solutions [on
 GitHub](https://github.com/google/comprehensive-rust/discussions). Let us know
 if you have a different or better solution than what is presented here.
-
-
-> **Note:** Please ignore the `// ANCHOR: label` and `// ANCHOR_END: label`
-> comments you see in the solutions. They are there to make it possible to
-> re-use parts of the solutions as the exercises.


### PR DESCRIPTION
The licenses end up in the PO files, causing extra unnecessary for work our translators. We save about 300 lines from each PO file with this.

This also solves another small problem: when a file is included with an anchor, other anchors are automatically stripped away. This removes some confusing `// ANCHOR: foo` and `// ANCHOR_END: foo` lines in the solutions.