### PR TITLE
Revert "Update boot-library.md"

### DIFF
--- a/src/exercises/day-2/book-library.md
+++ b/src/exercises/day-2/book-library.md
@@ -47,9 +47,3 @@ Use this to model a library's book collection. Copy the code below to
 
 {{#include book-library.rs:main}}
 ```
-
-<details>
-    
-[Solution](solutions-morning.md#designing-a-library)
-
-</details>


### PR DESCRIPTION
Reverts google/comprehensive-rust#225. We normally include links at the start of each exercise blocks — but we don't include links in the individual exercises.

If we want to add such links, we should do it consistently across the entire course.