### PR TITLE
Format the glossary using a Markdown list

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -4,73 +4,101 @@ The following is a glossary which aims to give a short definition of many Rust
 terms. For translations, this also serves to connect the term back to the
 English original.
 
-<!-- Translators: please list the English term in italic after your translation.
-For Danish, this would look like this: `allokere (_allocate_)`. -->
+<style>
+h1#glossary ~ ul {
+    list-style: none;
+    padding-inline-start: 0;
+}
 
-| Term                  | Notes                                                                        |
-| --------------------- | ---------------------------------------------------------------------------- |
-| allocate              | Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md). |
-| argument              |                                                                              |
-| Bare-metal Rust       | See [Bare-metal Rust](bare-metal.md).                                        |
-| block                 | See [Blocks](control-flow/blocks.md) and _scope_.                            |
-| borrow                | See [Borrowing](ownership/borrowing.md).                                     |
-| borrow checker        | The part of the Rust compiler which checks that all borrows are valid.       |
-| brace                 | `{` and `}`. Also called _curly brace_, they delimit _blocks_.               |
-| build                 |                                                                              |
-| call                  |                                                                              |
-| channel               | Used to safely pass messages [between threads](concurrency/channels.md).     |
-| Comprehensive Rust 🦀 | The courses here are jointly called Comprehensive Rust 🦀.                   |
-| concurrency           |                                                                              |
-| Concurrency in Rust   | See [Concurrency in Rust](concurrency.md).                                   |
-| constant              |                                                                              |
-| control flow          |                                                                              |
-| crash                 |                                                                              |
-| enumeration           |                                                                              |
-| error                 |                                                                              |
-| error handling        |                                                                              |
-| exercise              |                                                                              |
-| function              |                                                                              |
-| garbage collector     |                                                                              |
-| generics              |                                                                              |
-| immutable             |                                                                              |
-| integration test      |                                                                              |
-| keyword               |                                                                              |
-| library               |                                                                              |
-| macro                 |                                                                              |
-| main function         |                                                                              |
-| match                 |                                                                              |
-| memory leak           |                                                                              |
-| method                |                                                                              |
-| module                |                                                                              |
-| move                  |                                                                              |
-| mutable               |                                                                              |
-| ownership             |                                                                              |
-| panic                 |                                                                              |
-| parameter             |                                                                              |
-| pattern               |                                                                              |
-| payload               |                                                                              |
-| program               |                                                                              |
-| programming language  |                                                                              |
-| receiver              |                                                                              |
-| reference counting    |                                                                              |
-| return                |                                                                              |
-| Rust                  |                                                                              |
-| Rust Fundamentals     | Days 1 to 3 of this course.                                                  |
-| Rust in Android       | See [Rust in Android](android.md).                                           |
-| safe                  |                                                                              |
-| scope                 |                                                                              |
-| standard library      |                                                                              |
-| static                |                                                                              |
-| string                |                                                                              |
-| struct                |                                                                              |
-| test                  |                                                                              |
-| thread                |                                                                              |
-| thread safety         |                                                                              |
-| trait                 |                                                                              |
-| type                  |                                                                              |
-| type inference        |                                                                              |
-| undefined behavior    |                                                                              |
-| union                 |                                                                              |
-| unit test             |                                                                              |
-| unsafe                |                                                                              |
-| variable              |                                                                              |
+h1#glossary ~ ul > li {
+    /* Simplify with "text-indent: 2em hanging" when supported:
+       https://caniuse.com/mdn-css_properties_text-indent_hanging */
+    padding-left: 2em;
+    text-indent: -2em;
+}
+
+h1#glossary ~ ul > li:first-line {
+    font-weight: bold;
+}
+</style>
+
+<!--
+Translators: please add the English term in italic after your translated term.
+Also, please keep the hard line breaks to ensure a nice formatting.
+-->
+
+- allocate:\
+  Dynamic memory allocation on [the heap](memory-management/stack-vs-heap.md).
+- argument:\
+- Bare-metal Rust: See [Bare-metal Rust](bare-metal.md).
+- block:\
+  See [Blocks](control-flow/blocks.md) and _scope_.
+- borrow:\
+  See [Borrowing](ownership/borrowing.md).
+- borrow checker:\
+  The part of the Rust compiler which checks that all borrows are valid.
+- brace:\
+  `{` and `}`. Also called _curly brace_, they delimit _blocks_.
+- build:\
+- call:\
+- channel:\
+  Used to safely pass messages [between threads](concurrency/channels.md).
+- Comprehensive Rust 🦀:\
+  The courses here are jointly called Comprehensive Rust 🦀.
+- concurrency:\
+- Concurrency in Rust:\
+  See [Concurrency in Rust](concurrency.md).
+- constant:\
+- control flow:\
+- crash:\
+- enumeration:\
+- error:\
+- error handling:\
+- exercise:\
+- function:\
+- garbage collector:\
+- generics:\
+- immutable:\
+- integration test:\
+- keyword:\
+- library:\
+- macro:\
+- main function:\
+- match:\
+- memory leak:\
+- method:\
+- module:\
+- move:\
+- mutable:\
+- ownership:\
+- panic:\
+- parameter:\
+- pattern:\
+- payload:\
+- program:\
+- programming language:\
+- receiver:\
+- reference counting:\
+- return:\
+- Rust:\
+- Rust Fundamentals:\
+  Days 1 to 3 of this course.
+- Rust in Android:\
+  See [Rust in Android](android.md).
+- safe:\
+- scope:\
+- standard library:\
+- static:\
+- string:\
+- struct:\
+- test:\
+- thread:\
+- thread safety:\
+- trait:\
+- type:\
+- type inference:\
+- undefined behavior:\
+- union:\
+- unit test:\
+- unsafe:\
+- variable:\


### PR DESCRIPTION
This format has two advantages:

- is easier to maintain in the Markdown file. Tables cannot be wrapped in Markdown, which would severely limit what we can write for each term.
- it can be styled better. The layout now looks more like what you find in a dictionary.

Before:

![image](https://github.com/google/comprehensive-rust/assets/89623/26bdc39e-4c1d-4f33-90d5-a1637712bcb8)

After:

![image](https://github.com/google/comprehensive-rust/assets/89623/38c1b329-4a80-4771-b415-425a537a0388)


Followup to #1277.