### PR TITLE
Fix inconsistent filename styling

### DIFF
--- a/src/bare-metal/microcontrollers/debugging.md
+++ b/src/bare-metal/microcontrollers/debugging.md
@@ -1,6 +1,6 @@
 # Debugging
 
-Embed.toml:
+_Embed.toml_:
 
 ```toml
 [default.general]

--- a/src/exercises/bare-metal/solutions-afternoon.md
+++ b/src/exercises/bare-metal/solutions-afternoon.md
@@ -4,13 +4,13 @@
 
 ([back to exercise](rtc.md))
 
-`main.rs`:
+_main.rs_:
 
 ```rust,compile_fail
 {{#include rtc/src/main.rs:solution}}
 ```
 
-`pl031.rs`:
+_pl031.rs_:
 
 ```rust
 {{#include rtc/src/pl031.rs:solution}}

--- a/src/exercises/concurrency/solutions-afternoon.md
+++ b/src/exercises/concurrency/solutions-afternoon.md
@@ -12,13 +12,13 @@
 
 ([back to exercise](chat-app.md))
 
-`src/bin/server.rs`:
+_src/bin/server.rs_:
 
 ```rust,compile_fail
 {{#include chat-async/src/bin/server.rs:solution}}
 ```
 
-`src/bin/client.rs`:
+_src/bin/client.rs_:
 
 ```rust,compile_fail
 {{#include chat-async/src/bin/client.rs:solution}}


### PR DESCRIPTION
Addresses https://github.com/google/comprehensive-rust/issues/625

Pages with inconsistent styling:
[Bare Metal Rust Afternoon Solutions](https://google.github.io/comprehensive-rust/exercises/bare-metal/solutions-afternoon.html)
[Concurrency Afternoon Solutions](https://google.github.io/comprehensive-rust/exercises/concurrency/solutions-afternoon.html)
[Microcontroller > Debugging Page](https://google.github.io/comprehensive-rust/bare-metal/microcontrollers/debugging.html)


