### PR TITLE
Update to mdbook-i18n-helpers 0.2.4

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
 
     - name: Install mdbook-i18n-helpers
-      run: cargo install mdbook-i18n-helpers --locked --version 0.2.3
+      run: cargo install mdbook-i18n-helpers --locked --version 0.2.4
       shell: bash
 
     - name: Install mdbook-exerciser


### PR DESCRIPTION
This is the newest release of mdbook-i18n-helpers, fully backwards compatible with the old one.