### PR TITLE
Remove HTML tag <abbr>

### DIFF
--- a/src/bare-metal/aps/inline-assembly.md
+++ b/src/bare-metal/aps/inline-assembly.md
@@ -1,7 +1,7 @@
 # Inline assembly
 
 Sometimes we need to use assembly to do things that aren't possible with Rust code. For example,
-to make an <abbr title="hypervisor call">HVC</abbr> to tell the firmware to power off the system:
+to make an HVC (hypervisor call) to tell the firmware to power off the system:
 
 ```rust,editable,compile_fail
 {{#include examples/src/main_psci.rs:main}}

--- a/src/bare-metal/microcontrollers/probe-rs.md
+++ b/src/bare-metal/microcontrollers/probe-rs.md
@@ -3,13 +3,13 @@
 [probe-rs](https://probe.rs/) is a handy toolset for embedded debugging, like OpenOCD but better
 integrated.
 
-* <abbr title="Serial Wire Debug">SWD</abbr> and JTAG via CMSIS-DAP, ST-Link and J-Link probes
-* GDB stub and Microsoft <abbr title="Debug Adapter Protocol">DAP</abbr> server
+* SWD (Serial Wire Debug) and JTAG via CMSIS-DAP, ST-Link and J-Link probes
+* GDB stub and Microsoft DAP (Debug Adapter Protocol) server
 * Cargo integration
 
-`cargo-embed` is a cargo subcommand to build and flash binaries, log
-<abbr title="Real Time Transfers">RTT</abbr> output and connect GDB. It's configured by an
-`Embed.toml` file in your project directory.
+`cargo-embed` is a cargo subcommand to build and flash binaries, log RTT (Real
+Time Transfers) output and connect GDB. It's configured by an `Embed.toml` file
+in your project directory.
 
 <details>
 


### PR DESCRIPTION
The html tag seems to confuse the mdbook-i18n-helpers and make the translation work hard (#1284).

This simply replaces them with a set of parenthesis.