### PR TITLE
Build translations from `mdbook-i18-helpers`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,19 +41,7 @@ jobs:
         run: mdbook build -d book
 
       - name: Zip exercise templates
-        run: cd book/exerciser && zip --recurse-paths ../html/comprehensive-rust-exercises.zip comprehensive-rust-exercises/
-
-      - name: Build all translations
-        run: |
-          for po_lang in ${{ env.LANGUAGES }}; do
-              echo "::group::Building $po_lang translation"
-              MDBOOK_BOOK__LANGUAGE=$po_lang \
-              MDBOOK_OUTPUT__HTML__SITE_URL=/comprehensive-rust/$po_lang/ \
-              mdbook build -d book/$po_lang
-              (cd book/$po_lang/exerciser && zip --recurse-paths ../html/comprehensive-rust-exercises.zip comprehensive-rust-exercises/)
-              mv book/$po_lang/html book/html/$po_lang
-              echo "::endgroup::"
-          done
+        run: cd book && find . -name "exerciser" -type d -exec bash -c 'zip --recurse-paths ./html/$(dirname {})/comprehensive-rust-exercises.zip {}/comprehensive-rust-exercises/' \;
 
       - name: Setup Pages
         uses: actions/configure-pages@v2

--- a/book.toml
+++ b/book.toml
@@ -31,10 +31,10 @@ class = "bob"
 curly-quotes = true
 additional-js = ["theme/speaker-notes.js"]
 additional-css = [
-  "theme/css/svgbob.css",
-  "theme/css/speaker-notes.css",
-  "theme/css/language-picker.css",
-  "theme/css/frontmatter.css",
+    "theme/css/svgbob.css",
+    "theme/css/speaker-notes.css",
+    "theme/css/language-picker.css",
+    "theme/css/frontmatter.css",
 ]
 site-url = "/comprehensive-rust/"
 git-repository-url = "https://github.com/google/comprehensive-rust"
@@ -88,3 +88,14 @@ line-numbers = true
 
 [output.exerciser]
 output-directory = "comprehensive-rust-exercises"
+
+[output.i18n-helpers]
+default_language = "en"
+translate_all_languages = true
+move_translations_to_html_directory = true
+
+[output.i18n-helpers.languages]
+"en" = "English"
+"es" = "Spanish (Español)"
+"ko" = "Korean (한국어)"
+"pt-BR" = "Brazilian Portuguese (Português do Brasil)"


### PR DESCRIPTION
Supports `mdbook build` and `mdbook serve`. I'd recommend waiting a bit before submitting and let translators try it by manually patching this PR.