### PR TITLE
Set POT-Creation-Date field in PO files

### DIFF
--- a/po/bn.po
+++ b/po/bn.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-05\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Md. Rasel Mandol <raselm@duck.com>\n"
 "Language-Team: noob_rasel<raselm@duck.com>\n"

--- a/po/da.po
+++ b/po/da.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-24\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"

--- a/po/de.po
+++ b/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-19\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"

--- a/po/el.po
+++ b/po/el.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-08-26\n"
 "PO-Revision-Date: 2023-08-25 13:24-0700\n"
 "Last-Translator: root <andrikopoulos@google.com>\n"
 "Language-Team: Greek <team@lists.gnome.gr>\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-11\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-08-23\n"
 "PO-Revision-Date: 2023-08-08 21:41+0330\n"
 "Last-Translator: danny <danykhosravi@gmail.com>\n"
 "Language-Team: Persian\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-17\n"
 "PO-Revision-Date: 2023-09-12 14:14-0400\n"
 "Last-Translator: Olivier Charrez <olivier.charrez@hotmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"

--- a/po/id.po
+++ b/po/id.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-08-26\n"
 "PO-Revision-Date: 2023-08-25 14:03-0700\n"
 "Last-Translator: Aji Prio Sejati <ajiprio@hotmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"

--- a/po/it.po
+++ b/po/it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-19\n"
 "PO-Revision-Date: 2023-09-19 09:35+0100\n"
 "Last-Translator: Ivan De Marino <ivan.de.marino@gmail.com>\n"
 "Language-Team: \n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-24\n"
 "PO-Revision-Date: 2023-06-06 13:18+0900\n"
 "Last-Translator: Kenta Aratani <kentaaratani@coinez.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: [한국어]Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-24\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-08-26\n"
 "PO-Revision-Date: 2023-08-25 14:19-0700\n"
 "Last-Translator: Kuba Jaroszewski <jakub.jaroszewski@gmail.com>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"

--- a/po/pt-BR.po
+++ b/po/pt-BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-08-28\n"
 "PO-Revision-Date: 2023-08-25 09:32-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-08\n"
 "PO-Revision-Date: 2023-08-25 14:28-0700\n"
 "Last-Translator: Yauheni Baltukha <evgenii.boltuho@gmail.com>\n"
 "Language-Team: \n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-08-26\n"
 "PO-Revision-Date: 2023-08-25 14:48-0700\n"
 "Last-Translator: akerem@protonmail.com\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-19\n"
 "PO-Revision-Date: 2023-09-12 22:06+0000\n"
 "Last-Translator: Andrew Kushyk <akushyk@gmail.com>\n"
 "Language-Team: \n"

--- a/po/zh-CN.po
+++ b/po/zh-CN.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-09-18\n"
 "PO-Revision-Date: 2023-06-12 21:28-0700\n"
 "Last-Translator: Zhengping Jiang <zpin.jiang@gmail.com>\n"
 "Language-Team: Language zh-Hans\n"

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Comprehensive Rust 🦀\n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-08-23\n"
 "PO-Revision-Date: 2023-06-02 14:43+0800\n"
 "Last-Translator: Hank Chen <kuanhungchen@google.com>\n"
 "Language-Team: Traditional Chinese (Taiwan) <zh-l10n@lists.linux.org.tw>\n"


### PR DESCRIPTION
This updates each PO file to the date when it was last touched:

    for po_file in po/*.po; do
        POT_DATE=$(git log -1 --date=short --format=%ad $po_file)
        sed -i -e 's/"POT-Creation-Date:.*"/"POT-Creation-Date: '$POT_DATE'\\n"/' $po_file
    done

The dates will be updated with `msgmerge` in the future via https://github.com/google/mdbook-i18n-helpers/pull/87.

The dates here can be adjusted by hand if needed — the starting point here only serves as a rough anchor to let us freeze the translations from further updates. So if you know that you ran `msgmerge` most recently on a given date, please update the file to that date in a later PR.