### PR TITLE
Fix resolver setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ members = [
   "src/bare-metal/useful-crates/zerocopy-example",
   "src/exercises/concurrency/chat-async",
 ]
+resolver = "2"


### PR DESCRIPTION
Fixes: https://github.com/google/comprehensive-rust/issues/1249

Since `mdbook-exerciser` and `mdbook-course` are using Rust edition 2021, they naturally want to use the newer resolver (resolver = 2). 
<img width="571" alt="Screen Shot 2023-09-25 at 9 57 32 AM" src="https://github.com/google/comprehensive-rust/assets/38759997/50446a93-877d-408e-ab68-e88d8467f0e3">
