### PR TITLE
fr: removing references to Rust (as in... "iron oxide", "rouille" in French)

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -209,9 +209,8 @@ msgid "Enum Sizes"
 msgstr "Tailles d'énumération"
 
 #: src/SUMMARY.md:60 src/control-flow/novel.md:1
-#, fuzzy
 msgid "Novel Control Flow"
-msgstr "Flux de contrôle"
+msgstr "Nouvelles structures de contrôle"
 
 #: src/SUMMARY.md:61
 msgid "if let expressions"
@@ -251,9 +250,8 @@ msgid "Luhn Algorithm"
 msgstr "Algorithme de Luhn"
 
 #: src/SUMMARY.md:73
-#, fuzzy
 msgid "Pattern Matching (TBD)"
-msgstr "filtrage par motif"
+msgstr "Filtrage par motif"
 
 #: src/SUMMARY.md:75
 msgid "Day 2: Morning"
@@ -353,9 +351,8 @@ msgid "Example"
 msgstr "Exemple"
 
 #: src/SUMMARY.md:106 src/exercises/day-2/book-library.md:1
-#, fuzzy
 msgid "Storing Books"
-msgstr "String"
+msgstr "Stockage des livres"
 
 #: src/SUMMARY.md:107 src/exercises/day-2/health-statistics.md:1
 msgid "Health Statistics"
@@ -805,12 +802,11 @@ msgstr "Pilote"
 
 #: src/SUMMARY.md:247 src/SUMMARY.md:249
 msgid "Using It"
-msgstr "En l'utilisant"
+msgstr "Utilisation"
 
 #: src/SUMMARY.md:250 src/bare-metal/aps/exceptions.md:1
-#, fuzzy
 msgid "Exceptions"
-msgstr "Fonctions"
+msgstr "Exceptions"
 
 #: src/SUMMARY.md:252
 msgid "Useful Crates"
@@ -907,7 +903,6 @@ msgid "Multi-threaded Link Checker"
 msgstr "Vérificateur de liens à plusieurs threads"
 
 #: src/SUMMARY.md:286
-#, fuzzy
 msgid "Concurrency: Afternoon"
 msgstr "Concurrence : Après-midi"
 
@@ -917,10 +912,9 @@ msgstr ""
 
 #: src/SUMMARY.md:289
 msgid "async/await"
-msgstr ""
+msgstr "async/await"
 
 #: src/SUMMARY.md:290 src/async/futures.md:1
-#, fuzzy
 msgid "Futures"
 msgstr "Fermetures"
 
@@ -931,7 +925,7 @@ msgstr "Garanties d'exécution"
 
 #: src/SUMMARY.md:292 src/async/runtimes/tokio.md:1
 msgid "Tokio"
-msgstr ""
+msgstr "Tokio"
 
 #: src/SUMMARY.md:293 src/exercises/concurrency/link-checker.md:126
 #: src/async/tasks.md:1 src/exercises/concurrency/chat-app.md:140
@@ -947,9 +941,8 @@ msgid "Join"
 msgstr ""
 
 #: src/SUMMARY.md:297 src/async/control-flow/select.md:1
-#, fuzzy
 msgid "Select"
-msgstr "Installation"
+msgstr "Select"
 
 #: src/SUMMARY.md:298
 msgid "Pitfalls"
@@ -964,14 +957,12 @@ msgid "Pin"
 msgstr ""
 
 #: src/SUMMARY.md:301 src/async/pitfalls/async-traits.md:1
-#, fuzzy
 msgid "Async Traits"
 msgstr "Traits asynchrones"
 
 #: src/SUMMARY.md:302 src/async/pitfalls/cancellation.md:1
-#, fuzzy
 msgid "Cancellation"
-msgstr "Traductions"
+msgstr "Annulation"
 
 #: src/SUMMARY.md:305 src/exercises/concurrency/chat-app.md:1
 #: src/exercises/concurrency/solutions-afternoon.md:119
@@ -1344,9 +1335,8 @@ msgstr ""
 "discussions/100) !"
 
 #: src/running-the-course/course-structure.md:5
-#, fuzzy
 msgid "Rust Fundamentals"
