### PR TITLE
Introduce a glossary

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -310,6 +310,7 @@
 ----
 
 - [Thanks!](thanks.md)
+- [Glossary](glossary.md)
 - [Other Resources](other-resources.md)
 - [Credits](credits.md)
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,0 +1,76 @@
+# Glossary
+
+The following is a glossary which aims to give a short definition of many Rust
+terms. For translations, this also serves to connect the term back to the
+English original.
+
+<!-- Translators: please list the English term in italic after your translation.
+For Danish, this would look like this: `allokere (_allocate_)`. -->
+
+| Term                  | Notes                                                                        |
+| --------------------- | ---------------------------------------------------------------------------- |
+| allocate              | Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md). |
+| argument              |                                                                              |
+| Bare-metal Rust       | See [Bare-metal Rust](bare-metal.md).                                        |
+| block                 | See [Blocks](control-flow/blocks.md) and _scope_.                            |
+| borrow                | See [Borrowing](ownership/borrowing.md).                                     |
+| borrow checker        | The part of the Rust compiler which checks that all borrows are valid.       |
+| brace                 | `{` and `}`. Also called _curly brace_, they delimit _blocks_.               |
+| build                 |                                                                              |
+| call                  |                                                                              |
+| channel               | Used to safely pass messages [between threads](concurrency/channels.md).     |
+| Comprehensive Rust 🦀 | The courses here are jointly called Comprehensive Rust 🦀.                   |
+| concurrency           |                                                                              |
+| Concurrency in Rust   | See [Concurrency in Rust](concurrency.md).                                   |
+| constant              |                                                                              |
+| control flow          |                                                                              |
+| crash                 |                                                                              |
+| enumeration           |                                                                              |
+| error                 |                                                                              |
+| error handling        |                                                                              |
+| exercise              |                                                                              |
+| function              |                                                                              |
+| garbage collector     |                                                                              |
+| generics              |                                                                              |
+| immutable             |                                                                              |
+| integration test      |                                                                              |
+| keyword               |                                                                              |
+| library               |                                                                              |
+| macro                 |                                                                              |
+| main function         |                                                                              |
+| match                 |                                                                              |
+| memory leak           |                                                                              |
+| method                |                                                                              |
+| module                |                                                                              |
+| move                  |                                                                              |
+| mutable               |                                                                              |
+| ownership             |                                                                              |
+| panic                 |                                                                              |
+| parameter             |                                                                              |
+| pattern               |                                                                              |
+| payload               |                                                                              |
+| program               |                                                                              |
+| programming language  |                                                                              |
+| receiver              |                                                                              |
+| reference counting    |                                                                              |
+| return                |                                                                              |
+| Rust                  |                                                                              |
+| Rust Fundamentals     | Days 1 to 3 of this course.                                                  |
+| Rust in Android       | See [Rust in Android](android.md).                                           |
+| safe                  |                                                                              |
+| scope                 |                                                                              |
+| standard library      |                                                                              |
+| static                |                                                                              |
+| string                |                                                                              |
+| struct                |                                                                              |
+| test                  |                                                                              |
+| thread                |                                                                              |
+| thread safety         |                                                                              |
+| trait                 |                                                                              |
+| type                  |                                                                              |
+| type inference        |                                                                              |
+| undefined behavior    |                                                                              |
+| union                 |                                                                              |
+| unit test             |                                                                              |
+| unsafe                |                                                                              |
+| variable              |                                                                              |


### PR DESCRIPTION
The goal of this is twofold: give translators a place to document how certain terms are translated as well as giving people a place to quickly find a definition of a term. The slides might not always give a quick definition the same way a glossary can.