### PR TITLE
Replace `binary_search` example with `try_into`

### DIFF
--- a/src/std/option-result.md
+++ b/src/std/option-result.md
@@ -8,7 +8,7 @@ fn main() {
     let first: Option<&i8> = numbers.first();
     println!("first: {first:?}");
 
-    let arr: Result<[i8, 3], Vec<i8>> = numbers.try_into();
+    let arr: Result<[i8; 3], Vec<i8>> = numbers.try_into();
     println!("arr: {arr:?}");
 }
 ```

--- a/src/std/option-result.md
+++ b/src/std/option-result.md
@@ -8,8 +8,8 @@ fn main() {
     let first: Option<&i8> = numbers.first();
     println!("first: {first:?}");
 
-    let idx: Result<usize, usize> = numbers.binary_search(&10);
-    println!("idx: {idx:?}");
+    let arr: Result<[i8, 3], Vec<i8>> = numbers.try_into();
+    println!("arr: {arr:?}");
 }
 ```
 
@@ -18,8 +18,8 @@ fn main() {
 * `Option` and `Result` are widely used not just in the standard library.
 * `Option<&T>` has zero space overhead compared to `&T`.
 * `Result` is the standard type to implement error handling as we will see on Day 3.
-* `binary_search` returns `Result<usize, usize>`.
-  * If found, `Result::Ok` holds the index where the element is found.
-  * Otherwise, `Result::Err` contains the index where such an element should be inserted.
+* `try_into` attempts to convert the vector into a fixed-sized array. This can fail:
+  * If the vector has the right size, `Result::Ok` is returned with the array.
+  * Otherwise, `Result::Err` is returend with the original vector.
 
 </details>

--- a/src/std/option-result.md
+++ b/src/std/option-result.md
@@ -20,6 +20,6 @@ fn main() {
 * `Result` is the standard type to implement error handling as we will see on Day 3.
 * `try_into` attempts to convert the vector into a fixed-sized array. This can fail:
   * If the vector has the right size, `Result::Ok` is returned with the array.
-  * Otherwise, `Result::Err` is returend with the original vector.
+  * Otherwise, `Result::Err` is returned with the original vector.
 
 </details>


### PR DESCRIPTION
I don't think `binary_search` is the best example of using `Result` — it should actually use an `Either` type instead.