-msgstr "Binaires de rouille"
+msgstr "Fondations de Rust"
 
 #: src/running-the-course/course-structure.md:7
 msgid ""
@@ -2792,14 +2782,13 @@ msgstr ""
 "_actionnable_ feedback, prêt à copier-coller dans votre code."
 
 #: src/why-rust/modern.md:37
-#, fuzzy
 msgid ""
 "The Rust standard library is small compared to languages like Java, Python, "
 "and Go. Rust does not come with several things you might consider standard "
 "and essential:"
 msgstr ""
-"La bibliothèque standard Rust est petite comparée à des langages comme Java, "
-"Python, et aller. La rouille ne vient pas avec plusieurs choses que vous "
+"La bibliothèque standard de Rust est petite comparée à des langages comme Java, "
+"Python, et Go. Rust n'est pas distribue avec plusieures choses que vous "
 "pourriez considérer comme standard et essentiel:"
 
 #: src/why-rust/modern.md:41
@@ -3447,7 +3436,7 @@ msgstr ""
 #: src/basic-syntax/string-slices.md:20
 #, fuzzy
 msgid "Rust terminology:"
-msgstr "Terminologie de la rouille :"
+msgstr "Terminologie de la Rust :"
 
 #: src/basic-syntax/string-slices.md:22
 #, fuzzy
@@ -5109,13 +5098,12 @@ msgstr ""
 "ligne ne peut pas implémenter de traits, par exemple."
 
 #: src/enums/sizes.md:3
-#, fuzzy
 msgid ""
 "Rust enums are packed tightly, taking constraints due to alignment into "
 "account:"
 msgstr ""
-"Les énumérations de rouille sont emballées étroitement, en tenant compte des "
-"contraintes dues à l'alignement :"
+"Les énumérations de Rust sont emballés étroitement, en tenant compte des "
+"contraintes d'alignement :"
 
 #: src/enums/sizes.md:5
 msgid ""
@@ -5370,13 +5358,12 @@ msgstr ""
 #: src/control-flow/if-let-expressions.md:18
 #: src/control-flow/while-let-expressions.md:21
 #: src/control-flow/match-expressions.md:23
-#, fuzzy
 msgid ""
 "See [pattern matching](../pattern-matching.md) for more details on patterns "
 "in Rust."
 msgstr ""
-"Voir [pattern matching](../pattern-matching.md) pour plus de détails sur les "
-"modèles dans Rouiller."
+"Voir [Filtrage par motif](../pattern-matching.md) pour plus de détails sur les "
+"motifs avec Rust."
 
 #: src/control-flow/if-let-expressions.md:23
 msgid ""
@@ -12284,13 +12271,12 @@ msgstr ""
 "préalables ne sont pas respectées."
 
 #: src/unsafe.md:8
-#, fuzzy
 msgid ""
 "We will be seeing mostly safe Rust in this course, but it's important to "
 "know what Unsafe Rust is."
 msgstr ""
 "Nous verrons principalement Rust sûr dans ce cours, mais il est important de "
-"savoir ce qu'est la rouille dangereuse."
+"savoir ce qu'est Rust non securisé (_unsafe_)."
 
 #: src/unsafe.md:11
 #, fuzzy
@@ -13062,7 +13048,6 @@ msgstr ""
 "existantes."
 
 #: src/android.md:7
-#, fuzzy
 msgid ""
 "We will attempt to call Rust from one of your own projects today. So try to "
 "find a little corner of your code base where we can move some lines of code "
@@ -13070,10 +13055,10 @@ msgid ""
 "that parses some raw bytes would be ideal."
 msgstr ""
 "Nous allons essayer d'appeler Rust depuis l'un de vos propres projets "
-"aujourd'hui. Alors essayez de trouvez un petit coin de votre base de code où "
-"nous pouvons déplacer quelques lignes de code vers Rouille. Moins il y a de "
-"dépendances et de types \"exotiques\", mieux c'est. Quelque chose que "
-"analyser quelques octets bruts serait idéal."
+"aujourd'hui. Alors essayez de trouvez un petit coin de votre code où "
+"nous pouvons déplacer quelques lignes de code vers Rust. Le moins il y a de "
+"dépendances et de types \"exotiques\", le mieux c'est. Quelque chose qui "
+"analyse quelques octets bruts serait idéal."
 
 #: src/android/setup.md:3
 #, fuzzy
