### PR TITLE
Use `AND` between words in `mdbook` search

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -86,5 +86,8 @@ line-numbers = true
 # Send people to canonical URL instead of index.html
 "welcome.html" = "./"
 
+[output.html.search]
+use-boolean-and = true
+
 [output.exerciser]
 output-directory = "comprehensive-rust-exercises"


### PR DESCRIPTION
The default is to use `OR`, which I find counter-intuitive: the more I try to narrow down a search, the more hits I get. See the full documentation for more options:

https://rust-lang.github.io/mdBook/format/configuration/renderers.html#outputhtmlsearch