### PR TITLE
Consolidate editor recommendations in main text

### DIFF
--- a/src/cargo.md
+++ b/src/cargo.md
@@ -9,24 +9,23 @@ and how it fits into this training.
 
 > **Please follow the instructions on <https://rustup.rs/>.**
 
-This will give you the Cargo build tool (`cargo`) and the Rust compiler (`rustc`). You will also get `rustup`, a command line utility that you can use to install/switch toolchains, setup cross compilation, etc.
+This will give you the Cargo build tool (`cargo`) and the Rust compiler (`rustc`). You will also get `rustup`, a command line utility that you can use to install to different compiler versions.
+
+After installing Rust, you should configure your editor or IDE to work with Rust. Most editors do this by talking to [rust-analyzer], which provides auto-completion and jump-to-definition functionality for [VS Code], [Emacs], [Vim/Neovim], and many others. There is also a different IDE available called [RustRover].
 
 <details>
 
-* On Debian/Ubuntu, you can also install Cargo, the Rust source and the [Rust formatter][6] via `apt`. However, this gets you an outdated rust version and may lead to unexpected behavior. The command would be:
+* On Debian/Ubuntu, you can also install Cargo, the Rust source and the [Rust formatter] via `apt`. However, this gets you an outdated rust version and may lead to unexpected behavior. The command would be:
 
-```shell
-sudo apt install cargo rust-src rustfmt
-```
-
-* We suggest using [VS Code][2] to edit the code (but any LSP compatible editor works with [rust-analyzer][3]).
-
-* Some folks also like to use the [JetBrains][4] family of feature-rich IDEs, which offer timely support, regular updates, and an out-of-the-box experience. If you prefer them, you can use [RustRover][5], which as of September 2023 is still available as a (free) preview. It will eventually replace the Rust plugin which can also be used in, e.g., their CLion IDE.
+    ```shell
+    sudo apt install cargo rust-src rustfmt
+    ```
 
 </details>
 
-[2]: https://code.visualstudio.com/
-[3]: https://rust-analyzer.github.io/
-[4]: https://www.jetbrains.com/
-[5]: https://www.jetbrains.com/rust/
-[6]: https://github.com/rust-lang/rustfmt
+[rust-analyzer]: https://rust-analyzer.github.io/
+[VS Code]: https://code.visualstudio.com/
+[Emacs]: https://rust-analyzer.github.io/manual.html#emacs
+[Vim/Neovim]: https://rust-analyzer.github.io/manual.html#vimneovim
+[RustRover]: https://www.jetbrains.com/rust/
+[Rust formatter]: https://github.com/rust-lang/rustfmt


### PR DESCRIPTION
This streamlines the text about editors by simply mentioning them. RustRover is mentioned last since it's new and I don't have any experience with it yet.