@@ -13171,7 +13156,7 @@ msgstr ""
 #: src/android/build-rules.md:11
 #, fuzzy
 msgid "`rust_test`"
-msgstr "`test_rouille`"
+msgstr "`rust_test`"
 
 #: src/android/build-rules.md:11
 #, fuzzy
@@ -13223,9 +13208,8 @@ msgid "We will look at `rust_binary` and `rust_library` next."
 msgstr "Nous examinerons ensuite `rust_binary` et `rust_library`."
 
 #: src/android/build-rules/binary.md:1
-#, fuzzy
 msgid "Rust Binaries"
-msgstr "Binaires de rouille"
+msgstr "Binaires Rust"
 
 #: src/android/build-rules/binary.md:3
 #, fuzzy
@@ -13291,9 +13275,8 @@ msgid ""
 msgstr ""
 
 #: src/android/build-rules/library.md:1
-#, fuzzy
 msgid "Rust Libraries"
-msgstr "Bibliothèques de rouille"
+msgstr "Bibliothèques Rust"
 
 #: src/android/build-rules/library.md:3
 #, fuzzy
@@ -13319,8 +13302,8 @@ msgid ""
 "(https://cs.android.com/android/platform/superproject/+/master:external/rust/"
 "crates/)."
 msgstr ""
-"`libtextwrap`, qui est une caisse déjà vendue dans \\[`externe/rouille/"
-"caisses/`\\]\\[caisses\\]."
+"`libtextwrap`, qui est une caisse déjà disponible dans \\[`external/rust/"
+"crates/`\\]\\[crates\\]."
 
 #: src/android/build-rules/library.md:15
 msgid ""
@@ -14252,9 +14235,8 @@ msgid ""
 msgstr ""
 
 #: src/android/interoperability/with-c/rust.md:62
-#, fuzzy
 msgid "_interoperability/rust/analyze/Android.bp_"
-msgstr "_interopérabilité/rouille/analyse/Android.bp_"
+msgstr "_interoperability/rust/analyze/Android.bp_"
 
 #: src/android/interoperability/with-c/rust.md:64
 msgid ""
@@ -19822,7 +19804,7 @@ msgstr ""
 #: src/exercises/concurrency/morning.md:5
 #, fuzzy
 msgid "Dining philosophers: a classic problem in concurrency."
-msgstr "Dîner philosophes : un problème classique de la concurrence."
+msgstr "Dîner des philosophes : un problème classique de la concurrence."
 
 #: src/exercises/concurrency/morning.md:7
 #, fuzzy
@@ -19838,7 +19820,7 @@ msgstr ""
 #, fuzzy
 msgid "The dining philosophers problem is a classic problem in concurrency:"
 msgstr ""
-"Le problème des philosophes de la restauration est un problème classique en "
+"Le problème du dîner des philosophes est un problème classique en "
 "concurrence :"
 
 #: src/exercises/concurrency/dining-philosophers.md:5
@@ -21281,7 +21263,7 @@ msgstr ""
 #: src/exercises/concurrency/solutions-afternoon.md:3
 #, fuzzy
 msgid "Dining Philosophers - Async"
-msgstr "Philosophes de la restauration"
+msgstr "Dîner des philosophes - Asynchrone"
 
 #: src/exercises/concurrency/dining-philosophers-async.md:3
 msgid ""
@@ -21460,9 +21442,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/concurrency/chat-app.md:46
-#, fuzzy
 msgid "Two binaries"
-msgstr "Binaires de rouille"
+msgstr "Deux binaires"
 
 #: src/exercises/concurrency/chat-app.md:48
 msgid ""
@@ -21642,9 +21623,8 @@ msgstr ""
 "d'avoir de tes nouvelles."
 
 #: src/other-resources.md:1
-#, fuzzy
 msgid "Other Rust Resources"
