### PR TITLE
Italic filenames formatted accordingly

### DIFF
--- a/src/exercises/bare-metal/compass.md
+++ b/src/exercises/bare-metal/compass.md
@@ -23,7 +23,7 @@ Hints:
 Download the [exercise template](../../comprehensive-rust-exercises.zip) and look in the `compass`
 directory for the following files.
 
-`src/main.rs`:
+_src/main.rs_:
 
 <!-- File src/main.rs -->
 
@@ -40,7 +40,7 @@ use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};
 }
 ```
 
-`Cargo.toml` (you shouldn't need to change this):
+_Cargo.toml_ (you shouldn't need to change this):
 
 <!-- File Cargo.toml -->
 
@@ -48,7 +48,7 @@ use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};
 {{#include compass/Cargo.toml}}
 ```
 
-`Embed.toml` (you shouldn't need to change this):
+_Embed.toml_ (you shouldn't need to change this):
 
 <!-- File Embed.toml -->
 
@@ -56,7 +56,7 @@ use microbit::{hal::uarte::{Baudrate, Parity, Uarte}, Board};
 {{#include compass/Embed.toml}}
 ```
 
-`.cargo/config.toml` (you shouldn't need to change this):
+_.cargo/config.toml_ (you shouldn't need to change this):
 
 <!-- File .cargo/config.toml -->
 

--- a/src/exercises/bare-metal/rtc.md
+++ b/src/exercises/bare-metal/rtc.md
@@ -16,7 +16,7 @@ should write a driver for it.
 Download the [exercise template](../../comprehensive-rust-exercises.zip) and look in the `rtc`
 directory for the following files.
 
-`src/main.rs`:
+_src/main.rs_:
 
 <!-- File src/main.rs -->
 
@@ -34,7 +34,7 @@ directory for the following files.
 {{#include rtc/src/main.rs:main_end}}
 ```
 
-`src/exceptions.rs` (you should only need to change this for the 3rd part of the exercise):
+_src/exceptions.rs_ (you should only need to change this for the 3rd part of the exercise):
 
 <!-- File src/exceptions.rs -->
 
@@ -42,7 +42,7 @@ directory for the following files.
 {{#include rtc/src/exceptions.rs}}
 ```
 
-`src/logger.rs` (you shouldn't need to change this):
+_src/logger.rs_ (you shouldn't need to change this):
 
 <!-- File src/logger.rs -->
 
@@ -50,7 +50,7 @@ directory for the following files.
 {{#include rtc/src/logger.rs}}
 ```
 
-`src/pl011.rs` (you shouldn't need to change this):
+_src/pl011.rs_ (you shouldn't need to change this):
 
 <!-- File src/pl011.rs -->
 
@@ -58,7 +58,7 @@ directory for the following files.
 {{#include rtc/src/pl011.rs}}
 ```
 
-`Cargo.toml` (you shouldn't need to change this):
+_Cargo.toml_ (you shouldn't need to change this):
 
 <!-- File Cargo.toml -->
 
@@ -66,7 +66,7 @@ directory for the following files.
 {{#include rtc/Cargo.toml}}
 ```
 
-`build.rs` (you shouldn't need to change this):
+_build.rs_ (you shouldn't need to change this):
 
 <!-- File build.rs -->
 
@@ -74,7 +74,7 @@ directory for the following files.
 {{#include rtc/build.rs}}
 ```
 
-`entry.S` (you shouldn't need to change this):
+_entry.S_ (you shouldn't need to change this):
 
 <!-- File entry.S -->
 
@@ -82,7 +82,7 @@ directory for the following files.
 {{#include rtc/entry.S}}
 ```
 
-`exceptions.S` (you shouldn't need to change this):
+_exceptions.S_ (you shouldn't need to change this):
 
 <!-- File exceptions.S -->
 
@@ -90,7 +90,7 @@ directory for the following files.
 {{#include rtc/exceptions.S}}
 ```
 
-`idmap.S` (you shouldn't need to change this):
+_idmap.S_ (you shouldn't need to change this):
 
 <!-- File idmap.S -->
 
@@ -98,7 +98,7 @@ directory for the following files.
 {{#include rtc/idmap.S}}
 ```
 
-`image.ld` (you shouldn't need to change this):
+_image.ld_ (you shouldn't need to change this):
 
 <!-- File image.ld -->
 
@@ -106,7 +106,7 @@ directory for the following files.
 {{#include rtc/image.ld}}
 ```
 
-`Makefile` (you shouldn't need to change this):
+_Makefile_ (you shouldn't need to change this):
 
 <!-- File Makefile -->
 
@@ -114,7 +114,7 @@ directory for the following files.
 {{#include rtc/Makefile}}
 ```
 
-`.cargo/config.toml` (you shouldn't need to change this):
+_.cargo/config.toml_ (you shouldn't need to change this):
 
 <!-- File .cargo/config.toml -->
 

--- a/src/exercises/concurrency/chat-app.md
+++ b/src/exercises/concurrency/chat-app.md
@@ -12,7 +12,7 @@ server.
 
 Create a new Cargo project and add the following dependencies:
 
-`Cargo.toml`:
+_Cargo.toml_:
 
 <!-- File Cargo.toml -->
 
@@ -47,7 +47,7 @@ Copy the following server and client code into `src/bin/server.rs` and
 `src/bin/client.rs`, respectively. Your task is to complete these files as
 described below. 
 
-`src/bin/server.rs`:
+_src/bin/server.rs_:
 
 <!-- File src/bin/server.rs -->
 
@@ -61,7 +61,7 @@ described below.
 {{#include chat-async/src/bin/server.rs:main}}
 ```
 
-`src/bin/client.rs`:
+_src/bin/client.rs_:
 
 <!-- File src/bin/client.rs -->
 


### PR DESCRIPTION
**Task** Addresses: https://github.com/google/comprehensive-rust/issues/625
Certain pages in the mdbook that display filenames have inconsistent styling. 

The style we want to follow: [the interop section](https://google.github.io/comprehensive-rust/android/interoperability/java.html)

The current problem: [the RTC driver](https://google.github.io/comprehensive-rust/exercises/bare-metal/rtc.html) excercise page. 

--
@mgeisler I checked this feature by looking through every page

![work](https://github.com/google/comprehensive-rust/assets/38759997/8affd0c2-71f2-4708-88f6-f63cf3c24efa)