### PR TITLE
Fix typo (missing s on threads)

### DIFF
--- a/src/concurrency/send-sync.md
+++ b/src/concurrency/send-sync.md
@@ -1,6 +1,6 @@
 # `Send` and `Sync`
 
-How does Rust know to forbid shared access across thread? The answer is in two traits:
+How does Rust know to forbid shared access across threads? The answer is in two traits:
 
 * [`Send`][1]: a type `T` is `Send` if it is safe to move a `T` across a thread
   boundary.


### PR DESCRIPTION
Again, a clean pull request for this typo.