-msgstr "Autres ressources de rouille"
+msgstr "Autres ressources Rust"
 
 #: src/other-resources.md:3
 #, fuzzy
@@ -21679,7 +21659,6 @@ msgstr ""
 "peu de projets à construire."
 
 #: src/other-resources.md:13
-#, fuzzy
 msgid ""
 "[Rust By Example](https://doc.rust-lang.org/rust-by-example/): covers the "
 "Rust syntax via a series of examples which showcase different constructs. "
@@ -21687,9 +21666,9 @@ msgid ""
 "in the examples."
 msgstr ""
 "[Rust By Example](https://doc.rust-lang.org/rust-by-example/) : couvre la "
-"rouille syntaxe via une série d'exemples qui présentent différentes "
+"syntaxe de Rust via une série d'exemples qui présentent différentes "
 "constructions. Parfois comprend de petits exercices où l'on vous demande de "
-"développer le code dans le exemples."
+"développer le code de l'exemple."
 
 #: src/other-resources.md:17
 #, fuzzy
@@ -21715,26 +21694,24 @@ msgid "More specialized guides hosted on the official Rust site:"
 msgstr "Des guides plus spécialisés hébergés sur le site officiel de Rust :"
 
 #: src/other-resources.md:24
-#, fuzzy
 msgid ""
 "[The Rustonomicon](https://doc.rust-lang.org/nomicon/): covers unsafe Rust, "
 "including working with raw pointers and interfacing with other languages "
 "(FFI)."
 msgstr ""
-"[The Rustonomicon](https://doc.rust-lang.org/nomicon/) : couvre la rouille "
-"dangereuse, y compris le travail avec des pointeurs bruts et l'interfaçage "
+"[The Rustonomicon](https://doc.rust-lang.org/nomicon/) : couvre le Rust non "
+"securisé (_unsafe_), y compris les pointeurs nus et l'interfaçage "
 "avec d'autres langages (FFI)."
 
 #: src/other-resources.md:27
-#, fuzzy
 msgid ""
 "[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/): "
 "covers the new asynchronous programming model which was introduced after the "
 "Rust Book was written."
 msgstr ""
-"[Programmation asynchrone dans Rust](https://rust-lang.github.io/async-"
+"[Programmation asynchrone avec Rust](https://rust-lang.github.io/async-"
 "book/) : couvre le nouveau modèle de programmation asynchrone qui a été "
-"introduit après la Rust Book a été écrit."
+"introduit après la publication du livre Rust."
 
 #: src/other-resources.md:30
 #, fuzzy
@@ -21767,14 +21744,13 @@ msgstr ""
 "Rust du point de vue des programmeurs C de bas niveau."
 
 #: src/other-resources.md:39
-#, fuzzy
 msgid ""
 "[Rust for Embedded C Programmers](https://docs.opentitan.org/doc/ug/"
 "rust_for_c/): covers Rust from the perspective of developers who write "
 "firmware in C."
 msgstr ""
-"\\[Rouille pour Embedded C Programmeurs\\] (https://docs.opentitan.org/doc/"
-"ug/rust_for_c/) : couvre Rust de le point de vue des développeurs qui "
+"\\[Rust pour Programmeurs C Embarqué\\] (https://docs.opentitan.org/doc/"
+"ug/rust_for_c/) : couvre Rust du point de vue des développeurs qui "
 "écrivent des firmwares en C."
 
 #: src/other-resources.md:42
@@ -21799,16 +21775,15 @@ msgstr ""
 "pour vous aider vous apprenez Rust."
 
 #: src/other-resources.md:47
-#, fuzzy
 msgid ""
 "[Ferrous Teaching Material](https://ferrous-systems.github.io/teaching-"
 "material/index.html): a series of small presentations covering both basic "
 "and advanced part of the Rust language. Other topics such as WebAssembly, "
 "and async/await are also covered."
 msgstr ""
-"\\[Enseignement ferreux Matériel\\] (https://ferrous-systems.github.io/"
+"\\[Matériel de Ferrous Teaching\\] (https://ferrous-systems.github.io/"
 "teaching-material/index.html) : un série de petites présentations couvrant à "
-"la fois la partie de base et avancée de la Langue de rouille. D'autres "
+"la fois la partie de base et avancée de Rust. D'autres "
 "sujets tels que WebAssembly et async/wait sont également couvert."
 
 #: src/other-resources.md:52
@@ -21871,9 +21846,8 @@ msgstr ""
 "(../LICENSE) pour plus de détails."
 
 #: src/credits.md:12
-#, fuzzy
 msgid "Rust by Example"
-msgstr "Rouille par exemple"
+msgstr "Rust by Example"
 
 #: src/credits.md:14
 #, fuzzy
@@ -21889,21 +21863,19 @@ msgstr ""
 "licence conditions."
 
 #: src/credits.md:19
-#, fuzzy
 msgid "Rust on Exercism"
-msgstr "Rouille sur l'exercice"
+msgstr "Rust sur Exercism"
 
 #: src/credits.md:21
-#, fuzzy
 msgid ""
 "Some exercises have been copied and adapted from [Rust on Exercism](https://"
 "exercism.org/tracks/rust). Please see the `third_party/rust-on-exercism/` "
 "directory for details, including the license terms."
 msgstr ""
-"Certains exercices ont été copiés et adaptés de \\[Rust on Exercice\\] "
+"Certains exercices ont été copiés et adaptés de \\[Rust on Exercism\\] "
 "(https://exercism.org/tracks/rust). Veuillez consulter le Répertoire "
-"`third_party/rust-on-exercism/` pour plus de détails, y compris la licence "
-"conditions."
+"`third_party/rust-on-exercism/` pour plus de détails, y compris les conditions "
+" de la licence."
 
 #: src/credits.md:26
 #, fuzzy
@@ -23174,9 +23146,8 @@ msgid ""
 msgstr ""
 
 #: src/exercises/bare-metal/solutions-morning.md:1
-#, fuzzy
 msgid "Bare Metal Rust Morning Exercise"
-msgstr "Exercice du matin sur la rouille du métal nu"
+msgstr "Exercice du matin avec Rust sur bare metal"
 
 #: src/exercises/bare-metal/solutions-morning.md:5
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -2788,7 +2788,7 @@ msgid ""
 "and essential:"
 msgstr ""
 "La bibliothèque standard de Rust est petite comparée à des langages comme Java, "
-"Python, et Go. Rust n'est pas distribue avec plusieures choses que vous "
+"Python, et Go. Rust n'est pas distribué avec certains éléments que vous "
 "pourriez considérer comme standard et essentiel:"
 
 #: src/why-rust/modern.md:41
@@ -3436,7 +3436,7 @@ msgstr ""
 #: src/basic-syntax/string-slices.md:20
 #, fuzzy
 msgid "Rust terminology:"
-msgstr "Terminologie de la Rust :"
+msgstr "Terminologie de Rust :"
 
 #: src/basic-syntax/string-slices.md:22
 #, fuzzy
@@ -5102,7 +5102,7 @@ msgid ""
 "Rust enums are packed tightly, taking constraints due to alignment into "
 "account:"
 msgstr ""
-"Les énumérations de Rust sont emballés étroitement, en tenant compte des "
+"Les énumérations de Rust sont emballées étroitement, en tenant compte des "
 "contraintes d'alignement :"
 
 #: src/enums/sizes.md:5
@@ -13055,10 +13055,10 @@ msgid ""
 "that parses some raw bytes would be ideal."
 msgstr ""
 "Nous allons essayer d'appeler Rust depuis l'un de vos propres projets "
-"aujourd'hui. Alors essayez de trouvez un petit coin de votre code où "
+"aujourd'hui. Alors essayez de trouver un petit coin de votre code où "
 "nous pouvons déplacer quelques lignes de code vers Rust. Le moins il y a de "
 "dépendances et de types \"exotiques\", le mieux c'est. Quelque chose qui "
-"analyse quelques octets bruts serait idéal."
+"analyse quelques octets de donnée brute serait idéal."
 
 #: src/android/setup.md:3
 #, fuzzy


### PR DESCRIPTION
Plus a few more things I saw on the way.

Related to French translation #323